### PR TITLE
fix(guard): auto-sync first proof and unblock source fixtures

### DIFF
--- a/dashboard/src/feed-health-workspace.tsx
+++ b/dashboard/src/feed-health-workspace.tsx
@@ -146,7 +146,7 @@ export function FeedHealthWorkspace({ snapshot, onOpenSettings }: FeedHealthWork
             <div>
               <p className="text-sm font-semibold text-brand-dark">Full feed syncing</p>
               <p className="text-xs text-slate-600 mt-0.5">
-                Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly.
+                Guard Cloud is connected. Local Guard is finishing the first shared proof automatically.
               </p>
             </div>
           </div>

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -860,7 +860,7 @@ export function buildDemoRuntimeSnapshot(): GuardRuntimeSnapshot {
     proof_status: {
       state: "pending",
       label: "First proof pending",
-      detail: "Browser pairing finished. First proof sync has not completed yet.",
+      detail: "Browser pairing finished. Local Guard will retry the first proof sync automatically while the daemon is running, or you can run hol-guard sync now.",
       request_id: "demo-connect-request",
       pairing_completed_at: now,
       first_synced_at: null,

--- a/dashboard/src/home-dashboard.test.ts
+++ b/dashboard/src/home-dashboard.test.ts
@@ -280,7 +280,7 @@ assert(
 const demoProof: GuardProofStatus = {
   state: "pending",
   label: "First proof pending",
-  detail: "Browser pairing finished. First proof sync has not completed yet.",
+  detail: "Browser pairing finished. Local Guard will retry the first proof sync automatically while the daemon is running, or you can run hol-guard sync now.",
   request_id: "demo-connect-request",
   pairing_completed_at: new Date().toISOString(),
   first_synced_at: null,

--- a/dashboard/src/runtime-overview.test.ts
+++ b/dashboard/src/runtime-overview.test.ts
@@ -43,7 +43,8 @@ assert(pairedActiveCopy.detail.length > 0, "T508: paired_active detail should no
 assert(pairedActiveCopy.detail.includes("Guard Cloud"), "T508: paired_active detail should mention Guard Cloud");
 
 const pairedWaitingCopy = resolveCloudIntelCopy("paired_waiting");
-assert(pairedWaitingCopy.label === "Pairing…", "T508: paired_waiting label should be 'Pairing…'");
+assert(pairedWaitingCopy.label === "First sync in progress", "T508: paired_waiting label should describe automatic first sync");
+assert(pairedWaitingCopy.detail.includes("first shared proof"), "T508: paired_waiting detail should mention the first shared proof");
 
 const pairedActiveSyncCopy = resolveCloudSyncHealthCopy(healthHealthy);
 assert(pairedActiveSyncCopy.label === healthHealthy.label, "T508: healthy sync label should match");

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -32,7 +32,7 @@ function remediationLine(snapshot: GuardRuntimeSnapshot): string {
     return "Open the review queue, choose what to do with the blocked action, then retry in the same chat.";
   }
   if (snapshot.cloud_state === "paired_waiting") {
-    return "Open Guard Cloud while the first protected session lands and this machine finishes syncing.";
+    return "Keep Local Guard running while it finishes the first cloud sync automatically, or run hol-guard sync now.";
   }
   if (snapshot.cloud_state === "local_only") {
     return "Stay local for now or connect this machine when you want shared queue memory and cross-device proof.";
@@ -106,7 +106,7 @@ export function resolveCloudIntelCopy(state: "local_only" | "paired_waiting" | "
     return { label: "Offline, free", detail: "Running locally with no cloud sync. Your choices stay on this machine." };
   }
   if (state === "paired_waiting") {
-    return { label: "Pairing…", detail: "Connected to Guard Cloud, waiting for sync to start." };
+    return { label: "First sync in progress", detail: "Connected to Guard Cloud. Local Guard is sending the first shared proof now." };
   }
   return { label: "Synced, pro", detail: "Guard Cloud is active and syncing choices across your devices." };
 }

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -738,8 +738,11 @@ def _runtime_proof_status_detail(state: str) -> str:
     details = {
         "synced": "This device completed its first Guard Cloud proof sync.",
         "sync_unavailable": "Local Guard is connected. Shared cloud sync needs a paid Guard plan.",
-        "failed": "Run hol-guard connect again to finish first proof sync.",
-        "pending": "Browser sign-in finished. First proof sync has not completed yet.",
+        "failed": "Guard Cloud sign-in on this machine needs repair. Run hol-guard connect again.",
+        "pending": (
+            "Browser sign-in finished. Local Guard will retry the first proof sync automatically "
+            "while the daemon is running, or you can run hol-guard sync now."
+        ),
         "expired": "The sign-in link expired. Run hol-guard connect again.",
         "waiting": "Open the sign-in link to register this local Guard device.",
         "not_connected": "Connect Guard Cloud to sync this device proof.",
@@ -887,8 +890,8 @@ def _runtime_cloud_state_detail(cloud_state: str, *, oauth_repair_required: bool
         )
     if cloud_state == "paired_waiting":
         return (
-            "This machine is connected to Guard Cloud, but the first shared proof has not landed yet. "
-            "Open Fleet while the first sync settles."
+            "This machine is connected to Guard Cloud. Local Guard will finish the first shared proof "
+            "automatically while the daemon is running."
         )
     if cloud_state == "paired_active":
         return (
@@ -948,7 +951,7 @@ def _runtime_headline_detail(headline_state: str) -> str:
         "protected": "This machine is protected and the local queue is clear.",
         "blocked": "A blocked launch is waiting for review in the current request queue.",
         "local_only": "This machine is protected locally and can connect later when shared memory matters.",
-        "connected": "This machine is connected to Guard Cloud and waiting for the first shared proof to appear.",
+        "connected": "This machine is connected to Guard Cloud. Local Guard is sending the first shared proof now.",
     }
     return details.get(headline_state, "This machine is protected locally.")
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -7204,8 +7204,6 @@ def _codex_source_inspection_can_skip_secret_output(
         return all(
             match.classifier == "pem-private-key" for match in non_medium_matches
         ) and _codex_output_uses_placeholder_private_key_fixture(response_text)
-    if any(match.sensitivity != "medium" for match in content_matches):
-        return False
     if _codex_command_references_benign_source_dotfile(command_text):
         return _codex_output_is_only_benign_secret_fixture(response_text)
     return True
@@ -9376,6 +9374,24 @@ def _finalize_guard_connect_payload(
             }
         )
         return payload
+    except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now=now,
+            reason=str(error),
+        )
+        payload.update(
+            {
+                "status": "retry_required",
+                "milestone": "first_sync_failed",
+                "sync_succeeded": False,
+                "sync_error": str(error),
+                "repair_message": "Run hol-guard connect again to refresh Guard Cloud authorization.",
+                "latest_connect_state": store.get_latest_guard_connect_state(now=now),
+            }
+        )
+        return payload
     except RuntimeError as error:
         repair_message = (
             "Guard Cloud pairing finished, but the first proof sync is still pending. "
@@ -9394,24 +9410,6 @@ def _finalize_guard_connect_payload(
                 "sync_succeeded": False,
                 "sync_error": str(error),
                 "repair_message": repair_message,
-                "latest_connect_state": store.get_latest_guard_connect_state(now=now),
-            }
-        )
-        return payload
-    except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
-        store.record_latest_guard_connect_sync_result(
-            status="retry_required",
-            milestone="first_sync_failed",
-            now=now,
-            reason=str(error),
-        )
-        payload.update(
-            {
-                "status": "retry_required",
-                "milestone": "first_sync_failed",
-                "sync_succeeded": False,
-                "sync_error": str(error),
-                "repair_message": "Run hol-guard connect again to refresh Guard Cloud authorization.",
                 "latest_connect_state": store.get_latest_guard_connect_state(now=now),
             }
         )

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -7095,6 +7095,13 @@ _CODEX_BENIGN_SECRET_FIXTURE_ASSIGNMENT_PATTERN = re.compile(
     )
     \s*"""
 )
+_CODEX_PRIVATE_KEY_FIXTURE_PATTERN = re.compile(
+    r"-----BEGIN [A-Z ]*PRIVATE KEY-----(?P<body>.*?)-----END [A-Z ]*PRIVATE KEY-----",
+    re.DOTALL,
+)
+_CODEX_PRIVATE_KEY_FIXTURE_BODY_PATTERN = re.compile(
+    r"(?i)\b(?:secret-key-material|fixture|fake|example|sample|dummy|test-key|placeholder)\b"
+)
 _CODEX_SENSITIVE_SEARCH_BASENAMES = SOURCE_INSPECTION_SENSITIVE_PARTS | frozenset({"id_rsa"})
 _CODEX_GIT_DIFF_VALUE_OPTIONS = frozenset(
     {
@@ -7192,6 +7199,11 @@ def _codex_source_inspection_can_skip_secret_output(
         return False
     if _codex_command_targets_secret_like_source_name(command_text):
         return False
+    non_medium_matches = [match for match in content_matches if match.sensitivity != "medium"]
+    if non_medium_matches:
+        return all(
+            match.classifier == "pem-private-key" for match in non_medium_matches
+        ) and _codex_output_uses_placeholder_private_key_fixture(response_text)
     if any(match.sensitivity != "medium" for match in content_matches):
         return False
     if _codex_command_references_benign_source_dotfile(command_text):
@@ -7202,6 +7214,21 @@ def _codex_source_inspection_can_skip_secret_output(
 def _codex_output_is_only_benign_secret_fixture(response_text: str) -> bool:
     lines = [line for line in response_text.splitlines() if line.strip()]
     return bool(lines) and all(_CODEX_BENIGN_SECRET_FIXTURE_ASSIGNMENT_PATTERN.fullmatch(line) for line in lines)
+
+
+def _codex_output_uses_placeholder_private_key_fixture(response_text: str) -> bool:
+    matches = list(_CODEX_PRIVATE_KEY_FIXTURE_PATTERN.finditer(response_text))
+    if not matches:
+        return False
+    return all(
+        _CODEX_PRIVATE_KEY_FIXTURE_BODY_PATTERN.search(
+            " ".join(line.strip() for line in match.group("body").splitlines() if line.strip())
+            .replace("\\n", " ")
+            .replace("\\r", " ")
+        )
+        is not None
+        for match in matches
+    )
 
 
 def _codex_command_references_benign_source_dotfile(command_text: str) -> bool:
@@ -9349,7 +9376,29 @@ def _finalize_guard_connect_payload(
             }
         )
         return payload
-    except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError, RuntimeError) as error:
+    except RuntimeError as error:
+        repair_message = (
+            "Guard Cloud pairing finished, but the first proof sync is still pending. "
+            "Local Guard will retry automatically while the daemon is running, or run hol-guard sync now."
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="connected",
+            milestone="first_sync_pending",
+            now=now,
+            reason=str(error),
+        )
+        payload.update(
+            {
+                "status": "connected",
+                "milestone": "first_sync_pending",
+                "sync_succeeded": False,
+                "sync_error": str(error),
+                "repair_message": repair_message,
+                "latest_connect_state": store.get_latest_guard_connect_state(now=now),
+            }
+        )
+        return payload
+    except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
         store.record_latest_guard_connect_sync_result(
             status="retry_required",
             milestone="first_sync_failed",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3254,7 +3254,6 @@ class GuardDaemonServer:
             started_at=self._server.runtime_started_at,
             last_heartbeat_at=_now(),
         )
-        _maybe_queue_first_cloud_sync(store=self._server.store)
         self._start_watchdog()
         self._start_supply_chain_bundle_refresh()
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -419,6 +419,22 @@ def _queue_headless_cloud_sync(
     }
 
 
+def _maybe_queue_first_cloud_sync(*, store: GuardStore) -> dict[str, object] | None:
+    if store.get_cloud_sync_profile() is None:
+        return None
+    oauth_health = store.get_oauth_local_credential_health()
+    if bool(oauth_health.get("configured")) and str(oauth_health.get("state") or "") == "degraded":
+        return None
+    latest_state = store.get_effective_guard_connect_state(now=_now())
+    if latest_state is None:
+        return None
+    if str(latest_state.get("status") or "") != "connected":
+        return None
+    if str(latest_state.get("milestone") or "") != "first_sync_pending":
+        return None
+    return _queue_headless_cloud_sync(store=store)
+
+
 class _GuardDaemonHandler(BaseHTTPRequestHandler):
     _MAX_BODY_BYTES = 1_000_000
 
@@ -471,6 +487,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"items": store.list_guard_sessions(limit=200)})
             return
         if parsed.path == "/v1/runtime":
+            _maybe_queue_first_cloud_sync(store=store)
             config = load_guard_config(store.guard_home)
             snapshot = build_runtime_snapshot(
                 store=store,
@@ -3237,6 +3254,7 @@ class GuardDaemonServer:
             started_at=self._server.runtime_started_at,
             last_heartbeat_at=_now(),
         )
+        _maybe_queue_first_cloud_sync(store=self._server.store)
         self._start_watchdog()
         self._start_supply_chain_bundle_refresh()
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -361,11 +361,23 @@ def _run_headless_cloud_sync(
             "receipts_stored": sync_payload.get("receipts_stored", 0),
         }
     except GuardSyncAuthorizationExpiredError as error:
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now=recorded_at,
+            reason=str(error),
+        )
         summary = {
             "status": "auth_expired",
             "message": str(error),
         }
     except GuardSyncNotConfiguredError as error:
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now=recorded_at,
+            reason=str(error),
+        )
         summary = {
             "status": "not_configured",
             "message": str(error),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
@@ -85,7 +85,7 @@ function FeedHealthWorkspace({ snapshot, onOpenSettings }) {
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-blue", "aria-hidden": "true" }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: "Full feed syncing" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-600 mt-0.5", children: "Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly." })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-600 mt-0.5", children: "Guard Cloud is connected. Local Guard is finishing the first shared proof automatically." })
         ] })
       ] }),
       sourceMode === "live" && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2 rounded-xl border border-brand-green/20 bg-brand-green/[0.04] px-3 py-2.5", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/runtime-overview.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/runtime-overview.js
@@ -19,7 +19,7 @@ function resolveCloudIntelCopy(state) {
     return { label: "Offline, free", detail: "Running locally with no cloud sync. Your choices stay on this machine." };
   }
   if (state === "paired_waiting") {
-    return { label: "Pairing…", detail: "Connected to Guard Cloud, waiting for sync to start." };
+    return { label: "First sync in progress", detail: "Connected to Guard Cloud. Local Guard is sending the first shared proof now." };
   }
   return { label: "Synced, pro", detail: "Guard Cloud is active and syncing choices across your devices." };
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13335,7 +13335,7 @@ function buildDemoRuntimeSnapshot() {
     proof_status: {
       state: "pending",
       label: "First proof pending",
-      detail: "Browser pairing finished. First proof sync has not completed yet.",
+      detail: "Browser pairing finished. Local Guard will retry the first proof sync automatically while the daemon is running, or you can run hol-guard sync now.",
       request_id: "demo-connect-request",
       pairing_completed_at: now2,
       first_synced_at: null,

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -82,3 +82,41 @@ def test_guard_daemon_start_queues_pending_first_sync(tmp_path, monkeypatch) -> 
         assert calls == [str(store.guard_home)]
     finally:
         daemon.stop()
+
+
+def test_finalize_guard_connect_payload_keeps_reauth_failures_in_retry_required_state(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_url = "https://hol.org/guard/connect"
+    now = "2026-06-04T12:00:00+00:00"
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": True, "state": "healthy"},
+    )
+
+    def _raise_auth_expired(_store: GuardStore) -> dict[str, object]:
+        raise guard_commands_module.GuardSyncAuthorizationExpiredError("reauth required")
+
+    monkeypatch.setattr(guard_commands_module, "sync_receipts", _raise_auth_expired)
+
+    payload = guard_commands_module._finalize_guard_connect_payload(
+        store=store,
+        connect_url=connect_url,
+        payload={"status": "connected"},
+        now=now,
+    )
+
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
+    assert payload["sync_succeeded"] is False
+    assert payload["sync_error"] == "reauth required"
+    assert payload["repair_message"] == "Run hol-guard connect again to refresh Guard Cloud authorization."

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -1,12 +1,11 @@
 from __future__ import annotations
 
-import json
-import urllib.request
-
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
+from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_guard_headless_daemon_api import _dashboard_token, _read_json_response, _request
 
 
 def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sync_error(
@@ -83,8 +82,17 @@ def test_guard_daemon_runtime_request_queues_pending_first_sync(tmp_path, monkey
     try:
         daemon.start()
         assert calls == []
-        with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
-            payload = json.loads(response.read().decode("utf-8"))
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/runtime",
+                method="GET",
+                token=_dashboard_token(auth_token),
+            ),
+        )
+        assert status == 200
         assert payload["cloud_state"] == "paired_waiting"
         assert calls == [str(store.guard_home)]
     finally:

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sync_error(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_url = "https://hol.org/guard/connect"
+    now = "2026-06-04T12:00:00+00:00"
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": True, "state": "healthy"},
+    )
+
+    def _raise_runtime_error(_store: GuardStore) -> dict[str, object]:
+        raise RuntimeError("temporary receipt sync failure")
+
+    monkeypatch.setattr(guard_commands_module, "sync_receipts", _raise_runtime_error)
+
+    payload = guard_commands_module._finalize_guard_connect_payload(
+        store=store,
+        connect_url=connect_url,
+        payload={"status": "connected"},
+        now=now,
+    )
+
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_pending"
+    assert payload["sync_succeeded"] is False
+    assert payload["sync_error"] == "temporary receipt sync failure"
+    assert "retry automatically" in str(payload["repair_message"])
+
+    latest_state = payload["latest_connect_state"]
+    assert isinstance(latest_state, dict)
+    assert latest_state["status"] == "connected"
+    assert latest_state["milestone"] == "first_sync_pending"
+
+
+def test_guard_daemon_start_queues_pending_first_sync(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-06-04T12:00:00+00:00"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": True, "state": "healthy"},
+    )
+
+    def _record_queue(*, store: GuardStore) -> dict[str, object]:
+        calls.append(str(store.guard_home))
+        return {"status": "queued", "message": "Guard Cloud sync started."}
+
+    monkeypatch.setattr(daemon_server_module, "_queue_headless_cloud_sync", _record_queue)
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    try:
+        daemon.start()
+        assert calls == [str(store.guard_home)]
+    finally:
+        daemon.stop()

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
 
+import json
+import urllib.request
+
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
@@ -49,7 +52,7 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sy
     assert latest_state["milestone"] == "first_sync_pending"
 
 
-def test_guard_daemon_start_queues_pending_first_sync(tmp_path, monkeypatch) -> None:
+def test_guard_daemon_runtime_request_queues_pending_first_sync(tmp_path, monkeypatch) -> None:
     store = GuardStore(tmp_path / "guard-home")
     now = "2026-06-04T12:00:00+00:00"
     store.record_guard_connect_pairing_completed(
@@ -79,6 +82,10 @@ def test_guard_daemon_start_queues_pending_first_sync(tmp_path, monkeypatch) -> 
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     try:
         daemon.start()
+        assert calls == []
+        with urllib.request.urlopen(f"http://127.0.0.1:{daemon.port}/v1/runtime", timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["cloud_state"] == "paired_waiting"
         assert calls == [str(store.guard_home)]
     finally:
         daemon.stop()

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -135,3 +135,45 @@ def test_finalize_guard_connect_payload_keeps_reauth_failures_in_retry_required_
     assert payload["sync_succeeded"] is False
     assert payload["sync_error"] == "reauth required"
     assert payload["repair_message"] == "Run hol-guard connect again to refresh Guard Cloud authorization."
+
+
+def test_headless_first_sync_auth_expiry_marks_connect_state_for_repair(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-06-04T12:00:00+00:00"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+    queued_calls: list[str] = []
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": True, "state": "healthy"},
+    )
+
+    def _raise_auth_expired(_store: GuardStore) -> dict[str, object]:
+        raise guard_commands_module.GuardSyncAuthorizationExpiredError("reauth required")
+
+    def _record_queue(*, store: GuardStore) -> dict[str, object]:
+        queued_calls.append(str(store.guard_home))
+        return {"status": "queued", "message": "Guard Cloud sync started."}
+
+    monkeypatch.setattr(daemon_server_module, "sync_receipts", _raise_auth_expired)
+    monkeypatch.setattr(daemon_server_module, "_queue_headless_cloud_sync", _record_queue)
+
+    daemon_server_module._run_headless_cloud_sync(store=store)
+
+    latest_state = store.get_effective_guard_connect_state(now="2026-06-04T12:05:00+00:00")
+    assert latest_state is not None
+    assert latest_state["status"] == "retry_required"
+    assert latest_state["milestone"] == "first_sync_failed"
+    assert latest_state["reason"] == "reauth required"
+    assert daemon_server_module._maybe_queue_first_cloud_sync(store=store) is None
+    assert queued_calls == []

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -563,7 +563,10 @@ def test_runtime_snapshot_exposes_latest_connect_proof_without_pairing_secrets(t
             "first_sync_pending",
             "pending",
             "First proof pending",
-            "Browser sign-in finished. First proof sync has not completed yet.",
+            (
+                "Browser sign-in finished. Local Guard will retry the first proof sync automatically "
+                "while the daemon is running, or you can run hol-guard sync now."
+            ),
         ),
         (
             "waiting",

--- a/tests/test_guard_source_view_secret_fixtures.py
+++ b/tests/test_guard_source_view_secret_fixtures.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+
+
+def _write_text(path: Path, contents: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(contents, encoding="utf-8")
+
+
+def test_codex_source_view_allows_placeholder_private_key_fixture_output(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "tests" / "test_connect_fixture.py"
+    _write_text(
+        source_file,
+        (
+            'dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\n'
+            "secret-key-material\n"
+            '-----END PRIVATE KEY-----\n"\n'
+        ),
+    )
+
+    command = "sed -n '1,20p' tests/test_connect_fixture.py"
+
+    assert guard_commands_module._codex_command_is_read_only_source_inspection(
+        command,
+        cwd=workspace_dir,
+    )
+    artifact = guard_commands_module._codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": source_file.read_text(encoding="utf-8")},
+        },
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        source_scope="workspace",
+        cwd=workspace_dir,
+    )
+
+    assert artifact is None
+
+
+def test_codex_source_view_still_blocks_real_private_key_output(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "tests" / "test_connect_fixture.py"
+    _write_text(
+        source_file,
+        (
+            'dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\n'
+            "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQD0realmaterial\n"
+            '-----END PRIVATE KEY-----\n"\n'
+        ),
+    )
+
+    command = "sed -n '1,20p' tests/test_connect_fixture.py"
+
+    artifact = guard_commands_module._codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": source_file.read_text(encoding="utf-8")},
+        },
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        source_scope="workspace",
+        cwd=workspace_dir,
+    )
+
+    assert artifact is not None

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -108,14 +108,18 @@ class TestGuardSurfaceServer:
 
         assert "Open pairing flow" in dashboard_bundle
         assert "Open Guard connect" not in dashboard_bundle
-        assert "Browser pairing finished. First proof sync has not completed yet." in dashboard_bundle
-        assert "Browser sign-in finished. First proof sync has not completed yet." not in dashboard_bundle
-        assert 'label: "Pairing…"' in runtime_overview_chunk
+        assert (
+            "Browser pairing finished. Local Guard will retry the first proof sync automatically "
+            "while the daemon is running, or you can run hol-guard sync now."
+        ) in dashboard_bundle
+        assert "Browser pairing finished. First proof sync has not completed yet." not in dashboard_bundle
+        assert 'label: "First sync in progress"' in runtime_overview_chunk
+        assert "Connected to Guard Cloud. Local Guard is sending the first shared proof now." in runtime_overview_chunk
         assert '"Sync pending"' not in runtime_overview_chunk
-        assert "Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly." in (
+        assert "Guard Cloud is connected. Local Guard is finishing the first shared proof automatically." in (
             feed_health_chunk
         )
-        assert "Cloud connection is complete. Feed sync is in progress. First proof will arrive shortly." not in (
+        assert "Cloud pairing is complete. Feed sync is in progress. First proof will arrive shortly." not in (
             feed_health_chunk
         )
 


### PR DESCRIPTION
## Summary
- auto-start the first Guard Cloud proof sync from the local daemon, and keep connect in a connected/pending state for transient sync failures instead of telling users to reconnect
- update local dashboard copy and shipped assets so pending first sync reads as automatic progress, not a broken pairing state
- stop blocking read-only `sed` source inspection when test fixtures contain placeholder private-key material, while still blocking real private-key output

## Testing
- `python3 -m pytest tests/test_guard_auto_first_sync.py tests/test_guard_source_view_secret_fixtures.py tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_dashboard_assets_use_oauth_connect_copy tests/test_guard_cli.py -k 'guard_connect_runs_first_sync_and_surfaces_cloud_urls or guard_connect_pending_output_uses_product_copy or source_view or auto_first_sync or oauth_connect_copy'`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/approvals.py tests/test_guard_auto_first_sync.py tests/test_guard_source_view_secret_fixtures.py tests/test_guard_surface_server.py`
- `pnpm --dir dashboard test`
- `pnpm --dir dashboard build`

## Notes
- Verified the shipped local dashboard in a real browser against a seeded pending-first-sync daemon state; the page reached a synced proof state automatically without another `hol-guard connect` run.
- Re-ran `sed -n '6528,6595p' tests/test_guard_cli.py` through Guard after the source-fixture fix; it no longer prompts for approval.
