### PR TITLE
fix(connect): persist first proof sync state

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -376,10 +376,10 @@ def build_runtime_snapshot(
     first_request_id = str(queue_items[0]["request_id"]) if queue_items else None
     next_request_id = active_request_id if active_is_pending else first_request_id
     latest_receipts = store.list_receipts(limit=receipt_limit)
-    cloud_context = _build_runtime_cloud_context(store)
     snapshot_now = now or _now()
     config = load_guard_config(store.guard_home)
     latest_connect_state = _build_latest_connect_state(store, snapshot_now)
+    cloud_context = _build_runtime_cloud_context(store, latest_connect_state=latest_connect_state)
     headline_state = _resolve_runtime_headline_state(
         pending_count=store.count_approval_requests(),
         runtime_state=store.get_runtime_state(),
@@ -567,12 +567,16 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
-def _build_runtime_cloud_context(store: GuardStore) -> dict[str, object]:
+def _build_runtime_cloud_context(
+    store: GuardStore,
+    latest_connect_state: dict[str, object] | None,
+) -> dict[str, object]:
     cloud_profile = store.get_cloud_sync_profile()
     oauth_storage_health = store.get_oauth_local_credential_health()
     oauth_repair_required = (
         bool(oauth_storage_health.get("configured")) and oauth_storage_health.get("state") == "degraded"
     )
+    connect_retry_required = _connect_retry_required(latest_connect_state)
     sync_url = cloud_profile["sync_url"] if cloud_profile is not None else None
     sync_summary = store.get_sync_payload("sync_summary") or {}
     remote_policy = store.get_sync_payload("policy") or {}
@@ -590,6 +594,7 @@ def _build_runtime_cloud_context(store: GuardStore) -> dict[str, object]:
         cloud_profile is not None,
         cloud_state,
         oauth_repair_required=oauth_repair_required,
+        connect_retry_required=connect_retry_required,
     )
     return {
         "sync_configured": cloud_profile is not None,
@@ -598,6 +603,7 @@ def _build_runtime_cloud_context(store: GuardStore) -> dict[str, object]:
         "cloud_state_detail": _runtime_cloud_state_detail(
             cloud_state,
             oauth_repair_required=oauth_repair_required,
+            connect_retry_required=connect_retry_required,
         ),
         "cloud_sync_health": sync_health,
         "cloud_pairing_state": {
@@ -606,6 +612,7 @@ def _build_runtime_cloud_context(store: GuardStore) -> dict[str, object]:
             "detail": _runtime_cloud_state_detail(
                 cloud_state,
                 oauth_repair_required=oauth_repair_required,
+                connect_retry_required=connect_retry_required,
             ),
             "sync_configured": cloud_profile is not None,
             "dashboard_url": dashboard_url,
@@ -750,12 +757,21 @@ def _runtime_proof_status_detail(state: str) -> str:
     return details.get(state, "Connect Guard Cloud to sync this device proof.")
 
 
+def _connect_retry_required(latest_state: dict[str, object] | None) -> bool:
+    if latest_state is None:
+        return False
+    status = _optional_string(latest_state.get("status"))
+    milestone = _optional_string(latest_state.get("milestone"))
+    return status == "retry_required" or milestone == "first_sync_failed"
+
+
 def _build_cloud_sync_health(
     store: GuardStore,
     sync_configured: bool,
     cloud_state: str,
     *,
     oauth_repair_required: bool = False,
+    connect_retry_required: bool = False,
 ) -> dict[str, object]:
     pending_events = store.count_guard_events_v1(uploaded=False)
     event_summary = store.get_sync_payload("guard_events_v1_summary") or {}
@@ -766,7 +782,7 @@ def _build_cloud_sync_health(
         sync_summary.get("synced_at"),
         runtime_summary.get("synced_at"),
     )
-    if oauth_repair_required:
+    if oauth_repair_required or connect_retry_required:
         state = "failed"
     elif not sync_configured:
         state = "disabled"
@@ -791,6 +807,7 @@ def _build_cloud_sync_health(
             state,
             pending_events=pending_events,
             oauth_repair_required=oauth_repair_required,
+            connect_retry_required=connect_retry_required,
         ),
         "pending_events": pending_events,
         "last_synced_at": last_synced_at,
@@ -840,11 +857,17 @@ def _cloud_sync_health_label(state: str) -> str:
     return labels.get(state, "Cloud sync pending")
 
 
-def _cloud_sync_health_detail(state: str, *, pending_events: int, oauth_repair_required: bool = False) -> str:
+def _cloud_sync_health_detail(
+    state: str,
+    *,
+    pending_events: int,
+    oauth_repair_required: bool = False,
+    connect_retry_required: bool = False,
+) -> str:
     if state == "healthy":
         return "Guard Cloud has the latest local proof from this machine."
     if state == "failed":
-        if oauth_repair_required:
+        if oauth_repair_required or connect_retry_required:
             return (
                 "Guard Cloud authorization on this machine needs repair. Run hol-guard connect again to restore sync."
             )
@@ -882,11 +905,21 @@ def _runtime_cloud_state_label(cloud_state: str) -> str:
     return labels.get(cloud_state, "Local only")
 
 
-def _runtime_cloud_state_detail(cloud_state: str, *, oauth_repair_required: bool = False) -> str:
+def _runtime_cloud_state_detail(
+    cloud_state: str,
+    *,
+    oauth_repair_required: bool = False,
+    connect_retry_required: bool = False,
+) -> str:
     if oauth_repair_required:
         return (
             "Guard Cloud sign-in on this machine is incomplete. "
             "Run hol-guard connect again to repair local authorization and resume sync."
+        )
+    if connect_retry_required:
+        return (
+            "Guard Cloud connection on this machine needs repair before the first shared proof can land. "
+            "Run hol-guard connect again."
         )
     if cloud_state == "paired_waiting":
         return (

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -162,6 +162,7 @@ from ..runtime.runner import (
     extract_prompt_requests,
     guard_run,
     prompt_requests_to_artifacts,
+    sync_local_guard_cloud_proof,
     sync_receipts,
     sync_runtime_session,
     sync_supply_chain_bundle,
@@ -9441,7 +9442,7 @@ def _finalize_guard_connect_payload(
         return payload
     payload["sync_attempted"] = True
     try:
-        sync_payload = sync_receipts(store)
+        sync_payload = sync_local_guard_cloud_proof(store)
     except GuardSyncNotAvailableError as error:
         store.record_latest_guard_connect_sync_result(
             status="connected",

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -245,6 +245,7 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
     sync_summary = _coerce_payload_dict(store.get_sync_payload("sync_summary"))
     last_sync_at = _optional_string(sync_summary.get("synced_at"))
     latest_connect_state = store.get_effective_guard_connect_state(now=_now())
+    connect_retry_required = _connect_retry_required(latest_connect_state)
     remote_payload_active = bool(advisories or alert_preferences or remote_policy or team_policy_pack)
     cloud_state = _resolve_cloud_state(
         sync_configured=cloud_profile is not None,
@@ -259,6 +260,7 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
             connect_url,
             dashboard_url,
             oauth_repair_required=oauth_repair_required,
+            connect_retry_required=connect_retry_required,
         ),
         "sync_url": sync_url,
         "dashboard_url": dashboard_url,
@@ -330,8 +332,8 @@ def _build_connect_steps(payload: dict[str, object]) -> list[dict[str, str]]:
                 "title": "Finish the first cloud sync",
                 "command": str(payload.get("sync_command") or f"{GUARD_COMMAND} sync"),
                 "detail": (
-                    "Older pairing flows may still need one explicit sync before this machine has cloud history, "
-                    "advisories, and team defaults."
+                    "Keep Local Guard running so it can finish the first cloud sync automatically. "
+                    "Use the sync command only when you want to force the retry now."
                 ),
             }
         ]
@@ -471,16 +473,23 @@ def _cloud_state_detail(
     dashboard_url: str,
     *,
     oauth_repair_required: bool = False,
+    connect_retry_required: bool = False,
 ) -> str:
     if oauth_repair_required:
         return (
             "Guard Cloud sign-in on this machine is incomplete. "
             f"Run `{GUARD_COMMAND} connect` or reopen {connect_url} to repair local authorization and resume sync."
         )
+    if connect_retry_required:
+        return (
+            "Guard Cloud connection on this machine needs repair before the first shared proof can land. "
+            f"Run `{GUARD_COMMAND} connect` or reopen {connect_url} to repair the first sync."
+        )
     if cloud_state == "paired_waiting":
         return (
-            "Guard Cloud credentials are saved, but this machine has not finished a full sync yet. "
-            f"Run `{GUARD_COMMAND} sync` or reopen {connect_url} to finish the pairing loop."
+            "Guard Cloud credentials are saved, but this machine has not finished the first shared sync yet. "
+            f"Keep Local Guard running so it can retry automatically, or run "
+            f"`{GUARD_COMMAND} sync` to force a retry now."
         )
     if cloud_state == "paired_active":
         return (
@@ -495,6 +504,14 @@ def _cloud_state_detail(
 
 def _coerce_payload_dict(payload: dict[str, object] | list[object] | None) -> dict[str, object]:
     return payload if isinstance(payload, dict) else {}
+
+
+def _connect_retry_required(latest_state: dict[str, object] | None) -> bool:
+    if latest_state is None:
+        return False
+    status = _optional_string(latest_state.get("status"))
+    milestone = _optional_string(latest_state.get("milestone"))
+    return status == "retry_required" or milestone == "first_sync_failed"
 
 
 def _advisory_headline(advisories: list[dict[str, object]]) -> str | None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -88,7 +88,7 @@ from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
     GuardSyncNotAvailableError,
     GuardSyncNotConfiguredError,
-    sync_receipts,
+    sync_local_guard_cloud_proof,
     sync_supply_chain_bundle,
 )
 from ..runtime.surface_server import GuardSurfaceRuntime
@@ -357,11 +357,18 @@ def _run_headless_cloud_sync(
 ) -> None:
     recorded_at = _now()
     try:
-        sync_payload = sync_receipts(store)
+        sync_payload = sync_local_guard_cloud_proof(store)
+        store.record_latest_guard_connect_sync_success(
+            sync_payload=sync_payload,
+            now=str(sync_payload.get("synced_at") or recorded_at),
+        )
         summary = {
             "status": "synced",
             "synced_at": sync_payload.get("synced_at"),
             "receipts_stored": sync_payload.get("receipts_stored", 0),
+            "runtime_session_id": sync_payload.get("runtime_session_id"),
+            "runtime_session_synced_at": sync_payload.get("runtime_session_synced_at"),
+            "runtime_sessions_visible": sync_payload.get("runtime_sessions_visible"),
         }
     except GuardSyncAuthorizationExpiredError as error:
         store.record_latest_guard_connect_sync_result(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -358,10 +358,6 @@ def _run_headless_cloud_sync(
     recorded_at = _now()
     try:
         sync_payload = sync_local_guard_cloud_proof(store)
-        store.record_latest_guard_connect_sync_success(
-            sync_payload=sync_payload,
-            now=str(sync_payload.get("synced_at") or recorded_at),
-        )
         summary = {
             "status": "synced",
             "synced_at": sync_payload.get("synced_at"),

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -861,7 +861,12 @@ def sync_receipts(
     remote_decisions: set[PolicyDecision] = set()
     device_id, device_name = _guard_device_metadata(store)
     local_guard_online_at = _now()
-    sync_context = _receipt_sync_context(store=store, local_guard_online_at=local_guard_online_at)
+    sync_context = _receipt_sync_context(
+        store=store,
+        local_guard_online_at=local_guard_online_at,
+        device_id=device_id,
+        device_name=device_name,
+    )
     latest_uploaded_rowid: int | None = None
     for receipt_batch in _iter_receipt_sync_batches(receipts):
         body = json.dumps(
@@ -2554,8 +2559,17 @@ def _receipt_sync_rows_for_upload(store: GuardStore, *, cursor_rowid: int | None
     return store.list_receipts_since_rowid(after_rowid=cursor_rowid, limit=_RECEIPT_SYNC_CURSOR_PAGE_SIZE)
 
 
-def _receipt_sync_context(store: GuardStore, *, local_guard_online_at: str) -> dict[str, object]:
-    device_id, device_name = _guard_device_metadata(store)
+def _receipt_sync_context(
+    store: GuardStore,
+    *,
+    local_guard_online_at: str,
+    device_id: str | None = None,
+    device_name: str | None = None,
+) -> dict[str, object]:
+    resolved_device_id = device_id
+    resolved_device_name = device_name
+    if resolved_device_id is None or resolved_device_name is None:
+        resolved_device_id, resolved_device_name = _guard_device_metadata(store)
     runtime_summary = store.get_sync_payload("runtime_session_summary")
     runtime_synced_at = (
         _optional_string(runtime_summary.get("runtime_session_synced_at"))
@@ -2567,8 +2581,8 @@ def _receipt_sync_context(store: GuardStore, *, local_guard_online_at: str) -> d
     )
     sync_health = "healthy" if runtime_synced_at is not None else "degraded"
     context: dict[str, object] = {
-        "deviceId": device_id,
-        "deviceName": device_name,
+        "deviceId": resolved_device_id,
+        "deviceName": resolved_device_name,
         "harness": runtime_harness or "hol-guard",
         "localGuardOnlineAt": local_guard_online_at,
         "syncHealth": sync_health,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2563,9 +2563,7 @@ def _receipt_sync_context(store: GuardStore, *, local_guard_online_at: str) -> d
         else None
     )
     runtime_harness = (
-        _optional_string(runtime_summary.get("runtime_harness"))
-        if isinstance(runtime_summary, dict)
-        else None
+        _optional_string(runtime_summary.get("runtime_harness")) if isinstance(runtime_summary, dict) else None
     )
     sync_health = "healthy" if runtime_synced_at is not None else "degraded"
     context: dict[str, object] = {
@@ -2661,11 +2659,7 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
         workspace=workspace,
         generated_at=updated_at,
     )
-    local_identity = _cloud_local_identity_payload(
-        device_id,
-        daemon_version=_optional_string(session.get("client_version") or session.get("clientVersion")) or __version__,
-        observed_at=updated_at,
-    )
+    local_identity = _cloud_local_identity_payload(observed_at=updated_at)
     return {
         "sessionId": session_id,
         "harness": _optional_string(session.get("harness")) or "hol-guard",
@@ -2688,17 +2682,11 @@ def _cloud_runtime_session_payload(store: GuardStore, session: dict[str, object]
     }
 
 
-def _cloud_local_identity_payload(
-    device_id: str,
-    *,
-    daemon_version: str,
-    observed_at: str,
-) -> dict[str, object]:
+def _cloud_local_identity_payload(*, observed_at: str) -> dict[str, object]:
     hostname = _safe_hostname()
     private_ip = _safe_private_ip()
     if private_ip is None:
         private_ip = _safe_private_ipv6()
-    del device_id, daemon_version
     payload: dict[str, object] = {"lastSyncedAt": observed_at}
     if hostname is not None:
         payload["hostname"] = hostname

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -838,7 +838,12 @@ def _prompt_config_candidates(detection: HarnessDetection, context: HarnessConte
     return detection.config_paths
 
 
-def sync_receipts(store: GuardStore) -> dict[str, object]:
+def sync_receipts(
+    store: GuardStore,
+    *,
+    persist_sync_summary: bool = True,
+    persist_connect_state: bool = True,
+) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
     auth_context = _resolve_guard_sync_auth_context(store)
@@ -994,8 +999,10 @@ def sync_receipts(store: GuardStore) -> dict[str, object]:
     if remote_policy_sync_blocked:
         summary["remote_policy_sync_blocked"] = True
     summary["guard_events_v1"] = sync_guard_events(store, auth_context=auth_context)
-    store.set_sync_payload("sync_summary", summary, now)
-    store.record_latest_guard_connect_sync_success(sync_payload=summary, now=now)
+    if persist_sync_summary:
+        store.set_sync_payload("sync_summary", summary, now)
+    if persist_connect_state:
+        store.record_latest_guard_connect_sync_success(sync_payload=summary, now=now)
     return summary
 
 
@@ -1513,6 +1520,50 @@ def sync_runtime_session(
                 device_id=device_id,
             )
         )
+    return summary
+
+
+def _local_guard_runtime_session() -> dict[str, object]:
+    return {
+        "harness": "hol-guard",
+        "surface": "cli",
+        "status": "active",
+        "client_name": "hol-guard",
+        "client_title": "HOL Guard CLI",
+        "client_version": __version__,
+        "workspace": "local-machine",
+        "capabilities": ["approval-center", "guard-cloud-sync", "local-daemon"],
+    }
+
+
+def sync_local_guard_cloud_proof(store: GuardStore) -> dict[str, object]:
+    """Publish the local Guard runtime session before syncing receipts."""
+
+    runtime_summary = sync_runtime_session(store, session=_local_guard_runtime_session())
+    receipts_summary = sync_receipts(
+        store,
+        persist_sync_summary=False,
+        persist_connect_state=False,
+    )
+    summary = dict(receipts_summary)
+    summary.update(
+        {
+            "runtime_session_id": runtime_summary.get("runtime_session_id"),
+            "runtime_session_synced_at": runtime_summary.get("runtime_session_synced_at"),
+            "runtime_sessions_visible": runtime_summary.get("runtime_sessions_visible"),
+            "local_guard_online_at": runtime_summary.get("local_guard_online_at")
+            or receipts_summary.get("local_guard_online_at"),
+            "runtime_harness": runtime_summary.get("runtime_harness"),
+            "runtime_surface": runtime_summary.get("runtime_surface"),
+            "runtime_workspace": runtime_summary.get("runtime_workspace"),
+            "runtime_device_id": runtime_summary.get("runtime_device_id"),
+            "runtime": runtime_summary,
+            "receipts": dict(receipts_summary),
+        }
+    )
+    recorded_at = str(summary.get("synced_at") or summary.get("runtime_session_synced_at") or _now())
+    store.set_sync_payload("sync_summary", summary, recorded_at)
+    store.record_latest_guard_connect_sync_success(sync_payload=summary, now=recorded_at)
     return summary
 
 
@@ -2504,27 +2555,28 @@ def _receipt_sync_rows_for_upload(store: GuardStore, *, cursor_rowid: int | None
 
 
 def _receipt_sync_context(store: GuardStore, *, local_guard_online_at: str) -> dict[str, object]:
+    device_id, device_name = _guard_device_metadata(store)
     runtime_summary = store.get_sync_payload("runtime_session_summary")
     runtime_synced_at = (
         _optional_string(runtime_summary.get("runtime_session_synced_at"))
         if isinstance(runtime_summary, dict)
         else None
     )
-    prior_summary = store.get_sync_payload("sync_summary")
-    receipt_synced_at = (
-        _optional_string(prior_summary.get("synced_at")) or _optional_string(prior_summary.get("syncedAt"))
-        if isinstance(prior_summary, dict)
+    runtime_harness = (
+        _optional_string(runtime_summary.get("runtime_harness"))
+        if isinstance(runtime_summary, dict)
         else None
     )
     sync_health = "healthy" if runtime_synced_at is not None else "degraded"
     context: dict[str, object] = {
+        "deviceId": device_id,
+        "deviceName": device_name,
+        "harness": runtime_harness or "hol-guard",
         "localGuardOnlineAt": local_guard_online_at,
         "syncHealth": sync_health,
     }
     if runtime_synced_at is not None:
         context["lastRuntimeSyncAt"] = runtime_synced_at
-    if receipt_synced_at is not None:
-        context["lastReceiptSyncAt"] = receipt_synced_at
     return context
 
 
@@ -2646,13 +2698,8 @@ def _cloud_local_identity_payload(
     private_ip = _safe_private_ip()
     if private_ip is None:
         private_ip = _safe_private_ipv6()
-    payload: dict[str, object] = {
-        "daemonId": device_id,
-        "daemonVersion": daemon_version,
-        "daemonStatus": "healthy",
-        "relayState": "online",
-        "lastSyncedAt": observed_at,
-    }
+    del device_id, daemon_version
+    payload: dict[str, object] = {"lastSyncedAt": observed_at}
     if hostname is not None:
         payload["hostname"] = hostname
     if private_ip is not None:

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -30,7 +30,7 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sy
     def _raise_runtime_error(_store: GuardStore) -> dict[str, object]:
         raise RuntimeError("temporary receipt sync failure")
 
-    monkeypatch.setattr(guard_commands_module, "sync_receipts", _raise_runtime_error)
+    monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", _raise_runtime_error)
 
     payload = guard_commands_module._finalize_guard_connect_payload(
         store=store,
@@ -121,7 +121,7 @@ def test_finalize_guard_connect_payload_keeps_reauth_failures_in_retry_required_
     def _raise_auth_expired(_store: GuardStore) -> dict[str, object]:
         raise guard_commands_module.GuardSyncAuthorizationExpiredError("reauth required")
 
-    monkeypatch.setattr(guard_commands_module, "sync_receipts", _raise_auth_expired)
+    monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", _raise_auth_expired)
 
     payload = guard_commands_module._finalize_guard_connect_payload(
         store=store,
@@ -165,7 +165,7 @@ def test_headless_first_sync_auth_expiry_marks_connect_state_for_repair(tmp_path
         queued_calls.append(str(store.guard_home))
         return {"status": "queued", "message": "Guard Cloud sync started."}
 
-    monkeypatch.setattr(daemon_server_module, "sync_receipts", _raise_auth_expired)
+    monkeypatch.setattr(daemon_server_module, "sync_local_guard_cloud_proof", _raise_auth_expired)
     monkeypatch.setattr(daemon_server_module, "_queue_headless_cloud_sync", _record_queue)
 
     daemon_server_module._run_headless_cloud_sync(store=store)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6576,13 +6576,31 @@ url = http://127.0.0.1:8787/guard-canary
                 "workspace_id": "workspace-123",
             }
 
-        def fake_sync_receipts(store: GuardStore) -> dict[str, object]:
+        def fake_sync_local_guard_cloud_proof(store: GuardStore) -> dict[str, object]:
             del store
-            sync_calls.append("receipts")
+            sync_calls.append("first-proof")
             return {
                 "synced_at": "2026-06-04T18:31:00+00:00",
                 "receipts_stored": 4,
                 "inventory_tracked": 2,
+                "runtime_session_synced_at": "2026-06-04T18:30:59+00:00",
+                "runtime_session_id": "runtime-session-123",
+                "runtime_sessions_visible": 1,
+                "runtime_harness": "hol-guard",
+                "runtime_surface": "cli",
+                "runtime_workspace": "local-machine",
+                "runtime_device_id": "machine-123",
+                "local_guard_online_at": "2026-06-04T18:30:59+00:00",
+                "runtime": {
+                    "synced_at": "2026-06-04T18:30:59+00:00",
+                    "runtime_session_synced_at": "2026-06-04T18:30:59+00:00",
+                    "runtime_session_id": "runtime-session-123",
+                },
+                "receipts": {
+                    "synced_at": "2026-06-04T18:31:00+00:00",
+                    "receipts_stored": 4,
+                    "inventory_tracked": 2,
+                },
             }
 
         def fake_sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
@@ -6591,7 +6609,7 @@ url = http://127.0.0.1:8787/guard-canary
             return {"synced_at": "2026-06-04T18:31:05+00:00", "status": "synced"}
 
         monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
-        monkeypatch.setattr(guard_commands_module, "sync_receipts", fake_sync_receipts)
+        monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof)
         monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", fake_sync_supply_chain_bundle)
 
         rc = main(
@@ -6611,7 +6629,7 @@ url = http://127.0.0.1:8787/guard-canary
         latest_state = store.get_latest_guard_connect_state(now="2026-06-04T18:31:00+00:00")
 
         assert rc == 0
-        assert sync_calls == ["receipts"]
+        assert sync_calls == ["first-proof"]
         assert bundle_calls == ["bundle"]
         assert output["status"] == "connected"
         assert output["milestone"] == "first_sync_succeeded"
@@ -6621,9 +6639,12 @@ url = http://127.0.0.1:8787/guard-canary
         assert output["sync_url"] == "https://hol.org/api/guard/receipts/sync"
         assert output["last_sync_at"] == "2026-06-04T18:31:00+00:00"
         assert output["sync"]["receipts_stored"] == 4
+        assert output["sync"]["runtime_session_id"] == "runtime-session-123"
         assert isinstance(latest_state, dict)
         assert latest_state["status"] == "connected"
         assert latest_state["milestone"] == "first_sync_succeeded"
+        assert latest_state["proof"]["runtime_session_id"] == "runtime-session-123"
+        assert latest_state["proof"]["runtime_session_synced_at"] == "2026-06-04T18:30:59+00:00"
 
     def test_guard_status_reports_oauth_key_storage_health(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -569,6 +569,13 @@ def test_runtime_snapshot_exposes_latest_connect_proof_without_pairing_secrets(t
             ),
         ),
         (
+            "retry_required",
+            "first_sync_failed",
+            "failed",
+            "First proof needs retry",
+            "Guard Cloud sign-in on this machine needs repair. Run hol-guard connect again.",
+        ),
+        (
             "waiting",
             "waiting_for_browser",
             "waiting",

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -788,10 +788,6 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
     assert isinstance(session_payload, dict)
     assert session_payload["deviceId"] == store.get_or_create_installation_id()
     assert session_payload["deviceName"] == store.get_device_metadata()["device_label"]
-    assert session_payload["localIdentity"]["daemonId"] == store.get_or_create_installation_id()
-    assert session_payload["localIdentity"]["daemonVersion"] == guard_runner_module.__version__
-    assert session_payload["localIdentity"]["daemonStatus"] == "healthy"
-    assert session_payload["localIdentity"]["relayState"] == "online"
     assert session_payload["localIdentity"]["lastSyncedAt"] == "2026-04-24T00:01:00+00:00"
     assert session_payload["localIdentitySource"]["daemonId"] == "local-guard"
     assert session_payload["localIdentitySource"]["daemonVersion"] == "local-guard"
@@ -910,5 +906,5 @@ def test_sync_runtime_session_keeps_local_identity_when_package_coverage_missing
 
     session_payload = captured_body["session"]
     assert isinstance(session_payload, dict)
-    assert session_payload["localIdentity"]["daemonId"] == store.get_or_create_installation_id()
+    assert "daemonId" not in session_payload["localIdentity"]
     assert session_payload["localIdentitySource"]["daemonId"] == "local-guard"

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -881,7 +881,7 @@ def test_headless_app_scan_does_not_spawn_unbounded_cloud_sync_threads(
     sync_started = threading.Event()
     sync_release = threading.Event()
 
-    def blocking_sync_receipts(current_store: GuardStore) -> dict[str, object]:
+    def blocking_sync_local_guard_cloud_proof(current_store: GuardStore) -> dict[str, object]:
         assert current_store is store
         sync_calls.append(1)
         sync_started.set()
@@ -891,7 +891,12 @@ def test_headless_app_scan_does_not_spawn_unbounded_cloud_sync_threads(
             "receipts_stored": 1,
         }
 
-    monkeypatch.setattr(daemon_server, "sync_receipts", blocking_sync_receipts, raising=False)
+    monkeypatch.setattr(
+        daemon_server,
+        "sync_local_guard_cloud_proof",
+        blocking_sync_local_guard_cloud_proof,
+        raising=False,
+    )
 
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -14,11 +14,11 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
-from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -804,19 +804,29 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
         "2026-05-23T17:18:00.000Z",
         workspace_id="workspace-1",
     )
-    sync_calls: list[bool] = []
+    sync_calls: list[str] = []
     sync_finished = threading.Event()
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-05-23T17:18:20.000Z",
+        request_id="connect-1",
+    )
 
-    def fake_sync_receipts(current_store: GuardStore) -> dict[str, object]:
+    def fake_sync_local_guard_cloud_proof(current_store: GuardStore) -> dict[str, object]:
         assert current_store is store
-        sync_calls.append(True)
+        sync_calls.append("runtime")
+        sync_calls.append("receipts")
         sync_finished.set()
         return {
             "synced_at": "2026-05-23T17:18:40.061Z",
             "receipts_stored": 1,
+            "runtime_session_synced_at": "2026-05-23T17:18:35.000Z",
+            "runtime_session_id": "runtime-session-1",
+            "runtime_sessions_visible": 1,
         }
 
-    monkeypatch.setattr(daemon_server, "sync_receipts", fake_sync_receipts, raising=False)
+    monkeypatch.setattr(daemon_server, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof, raising=False)
 
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -844,7 +854,11 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
         "message": "Guard Cloud sync started.",
     }
     assert sync_finished.wait(timeout=2)
-    assert sync_calls == [True]
+    assert sync_calls == ["runtime", "receipts"]
+    latest_state = store.get_latest_guard_connect_state(now="2026-05-23T17:18:40.061Z")
+    assert isinstance(latest_state, dict)
+    assert latest_state["proof"]["runtime_session_id"] == "runtime-session-1"
+    assert latest_state["proof"]["runtime_session_synced_at"] == "2026-05-23T17:18:35.000Z"
 
 
 def test_headless_app_scan_does_not_spawn_unbounded_cloud_sync_threads(

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -818,13 +818,18 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
         sync_calls.append("runtime")
         sync_calls.append("receipts")
         sync_finished.set()
-        return {
+        summary = {
             "synced_at": "2026-05-23T17:18:40.061Z",
             "receipts_stored": 1,
             "runtime_session_synced_at": "2026-05-23T17:18:35.000Z",
             "runtime_session_id": "runtime-session-1",
             "runtime_sessions_visible": 1,
         }
+        current_store.record_latest_guard_connect_sync_success(
+            sync_payload=summary,
+            now="2026-05-23T17:18:40.061Z",
+        )
+        return summary
 
     monkeypatch.setattr(daemon_server, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof, raising=False)
 

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -392,6 +392,65 @@ args = ["workspace-skill.js", "--changed"]
         assert output["dashboard_url"] == "https://hol.org/guard"
         assert output["inbox_url"] == "https://hol.org/guard/inbox"
         assert output["fleet_url"] == "https://hol.org/guard/fleet"
+        assert "retry automatically" in output["cloud_state_detail"]
+        assert "finish the pairing loop" not in output["cloud_state_detail"]
+
+    def test_guard_status_json_surfaces_first_sync_repair_over_generic_pending_copy(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        guard_home = tmp_path / "guard-home"
+        _build_guard_fixture(home_dir, workspace_dir)
+        store = GuardStore(guard_home)
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            workspace_id="workspace-123",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        store.record_guard_connect_pairing_completed(
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            allowed_origin="https://hol.org",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now="2026-06-04T18:31:00+00:00",
+            reason="Guard authorization expired.",
+        )
+
+        rc = main(
+            [
+                "guard",
+                "status",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["cloud_state"] == "paired_waiting"
+        assert "needs repair before the first shared proof can land" in output["cloud_state_detail"]
+        assert "retry automatically" not in output["cloud_state_detail"]
 
     def test_guard_help_groups_commands_by_everyday_cloud_and_advanced_work(self, capsys, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["hol-guard"])

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3448,6 +3448,210 @@ clearer UX and an implementation plan with technical references.
         assert summary["runtime_session_sync_skipped"] is True
         assert summary["runtime_session_sync_reason"] == "runtime_session_endpoint_unavailable"
 
+    def test_sync_local_guard_cloud_proof_publishes_runtime_before_receipts(
+        self,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        call_order: list[str] = []
+
+        def fake_sync_runtime_session(current_store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
+            assert current_store is store
+            call_order.append("runtime")
+            assert session == {
+                "harness": "hol-guard",
+                "surface": "cli",
+                "status": "active",
+                "client_name": "hol-guard",
+                "client_title": "HOL Guard CLI",
+                "client_version": guard_runner_module.__version__,
+                "workspace": "local-machine",
+                "capabilities": ["approval-center", "guard-cloud-sync", "local-daemon"],
+            }
+            return {
+                "synced_at": "2026-06-05T12:00:00+00:00",
+                "runtime_session_synced_at": "2026-06-05T12:00:00+00:00",
+                "runtime_session_id": "runtime-session-1",
+                "runtime_sessions_visible": 1,
+                "runtime_harness": "hol-guard",
+                "runtime_surface": "cli",
+                "runtime_workspace": "local-machine",
+                "runtime_device_id": "device-1",
+                "local_guard_online_at": "2026-06-05T12:00:00+00:00",
+            }
+
+        def fake_sync_receipts(
+            current_store: GuardStore,
+            *,
+            persist_sync_summary: bool = True,
+            persist_connect_state: bool = True,
+        ) -> dict[str, object]:
+            assert current_store is store
+            assert persist_sync_summary is False
+            assert persist_connect_state is False
+            call_order.append("receipts")
+            return {
+                "synced_at": "2026-06-05T12:00:05+00:00",
+                "receipts_stored": 3,
+                "inventory_tracked": 2,
+                "local_guard_online_at": "2026-06-05T12:00:05+00:00",
+            }
+
+        monkeypatch.setattr(guard_runner_module, "sync_runtime_session", fake_sync_runtime_session)
+        monkeypatch.setattr(guard_runner_module, "sync_receipts", fake_sync_receipts)
+
+        payload = guard_runner_module.sync_local_guard_cloud_proof(store)
+
+        assert call_order == ["runtime", "receipts"]
+        assert payload["runtime_session_id"] == "runtime-session-1"
+        assert payload["runtime_session_synced_at"] == "2026-06-05T12:00:00+00:00"
+        assert payload["runtime_sessions_visible"] == 1
+        assert payload["receipts_stored"] == 3
+        assert payload["runtime"] == {
+            "synced_at": "2026-06-05T12:00:00+00:00",
+            "runtime_session_synced_at": "2026-06-05T12:00:00+00:00",
+            "runtime_session_id": "runtime-session-1",
+            "runtime_sessions_visible": 1,
+            "runtime_harness": "hol-guard",
+            "runtime_surface": "cli",
+            "runtime_workspace": "local-machine",
+            "runtime_device_id": "device-1",
+            "local_guard_online_at": "2026-06-05T12:00:00+00:00",
+        }
+        assert payload["receipts"] == {
+            "synced_at": "2026-06-05T12:00:05+00:00",
+            "receipts_stored": 3,
+            "inventory_tracked": 2,
+            "local_guard_online_at": "2026-06-05T12:00:05+00:00",
+        }
+
+    def test_sync_local_guard_cloud_proof_persists_runtime_fields_in_connect_state(
+        self,
+        monkeypatch,
+        tmp_path,
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        store.record_guard_connect_pairing_completed(
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            allowed_origin="https://hol.org",
+            now="2026-06-05T12:00:00+00:00",
+            request_id="connect-1",
+        )
+
+        def fake_sync_runtime_session(current_store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
+            assert current_store is store
+            assert session["harness"] == "hol-guard"
+            return {
+                "synced_at": "2026-06-05T12:00:02+00:00",
+                "runtime_session_synced_at": "2026-06-05T12:00:02+00:00",
+                "runtime_session_id": "runtime-session-1",
+                "runtime_sessions_visible": 1,
+                "runtime_harness": "hol-guard",
+                "runtime_surface": "cli",
+                "runtime_workspace": "local-machine",
+                "runtime_device_id": "device-1",
+                "local_guard_online_at": "2026-06-05T12:00:02+00:00",
+            }
+
+        def fake_sync_receipts(
+            current_store: GuardStore,
+            *,
+            persist_sync_summary: bool = True,
+            persist_connect_state: bool = True,
+        ) -> dict[str, object]:
+            assert current_store is store
+            assert persist_sync_summary is False
+            assert persist_connect_state is False
+            return {
+                "synced_at": "2026-06-05T12:00:05+00:00",
+                "receipts_stored": 0,
+                "inventory_tracked": 0,
+                "local_guard_online_at": "2026-06-05T12:00:05+00:00",
+            }
+
+        monkeypatch.setattr(guard_runner_module, "sync_runtime_session", fake_sync_runtime_session)
+        monkeypatch.setattr(guard_runner_module, "sync_receipts", fake_sync_receipts)
+
+        payload = guard_runner_module.sync_local_guard_cloud_proof(store)
+        latest_state = store.get_latest_guard_connect_state(now="2026-06-05T12:00:05+00:00")
+        sync_summary = store.get_sync_payload("sync_summary")
+
+        assert payload["runtime_session_id"] == "runtime-session-1"
+        assert isinstance(sync_summary, dict)
+        assert sync_summary["runtime_session_id"] == "runtime-session-1"
+        assert sync_summary["runtime_session_synced_at"] == "2026-06-05T12:00:02+00:00"
+        assert latest_state is not None
+        assert latest_state["milestone"] == "first_sync_succeeded"
+        proof = latest_state["proof"]
+        assert isinstance(proof, dict)
+        assert proof["runtime_session_id"] == "runtime-session-1"
+        assert proof["runtime_session_synced_at"] == "2026-06-05T12:00:02+00:00"
+        assert proof["first_synced_at"] == "2026-06-05T12:00:05+00:00"
+
+    def test_cloud_runtime_session_payload_uses_contract_safe_local_identity(
+        self,
+        tmp_path,
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+
+        payload = guard_runner_module._cloud_runtime_session_payload(
+            store,
+            {
+                "session_id": "runtime-session-1",
+                "harness": "hol-guard",
+                "surface": "cli",
+                "status": "active",
+                "client_name": "hol-guard",
+                "client_title": "HOL Guard CLI",
+                "client_version": "2.0.345",
+                "workspace": "local-machine",
+                "capabilities": ["approval-center", "guard-cloud-sync", "local-daemon"],
+            },
+        )
+
+        local_identity = payload["localIdentity"]
+        assert isinstance(local_identity, dict)
+        assert "lastSyncedAt" in local_identity
+        assert "daemonId" not in local_identity
+        assert "daemonVersion" not in local_identity
+        assert "daemonStatus" not in local_identity
+        assert "relayState" not in local_identity
+
+    def test_receipt_sync_context_matches_cloud_contract_for_empty_first_sync(
+        self,
+        tmp_path,
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_sync_payload(
+            "runtime_session_summary",
+            {
+                "runtime_harness": "hol-guard",
+                "runtime_session_synced_at": "2026-06-05T12:00:00+00:00",
+            },
+            "2026-06-05T12:00:00+00:00",
+        )
+        store.set_sync_payload(
+            "sync_summary",
+            {
+                "synced_at": "2026-06-05T11:59:00+00:00",
+            },
+            "2026-06-05T11:59:00+00:00",
+        )
+
+        context = guard_runner_module._receipt_sync_context(
+            store,
+            local_guard_online_at="2026-06-05T12:00:05+00:00",
+        )
+
+        assert context["deviceId"] == store.get_or_create_installation_id()
+        assert isinstance(context["deviceName"], str)
+        assert context["harness"] == "hol-guard"
+        assert context["lastRuntimeSyncAt"] == "2026-06-05T12:00:00+00:00"
+        assert context["localGuardOnlineAt"] == "2026-06-05T12:00:05+00:00"
+        assert context["syncHealth"] == "healthy"
+        assert "lastReceiptSyncAt" not in context
+
     def test_guard_store_initializes_runtime_tables_and_receipt_columns(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15781,7 +15781,7 @@ def test_sync_receipts_uses_rowid_cursor_and_sync_context(tmp_path, monkeypatch)
     assert second_summary["receipts"] == 1
     assert len(sync_payloads) == 2
     assert sync_payloads[1]["receipts"][0]["receiptId"] == "receipt-late"
-    assert sync_payloads[1]["syncContext"]["lastReceiptSyncAt"] == "2026-04-19T00:00:10+00:00"
+    assert "lastReceiptSyncAt" not in sync_payloads[1]["syncContext"]
     latest_cursor = store.get_sync_payload("receipt_sync_cursor")
     assert isinstance(latest_cursor, dict)
     assert isinstance(latest_cursor["last_rowid"], int)

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -996,6 +996,57 @@ class TestGuardSurfaceServer:
         assert "sign-in on this machine is incomplete" in payload["cloud_state_detail"]
         assert payload["cloud_pairing_state"]["detail"] == payload["cloud_state_detail"]
 
+    def test_guard_daemon_runtime_snapshot_surfaces_first_sync_repair_consistently(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            workspace_id="workspace-123",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        store.record_guard_connect_pairing_completed(
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            allowed_origin="https://hol.org",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now="2026-06-04T18:31:00+00:00",
+            reason="Guard authorization expired.",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert payload["cloud_state"] == "paired_waiting"
+        assert "needs repair before the first shared proof can land" in payload["cloud_state_detail"]
+        assert payload["cloud_pairing_state"]["detail"] == payload["cloud_state_detail"]
+        assert payload["proof_status"]["state"] == "failed"
+        assert payload["cloud_sync_health"]["state"] == "failed"
+        assert "Run hol-guard connect again to restore sync." in payload["cloud_sync_health"]["detail"]
+
     def test_guard_daemon_runtime_snapshot_keeps_failed_sync_copy_distinct_from_oauth_repair(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         store.set_oauth_local_credentials(


### PR DESCRIPTION
## Summary
- persist the first Guard Cloud proof as one merged runtime-plus-receipt sync result so local connect state keeps runtime session fields
- align local status and dashboard cloud-sync copy with real first-sync failure vs auto-retry pending states

## Testing
- `python3 -m pytest tests/test_guard_runtime.py -k 'sync_local_guard_cloud_proof_publishes_runtime_before_receipts or persists_runtime_fields_in_connect_state or contract_safe_local_identity or receipt_sync_context_matches_cloud_contract_for_empty_first_sync' -q`
- `python3 -m pytest tests/test_guard_cli.py -k 'runs_first_sync_and_surfaces_cloud_urls' -q`
- `python3 -m pytest tests/test_guard_headless_daemon_api.py -k 'headless_app_scan_syncs_receipt_to_cloud_when_connected' -q`
- `python3 -m pytest tests/test_guard_cloud_local_sync.py -k 'proof_statuses' -q`
- `python3 -m pytest tests/test_guard_surface_server.py -k 'runtime_snapshot_surfaces_first_sync_repair_consistently or runtime_snapshot_mirrors_oauth_repair_detail_in_pairing_state or runtime_snapshot_keeps_failed_sync_copy_distinct_from_oauth_repair' -q`
- `python3 -m pytest tests/test_guard_product_flow.py -k 'uses_oauth_profile_for_cloud_state or surfaces_first_sync_repair_over_generic_pending_copy' -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/cli/product.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_cli.py tests/test_guard_cloud_local_sync.py tests/test_guard_headless_daemon_api.py tests/test_guard_product_flow.py tests/test_guard_runtime.py tests/test_guard_surface_server.py`

## Notes
- verified source-level local-cloud connect against local Guard Cloud on `http://127.0.0.1:3001`: device approval completed, portal stored 1 device and 1 runtime session, and local daemon `/v1/runtime` reported `proof_status=synced` and `cloud_sync_health=healthy`
