### PR TITLE
fix(guard): unblock first shared proof sync

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -847,9 +847,7 @@ def sync_receipts(
 ) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
-    resolved_auth_context = (
-        auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
-    )
+    resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
     sync_url = _normalized_receipts_sync_url(resolved_auth_context["sync_url"])
     prior_receipt_cursor = _receipt_sync_cursor_rowid(store)
     receipts = _receipt_sync_rows_for_upload(store, cursor_rowid=prior_receipt_cursor)
@@ -1312,9 +1310,7 @@ def sync_guard_events(
 ) -> dict[str, object]:
     """Push pending GuardEventV1 envelopes to Guard Cloud."""
 
-    resolved_auth_context = (
-        auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
-    )
+    resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
     sync_url = _guard_events_sync_url(resolved_auth_context["sync_url"])
     previous_summary = store.get_sync_payload("guard_events_v1_summary")
     total_events = 0

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -847,7 +847,9 @@ def sync_receipts(
 ) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
-    resolved_auth_context = auth_context or _resolve_guard_sync_auth_context(store)
+    resolved_auth_context = (
+        auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
+    )
     sync_url = _normalized_receipts_sync_url(resolved_auth_context["sync_url"])
     prior_receipt_cursor = _receipt_sync_cursor_rowid(store)
     receipts = _receipt_sync_rows_for_upload(store, cursor_rowid=prior_receipt_cursor)
@@ -1310,7 +1312,9 @@ def sync_guard_events(
 ) -> dict[str, object]:
     """Push pending GuardEventV1 envelopes to Guard Cloud."""
 
-    resolved_auth_context = auth_context or _resolve_guard_sync_auth_context(store)
+    resolved_auth_context = (
+        auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
+    )
     sync_url = _guard_events_sync_url(resolved_auth_context["sync_url"])
     previous_summary = store.get_sync_payload("guard_events_v1_summary")
     total_events = 0

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -843,11 +843,12 @@ def sync_receipts(
     *,
     persist_sync_summary: bool = True,
     persist_connect_state: bool = True,
+    auth_context: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
-    auth_context = _resolve_guard_sync_auth_context(store)
-    sync_url = _normalized_receipts_sync_url(auth_context["sync_url"])
+    resolved_auth_context = auth_context or _resolve_guard_sync_auth_context(store)
+    sync_url = _normalized_receipts_sync_url(resolved_auth_context["sync_url"])
     prior_receipt_cursor = _receipt_sync_cursor_rowid(store)
     receipts = _receipt_sync_rows_for_upload(store, cursor_rowid=prior_receipt_cursor)
     inventory = store.list_inventory()
@@ -883,7 +884,7 @@ def sync_receipts(
             sync_url,
             data=body,
             method="POST",
-            headers=_guard_sync_headers(auth_context, request_url=sync_url, method="POST"),
+            headers=_guard_sync_headers(resolved_auth_context, request_url=sync_url, method="POST"),
         )
         try:
             payload = _urlopen_json_with_timeout_retry(
@@ -976,7 +977,7 @@ def sync_receipts(
         exceptions=deduped_exceptions,
         now=now,
     )
-    pain_signals_uploaded = sync_pain_signals(store, auth_context=auth_context)
+    pain_signals_uploaded = sync_pain_signals(store, auth_context=resolved_auth_context)
     value_metrics = _build_value_metrics(store)
     weekly_digest = _build_weekly_firewall_digest(metrics=value_metrics, now=now)
     summary = {
@@ -1003,7 +1004,7 @@ def sync_receipts(
     }
     if remote_policy_sync_blocked:
         summary["remote_policy_sync_blocked"] = True
-    summary["guard_events_v1"] = sync_guard_events(store, auth_context=auth_context)
+    summary["guard_events_v1"] = sync_guard_events(store, auth_context=resolved_auth_context)
     if persist_sync_summary:
         store.set_sync_payload("sync_summary", summary, now)
     if persist_connect_state:
@@ -1458,18 +1459,19 @@ def sync_runtime_session(
     store: GuardStore,
     *,
     session: dict[str, object],
+    auth_context: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Publish the active Guard runtime session so the dashboard can show the machine immediately."""
 
-    auth_context = _resolve_guard_sync_auth_context(store)
-    sync_url = _normalized_runtime_sessions_sync_url(auth_context["sync_url"])
+    resolved_auth_context = auth_context or _resolve_guard_sync_auth_context(store)
+    sync_url = _normalized_runtime_sessions_sync_url(resolved_auth_context["sync_url"])
     session_payload = _cloud_runtime_session_payload(store, session)
     body = json.dumps({"session": session_payload}).encode("utf-8")
     request = urllib.request.Request(
         sync_url,
         data=body,
         method="POST",
-        headers=_guard_sync_headers(auth_context, request_url=sync_url, method="POST"),
+        headers=_guard_sync_headers(resolved_auth_context, request_url=sync_url, method="POST"),
     )
     try:
         payload = _urlopen_json_with_timeout_retry(
@@ -1544,11 +1546,17 @@ def _local_guard_runtime_session() -> dict[str, object]:
 def sync_local_guard_cloud_proof(store: GuardStore) -> dict[str, object]:
     """Publish the local Guard runtime session before syncing receipts."""
 
-    runtime_summary = sync_runtime_session(store, session=_local_guard_runtime_session())
+    auth_context = _resolve_guard_sync_auth_context(store)
+    runtime_summary = sync_runtime_session(
+        store,
+        session=_local_guard_runtime_session(),
+        auth_context=auth_context,
+    )
     receipts_summary = sync_receipts(
         store,
         persist_sync_summary=False,
         persist_connect_state=False,
+        auth_context=auth_context,
     )
     summary = dict(receipts_summary)
     summary.update(

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -982,6 +982,10 @@ class TestGuardApprovals:
         expected_port = daemon_manager_module._configured_port(guard_home)
         responses = iter([None, None, f"http://127.0.0.1:{expected_port}"])
 
+        class FakeProcess:
+            def poll(self):
+                return None
+
         monkeypatch.delenv("GUARD_DAEMON_PORT", raising=False)
         monkeypatch.setattr(
             daemon_manager_module,
@@ -990,9 +994,14 @@ class TestGuardApprovals:
         )
         monkeypatch.setattr(daemon_manager_module, "_running_ephemeral_guard_daemon_processes", lambda: [])
         monkeypatch.setattr(
+            daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [],
+        )
+        monkeypatch.setattr(
             daemon_manager_module.subprocess,
             "Popen",
-            lambda command, **_kwargs: launched_commands.append(command) or SimpleNamespace(),
+            lambda command, **_kwargs: launched_commands.append(command) or FakeProcess(),
         )
 
         url = daemon_manager_module.ensure_guard_daemon(guard_home)

--- a/tests/test_guard_daemon_wake.py
+++ b/tests/test_guard_daemon_wake.py
@@ -28,6 +28,12 @@ def _make_start_mock(guard_home: Path, port: int = 5700):
         def poll(self):
             return None
 
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
     def _popen(*_args, **_kwargs):
         state = {
             "port": port,
@@ -54,6 +60,11 @@ class TestNoDashboardApprovalURLWake:
         port = 5700
 
         monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [],
+        )
 
         url_iter = iter([None, None, f"http://127.0.0.1:{port}"])
         monkeypatch.setattr(
@@ -87,6 +98,11 @@ class TestNoDashboardApprovalURLWake:
         monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
         monkeypatch.setattr(
             daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [],
+        )
+        monkeypatch.setattr(
+            daemon_manager_module,
             "load_guard_daemon_url",
             lambda _gh: f"http://127.0.0.1:{port}",
         )
@@ -108,6 +124,11 @@ class TestNoDashboardApprovalURLWake:
         port = 5702
 
         monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [],
+        )
         monkeypatch.setattr(
             daemon_manager_module,
             "load_guard_daemon_url",
@@ -136,6 +157,11 @@ class TestNoDashboardApprovalURLWake:
         monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
         monkeypatch.setattr(
             daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [],
+        )
+        monkeypatch.setattr(
+            daemon_manager_module,
             "load_guard_daemon_url",
             lambda _gh: f"http://127.0.0.1:{port}",
         )
@@ -152,6 +178,11 @@ class TestNoDashboardApprovalURLWake:
         port = 5704
 
         monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_: None)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [],
+        )
 
         stale_state = {
             "pid": 99999,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3456,9 +3456,25 @@ clearer UX and an implementation plan with technical references.
         store = GuardStore(tmp_path / "guard-home")
         call_order: list[str] = []
 
-        def fake_sync_runtime_session(current_store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
+        shared_auth_context = {
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "oauth-access-token-1",
+            "dpop_key_material": object(),
+        }
+
+        def fake_resolve_guard_sync_auth_context(current_store: GuardStore) -> dict[str, object]:
+            assert current_store is store
+            return shared_auth_context
+
+        def fake_sync_runtime_session(
+            current_store: GuardStore,
+            *,
+            session: dict[str, object],
+            auth_context: dict[str, object] | None = None,
+        ) -> dict[str, object]:
             assert current_store is store
             call_order.append("runtime")
+            assert auth_context is shared_auth_context
             assert session == {
                 "harness": "hol-guard",
                 "surface": "cli",
@@ -3486,11 +3502,13 @@ clearer UX and an implementation plan with technical references.
             *,
             persist_sync_summary: bool = True,
             persist_connect_state: bool = True,
+            auth_context: dict[str, object] | None = None,
         ) -> dict[str, object]:
             assert current_store is store
             assert persist_sync_summary is False
             assert persist_connect_state is False
             call_order.append("receipts")
+            assert auth_context is shared_auth_context
             return {
                 "synced_at": "2026-06-05T12:00:05+00:00",
                 "receipts_stored": 3,
@@ -3498,6 +3516,11 @@ clearer UX and an implementation plan with technical references.
                 "local_guard_online_at": "2026-06-05T12:00:05+00:00",
             }
 
+        monkeypatch.setattr(
+            guard_runner_module,
+            "_resolve_guard_sync_auth_context",
+            fake_resolve_guard_sync_auth_context,
+        )
         monkeypatch.setattr(guard_runner_module, "sync_runtime_session", fake_sync_runtime_session)
         monkeypatch.setattr(guard_runner_module, "sync_receipts", fake_sync_receipts)
 
@@ -3539,8 +3562,24 @@ clearer UX and an implementation plan with technical references.
             request_id="connect-1",
         )
 
-        def fake_sync_runtime_session(current_store: GuardStore, *, session: dict[str, object]) -> dict[str, object]:
+        shared_auth_context = {
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "oauth-access-token-1",
+            "dpop_key_material": object(),
+        }
+
+        def fake_resolve_guard_sync_auth_context(current_store: GuardStore) -> dict[str, object]:
             assert current_store is store
+            return shared_auth_context
+
+        def fake_sync_runtime_session(
+            current_store: GuardStore,
+            *,
+            session: dict[str, object],
+            auth_context: dict[str, object] | None = None,
+        ) -> dict[str, object]:
+            assert current_store is store
+            assert auth_context is shared_auth_context
             assert session["harness"] == "hol-guard"
             return {
                 "synced_at": "2026-06-05T12:00:02+00:00",
@@ -3559,10 +3598,12 @@ clearer UX and an implementation plan with technical references.
             *,
             persist_sync_summary: bool = True,
             persist_connect_state: bool = True,
+            auth_context: dict[str, object] | None = None,
         ) -> dict[str, object]:
             assert current_store is store
             assert persist_sync_summary is False
             assert persist_connect_state is False
+            assert auth_context is shared_auth_context
             return {
                 "synced_at": "2026-06-05T12:00:05+00:00",
                 "receipts_stored": 0,
@@ -3570,6 +3611,11 @@ clearer UX and an implementation plan with technical references.
                 "local_guard_online_at": "2026-06-05T12:00:05+00:00",
             }
 
+        monkeypatch.setattr(
+            guard_runner_module,
+            "_resolve_guard_sync_auth_context",
+            fake_resolve_guard_sync_auth_context,
+        )
         monkeypatch.setattr(guard_runner_module, "sync_runtime_session", fake_sync_runtime_session)
         monkeypatch.setattr(guard_runner_module, "sync_receipts", fake_sync_receipts)
 
@@ -16490,7 +16536,6 @@ def test_sign_guard_dpop_proof_sets_access_token_hash_claim() -> None:
 
     assert claims["ath"] == expected_ath
 
-
 def test_sync_receipts_uses_distinct_dpop_proofs_per_batch(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     dpop_key_material = generate_dpop_key_pair()
@@ -16579,9 +16624,100 @@ def test_sync_receipts_uses_distinct_dpop_proofs_per_batch(tmp_path, monkeypatch
     payload = guard_runner_module.sync_receipts(store)
 
     assert len(token_requests) == 1
+    assert _request_header(token_requests[0], "User-Agent") == f"hol-guard/{guard_runner_module.__version__}"
     assert len(receipt_dpop_headers) >= 2
     assert receipt_dpop_headers[0] != receipt_dpop_headers[1]
     assert payload["receipts_stored"] == 51
+
+
+def test_sync_local_guard_cloud_proof_refreshes_oauth_once(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    token_requests: list[urllib.request.Request] = []
+    sync_requests: list[urllib.request.Request] = []
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        if request.full_url == "https://hol.org/api/guard/oauth/token":
+            token_requests.append(request)
+            return _Response(
+                {
+                    "access_token": "oauth-access-token-1",
+                    "refresh_token": "refresh-token-1",
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }
+            )
+        sync_requests.append(request)
+        if request.full_url == "https://hol.org/api/guard/runtime/sessions/sync":
+            return _Response(
+                {
+                    "syncedAt": "2026-06-01T00:00:05+00:00",
+                    "items": [{"sessionId": "runtime-session-1"}],
+                }
+            )
+        if request.full_url == "https://hol.org/api/guard/receipts/sync":
+            return _Response(
+                {
+                    "syncedAt": "2026-06-01T00:00:06+00:00",
+                    "receiptsStored": 0,
+                    "advisories": [],
+                    "policy": {},
+                    "alertPreferences": {},
+                    "teamPolicyPack": {},
+                    "exceptions": [],
+                }
+            )
+        if request.full_url == "https://hol.org/api/v1/guard/events":
+            return _Response(
+                {
+                    "syncedAt": "2026-06-01T00:00:07+00:00",
+                    "accepted": 1,
+                    "events": 1,
+                }
+            )
+        raise AssertionError(f"unexpected request: {request.full_url}")
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_local_guard_cloud_proof(store)
+    expected_session_id = guard_runner_module._cloud_runtime_session_payload(
+        store,
+        guard_runner_module._local_guard_runtime_session(),
+    )["sessionId"]
+
+    assert len(token_requests) == 1
+    assert _request_header(token_requests[0], "User-Agent") == f"hol-guard/{guard_runner_module.__version__}"
+    assert [request.full_url for request in sync_requests] == [
+        "https://hol.org/api/guard/runtime/sessions/sync",
+        "https://hol.org/api/guard/receipts/sync",
+        "https://hol.org/api/v1/guard/events",
+    ]
+    assert payload["runtime_session_id"] == expected_session_id
 
 
 def test_sync_pain_signals_raises_when_oauth_refresh_is_revoked(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- send the first proof OAuth refresh with the same Guard user agent as other cloud sync requests
- reuse one resolved OAuth auth context across runtime-session and receipt sync so the first proof does not refresh twice

## Testing
- `python3 -m pytest tests/test_guard_runtime.py -k 'sync_local_guard_cloud_proof or sync_receipts_uses_distinct_dpop_proofs_per_batch or sync_runtime_session_treats_token_endpoint_503_as_retryable_error or sync_pain_signals_raises_when_oauth_refresh_is_revoked' -q`
- `python3 -m pytest tests/test_guard_auto_first_sync.py tests/test_guard_cli.py -k 'first_sync or connect_status_prefers_active_sync_over_expired_browser_pairing or guard_connect' -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_runtime.py`

## Notes
- Live production repro showed the first shared proof refresh was blocked by Cloudflare because `/api/guard/oauth/token` requests from `hol-guard` omitted the CLI user agent.
