### PR TITLE
feat(evidence): redesign Insights, Apps, Categories tabs; remove Story tab

### DIFF
--- a/dashboard/src/evidence/app-tab.tsx
+++ b/dashboard/src/evidence/app-tab.tsx
@@ -158,6 +158,12 @@ function AppTabRaw({ receipts }: AppTabProps) {
     return items;
   }, [apps, selectedApp, decisionFilter, categoryFilter]);
 
+  const categories = useMemo(() => {
+    if (!selectedApp) return [];
+    const allItems = apps.find(([h]) => h === selectedApp)?.[1] ?? [];
+    return Array.from(new Set(allItems.map((r) => detectCategory(r))));
+  }, [apps, selectedApp]);
+
   if (appReceipts.length === 0) {
     return (
       <div className="py-12 text-center">
@@ -172,8 +178,6 @@ function AppTabRaw({ receipts }: AppTabProps) {
     const allowed = allItems.filter((r) => r.policy_decision === "allow").length;
     const blocked = allItems.filter((r) => r.policy_decision === "block").length;
     const color = harnessColor(selectedApp);
-
-    const categories = Array.from(new Set(allItems.map((r) => detectCategory(r))));
 
     return (
       <div className="space-y-5">

--- a/dashboard/src/evidence/app-tab.tsx
+++ b/dashboard/src/evidence/app-tab.tsx
@@ -3,11 +3,15 @@ import {
   HiMiniChevronRight,
   HiMiniChevronLeft,
   HiMiniArrowTopRightOnSquare,
+  HiMiniFunnel,
+  HiMiniShieldCheck,
+  HiMiniNoSymbol,
+  HiMiniQuestionMarkCircle,
 } from "react-icons/hi2";
 import type { GuardReceipt } from "../guard-types";
-import { harnessDisplayName, isDisplayableHarness } from "../approval-center-utils";
-import { plainEnglishDescription } from "./plain-english";
-import { formatRelativeTime } from "../approval-center-utils";
+import { harnessDisplayName, isDisplayableHarness, formatRelativeTime } from "../approval-center-utils";
+import { plainEnglishDescription, humanFileName } from "./plain-english";
+import { detectCategory, getCategoryInfo } from "./categories";
 import { guardAwareHref } from "../guard-api";
 
 interface AppTabProps {
@@ -32,13 +36,38 @@ function harnessColor(harness: string): string {
   return `hsl(${hue} 70% 45%)`;
 }
 
-interface AppListRowProps {
+function DecisionBadge({ decision }: { decision: string }) {
+  if (decision === "allow") {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-[10px] font-semibold text-green-700 ring-1 ring-green-200">
+        <HiMiniShieldCheck className="h-3 w-3" aria-hidden="true" />
+        Allowed
+      </span>
+    );
+  }
+  if (decision === "block") {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700 ring-1 ring-amber-200">
+        <HiMiniNoSymbol className="h-3 w-3" aria-hidden="true" />
+        Stopped
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-700 ring-1 ring-blue-200">
+      <HiMiniQuestionMarkCircle className="h-3 w-3" aria-hidden="true" />
+      Reviewed
+    </span>
+  );
+}
+
+interface AppListCardProps {
   harness: string;
   items: GuardReceipt[];
   onSelect: (harness: string) => void;
 }
 
-function AppListRow({ harness, items, onSelect }: AppListRowProps) {
+function AppListCard({ harness, items, onSelect }: AppListCardProps) {
   const allowed = items.filter((r) => r.policy_decision === "allow").length;
   const blocked = items.filter((r) => r.policy_decision === "block").length;
   const lastActive = items[0]?.timestamp;
@@ -48,17 +77,17 @@ function AppListRow({ harness, items, onSelect }: AppListRowProps) {
   return (
     <button
       onClick={handleClick}
-      className="flex w-full items-center justify-between gap-3 py-2.5 text-left transition-colors hover:bg-slate-50/50 rounded-lg px-2 -mx-2"
+      className="w-full rounded-2xl border border-slate-200 bg-white p-4 text-left transition-all hover:shadow-md hover:border-slate-300"
     >
-      <div className="flex items-center gap-2.5 min-w-0">
+      <div className="flex items-center gap-3">
         <span
-          className="inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold text-white shrink-0"
+          className="inline-flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white shrink-0"
           style={{ backgroundColor: color }}
         >
           {harness[0]?.toUpperCase()}
         </span>
-        <div className="min-w-0">
-          <p className="text-sm font-medium text-brand-dark truncate">{harnessDisplayName(harness)}</p>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-brand-dark truncate">{harnessDisplayName(harness)}</p>
           <p className="text-xs text-slate-500">
             {items.length} actions · {allowed} allowed · {blocked} stopped
           </p>
@@ -66,8 +95,8 @@ function AppListRow({ harness, items, onSelect }: AppListRowProps) {
             <p className="text-xs text-slate-400">Last active {formatRelativeTime(lastActive)}</p>
           )}
         </div>
+        <HiMiniChevronRight className="h-4 w-4 text-slate-300 shrink-0" aria-hidden="true" />
       </div>
-      <HiMiniChevronRight className="h-4 w-4 text-slate-300 shrink-0" aria-hidden="true" />
     </button>
   );
 }
@@ -75,7 +104,13 @@ function AppListRow({ harness, items, onSelect }: AppListRowProps) {
 function AppTabRaw({ receipts }: AppTabProps) {
   const [selectedApp, setSelectedApp] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const appReceipts = useMemo(() => receipts.filter((receipt) => isDisplayableHarness(receipt.harness)), [receipts]);
+  const [decisionFilter, setDecisionFilter] = useState<string>("all");
+  const [categoryFilter, setCategoryFilter] = useState<string>("");
+
+  const appReceipts = useMemo(
+    () => receipts.filter((receipt) => isDisplayableHarness(receipt.harness)),
+    [receipts]
+  );
 
   const apps = useMemo(() => {
     const map = new Map<string, GuardReceipt[]>();
@@ -99,8 +134,29 @@ function AppTabRaw({ receipts }: AppTabProps) {
     setSearchTerm(e.target.value);
   }, []);
 
-  const handleBack = useCallback(() => setSelectedApp(null), []);
-  const handleSelectApp = useCallback((h: string) => setSelectedApp(h), []);
+  const handleBack = useCallback(() => {
+    setSelectedApp(null);
+    setDecisionFilter("all");
+    setCategoryFilter("");
+  }, []);
+
+  const handleSelectApp = useCallback((h: string) => {
+    setSelectedApp(h);
+    setDecisionFilter("all");
+    setCategoryFilter("");
+  }, []);
+
+  const selectedItems = useMemo(() => {
+    if (!selectedApp) return [];
+    let items = apps.find(([h]) => h === selectedApp)?.[1] ?? [];
+    if (decisionFilter !== "all") {
+      items = items.filter((r) => r.policy_decision === decisionFilter);
+    }
+    if (categoryFilter) {
+      items = items.filter((r) => detectCategory(r) === categoryFilter);
+    }
+    return items;
+  }, [apps, selectedApp, decisionFilter, categoryFilter]);
 
   if (appReceipts.length === 0) {
     return (
@@ -112,10 +168,12 @@ function AppTabRaw({ receipts }: AppTabProps) {
   }
 
   if (selectedApp) {
-    const items = apps.find(([h]) => h === selectedApp)?.[1] ?? [];
-    const allowed = items.filter((r) => r.policy_decision === "allow").length;
-    const blocked = items.filter((r) => r.policy_decision === "block").length;
+    const allItems = apps.find(([h]) => h === selectedApp)?.[1] ?? [];
+    const allowed = allItems.filter((r) => r.policy_decision === "allow").length;
+    const blocked = allItems.filter((r) => r.policy_decision === "block").length;
     const color = harnessColor(selectedApp);
+
+    const categories = Array.from(new Set(allItems.map((r) => detectCategory(r))));
 
     return (
       <div className="space-y-5">
@@ -138,45 +196,116 @@ function AppTabRaw({ receipts }: AppTabProps) {
           </a>
         </div>
 
-        <div className="flex items-center gap-3">
-          <span
-            className="inline-flex h-9 w-9 items-center justify-center rounded-full text-xs font-bold text-white"
-            style={{ backgroundColor: color }}
-          >
-            {selectedApp[0]?.toUpperCase()}
-          </span>
-          <div>
-            <h2 className="text-base font-semibold text-brand-dark">{harnessDisplayName(selectedApp)}</h2>
-            <p className="text-xs text-slate-500">
-              {items.length} action{items.length !== 1 ? "s" : ""} · {allowed} allowed · {blocked} stopped
-            </p>
-          </div>
-        </div>
-
-        <AppSparkline items={items} />
-
-        <div className="space-y-0 divide-y divide-slate-100/60">
-          {items.map((receipt) => (
-            <div
-              key={receipt.receipt_id}
-              className="flex items-start justify-between gap-3 py-2"
+        <div className="rounded-2xl border border-slate-200 bg-white p-5">
+          <div className="flex items-center gap-3">
+            <span
+              className="inline-flex h-12 w-12 items-center justify-center rounded-full text-sm font-bold text-white"
+              style={{ backgroundColor: color }}
             >
-              <div className="min-w-0 flex-1">
-                <p className="text-sm text-brand-dark">{plainEnglishDescription(receipt)}</p>
-                <p className="mt-0.5 text-xs text-slate-400">{formatRelativeTime(receipt.timestamp)}</p>
-              </div>
-              <span className={`shrink-0 text-xs font-medium ${receipt.policy_decision === "allow" ? "text-emerald-500" : "text-brand-attention"}`}>
-                {receipt.policy_decision === "allow" ? "Allowed" : "Stopped"}
-              </span>
+              {selectedApp[0]?.toUpperCase()}
+            </span>
+            <div>
+              <h2 className="text-base font-semibold text-brand-dark">{harnessDisplayName(selectedApp)}</h2>
+              <p className="text-xs text-slate-500">
+                {allItems.length} action{allItems.length !== 1 ? "s" : ""} · {allowed} allowed · {blocked} stopped
+              </p>
             </div>
-          ))}
+          </div>
+
+          <AppSparkline items={allItems} />
         </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-1.5 text-xs text-slate-500">
+            <HiMiniFunnel className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>Filter:</span>
+          </div>
+          <select
+            value={decisionFilter}
+            onChange={(e) => setDecisionFilter(e.target.value)}
+            className="min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
+          >
+            <option value="all">All decisions</option>
+            <option value="allow">Allowed</option>
+            <option value="block">Stopped</option>
+          </select>
+          <select
+            value={categoryFilter}
+            onChange={(e) => setCategoryFilter(e.target.value)}
+            className="min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
+          >
+            <option value="">All categories</option>
+            {categories.map((cat) => {
+              const info = getCategoryInfo(cat);
+              return (
+                <option key={cat} value={cat}>{info.label}</option>
+              );
+            })}
+          </select>
+          {(decisionFilter !== "all" || categoryFilter) && (
+            <button
+              type="button"
+              onClick={() => { setDecisionFilter("all"); setCategoryFilter(""); }}
+              className="text-xs font-medium text-brand-blue hover:text-brand-dark transition-colors"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        {selectedItems.length === 0 ? (
+          <div className="py-8 text-center">
+            <p className="text-sm text-slate-500">No actions match the selected filters.</p>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" aria-label={`${harnessDisplayName(selectedApp)} actions`}>
+                <thead>
+                  <tr className="border-b border-slate-100 bg-slate-50/60">
+                    <th scope="col" className="w-8 px-3 py-2.5" />
+                    <th scope="col" className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">Artifact</th>
+                    <th scope="col" className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 hidden md:table-cell">Category</th>
+                    <th scope="col" className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">Decision</th>
+                    <th scope="col" className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 hidden lg:table-cell">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selectedItems.map((receipt) => {
+                    const category = detectCategory(receipt);
+                    const catInfo = getCategoryInfo(category);
+                    const artifactLabel = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
+                    return (
+                      <tr key={receipt.receipt_id} className="border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors">
+                        <td className="px-3 py-2.5">
+                          <span className={`${catInfo.color}`} aria-hidden="true">{catInfo.icon}</span>
+                        </td>
+                        <td className="px-3 py-2.5">
+                          <span className="text-sm font-medium text-brand-dark truncate block max-w-[200px]">{artifactLabel}</span>
+                        </td>
+                        <td className="px-3 py-2.5 hidden md:table-cell">
+                          <span className="text-xs text-slate-500">{catInfo.label}</span>
+                        </td>
+                        <td className="px-3 py-2.5">
+                          <DecisionBadge decision={receipt.policy_decision} />
+                        </td>
+                        <td className="px-3 py-2.5 hidden lg:table-cell">
+                          <span className="text-xs text-slate-400 whitespace-nowrap">{formatRelativeTime(receipt.timestamp)}</span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
       </div>
     );
   }
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-4">
       <label className="block">
         <span className="sr-only">Search apps</span>
         <input
@@ -188,9 +317,9 @@ function AppTabRaw({ receipts }: AppTabProps) {
         />
       </label>
 
-      <div className="space-y-0 divide-y divide-slate-100/60">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         {filteredApps.map(([harness, items]) => (
-          <AppListRow
+          <AppListCard
             key={harness}
             harness={harness}
             items={items}
@@ -226,14 +355,15 @@ function AppSparkline({ items }: { items: GuardReceipt[] }) {
   const max = Math.max(...buckets, 1);
 
   return (
-    <div className="py-1">
-      <p className="text-[11px] font-medium text-slate-400">Last 7 days</p>
-      <div className="mt-1 flex h-8 w-full items-end gap-0.5">
+    <div className="mt-4 pt-4 border-t border-slate-100">
+      <p className="text-[11px] font-medium text-slate-400 mb-2">Last 7 days</p>
+      <div className="flex h-10 w-full items-end gap-1">
         {buckets.map((count, i) => (
           <div
             key={i}
-            className="flex-1 rounded-sm bg-brand-blue/30"
-            style={{ height: `${Math.max((count / max) * 100, count > 0 ? 8 : 0)}%` }}
+            className="flex-1 rounded-sm bg-brand-blue/20 transition-all hover:bg-brand-blue/30"
+            style={{ height: `${Math.max((count / max) * 100, count > 0 ? 8 : 4)}%` }}
+            title={`${count} action${count !== 1 ? "s" : ""}`}
           />
         ))}
       </div>

--- a/dashboard/src/evidence/category-tab.tsx
+++ b/dashboard/src/evidence/category-tab.tsx
@@ -1,16 +1,31 @@
 import { useMemo, useState, memo, useCallback } from "react";
-import { HiMiniChevronRight, HiMiniLockClosed, HiMiniGlobeAlt, HiMiniExclamationTriangle, HiMiniEyeSlash, HiMiniDocumentText, HiMiniWrenchScrewdriver, HiMiniCircleStack, HiMiniChevronLeft } from "react-icons/hi2";
+import {
+  HiMiniChevronRight,
+  HiMiniLockClosed,
+  HiMiniGlobeAlt,
+  HiMiniExclamationTriangle,
+  HiMiniEyeSlash,
+  HiMiniDocumentText,
+  HiMiniWrenchScrewdriver,
+  HiMiniCircleStack,
+  HiMiniChevronLeft,
+  HiMiniFunnel,
+  HiMiniShieldCheck,
+  HiMiniNoSymbol,
+  HiMiniQuestionMarkCircle,
+} from "react-icons/hi2";
 import type { GuardReceipt } from "../guard-types";
 import { groupByCategory, getCategoryInfo, type ReceiptCategory, CATEGORIES } from "./categories";
-import { plainEnglishDescription } from "./plain-english";
+import { plainEnglishDescription, humanFileName } from "./plain-english";
 import { formatRelativeTime, harnessDisplayName } from "../approval-center-utils";
+import { detectCategory } from "./categories";
 
 interface CategoryTabProps {
   receipts: GuardReceipt[];
   onFilterCategory?: (category: ReceiptCategory) => void;
 }
 
-const ICON_MAP: Record<ReceiptCategory, React.ReactNode> = {
+const ICON_MAP: Record<string, React.ReactNode> = {
   secret: <HiMiniLockClosed className="h-5 w-5" aria-hidden="true" />,
   network: <HiMiniGlobeAlt className="h-5 w-5" aria-hidden="true" />,
   destructive: <HiMiniExclamationTriangle className="h-5 w-5" aria-hidden="true" />,
@@ -18,15 +33,45 @@ const ICON_MAP: Record<ReceiptCategory, React.ReactNode> = {
   "file-write": <HiMiniDocumentText className="h-5 w-5" aria-hidden="true" />,
   "tool-call": <HiMiniWrenchScrewdriver className="h-5 w-5" aria-hidden="true" />,
   other: <HiMiniCircleStack className="h-5 w-5" aria-hidden="true" />,
+  mcp: <HiMiniWrenchScrewdriver className="h-5 w-5" aria-hidden="true" />,
+  skill: <HiMiniWrenchScrewdriver className="h-5 w-5" aria-hidden="true" />,
+  "supply-chain": <HiMiniCircleStack className="h-5 w-5" aria-hidden="true" />,
+  data: <HiMiniCircleStack className="h-5 w-5" aria-hidden="true" />,
 };
 
-interface CategoryRowProps {
+function DecisionBadge({ decision }: { decision: string }) {
+  if (decision === "allow") {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-[10px] font-semibold text-green-700 ring-1 ring-green-200">
+        <HiMiniShieldCheck className="h-3 w-3" aria-hidden="true" />
+        Allowed
+      </span>
+    );
+  }
+  if (decision === "block") {
+    return (
+      <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700 ring-1 ring-amber-200">
+        <HiMiniNoSymbol className="h-3 w-3" aria-hidden="true" />
+        Stopped
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-700 ring-1 ring-blue-200">
+      <HiMiniQuestionMarkCircle className="h-3 w-3" aria-hidden="true" />
+      Reviewed
+    </span>
+  );
+}
+
+interface CategoryCardProps {
   cat: typeof CATEGORIES[0];
   count: number;
+  blocked: number;
   onSelect: (key: ReceiptCategory) => void;
 }
 
-function CategoryRow({ cat, count, onSelect }: CategoryRowProps) {
+function CategoryCard({ cat, count, blocked, onSelect }: CategoryCardProps) {
   const handleClick = useCallback(() => {
     onSelect(cat.key);
   }, [cat.key, onSelect]);
@@ -35,41 +80,64 @@ function CategoryRow({ cat, count, onSelect }: CategoryRowProps) {
     <button
       key={cat.key}
       onClick={handleClick}
-      className="flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-white p-4 text-left shadow-sm transition-all hover:shadow-md"
+      className="w-full rounded-2xl border border-slate-200 bg-white p-4 text-left transition-all hover:shadow-md hover:border-slate-300"
     >
       <div className="flex items-center gap-3">
         <span className={`inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-50 ${cat.color}`}>
-          {ICON_MAP[cat.key]}
+          {ICON_MAP[cat.key] ?? ICON_MAP.other}
         </span>
-        <div>
-          <p className="text-sm font-medium text-brand-dark">{cat.label}</p>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm font-semibold text-brand-dark">{cat.label}</p>
           <p className="text-xs text-slate-500">{count} action{count !== 1 ? "s" : ""}</p>
         </div>
+        {blocked > 0 && (
+          <span className="text-[10px] font-medium text-amber-600 shrink-0">{blocked} stopped</span>
+        )}
+        <HiMiniChevronRight className="h-4 w-4 text-slate-300 shrink-0" aria-hidden="true" />
       </div>
-      <HiMiniChevronRight className="h-4 w-4 text-slate-300" aria-hidden="true" />
     </button>
   );
 }
 
 function CategoryTabRaw({ receipts, onFilterCategory }: CategoryTabProps) {
   const [selectedCategory, setSelectedCategory] = useState<ReceiptCategory | null>(null);
+  const [decisionFilter, setDecisionFilter] = useState<string>("all");
+  const [harnessFilter, setHarnessFilter] = useState<string>("");
 
   const groups = useMemo(() => groupByCategory(receipts), [receipts]);
 
   const handleBack = useCallback(() => {
     setSelectedCategory(null);
+    setDecisionFilter("all");
+    setHarnessFilter("");
   }, []);
 
   const handleSelectCategory = useCallback((key: ReceiptCategory) => {
     setSelectedCategory(key);
+    setDecisionFilter("all");
+    setHarnessFilter("");
     onFilterCategory?.(key);
   }, [onFilterCategory]);
 
+  const selectedItems = useMemo(() => {
+    if (!selectedCategory) return [];
+    let items = groups.get(selectedCategory) ?? [];
+    if (decisionFilter !== "all") {
+      items = items.filter((r) => r.policy_decision === decisionFilter);
+    }
+    if (harnessFilter) {
+      items = items.filter((r) => r.harness === harnessFilter);
+    }
+    return items;
+  }, [groups, selectedCategory, decisionFilter, harnessFilter]);
+
   if (selectedCategory) {
-    const items = groups.get(selectedCategory) ?? [];
+    const allItems = groups.get(selectedCategory) ?? [];
     const info = getCategoryInfo(selectedCategory);
+    const harnesses = Array.from(new Set(allItems.map((r) => r.harness)));
+
     return (
-      <div className="space-y-6">
+      <div className="space-y-5">
         <button
           onClick={handleBack}
           className="inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-100"
@@ -78,62 +146,125 @@ function CategoryTabRaw({ receipts, onFilterCategory }: CategoryTabProps) {
           Back to categories
         </button>
 
-        <div className="rounded-2xl border border-slate-100 bg-white/60 p-5">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5">
           <div className="flex items-center gap-3">
-            <span className={`inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-50 ${info.color}`}>
-              {ICON_MAP[selectedCategory]}
+            <span className={`inline-flex h-12 w-12 items-center justify-center rounded-full bg-slate-50 ${info.color}`}>
+              {ICON_MAP[selectedCategory] ?? ICON_MAP.other}
             </span>
             <div>
-              <h2 className="text-lg font-semibold text-brand-dark">{info.label}</h2>
-              <p className="text-sm text-slate-500">{info.description}</p>
+              <h2 className="text-base font-semibold text-brand-dark">{info.label}</h2>
+              <p className="text-xs text-slate-500">{info.description}</p>
             </div>
           </div>
-          <p className="mt-4 text-sm text-brand-dark">
-            {items.length} action{items.length !== 1 ? "s" : ""} in this category
+          <p className="mt-3 text-sm text-brand-dark">
+            {allItems.length} action{allItems.length !== 1 ? "s" : ""} in this category
           </p>
         </div>
 
-        <div className="space-y-3">
-          {items.map((receipt) => (
-            <div
-              key={receipt.receipt_id}
-              className="rounded-2xl border border-slate-100 bg-white p-4 shadow-sm"
+        <div className="flex flex-wrap items-center gap-2">
+          <div className="flex items-center gap-1.5 text-xs text-slate-500">
+            <HiMiniFunnel className="h-3.5 w-3.5" aria-hidden="true" />
+            <span>Filter:</span>
+          </div>
+          <select
+            value={decisionFilter}
+            onChange={(e) => setDecisionFilter(e.target.value)}
+            className="min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
+          >
+            <option value="all">All decisions</option>
+            <option value="allow">Allowed</option>
+            <option value="block">Stopped</option>
+          </select>
+          <select
+            value={harnessFilter}
+            onChange={(e) => setHarnessFilter(e.target.value)}
+            className="min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
+          >
+            <option value="">All apps</option>
+            {harnesses.map((h) => (
+              <option key={h} value={h}>{harnessDisplayName(h)}</option>
+            ))}
+          </select>
+          {(decisionFilter !== "all" || harnessFilter) && (
+            <button
+              type="button"
+              onClick={() => { setDecisionFilter("all"); setHarnessFilter(""); }}
+              className="text-xs font-medium text-brand-blue hover:text-brand-dark transition-colors"
             >
-              <div className="flex items-start justify-between gap-3">
-                <div className="min-w-0 flex-1">
-                  <p className="text-sm text-brand-dark">{plainEnglishDescription(receipt)}</p>
-                  <p className="mt-1 text-xs text-slate-400">
-                    {harnessDisplayName(receipt.harness)} · {formatRelativeTime(receipt.timestamp)}
-                  </p>
-                </div>
-                <span className={`shrink-0 text-xs font-medium ${receipt.policy_decision === "allow" ? "text-emerald-600" : "text-brand-attention"}`}>
-                  {receipt.policy_decision === "allow" ? "Allowed" : "Stopped"}
-                </span>
-              </div>
-            </div>
-          ))}
+              Clear filters
+            </button>
+          )}
         </div>
+
+        {selectedItems.length === 0 ? (
+          <div className="py-8 text-center">
+            <p className="text-sm text-slate-500">No actions match the selected filters.</p>
+          </div>
+        ) : (
+          <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm" aria-label={`${info.label} actions`}>
+                <thead>
+                  <tr className="border-b border-slate-100 bg-slate-50/60">
+                    <th scope="col" className="w-8 px-3 py-2.5" />
+                    <th scope="col" className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">Artifact</th>
+                    <th scope="col" className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 hidden md:table-cell">App</th>
+                    <th scope="col" className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500">Decision</th>
+                    <th scope="col" className="px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 hidden lg:table-cell">Time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {selectedItems.map((receipt) => {
+                    const category = detectCategory(receipt);
+                    const catInfo = getCategoryInfo(category);
+                    const artifactLabel = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
+                    return (
+                      <tr key={receipt.receipt_id} className="border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors">
+                        <td className="px-3 py-2.5">
+                          <span className={`${catInfo.color}`} aria-hidden="true">{catInfo.icon}</span>
+                        </td>
+                        <td className="px-3 py-2.5">
+                          <span className="text-sm font-medium text-brand-dark truncate block max-w-[200px]">{artifactLabel}</span>
+                        </td>
+                        <td className="px-3 py-2.5 hidden md:table-cell">
+                          <span className="text-xs text-slate-500">{harnessDisplayName(receipt.harness)}</span>
+                        </td>
+                        <td className="px-3 py-2.5">
+                          <DecisionBadge decision={receipt.policy_decision} />
+                        </td>
+                        <td className="px-3 py-2.5 hidden lg:table-cell">
+                          <span className="text-xs text-slate-400 whitespace-nowrap">{formatRelativeTime(receipt.timestamp)}</span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        )}
       </div>
     );
   }
 
   return (
-    <div className="space-y-4">
+    <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
       {CATEGORIES.map((cat) => {
         const items = groups.get(cat.key) ?? [];
         if (items.length === 0) return null;
         return (
-          <CategoryRow
+          <CategoryCard
             key={cat.key}
             cat={cat}
             count={items.length}
+            blocked={items.filter((r) => r.policy_decision === "block").length}
             onSelect={handleSelectCategory}
           />
         );
       })}
 
       {Array.from(groups.values()).every((items) => items.length === 0) && (
-        <div className="rounded-2xl border border-slate-100 bg-white/60 p-8 text-center">
+        <div className="col-span-full rounded-2xl border border-slate-100 bg-white/60 p-8 text-center">
           <p className="text-sm text-slate-500">No activity yet.</p>
         </div>
       )}

--- a/dashboard/src/evidence/category-tab.tsx
+++ b/dashboard/src/evidence/category-tab.tsx
@@ -1,13 +1,6 @@
 import { useMemo, useState, memo, useCallback } from "react";
 import {
   HiMiniChevronRight,
-  HiMiniLockClosed,
-  HiMiniGlobeAlt,
-  HiMiniExclamationTriangle,
-  HiMiniEyeSlash,
-  HiMiniDocumentText,
-  HiMiniWrenchScrewdriver,
-  HiMiniCircleStack,
   HiMiniChevronLeft,
   HiMiniFunnel,
   HiMiniShieldCheck,
@@ -15,29 +8,14 @@ import {
   HiMiniQuestionMarkCircle,
 } from "react-icons/hi2";
 import type { GuardReceipt } from "../guard-types";
-import { groupByCategory, getCategoryInfo, type ReceiptCategory, CATEGORIES } from "./categories";
+import { groupByCategory, getCategoryInfo, type ReceiptCategory, CATEGORIES, detectCategory } from "./categories";
 import { plainEnglishDescription, humanFileName } from "./plain-english";
 import { formatRelativeTime, harnessDisplayName } from "../approval-center-utils";
-import { detectCategory } from "./categories";
 
 interface CategoryTabProps {
   receipts: GuardReceipt[];
   onFilterCategory?: (category: ReceiptCategory) => void;
 }
-
-const ICON_MAP: Record<string, React.ReactNode> = {
-  secret: <HiMiniLockClosed className="h-5 w-5" aria-hidden="true" />,
-  network: <HiMiniGlobeAlt className="h-5 w-5" aria-hidden="true" />,
-  destructive: <HiMiniExclamationTriangle className="h-5 w-5" aria-hidden="true" />,
-  hidden: <HiMiniEyeSlash className="h-5 w-5" aria-hidden="true" />,
-  "file-write": <HiMiniDocumentText className="h-5 w-5" aria-hidden="true" />,
-  "tool-call": <HiMiniWrenchScrewdriver className="h-5 w-5" aria-hidden="true" />,
-  other: <HiMiniCircleStack className="h-5 w-5" aria-hidden="true" />,
-  mcp: <HiMiniWrenchScrewdriver className="h-5 w-5" aria-hidden="true" />,
-  skill: <HiMiniWrenchScrewdriver className="h-5 w-5" aria-hidden="true" />,
-  "supply-chain": <HiMiniCircleStack className="h-5 w-5" aria-hidden="true" />,
-  data: <HiMiniCircleStack className="h-5 w-5" aria-hidden="true" />,
-};
 
 function DecisionBadge({ decision }: { decision: string }) {
   if (decision === "allow") {
@@ -84,7 +62,7 @@ function CategoryCard({ cat, count, blocked, onSelect }: CategoryCardProps) {
     >
       <div className="flex items-center gap-3">
         <span className={`inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-50 ${cat.color}`}>
-          {ICON_MAP[cat.key] ?? ICON_MAP.other}
+          {cat.icon}
         </span>
         <div className="flex-1 min-w-0">
           <p className="text-sm font-semibold text-brand-dark">{cat.label}</p>
@@ -131,10 +109,15 @@ function CategoryTabRaw({ receipts, onFilterCategory }: CategoryTabProps) {
     return items;
   }, [groups, selectedCategory, decisionFilter, harnessFilter]);
 
+  const harnesses = useMemo(() => {
+    if (!selectedCategory) return [];
+    const allItems = groups.get(selectedCategory) ?? [];
+    return Array.from(new Set(allItems.map((r) => r.harness)));
+  }, [groups, selectedCategory]);
+
   if (selectedCategory) {
     const allItems = groups.get(selectedCategory) ?? [];
     const info = getCategoryInfo(selectedCategory);
-    const harnesses = Array.from(new Set(allItems.map((r) => r.harness)));
 
     return (
       <div className="space-y-5">
@@ -149,7 +132,7 @@ function CategoryTabRaw({ receipts, onFilterCategory }: CategoryTabProps) {
         <div className="rounded-2xl border border-slate-200 bg-white p-5">
           <div className="flex items-center gap-3">
             <span className={`inline-flex h-12 w-12 items-center justify-center rounded-full bg-slate-50 ${info.color}`}>
-              {ICON_MAP[selectedCategory] ?? ICON_MAP.other}
+              {info.icon}
             </span>
             <div>
               <h2 className="text-base font-semibold text-brand-dark">{info.label}</h2>

--- a/dashboard/src/evidence/evidence-analytics-panel.tsx
+++ b/dashboard/src/evidence/evidence-analytics-panel.tsx
@@ -10,6 +10,14 @@ interface EvidenceAnalyticsPanelProps {
   onFilterCategory: (category: string) => void;
 }
 
+const TONE_STYLES: Record<string, { bg: string; text: string; accent: string }> = {
+  blue: { bg: "bg-brand-blue/[0.04]", text: "text-brand-blue", accent: "bg-brand-blue" },
+  green: { bg: "bg-emerald-50", text: "text-emerald-700", accent: "bg-emerald-500" },
+  amber: { bg: "bg-amber-50", text: "text-amber-700", accent: "bg-amber-500" },
+  purple: { bg: "bg-purple-50", text: "text-purple-700", accent: "bg-purple-500" },
+  slate: { bg: "bg-slate-50", text: "text-slate-700", accent: "bg-slate-500" },
+};
+
 function StatCard({
   label,
   value,
@@ -21,14 +29,7 @@ function StatCard({
   subtext?: string;
   tone: "blue" | "green" | "amber" | "purple" | "slate";
 }) {
-  const toneStyles: Record<string, { bg: string; text: string; accent: string }> = {
-    blue: { bg: "bg-brand-blue/[0.04]", text: "text-brand-blue", accent: "bg-brand-blue" },
-    green: { bg: "bg-emerald-50", text: "text-emerald-700", accent: "bg-emerald-500" },
-    amber: { bg: "bg-amber-50", text: "text-amber-700", accent: "bg-amber-500" },
-    purple: { bg: "bg-purple-50", text: "text-purple-700", accent: "bg-purple-500" },
-    slate: { bg: "bg-slate-50", text: "text-slate-700", accent: "bg-slate-500" },
-  };
-  const style = toneStyles[tone];
+  const style = TONE_STYLES[tone];
 
   return (
     <div className={`rounded-2xl ${style.bg} p-5`}>

--- a/dashboard/src/evidence/evidence-analytics-panel.tsx
+++ b/dashboard/src/evidence/evidence-analytics-panel.tsx
@@ -10,185 +10,214 @@ interface EvidenceAnalyticsPanelProps {
   onFilterCategory: (category: string) => void;
 }
 
-interface TrendBarProps {
-  bucket: TrendBucket;
-  maxTotal: number;
-}
-
-function TrendBar({ bucket, maxTotal }: TrendBarProps) {
-  const total = bucket.allowed + bucket.blocked + bucket.reviewed;
-  const heightPct = maxTotal > 0 ? Math.max(4, (total / maxTotal) * 100) : 4;
-  const blockedPct = total > 0 ? (bucket.blocked / total) * 100 : 0;
-  const allowedPct = total > 0 ? (bucket.allowed / total) * 100 : 0;
+function StatCard({
+  label,
+  value,
+  subtext,
+  tone,
+}: {
+  label: string;
+  value: string;
+  subtext?: string;
+  tone: "blue" | "green" | "amber" | "purple" | "slate";
+}) {
+  const toneStyles: Record<string, { bg: string; text: string; accent: string }> = {
+    blue: { bg: "bg-brand-blue/[0.04]", text: "text-brand-blue", accent: "bg-brand-blue" },
+    green: { bg: "bg-emerald-50", text: "text-emerald-700", accent: "bg-emerald-500" },
+    amber: { bg: "bg-amber-50", text: "text-amber-700", accent: "bg-amber-500" },
+    purple: { bg: "bg-purple-50", text: "text-purple-700", accent: "bg-purple-500" },
+    slate: { bg: "bg-slate-50", text: "text-slate-700", accent: "bg-slate-500" },
+  };
+  const style = toneStyles[tone];
 
   return (
-    <div className="flex flex-col items-center gap-1 flex-1 min-w-0">
-      <div
-        className="w-full rounded-sm overflow-hidden flex flex-col-reverse bg-slate-100"
-        style={{ height: 48 }}
-        aria-label={`${bucket.label}: ${total} actions`}
-      >
-        <div
-          className="w-full bg-emerald-300 transition-all"
-          style={{ height: `${heightPct * (allowedPct / 100)}%` }}
-          aria-hidden="true"
-        />
-        {bucket.blocked > 0 && (
-          <div
-            className="w-full bg-amber-400 transition-all"
-            style={{ height: `${heightPct * (blockedPct / 100)}%` }}
-            aria-hidden="true"
-          />
-        )}
-      </div>
-      <span className="text-[10px] text-slate-400 truncate w-full text-center">
-        {bucket.label}
-      </span>
+    <div className={`rounded-2xl ${style.bg} p-5`}>
+      <p className={`text-[11px] font-semibold uppercase tracking-wider ${style.text} opacity-70`}>
+        {label}
+      </p>
+      <p className={`mt-1 text-3xl font-bold tabular-nums ${style.text}`}>{value}</p>
+      {subtext && <p className="mt-1 text-xs text-slate-500">{subtext}</p>}
     </div>
   );
 }
 
-interface AppBreakdownRowProps {
-  harness: string;
-  total: number;
-  blocked: number;
-  maxTotal: number;
-  onFilter: (harness: string) => void;
+function TrendChart({ buckets }: { buckets: TrendBucket[] }) {
+  const maxTotal = Math.max(...buckets.map((b) => b.allowed + b.blocked + b.reviewed), 1);
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-4">
+        7-Day Activity
+      </p>
+      <div className="flex items-end gap-2 h-40">
+        {buckets.map((bucket) => {
+          const total = bucket.allowed + bucket.blocked + bucket.reviewed;
+          const heightPct = maxTotal > 0 ? (total / maxTotal) * 100 : 0;
+          const blockedHeight = total > 0 ? (bucket.blocked / total) * heightPct : 0;
+          const allowedHeight = total > 0 ? (bucket.allowed / total) * heightPct : 0;
+
+          return (
+            <div key={bucket.dateKey} className="flex-1 flex flex-col items-center gap-1.5 min-w-0">
+              <div className="w-full flex-1 flex items-end rounded-lg overflow-hidden bg-slate-50">
+                <div className="w-full flex flex-col-reverse">
+                  {bucket.blocked > 0 && (
+                    <div
+                      className="w-full bg-amber-400 rounded-b-sm"
+                      style={{ height: `${Math.max(blockedHeight, 2)}%` }}
+                    />
+                  )}
+                  {bucket.allowed > 0 && (
+                    <div
+                      className="w-full bg-emerald-400"
+                      style={{ height: `${Math.max(allowedHeight, 2)}%` }}
+                    />
+                  )}
+                  {bucket.reviewed > 0 && (
+                    <div
+                      className="w-full bg-brand-blue rounded-t-sm"
+                      style={{
+                        height: `${Math.max(heightPct - blockedHeight - allowedHeight, 2)}%`,
+                      }}
+                    />
+                  )}
+                </div>
+              </div>
+              <span className="text-[10px] text-slate-400 truncate w-full text-center">
+                {bucket.label}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+      <div className="mt-3 flex items-center gap-4 text-[11px] text-slate-500">
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full bg-emerald-400" />
+          Allowed
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full bg-amber-400" />
+          Stopped
+        </span>
+        <span className="flex items-center gap-1.5">
+          <span className="inline-block h-2 w-2 rounded-full bg-brand-blue" />
+          Reviewed
+        </span>
+      </div>
+    </div>
+  );
 }
 
-function AppBreakdownRow({
+function PeriodComparisonCard({ comparison, label }: { comparison: PeriodComparison; label: string }) {
+  const blockedDeltaSign = comparison.blockedDelta > 0 ? "+" : "";
+  const totalDeltaSign = comparison.totalDelta > 0 ? "+" : "";
+  const blockedColor = comparison.blockedDelta > 0 ? "text-amber-600" : comparison.blockedDelta < 0 ? "text-emerald-600" : "text-slate-400";
+  const totalColor = comparison.totalDelta > 0 ? "text-brand-blue" : comparison.totalDelta < 0 ? "text-slate-400" : "text-slate-400";
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-5">
+      <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-3">
+        {label}
+      </p>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <p className="text-2xl font-bold text-brand-dark tabular-nums">{comparison.currentTotal}</p>
+          <p className="text-xs text-slate-500 mt-0.5">Total actions</p>
+          <p className={`text-xs font-medium mt-1 ${totalColor}`}>
+            {totalDeltaSign}{comparison.totalDelta} from prior period
+          </p>
+        </div>
+        <div>
+          <p className="text-2xl font-bold text-brand-dark tabular-nums">{comparison.currentBlocked}</p>
+          <p className="text-xs text-slate-500 mt-0.5">Stopped</p>
+          <p className={`text-xs font-medium mt-1 ${blockedColor}`}>
+            {blockedDeltaSign}{comparison.blockedDelta} from prior period
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function AppBreakdownCard({
   harness,
   total,
   blocked,
+  allowed,
   maxTotal,
   onFilter,
-}: AppBreakdownRowProps) {
+}: {
+  harness: string;
+  total: number;
+  blocked: number;
+  allowed: number;
+  maxTotal: number;
+  onFilter: (harness: string) => void;
+}) {
   const pct = maxTotal > 0 ? (total / maxTotal) * 100 : 0;
-
-  const handleClick = useCallback(() => {
-    onFilter(harness);
-  }, [harness, onFilter]);
+  const handleClick = useCallback(() => onFilter(harness), [harness, onFilter]);
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      aria-label={`Filter by app ${harnessDisplayName(harness)}`}
-      className="w-full flex items-center gap-3 px-2 py-1.5 rounded-lg hover:bg-slate-50 transition-colors text-left"
+      className="w-full rounded-xl border border-slate-200 bg-white p-4 text-left transition-all hover:shadow-md hover:border-slate-300"
     >
-      <span className="text-sm font-medium text-brand-dark w-28 shrink-0 truncate">
-        {harnessDisplayName(harness)}
-      </span>
-      <div className="flex-1 bg-slate-100 rounded-full h-1.5 overflow-hidden">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-semibold text-brand-dark">{harnessDisplayName(harness)}</span>
+        <span className="text-xs tabular-nums text-slate-500">{total} actions</span>
+      </div>
+      <div className="w-full bg-slate-100 rounded-full h-2 overflow-hidden mb-2">
         <div
-          className="bg-brand-blue h-1.5 rounded-full transition-all"
+          className="bg-brand-blue h-2 rounded-full transition-all"
           style={{ width: `${pct}%` }}
-          aria-hidden="true"
         />
       </div>
-      <span className="text-xs tabular-nums text-slate-500 shrink-0 w-6 text-right">{total}</span>
-      {blocked > 0 && (
-        <span className="text-[10px] font-medium text-brand-attention shrink-0">
-          {blocked} blocked
-        </span>
-      )}
+      <div className="flex items-center gap-3 text-[11px] text-slate-500">
+        <span className="text-emerald-600">{allowed} allowed</span>
+        {blocked > 0 && <span className="text-amber-600">{blocked} stopped</span>}
+      </div>
     </button>
   );
 }
 
-interface CategoryBreakdownRowProps {
-  categoryKey: string;
-  total: number;
-  blocked: number;
-  maxTotal: number;
-  onFilter: (category: string) => void;
-}
-
-function CategoryBreakdownRow({
+function CategoryBreakdownCard({
   categoryKey,
   total,
   blocked,
   maxTotal,
   onFilter,
-}: CategoryBreakdownRowProps) {
+}: {
+  categoryKey: string;
+  total: number;
+  blocked: number;
+  maxTotal: number;
+  onFilter: (category: string) => void;
+}) {
   const pct = maxTotal > 0 ? (total / maxTotal) * 100 : 0;
   const catInfo = getCategoryInfo(categoryKey as ReceiptCategory);
-
-  const handleClick = useCallback(() => {
-    onFilter(categoryKey);
-  }, [categoryKey, onFilter]);
+  const handleClick = useCallback(() => onFilter(categoryKey), [categoryKey, onFilter]);
 
   return (
     <button
       type="button"
       onClick={handleClick}
-      aria-label={`Filter by category ${catInfo.label}`}
-      className="w-full flex items-center gap-3 px-2 py-1.5 rounded-lg hover:bg-slate-50 transition-colors text-left"
+      className="w-full rounded-xl border border-slate-200 bg-white p-4 text-left transition-all hover:shadow-md hover:border-slate-300"
     >
-      <span className={`shrink-0 ${catInfo.color}`} aria-hidden="true">
-        {catInfo.icon}
-      </span>
-      <span className="text-sm font-medium text-brand-dark w-24 shrink-0 truncate">
-        {catInfo.label}
-      </span>
-      <div className="flex-1 bg-slate-100 rounded-full h-1.5 overflow-hidden">
+      <div className="flex items-center gap-3 mb-2">
+        <span className={`${catInfo.color}`} aria-hidden="true">{catInfo.icon}</span>
+        <span className="text-sm font-semibold text-brand-dark">{catInfo.label}</span>
+        <span className="ml-auto text-xs tabular-nums text-slate-500">{total} actions</span>
+      </div>
+      <div className="w-full bg-slate-100 rounded-full h-2 overflow-hidden mb-2">
         <div
-          className="bg-brand-purple h-1.5 rounded-full transition-all"
+          className="bg-purple-500 h-2 rounded-full transition-all"
           style={{ width: `${pct}%` }}
-          aria-hidden="true"
         />
       </div>
-      <span className="text-xs tabular-nums text-slate-500 shrink-0 w-6 text-right">{total}</span>
       {blocked > 0 && (
-        <span className="text-[10px] font-medium text-brand-attention shrink-0">
-          {blocked} blocked
-        </span>
+        <p className="text-[11px] text-amber-600">{blocked} stopped</p>
       )}
     </button>
-  );
-}
-
-interface SectionHeadingProps {
-  children: React.ReactNode;
-}
-
-function SectionHeading({ children }: SectionHeadingProps) {
-  return (
-    <h3 className="text-[11px] font-semibold uppercase tracking-wide text-slate-400 px-2">
-      {children}
-    </h3>
-  );
-}
-
-interface PeriodComparisonCardProps {
-  comparison: PeriodComparison;
-  label: string;
-}
-
-function PeriodComparisonCard({ comparison, label }: PeriodComparisonCardProps) {
-  const blockedDeltaSign = comparison.blockedDelta > 0 ? "+" : "";
-  const totalDeltaSign = comparison.totalDelta > 0 ? "+" : "";
-  let blockedColor = "text-slate-400";
-  if (comparison.blockedDelta > 0) {
-    blockedColor = "text-brand-attention";
-  } else if (comparison.blockedDelta < 0) {
-    blockedColor = "text-emerald-600";
-  }
-
-  return (
-    <div className="rounded-xl bg-slate-50 px-3 py-2.5 space-y-1">
-      <p className="text-[11px] font-semibold uppercase tracking-wide text-slate-400">{label}</p>
-      <div className="flex items-baseline gap-3">
-        <span className="text-sm font-medium text-brand-dark tabular-nums">
-          {comparison.currentTotal} actions
-          <span className="ml-1.5 text-xs text-slate-400">({totalDeltaSign}{comparison.totalDelta})</span>
-        </span>
-        <span className={`text-xs font-medium tabular-nums ${blockedColor}`}>
-          {comparison.currentBlocked} stopped
-          <span className="ml-1">({blockedDeltaSign}{comparison.blockedDelta})</span>
-        </span>
-      </div>
-    </div>
   );
 }
 
@@ -197,11 +226,6 @@ export function EvidenceAnalyticsPanel({
   onFilterHarness,
   onFilterCategory,
 }: EvidenceAnalyticsPanelProps) {
-  const maxBucketTotal = Math.max(
-    ...metrics.trendBuckets.map((b) => b.allowed + b.blocked),
-    1
-  );
-
   const sortedHarnesses = Array.from(metrics.byHarness.entries()).sort(
     (a, b) => b[1].total - a[1].total
   );
@@ -212,58 +236,49 @@ export function EvidenceAnalyticsPanel({
   );
   const maxCatTotal = sortedCategories[0]?.[1].total ?? 1;
 
+  const appCount = metrics.byHarness.size;
+  const catCount = metrics.byCategory.size;
+  const stopRate = metrics.total > 0 ? Math.round((metrics.blocked / metrics.total) * 100) : 0;
+
   if (metrics.total === 0) {
     return (
       <div className="flex flex-col items-center justify-center py-16 text-center">
         <p className="text-sm font-medium text-brand-dark">No data yet</p>
-        <p className="mt-1 text-xs text-slate-500">
-          Insights will appear once actions are recorded.
-        </p>
+        <p className="mt-1 text-xs text-slate-500">Insights will appear once actions are recorded.</p>
       </div>
     );
   }
 
   return (
     <div className="space-y-6">
-      <div className="space-y-2">
-        <SectionHeading>7-day trend</SectionHeading>
-        <div className="flex items-end gap-1.5 px-2 pt-1">
-          {metrics.trendBuckets.map((bucket) => (
-            <TrendBar
-              key={bucket.dateKey}
-              bucket={bucket}
-              maxTotal={maxBucketTotal}
-            />
-          ))}
-        </div>
-        <div className="flex items-center gap-3 px-2 text-[11px] text-slate-400">
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-sm bg-emerald-300" aria-hidden="true" />
-            Allowed
-          </span>
-          <span className="flex items-center gap-1">
-            <span className="inline-block h-2 w-2 rounded-sm bg-amber-400" aria-hidden="true" />
-            Stopped
-          </span>
-        </div>
+      <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+        <StatCard label="Total Actions" value={String(metrics.total)} tone="blue" />
+        <StatCard label="Stopped" value={String(metrics.blocked)} tone="amber" subtext={`${stopRate}% of total`} />
+        <StatCard label="Allowed" value={String(metrics.allowed)} tone="green" />
+        <StatCard label="Apps Seen" value={String(appCount)} tone="purple" />
+        <StatCard label="Categories" value={String(catCount)} tone="slate" />
       </div>
 
-      <div className="space-y-2">
-        <SectionHeading>Period comparison</SectionHeading>
-        <PeriodComparisonCard comparison={metrics.periodComparison7d} label="vs. prior 7 days" />
-        <PeriodComparisonCard comparison={metrics.periodComparison30d} label="vs. prior 30 days" />
+      <TrendChart buckets={metrics.trendBuckets} />
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+        <PeriodComparisonCard comparison={metrics.periodComparison7d} label="vs. Prior 7 Days" />
+        <PeriodComparisonCard comparison={metrics.periodComparison30d} label="vs. Prior 30 Days" />
       </div>
 
       {sortedHarnesses.length > 0 && (
-        <div className="space-y-1">
-          <SectionHeading>By app</SectionHeading>
-          <div className="space-y-0.5">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-3 px-1">
+            By App
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {sortedHarnesses.map(([harness, counts]) => (
-              <AppBreakdownRow
+              <AppBreakdownCard
                 key={harness}
                 harness={harness}
                 total={counts.total}
                 blocked={counts.blocked}
+                allowed={counts.allowed}
                 maxTotal={maxHarnessTotal}
                 onFilter={onFilterHarness}
               />
@@ -273,11 +288,13 @@ export function EvidenceAnalyticsPanel({
       )}
 
       {sortedCategories.length > 0 && (
-        <div className="space-y-1">
-          <SectionHeading>By category</SectionHeading>
-          <div className="space-y-0.5">
+        <div>
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-3 px-1">
+            By Category
+          </p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
             {sortedCategories.map(([cat, counts]) => (
-              <CategoryBreakdownRow
+              <CategoryBreakdownCard
                 key={cat}
                 categoryKey={cat}
                 total={counts.total}
@@ -291,23 +308,21 @@ export function EvidenceAnalyticsPanel({
       )}
 
       {metrics.topRecurring.length > 0 && (
-        <div className="space-y-1">
-          <SectionHeading>Top recurring actions</SectionHeading>
-          <div className="divide-y divide-slate-100/60">
+        <div className="rounded-2xl border border-slate-200 bg-white p-5">
+          <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-3">
+            Top Recurring Actions
+          </p>
+          <div className="divide-y divide-slate-100">
             {metrics.topRecurring.slice(0, 5).map((action) => (
               <div
                 key={action.name}
-                className="flex items-center justify-between px-2 py-1.5"
+                className="flex items-center justify-between py-2.5"
               >
-                <span className="text-sm text-brand-dark truncate">{action.name}</span>
-                <div className="flex items-center gap-2 shrink-0">
-                  <span className="text-xs tabular-nums text-slate-500">
-                    {action.total}×
-                  </span>
+                <span className="text-sm text-brand-dark truncate pr-4">{action.name}</span>
+                <div className="flex items-center gap-3 shrink-0">
+                  <span className="text-xs tabular-nums text-slate-500">{action.total}×</span>
                   {action.blocked > 0 && (
-                    <span className="text-[10px] font-medium text-brand-attention">
-                      {action.blocked} blocked
-                    </span>
+                    <span className="text-[10px] font-medium text-amber-600">{action.blocked} stopped</span>
                   )}
                 </div>
               </div>

--- a/dashboard/src/evidence/evidence-analytics-panel.tsx
+++ b/dashboard/src/evidence/evidence-analytics-panel.tsx
@@ -50,7 +50,7 @@ function TrendChart({ buckets }: { buckets: TrendBucket[] }) {
       <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-4">
         7-Day Activity
       </p>
-      <div className="flex items-end gap-2 h-40">
+      <div className="flex gap-2 h-40">
         {buckets.map((bucket) => {
           const total = bucket.allowed + bucket.blocked + bucket.reviewed;
           const heightPct = maxTotal > 0 ? (total / maxTotal) * 100 : 0;
@@ -58,30 +58,29 @@ function TrendChart({ buckets }: { buckets: TrendBucket[] }) {
           const allowedHeight = total > 0 ? (bucket.allowed / total) * heightPct : 0;
 
           return (
-            <div key={bucket.dateKey} className="flex-1 flex flex-col items-center gap-1.5 min-w-0">
-              <div className="w-full flex-1 flex items-end rounded-lg overflow-hidden bg-slate-50">
-                <div className="w-full flex flex-col-reverse">
-                  {bucket.blocked > 0 && (
-                    <div
-                      className="w-full bg-amber-400 rounded-b-sm"
-                      style={{ height: `${Math.max(blockedHeight, 2)}%` }}
-                    />
-                  )}
-                  {bucket.allowed > 0 && (
-                    <div
-                      className="w-full bg-emerald-400"
-                      style={{ height: `${Math.max(allowedHeight, 2)}%` }}
-                    />
-                  )}
-                  {bucket.reviewed > 0 && (
-                    <div
-                      className="w-full bg-brand-blue rounded-t-sm"
-                      style={{
-                        height: `${Math.max(heightPct - blockedHeight - allowedHeight, 2)}%`,
-                      }}
-                    />
-                  )}
-                </div>
+            <div key={bucket.dateKey} className="flex-1 flex flex-col justify-end gap-1.5 min-w-0">
+              <div className="w-full flex-1 flex flex-col-reverse rounded-lg overflow-hidden bg-slate-50">
+                {bucket.blocked > 0 && (
+                  <div
+                    className="w-full bg-amber-400"
+                    style={{ height: `${Math.max(blockedHeight, 2)}%`, minHeight: total > 0 ? "2%" : "0" }}
+                  />
+                )}
+                {bucket.allowed > 0 && (
+                  <div
+                    className="w-full bg-emerald-400"
+                    style={{ height: `${Math.max(allowedHeight, 2)}%`, minHeight: total > 0 ? "2%" : "0" }}
+                  />
+                )}
+                {bucket.reviewed > 0 && (
+                  <div
+                    className="w-full bg-brand-blue"
+                    style={{
+                      height: `${Math.max(heightPct - blockedHeight - allowedHeight, 2)}%`,
+                      minHeight: total > 0 ? "2%" : "0",
+                    }}
+                  />
+                )}
               </div>
               <span className="text-[10px] text-slate-400 truncate w-full text-center">
                 {bucket.label}

--- a/dashboard/src/evidence/evidence-types.ts
+++ b/dashboard/src/evidence/evidence-types.ts
@@ -2,7 +2,7 @@ export type EvidenceDecision = "allow" | "block" | "ask" | "all";
 export type EvidenceTimeFilter = "all" | "today" | "yesterday" | "week" | "last7d" | "last30d";
 export type EvidenceSortKey = "newest" | "oldest" | "app" | "decision" | "category" | "artifact";
 export type EvidenceExportFormat = "csv" | "json";
-export type EvidenceView = "actions" | "insights" | "apps" | "export" | "story" | "categories";
+export type EvidenceView = "actions" | "insights" | "apps" | "export" | "categories";
 
 export interface EvidenceFilterState {
   search: string;

--- a/dashboard/src/evidence/evidence-view-shell.tsx
+++ b/dashboard/src/evidence/evidence-view-shell.tsx
@@ -4,7 +4,6 @@ export const VIEW_TABS: { key: EvidenceView; label: string }[] = [
   { key: "actions", label: "All actions" },
   { key: "insights", label: "Insights" },
   { key: "apps", label: "Apps" },
-  { key: "story", label: "Story" },
   { key: "categories", label: "Categories" },
   { key: "export", label: "Export" },
 ];

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -27,7 +27,6 @@ import { EvidenceAnalyticsPanel } from "./evidence/evidence-analytics-panel";
 import { EvidenceExportDrawer } from "./evidence/evidence-export-drawer";
 import { EvidenceClearModal } from "./evidence/evidence-clear-modal";
 import { AppTab } from "./evidence/app-tab";
-import { StoryTab } from "./evidence/story-tab";
 import { CategoryTab } from "./evidence/category-tab";
 
 export type ReceiptsState =
@@ -90,7 +89,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
 
   useEffect(() => {
     setPage(0);
-  }, [debouncedSearch, filters.harness, filters.decision, filters.time, filters.day, filters.category, filters.sourceScope]);
+  }, [debouncedSearch, filters.harness, filters.decision, filters.time, filters.category, filters.sourceScope]);
 
   const effectiveFilters = useMemo(
     () => ({ ...filters, search: debouncedSearch }),
@@ -144,10 +143,6 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
   const handleSortChange = useCallback((sort: EvidenceSortKey) => {
     handleFilterChange({ sort });
   }, [handleFilterChange]);
-
-  const handleSelectDay = useCallback((day: string) => {
-    setFilters((prev) => ({ ...prev, day }));
-  }, []);
 
   const handleLoadMore = useCallback(() => {
     setPage((prev) => prev + 1);
@@ -258,7 +253,6 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
             id="tabpanel-insights"
             role="tabpanel"
             aria-labelledby="tab-insights"
-            className="max-w-2xl"
           >
             <EvidenceAnalyticsPanel
               metrics={metrics}
@@ -276,21 +270,6 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
             className="max-w-2xl"
           >
             <AppTab receipts={filtered} />
-          </div>
-        )}
-
-        {filters.view === "story" && (
-          <div
-            id="tabpanel-story"
-            role="tabpanel"
-            aria-labelledby="tab-story"
-            className="max-w-2xl"
-          >
-            <StoryTab
-              receipts={filtered}
-              selectedDay={filters.day ?? ""}
-              onSelectDay={handleSelectDay}
-            />
           </div>
         )}
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14175,6 +14175,9 @@ function HiMiniHome(props) {
 function HiMiniGlobeAlt(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M16.555 5.412a8.028 8.028 0 0 0-3.503-2.81 14.899 14.899 0 0 1 1.663 4.472 8.547 8.547 0 0 0 1.84-1.662ZM13.326 7.825a13.43 13.43 0 0 0-2.413-5.773 8.087 8.087 0 0 0-1.826 0 13.43 13.43 0 0 0-2.413 5.773A8.473 8.473 0 0 0 10 8.5c1.18 0 2.304-.24 3.326-.675ZM6.514 9.376A9.98 9.98 0 0 0 10 10c1.226 0 2.4-.22 3.486-.624a13.54 13.54 0 0 1-.351 3.759A13.54 13.54 0 0 1 10 13.5c-1.079 0-2.128-.127-3.134-.366a13.538 13.538 0 0 1-.352-3.758ZM5.285 7.074a14.9 14.9 0 0 1 1.663-4.471 8.028 8.028 0 0 0-3.503 2.81c.529.638 1.149 1.199 1.84 1.66ZM17.334 6.798a7.973 7.973 0 0 1 .614 4.115 13.47 13.47 0 0 1-3.178 1.72 15.093 15.093 0 0 0 .174-3.939 10.043 10.043 0 0 0 2.39-1.896ZM2.666 6.798a10.042 10.042 0 0 0 2.39 1.896 15.196 15.196 0 0 0 .174 3.94 13.472 13.472 0 0 1-3.178-1.72 7.973 7.973 0 0 1 .615-4.115ZM10 15c.898 0 1.778-.079 2.633-.23a13.473 13.473 0 0 1-1.72 3.178 8.099 8.099 0 0 1-1.826 0 13.47 13.47 0 0 1-1.72-3.178c.855.151 1.735.23 2.633.23ZM14.357 14.357a14.912 14.912 0 0 1-1.305 3.04 8.027 8.027 0 0 0 4.345-4.345c-.953.542-1.971.981-3.04 1.305ZM6.948 17.397a8.027 8.027 0 0 1-4.345-4.345c.953.542 1.971.981 3.04 1.305a14.912 14.912 0 0 0 1.305 3.04Z" }, "child": [] }] })(props);
 }
+function HiMiniFunnel(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M2.628 1.601C5.028 1.206 7.49 1 10 1s4.973.206 7.372.601a.75.75 0 0 1 .628.74v2.288a2.25 2.25 0 0 1-.659 1.59l-4.682 4.683a2.25 2.25 0 0 0-.659 1.59v3.037c0 .684-.31 1.33-.844 1.757l-1.937 1.55A.75.75 0 0 1 8 18.25v-5.757a2.25 2.25 0 0 0-.659-1.591L2.659 6.22A2.25 2.25 0 0 1 2 4.629V2.34a.75.75 0 0 1 .628-.74Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
 function HiMiniEye(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M10 12.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M.664 10.59a1.651 1.651 0 0 1 0-1.186A10.004 10.004 0 0 1 10 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0 1 10 17c-4.257 0-7.893-2.66-9.336-6.41ZM14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
@@ -15152,6 +15155,7 @@ function TabBar(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "tablist", className: "flex flex-wrap gap-1 rounded-lg border border-slate-200 bg-slate-50 p-0.5", children: props.tabs.map((tab) => /* @__PURE__ */ jsxRuntimeExports.jsx(
     "button",
     {
+      id: tab.id ?? tab.value,
       type: "button",
       role: "tab",
       "aria-selected": props.active === tab.value,
@@ -15869,7 +15873,6 @@ const VIEW_TABS = [
   { key: "actions", label: "All actions" },
   { key: "insights", label: "Insights" },
   { key: "apps", label: "Apps" },
-  { key: "story", label: "Story" },
   { key: "categories", label: "Categories" },
   { key: "export", label: "Export" }
 ];
@@ -15897,7 +15900,7 @@ function EvidenceHeader({
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-0.5 min-w-0", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-lg font-semibold text-brand-dark", children: "Evidence" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Every action Guard reviewed on this machine." }),
-      lastActivityLabel && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "flex items-center gap-1 text-[11px] text-slate-400", children: [
+      lastActivityLabel && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-[11px] text-slate-400", children: [
         "Last activity: ",
         lastActivityLabel
       ] })
@@ -16346,6 +16349,14 @@ function DecisionChip({ decision }) {
     "Reviewed"
   ] });
 }
+const SORT_TOGGLE_MAP = {
+  newest: "oldest",
+  oldest: "newest",
+  artifact: "artifact",
+  app: "app",
+  category: "category",
+  decision: "decision"
+};
 function SortHeader({
   label,
   active,
@@ -16357,6 +16368,7 @@ function SortHeader({
     "th",
     {
       scope: "col",
+      "aria-sort": active ? ascending ? "ascending" : "descending" : "none",
       className: `px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 ${className}`,
       children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
@@ -16390,10 +16402,8 @@ function EvidenceActionList({
   const showLoadMore = hasMore(page, pageSize, receipts.length);
   const handleSort = reactExports.useCallback(
     (key) => {
-      if (sort === key && key === "newest") {
-        onSortChange("oldest");
-      } else if (sort === key && key === "oldest") {
-        onSortChange("newest");
+      if (sort === key) {
+        onSortChange(SORT_TOGGLE_MAP[key]);
       } else {
         onSortChange(key);
       }
@@ -16420,7 +16430,7 @@ function EvidenceActionList({
           {
             label: "Artifact",
             active: sort === "artifact",
-            ascending: true,
+            ascending: sort === "artifact",
             onClick: () => handleSort("artifact"),
             className: "min-w-[180px]"
           }
@@ -16430,7 +16440,7 @@ function EvidenceActionList({
           {
             label: "App",
             active: sort === "app",
-            ascending: true,
+            ascending: sort === "app",
             onClick: () => handleSort("app"),
             className: "hidden sm:table-cell"
           }
@@ -16440,7 +16450,7 @@ function EvidenceActionList({
           {
             label: "Category",
             active: sort === "category",
-            ascending: true,
+            ascending: sort === "category",
             onClick: () => handleSort("category"),
             className: "hidden md:table-cell"
           }
@@ -16450,7 +16460,7 @@ function EvidenceActionList({
           {
             label: "Decision",
             active: sort === "decision",
-            ascending: true,
+            ascending: sort === "decision",
             onClick: () => handleSort("decision")
           }
         ),
@@ -16459,7 +16469,7 @@ function EvidenceActionList({
           {
             label: "Time",
             active: sort === "newest" || sort === "oldest",
-            ascending: sort === "newest",
+            ascending: sort === "oldest",
             onClick: () => handleSort("newest"),
             className: "hidden lg:table-cell"
           }
@@ -16528,7 +16538,6 @@ function ActionRow({
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "tr",
     {
-      role: "button",
       tabIndex: 0,
       onClick: handleClick,
       onKeyDown: handleKeyDown,
@@ -16563,7 +16572,7 @@ function ActionRow({
     }
   );
 }
-function DecisionBadge$1({ decision }) {
+function DecisionBadge$2({ decision }) {
   if (decision === "allow") {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-1 rounded-full bg-green-50 px-2.5 py-1 text-xs font-semibold text-green-700 ring-1 ring-green-200", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
@@ -16704,8 +16713,7 @@ function TechnicalSection({ receipt }) {
           value: (receipt.changed_capabilities ?? []).join(", ")
         }
       ),
-      receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Capabilities", value: receipt.capabilities_summary }),
-      receipt.diff_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Diff summary", value: receipt.diff_summary })
+      receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Capabilities", value: receipt.capabilities_summary })
     ] })
   ] });
 }
@@ -16837,7 +16845,7 @@ function EvidenceActionDetail({
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1 overflow-y-auto px-5 py-4 space-y-4", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionBadge$1, { decision: receipt.policy_decision }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionBadge$2, { decision: receipt.policy_decision }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: harnessDisplayName(receipt.harness) }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400", children: "·" }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: formatRelativeTime(receipt.timestamp) })
@@ -16909,79 +16917,155 @@ function EvidenceInsightStrip({ metrics }) {
     }
   );
 }
-function TrendBar({ bucket, maxTotal }) {
-  const total = bucket.allowed + bucket.blocked + bucket.reviewed;
-  const heightPct = maxTotal > 0 ? Math.max(4, total / maxTotal * 100) : 4;
-  const blockedPct = total > 0 ? bucket.blocked / total * 100 : 0;
-  const allowedPct = total > 0 ? bucket.allowed / total * 100 : 0;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col items-center gap-1 flex-1 min-w-0", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "div",
-      {
-        className: "w-full rounded-sm overflow-hidden flex flex-col-reverse bg-slate-100",
-        style: { height: 48 },
-        "aria-label": `${bucket.label}: ${total} actions`,
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "div",
-            {
-              className: "w-full bg-emerald-300 transition-all",
-              style: { height: `${heightPct * (allowedPct / 100)}%` },
-              "aria-hidden": "true"
-            }
-          ),
+function StatCard({
+  label,
+  value,
+  subtext,
+  tone
+}) {
+  const toneStyles = {
+    blue: { bg: "bg-brand-blue/[0.04]", text: "text-brand-blue", accent: "bg-brand-blue" },
+    green: { bg: "bg-emerald-50", text: "text-emerald-700", accent: "bg-emerald-500" },
+    amber: { bg: "bg-amber-50", text: "text-amber-700", accent: "bg-amber-500" },
+    purple: { bg: "bg-purple-50", text: "text-purple-700", accent: "bg-purple-500" },
+    slate: { bg: "bg-slate-50", text: "text-slate-700", accent: "bg-slate-500" }
+  };
+  const style = toneStyles[tone];
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `rounded-2xl ${style.bg} p-5`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `text-[11px] font-semibold uppercase tracking-wider ${style.text} opacity-70`, children: label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: `mt-1 text-3xl font-bold tabular-nums ${style.text}`, children: value }),
+    subtext && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-slate-500", children: subtext })
+  ] });
+}
+function TrendChart({ buckets }) {
+  const maxTotal = Math.max(...buckets.map((b) => b.allowed + b.blocked + b.reviewed), 1);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-4", children: "7-Day Activity" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex items-end gap-2 h-40", children: buckets.map((bucket) => {
+      const total = bucket.allowed + bucket.blocked + bucket.reviewed;
+      const heightPct = maxTotal > 0 ? total / maxTotal * 100 : 0;
+      const blockedHeight = total > 0 ? bucket.blocked / total * heightPct : 0;
+      const allowedHeight = total > 0 ? bucket.allowed / total * heightPct : 0;
+      return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1 flex flex-col items-center gap-1.5 min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full flex-1 flex items-end rounded-lg overflow-hidden bg-slate-50", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "w-full flex flex-col-reverse", children: [
           bucket.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
             "div",
             {
-              className: "w-full bg-amber-400 transition-all",
-              style: { height: `${heightPct * (blockedPct / 100)}%` },
-              "aria-hidden": "true"
+              className: "w-full bg-amber-400 rounded-b-sm",
+              style: { height: `${Math.max(blockedHeight, 2)}%` }
+            }
+          ),
+          bucket.allowed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "div",
+            {
+              className: "w-full bg-emerald-400",
+              style: { height: `${Math.max(allowedHeight, 2)}%` }
+            }
+          ),
+          bucket.reviewed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "div",
+            {
+              className: "w-full bg-brand-blue rounded-t-sm",
+              style: {
+                height: `${Math.max(heightPct - blockedHeight - allowedHeight, 2)}%`
+              }
             }
           )
-        ]
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[10px] text-slate-400 truncate w-full text-center", children: bucket.label })
+        ] }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[10px] text-slate-400 truncate w-full text-center", children: bucket.label })
+      ] }, bucket.dateKey);
+    }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex items-center gap-4 text-[11px] text-slate-500", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1.5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2 w-2 rounded-full bg-emerald-400" }),
+        "Allowed"
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1.5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2 w-2 rounded-full bg-amber-400" }),
+        "Stopped"
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1.5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2 w-2 rounded-full bg-brand-blue" }),
+        "Reviewed"
+      ] })
+    ] })
   ] });
 }
-function AppBreakdownRow({
+function PeriodComparisonCard({ comparison, label }) {
+  const blockedDeltaSign = comparison.blockedDelta > 0 ? "+" : "";
+  const totalDeltaSign = comparison.totalDelta > 0 ? "+" : "";
+  const blockedColor = comparison.blockedDelta > 0 ? "text-amber-600" : comparison.blockedDelta < 0 ? "text-emerald-600" : "text-slate-400";
+  const totalColor = comparison.totalDelta > 0 ? "text-brand-blue" : comparison.totalDelta < 0 ? "text-slate-400" : "text-slate-400";
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-3", children: label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid grid-cols-2 gap-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-2xl font-bold text-brand-dark tabular-nums", children: comparison.currentTotal }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500 mt-0.5", children: "Total actions" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: `text-xs font-medium mt-1 ${totalColor}`, children: [
+          totalDeltaSign,
+          comparison.totalDelta,
+          " from prior period"
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-2xl font-bold text-brand-dark tabular-nums", children: comparison.currentBlocked }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500 mt-0.5", children: "Stopped" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: `text-xs font-medium mt-1 ${blockedColor}`, children: [
+          blockedDeltaSign,
+          comparison.blockedDelta,
+          " from prior period"
+        ] })
+      ] })
+    ] })
+  ] });
+}
+function AppBreakdownCard({
   harness,
   total,
   blocked,
+  allowed,
   maxTotal,
   onFilter
 }) {
   const pct = maxTotal > 0 ? total / maxTotal * 100 : 0;
-  const handleClick = reactExports.useCallback(() => {
-    onFilter(harness);
-  }, [harness, onFilter]);
+  const handleClick = reactExports.useCallback(() => onFilter(harness), [harness, onFilter]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "button",
     {
       type: "button",
       onClick: handleClick,
-      "aria-label": `Filter by app ${harnessDisplayName(harness)}`,
-      className: "w-full flex items-center gap-3 px-2 py-1.5 rounded-lg hover:bg-slate-50 transition-colors text-left",
+      className: "w-full rounded-xl border border-slate-200 bg-white p-4 text-left transition-all hover:shadow-md hover:border-slate-300",
       children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark w-28 shrink-0 truncate", children: harnessDisplayName(harness) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex-1 bg-slate-100 rounded-full h-1.5 overflow-hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between mb-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold text-brand-dark", children: harnessDisplayName(harness) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs tabular-nums text-slate-500", children: [
+            total,
+            " actions"
+          ] })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full bg-slate-100 rounded-full h-2 overflow-hidden mb-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
           "div",
           {
-            className: "bg-brand-blue h-1.5 rounded-full transition-all",
-            style: { width: `${pct}%` },
-            "aria-hidden": "true"
+            className: "bg-brand-blue h-2 rounded-full transition-all",
+            style: { width: `${pct}%` }
           }
         ) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs tabular-nums text-slate-500 shrink-0 w-6 text-right", children: total }),
-        blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-[10px] font-medium text-brand-attention shrink-0", children: [
-          blocked,
-          " blocked"
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3 text-[11px] text-slate-500", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-emerald-600", children: [
+            allowed,
+            " allowed"
+          ] }),
+          blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-amber-600", children: [
+            blocked,
+            " stopped"
+          ] })
         ] })
       ]
     }
   );
 }
-function CategoryBreakdownRow({
+function CategoryBreakdownCard({
   categoryKey,
   total,
   blocked,
@@ -16990,83 +17074,42 @@ function CategoryBreakdownRow({
 }) {
   const pct = maxTotal > 0 ? total / maxTotal * 100 : 0;
   const catInfo = getCategoryInfo(categoryKey);
-  const handleClick = reactExports.useCallback(() => {
-    onFilter(categoryKey);
-  }, [categoryKey, onFilter]);
+  const handleClick = reactExports.useCallback(() => onFilter(categoryKey), [categoryKey, onFilter]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "button",
     {
       type: "button",
       onClick: handleClick,
-      "aria-label": `Filter by category ${catInfo.label}`,
-      className: "w-full flex items-center gap-3 px-2 py-1.5 rounded-lg hover:bg-slate-50 transition-colors text-left",
+      className: "w-full rounded-xl border border-slate-200 bg-white p-4 text-left transition-all hover:shadow-md hover:border-slate-300",
       children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `shrink-0 ${catInfo.color}`, "aria-hidden": "true", children: catInfo.icon }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark w-24 shrink-0 truncate", children: catInfo.label }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex-1 bg-slate-100 rounded-full h-1.5 overflow-hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3 mb-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `${catInfo.color}`, "aria-hidden": "true", children: catInfo.icon }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-semibold text-brand-dark", children: catInfo.label }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-auto text-xs tabular-nums text-slate-500", children: [
+            total,
+            " actions"
+          ] })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full bg-slate-100 rounded-full h-2 overflow-hidden mb-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
           "div",
           {
-            className: "bg-brand-purple h-1.5 rounded-full transition-all",
-            style: { width: `${pct}%` },
-            "aria-hidden": "true"
+            className: "bg-purple-500 h-2 rounded-full transition-all",
+            style: { width: `${pct}%` }
           }
         ) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs tabular-nums text-slate-500 shrink-0 w-6 text-right", children: total }),
-        blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-[10px] font-medium text-brand-attention shrink-0", children: [
+        blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-[11px] text-amber-600", children: [
           blocked,
-          " blocked"
+          " stopped"
         ] })
       ]
     }
   );
-}
-function SectionHeading({ children }) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-[11px] font-semibold uppercase tracking-wide text-slate-400 px-2", children });
-}
-function PeriodComparisonCard({ comparison, label }) {
-  const blockedDeltaSign = comparison.blockedDelta > 0 ? "+" : "";
-  const totalDeltaSign = comparison.totalDelta > 0 ? "+" : "";
-  let blockedColor = "text-slate-400";
-  if (comparison.blockedDelta > 0) {
-    blockedColor = "text-brand-attention";
-  } else if (comparison.blockedDelta < 0) {
-    blockedColor = "text-emerald-600";
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl bg-slate-50 px-3 py-2.5 space-y-1", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-wide text-slate-400", children: label }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-baseline gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-sm font-medium text-brand-dark tabular-nums", children: [
-        comparison.currentTotal,
-        " actions",
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-1.5 text-xs text-slate-400", children: [
-          "(",
-          totalDeltaSign,
-          comparison.totalDelta,
-          ")"
-        ] })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: `text-xs font-medium tabular-nums ${blockedColor}`, children: [
-        comparison.currentBlocked,
-        " stopped",
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "ml-1", children: [
-          "(",
-          blockedDeltaSign,
-          comparison.blockedDelta,
-          ")"
-        ] })
-      ] })
-    ] })
-  ] });
 }
 function EvidenceAnalyticsPanel({
   metrics,
   onFilterHarness,
   onFilterCategory
 }) {
-  const maxBucketTotal = Math.max(
-    ...metrics.trendBuckets.map((b) => b.allowed + b.blocked),
-    1
-  );
   const sortedHarnesses = Array.from(metrics.byHarness.entries()).sort(
     (a, b) => b[1].total - a[1].total
   );
@@ -17075,6 +17118,9 @@ function EvidenceAnalyticsPanel({
     (a, b) => b[1].total - a[1].total
   );
   const maxCatTotal = sortedCategories[0]?.[1].total ?? 1;
+  const appCount = metrics.byHarness.size;
+  const catCount = metrics.byCategory.size;
+  const stopRate = metrics.total > 0 ? Math.round(metrics.blocked / metrics.total * 100) : 0;
   if (metrics.total === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col items-center justify-center py-16 text-center", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "No data yet" }),
@@ -17082,50 +17128,37 @@ function EvidenceAnalyticsPanel({
     ] });
   }
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeading, { children: "7-day trend" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex items-end gap-1.5 px-2 pt-1", children: metrics.trendBuckets.map((bucket) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-        TrendBar,
-        {
-          bucket,
-          maxTotal: maxBucketTotal
-        },
-        bucket.dateKey
-      )) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3 px-2 text-[11px] text-slate-400", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2 w-2 rounded-sm bg-emerald-300", "aria-hidden": "true" }),
-          "Allowed"
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "flex items-center gap-1", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2 w-2 rounded-sm bg-amber-400", "aria-hidden": "true" }),
-          "Stopped"
-        ] })
-      ] })
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Total Actions", value: String(metrics.total), tone: "blue" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Stopped", value: String(metrics.blocked), tone: "amber", subtext: `${stopRate}% of total` }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Allowed", value: String(metrics.allowed), tone: "green" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Apps Seen", value: String(appCount), tone: "purple" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Categories", value: String(catCount), tone: "slate" })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeading, { children: "Period comparison" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(PeriodComparisonCard, { comparison: metrics.periodComparison7d, label: "vs. prior 7 days" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(PeriodComparisonCard, { comparison: metrics.periodComparison30d, label: "vs. prior 30 days" })
+    /* @__PURE__ */ jsxRuntimeExports.jsx(TrendChart, { buckets: metrics.trendBuckets }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid grid-cols-1 md:grid-cols-2 gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(PeriodComparisonCard, { comparison: metrics.periodComparison7d, label: "vs. Prior 7 Days" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(PeriodComparisonCard, { comparison: metrics.periodComparison30d, label: "vs. Prior 30 Days" })
     ] }),
-    sortedHarnesses.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeading, { children: "By app" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-0.5", children: sortedHarnesses.map(([harness, counts]) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-        AppBreakdownRow,
+    sortedHarnesses.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-3 px-1", children: "By App" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3", children: sortedHarnesses.map(([harness, counts]) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        AppBreakdownCard,
         {
           harness,
           total: counts.total,
           blocked: counts.blocked,
+          allowed: counts.allowed,
           maxTotal: maxHarnessTotal,
           onFilter: onFilterHarness
         },
         harness
       )) })
     ] }),
-    sortedCategories.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeading, { children: "By category" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-0.5", children: sortedCategories.map(([cat, counts]) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-        CategoryBreakdownRow,
+    sortedCategories.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-3 px-1", children: "By Category" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3", children: sortedCategories.map(([cat, counts]) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        CategoryBreakdownCard,
         {
           categoryKey: cat,
           total: counts.total,
@@ -17136,22 +17169,22 @@ function EvidenceAnalyticsPanel({
         cat
       )) })
     ] }),
-    metrics.topRecurring.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionHeading, { children: "Top recurring actions" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "divide-y divide-slate-100/60", children: metrics.topRecurring.slice(0, 5).map((action) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    metrics.topRecurring.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-3", children: "Top Recurring Actions" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "divide-y divide-slate-100", children: metrics.topRecurring.slice(0, 5).map((action) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "div",
         {
-          className: "flex items-center justify-between px-2 py-1.5",
+          className: "flex items-center justify-between py-2.5",
           children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-brand-dark truncate", children: action.name }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2 shrink-0", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-brand-dark truncate pr-4", children: action.name }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3 shrink-0", children: [
               /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-xs tabular-nums text-slate-500", children: [
                 action.total,
                 "×"
               ] }),
-              action.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-[10px] font-medium text-brand-attention", children: [
+              action.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-[10px] font-medium text-amber-600", children: [
                 action.blocked,
-                " blocked"
+                " stopped"
               ] })
             ] })
           ]
@@ -17526,52 +17559,73 @@ function harnessColor(harness) {
   const hue = HUE_PALETTE[hash % HUE_PALETTE.length];
   return `hsl(${hue} 70% 45%)`;
 }
-function AppListRow({ harness, items, onSelect }) {
+function DecisionBadge$1({ decision }) {
+  if (decision === "allow") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex shrink-0 items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-[10px] font-semibold text-green-700 ring-1 ring-green-200", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-3 w-3", "aria-hidden": "true" }),
+      "Allowed"
+    ] });
+  }
+  if (decision === "block") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700 ring-1 ring-amber-200", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniNoSymbol, { className: "h-3 w-3", "aria-hidden": "true" }),
+      "Stopped"
+    ] });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-700 ring-1 ring-blue-200", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniQuestionMarkCircle, { className: "h-3 w-3", "aria-hidden": "true" }),
+    "Reviewed"
+  ] });
+}
+function AppListCard({ harness, items, onSelect }) {
   const allowed = items.filter((r) => r.policy_decision === "allow").length;
   const blocked = items.filter((r) => r.policy_decision === "block").length;
   const lastActive = items[0]?.timestamp;
   const color = harnessColor(harness);
   const handleClick = reactExports.useCallback(() => onSelect(harness), [harness, onSelect]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
     "button",
     {
       onClick: handleClick,
-      className: "flex w-full items-center justify-between gap-3 py-2.5 text-left transition-colors hover:bg-slate-50/50 rounded-lg px-2 -mx-2",
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2.5 min-w-0", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "span",
-            {
-              className: "inline-flex h-8 w-8 items-center justify-center rounded-full text-xs font-bold text-white shrink-0",
-              style: { backgroundColor: color },
-              children: harness[0]?.toUpperCase()
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark truncate", children: harnessDisplayName(harness) }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-500", children: [
-              items.length,
-              " actions · ",
-              allowed,
-              " allowed · ",
-              blocked,
-              " stopped"
-            ] }),
-            lastActive && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-400", children: [
-              "Last active ",
-              formatRelativeTime(lastActive)
-            ] })
+      className: "w-full rounded-2xl border border-slate-200 bg-white p-4 text-left transition-all hover:shadow-md hover:border-slate-300",
+      children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "span",
+          {
+            className: "inline-flex h-10 w-10 items-center justify-center rounded-full text-sm font-bold text-white shrink-0",
+            style: { backgroundColor: color },
+            children: harness[0]?.toUpperCase()
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1 min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark truncate", children: harnessDisplayName(harness) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-500", children: [
+            items.length,
+            " actions · ",
+            allowed,
+            " allowed · ",
+            blocked,
+            " stopped"
+          ] }),
+          lastActive && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-400", children: [
+            "Last active ",
+            formatRelativeTime(lastActive)
           ] })
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300 shrink-0", "aria-hidden": "true" })
-      ]
+      ] })
     }
   );
 }
 function AppTabRaw({ receipts }) {
   const [selectedApp, setSelectedApp] = reactExports.useState(null);
   const [searchTerm, setSearchTerm] = reactExports.useState("");
-  const appReceipts = reactExports.useMemo(() => receipts.filter((receipt) => isDisplayableHarness(receipt.harness)), [receipts]);
+  const [decisionFilter, setDecisionFilter] = reactExports.useState("all");
+  const [categoryFilter, setCategoryFilter] = reactExports.useState("");
+  const appReceipts = reactExports.useMemo(
+    () => receipts.filter((receipt) => isDisplayableHarness(receipt.harness)),
+    [receipts]
+  );
   const apps = reactExports.useMemo(() => {
     const map = /* @__PURE__ */ new Map();
     for (const receipt of appReceipts) {
@@ -17591,8 +17645,27 @@ function AppTabRaw({ receipts }) {
   const handleSearchChange = reactExports.useCallback((e) => {
     setSearchTerm(e.target.value);
   }, []);
-  const handleBack = reactExports.useCallback(() => setSelectedApp(null), []);
-  const handleSelectApp = reactExports.useCallback((h) => setSelectedApp(h), []);
+  const handleBack = reactExports.useCallback(() => {
+    setSelectedApp(null);
+    setDecisionFilter("all");
+    setCategoryFilter("");
+  }, []);
+  const handleSelectApp = reactExports.useCallback((h) => {
+    setSelectedApp(h);
+    setDecisionFilter("all");
+    setCategoryFilter("");
+  }, []);
+  const selectedItems = reactExports.useMemo(() => {
+    if (!selectedApp) return [];
+    let items = apps.find(([h]) => h === selectedApp)?.[1] ?? [];
+    if (decisionFilter !== "all") {
+      items = items.filter((r) => r.policy_decision === decisionFilter);
+    }
+    if (categoryFilter) {
+      items = items.filter((r) => detectCategory(r) === categoryFilter);
+    }
+    return items;
+  }, [apps, selectedApp, decisionFilter, categoryFilter]);
   if (appReceipts.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "py-12 text-center", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "No activity yet." }),
@@ -17600,10 +17673,11 @@ function AppTabRaw({ receipts }) {
     ] });
   }
   if (selectedApp) {
-    const items = apps.find(([h]) => h === selectedApp)?.[1] ?? [];
-    const allowed = items.filter((r) => r.policy_decision === "allow").length;
-    const blocked = items.filter((r) => r.policy_decision === "block").length;
+    const allItems = apps.find(([h]) => h === selectedApp)?.[1] ?? [];
+    const allowed = allItems.filter((r) => r.policy_decision === "allow").length;
+    const blocked = allItems.filter((r) => r.policy_decision === "block").length;
     const color = harnessColor(selectedApp);
+    const categories = Array.from(new Set(allItems.map((r) => detectCategory(r))));
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-5", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -17631,47 +17705,102 @@ function AppTabRaw({ receipts }) {
           }
         )
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          "span",
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "span",
+            {
+              className: "inline-flex h-12 w-12 items-center justify-center rounded-full text-sm font-bold text-white",
+              style: { backgroundColor: color },
+              children: selectedApp[0]?.toUpperCase()
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-base font-semibold text-brand-dark", children: harnessDisplayName(selectedApp) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-500", children: [
+              allItems.length,
+              " action",
+              allItems.length !== 1 ? "s" : "",
+              " · ",
+              allowed,
+              " allowed · ",
+              blocked,
+              " stopped"
+            ] })
+          ] })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(AppSparkline, { items: allItems })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 text-xs text-slate-500", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniFunnel, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Filter:" })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "select",
           {
-            className: "inline-flex h-9 w-9 items-center justify-center rounded-full text-xs font-bold text-white",
-            style: { backgroundColor: color },
-            children: selectedApp[0]?.toUpperCase()
+            value: decisionFilter,
+            onChange: (e) => setDecisionFilter(e.target.value),
+            className: "min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "all", children: "All decisions" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "allow", children: "Allowed" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "block", children: "Stopped" })
+            ]
           }
         ),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-base font-semibold text-brand-dark", children: harnessDisplayName(selectedApp) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-500", children: [
-            items.length,
-            " action",
-            items.length !== 1 ? "s" : "",
-            " · ",
-            allowed,
-            " allowed · ",
-            blocked,
-            " stopped"
-          ] })
-        ] })
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "select",
+          {
+            value: categoryFilter,
+            onChange: (e) => setCategoryFilter(e.target.value),
+            className: "min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "", children: "All categories" }),
+              categories.map((cat) => {
+                const info = getCategoryInfo(cat);
+                return /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: cat, children: info.label }, cat);
+              })
+            ]
+          }
+        ),
+        (decisionFilter !== "all" || categoryFilter) && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            type: "button",
+            onClick: () => {
+              setDecisionFilter("all");
+              setCategoryFilter("");
+            },
+            className: "text-xs font-medium text-brand-blue hover:text-brand-dark transition-colors",
+            children: "Clear filters"
+          }
+        )
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(AppSparkline, { items }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-0 divide-y divide-slate-100/60", children: items.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "div",
-        {
-          className: "flex items-start justify-between gap-3 py-2",
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: plainEnglishDescription(receipt) }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs text-slate-400", children: formatRelativeTime(receipt.timestamp) })
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `shrink-0 text-xs font-medium ${receipt.policy_decision === "allow" ? "text-emerald-500" : "text-brand-attention"}`, children: receipt.policy_decision === "allow" ? "Allowed" : "Stopped" })
-          ]
-        },
-        receipt.receipt_id
-      )) })
+      selectedItems.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "py-8 text-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "No actions match the selected filters." }) }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-slate-200 bg-white overflow-hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "overflow-x-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "w-full text-sm", "aria-label": `${harnessDisplayName(selectedApp)} actions`, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { className: "border-b border-slate-100 bg-slate-50/60", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "w-8 px-3 py-2.5" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500", children: "Artifact" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 hidden md:table-cell", children: "Category" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500", children: "Decision" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 hidden lg:table-cell", children: "Time" })
+        ] }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: selectedItems.map((receipt) => {
+          const category = detectCategory(receipt);
+          const catInfo = getCategoryInfo(category);
+          const artifactLabel = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
+          return /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { className: "border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `${catInfo.color}`, "aria-hidden": "true", children: catInfo.icon }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[200px]", children: artifactLabel }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden md:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: catInfo.label }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionBadge$1, { decision: receipt.policy_decision }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden lg:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400 whitespace-nowrap", children: formatRelativeTime(receipt.timestamp) }) })
+          ] }, receipt.receipt_id);
+        }) })
+      ] }) }) })
     ] });
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Search apps" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -17685,8 +17814,8 @@ function AppTabRaw({ receipts }) {
         }
       )
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-0 divide-y divide-slate-100/60", children: filteredApps.map(([harness, items]) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-      AppListRow,
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid grid-cols-1 sm:grid-cols-2 gap-3", children: filteredApps.map(([harness, items]) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+      AppListCard,
       {
         harness,
         items,
@@ -17712,178 +17841,20 @@ function AppSparkline({ items }) {
     return counts;
   }, [items]);
   const max = Math.max(...buckets, 1);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "py-1", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-medium text-slate-400", children: "Last 7 days" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-1 flex h-8 w-full items-end gap-0.5", children: buckets.map((count, i) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 pt-4 border-t border-slate-100", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-medium text-slate-400 mb-2", children: "Last 7 days" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex h-10 w-full items-end gap-1", children: buckets.map((count, i) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       "div",
       {
-        className: "flex-1 rounded-sm bg-brand-blue/30",
-        style: { height: `${Math.max(count / max * 100, count > 0 ? 8 : 0)}%` }
+        className: "flex-1 rounded-sm bg-brand-blue/20 transition-all hover:bg-brand-blue/30",
+        style: { height: `${Math.max(count / max * 100, count > 0 ? 8 : 4)}%` },
+        title: `${count} action${count !== 1 ? "s" : ""}`
       },
       i
     )) })
   ] });
 }
 const AppTab = reactExports.memo(AppTabRaw);
-function StoryTabRaw({ receipts, selectedDay, onSelectDay }) {
-  const daysWithData = reactExports.useMemo(() => {
-    const set = /* @__PURE__ */ new Set();
-    for (const r of receipts) {
-      const d = new Date(r.timestamp);
-      const key = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
-      set.add(key);
-    }
-    return set;
-  }, [receipts]);
-  const effectiveDay = reactExports.useMemo(() => {
-    if (selectedDay) return selectedDay;
-    if (daysWithData.size === 0) return "";
-    const sorted = Array.from(daysWithData).sort();
-    return sorted[sorted.length - 1];
-  }, [selectedDay, daysWithData]);
-  const dayReceipts = reactExports.useMemo(() => {
-    if (!effectiveDay) return [];
-    const start = new Date(effectiveDay);
-    start.setHours(0, 0, 0, 0);
-    const end = new Date(start);
-    end.setDate(end.getDate() + 1);
-    return receipts.filter((r) => {
-      const d = new Date(r.timestamp);
-      return d >= start && d < end;
-    });
-  }, [receipts, effectiveDay]);
-  const summary = reactExports.useMemo(() => {
-    const allowed = dayReceipts.filter((r) => r.policy_decision === "allow").length;
-    const blocked = dayReceipts.filter((r) => r.policy_decision === "block").length;
-    return { allowed, blocked, total: dayReceipts.length };
-  }, [dayReceipts]);
-  const dayLabel = reactExports.useMemo(() => {
-    if (!effectiveDay) return "No data";
-    const d = new Date(effectiveDay);
-    const today = /* @__PURE__ */ new Date();
-    today.setHours(0, 0, 0, 0);
-    const diff = Math.floor((today.getTime() - d.getTime()) / (1e3 * 60 * 60 * 24));
-    if (diff === 0) return "Today";
-    if (diff === 1) return "Yesterday";
-    return d.toLocaleDateString("en-US", { weekday: "long", month: "short", day: "numeric" });
-  }, [effectiveDay]);
-  const sortedDays = reactExports.useMemo(() => Array.from(daysWithData).sort(), [daysWithData]);
-  const currentIndex = reactExports.useMemo(() => sortedDays.indexOf(effectiveDay), [sortedDays, effectiveDay]);
-  const handlePrevDay = () => {
-    if (currentIndex <= 0) return;
-    onSelectDay(sortedDays[currentIndex - 1]);
-  };
-  const handleNextDay = () => {
-    if (currentIndex < 0 || currentIndex >= sortedDays.length - 1) return;
-    onSelectDay(sortedDays[currentIndex + 1]);
-  };
-  const hasPrev = currentIndex > 0;
-  const hasNext = currentIndex >= 0 && currentIndex < sortedDays.length - 1;
-  if (receipts.length === 0) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-100 bg-white/60 p-8 text-center", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "All quiet. Guard is watching." }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-slate-400", children: "Saved decisions will appear here." })
-    ] });
-  }
-  if (dayReceipts.length === 0) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(DayHeader, { dayLabel, onPrev: handlePrevDay, onNext: handleNextDay, hasPrev, hasNext }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-2xl border border-slate-100 bg-white/60 p-8 text-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "No decisions on this day." }) })
-    ] });
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(DayHeader, { dayLabel, onPrev: handlePrevDay, onNext: handleNextDay, hasPrev, hasNext }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-2xl border border-slate-100 bg-white/60 p-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm text-brand-dark", children: [
-      "Guard reviewed ",
-      summary.total,
-      " action",
-      summary.total !== 1 ? "s" : "",
-      ".",
-      " ",
-      summary.allowed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-brand-green", children: [
-        "Allowed ",
-        summary.allowed,
-        "."
-      ] }),
-      " ",
-      summary.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-brand-attention", children: [
-        "Stopped ",
-        summary.blocked,
-        "."
-      ] })
-    ] }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4", children: dayReceipts.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsx(StoryCard, { receipt }, receipt.receipt_id)) })
-  ] });
-}
-function DayHeader({
-  dayLabel,
-  onPrev,
-  onNext,
-  hasPrev,
-  hasNext
-}) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        onClick: onPrev,
-        disabled: !hasPrev,
-        className: "inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-100 disabled:opacity-30 disabled:hover:bg-transparent",
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronLeft, { className: "h-4 w-4", "aria-hidden": "true" }),
-          "Previous"
-        ]
-      }
-    ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-lg font-semibold text-brand-dark", children: dayLabel }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        onClick: onNext,
-        disabled: !hasNext,
-        className: "inline-flex items-center gap-1 rounded-lg px-3 py-1.5 text-sm font-medium text-brand-dark transition-colors hover:bg-slate-100 disabled:opacity-30 disabled:hover:bg-transparent",
-        children: [
-          "Next",
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4", "aria-hidden": "true" })
-        ]
-      }
-    )
-  ] });
-}
-function StoryCard({ receipt }) {
-  const category = detectCategory(receipt);
-  const catInfo = getCategoryInfo(category);
-  const description = plainEnglishDescription(receipt);
-  const isAllowed = receipt.policy_decision === "allow";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-100 bg-white p-4 shadow-sm transition-all hover:shadow-md", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-6 w-6 items-center justify-center rounded-full bg-slate-50 ${catInfo.color}`, children: catInfo.icon }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-slate-500", children: harnessDisplayName(receipt.harness) }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400", children: "·" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400", children: formatRelativeTime(receipt.timestamp) })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark", children: description })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionBadge, { allowed: isAllowed })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex items-center gap-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex items-center rounded-full px-2.5 py-0.5 text-[10px] font-medium uppercase tracking-wider ${catInfo.color} bg-slate-50`, children: catInfo.label }) })
-  ] });
-}
-function DecisionBadge({ allowed }) {
-  if (allowed) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
-      "Allowed"
-    ] });
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-1 rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-brand-dark", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniNoSymbol, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
-    "Stopped"
-  ] });
-}
-const StoryTab = reactExports.memo(StoryTabRaw);
 const ICON_MAP = {
   secret: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniLockClosed, { className: "h-5 w-5", "aria-hidden": "true" }),
   network: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniGlobeAlt, { className: "h-5 w-5", "aria-hidden": "true" }),
@@ -17891,49 +17862,91 @@ const ICON_MAP = {
   hidden: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniEyeSlash, { className: "h-5 w-5", "aria-hidden": "true" }),
   "file-write": /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniDocumentText, { className: "h-5 w-5", "aria-hidden": "true" }),
   "tool-call": /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniWrenchScrewdriver, { className: "h-5 w-5", "aria-hidden": "true" }),
-  other: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCircleStack, { className: "h-5 w-5", "aria-hidden": "true" })
+  other: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCircleStack, { className: "h-5 w-5", "aria-hidden": "true" }),
+  mcp: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniWrenchScrewdriver, { className: "h-5 w-5", "aria-hidden": "true" }),
+  skill: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniWrenchScrewdriver, { className: "h-5 w-5", "aria-hidden": "true" }),
+  "supply-chain": /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCircleStack, { className: "h-5 w-5", "aria-hidden": "true" }),
+  data: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCircleStack, { className: "h-5 w-5", "aria-hidden": "true" })
 };
-function CategoryRow({ cat, count, onSelect }) {
+function DecisionBadge({ decision }) {
+  if (decision === "allow") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex shrink-0 items-center gap-1 rounded-full bg-green-50 px-2 py-0.5 text-[10px] font-semibold text-green-700 ring-1 ring-green-200", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-3 w-3", "aria-hidden": "true" }),
+      "Allowed"
+    ] });
+  }
+  if (decision === "block") {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex shrink-0 items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[10px] font-semibold text-amber-700 ring-1 ring-amber-200", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniNoSymbol, { className: "h-3 w-3", "aria-hidden": "true" }),
+      "Stopped"
+    ] });
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex shrink-0 items-center gap-1 rounded-full bg-blue-50 px-2 py-0.5 text-[10px] font-semibold text-blue-700 ring-1 ring-blue-200", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniQuestionMarkCircle, { className: "h-3 w-3", "aria-hidden": "true" }),
+    "Reviewed"
+  ] });
+}
+function CategoryCard({ cat, count, blocked, onSelect }) {
   const handleClick = reactExports.useCallback(() => {
     onSelect(cat.key);
   }, [cat.key, onSelect]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
     "button",
     {
       onClick: handleClick,
-      className: "flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-100 bg-white p-4 text-left shadow-sm transition-all hover:shadow-md",
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-50 ${cat.color}`, children: ICON_MAP[cat.key] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: cat.label }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-500", children: [
-              count,
-              " action",
-              count !== 1 ? "s" : ""
-            ] })
+      className: "w-full rounded-2xl border border-slate-200 bg-white p-4 text-left transition-all hover:shadow-md hover:border-slate-300",
+      children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-50 ${cat.color}`, children: ICON_MAP[cat.key] ?? ICON_MAP.other }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex-1 min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: cat.label }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-500", children: [
+            count,
+            " action",
+            count !== 1 ? "s" : ""
           ] })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300", "aria-hidden": "true" })
-      ]
+        blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-[10px] font-medium text-amber-600 shrink-0", children: [
+          blocked,
+          " stopped"
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-4 w-4 text-slate-300 shrink-0", "aria-hidden": "true" })
+      ] })
     },
     cat.key
   );
 }
 function CategoryTabRaw({ receipts, onFilterCategory }) {
   const [selectedCategory, setSelectedCategory] = reactExports.useState(null);
+  const [decisionFilter, setDecisionFilter] = reactExports.useState("all");
+  const [harnessFilter, setHarnessFilter] = reactExports.useState("");
   const groups = reactExports.useMemo(() => groupByCategory(receipts), [receipts]);
   const handleBack = reactExports.useCallback(() => {
     setSelectedCategory(null);
+    setDecisionFilter("all");
+    setHarnessFilter("");
   }, []);
   const handleSelectCategory = reactExports.useCallback((key) => {
     setSelectedCategory(key);
+    setDecisionFilter("all");
+    setHarnessFilter("");
     onFilterCategory?.(key);
   }, [onFilterCategory]);
+  const selectedItems = reactExports.useMemo(() => {
+    if (!selectedCategory) return [];
+    let items = groups.get(selectedCategory) ?? [];
+    if (decisionFilter !== "all") {
+      items = items.filter((r) => r.policy_decision === decisionFilter);
+    }
+    if (harnessFilter) {
+      items = items.filter((r) => r.harness === harnessFilter);
+    }
+    return items;
+  }, [groups, selectedCategory, decisionFilter, harnessFilter]);
   if (selectedCategory) {
-    const items = groups.get(selectedCategory) ?? [];
+    const allItems = groups.get(selectedCategory) ?? [];
     const info = getCategoryInfo(selectedCategory);
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+    const harnesses = Array.from(new Set(allItems.map((r) => r.harness)));
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-5", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
         {
@@ -17945,56 +17958,103 @@ function CategoryTabRaw({ receipts, onFilterCategory }) {
           ]
         }
       ),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-100 bg-white/60 p-5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-10 w-10 items-center justify-center rounded-full bg-slate-50 ${info.color}`, children: ICON_MAP[selectedCategory] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-12 w-12 items-center justify-center rounded-full bg-slate-50 ${info.color}`, children: ICON_MAP[selectedCategory] ?? ICON_MAP.other }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-lg font-semibold text-brand-dark", children: info.label }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: info.description })
+            /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-base font-semibold text-brand-dark", children: info.label }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: info.description })
           ] })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-4 text-sm text-brand-dark", children: [
-          items.length,
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-3 text-sm text-brand-dark", children: [
+          allItems.length,
           " action",
-          items.length !== 1 ? "s" : "",
+          allItems.length !== 1 ? "s" : "",
           " in this category"
         ] })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-3", children: items.map((receipt) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "div",
-        {
-          className: "rounded-2xl border border-slate-100 bg-white p-4 shadow-sm",
-          children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: plainEnglishDescription(receipt) }),
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 text-xs text-slate-400", children: [
-                harnessDisplayName(receipt.harness),
-                " · ",
-                formatRelativeTime(receipt.timestamp)
-              ] })
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `shrink-0 text-xs font-medium ${receipt.policy_decision === "allow" ? "text-emerald-600" : "text-brand-attention"}`, children: receipt.policy_decision === "allow" ? "Allowed" : "Stopped" })
-          ] })
-        },
-        receipt.receipt_id
-      )) })
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5 text-xs text-slate-500", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniFunnel, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Filter:" })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "select",
+          {
+            value: decisionFilter,
+            onChange: (e) => setDecisionFilter(e.target.value),
+            className: "min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "all", children: "All decisions" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "allow", children: "Allowed" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "block", children: "Stopped" })
+            ]
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "select",
+          {
+            value: harnessFilter,
+            onChange: (e) => setHarnessFilter(e.target.value),
+            className: "min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "", children: "All apps" }),
+              harnesses.map((h) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: h, children: harnessDisplayName(h) }, h))
+            ]
+          }
+        ),
+        (decisionFilter !== "all" || harnessFilter) && /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            type: "button",
+            onClick: () => {
+              setDecisionFilter("all");
+              setHarnessFilter("");
+            },
+            className: "text-xs font-medium text-brand-blue hover:text-brand-dark transition-colors",
+            children: "Clear filters"
+          }
+        )
+      ] }),
+      selectedItems.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "py-8 text-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "No actions match the selected filters." }) }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-slate-200 bg-white overflow-hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "overflow-x-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "w-full text-sm", "aria-label": `${info.label} actions`, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { className: "border-b border-slate-100 bg-slate-50/60", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "w-8 px-3 py-2.5" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500", children: "Artifact" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 hidden md:table-cell", children: "App" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500", children: "Decision" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("th", { scope: "col", className: "px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 hidden lg:table-cell", children: "Time" })
+        ] }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: selectedItems.map((receipt) => {
+          const category = detectCategory(receipt);
+          const catInfo = getCategoryInfo(category);
+          const artifactLabel = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
+          return /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { className: "border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `${catInfo.color}`, "aria-hidden": "true", children: catInfo.icon }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[200px]", children: artifactLabel }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden md:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: harnessDisplayName(receipt.harness) }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionBadge, { decision: receipt.policy_decision }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden lg:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400 whitespace-nowrap", children: formatRelativeTime(receipt.timestamp) }) })
+          ] }, receipt.receipt_id);
+        }) })
+      ] }) }) })
     ] });
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid grid-cols-1 sm:grid-cols-2 gap-3", children: [
     CATEGORIES.map((cat) => {
       const items = groups.get(cat.key) ?? [];
       if (items.length === 0) return null;
       return /* @__PURE__ */ jsxRuntimeExports.jsx(
-        CategoryRow,
+        CategoryCard,
         {
           cat,
           count: items.length,
+          blocked: items.filter((r) => r.policy_decision === "block").length,
           onSelect: handleSelectCategory
         },
         cat.key
       );
     }),
-    Array.from(groups.values()).every((items) => items.length === 0) && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-2xl border border-slate-100 bg-white/60 p-8 text-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "No activity yet." }) })
+    Array.from(groups.values()).every((items) => items.length === 0) && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "col-span-full rounded-2xl border border-slate-100 bg-white/60 p-8 text-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "No activity yet." }) })
   ] });
 }
 const CategoryTab = reactExports.memo(CategoryTabRaw);
@@ -18039,7 +18099,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
   }, [harnesses, filters.harness]);
   reactExports.useEffect(() => {
     setPage(0);
-  }, [debouncedSearch, filters.harness, filters.decision, filters.time, filters.day, filters.category, filters.sourceScope]);
+  }, [debouncedSearch, filters.harness, filters.decision, filters.time, filters.category, filters.sourceScope]);
   const effectiveFilters = reactExports.useMemo(
     () => ({ ...filters, search: debouncedSearch }),
     [filters, debouncedSearch]
@@ -18082,9 +18142,6 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
   const handleSortChange = reactExports.useCallback((sort) => {
     handleFilterChange({ sort });
   }, [handleFilterChange]);
-  const handleSelectDay = reactExports.useCallback((day) => {
-    setFilters((prev) => ({ ...prev, day }));
-  }, []);
   const handleLoadMore = reactExports.useCallback(() => {
     setPage((prev) => prev + 1);
   }, []);
@@ -18127,7 +18184,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
       }
     );
   }
-  const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label }));
+  const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label, id: t.key }));
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       EvidenceHeader,
@@ -18192,7 +18249,6 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
           id: "tabpanel-insights",
           role: "tabpanel",
           "aria-labelledby": "tab-insights",
-          className: "max-w-2xl",
           children: /* @__PURE__ */ jsxRuntimeExports.jsx(
             EvidenceAnalyticsPanel,
             {
@@ -18211,23 +18267,6 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
           "aria-labelledby": "tab-apps",
           className: "max-w-2xl",
           children: /* @__PURE__ */ jsxRuntimeExports.jsx(AppTab, { receipts: filtered })
-        }
-      ),
-      filters.view === "story" && /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "div",
-        {
-          id: "tabpanel-story",
-          role: "tabpanel",
-          "aria-labelledby": "tab-story",
-          className: "max-w-2xl",
-          children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-            StoryTab,
-            {
-              receipts: filtered,
-              selectedDay: filters.day ?? "",
-              onSelectDay: handleSelectDay
-            }
-          )
         }
       ),
       filters.view === "categories" && /* @__PURE__ */ jsxRuntimeExports.jsx(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -118,6 +118,7 @@
     --color-indigo-300: oklch(78.5% .115 274.713);
     --color-purple-50: oklch(97.7% .014 308.299);
     --color-purple-200: oklch(90.2% .063 306.703);
+    --color-purple-500: oklch(62.7% .265 303.9);
     --color-purple-700: oklch(49.6% .265 301.924);
     --color-slate-50: oklch(98.4% .003 247.858);
     --color-slate-100: oklch(96.8% .007 247.896);
@@ -601,6 +602,10 @@
     z-index: 50;
   }
 
+  .col-span-full {
+    grid-column: 1 / -1;
+  }
+
   .container {
     width: 100%;
   }
@@ -637,10 +642,6 @@
 
   .-m-1 {
     margin: calc(var(--spacing) * -1);
-  }
-
-  .-mx-2 {
-    margin-inline: calc(var(--spacing) * -2);
   }
 
   .-mx-4 {
@@ -907,6 +908,10 @@
     height: calc(var(--spacing) * 11);
   }
 
+  .h-12 {
+    height: calc(var(--spacing) * 12);
+  }
+
   .h-14 {
     height: calc(var(--spacing) * 14);
   }
@@ -957,6 +962,10 @@
 
   .max-h-\[min\(34rem\,48vh\)\] {
     max-height: min(34rem, 48vh);
+  }
+
+  .min-h-7 {
+    min-height: calc(var(--spacing) * 7);
   }
 
   .min-h-8 {
@@ -1071,6 +1080,10 @@
     width: calc(var(--spacing) * 11);
   }
 
+  .w-12 {
+    width: calc(var(--spacing) * 12);
+  }
+
   .w-14 {
     width: calc(var(--spacing) * 14);
   }
@@ -1081,10 +1094,6 @@
 
   .w-24 {
     width: calc(var(--spacing) * 24);
-  }
-
-  .w-28 {
-    width: calc(var(--spacing) * 28);
   }
 
   .w-36 {
@@ -1272,10 +1281,6 @@
     flex-wrap: wrap;
   }
 
-  .items-baseline {
-    align-items: baseline;
-  }
-
   .items-center {
     align-items: center;
   }
@@ -1447,16 +1452,6 @@
     border-color: var(--color-slate-100);
   }
 
-  :where(.divide-slate-100\/60 > :not(:last-child)) {
-    border-color: #f1f5f999;
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    :where(.divide-slate-100\/60 > :not(:last-child)) {
-      border-color: color-mix(in oklab, var(--color-slate-100) 60%, transparent);
-    }
-  }
-
   :where(.divide-slate-200\/70 > :not(:last-child)) {
     border-color: #e2e8f0b3;
   }
@@ -1546,6 +1541,11 @@
   .rounded-t-sm {
     border-top-left-radius: var(--radius-sm);
     border-top-right-radius: var(--radius-sm);
+  }
+
+  .rounded-b-sm {
+    border-bottom-right-radius: var(--radius-sm);
+    border-bottom-left-radius: var(--radius-sm);
   }
 
   .border {
@@ -2155,13 +2155,13 @@
     }
   }
 
-  .bg-brand-blue\/30 {
+  .bg-brand-blue\/20 {
     background-color: var(--brand-blue);
   }
 
   @supports (color: color-mix(in lab, red, red)) {
-    .bg-brand-blue\/30 {
-      background-color: color-mix(in oklab, var(--brand-blue) 30%, transparent);
+    .bg-brand-blue\/20 {
+      background-color: color-mix(in oklab, var(--brand-blue) 20%, transparent);
     }
   }
 
@@ -2437,10 +2437,6 @@
     }
   }
 
-  .bg-emerald-300 {
-    background-color: var(--color-emerald-300);
-  }
-
   .bg-emerald-400 {
     background-color: var(--color-emerald-400);
   }
@@ -2465,6 +2461,10 @@
     background-color: var(--color-orange-50);
   }
 
+  .bg-purple-50 {
+    background-color: var(--color-purple-50);
+  }
+
   .bg-purple-50\/60 {
     background-color: #faf5ff99;
   }
@@ -2473,6 +2473,10 @@
     .bg-purple-50\/60 {
       background-color: color-mix(in oklab, var(--color-purple-50) 60%, transparent);
     }
+  }
+
+  .bg-purple-500 {
+    background-color: var(--color-purple-500);
   }
 
   .bg-red-50\/40 {
@@ -2559,6 +2563,10 @@
 
   .bg-slate-300 {
     background-color: var(--color-slate-300);
+  }
+
+  .bg-slate-500 {
+    background-color: var(--color-slate-500);
   }
 
   .bg-slate-950\/40 {
@@ -3195,6 +3203,11 @@
   .text-2xl {
     font-size: var(--text-2xl);
     line-height: var(--tw-leading, var(--text-2xl--line-height));
+  }
+
+  .text-3xl {
+    font-size: var(--text-3xl);
+    line-height: var(--tw-leading, var(--text-3xl--line-height));
   }
 
   .text-base {
@@ -4050,6 +4063,16 @@
       }
     }
 
+    .hover\:bg-brand-blue\/30:hover {
+      background-color: var(--brand-blue);
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-brand-blue\/30:hover {
+        background-color: color-mix(in oklab, var(--brand-blue) 30%, transparent);
+      }
+    }
+
     .hover\:bg-brand-blue\/90:hover {
       background-color: var(--brand-blue);
     }
@@ -4115,16 +4138,6 @@
     @supports (color: color-mix(in lab, red, red)) {
       .hover\:bg-slate-50\/40:hover {
         background-color: color-mix(in oklab, var(--color-slate-50) 40%, transparent);
-      }
-    }
-
-    .hover\:bg-slate-50\/50:hover {
-      background-color: #f8fafc80;
-    }
-
-    @supports (color: color-mix(in lab, red, red)) {
-      .hover\:bg-slate-50\/50:hover {
-        background-color: color-mix(in oklab, var(--color-slate-50) 50%, transparent);
       }
     }
 
@@ -4697,6 +4710,10 @@
 
     .lg\:grid-cols-4 {
       grid-template-columns: repeat(4, minmax(0, 1fr));
+    }
+
+    .lg\:grid-cols-5 {
+      grid-template-columns: repeat(5, minmax(0, 1fr));
     }
 
     .lg\:grid-cols-\[1fr_340px\] {


### PR DESCRIPTION
## Summary
- Redesigned Insights tab with full-width layout, big stat cards, fixed trend chart, and grid-based breakdowns
- Redesigned Apps tab with card grid, app-specific filters (decision + category), and evidence table in detail view
- Redesigned Categories tab with card grid, category-specific filters (decision + app), and evidence table in detail view
- Removed Story tab entirely

## Testing
- `pnpm run build` — dashboard builds successfully
- All evidence test suites pass (10/10)
- Workspace tests pass

## Notes
- Story tab removed due to low utility and AI-slop appearance per user feedback
- Apps and Categories detail views now share table patterns with All Actions tab
- Category ICON_MAP expanded to include all ReceiptCategory types