### PR TITLE
fix(guard): mirror oauth secrets to fallback store

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -603,6 +603,12 @@ class GuardStore:
     def _promote_secret_to_primary(self, secret_store: SecretStore, secret_id: str, value: str) -> None:
         if isinstance(secret_store, FallbackSecretStore):
             secret_store.promote_secret(secret_id, value)
+            fallback_value = self._get_secret_from_store(secret_store.fallback, secret_id)
+            if fallback_value != value:
+                try:
+                    secret_store.fallback.set_secret(secret_id, value)
+                except Exception:
+                    return
 
     def _get_secret_from_store(self, store: SecretStore, secret_id: str) -> str | None:
         try:
@@ -3101,6 +3107,7 @@ class GuardStore:
         if runtime_label:
             payload["runtime_label"] = runtime_label
         self._oauth_secret_store.set_secret(self._oauth_local_credentials_ref, secret_json)
+        self._promote_secret_to_primary(self._oauth_secret_store, self._oauth_local_credentials_ref, secret_json)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
 
     def get_oauth_local_credentials(self) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -603,12 +603,13 @@ class GuardStore:
     def _promote_secret_to_primary(self, secret_store: SecretStore, secret_id: str, value: str) -> None:
         if isinstance(secret_store, FallbackSecretStore):
             secret_store.promote_secret(secret_id, value)
-            fallback_value = self._get_secret_from_store(secret_store.fallback, secret_id)
-            if fallback_value != value:
-                try:
-                    secret_store.fallback.set_secret(secret_id, value)
-                except Exception:
-                    return
+            if isinstance(secret_store.fallback, EncryptedFileSecretStore):
+                fallback_value = self._get_secret_from_store(secret_store.fallback, secret_id)
+                if fallback_value != value:
+                    try:
+                        secret_store.fallback.set_secret(secret_id, value)
+                    except Exception:
+                        return
 
     def _get_secret_from_store(self, store: SecretStore, secret_id: str) -> str | None:
         try:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -603,13 +603,20 @@ class GuardStore:
     def _promote_secret_to_primary(self, secret_store: SecretStore, secret_id: str, value: str) -> None:
         if isinstance(secret_store, FallbackSecretStore):
             secret_store.promote_secret(secret_id, value)
-            if isinstance(secret_store.fallback, EncryptedFileSecretStore):
-                fallback_value = self._get_secret_from_store(secret_store.fallback, secret_id)
-                if fallback_value != value:
-                    try:
-                        secret_store.fallback.set_secret(secret_id, value)
-                    except Exception:
-                        return
+
+    def _mirror_oauth_secret_to_fallback(self, secret_id: str, value: str) -> None:
+        secret_store = self._oauth_secret_store
+        if not isinstance(secret_store, FallbackSecretStore):
+            return
+        if not isinstance(secret_store.fallback, EncryptedFileSecretStore):
+            return
+        fallback_value = self._get_secret_from_store(secret_store.fallback, secret_id)
+        if fallback_value == value:
+            return
+        try:
+            secret_store.fallback.set_secret(secret_id, value)
+        except Exception:
+            return
 
     def _get_secret_from_store(self, store: SecretStore, secret_id: str) -> str | None:
         try:
@@ -3108,7 +3115,7 @@ class GuardStore:
         if runtime_label:
             payload["runtime_label"] = runtime_label
         self._oauth_secret_store.set_secret(self._oauth_local_credentials_ref, secret_json)
-        self._promote_secret_to_primary(self._oauth_secret_store, self._oauth_local_credentials_ref, secret_json)
+        self._mirror_oauth_secret_to_fallback(self._oauth_local_credentials_ref, secret_json)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
 
     def get_oauth_local_credentials(self) -> dict[str, object] | None:
@@ -3207,6 +3214,7 @@ class GuardStore:
                 continue
             if promote:
                 self._promote_secret_to_primary(self._oauth_secret_store, secret_ref, candidate)
+                self._mirror_oauth_secret_to_fallback(secret_ref, candidate)
             return secret_payload
         return None
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -616,6 +616,10 @@ class GuardStore:
         try:
             secret_store.fallback.set_secret(secret_id, value)
         except Exception:
+            _store_logger.warning(
+                "Failed to mirror OAuth credentials into encrypted fallback store; "
+                "headless environments may not be able to read credentials."
+            )
             return
 
     def _get_secret_from_store(self, store: SecretStore, secret_id: str) -> str | None:

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -988,6 +988,11 @@ class TestGuardApprovals:
             "load_guard_daemon_url",
             lambda _guard_home: next(responses),
         )
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [],
+        )
         monkeypatch.setattr(daemon_manager_module, "_running_ephemeral_guard_daemon_processes", lambda: [])
         monkeypatch.setattr(
             daemon_manager_module.subprocess,

--- a/tests/test_guard_daemon_wake.py
+++ b/tests/test_guard_daemon_wake.py
@@ -63,6 +63,7 @@ class TestNoDashboardApprovalURLWake:
         )
 
         monkeypatch.setattr(daemon_manager_module, "_load_state", lambda _gh: None)
+        monkeypatch.setattr(daemon_manager_module, "_running_guard_daemon_processes_for_guard_home", lambda _gh: [])
         monkeypatch.setattr(daemon_manager_module, "_guard_daemon_start_in_progress", lambda _gh: False)
         monkeypatch.setattr(daemon_manager_module.time, "sleep", lambda _: None)
         monkeypatch.setattr(daemon_manager_module.subprocess, "Popen", _make_start_mock(guard_home, port))
@@ -90,6 +91,7 @@ class TestNoDashboardApprovalURLWake:
             "load_guard_daemon_url",
             lambda _gh: f"http://127.0.0.1:{port}",
         )
+        monkeypatch.setattr(daemon_manager_module, "_running_guard_daemon_processes_for_guard_home", lambda _gh: [])
 
         def _boom(*_args, **_kwargs):
             spawn_calls.append("spawn")
@@ -173,6 +175,7 @@ class TestNoDashboardApprovalURLWake:
             "_retire_guard_daemon_process",
             lambda state: retire_calls.append(state),
         )
+        monkeypatch.setattr(daemon_manager_module, "_running_guard_daemon_processes_for_guard_home", lambda _gh: [])
         monkeypatch.setattr(daemon_manager_module, "_guard_daemon_start_in_progress", lambda _gh: False)
         monkeypatch.setattr(daemon_manager_module.time, "sleep", lambda _: None)
         monkeypatch.setattr(daemon_manager_module.subprocess, "Popen", _make_start_mock(guard_home, port))

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -644,6 +644,35 @@ def test_set_oauth_local_credentials_does_not_use_generic_secret_promotion(tmp_p
     assert headless_store.get_oauth_local_credentials() is not None
 
 
+def test_set_oauth_local_credentials_logs_when_fallback_mirror_fails(tmp_path, monkeypatch, caplog):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+
+    def fail_fallback_set_secret(secret_id: str, value: str) -> None:
+        raise RuntimeError("disk full")
+
+    monkeypatch.setattr(store._oauth_secret_store.fallback, "set_secret", fail_fallback_set_secret)
+    caplog.set_level(logging.WARNING, logger="codex_plugin_scanner.guard.store")
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    assert store.get_oauth_local_credentials() is not None
+    assert "Failed to mirror OAuth credentials into encrypted fallback store" in caplog.text
+
+
 def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_keyring_only_state(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
     guard_home = tmp_path / "guard-home"

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -614,6 +614,36 @@ def test_oauth_local_credentials_mirror_secret_into_encrypted_fallback_store(tmp
     assert headless_store.get_oauth_local_credential_health()["state"] == "healthy"
 
 
+def test_set_oauth_local_credentials_does_not_use_generic_secret_promotion(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+
+    monkeypatch.setattr(
+        store,
+        "_promote_secret_to_primary",
+        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("OAuth writes must not use generic promotion")),
+    )
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: None))
+    headless_store = GuardStore(guard_home)
+
+    assert headless_store.get_oauth_local_credentials() is not None
+
+
 def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_keyring_only_state(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
     guard_home = tmp_path / "guard-home"

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -586,6 +586,65 @@ def test_oauth_local_credential_health_reports_system_keyring_backend(tmp_path, 
     }
 
 
+def test_oauth_local_credentials_mirror_secret_into_encrypted_fallback_store(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: None))
+    headless_store = GuardStore(guard_home)
+
+    credentials = headless_store.get_oauth_local_credentials()
+
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-secret-value"
+    assert headless_store.get_oauth_local_credential_health()["state"] == "healthy"
+
+
+def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_keyring_only_state(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+
+    credentials = store.get_oauth_local_credentials()
+
+    assert credentials is not None
+    assert store._oauth_secret_store.fallback.get_secret(store._oauth_local_credentials_ref) is not None
+
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: None))
+    headless_store = GuardStore(guard_home)
+
+    assert headless_store.get_oauth_local_credentials() is not None
+
+
 def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_write_failure(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     store.set_oauth_local_credentials(


### PR DESCRIPTION
## Summary
- mirror OAuth secrets into the encrypted fallback store when credentials are written
- backfill the encrypted fallback when a keyring-backed secret is read from legacy state
- add regression coverage for cold headless daemons that cannot access the system keyring

## Verification
- uv run --extra dev ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_store_migrations.py
- uv run --extra dev python -m pytest -q tests/test_guard_store_migrations.py -k "oauth_local_credentials_mirror_secret_into_encrypted_fallback_store or get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_keyring_only_state or oauth_local_credential_health_reports_system_keyring_backend"
- live proof: patched login-shell read preserved paid entitlement, patched cold python3 daemon on :5476 returned approval_gate_required instead of guard_cloud_reconnect_required