### PR TITLE
fix(guard): heal package firewall auth and daemon reuse

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -108,6 +108,7 @@ from ..local_supply_chain import (
     build_supply_chain_status_payload,
     build_workspace_audit_payload,
     build_workspace_scan_payload,
+    resolve_package_firewall_entitlement_with_refresh,
 )
 from ..mcp_tool_calls import (
     allow_tool_call,
@@ -117,10 +118,7 @@ from ..mcp_tool_calls import (
     evaluate_tool_call,
 )
 from ..models import SEVERITY_RANK, GuardArtifact, HarnessDetection, PolicyDecision
-from ..package_firewall_entitlement import (
-    package_firewall_block_details,
-    resolve_package_firewall_entitlement,
-)
+from ..package_firewall_entitlement import package_firewall_block_details
 from ..policy.engine import SAFE_CHANGED_HASH_ACTION, VALID_GUARD_ACTIONS, build_decision_v2, guard_action_severity
 from ..protect import build_protect_payload
 from ..proxy import (
@@ -2094,7 +2092,7 @@ def run_guard_command(
             if isinstance(manager, str) and manager.strip()
         )
         shim_command = getattr(args, "package_shims_command", "status")
-        entitlement = resolve_package_firewall_entitlement(store)
+        entitlement = resolve_package_firewall_entitlement_with_refresh(store)
         if shim_command == "status":
             payload = package_shim_status(context)
             payload["actions"] = _package_firewall_action_states(entitlement)

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -201,12 +201,14 @@ def _daemon_healthz_details_match_guard_home(url: str, guard_home: Path, *, auth
 def _guard_daemon_url_port(url: str) -> int | None:
     try:
         parsed = urllib.parse.urlparse(url)
+        return parsed.port
     except ValueError:
         return None
-    return parsed.port
 
 
 def _adopt_existing_guard_daemon(guard_home: Path) -> str | None:
+    if os.name == "nt":
+        return None
     candidate_ports = _adoptable_guard_daemon_ports(guard_home)
     for port in candidate_ports:
         adopted = _initialize_existing_guard_daemon(guard_home, port)
@@ -713,6 +715,12 @@ def _guard_daemon_port_from_command(command: str) -> int | None:
     except ValueError:
         return None
     for index, part in enumerate(parts):
+        if part.startswith("--port="):
+            try:
+                port = int(part.split("=", 1)[1])
+            except ValueError:
+                return None
+            return port if port > 0 else None
         if part != "--port" or index + 1 >= len(parts):
             continue
         try:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -187,15 +187,23 @@ def _daemon_health_request(url: str, auth_token: str | None = None) -> urllib.re
     return urllib.request.Request(url, headers=headers, method="GET")
 
 
-def _daemon_healthz_details_match_guard_home(url: str, guard_home: Path, *, auth_token: str) -> bool:
+def _daemon_healthz_details_payload(url: str, auth_token: str) -> dict[str, object] | None:
     try:
         request = _daemon_health_request(f"{url}/v1/healthz/details", auth_token)
         with urllib.request.urlopen(request, timeout=1) as response:
             if response.status != 200:
-                return False
-            return _healthz_payload_matches_guard_home(response.read().decode("utf-8"), guard_home)
-    except (OSError, ValueError, urllib.error.URLError):
+                return None
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _daemon_healthz_details_match_guard_home(url: str, guard_home: Path, *, auth_token: str) -> bool:
+    payload = _daemon_healthz_details_payload(url, auth_token)
+    if payload is None:
         return False
+    return _healthz_payload_matches_guard_home(json.dumps(payload), guard_home)
 
 
 def _guard_daemon_url_port(url: str) -> int | None:
@@ -214,10 +222,7 @@ def _adopt_existing_guard_daemon(guard_home: Path) -> str | None:
         adopted = _initialize_existing_guard_daemon(guard_home, port)
         if adopted is None:
             continue
-        pid = _guard_daemon_pid_for_guard_home_port(guard_home, port)
-        if pid is None:
-            continue
-        write_guard_daemon_state(guard_home, port, adopted["auth_token"], pid=pid)
+        write_guard_daemon_state(guard_home, port, adopted["auth_token"], pid=adopted["pid"])
         return adopted["url"]
     return None
 
@@ -243,7 +248,7 @@ def _adoptable_guard_daemon_ports(guard_home: Path) -> list[int]:
     return ordered
 
 
-def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> dict[str, str] | None:
+def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> dict[str, str | int] | None:
     url = f"http://127.0.0.1:{port}"
     try:
         with urllib.request.urlopen(_daemon_health_request(f"{url}/healthz"), timeout=1) as response:
@@ -275,9 +280,13 @@ def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> dict[str, 
     auth_token = payload.get("auth_token")
     if not isinstance(auth_token, str) or not auth_token.strip():
         return None
-    if not _daemon_healthz_details_match_guard_home(url, guard_home, auth_token=auth_token):
+    details_payload = _daemon_healthz_details_payload(url, auth_token)
+    if details_payload is None or not _healthz_payload_matches_guard_home(json.dumps(details_payload), guard_home):
         return None
-    return {"url": url, "auth_token": auth_token}
+    pid = details_payload.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    return {"url": url, "auth_token": auth_token, "pid": pid}
 
 
 def _retire_duplicate_guard_daemons(guard_home: Path, *, keep_port: int | None) -> None:
@@ -740,8 +749,9 @@ def _running_guard_daemon_processes_for_guard_home(guard_home: Path) -> list[tup
             check=False,
             capture_output=True,
             text=True,
+            timeout=5,
         )
-    except OSError:
+    except (OSError, subprocess.TimeoutExpired):
         return []
     processes: list[tuple[int, int]] = []
     for line in result.stdout.splitlines():

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -15,6 +15,7 @@ import tempfile
 import threading
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from contextlib import contextmanager, suppress
 from datetime import datetime, timezone
@@ -72,17 +73,24 @@ def ensure_guard_daemon(guard_home: Path) -> str:
     state_path = _state_path(guard_home)
     existing_url = load_guard_daemon_url(guard_home)
     if existing_url is not None:
+        _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(existing_url))
         return existing_url
     with _guard_daemon_start_lock(guard_home):
         existing_url = load_guard_daemon_url(guard_home)
         if existing_url is not None:
+            _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(existing_url))
             return existing_url
+        adopted_url = _adopt_existing_guard_daemon(guard_home)
+        if adopted_url is not None:
+            _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(adopted_url))
+            return adopted_url
         stale_state = _load_state(guard_home)
         if isinstance(stale_state, dict) and not _guard_daemon_state_matches_current_runtime(stale_state):
             _retire_guard_daemon_process({**stale_state, "guard_home": str(guard_home)})
         if _guard_daemon_start_in_progress(guard_home):
             inflight_url = _wait_for_guard_daemon_url(guard_home, timeout=GUARD_DAEMON_START_TIMEOUT_SECONDS)
             if inflight_url is not None:
+                _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(inflight_url))
                 return inflight_url
         clear_guard_daemon_state(guard_home)
         for candidate_port in _candidate_ports(guard_home):
@@ -115,6 +123,7 @@ def ensure_guard_daemon(guard_home: Path) -> str:
                 process=process,
             )
             if url is not None:
+                _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(url))
                 return url
     raise RuntimeError(f"Guard approval center did not start. Expected state file at {state_path}.")
 
@@ -189,7 +198,103 @@ def _daemon_healthz_details_match_guard_home(url: str, guard_home: Path, *, auth
         return False
 
 
-def write_guard_daemon_state(guard_home: Path, port: int, auth_token: str) -> None:
+def _guard_daemon_url_port(url: str) -> int | None:
+    try:
+        parsed = urllib.parse.urlparse(url)
+    except ValueError:
+        return None
+    return parsed.port
+
+
+def _adopt_existing_guard_daemon(guard_home: Path) -> str | None:
+    candidate_ports = _adoptable_guard_daemon_ports(guard_home)
+    for port in candidate_ports:
+        adopted = _initialize_existing_guard_daemon(guard_home, port)
+        if adopted is None:
+            continue
+        pid = _guard_daemon_pid_for_guard_home_port(guard_home, port)
+        if pid is None:
+            continue
+        write_guard_daemon_state(guard_home, port, adopted["auth_token"], pid=pid)
+        return adopted["url"]
+    return None
+
+
+def _adoptable_guard_daemon_ports(guard_home: Path) -> list[int]:
+    preferred_ports: list[int] = []
+    state = _load_state(guard_home)
+    state_port = state.get("port") if isinstance(state, dict) else None
+    if isinstance(state_port, int) and state_port > 0:
+        preferred_ports.append(state_port)
+    configured_port = _configured_port(guard_home)
+    if isinstance(configured_port, int) and configured_port > 0:
+        preferred_ports.append(configured_port)
+    for _pid, port in _running_guard_daemon_processes_for_guard_home(guard_home):
+        preferred_ports.append(port)
+    seen: set[int] = set()
+    ordered: list[int] = []
+    for port in preferred_ports:
+        if port in seen:
+            continue
+        seen.add(port)
+        ordered.append(port)
+    return ordered
+
+
+def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> dict[str, str] | None:
+    url = f"http://127.0.0.1:{port}"
+    try:
+        with urllib.request.urlopen(_daemon_health_request(f"{url}/healthz"), timeout=1) as response:
+            raw_payload = response.read().decode("utf-8")
+            if response.status != 200 or not _healthz_payload_is_current(raw_payload):
+                return None
+        request = urllib.request.Request(
+            f"{url}/v1/initialize",
+            data=json.dumps(
+                {
+                    "client_name": "guard-daemon-manager",
+                    "client_title": "HOL Guard daemon manager",
+                    "surface": "cli",
+                    "capabilities": ["daemon-adoption"],
+                    "supported_protocol_versions": [1],
+                }
+            ).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=2) as response:
+            if response.status != 200:
+                return None
+            payload = json.loads(response.read().decode("utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError):
+        return None
+    if not isinstance(payload, dict):
+        return None
+    auth_token = payload.get("auth_token")
+    if not isinstance(auth_token, str) or not auth_token.strip():
+        return None
+    if not _daemon_healthz_details_match_guard_home(url, guard_home, auth_token=auth_token):
+        return None
+    return {"url": url, "auth_token": auth_token}
+
+
+def _retire_duplicate_guard_daemons(guard_home: Path, *, keep_port: int | None) -> None:
+    if keep_port is None:
+        return
+    for pid, port in _running_guard_daemon_processes_for_guard_home(guard_home):
+        if port == keep_port:
+            continue
+        _retire_guard_daemon_pid(pid, expected_guard_home=guard_home)
+
+
+def _guard_daemon_pid_for_guard_home_port(guard_home: Path, port: int) -> int | None:
+    for pid, candidate_port in _running_guard_daemon_processes_for_guard_home(guard_home):
+        if candidate_port == port:
+            return pid
+    return None
+
+
+def write_guard_daemon_state(guard_home: Path, port: int, auth_token: str, *, pid: int | None = None) -> None:
     state_path = _state_path(guard_home)
     _ensure_private_directory(state_path.parent)
     _write_private_text(
@@ -202,7 +307,7 @@ def write_guard_daemon_state(guard_home: Path, port: int, auth_token: str) -> No
                 "package_version": __version__,
                 "source_root": _current_guard_daemon_source_root(),
                 "runtime_fingerprint": _current_guard_daemon_runtime_fingerprint(),
-                "pid": os.getpid(),
+                "pid": pid if isinstance(pid, int) and pid > 0 else os.getpid(),
                 "started_at": datetime.now(timezone.utc).isoformat(),
             },
             indent=2,
@@ -600,6 +705,56 @@ def _guard_home_from_command(command: str) -> Path | None:
         if part == "--guard-home" and index + 1 < len(parts):
             return Path(parts[index + 1])
     return None
+
+
+def _guard_daemon_port_from_command(command: str) -> int | None:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return None
+    for index, part in enumerate(parts):
+        if part != "--port" or index + 1 >= len(parts):
+            continue
+        try:
+            port = int(parts[index + 1])
+        except ValueError:
+            return None
+        return port if port > 0 else None
+    return None
+
+
+def _running_guard_daemon_processes_for_guard_home(guard_home: Path) -> list[tuple[int, int]]:
+    if os.name == "nt":
+        return []
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,command="],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+    except OSError:
+        return []
+    processes: list[tuple[int, int]] = []
+    for line in result.stdout.splitlines():
+        match = re.match(r"^\s*(\d+)\s+(.*)$", line)
+        if match is None:
+            continue
+        pid = int(match.group(1))
+        command = match.group(2).strip()
+        if "codex_plugin_scanner.cli" not in command or "guard daemon --serve" not in command:
+            continue
+        command_guard_home = _guard_home_from_command(command)
+        port = _guard_daemon_port_from_command(command)
+        if command_guard_home is None or port is None:
+            continue
+        try:
+            matches_home = command_guard_home.resolve() == guard_home.resolve()
+        except OSError:
+            matches_home = command_guard_home == guard_home
+        if matches_home:
+            processes.append((pid, port))
+    return sorted(processes, key=lambda item: item[1])
 
 
 def _guard_daemon_state_matches_current_runtime(payload: dict[str, object]) -> bool:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2759,6 +2759,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "approvals": pending_approvals,
             "pending_approvals": pending_approvals,
             "uptime_seconds": uptime,
+            "pid": os.getpid(),
             "tables": store.list_table_names(),
             "compatibility_version": GUARD_DAEMON_COMPATIBILITY_VERSION,
             "package_version": __version__,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -77,12 +77,12 @@ from ..desktop_notifications import (
     ensure_desktop_notification_setup,
     macos_notification_guidance,
 )
-from ..local_supply_chain import build_local_supply_chain_posture
-from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
-from ..package_firewall_entitlement import (
-    package_firewall_block_details,
-    resolve_package_firewall_entitlement,
+from ..local_supply_chain import (
+    build_local_supply_chain_posture,
+    resolve_package_firewall_entitlement_with_refresh,
 )
+from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
+from ..package_firewall_entitlement import package_firewall_block_details
 from ..receipts.manager import build_receipt
 from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
@@ -1519,7 +1519,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         return managers, None
 
     def _supply_chain_entitlement(self) -> dict[str, object]:
-        return resolve_package_firewall_entitlement(self.server.store)  # type: ignore[attr-defined]
+        return resolve_package_firewall_entitlement_with_refresh(self.server.store)  # type: ignore[attr-defined]
 
     @staticmethod
     def _supply_chain_action_states(entitlement: dict[str, object]) -> dict[str, str]:

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -276,6 +276,7 @@ def resolve_package_firewall_entitlement_with_refresh(store: GuardStore) -> dict
             GuardSyncAuthorizationExpiredError,
             GuardSyncNotAvailableError,
             GuardSyncNotConfiguredError,
+            OSError,
             RuntimeError,
         ):
             continue

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -17,6 +17,7 @@ from pathlib import Path
 
 from .adapters.base import HarnessContext
 from .config import GuardConfig, resolve_risk_action
+from .package_firewall_entitlement import resolve_package_firewall_entitlement
 from .receipts import build_receipt
 from .redaction import redact_text
 from .runtime.package_intent_common import (
@@ -33,9 +34,12 @@ from .runtime.package_intent_common import (
 from .runtime.package_manifest_diff import parse_manifest_dependencies, parse_manifest_dependency_changes
 from .runtime.runner import (
     GuardSyncAuthorizationExpiredError,
+    GuardSyncNotAvailableError,
     GuardSyncNotConfiguredError,
     _guard_sync_headers,
     _resolve_guard_sync_auth_context,
+    sync_local_guard_cloud_proof,
+    sync_supply_chain_bundle,
 )
 from .runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from .runtime.supply_chain_support import ecosystem_support_matrix
@@ -253,6 +257,29 @@ def build_supply_chain_status_payload(
         "dry_run": True,
         "supply_chain": posture,
     }
+
+
+def resolve_package_firewall_entitlement_with_refresh(store: GuardStore) -> dict[str, object]:
+    """Resolve package-firewall access and opportunistically heal stale cloud state."""
+
+    entitlement = resolve_package_firewall_entitlement(store)
+    if bool(entitlement.get("allowed")):
+        return entitlement
+    if store.get_cloud_sync_profile() is None:
+        return entitlement
+    if str(entitlement.get("reason") or "") not in {"guard_cloud_reconnect_required", "paid_guard_cloud_required"}:
+        return entitlement
+    for refresh in (sync_local_guard_cloud_proof, sync_supply_chain_bundle):
+        try:
+            refresh(store)
+        except (
+            GuardSyncAuthorizationExpiredError,
+            GuardSyncNotAvailableError,
+            GuardSyncNotConfiguredError,
+            RuntimeError,
+        ):
+            continue
+    return resolve_package_firewall_entitlement(store)
 
 
 def build_workspace_scan_payload(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1827,6 +1827,7 @@ def _refresh_guard_oauth_access_token(
         headers={
             "Content-Type": "application/x-www-form-urlencoded",
             "Accept": "application/json",
+            "User-Agent": _GUARD_SYNC_USER_AGENT,
             "DPoP": _sign_guard_dpop_proof(
                 request_url=token_endpoint,
                 method="POST",

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -12,6 +12,18 @@ from types import SimpleNamespace
 from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
 
 
+def _disable_daemon_adoption(monkeypatch) -> None:
+    monkeypatch.setattr(daemon_manager_module, "_adopt_existing_guard_daemon", lambda _guard_home: None)
+
+
+def _disable_duplicate_retire(monkeypatch) -> None:
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_retire_duplicate_guard_daemons",
+        lambda _guard_home, *, keep_port: None,
+    )
+
+
 def test_write_guard_daemon_state_keeps_auth_token_out_of_state_file(tmp_path):
     guard_home = tmp_path / "guard-home"
 
@@ -159,6 +171,8 @@ def test_ensure_guard_daemon_reuses_inflight_pid_before_respawning(tmp_path, mon
     guard_home = tmp_path / "guard-home"
     responses = iter((None, None, "http://127.0.0.1:5409"))
 
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_kwargs: None)
     monkeypatch.setattr(
         daemon_manager_module,
@@ -188,6 +202,60 @@ def test_ensure_guard_daemon_reuses_inflight_pid_before_respawning(tmp_path, mon
     assert url == "http://127.0.0.1:5409"
 
 
+def test_ensure_guard_daemon_adopts_running_guard_daemon_before_respawning(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+
+    monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_kwargs: None)
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", lambda _guard_home: None)
+    monkeypatch.setattr(daemon_manager_module, "_adoptable_guard_daemon_ports", lambda _guard_home: [5474])
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_initialize_existing_guard_daemon",
+        lambda _guard_home, port: {"url": f"http://127.0.0.1:{port}", "auth_token": "secret-token"},
+    )
+    monkeypatch.setattr(
+        daemon_manager_module.subprocess,
+        "Popen",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not spawn a new daemon")),
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_running_guard_daemon_processes_for_guard_home",
+        lambda _guard_home: [(111, 5474)],
+    )
+
+    url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+    assert url == "http://127.0.0.1:5474"
+    assert daemon_manager_module.load_guard_daemon_auth_token(guard_home) == "secret-token"
+    state_payload = json.loads(daemon_manager_module._state_path(guard_home).read_text(encoding="utf-8"))
+    assert state_payload["port"] == 5474
+    assert state_payload["pid"] == 111
+
+
+def test_ensure_guard_daemon_retires_duplicate_ports_for_same_guard_home(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    killed: list[int] = []
+
+    monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_kwargs: None)
+    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", lambda _guard_home: "http://127.0.0.1:5474")
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_running_guard_daemon_processes_for_guard_home",
+        lambda _guard_home: [(111, 5474), (222, 5475)],
+    )
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_retire_guard_daemon_pid",
+        lambda pid, *, expected_guard_home=None: killed.append(pid) or True,
+    )
+
+    url = daemon_manager_module.ensure_guard_daemon(guard_home)
+
+    assert url == "http://127.0.0.1:5474"
+    assert killed == [222]
+
+
 def test_ensure_guard_daemon_serializes_parallel_start_attempts(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     launched_commands: list[list[str]] = []
@@ -195,6 +263,8 @@ def test_ensure_guard_daemon_serializes_parallel_start_attempts(tmp_path, monkey
     launched_event = threading.Event()
     barrier = threading.Barrier(8)
 
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_kwargs: None)
 
     def fake_load_guard_daemon_url(_guard_home):
@@ -244,6 +314,8 @@ def test_ensure_guard_daemon_advances_ports_after_early_process_exit(tmp_path, m
     launched_commands: list[list[str]] = []
     poll_count = {"value": 0}
 
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_kwargs: None)
 
     class FakeProcess:
@@ -282,6 +354,8 @@ def test_ensure_guard_daemon_retires_stale_daemon_from_different_source_root(tmp
     launched_commands: list[list[str]] = []
     killed: list[int] = []
 
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     def fake_load_guard_daemon_url(_guard_home):
         if launched_commands:
             return "http://127.0.0.1:5412"
@@ -326,6 +400,8 @@ def test_ensure_guard_daemon_spawns_with_current_package_import_path(tmp_path, m
     responses = iter((None, None, "http://127.0.0.1:5412"))
     captured_env: dict[str, str] = {}
 
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     def fake_load_guard_daemon_url(_guard_home):
         return next(responses, "http://127.0.0.1:5412")
 
@@ -350,6 +426,8 @@ def test_ensure_guard_daemon_spawns_with_current_package_import_path(tmp_path, m
 
 
 def test_ensure_guard_daemon_reaps_stale_ephemeral_daemon_states(tmp_path, monkeypatch):
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     guard_home = tmp_path / "guard-home"
     stale_guard_home = tmp_path / "pytest-of-user" / "pytest-1" / "test-stale" / "home"
     stale_guard_home.mkdir(parents=True)
@@ -438,6 +516,8 @@ def test_ensure_guard_daemon_reaps_stale_ephemeral_daemon_states(tmp_path, monke
 
 
 def test_ensure_guard_daemon_keeps_ephemeral_state_with_recent_runtime_heartbeat(tmp_path, monkeypatch):
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     guard_home = tmp_path / "guard-home"
     active_guard_home = tmp_path / "pytest-of-user" / "pytest-3" / "test-active" / "home"
     active_guard_home.mkdir(parents=True)
@@ -490,6 +570,8 @@ def test_ensure_guard_daemon_keeps_ephemeral_state_with_recent_runtime_heartbeat
 
 
 def test_ensure_guard_daemon_does_not_clobber_unowned_ephemeral_state_files(tmp_path, monkeypatch):
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     guard_home = tmp_path / "guard-home"
     foreign_guard_home = tmp_path / "pytest-of-user" / "pytest-7" / "test-foreign" / "home"
     foreign_guard_home.mkdir(parents=True)
@@ -523,6 +605,8 @@ def test_ensure_guard_daemon_does_not_clobber_unowned_ephemeral_state_files(tmp_
 
 
 def test_ensure_guard_daemon_keeps_stale_state_when_pid_no_longer_matches_guard_home(tmp_path, monkeypatch):
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     guard_home = tmp_path / "guard-home"
     stale_guard_home = tmp_path / "pytest-of-user" / "pytest-8" / "test-reused-pid" / "home"
     stale_guard_home.mkdir(parents=True)
@@ -569,6 +653,8 @@ def test_ensure_guard_daemon_keeps_stale_state_when_pid_no_longer_matches_guard_
 
 
 def test_ensure_guard_daemon_reaps_stale_ephemeral_processes_without_state_file(tmp_path, monkeypatch):
+    _disable_daemon_adoption(monkeypatch)
+    _disable_duplicate_retire(monkeypatch)
     guard_home = tmp_path / "guard-home"
     stale_guard_home = tmp_path / "pytest-of-user" / "pytest-9" / "test-stale" / "home"
     stale_guard_home.mkdir(parents=True)

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -167,6 +167,18 @@ def test_healthz_payload_is_current_accepts_redacted_public_healthz() -> None:
     assert daemon_manager_module._healthz_payload_is_current(payload) is True
 
 
+def test_guard_daemon_url_port_rejects_invalid_port_text() -> None:
+    assert daemon_manager_module._guard_daemon_url_port("http://127.0.0.1:not-a-port") is None
+
+
+def test_guard_daemon_port_from_command_supports_equals_syntax() -> None:
+    command = (
+        "python -m codex_plugin_scanner.cli guard daemon --serve "
+        "--guard-home /tmp/guard-home --port=5474"
+    )
+    assert daemon_manager_module._guard_daemon_port_from_command(command) == 5474
+
+
 def test_ensure_guard_daemon_reuses_inflight_pid_before_respawning(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     responses = iter((None, None, "http://127.0.0.1:5409"))
@@ -231,6 +243,21 @@ def test_ensure_guard_daemon_adopts_running_guard_daemon_before_respawning(tmp_p
     state_payload = json.loads(daemon_manager_module._state_path(guard_home).read_text(encoding="utf-8"))
     assert state_payload["port"] == 5474
     assert state_payload["pid"] == 111
+
+
+def test_adopt_existing_guard_daemon_skips_scan_on_windows(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+
+    monkeypatch.setattr(daemon_manager_module.os, "name", "nt", raising=False)
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_initialize_existing_guard_daemon",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not attempt adoption")),
+    )
+
+    url = daemon_manager_module._adopt_existing_guard_daemon(guard_home)
+
+    assert url is None
 
 
 def test_ensure_guard_daemon_retires_duplicate_ports_for_same_guard_home(tmp_path, monkeypatch):

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -179,6 +179,17 @@ def test_guard_daemon_port_from_command_supports_equals_syntax() -> None:
     assert daemon_manager_module._guard_daemon_port_from_command(command) == 5474
 
 
+def test_running_guard_daemon_processes_for_guard_home_returns_empty_on_ps_timeout(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+
+    def fake_run(*_args, **_kwargs):
+        raise daemon_manager_module.subprocess.TimeoutExpired(cmd=["ps"], timeout=5)
+
+    monkeypatch.setattr(daemon_manager_module.subprocess, "run", fake_run)
+
+    assert daemon_manager_module._running_guard_daemon_processes_for_guard_home(guard_home) == []
+
+
 def test_ensure_guard_daemon_reuses_inflight_pid_before_respawning(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     responses = iter((None, None, "http://127.0.0.1:5409"))
@@ -223,18 +234,14 @@ def test_ensure_guard_daemon_adopts_running_guard_daemon_before_respawning(tmp_p
     monkeypatch.setattr(
         daemon_manager_module,
         "_initialize_existing_guard_daemon",
-        lambda _guard_home, port: {"url": f"http://127.0.0.1:{port}", "auth_token": "secret-token"},
+        lambda _guard_home, port: {"url": f"http://127.0.0.1:{port}", "auth_token": "secret-token", "pid": 111},
     )
     monkeypatch.setattr(
         daemon_manager_module.subprocess,
         "Popen",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not spawn a new daemon")),
     )
-    monkeypatch.setattr(
-        daemon_manager_module,
-        "_running_guard_daemon_processes_for_guard_home",
-        lambda _guard_home: [(111, 5474)],
-    )
+    monkeypatch.setattr(daemon_manager_module, "_running_guard_daemon_processes_for_guard_home", lambda _guard_home: [])
 
     url = daemon_manager_module.ensure_guard_daemon(guard_home)
 

--- a/tests/test_guard_daemon_registry.py
+++ b/tests/test_guard_daemon_registry.py
@@ -131,6 +131,7 @@ class TestHealthzEndpoint:
             assert "package_version" in payload
             assert "tables" in payload
             assert "pending_approvals" in payload
+            assert isinstance(payload.get("pid"), int)
             assert "uptime_seconds" in payload
         finally:
             server.stop()

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server
@@ -220,7 +221,10 @@ def test_supply_chain_package_firewall_install_requires_paid_entitlement(tmp_pat
     assert payload["available_actions"] == ["status", "education", "cli_fallback"]
 
 
-def test_supply_chain_package_firewall_status_reports_reconnect_gate_for_expired_cloud_auth(tmp_path: Path) -> None:
+def test_supply_chain_package_firewall_status_reports_reconnect_gate_for_expired_cloud_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.set_oauth_local_credentials(
         issuer="https://hol.org",
@@ -245,6 +249,16 @@ def test_supply_chain_package_firewall_status_reports_reconnect_gate_for_expired
         milestone="first_sync_failed",
         now="2026-06-05T01:40:10+00:00",
         reason="Guard authorization expired. Run `hol-guard connect` again.",
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "sync_local_guard_cloud_proof",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("cloud auth still expired")),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "sync_supply_chain_bundle",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("bundle refresh blocked")),
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -271,7 +285,10 @@ def test_supply_chain_package_firewall_status_reports_reconnect_gate_for_expired
     assert payload["actions"]["install"] == "reconnect_required"
 
 
-def test_supply_chain_package_firewall_install_requires_reconnect_when_cloud_auth_expired(tmp_path: Path) -> None:
+def test_supply_chain_package_firewall_install_requires_reconnect_when_cloud_auth_expired(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.set_oauth_local_credentials(
         issuer="https://hol.org",
@@ -297,6 +314,16 @@ def test_supply_chain_package_firewall_install_requires_reconnect_when_cloud_aut
         now="2026-06-05T01:40:10+00:00",
         reason="Guard authorization expired. Run `hol-guard connect` again.",
     )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "sync_local_guard_cloud_proof",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("cloud auth still expired")),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "sync_supply_chain_bundle",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("bundle refresh blocked")),
+    )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
@@ -315,6 +342,88 @@ def test_supply_chain_package_firewall_install_requires_reconnect_when_cloud_aut
     assert status == 403
     assert payload["error"] == "guard_cloud_reconnect_required"
     assert payload["entitlement"]["tier"] == "unknown"
+
+
+def test_supply_chain_package_firewall_install_self_heals_retry_required_cloud_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem="private-key",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value"},
+        dpop_public_jwk_thumbprint="thumbprint-1",
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-05T01:39:51+00:00",
+    )
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-05T01:39:51+00:00",
+        request_id="connect-1",
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-06-05T01:40:10+00:00",
+        reason="Guard authorization expired. Run `hol-guard connect` again.",
+    )
+
+    def fake_sync_local_guard_cloud_proof(current_store: GuardStore) -> dict[str, object]:
+        assert current_store is store
+        current_store.record_latest_guard_connect_sync_success(
+            sync_payload={"synced_at": "2026-06-05T01:41:00+00:00", "receipts_stored": 1},
+            now="2026-06-05T01:41:00+00:00",
+        )
+        return {"synced_at": "2026-06-05T01:41:00+00:00", "receipts_stored": 1}
+
+    def fake_sync_supply_chain_bundle(current_store: GuardStore) -> dict[str, object]:
+        assert current_store is store
+        current_store.set_sync_payload(
+            "supply_chain_bundle_entitlement",
+            {
+                "bundle_version": "bundle-version-test",
+                "key_id": "bundle-key-test",
+                "policy_hash": "policy-hash-test",
+                "tier": "pro",
+                "workspace_id": "workspace-1",
+            },
+            "2026-06-05T01:41:05+00:00",
+        )
+        return {"bundle_version": "bundle-version-test", "tier": "pro"}
+
+    monkeypatch.setattr(local_supply_chain_module, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof)
+    monkeypatch.setattr(local_supply_chain_module, "sync_supply_chain_bundle", fake_sync_supply_chain_bundle)
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/install",
+                token=token,
+                payload={"managers": ["npm"]},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["status"] == "completed"
+    assert payload["entitlement"] == {
+        "allowed": True,
+        "reason": "paid_entitlement_active",
+        "tier": "pro",
+        "upgrade_cta": None,
+    }
+    assert payload["result"]["installed_managers"] == ["npm"]
 
 
 def test_supply_chain_package_firewall_status_accepts_paid_oauth_entitlement(tmp_path: Path) -> None:

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -85,10 +86,21 @@ def test_package_shims_install_requires_paid_entitlement(tmp_path: Path, capsys:
 
 def test_package_shims_status_reports_reconnect_required_when_cloud_auth_expired(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     guard_home = tmp_path / "guard-home"
     _seed_retry_required_oauth_connect(guard_home)
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "sync_local_guard_cloud_proof",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("cloud auth still expired")),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "sync_supply_chain_bundle",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("bundle refresh blocked")),
+    )
 
     rc = main(["guard", "package-shims", "status", "--home", str(guard_home), "--json"])
 
@@ -105,10 +117,21 @@ def test_package_shims_status_reports_reconnect_required_when_cloud_auth_expired
 
 def test_package_shims_install_requires_reconnect_when_cloud_auth_expired(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
     guard_home = tmp_path / "guard-home"
     _seed_retry_required_oauth_connect(guard_home)
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "sync_local_guard_cloud_proof",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("cloud auth still expired")),
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "sync_supply_chain_bundle",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("bundle refresh blocked")),
+    )
 
     rc = main(["guard", "package-shims", "install", "--manager", "npm", "--home", str(guard_home), "--json"])
 
@@ -116,6 +139,57 @@ def test_package_shims_install_requires_reconnect_when_cloud_auth_expired(
     assert rc == 2
     assert payload["error"] == "guard_cloud_reconnect_required"
     assert payload["entitlement"]["tier"] == "unknown"
+
+
+def test_package_shims_install_self_heals_retry_required_cloud_auth(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    guard_home = tmp_path / "guard-home"
+    _seed_retry_required_oauth_connect(guard_home)
+
+    def fake_sync_local_guard_cloud_proof(store: GuardStore) -> dict[str, object]:
+        store.record_latest_guard_connect_sync_success(
+            sync_payload={"synced_at": "2026-06-05T01:41:00+00:00", "receipts_stored": 1},
+            now="2026-06-05T01:41:00+00:00",
+        )
+        return {"synced_at": "2026-06-05T01:41:00+00:00", "receipts_stored": 1}
+
+    def fake_sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
+        store.set_sync_payload(
+            "supply_chain_bundle_entitlement",
+            {
+                "bundle_version": "bundle-version-test",
+                "key_id": "bundle-key-test",
+                "policy_hash": "policy-hash-test",
+                "tier": "pro",
+                "workspace_id": "workspace-1",
+            },
+            "2026-06-05T01:41:05+00:00",
+        )
+        return {"bundle_version": "bundle-version-test", "tier": "pro"}
+
+    monkeypatch.setattr(local_supply_chain_module, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof)
+    monkeypatch.setattr(local_supply_chain_module, "sync_supply_chain_bundle", fake_sync_supply_chain_bundle)
+
+    rc = main(["guard", "package-shims", "install", "--manager", "npm", "--home", str(guard_home), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    shim_path = guard_home / "package-shims" / "bin" / "npm"
+    assert rc == 0
+    assert payload["entitlement"] == {
+        "allowed": True,
+        "reason": "paid_entitlement_active",
+        "tier": "pro",
+        "upgrade_cta": None,
+    }
+    assert payload["installed_managers"] == ["npm"]
+    assert shim_path.exists()
 
 
 def test_package_shims_status_reports_paid_oauth_entitlement(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -16421,6 +16421,7 @@ def test_sync_runtime_session_refreshes_oauth_access_token_and_rotates_refresh_t
             assert body["grant_type"] == ["refresh_token"]
             assert body["client_id"] == ["guard-local-daemon"]
             assert body["refresh_token"] == ["refresh-token-1"]
+            assert _request_header(request, "User-Agent") == guard_runner_module._GUARD_SYNC_USER_AGENT
             assert isinstance(_request_header(request, "DPoP"), str) and _request_header(request, "DPoP")
             return _Response(
                 {


### PR DESCRIPTION
## Summary
- refresh package-firewall cloud auth before blocking status and install flows so stale connect state can self-heal without forcing a reconnect
- add a sync refresh `User-Agent` header and reuse a single local daemon per guard home while reaping duplicate same-home daemon ports

## Testing
- `uv run --extra dev python -m pytest -q tests/test_guard_daemon_manager.py tests/test_guard_package_shims_cli.py tests/test_guard_headless_daemon_api.py tests/test_guard_runtime.py -k 'daemon_manager or package_shims or supply_chain_package_firewall or test_sync_runtime_session_refreshes_oauth_access_token_and_rotates_refresh_token'`
- `uv run --extra dev ruff check src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/cli/commands.py src/codex_plugin_scanner/guard/daemon/manager.py tests/test_guard_runtime.py tests/test_guard_package_shims_cli.py tests/test_guard_headless_daemon_api.py tests/test_guard_daemon_manager.py`

## Notes
- live verification against a real local Guard home confirmed the home route opens Trust Center, package-firewall status heals to paid access, the daemon converges back to a single stable port, and audit remediation opens the approval-password modal before execution
