### PR TITLE
fix(evidence): redesign evidence screen with scanner data, sortable table, unified tabs

### DIFF
--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -874,7 +874,7 @@ export function ListRow(props: {
 }
 
 export function TabBar<T extends string>(props: {
-  tabs: Array<{ value: T; label: string }>;
+  tabs: Array<{ value: T; label: string; id?: string }>;
   active: T;
   onChange: (value: T) => void;
 }) {
@@ -883,6 +883,7 @@ export function TabBar<T extends string>(props: {
       {props.tabs.map((tab) => (
         <button
           key={tab.value}
+          id={tab.id ?? tab.value}
           type="button"
           role="tab"
           aria-selected={props.active === tab.value}

--- a/dashboard/src/evidence/evidence-action-detail.tsx
+++ b/dashboard/src/evidence/evidence-action-detail.tsx
@@ -204,9 +204,6 @@ function TechnicalSection({ receipt }: TechnicalSectionProps) {
           {receipt.capabilities_summary && (
             <DetailRow label="Capabilities" value={receipt.capabilities_summary} />
           )}
-          {receipt.diff_summary && (
-            <DetailRow label="Diff summary" value={receipt.diff_summary} />
-          )}
         </div>
       )}
     </div>

--- a/dashboard/src/evidence/evidence-action-detail.tsx
+++ b/dashboard/src/evidence/evidence-action-detail.tsx
@@ -7,9 +7,13 @@ import {
   HiMiniQuestionMarkCircle,
   HiMiniChevronDown,
   HiMiniChevronUp,
+  HiMiniExclamationTriangle,
+  HiMiniInformationCircle,
+  HiMiniBolt,
+  HiMiniDocumentText,
 } from "react-icons/hi2";
 import { useState } from "react";
-import type { GuardReceipt } from "../guard-types";
+import type { GuardReceipt, RiskSignalV2 } from "../guard-types";
 import { harnessDisplayName, formatRelativeTime } from "../approval-center-utils";
 import { plainEnglishDescription, humanFileName } from "./plain-english";
 import { detectCategory, getCategoryInfo } from "./categories";
@@ -45,6 +49,108 @@ function DecisionBadge({ decision }: DecisionBadgeProps) {
       <HiMiniQuestionMarkCircle className="h-3.5 w-3.5" aria-hidden="true" />
       Reviewed
     </span>
+  );
+}
+
+function SeverityIcon({ severity }: { severity: string }) {
+  if (severity === "critical" || severity === "high") {
+    return <HiMiniExclamationTriangle className="h-4 w-4 text-amber-500" aria-hidden="true" />;
+  }
+  if (severity === "medium") {
+    return <HiMiniBolt className="h-4 w-4 text-orange-400" aria-hidden="true" />;
+  }
+  return <HiMiniInformationCircle className="h-4 w-4 text-brand-blue" aria-hidden="true" />;
+}
+
+function SeverityBadge({ severity }: { severity: string }) {
+  const styles: Record<string, string> = {
+    critical: "bg-amber-100 text-amber-800 ring-amber-200",
+    high: "bg-amber-50 text-amber-700 ring-amber-200",
+    medium: "bg-orange-50 text-orange-700 ring-orange-200",
+    low: "bg-blue-50 text-brand-blue ring-blue-200",
+    info: "bg-slate-100 text-slate-600 ring-slate-200",
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ring-1 ${styles[severity] ?? styles.info}`}
+    >
+      {severity}
+    </span>
+  );
+}
+
+function ScannerEvidenceSection({ signals }: { signals: RiskSignalV2[] }) {
+  const [expanded, setExpanded] = useState<Record<string, boolean>>({});
+
+  const toggle = useCallback((id: string) => {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+  }, []);
+
+  if (signals.length === 0) return null;
+
+  return (
+    <div className="space-y-2">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+        Scanner findings ({signals.length})
+      </p>
+      <div className="space-y-2">
+        {signals.map((signal) => {
+          const isOpen = expanded[signal.signal_id] ?? false;
+          return (
+            <div
+              key={signal.signal_id}
+              className="rounded-lg border border-slate-200 bg-white overflow-hidden"
+            >
+              <button
+                type="button"
+                onClick={() => toggle(signal.signal_id)}
+                aria-expanded={isOpen}
+                className="flex w-full items-center gap-2 px-3 py-2.5 text-left hover:bg-slate-50 transition-colors"
+              >
+                <SeverityIcon severity={signal.severity} />
+                <span className="flex-1 text-xs font-medium text-brand-dark truncate">
+                  {signal.title}
+                </span>
+                <SeverityBadge severity={signal.severity} />
+                {isOpen ? (
+                  <HiMiniChevronUp className="h-3.5 w-3.5 text-slate-400 shrink-0" aria-hidden="true" />
+                ) : (
+                  <HiMiniChevronDown className="h-3.5 w-3.5 text-slate-400 shrink-0" aria-hidden="true" />
+                )}
+              </button>
+              {isOpen && (
+                <div className="border-t border-slate-100 px-3 py-2.5 space-y-2">
+                  <p className="text-xs text-brand-dark/80 leading-relaxed">
+                    {signal.plain_reason}
+                  </p>
+                  {signal.technical_detail && (
+                    <div className="rounded-md bg-slate-50 px-2.5 py-2">
+                      <p className="text-[10px] font-medium uppercase tracking-wide text-slate-400 mb-1">
+                        Technical detail
+                      </p>
+                      <p className="text-xs font-mono text-brand-dark/70 break-all leading-relaxed">
+                        {signal.technical_detail}
+                      </p>
+                    </div>
+                  )}
+                  {signal.false_positive_hint && (
+                    <p className="text-[11px] text-slate-500 italic">
+                      {signal.false_positive_hint}
+                    </p>
+                  )}
+                  <div className="flex items-center gap-2 text-[10px] text-slate-400">
+                    <span>Detector: {signal.detector}</span>
+                    {signal.advisory_id && (
+                      <span>· Advisory: {signal.advisory_id}</span>
+                    )}
+                  </div>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
   );
 }
 
@@ -97,6 +203,9 @@ function TechnicalSection({ receipt }: TechnicalSectionProps) {
           )}
           {receipt.capabilities_summary && (
             <DetailRow label="Capabilities" value={receipt.capabilities_summary} />
+          )}
+          {receipt.diff_summary && (
+            <DetailRow label="Diff summary" value={receipt.diff_summary} />
           )}
         </div>
       )}
@@ -222,6 +331,7 @@ export function EvidenceActionDetail({
   const catInfo = getCategoryInfo(category);
   const description = plainEnglishDescription(receipt);
   const artifactLabel = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
+  const signals = receipt.scanner_evidence ?? [];
   let copyLabel = "Copy receipt ID";
   if (copied) {
     copyLabel = "Copied!";
@@ -286,9 +396,23 @@ export function EvidenceActionDetail({
           </div>
         )}
 
+        {receipt.diff_summary && (
+          <div className="rounded-lg border border-slate-100 bg-slate-50/60 px-3 py-2.5">
+            <div className="flex items-center gap-1.5 mb-1">
+              <HiMiniDocumentText className="h-3.5 w-3.5 text-slate-400" aria-hidden="true" />
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+                What changed
+              </p>
+            </div>
+            <p className="text-xs text-slate-700">{receipt.diff_summary}</p>
+          </div>
+        )}
+
         {receipt.policy_decision === "block" && (
           <NextSafeCommandHint receipt={receipt} />
         )}
+
+        <ScannerEvidenceSection signals={signals} />
 
         <EvidenceTimeline receipt={receipt} />
 

--- a/dashboard/src/evidence/evidence-action-list.tsx
+++ b/dashboard/src/evidence/evidence-action-list.tsx
@@ -56,6 +56,15 @@ function DecisionChip({ decision }: DecisionChipProps) {
   );
 }
 
+const SORT_TOGGLE_MAP: Record<EvidenceSortKey, EvidenceSortKey> = {
+  newest: "oldest",
+  oldest: "newest",
+  artifact: "artifact",
+  app: "app",
+  category: "category",
+  decision: "decision",
+};
+
 function SortHeader({
   label,
   active,
@@ -72,6 +81,7 @@ function SortHeader({
   return (
     <th
       scope="col"
+      aria-sort={active ? (ascending ? "ascending" : "descending") : "none"}
       className={`px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 ${className}`}
     >
       <button
@@ -110,10 +120,8 @@ export function EvidenceActionList({
 
   const handleSort = useCallback(
     (key: EvidenceSortKey) => {
-      if (sort === key && key === "newest") {
-        onSortChange("oldest");
-      } else if (sort === key && key === "oldest") {
-        onSortChange("newest");
+      if (sort === key) {
+        onSortChange(SORT_TOGGLE_MAP[key]);
       } else {
         onSortChange(key);
       }
@@ -149,34 +157,34 @@ export function EvidenceActionList({
                 <SortHeader
                   label="Artifact"
                   active={sort === "artifact"}
-                  ascending={true}
+                  ascending={sort === "artifact"}
                   onClick={() => handleSort("artifact")}
                   className="min-w-[180px]"
                 />
                 <SortHeader
                   label="App"
                   active={sort === "app"}
-                  ascending={true}
+                  ascending={sort === "app"}
                   onClick={() => handleSort("app")}
                   className="hidden sm:table-cell"
                 />
                 <SortHeader
                   label="Category"
                   active={sort === "category"}
-                  ascending={true}
+                  ascending={sort === "category"}
                   onClick={() => handleSort("category")}
                   className="hidden md:table-cell"
                 />
                 <SortHeader
                   label="Decision"
                   active={sort === "decision"}
-                  ascending={true}
+                  ascending={sort === "decision"}
                   onClick={() => handleSort("decision")}
                 />
                 <SortHeader
                   label="Time"
                   active={sort === "newest" || sort === "oldest"}
-                  ascending={sort === "newest"}
+                  ascending={sort === "oldest"}
                   onClick={() => handleSort("newest")}
                   className="hidden lg:table-cell"
                 />
@@ -265,7 +273,6 @@ function ActionRow({
 
   return (
     <tr
-      role="button"
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={handleKeyDown}

--- a/dashboard/src/evidence/evidence-action-list.tsx
+++ b/dashboard/src/evidence/evidence-action-list.tsx
@@ -4,11 +4,11 @@ import {
   HiMiniShieldCheck,
   HiMiniNoSymbol,
   HiMiniQuestionMarkCircle,
+  HiMiniChevronUp,
   HiMiniChevronDown,
 } from "react-icons/hi2";
 import type { GuardReceipt } from "../guard-types";
 import type { EvidenceSortKey } from "./evidence-types";
-import { EVIDENCE_SORT_OPTIONS } from "./evidence-types";
 import { harnessDisplayName, formatRelativeTime } from "../approval-center-utils";
 import { detectCategory, getCategoryInfo } from "./categories";
 import { humanFileName } from "./plain-english";
@@ -53,6 +53,163 @@ function DecisionChip({ decision }: DecisionChipProps) {
       <HiMiniQuestionMarkCircle className="h-3 w-3" aria-hidden="true" />
       Reviewed
     </span>
+  );
+}
+
+function SortHeader({
+  label,
+  active,
+  ascending,
+  onClick,
+  className = "",
+}: {
+  label: string;
+  active: boolean;
+  ascending: boolean;
+  onClick: () => void;
+  className?: string;
+}) {
+  return (
+    <th
+      scope="col"
+      className={`px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 ${className}`}
+    >
+      <button
+        type="button"
+        onClick={onClick}
+        className="inline-flex items-center gap-1 hover:text-brand-dark transition-colors"
+        aria-label={`Sort by ${label}${active ? (ascending ? ", ascending" : ", descending") : ""}`}
+      >
+        {label}
+        {active && (
+          ascending ? (
+            <HiMiniChevronUp className="h-3 w-3" aria-hidden="true" />
+          ) : (
+            <HiMiniChevronDown className="h-3 w-3" aria-hidden="true" />
+          )
+        )}
+      </button>
+    </th>
+  );
+}
+
+export function EvidenceActionList({
+  receipts,
+  selectedId,
+  onSelectId,
+  onFilterHarness,
+  onFilterCategory,
+  sort,
+  onSortChange,
+  page,
+  pageSize,
+  onLoadMore,
+}: EvidenceActionListProps) {
+  const visible = receipts.slice(0, (page + 1) * pageSize);
+  const showLoadMore = hasMore(page, pageSize, receipts.length);
+
+  const handleSort = useCallback(
+    (key: EvidenceSortKey) => {
+      if (sort === key && key === "newest") {
+        onSortChange("oldest");
+      } else if (sort === key && key === "oldest") {
+        onSortChange("newest");
+      } else {
+        onSortChange(key);
+      }
+    },
+    [sort, onSortChange]
+  );
+
+  if (receipts.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-16 text-center">
+        <p className="text-sm font-medium text-brand-dark">No actions match</p>
+        <p className="mt-1 text-xs text-slate-500">
+          Try adjusting the filters above.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between px-1">
+        <span className="text-xs font-medium text-slate-500">
+          {receipts.length} action{receipts.length !== 1 ? "s" : ""}
+        </span>
+      </div>
+
+      <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm" aria-label="Evidence actions">
+            <thead>
+              <tr className="border-b border-slate-100 bg-slate-50/60">
+                <th scope="col" className="w-8 px-3 py-2.5" />
+                <SortHeader
+                  label="Artifact"
+                  active={sort === "artifact"}
+                  ascending={true}
+                  onClick={() => handleSort("artifact")}
+                  className="min-w-[180px]"
+                />
+                <SortHeader
+                  label="App"
+                  active={sort === "app"}
+                  ascending={true}
+                  onClick={() => handleSort("app")}
+                  className="hidden sm:table-cell"
+                />
+                <SortHeader
+                  label="Category"
+                  active={sort === "category"}
+                  ascending={true}
+                  onClick={() => handleSort("category")}
+                  className="hidden md:table-cell"
+                />
+                <SortHeader
+                  label="Decision"
+                  active={sort === "decision"}
+                  ascending={true}
+                  onClick={() => handleSort("decision")}
+                />
+                <SortHeader
+                  label="Time"
+                  active={sort === "newest" || sort === "oldest"}
+                  ascending={sort === "newest"}
+                  onClick={() => handleSort("newest")}
+                  className="hidden lg:table-cell"
+                />
+              </tr>
+            </thead>
+            <tbody>
+              {visible.map((receipt) => (
+                <ActionRow
+                  key={receipt.receipt_id}
+                  receipt={receipt}
+                  isSelected={selectedId === receipt.receipt_id}
+                  onSelect={onSelectId}
+                  onFilterHarness={onFilterHarness}
+                  onFilterCategory={onFilterCategory}
+                />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {showLoadMore && (
+        <div className="flex justify-center pt-2">
+          <button
+            type="button"
+            onClick={onLoadMore}
+            className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-brand-dark hover:bg-slate-50 transition-colors"
+          >
+            Load more
+          </button>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -107,145 +264,54 @@ function ActionRow({
   );
 
   return (
-    <div
+    <tr
       role="button"
       tabIndex={0}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
       aria-selected={isSelected}
-      className={`w-full text-left flex items-center gap-3 px-4 py-3 transition-colors border-b border-slate-100 last:border-0 hover:bg-slate-50 focus:outline-none focus:bg-slate-50 cursor-pointer ${
-        isSelected ? "bg-brand-blue/5 border-l-2 border-l-brand-blue" : ""
+      className={`border-b border-slate-100 last:border-0 transition-colors cursor-pointer ${
+        isSelected ? "bg-brand-blue/[0.04]" : "hover:bg-slate-50"
       }`}
     >
-      <span
-        className={`shrink-0 ${catInfo.color}`}
-        aria-hidden="true"
-      >
-        {catInfo.icon}
-      </span>
-
-      <div className="flex-1 min-w-0 space-y-0.5">
-        <div className="flex items-center gap-2 flex-wrap">
-          <span className="text-sm font-medium text-brand-dark truncate">
-            {artifactLabel}
-          </span>
-          <DecisionChip decision={receipt.policy_decision} />
-        </div>
-
-        <div className="flex items-center gap-2 flex-wrap">
-          <button
-            type="button"
-            onClick={handleHarnessClick}
-            aria-label={`Filter by app ${harnessDisplayName(receipt.harness)}`}
-            className="text-[11px] font-medium text-brand-blue hover:underline shrink-0"
-          >
-            {harnessDisplayName(receipt.harness)}
-          </button>
-          <span className="text-slate-300 text-[11px]">·</span>
-          <button
-            type="button"
-            onClick={handleCategoryClick}
-            aria-label={`Filter by category ${catInfo.label}`}
-            className="text-[11px] text-slate-500 hover:text-brand-dark shrink-0"
-          >
-            {catInfo.label}
-          </button>
-          <span className="text-slate-300 text-[11px]">·</span>
-          <span className="text-[11px] text-slate-400 shrink-0">
-            {formatRelativeTime(receipt.timestamp)}
-          </span>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-export function EvidenceActionList({
-  receipts,
-  selectedId,
-  onSelectId,
-  onFilterHarness,
-  onFilterCategory,
-  sort,
-  onSortChange,
-  page,
-  pageSize,
-  onLoadMore,
-}: EvidenceActionListProps) {
-  const handleSortChange = useCallback(
-    (e: React.ChangeEvent<HTMLSelectElement>) => {
-      onSortChange(e.target.value as EvidenceSortKey);
-    },
-    [onSortChange]
-  );
-
-  const visible = receipts.slice(0, (page + 1) * pageSize);
-  const showLoadMore = hasMore(page, pageSize, receipts.length);
-
-  if (receipts.length === 0) {
-    return (
-      <div className="flex flex-col items-center justify-center py-16 text-center">
-        <p className="text-sm font-medium text-brand-dark">No actions match</p>
-        <p className="mt-1 text-xs text-slate-500">
-          Try adjusting the filters above.
-        </p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between px-1">
-        <span className="text-xs font-medium text-slate-500">
-          {receipts.length} action{receipts.length !== 1 ? "s" : ""}
+      <td className="px-3 py-2.5">
+        <span className={`${catInfo.color}`} aria-hidden="true">
+          {catInfo.icon}
         </span>
-        <label className="flex items-center gap-1.5 text-xs text-slate-500">
-          Sort by:
-          <select
-            value={sort}
-            onChange={handleSortChange}
-            aria-label="Sort actions"
-            className="rounded-md border-0 bg-transparent py-0.5 text-xs font-medium text-brand-dark focus:outline-none focus:ring-1 focus:ring-brand-blue/30"
-          >
-            {EVIDENCE_SORT_OPTIONS.map((opt) => (
-              <option key={opt.key} value={opt.key}>
-                {opt.label}
-              </option>
-            ))}
-          </select>
-          <HiMiniChevronDown className="h-3 w-3 text-slate-400 pointer-events-none" aria-hidden="true" />
-        </label>
-      </div>
-
-      <div
-        className="rounded-xl border border-slate-200 bg-white overflow-hidden"
-        role="list"
-        aria-label="Evidence actions"
-      >
-        {visible.map((receipt) => (
-          <div role="listitem" key={receipt.receipt_id}>
-            <ActionRow
-              receipt={receipt}
-              isSelected={selectedId === receipt.receipt_id}
-              onSelect={onSelectId}
-              onFilterHarness={onFilterHarness}
-              onFilterCategory={onFilterCategory}
-            />
-          </div>
-        ))}
-      </div>
-
-      {showLoadMore && (
-        <div className="flex justify-center pt-2">
-          <button
-            type="button"
-            onClick={onLoadMore}
-            className="rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-brand-dark hover:bg-slate-50 transition-colors"
-          >
-            Load more
-          </button>
-        </div>
-      )}
-    </div>
+      </td>
+      <td className="px-3 py-2.5">
+        <span className="text-sm font-medium text-brand-dark truncate block max-w-[200px]">
+          {artifactLabel}
+        </span>
+      </td>
+      <td className="px-3 py-2.5 hidden sm:table-cell">
+        <button
+          type="button"
+          onClick={handleHarnessClick}
+          aria-label={`Filter by app ${harnessDisplayName(receipt.harness)}`}
+          className="text-xs font-medium text-brand-blue hover:underline"
+        >
+          {harnessDisplayName(receipt.harness)}
+        </button>
+      </td>
+      <td className="px-3 py-2.5 hidden md:table-cell">
+        <button
+          type="button"
+          onClick={handleCategoryClick}
+          aria-label={`Filter by category ${catInfo.label}`}
+          className="text-xs text-slate-500 hover:text-brand-dark"
+        >
+          {catInfo.label}
+        </button>
+      </td>
+      <td className="px-3 py-2.5">
+        <DecisionChip decision={receipt.policy_decision} />
+      </td>
+      <td className="px-3 py-2.5 hidden lg:table-cell">
+        <span className="text-xs text-slate-400 whitespace-nowrap">
+          {formatRelativeTime(receipt.timestamp)}
+        </span>
+      </td>
+    </tr>
   );
 }

--- a/dashboard/src/evidence/evidence-view-shell.tsx
+++ b/dashboard/src/evidence/evidence-view-shell.tsx
@@ -55,7 +55,7 @@ export function EvidenceHeader({
           Every action Guard reviewed on this machine.
         </p>
         {lastActivityLabel && (
-          <p className="flex items-center gap-1 text-[11px] text-slate-400">
+          <p className="text-[11px] text-slate-400">
             Last activity: {lastActivityLabel}
           </p>
         )}

--- a/dashboard/src/evidence/evidence-view-shell.tsx
+++ b/dashboard/src/evidence/evidence-view-shell.tsx
@@ -1,23 +1,12 @@
-import { useCallback } from "react";
-import type { ElementType } from "react";
-import {
-  HiMiniListBullet,
-  HiMiniChartBar,
-  HiMiniComputerDesktop,
-  HiMiniArrowDownTray,
-  HiMiniClock,
-  HiMiniCalendarDays,
-  HiMiniSquares2X2,
-} from "react-icons/hi2";
 import type { EvidenceView } from "./evidence-types";
 
-export const VIEW_TABS: { key: EvidenceView; label: string; icon: ElementType }[] = [
-  { key: "actions", label: "All actions", icon: HiMiniListBullet },
-  { key: "insights", label: "Insights", icon: HiMiniChartBar },
-  { key: "apps", label: "Apps", icon: HiMiniComputerDesktop },
-  { key: "story", label: "Story", icon: HiMiniCalendarDays },
-  { key: "categories", label: "Categories", icon: HiMiniSquares2X2 },
-  { key: "export", label: "Export", icon: HiMiniArrowDownTray },
+export const VIEW_TABS: { key: EvidenceView; label: string }[] = [
+  { key: "actions", label: "All actions" },
+  { key: "insights", label: "Insights" },
+  { key: "apps", label: "Apps" },
+  { key: "story", label: "Story" },
+  { key: "categories", label: "Categories" },
+  { key: "export", label: "Export" },
 ];
 
 export function EvidenceLoadingState() {
@@ -67,7 +56,6 @@ export function EvidenceHeader({
         </p>
         {lastActivityLabel && (
           <p className="flex items-center gap-1 text-[11px] text-slate-400">
-            <HiMiniClock className="h-3 w-3" aria-hidden="true" />
             Last activity: {lastActivityLabel}
           </p>
         )}
@@ -79,7 +67,6 @@ export function EvidenceHeader({
           aria-label="Export evidence"
           className="inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-brand-dark hover:bg-slate-50 transition-colors"
         >
-          <HiMiniArrowDownTray className="h-3.5 w-3.5" aria-hidden="true" />
           Export
         </button>
         {onClear && totalCount > 0 && (
@@ -94,76 +81,5 @@ export function EvidenceHeader({
         )}
       </div>
     </div>
-  );
-}
-
-export interface ViewTabBarProps {
-  view: EvidenceView;
-  onViewChange: (view: EvidenceView) => void;
-}
-
-export function ViewTabBar({ view, onViewChange }: ViewTabBarProps) {
-  return (
-    <div
-      className="flex gap-1 border-b border-slate-200/60"
-      role="tablist"
-      aria-label="Evidence views"
-    >
-      {VIEW_TABS.map((tab) => {
-        const Icon = tab.icon;
-        const isActive = view === tab.key;
-        return (
-          <ViewTabButton
-            key={tab.key}
-            tabKey={tab.key}
-            label={tab.label}
-            icon={Icon}
-            isActive={isActive}
-            onSelect={onViewChange}
-          />
-        );
-      })}
-    </div>
-  );
-}
-
-interface ViewTabButtonProps {
-  tabKey: EvidenceView;
-  label: string;
-  icon: ElementType;
-  isActive: boolean;
-  onSelect: (key: EvidenceView) => void;
-}
-
-function ViewTabButton({
-  tabKey,
-  label,
-  icon: Icon,
-  isActive,
-  onSelect,
-}: ViewTabButtonProps) {
-  const handleClick = useCallback(() => {
-    onSelect(tabKey);
-  }, [tabKey, onSelect]);
-
-  return (
-    <button
-      role="tab"
-      aria-selected={isActive}
-      aria-controls={`tabpanel-${tabKey}`}
-      id={`tab-${tabKey}`}
-      onClick={handleClick}
-      className={`relative flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium transition-colors ${
-        isActive
-          ? "text-brand-dark"
-          : "text-slate-500 hover:text-brand-dark"
-      }`}
-    >
-      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
-      <span className="hidden sm:inline">{label}</span>
-      {isActive && (
-        <span className="absolute bottom-0 left-1 right-1 h-0.5 rounded-full bg-brand-blue" />
-      )}
-    </button>
   );
 }

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -69,7 +69,7 @@ export function plainEnglishRequestTitle(request: GuardApprovalRequest): string 
     timestamp: request.created_at,
     policy_decision: request.policy_action === "block" ? "block" : "allow",
     receipt_id: request.request_id,
-  } as GuardReceipt);
+  } as unknown as GuardReceipt);
   const app = harnessDisplayName(request.harness);
   const name = humanFileName(request.artifact_name ?? request.artifact_id);
 
@@ -97,7 +97,7 @@ export function whyPaused(request: GuardApprovalRequest): string {
     timestamp: request.created_at,
     policy_decision: request.policy_action === "block" ? "block" : "allow",
     receipt_id: request.request_id,
-  } as GuardReceipt);
+  } as unknown as GuardReceipt);
 
   switch (category) {
     case "secret":

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -337,6 +337,8 @@ export type GuardReceipt = {
   artifact_name: string | null;
   source_scope: string | null;
   timestamp: string;
+  diff_summary?: string | null;
+  scanner_evidence?: RiskSignalV2[];
 };
 
 export type GuardArtifactDiff = {

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -199,7 +199,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
     );
   }
 
-  const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label }));
+  const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label, id: t.key }));
 
   return (
     <div className="space-y-4">

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { HiMiniArrowDownTray } from "react-icons/hi2";
 
-import { EmptyState } from "./approval-center-primitives";
+import { EmptyState, TabBar } from "./approval-center-primitives";
 import { isDisplayableHarness, normalizeHarnessFilter } from "./approval-center-utils";
 import type { GuardReceipt } from "./guard-types";
 import type { EvidenceFilterState, EvidenceView, EvidenceSortKey } from "./evidence/evidence-types";
@@ -17,7 +17,7 @@ import {
   EvidenceLoadingState,
   EvidenceErrorState,
   EvidenceHeader,
-  ViewTabBar,
+  VIEW_TABS,
 } from "./evidence/evidence-view-shell";
 import { EvidenceFilterBar } from "./evidence/evidence-filter-bar";
 import { EvidenceActionList } from "./evidence/evidence-action-list";
@@ -199,8 +199,10 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
     );
   }
 
+  const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label }));
+
   return (
-    <div className="space-y-2">
+    <div className="space-y-4">
       <EvidenceHeader
         totalCount={receiptItems.length}
         lastActivityAt={metrics.lastActivityAt}
@@ -208,17 +210,9 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
         onClear={handleOpenClear}
       />
 
-      <EvidenceFilterBar
-        filters={filters}
-        onChange={handleFilterChange}
-        totalCount={receiptItems.length}
-        filteredCount={filtered.length}
-        harnesses={harnesses}
-      />
+      <TabBar tabs={tabOptions} active={filters.view} onChange={handleViewChange} />
 
-      <ViewTabBar view={filters.view} onViewChange={handleViewChange} />
-
-      <div className="pt-2">
+      <div className="pt-1">
         {filters.view === "actions" && (
           <div
             id="tabpanel-actions"
@@ -227,6 +221,13 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
             className={selectedReceipt ? "grid grid-cols-1 gap-3 lg:grid-cols-[1fr_340px]" : ""}
           >
             <div className="space-y-3">
+              <EvidenceFilterBar
+                filters={filters}
+                onChange={handleFilterChange}
+                totalCount={receiptItems.length}
+                filteredCount={filtered.length}
+                harnesses={harnesses}
+              />
               <EvidenceInsightStrip metrics={metrics} />
               <EvidenceActionList
                 receipts={sorted}

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14160,9 +14160,6 @@ function HiMiniMagnifyingGlass(props) {
 function HiMiniLockClosed(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M10 1a4.5 4.5 0 0 0-4.5 4.5V9H5a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-6a2 2 0 0 0-2-2h-.5V5.5A4.5 4.5 0 0 0 10 1Zm3 8V5.5a3 3 0 1 0-6 0V9h6Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
-function HiMiniListBullet(props) {
-  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M6 4.75A.75.75 0 0 1 6.75 4h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 4.75ZM6 10a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75A.75.75 0 0 1 6 10Zm0 5.25a.75.75 0 0 1 .75-.75h10.5a.75.75 0 0 1 0 1.5H6.75a.75.75 0 0 1-.75-.75ZM1.99 4.75a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 15.25a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1v-.01ZM1.99 10a1 1 0 0 1 1-1H3a1 1 0 0 1 1 1v.01a1 1 0 0 1-1 1h-.01a1 1 0 0 1-1-1V10Z", "clipRule": "evenodd" }, "child": [] }] })(props);
-}
 function HiMiniKey(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M8 7a5 5 0 1 1 3.61 4.804l-1.903 1.903A1 1 0 0 1 9 14H8v1a1 1 0 0 1-1 1H6v1a1 1 0 0 1-1 1H3a1 1 0 0 1-1-1v-2a1 1 0 0 1 .293-.707L8.196 8.39A5.002 5.002 0 0 1 8 7Zm5-3a.75.75 0 0 0 0 1.5A1.5 1.5 0 0 1 14.5 7 .75.75 0 0 0 16 7a3 3 0 0 0-3-3Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
@@ -14204,9 +14201,6 @@ function HiMiniCube(props) {
 }
 function HiMiniCpuChip(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M14 6H6v8h8V6Z" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M9.25 3V1.75a.75.75 0 0 1 1.5 0V3h1.5V1.75a.75.75 0 0 1 1.5 0V3h.5A2.75 2.75 0 0 1 17 5.75v.5h1.25a.75.75 0 0 1 0 1.5H17v1.5h1.25a.75.75 0 0 1 0 1.5H17v1.5h1.25a.75.75 0 0 1 0 1.5H17v.5A2.75 2.75 0 0 1 14.25 17h-.5v1.25a.75.75 0 0 1-1.5 0V17h-1.5v1.25a.75.75 0 0 1-1.5 0V17h-1.5v1.25a.75.75 0 0 1-1.5 0V17h-.5A2.75 2.75 0 0 1 3 14.25v-.5H1.75a.75.75 0 0 1 0-1.5H3v-1.5H1.75a.75.75 0 0 1 0-1.5H3v-1.5H1.75a.75.75 0 0 1 0-1.5H3v-.5A2.75 2.75 0 0 1 5.75 3h.5V1.75a.75.75 0 0 1 1.5 0V3h1.5ZM4.5 5.75c0-.69.56-1.25 1.25-1.25h8.5c.69 0 1.25.56 1.25 1.25v8.5c0 .69-.56 1.25-1.25 1.25h-8.5c-.69 0-1.25-.56-1.25-1.25v-8.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
-}
-function HiMiniComputerDesktop(props) {
-  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M2 4.25A2.25 2.25 0 0 1 4.25 2h11.5A2.25 2.25 0 0 1 18 4.25v8.5A2.25 2.25 0 0 1 15.75 15h-3.105a3.501 3.501 0 0 0 1.1 1.677A.75.75 0 0 1 13.26 18H6.74a.75.75 0 0 1-.484-1.323A3.501 3.501 0 0 0 7.355 15H4.25A2.25 2.25 0 0 1 2 12.75v-8.5Zm1.5 0a.75.75 0 0 1 .75-.75h11.5a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-.75.75H4.25a.75.75 0 0 1-.75-.75v-7.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
 function HiMiniCommandLine(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M3.25 3A2.25 2.25 0 0 0 1 5.25v9.5A2.25 2.25 0 0 0 3.25 17h13.5A2.25 2.25 0 0 0 19 14.75v-9.5A2.25 2.25 0 0 0 16.75 3H3.25Zm.943 8.752a.75.75 0 0 1 .055-1.06L6.128 9l-1.88-1.693a.75.75 0 1 1 1.004-1.114l2.5 2.25a.75.75 0 0 1 0 1.114l-2.5 2.25a.75.75 0 0 1-1.06-.055ZM9.75 10.25a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5h-2.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
@@ -14255,9 +14249,6 @@ function HiMiniCheckCircle(props) {
 }
 function HiMiniChartBar(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M15.5 2A1.5 1.5 0 0 0 14 3.5v13a1.5 1.5 0 0 0 1.5 1.5h1a1.5 1.5 0 0 0 1.5-1.5v-13A1.5 1.5 0 0 0 16.5 2h-1ZM9.5 6A1.5 1.5 0 0 0 8 7.5v9A1.5 1.5 0 0 0 9.5 18h1a1.5 1.5 0 0 0 1.5-1.5v-9A1.5 1.5 0 0 0 10.5 6h-1ZM3.5 10A1.5 1.5 0 0 0 2 11.5v5A1.5 1.5 0 0 0 3.5 18h1A1.5 1.5 0 0 0 6 16.5v-5A1.5 1.5 0 0 0 4.5 10h-1Z" }, "child": [] }] })(props);
-}
-function HiMiniCalendarDays(props) {
-  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M5.25 12a.75.75 0 0 1 .75-.75h.01a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75H6a.75.75 0 0 1-.75-.75V12ZM6 13.25a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 0 0 .75-.75V14a.75.75 0 0 0-.75-.75H6ZM7.25 12a.75.75 0 0 1 .75-.75h.01a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75H8a.75.75 0 0 1-.75-.75V12ZM8 13.25a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 0 0 .75-.75V14a.75.75 0 0 0-.75-.75H8ZM9.25 10a.75.75 0 0 1 .75-.75h.01a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75H10a.75.75 0 0 1-.75-.75V10ZM10 11.25a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 0 0 .75-.75V12a.75.75 0 0 0-.75-.75H10ZM9.25 14a.75.75 0 0 1 .75-.75h.01a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75H10a.75.75 0 0 1-.75-.75V14ZM12 9.25a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 0 0 .75-.75V10a.75.75 0 0 0-.75-.75H12ZM11.25 12a.75.75 0 0 1 .75-.75h.01a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75H12a.75.75 0 0 1-.75-.75V12ZM12 13.25a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 0 0 .75-.75V14a.75.75 0 0 0-.75-.75H12ZM13.25 10a.75.75 0 0 1 .75-.75h.01a.75.75 0 0 1 .75.75v.01a.75.75 0 0 1-.75.75H14a.75.75 0 0 1-.75-.75V10ZM14 11.25a.75.75 0 0 0-.75.75v.01c0 .414.336.75.75.75h.01a.75.75 0 0 0 .75-.75V12a.75.75 0 0 0-.75-.75H14Z" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M5.75 2a.75.75 0 0 1 .75.75V4h7V2.75a.75.75 0 0 1 1.5 0V4h.25A2.75 2.75 0 0 1 18 6.75v8.5A2.75 2.75 0 0 1 15.25 18H4.75A2.75 2.75 0 0 1 2 15.25v-8.5A2.75 2.75 0 0 1 4.75 4H5V2.75A.75.75 0 0 1 5.75 2Zm-1 5.5c-.69 0-1.25.56-1.25 1.25v6.5c0 .69.56 1.25 1.25 1.25h10.5c.69 0 1.25-.56 1.25-1.25v-6.5c0-.69-.56-1.25-1.25-1.25H4.75Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
 function HiMiniBugAnt(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M6.56 1.14a.75.75 0 0 1 .177 1.045 3.989 3.989 0 0 0-.464.86c.185.17.382.329.59.473A3.993 3.993 0 0 1 10 2c1.272 0 2.405.594 3.137 1.518.208-.144.405-.302.59-.473a3.989 3.989 0 0 0-.464-.86.75.75 0 0 1 1.222-.869c.369.519.65 1.105.822 1.736a.75.75 0 0 1-.174.707 7.03 7.03 0 0 1-1.299 1.098A4 4 0 0 1 14 6c0 .52-.301.963-.723 1.187a6.961 6.961 0 0 1-1.158.486c.13.208.231.436.296.679 1.413-.174 2.779-.5 4.081-.96a19.655 19.655 0 0 0-.09-2.319.75.75 0 1 1 1.493-.146 21.239 21.239 0 0 1 .08 3.028.75.75 0 0 1-.482.667 20.873 20.873 0 0 1-5.153 1.249 2.521 2.521 0 0 1-.107.247 20.945 20.945 0 0 1 5.252 1.257.75.75 0 0 1 .482.74 20.945 20.945 0 0 1-.908 5.107.75.75 0 0 1-1.433-.444c.415-1.34.69-2.743.806-4.191-.495-.173-1-.327-1.512-.46.05.284.076.575.076.873 0 1.814-.517 3.312-1.426 4.37A4.639 4.639 0 0 1 10 19a4.639 4.639 0 0 1-3.574-1.63C5.516 16.311 5 14.813 5 13c0-.298.026-.59.076-.873-.513.133-1.017.287-1.512.46.116 1.448.39 2.85.806 4.191a.75.75 0 1 1-1.433.444 20.94 20.94 0 0 1-.908-5.107.75.75 0 0 1 .482-.74 20.838 20.838 0 0 1 5.252-1.257 2.493 2.493 0 0 1-.107-.247 20.874 20.874 0 0 1-5.153-1.249.75.75 0 0 1-.482-.667 21.342 21.342 0 0 1 .08-3.028.75.75 0 1 1 1.493.146 19.745 19.745 0 0 0-.09 2.319c1.302.46 2.668.786 4.08.96.066-.243.166-.471.297-.679a6.962 6.962 0 0 1-1.158-.486A1.348 1.348 0 0 1 6 6a4 4 0 0 1 .166-1.143 7.032 7.032 0 0 1-1.3-1.098.75.75 0 0 1-.173-.707 5.48 5.48 0 0 1 .822-1.736.75.75 0 0 1 1.046-.177Z", "clipRule": "evenodd" }, "child": [] }] })(props);
@@ -15875,12 +15866,12 @@ function writeEvidenceUrlState(state) {
   window.history.replaceState({}, "", url.toString());
 }
 const VIEW_TABS = [
-  { key: "actions", label: "All actions", icon: HiMiniListBullet },
-  { key: "insights", label: "Insights", icon: HiMiniChartBar },
-  { key: "apps", label: "Apps", icon: HiMiniComputerDesktop },
-  { key: "story", label: "Story", icon: HiMiniCalendarDays },
-  { key: "categories", label: "Categories", icon: HiMiniSquares2X2 },
-  { key: "export", label: "Export", icon: HiMiniArrowDownTray }
+  { key: "actions", label: "All actions" },
+  { key: "insights", label: "Insights" },
+  { key: "apps", label: "Apps" },
+  { key: "story", label: "Story" },
+  { key: "categories", label: "Categories" },
+  { key: "export", label: "Export" }
 ];
 function EvidenceLoadingState() {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", "aria-busy": "true", "aria-label": "Loading evidence", children: [
@@ -15907,23 +15898,19 @@ function EvidenceHeader({
       /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-lg font-semibold text-brand-dark", children: "Evidence" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Every action Guard reviewed on this machine." }),
       lastActivityLabel && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "flex items-center gap-1 text-[11px] text-slate-400", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClock, { className: "h-3 w-3", "aria-hidden": "true" }),
         "Last activity: ",
         lastActivityLabel
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 shrink-0", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
         "button",
         {
           type: "button",
           onClick: onExport,
           "aria-label": "Export evidence",
           className: "inline-flex items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 py-1.5 text-xs font-medium text-brand-dark hover:bg-slate-50 transition-colors",
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowDownTray, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
-            "Export"
-          ]
+          children: "Export"
         }
       ),
       onClear && totalCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -15939,66 +15926,6 @@ function EvidenceHeader({
     ] })
   ] });
 }
-function ViewTabBar({ view, onViewChange }) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(
-    "div",
-    {
-      className: "flex gap-1 border-b border-slate-200/60",
-      role: "tablist",
-      "aria-label": "Evidence views",
-      children: VIEW_TABS.map((tab) => {
-        const Icon = tab.icon;
-        const isActive = view === tab.key;
-        return /* @__PURE__ */ jsxRuntimeExports.jsx(
-          ViewTabButton,
-          {
-            tabKey: tab.key,
-            label: tab.label,
-            icon: Icon,
-            isActive,
-            onSelect: onViewChange
-          },
-          tab.key
-        );
-      })
-    }
-  );
-}
-function ViewTabButton({
-  tabKey,
-  label,
-  icon: Icon,
-  isActive,
-  onSelect
-}) {
-  const handleClick = reactExports.useCallback(() => {
-    onSelect(tabKey);
-  }, [tabKey, onSelect]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "button",
-    {
-      role: "tab",
-      "aria-selected": isActive,
-      "aria-controls": `tabpanel-${tabKey}`,
-      id: `tab-${tabKey}`,
-      onClick: handleClick,
-      className: `relative flex items-center gap-1 px-2.5 py-1.5 text-xs font-medium transition-colors ${isActive ? "text-brand-dark" : "text-slate-500 hover:text-brand-dark"}`,
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "hidden sm:inline", children: label }),
-        isActive && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "absolute bottom-0 left-1 right-1 h-0.5 rounded-full bg-brand-blue" })
-      ]
-    }
-  );
-}
-const EVIDENCE_SORT_OPTIONS = [
-  { key: "newest", label: "Newest first" },
-  { key: "oldest", label: "Oldest first" },
-  { key: "app", label: "App" },
-  { key: "decision", label: "Decision" },
-  { key: "category", label: "Category" },
-  { key: "artifact", label: "Artifact" }
-];
 const EVIDENCE_TIME_LABELS = {
   all: "All time",
   today: "Today",
@@ -16419,6 +16346,148 @@ function DecisionChip({ decision }) {
     "Reviewed"
   ] });
 }
+function SortHeader({
+  label,
+  active,
+  ascending,
+  onClick,
+  className = ""
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "th",
+    {
+      scope: "col",
+      className: `px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 ${className}`,
+      children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          type: "button",
+          onClick,
+          className: "inline-flex items-center gap-1 hover:text-brand-dark transition-colors",
+          "aria-label": `Sort by ${label}${active ? ascending ? ", ascending" : ", descending" : ""}`,
+          children: [
+            label,
+            active && (ascending ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-3 w-3", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3 w-3", "aria-hidden": "true" }))
+          ]
+        }
+      )
+    }
+  );
+}
+function EvidenceActionList({
+  receipts,
+  selectedId,
+  onSelectId,
+  onFilterHarness,
+  onFilterCategory,
+  sort,
+  onSortChange,
+  page,
+  pageSize,
+  onLoadMore
+}) {
+  const visible = receipts.slice(0, (page + 1) * pageSize);
+  const showLoadMore = hasMore(page, pageSize, receipts.length);
+  const handleSort = reactExports.useCallback(
+    (key) => {
+      if (sort === key && key === "newest") {
+        onSortChange("oldest");
+      } else if (sort === key && key === "oldest") {
+        onSortChange("newest");
+      } else {
+        onSortChange(key);
+      }
+    },
+    [sort, onSortChange]
+  );
+  if (receipts.length === 0) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col items-center justify-center py-16 text-center", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "No actions match" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-slate-500", children: "Try adjusting the filters above." })
+    ] });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex items-center justify-between px-1", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs font-medium text-slate-500", children: [
+      receipts.length,
+      " action",
+      receipts.length !== 1 ? "s" : ""
+    ] }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-slate-200 bg-white overflow-hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "overflow-x-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "w-full text-sm", "aria-label": "Evidence actions", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { className: "border-b border-slate-100 bg-slate-50/60", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "w-8 px-3 py-2.5" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          SortHeader,
+          {
+            label: "Artifact",
+            active: sort === "artifact",
+            ascending: true,
+            onClick: () => handleSort("artifact"),
+            className: "min-w-[180px]"
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          SortHeader,
+          {
+            label: "App",
+            active: sort === "app",
+            ascending: true,
+            onClick: () => handleSort("app"),
+            className: "hidden sm:table-cell"
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          SortHeader,
+          {
+            label: "Category",
+            active: sort === "category",
+            ascending: true,
+            onClick: () => handleSort("category"),
+            className: "hidden md:table-cell"
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          SortHeader,
+          {
+            label: "Decision",
+            active: sort === "decision",
+            ascending: true,
+            onClick: () => handleSort("decision")
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          SortHeader,
+          {
+            label: "Time",
+            active: sort === "newest" || sort === "oldest",
+            ascending: sort === "newest",
+            onClick: () => handleSort("newest"),
+            className: "hidden lg:table-cell"
+          }
+        )
+      ] }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: visible.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        ActionRow,
+        {
+          receipt,
+          isSelected: selectedId === receipt.receipt_id,
+          onSelect: onSelectId,
+          onFilterHarness,
+          onFilterCategory
+        },
+        receipt.receipt_id
+      )) })
+    ] }) }) }),
+    showLoadMore && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex justify-center pt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        onClick: onLoadMore,
+        className: "rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-brand-dark hover:bg-slate-50 transition-colors",
+        children: "Load more"
+      }
+    ) })
+  ] });
+}
 function ActionRow({
   receipt,
   isSelected,
@@ -16457,134 +16526,42 @@ function ActionRow({
     [receipt.receipt_id, onSelect]
   );
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "div",
+    "tr",
     {
       role: "button",
       tabIndex: 0,
       onClick: handleClick,
       onKeyDown: handleKeyDown,
       "aria-selected": isSelected,
-      className: `w-full text-left flex items-center gap-3 px-4 py-3 transition-colors border-b border-slate-100 last:border-0 hover:bg-slate-50 focus:outline-none focus:bg-slate-50 cursor-pointer ${isSelected ? "bg-brand-blue/5 border-l-2 border-l-brand-blue" : ""}`,
+      className: `border-b border-slate-100 last:border-0 transition-colors cursor-pointer ${isSelected ? "bg-brand-blue/[0.04]" : "hover:bg-slate-50"}`,
       children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "span",
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `${catInfo.color}`, "aria-hidden": "true", children: catInfo.icon }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[200px]", children: artifactLabel }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden sm:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
           {
-            className: `shrink-0 ${catInfo.color}`,
-            "aria-hidden": "true",
-            children: catInfo.icon
+            type: "button",
+            onClick: handleHarnessClick,
+            "aria-label": `Filter by app ${harnessDisplayName(receipt.harness)}`,
+            className: "text-xs font-medium text-brand-blue hover:underline",
+            children: harnessDisplayName(receipt.harness)
           }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1 min-w-0 space-y-0.5", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2 flex-wrap", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate", children: artifactLabel }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionChip, { decision: receipt.policy_decision })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2 flex-wrap", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "button",
-              {
-                type: "button",
-                onClick: handleHarnessClick,
-                "aria-label": `Filter by app ${harnessDisplayName(receipt.harness)}`,
-                className: "text-[11px] font-medium text-brand-blue hover:underline shrink-0",
-                children: harnessDisplayName(receipt.harness)
-              }
-            ),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-slate-300 text-[11px]", children: "·" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "button",
-              {
-                type: "button",
-                onClick: handleCategoryClick,
-                "aria-label": `Filter by category ${catInfo.label}`,
-                className: "text-[11px] text-slate-500 hover:text-brand-dark shrink-0",
-                children: catInfo.label
-              }
-            ),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-slate-300 text-[11px]", children: "·" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[11px] text-slate-400 shrink-0", children: formatRelativeTime(receipt.timestamp) })
-          ] })
-        ] })
+        ) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden md:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            type: "button",
+            onClick: handleCategoryClick,
+            "aria-label": `Filter by category ${catInfo.label}`,
+            className: "text-xs text-slate-500 hover:text-brand-dark",
+            children: catInfo.label
+          }
+        ) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionChip, { decision: receipt.policy_decision }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden lg:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400 whitespace-nowrap", children: formatRelativeTime(receipt.timestamp) }) })
       ]
     }
   );
-}
-function EvidenceActionList({
-  receipts,
-  selectedId,
-  onSelectId,
-  onFilterHarness,
-  onFilterCategory,
-  sort,
-  onSortChange,
-  page,
-  pageSize,
-  onLoadMore
-}) {
-  const handleSortChange = reactExports.useCallback(
-    (e) => {
-      onSortChange(e.target.value);
-    },
-    [onSortChange]
-  );
-  const visible = receipts.slice(0, (page + 1) * pageSize);
-  const showLoadMore = hasMore(page, pageSize, receipts.length);
-  if (receipts.length === 0) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col items-center justify-center py-16 text-center", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "No actions match" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-slate-500", children: "Try adjusting the filters above." })
-    ] });
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between px-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs font-medium text-slate-500", children: [
-        receipts.length,
-        " action",
-        receipts.length !== 1 ? "s" : ""
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "flex items-center gap-1.5 text-xs text-slate-500", children: [
-        "Sort by:",
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "select",
-          {
-            value: sort,
-            onChange: handleSortChange,
-            "aria-label": "Sort actions",
-            className: "rounded-md border-0 bg-transparent py-0.5 text-xs font-medium text-brand-dark focus:outline-none focus:ring-1 focus:ring-brand-blue/30",
-            children: EVIDENCE_SORT_OPTIONS.map((opt) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: opt.key, children: opt.label }, opt.key))
-          }
-        ),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3 w-3 text-slate-400 pointer-events-none", "aria-hidden": "true" })
-      ] })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "div",
-      {
-        className: "rounded-xl border border-slate-200 bg-white overflow-hidden",
-        role: "list",
-        "aria-label": "Evidence actions",
-        children: visible.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "listitem", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-          ActionRow,
-          {
-            receipt,
-            isSelected: selectedId === receipt.receipt_id,
-            onSelect: onSelectId,
-            onFilterHarness,
-            onFilterCategory
-          }
-        ) }, receipt.receipt_id))
-      }
-    ),
-    showLoadMore && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex justify-center pt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "button",
-      {
-        type: "button",
-        onClick: onLoadMore,
-        className: "rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-medium text-brand-dark hover:bg-slate-50 transition-colors",
-        children: "Load more"
-      }
-    ) })
-  ] });
 }
 function DecisionBadge$1({ decision }) {
   if (decision === "allow") {
@@ -16602,6 +16579,90 @@ function DecisionBadge$1({ decision }) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-1 rounded-full bg-blue-50 px-2.5 py-1 text-xs font-semibold text-brand-blue ring-1 ring-blue-200", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniQuestionMarkCircle, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
     "Reviewed"
+  ] });
+}
+function SeverityIcon({ severity }) {
+  if (severity === "critical" || severity === "high") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "h-4 w-4 text-amber-500", "aria-hidden": "true" });
+  }
+  if (severity === "medium") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBolt, { className: "h-4 w-4 text-orange-400", "aria-hidden": "true" });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniInformationCircle, { className: "h-4 w-4 text-brand-blue", "aria-hidden": "true" });
+}
+function SeverityBadge({ severity }) {
+  const styles = {
+    critical: "bg-amber-100 text-amber-800 ring-amber-200",
+    high: "bg-amber-50 text-amber-700 ring-amber-200",
+    medium: "bg-orange-50 text-orange-700 ring-orange-200",
+    low: "bg-blue-50 text-brand-blue ring-blue-200",
+    info: "bg-slate-100 text-slate-600 ring-slate-200"
+  };
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "span",
+    {
+      className: `inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider ring-1 ${styles[severity] ?? styles.info}`,
+      children: severity
+    }
+  );
+}
+function ScannerEvidenceSection$1({ signals }) {
+  const [expanded, setExpanded] = reactExports.useState({});
+  const toggle = reactExports.useCallback((id) => {
+    setExpanded((prev) => ({ ...prev, [id]: !prev[id] }));
+  }, []);
+  if (signals.length === 0) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400", children: [
+      "Scanner findings (",
+      signals.length,
+      ")"
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-2", children: signals.map((signal) => {
+      const isOpen = expanded[signal.signal_id] ?? false;
+      return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "div",
+        {
+          className: "rounded-lg border border-slate-200 bg-white overflow-hidden",
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs(
+              "button",
+              {
+                type: "button",
+                onClick: () => toggle(signal.signal_id),
+                "aria-expanded": isOpen,
+                className: "flex w-full items-center gap-2 px-3 py-2.5 text-left hover:bg-slate-50 transition-colors",
+                children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx(SeverityIcon, { severity: signal.severity }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex-1 text-xs font-medium text-brand-dark truncate", children: signal.title }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx(SeverityBadge, { severity: signal.severity }),
+                  isOpen ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-3.5 w-3.5 text-slate-400 shrink-0", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-3.5 w-3.5 text-slate-400 shrink-0", "aria-hidden": "true" })
+                ]
+              }
+            ),
+            isOpen && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-100 px-3 py-2.5 space-y-2", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-brand-dark/80 leading-relaxed", children: signal.plain_reason }),
+              signal.technical_detail && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-md bg-slate-50 px-2.5 py-2", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-medium uppercase tracking-wide text-slate-400 mb-1", children: "Technical detail" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-mono text-brand-dark/70 break-all leading-relaxed", children: signal.technical_detail })
+              ] }),
+              signal.false_positive_hint && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] text-slate-500 italic", children: signal.false_positive_hint }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2 text-[10px] text-slate-400", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+                  "Detector: ",
+                  signal.detector
+                ] }),
+                signal.advisory_id && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+                  "· Advisory: ",
+                  signal.advisory_id
+                ] })
+              ] })
+            ] })
+          ]
+        },
+        signal.signal_id
+      );
+    }) })
   ] });
 }
 function TechnicalSection({ receipt }) {
@@ -16643,7 +16704,8 @@ function TechnicalSection({ receipt }) {
           value: (receipt.changed_capabilities ?? []).join(", ")
         }
       ),
-      receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Capabilities", value: receipt.capabilities_summary })
+      receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Capabilities", value: receipt.capabilities_summary }),
+      receipt.diff_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Diff summary", value: receipt.diff_summary })
     ] })
   ] });
 }
@@ -16736,6 +16798,7 @@ function EvidenceActionDetail({
   const catInfo = getCategoryInfo(category);
   const description = plainEnglishDescription(receipt);
   const artifactLabel = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
+  const signals = receipt.scanner_evidence ?? [];
   let copyLabel = "Copy receipt ID";
   if (copied) {
     copyLabel = "Copied!";
@@ -16785,7 +16848,15 @@ function EvidenceActionDetail({
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400 mb-1", children: "Provenance" }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-700", children: receipt.provenance_summary })
           ] }),
+          receipt.diff_summary && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg border border-slate-100 bg-slate-50/60 px-3 py-2.5", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 mb-1", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniDocumentText, { className: "h-3.5 w-3.5 text-slate-400", "aria-hidden": "true" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400", children: "What changed" })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-700", children: receipt.diff_summary })
+          ] }),
           receipt.policy_decision === "block" && /* @__PURE__ */ jsxRuntimeExports.jsx(NextSafeCommandHint, { receipt }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(ScannerEvidenceSection$1, { signals }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(EvidenceTimeline, { receipt }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(TechnicalSection, { receipt }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -18056,7 +18127,8 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
       }
     );
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+  const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label }));
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       EvidenceHeader,
       {
@@ -18066,18 +18138,8 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
         onClear: handleOpenClear
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      EvidenceFilterBar,
-      {
-        filters,
-        onChange: handleFilterChange,
-        totalCount: receiptItems.length,
-        filteredCount: filtered.length,
-        harnesses
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(ViewTabBar, { view: filters.view, onViewChange: handleViewChange }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pt-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(TabBar, { tabs: tabOptions, active: filters.view, onChange: handleViewChange }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "pt-1", children: [
       filters.view === "actions" && /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "div",
         {
@@ -18087,6 +18149,16 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
           className: selectedReceipt ? "grid grid-cols-1 gap-3 lg:grid-cols-[1fr_340px]" : "",
           children: [
             /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                EvidenceFilterBar,
+                {
+                  filters,
+                  onChange: handleFilterChange,
+                  totalCount: receiptItems.length,
+                  filteredCount: filtered.length,
+                  harnesses
+                }
+              ),
               /* @__PURE__ */ jsxRuntimeExports.jsx(EvidenceInsightStrip, { metrics }),
               /* @__PURE__ */ jsxRuntimeExports.jsx(
                 EvidenceActionList,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -82,7 +82,12 @@
     --color-red-200: oklch(88.5% .062 18.334);
     --color-red-300: oklch(80.8% .114 19.571);
     --color-red-500: oklch(63.7% .237 25.331);
+    --color-orange-50: oklch(98% .016 73.684);
+    --color-orange-200: oklch(90.1% .076 70.697);
+    --color-orange-400: oklch(75% .183 55.934);
+    --color-orange-700: oklch(55.3% .195 38.402);
     --color-amber-50: oklch(98.7% .022 95.277);
+    --color-amber-100: oklch(96.2% .059 95.617);
     --color-amber-200: oklch(92.4% .12 95.746);
     --color-amber-300: oklch(87.9% .169 91.605);
     --color-amber-400: oklch(82.8% .189 84.429);
@@ -528,10 +533,6 @@
     right: calc(var(--spacing) * 0);
   }
 
-  .right-1 {
-    right: calc(var(--spacing) * 1);
-  }
-
   .right-2 {
     right: calc(var(--spacing) * 2);
   }
@@ -570,10 +571,6 @@
 
   .left-0\.5 {
     left: calc(var(--spacing) * .5);
-  }
-
-  .left-1 {
-    left: calc(var(--spacing) * 1);
   }
 
   .left-2\.5 {
@@ -1186,6 +1183,10 @@
     min-width: 160px;
   }
 
+  .min-w-\[180px\] {
+    min-width: 180px;
+  }
+
   .min-w-\[500px\] {
     min-width: 500px;
   }
@@ -1550,11 +1551,6 @@
   .border {
     border-style: var(--tw-border-style);
     border-width: 1px;
-  }
-
-  .border-0 {
-    border-style: var(--tw-border-style);
-    border-width: 0;
   }
 
   .border-t {
@@ -1969,10 +1965,6 @@
     }
   }
 
-  .border-l-brand-blue {
-    border-left-color: var(--brand-blue);
-  }
-
   .bg-\[\#0f172a\] {
     background-color: #0f172a;
   }
@@ -2011,6 +2003,10 @@
     .bg-amber-50\/60 {
       background-color: color-mix(in oklab, var(--color-amber-50) 60%, transparent);
     }
+  }
+
+  .bg-amber-100 {
+    background-color: var(--color-amber-100);
   }
 
   .bg-amber-200 {
@@ -2139,17 +2135,7 @@
     }
   }
 
-  .bg-brand-blue, .bg-brand-blue\/5 {
-    background-color: var(--brand-blue);
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    .bg-brand-blue\/5 {
-      background-color: color-mix(in oklab, var(--brand-blue) 5%, transparent);
-    }
-  }
-
-  .bg-brand-blue\/10 {
+  .bg-brand-blue, .bg-brand-blue\/10 {
     background-color: var(--brand-blue);
   }
 
@@ -2473,6 +2459,10 @@
 
   .bg-green-50 {
     background-color: var(--color-green-50);
+  }
+
+  .bg-orange-50 {
+    background-color: var(--color-orange-50);
   }
 
   .bg-purple-50\/60 {
@@ -3381,6 +3371,10 @@
     color: hsl(var(--accent));
   }
 
+  .text-amber-500 {
+    color: var(--color-amber-500);
+  }
+
   .text-amber-600 {
     color: var(--color-amber-600);
   }
@@ -3537,6 +3531,14 @@
 
   .text-muted-foreground {
     color: hsl(var(--muted-foreground));
+  }
+
+  .text-orange-400 {
+    color: var(--color-orange-400);
+  }
+
+  .text-orange-700 {
+    color: var(--color-orange-700);
   }
 
   .text-purple-700 {
@@ -3797,8 +3799,16 @@
     --tw-ring-color: var(--color-green-200);
   }
 
+  .ring-orange-200 {
+    --tw-ring-color: var(--color-orange-200);
+  }
+
   .ring-slate-100 {
     --tw-ring-color: var(--color-slate-100);
+  }
+
+  .ring-slate-200 {
+    --tw-ring-color: var(--color-slate-200);
   }
 
   .ring-offset-1 {
@@ -4336,10 +4346,6 @@
     }
   }
 
-  .focus\:bg-slate-50:focus {
-    background-color: var(--color-slate-50);
-  }
-
   .focus\:px-4:focus {
     padding-inline: calc(var(--spacing) * 4);
   }
@@ -4497,6 +4503,10 @@
       display: inline;
     }
 
+    .sm\:table-cell {
+      display: table-cell;
+    }
+
     .sm\:grid-cols-2 {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -4611,6 +4621,10 @@
       display: none;
     }
 
+    .md\:table-cell {
+      display: table-cell;
+    }
+
     .md\:grid-cols-2 {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -4663,6 +4677,10 @@
 
     .lg\:hidden {
       display: none;
+    }
+
+    .lg\:table-cell {
+      display: table-cell;
     }
 
     .lg\:grid-cols-1 {


### PR DESCRIPTION
## Changes

- **Fix evidence detail data**: Added `scanner_evidence` and `diff_summary` to `GuardReceipt` type. Redesigned detail panel to show scanner findings with severity badges, titles, plain reasons, technical details, detector info, and false positive hints.
- **Sortable table**: Replaced the vertical action list with a proper HTML table featuring sortable column headers (Artifact, App, Category, Decision, Time). Responsive columns hide on smaller screens.
- **Unified tabs**: Replaced custom `ViewTabBar` with shared `TabBar` component (same as Trust Center) for consistent tab styling across the app.
- **Tab-specific filters**: Moved `EvidenceFilterBar` to only appear inside the "All Actions" tab, since filters only apply to that view.
- **Type safety**: Fixed `plain-english.ts` casts to go through `unknown` first.

## Verification
- Build: ✅
- Evidence tests: ✅ (all 10 test suites pass)
- Workspace tests: ✅

Fixes generic "OpenCode did something with bash" detail by surfacing actual scanner evidence from local DB.