### PR TITLE
fix(guard-daemon): protect local get routes

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -444,25 +444,27 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not self._origin_is_allowed_for_request(parsed.path, path_parts):
             self._write_json({"error": "forbidden_origin"}, status=403)
             return
-        if (
-            self._is_hosted_dashboard_origin()
-            and self._is_hosted_dashboard_api_path(parsed.path, path_parts)
-            and not self._header_token_is_valid()
-        ):
-            self._write_json({"error": "unauthorized"}, status=401)
-            return
         if parsed.path == "/healthz":
             self._write_json(self._public_healthz_payload())
             return
         if parsed.path == "/v1/healthz/details":
             if not self._header_token_is_valid():
-                self._write_json(
-                    {"error": "unauthorized"},
-                    status=401,
-                    extra_headers=self._cors_headers_for_request(),
-                )
+                self._write_unauthorized(extra_headers=self._cors_headers_for_request())
                 return
             self._write_json(self._detailed_healthz_payload())
+            return
+        if parsed.path == "/v1/events/stream":
+            if self._query_has_guard_token(parsed.query):
+                self._record_query_token_rejection()
+                self._write_unauthorized(extra_headers=self._cors_headers_for_request())
+                return
+            if not self._header_token_is_valid():
+                self._write_unauthorized(extra_headers=self._cors_headers_for_request())
+                return
+            self._stream_events(_int_query_value(parsed.query, "cursor"))
+            return
+        if parsed.path.startswith("/v1/") and not self._header_token_is_valid():
+            self._write_unauthorized(extra_headers=self._cors_headers_for_request())
             return
         if parsed.path == "/v1/capabilities":
             self._handle_capabilities()
@@ -677,16 +679,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path.startswith("/assets/") or parsed.path.startswith("/brand/"):
             self._write_static_asset(parsed.path.removeprefix("/"))
-            return
-        if parsed.path == "/v1/events/stream":
-            if self._query_has_guard_token(parsed.query):
-                self._record_query_token_rejection()
-                self._write_unauthorized()
-                return
-            if not self._header_token_is_valid():
-                self._write_unauthorized()
-                return
-            self._stream_events(_int_query_value(parsed.query, "cursor"))
             return
         if self._is_dashboard_route(parsed.path):
             self._write_dashboard_shell()
@@ -2719,14 +2711,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         return origin in _HOSTED_GUARD_DASHBOARD_ORIGINS
 
     def _public_healthz_payload(self) -> dict[str, object]:
-        uptime = round(time.monotonic() - self.server.start_monotonic, 1)  # type: ignore[attr-defined]
-        pending_approvals = self.server.store.count_approval_requests()  # type: ignore[attr-defined]
         return {
             "ok": True,
-            "pending_approvals": pending_approvals,
-            "uptime_seconds": uptime,
             "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
-            "package_version": __version__,
         }
 
     def _detailed_healthz_payload(self) -> dict[str, object]:

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -109,6 +109,7 @@ def test_load_guard_daemon_url_accepts_matching_healthz_guard_home_for_in_proces
         "_guard_daemon_pid_matches_command",
         lambda _pid, expected_guard_home=None: False,
     )
+
     def fake_urlopen(request, *_args, **_kwargs):
         requested_urls.append(request.full_url if hasattr(request, "full_url") else str(request))
         if hasattr(request, "header_items"):
@@ -148,8 +149,6 @@ def test_healthz_payload_is_current_accepts_redacted_public_healthz() -> None:
         {
             "ok": True,
             "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
-            "pending_approvals": 0,
-            "uptime_seconds": 1.2,
         }
     )
 

--- a/tests/test_guard_daemon_registry.py
+++ b/tests/test_guard_daemon_registry.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import urllib.error
 import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
@@ -79,35 +80,38 @@ class TestHealthzEndpoint:
         with urllib.request.urlopen(request, timeout=3) as resp:
             return json.loads(resp.read())
 
-    def test_healthz_includes_pending_approvals(self, tmp_path: Path) -> None:
+    def test_healthz_redacts_pending_approval_counts(self, tmp_path: Path) -> None:
         url, server = self._start_server(tmp_path)
         try:
             payload = self._get_healthz(url)
-            assert "pending_approvals" in payload, "/healthz must include pending_approvals"
+            assert "pending_approvals" not in payload
         finally:
             server.stop()
 
-    def test_healthz_includes_uptime_seconds(self, tmp_path: Path) -> None:
+    def test_healthz_redacts_uptime_seconds(self, tmp_path: Path) -> None:
         url, server = self._start_server(tmp_path)
         try:
             payload = self._get_healthz(url)
-            assert "uptime_seconds" in payload, "/healthz must include uptime_seconds"
+            assert "uptime_seconds" not in payload
         finally:
             server.stop()
 
-    def test_healthz_uptime_is_non_negative(self, tmp_path: Path) -> None:
+    def test_healthz_exposes_compatibility_version_only(self, tmp_path: Path) -> None:
         url, server = self._start_server(tmp_path)
         try:
             payload = self._get_healthz(url)
-            assert payload["uptime_seconds"] >= 0.0
+            assert payload == {
+                "ok": True,
+                "compatibility_version": daemon_manager_module.GUARD_DAEMON_COMPATIBILITY_VERSION,
+            }
         finally:
             server.stop()
 
-    def test_healthz_pending_approvals_is_int(self, tmp_path: Path) -> None:
+    def test_healthz_redacts_package_version(self, tmp_path: Path) -> None:
         url, server = self._start_server(tmp_path)
         try:
             payload = self._get_healthz(url)
-            assert isinstance(payload["pending_approvals"], int)
+            assert "package_version" not in payload
         finally:
             server.stop()
 
@@ -126,6 +130,8 @@ class TestHealthzEndpoint:
             assert "compatibility_version" in payload
             assert "package_version" in payload
             assert "tables" in payload
+            assert "pending_approvals" in payload
+            assert "uptime_seconds" in payload
         finally:
             server.stop()
 
@@ -134,5 +140,17 @@ class TestHealthzEndpoint:
         try:
             payload = self._get_healthz_details(url, server)
             assert payload["guard_home"] == str((tmp_path / "guard-home").resolve())
+        finally:
+            server.stop()
+
+    def test_healthz_details_requires_auth(self, tmp_path: Path) -> None:
+        url, server = self._start_server(tmp_path)
+        try:
+            with urllib.request.urlopen(f"{url}/v1/healthz/details", timeout=3):
+                raise AssertionError("expected healthz details to require daemon auth")
+        except urllib.error.HTTPError as error:
+            assert error.code == 401
+            payload = json.loads(error.read())
+            assert payload["error"] == "unauthorized"
         finally:
             server.stop()

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -451,7 +451,7 @@ def test_headless_capabilities_rejects_dashboard_session_from_guard_token_header
     assert payload["error"] == "unauthorized"
 
 
-def test_cloud_app_handoff_get_rejects_legacy_local_page(tmp_path: Path) -> None:
+def test_cloud_app_handoff_get_requires_auth_before_legacy_local_page_branch(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -470,8 +470,8 @@ def test_cloud_app_handoff_get_rejects_legacy_local_page(tmp_path: Path) -> None
     finally:
         daemon.stop()
 
-    assert status == 410
-    assert payload["error"] == "legacy_cloud_handoff_disabled"
+    assert status == 401
+    assert payload["error"] == "unauthorized"
     serialized = json.dumps(payload)
     assert "handoffToken" not in serialized
     assert "dashboardSessionToken" not in serialized
@@ -531,7 +531,7 @@ def test_cloud_app_handoff_start_does_not_save_raw_sync_credentials(tmp_path: Pa
     assert store.get_sync_credentials() is None
 
 
-def test_cloud_app_handoff_navigation_does_not_save_raw_sync_credentials(tmp_path: Path) -> None:
+def test_cloud_app_handoff_navigation_requires_auth_before_legacy_sync_query_handling(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     path = (
@@ -557,8 +557,8 @@ def test_cloud_app_handoff_navigation_does_not_save_raw_sync_credentials(tmp_pat
     finally:
         daemon.stop()
 
-    assert status == 410
-    assert payload["error"] == "legacy_cloud_handoff_disabled"
+    assert status == 401
+    assert payload["error"] == "unauthorized"
     assert "guard-runtime-token" not in json.dumps(payload)
     assert store.get_sync_credentials() is None
 

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -25,6 +25,14 @@ from codex_plugin_scanner.guard.schemas import build_surface_server_contract
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _guard_get_request(port: int, path: str, auth_token: str) -> urllib.request.Request:
+    return urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        headers={"X-Guard-Token": auth_token},
+        method="GET",
+    )
+
+
 class TestGuardSurfaceServer:
     def test_guard_daemon_serves_dashboard_shell_for_home_and_section_routes(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
@@ -259,7 +267,7 @@ class TestGuardSurfaceServer:
 
         try:
             with urllib.request.urlopen(
-                f"http://127.0.0.1:{daemon.port}/v1/settings",
+                _guard_get_request(daemon.port, "/v1/settings", daemon._server.auth_token),
                 timeout=5,
             ) as read_response:
                 read_payload = json.loads(read_response.read().decode("utf-8"))
@@ -812,7 +820,10 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -860,7 +871,10 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/inventory", timeout=5) as response:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/inventory", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -879,7 +893,10 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -917,7 +934,10 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -960,7 +980,10 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -1003,7 +1026,10 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -1075,7 +1101,10 @@ class TestGuardSurfaceServer:
         daemon.start()
 
         try:
-            with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         finally:
             daemon.stop()
@@ -1086,6 +1115,23 @@ class TestGuardSurfaceServer:
         assert payload["proof_status"]["first_synced_at"] == "2026-06-04T18:31:00+00:00"
         assert payload["latest_connect_state"]["status"] == "connected"
         assert payload["latest_connect_state"]["milestone"] == "first_sync_succeeded"
+
+    def test_guard_daemon_receipts_endpoint_requires_auth_and_records_audit(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/receipts", timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 401
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "unauthorized"
+        events = store.list_events(event_name="daemon.auth.unauthorized")
+        assert events[-1]["payload"]["path"] == "/v1/receipts"
 
     def test_guard_daemon_claude_hook_endpoint_accepts_empty_allow_response(self, tmp_path) -> None:
         home_dir = tmp_path / "home"
@@ -1573,7 +1619,11 @@ class TestGuardSurfaceServer:
                 attach_payload = json.loads(response.read().decode("utf-8"))
 
             with urllib.request.urlopen(
-                f"http://127.0.0.1:{daemon.port}/v1/sessions/{session_payload['session_id']}/resume",
+                _guard_get_request(
+                    daemon.port,
+                    f"/v1/sessions/{session_payload['session_id']}/resume",
+                    initialize_payload["auth_token"],
+                ),
                 timeout=5,
             ) as response:
                 attached_resume_payload = json.loads(response.read().decode("utf-8"))
@@ -1598,7 +1648,11 @@ class TestGuardSurfaceServer:
                 operation_payload = json.loads(response.read().decode("utf-8"))
 
             with urllib.request.urlopen(
-                f"http://127.0.0.1:{daemon.port}/v1/sessions/{session_payload['session_id']}/resume",
+                _guard_get_request(
+                    daemon.port,
+                    f"/v1/sessions/{session_payload['session_id']}/resume",
+                    initialize_payload["auth_token"],
+                ),
                 timeout=5,
             ) as response:
                 active_resume_payload = json.loads(response.read().decode("utf-8"))


### PR DESCRIPTION
## Summary
- require daemon auth for local `/v1/*` GET routes, with `/v1/events/stream` kept on its hardened stream-specific path
- redact public `/healthz` to compatibility-only data while keeping authenticated detailed health available
- update daemon regression coverage for protected reads, redacted health, and legacy cloud-handoff GET denial ordering

## Testing
- `uv run ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py tests/test_guard_daemon_registry.py tests/test_guard_daemon_manager.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py tests/test_guard_daemon_registry.py tests/test_guard_daemon_manager.py`
- `uv run pytest tests/test_guard_surface_server.py tests/test_guard_daemon_registry.py tests/test_guard_daemon_manager.py tests/test_guard_headless_daemon_api.py -q`

## Notes
- `tests/test_guard_headless_daemon_api.py` still has a pre-existing repo-wide import-order lint issue outside this diff, so lint verification stayed scoped to changed files.
