### PR TITLE
fix(guard): retry oauth requests with dpop nonce

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -198,6 +198,14 @@ def _oauth_response_header_value(response: object, header_name: str) -> str | No
     if headers is None:
         return None
     value = headers.get(header_name)
+    if value is None:
+        header_items = getattr(headers, "items", None)
+        if callable(header_items):
+            target_header = header_name.lower()
+            for current_name, current_value in header_items():
+                if isinstance(current_name, str) and current_name.lower() == target_header:
+                    value = current_value
+                    break
     if not isinstance(value, str):
         return None
     normalized_value = value.strip()
@@ -557,6 +565,7 @@ def exchange_guard_device_code(
     deadline = time.monotonic() + wait_window_seconds
     current_interval = max(interval_seconds, 1)
     dpop_nonce: str | None = None
+    nonce_retry_count = 0
     while True:
         request = urllib.request.Request(
             token_endpoint,
@@ -577,8 +586,9 @@ def exchange_guard_device_code(
         except urllib.error.HTTPError as error:
             payload = _load_error_payload(error)
             challenge_nonce = _oauth_dpop_nonce_from_http_error(error, payload)
-            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce and nonce_retry_count < 3:
                 dpop_nonce = challenge_nonce
+                nonce_retry_count += 1
                 continue
             oauth_error = str(payload.get("error") or "").strip() if isinstance(payload, dict) else ""
             if oauth_error == "authorization_pending":
@@ -636,6 +646,7 @@ def exchange_guard_authorization_code(
         }
     ).encode("utf-8")
     dpop_nonce: str | None = None
+    nonce_retry_count = 0
     while True:
         request = urllib.request.Request(
             token_endpoint,
@@ -656,8 +667,9 @@ def exchange_guard_authorization_code(
         except urllib.error.HTTPError as error:
             payload = _load_error_payload(error)
             challenge_nonce = _oauth_dpop_nonce_from_http_error(error, payload)
-            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce and nonce_retry_count < 3:
                 dpop_nonce = challenge_nonce
+                nonce_retry_count += 1
                 continue
             raise
         if not isinstance(payload, dict):
@@ -675,6 +687,7 @@ def refresh_guard_access_token(
     now: datetime | None = None,
 ) -> GuardOAuthTokenExchangeResult:
     dpop_nonce: str | None = None
+    nonce_retry_count = 0
     while True:
         request = urllib.request.Request(
             token_endpoint,
@@ -698,8 +711,9 @@ def refresh_guard_access_token(
         except urllib.error.HTTPError as error:
             payload = _load_error_payload(error)
             challenge_nonce = _oauth_dpop_nonce_from_http_error(error, payload)
-            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce and nonce_retry_count < 3:
                 dpop_nonce = challenge_nonce
+                nonce_retry_count += 1
                 continue
             message = (
                 str(payload.get("error_description") or payload.get("error") or error.reason)
@@ -724,6 +738,7 @@ def revoke_guard_self_oauth_grant(
 ) -> None:
     revoke_url = f"{oauth_client.issuer.rstrip('/')}/api/guard/oauth/revoke/self"
     dpop_nonce: str | None = None
+    nonce_retry_count = 0
     while True:
         request = urllib.request.Request(
             revoke_url,
@@ -750,8 +765,9 @@ def revoke_guard_self_oauth_grant(
         except urllib.error.HTTPError as error:
             payload = _load_error_payload(error)
             challenge_nonce = _oauth_dpop_nonce_from_http_error(error, payload)
-            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce and nonce_retry_count < 3:
                 dpop_nonce = challenge_nonce
+                nonce_retry_count += 1
                 continue
             message = (
                 str(payload.get("error_description") or payload.get("error") or error.reason)

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -157,19 +157,29 @@ def _encode_jwt_segment(payload: dict[str, object]) -> str:
     return _base64url_encode(json.dumps(payload, separators=(",", ":"), sort_keys=True).encode("utf-8"))
 
 
-def _sign_dpop_proof(*, token_endpoint: str, dpop_key_material: GuardDpopKeyMaterial, now: datetime) -> str:
+def _sign_dpop_proof(
+    *,
+    token_endpoint: str,
+    dpop_key_material: GuardDpopKeyMaterial,
+    now: datetime,
+    nonce: str | None = None,
+) -> str:
     issued_at = int(now.timestamp())
     header = {
         "alg": dpop_key_material.algorithm,
         "jwk": dpop_key_material.public_jwk,
         "typ": "dpop+jwt",
     }
-    claims = {
+    claims: dict[str, object] = {
         "htu": token_endpoint,
         "htm": "POST",
         "iat": issued_at,
         "jti": str(uuid4()),
     }
+    if isinstance(nonce, str):
+        normalized_nonce = nonce.strip()
+        if normalized_nonce:
+            claims["nonce"] = normalized_nonce
     signing_input = f"{_encode_jwt_segment(header)}.{_encode_jwt_segment(claims)}".encode("ascii")
     private_key = serialization.load_pem_private_key(
         dpop_key_material.private_key_pem.encode("ascii"),
@@ -181,6 +191,33 @@ def _sign_dpop_proof(*, token_endpoint: str, dpop_key_material: GuardDpopKeyMate
     r_value, s_value = decode_dss_signature(der_signature)
     jose_signature = _base64url_encode(r_value.to_bytes(32, byteorder="big") + s_value.to_bytes(32, byteorder="big"))
     return f"{signing_input.decode('ascii')}.{jose_signature}"
+
+
+def _oauth_response_header_value(response: object, header_name: str) -> str | None:
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    value = headers.get(header_name)
+    if not isinstance(value, str):
+        return None
+    normalized_value = value.strip()
+    return normalized_value or None
+
+
+def _oauth_dpop_nonce_from_http_error(
+    error: urllib.error.HTTPError,
+    payload: object,
+) -> str | None:
+    if error.code not in {400, 401}:
+        return None
+    nonce = _oauth_response_header_value(error, "DPoP-Nonce")
+    if nonce is None:
+        return None
+    if isinstance(payload, dict):
+        oauth_error = str(payload.get("error") or "").strip()
+        if oauth_error and oauth_error not in {"use_dpop_nonce", "invalid_dpop_proof"}:
+            return None
+    return nonce
 
 
 def _build_browser_authorize_url(
@@ -519,6 +556,7 @@ def exchange_guard_device_code(
         wait_window_seconds = min(wait_window_seconds, max(wait_timeout_seconds, 0))
     deadline = time.monotonic() + wait_window_seconds
     current_interval = max(interval_seconds, 1)
+    dpop_nonce: str | None = None
     while True:
         request = urllib.request.Request(
             token_endpoint,
@@ -529,6 +567,7 @@ def exchange_guard_device_code(
                     token_endpoint=token_endpoint,
                     dpop_key_material=dpop_key_material,
                     now=now or datetime.now(timezone.utc),
+                    nonce=dpop_nonce,
                 ),
             ),
         )
@@ -537,6 +576,10 @@ def exchange_guard_device_code(
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             payload = _load_error_payload(error)
+            challenge_nonce = _oauth_dpop_nonce_from_http_error(error, payload)
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+                dpop_nonce = challenge_nonce
+                continue
             oauth_error = str(payload.get("error") or "").strip() if isinstance(payload, dict) else ""
             if oauth_error == "authorization_pending":
                 if time.monotonic() >= deadline:
@@ -592,23 +635,34 @@ def exchange_guard_authorization_code(
             "code_verifier": code_verifier,
         }
     ).encode("utf-8")
-    request = urllib.request.Request(
-        token_endpoint,
-        data=request_body,
-        method="POST",
-        headers=_guard_oauth_request_headers(
-            dpop=_sign_dpop_proof(
-                token_endpoint=token_endpoint,
-                dpop_key_material=dpop_key_material,
-                now=now or datetime.now(timezone.utc),
+    dpop_nonce: str | None = None
+    while True:
+        request = urllib.request.Request(
+            token_endpoint,
+            data=request_body,
+            method="POST",
+            headers=_guard_oauth_request_headers(
+                dpop=_sign_dpop_proof(
+                    token_endpoint=token_endpoint,
+                    dpop_key_material=dpop_key_material,
+                    now=now or datetime.now(timezone.utc),
+                    nonce=dpop_nonce,
+                ),
             ),
-        ),
-    )
-    with urlopen(request, timeout=20) as response:
-        payload = json.loads(response.read().decode("utf-8"))
-    if not isinstance(payload, dict):
-        raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
-    return _parse_guard_token_exchange_payload(payload)
+        )
+        try:
+            with urlopen(request, timeout=20) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            payload = _load_error_payload(error)
+            challenge_nonce = _oauth_dpop_nonce_from_http_error(error, payload)
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+                dpop_nonce = challenge_nonce
+                continue
+            raise
+        if not isinstance(payload, dict):
+            raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
+        return _parse_guard_token_exchange_payload(payload)
 
 
 def refresh_guard_access_token(
@@ -620,35 +674,42 @@ def refresh_guard_access_token(
     urlopen=urllib.request.urlopen,
     now: datetime | None = None,
 ) -> GuardOAuthTokenExchangeResult:
-    request = urllib.request.Request(
-        token_endpoint,
-        data=_refresh_token_request_body(
-            client_id=client_id,
-            refresh_token=refresh_token,
-        ),
-        method="POST",
-        headers=_guard_oauth_request_headers(
-            dpop=_sign_dpop_proof(
-                token_endpoint=token_endpoint,
-                dpop_key_material=dpop_key_material,
-                now=now or datetime.now(timezone.utc),
+    dpop_nonce: str | None = None
+    while True:
+        request = urllib.request.Request(
+            token_endpoint,
+            data=_refresh_token_request_body(
+                client_id=client_id,
+                refresh_token=refresh_token,
             ),
-        ),
-    )
-    try:
-        with urlopen(request, timeout=20) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        payload = _load_error_payload(error)
-        message = (
-            str(payload.get("error_description") or payload.get("error") or error.reason)
-            if isinstance(payload, dict)
-            else str(error.reason)
+            method="POST",
+            headers=_guard_oauth_request_headers(
+                dpop=_sign_dpop_proof(
+                    token_endpoint=token_endpoint,
+                    dpop_key_material=dpop_key_material,
+                    now=now or datetime.now(timezone.utc),
+                    nonce=dpop_nonce,
+                ),
+            ),
         )
-        raise RuntimeError(f"Guard OAuth token exchange failed: {message}") from error
-    if not isinstance(payload, dict):
-        raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
-    return _parse_guard_token_exchange_payload(payload)
+        try:
+            with urlopen(request, timeout=20) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            payload = _load_error_payload(error)
+            challenge_nonce = _oauth_dpop_nonce_from_http_error(error, payload)
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+                dpop_nonce = challenge_nonce
+                continue
+            message = (
+                str(payload.get("error_description") or payload.get("error") or error.reason)
+                if isinstance(payload, dict)
+                else str(error.reason)
+            )
+            raise RuntimeError(f"Guard OAuth token exchange failed: {message}") from error
+        if not isinstance(payload, dict):
+            raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
+        return _parse_guard_token_exchange_payload(payload)
 
 
 def revoke_guard_self_oauth_grant(
@@ -661,36 +722,43 @@ def revoke_guard_self_oauth_grant(
     urlopen=urllib.request.urlopen,
     now: datetime | None = None,
 ) -> None:
-    revoke_url = f"{oauth_client.issuer}{_SELF_REVOKE_PATH}"
-    request = urllib.request.Request(
-        revoke_url,
-        data=_self_revoke_request_body(
-            workspace_id=workspace_id,
-            revoke_cloud_grant=revoke_cloud_grant,
-        ),
-        method="POST",
-        headers={
-            **_guard_oauth_request_headers(
-                dpop=_sign_dpop_proof(
-                    token_endpoint=revoke_url,
-                    dpop_key_material=dpop_key_material,
-                    now=now or datetime.now(timezone.utc),
-                ),
+    revoke_url = f"{oauth_client.issuer.rstrip('/')}/api/guard/oauth/revoke/self"
+    dpop_nonce: str | None = None
+    while True:
+        request = urllib.request.Request(
+            revoke_url,
+            data=_self_revoke_request_body(
+                workspace_id=workspace_id,
+                revoke_cloud_grant=revoke_cloud_grant,
             ),
-            "Authorization": f"Bearer {access_token}",
-        },
-    )
-    try:
-        with urlopen(request, timeout=20):
-            return
-    except urllib.error.HTTPError as error:
-        payload = _load_error_payload(error)
-        message = (
-            str(payload.get("error_description") or payload.get("error") or error.reason)
-            if isinstance(payload, dict)
-            else str(error.reason)
+            method="POST",
+            headers={
+                **_guard_oauth_request_headers(
+                    dpop=_sign_dpop_proof(
+                        token_endpoint=revoke_url,
+                        dpop_key_material=dpop_key_material,
+                        now=now or datetime.now(timezone.utc),
+                        nonce=dpop_nonce,
+                    ),
+                ),
+                "Authorization": f"Bearer {access_token}",
+            },
         )
-        raise RuntimeError(f"Guard OAuth disconnect failed: {message}") from error
+        try:
+            with urlopen(request, timeout=20):
+                return
+        except urllib.error.HTTPError as error:
+            payload = _load_error_payload(error)
+            challenge_nonce = _oauth_dpop_nonce_from_http_error(error, payload)
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+                dpop_nonce = challenge_nonce
+                continue
+            message = (
+                str(payload.get("error_description") or payload.get("error") or error.reason)
+                if isinstance(payload, dict)
+                else str(error.reason)
+            )
+            raise RuntimeError(f"Guard OAuth disconnect failed: {message}") from error
 
 
 def _require_oauth_credential_string(credentials: dict[str, object], key: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -880,11 +880,12 @@ def sync_receipts(
                 "syncContext": sync_context,
             }
         ).encode("utf-8")
-        request = urllib.request.Request(
-            sync_url,
-            data=body,
+        request = _guard_sync_request(
+            resolved_auth_context,
+            request_url=sync_url,
             method="POST",
-            headers=_guard_sync_headers(resolved_auth_context, request_url=sync_url, method="POST"),
+            data=body,
+            extra_headers=None,
         )
         try:
             payload = _urlopen_json_with_timeout_retry(
@@ -1071,15 +1072,12 @@ def _sync_supply_chain_bundle_incremental(
     trusted_keys: tuple[object, ...],
     workspace_id: str,
 ) -> dict[str, object] | None:
-    index_request = urllib.request.Request(
-        _normalized_supply_chain_bundle_index_url(bundle_url),
+    index_request = _guard_sync_request(
+        auth_context,
+        request_url=_normalized_supply_chain_bundle_index_url(bundle_url),
         method="GET",
-        headers=_guard_sync_headers(
-            auth_context,
-            request_url=_normalized_supply_chain_bundle_index_url(bundle_url),
-            method="GET",
-            extra_headers={"Accept-Encoding": "identity"},
-        ),
+        data=None,
+        extra_headers={"Accept-Encoding": "identity"},
     )
     try:
         index_payload = _fetch_supply_chain_bundle_payload(index_request)
@@ -1123,23 +1121,14 @@ def _sync_supply_chain_bundle_incremental(
                     response = None
         if response is None:
             try:
-                partition_request = urllib.request.Request(
-                    _supply_chain_partition_bundle_url(
-                        bundle_url,
-                        ecosystem=ecosystem,
-                        partition=partition,
+                partition_request = _guard_sync_request(
+                    auth_context,
+                    request_url=_supply_chain_partition_bundle_url(
+                        bundle_url, ecosystem=ecosystem, partition=partition
                     ),
                     method="GET",
-                    headers=_guard_sync_headers(
-                        auth_context,
-                        request_url=_supply_chain_partition_bundle_url(
-                            bundle_url,
-                            ecosystem=ecosystem,
-                            partition=partition,
-                        ),
-                        method="GET",
-                        extra_headers={"Accept-Encoding": "identity"},
-                    ),
+                    data=None,
+                    extra_headers={"Accept-Encoding": "identity"},
                 )
                 partition_payload = _fetch_supply_chain_bundle_payload(partition_request)
                 response = load_supply_chain_bundle_response(partition_payload)
@@ -1214,15 +1203,12 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
             )
         except SupplyChainBundleError:
             try:
-                request = urllib.request.Request(
-                    bundle_url,
+                request = _guard_sync_request(
+                    auth_context,
+                    request_url=bundle_url,
                     method="GET",
-                    headers=_guard_sync_headers(
-                        auth_context,
-                        request_url=bundle_url,
-                        method="GET",
-                        extra_headers={"Accept-Encoding": "identity"},
-                    ),
+                    data=None,
+                    extra_headers={"Accept-Encoding": "identity"},
                 )
                 payload = _fetch_supply_chain_bundle_payload(request)
                 response = load_supply_chain_bundle_response(payload)
@@ -1234,15 +1220,12 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
             except (RuntimeError, SupplyChainBundleError) as error:
                 raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
     else:
-        request = urllib.request.Request(
-            bundle_url,
+        request = _guard_sync_request(
+            auth_context,
+            request_url=bundle_url,
             method="GET",
-            headers=_guard_sync_headers(
-                auth_context,
-                request_url=bundle_url,
-                method="GET",
-                extra_headers={"Accept-Encoding": "identity"},
-            ),
+            data=None,
+            extra_headers={"Accept-Encoding": "identity"},
         )
         payload = _fetch_supply_chain_bundle_payload(request)
         try:
@@ -1328,11 +1311,12 @@ def sync_guard_events(
                 return previous_summary
             break
         body = json.dumps({"events": [event["payload"] for event in pending_events]}).encode("utf-8")
-        request = urllib.request.Request(
-            sync_url,
-            data=body,
+        request = _guard_sync_request(
+            resolved_auth_context,
+            request_url=sync_url,
             method="POST",
-            headers=_guard_sync_headers(resolved_auth_context, request_url=sync_url, method="POST"),
+            data=body,
+            extra_headers=None,
         )
         try:
             payload = _urlopen_json_with_timeout_retry(
@@ -1467,11 +1451,12 @@ def sync_runtime_session(
     sync_url = _normalized_runtime_sessions_sync_url(resolved_auth_context["sync_url"])
     session_payload = _cloud_runtime_session_payload(store, session)
     body = json.dumps({"session": session_payload}).encode("utf-8")
-    request = urllib.request.Request(
-        sync_url,
-        data=body,
+    request = _guard_sync_request(
+        resolved_auth_context,
+        request_url=sync_url,
         method="POST",
-        headers=_guard_sync_headers(resolved_auth_context, request_url=sync_url, method="POST"),
+        data=body,
+        extra_headers=None,
     )
     try:
         payload = _urlopen_json_with_timeout_retry(
@@ -1618,15 +1603,12 @@ def sync_pain_signals(
             if pain_signal is not None:
                 signal_items.append(pain_signal)
         if signal_items:
-            request = urllib.request.Request(
-                _pain_signal_sync_url(normalized_sync_url),
-                data=json.dumps({"items": signal_items}).encode("utf-8"),
+            request = _guard_sync_request(
+                resolved_auth_context,
+                request_url=_pain_signal_sync_url(normalized_sync_url),
                 method="POST",
-                headers=_guard_sync_headers(
-                    resolved_auth_context,
-                    request_url=_pain_signal_sync_url(normalized_sync_url),
-                    method="POST",
-                ),
+                data=json.dumps({"items": signal_items}).encode("utf-8"),
+                extra_headers=None,
             )
             try:
                 _urlopen_with_timeout_retry(
@@ -1746,6 +1728,7 @@ def _sign_guard_dpop_proof(
     method: str,
     dpop_key_material: GuardDpopKeyMaterial,
     access_token: str | None = None,
+    nonce: str | None = None,
     now: datetime | None = None,
 ) -> str:
     issued_at = int((now or datetime.now(timezone.utc)).timestamp())
@@ -1762,6 +1745,10 @@ def _sign_guard_dpop_proof(
     }
     if isinstance(access_token, str) and access_token:
         claims["ath"] = _dpop_access_token_confirmation_claim(access_token)
+    if isinstance(nonce, str):
+        normalized_nonce = nonce.strip()
+        if normalized_nonce:
+            claims["nonce"] = normalized_nonce
     signing_input = f"{_encode_jwt_segment(header)}.{_encode_jwt_segment(claims)}".encode("ascii")
     private_key = serialization.load_pem_private_key(
         dpop_key_material.private_key_pem.encode("ascii"),
@@ -1773,6 +1760,58 @@ def _sign_guard_dpop_proof(
     r_value, s_value = decode_dss_signature(der_signature)
     jose_signature = _base64url_encode(r_value.to_bytes(32, byteorder="big") + s_value.to_bytes(32, byteorder="big"))
     return f"{signing_input.decode('ascii')}.{jose_signature}"
+
+
+def _guard_http_header_value(response: object, header_name: str) -> str | None:
+    headers = getattr(response, "headers", None)
+    if headers is None:
+        return None
+    value = headers.get(header_name)
+    if not isinstance(value, str):
+        return None
+    normalized_value = value.strip()
+    return normalized_value or None
+
+
+def _dpop_nonce_from_http_error(error: urllib.error.HTTPError) -> str | None:
+    if error.code not in {400, 401}:
+        return None
+    return _guard_http_header_value(error, "DPoP-Nonce")
+
+
+_GUARD_DPOP_REQUEST_CONTEXTS: dict[str, dict[str, object]] = {}
+
+
+def _guard_sync_request(
+    auth_context: dict[str, object],
+    *,
+    request_url: str,
+    method: str,
+    data: bytes | None = None,
+    extra_headers: dict[str, str] | None = None,
+    dpop_nonce: str | None = None,
+) -> urllib.request.Request:
+    headers = _guard_sync_headers(
+        auth_context,
+        request_url=request_url,
+        method=method,
+        extra_headers=extra_headers,
+        dpop_nonce=dpop_nonce,
+    )
+    request = urllib.request.Request(
+        request_url,
+        data=data,
+        method=method,
+        headers=headers,
+    )
+    request._guard_dpop_retry_context = {
+        "auth_context": auth_context,
+        "request_url": request_url,
+        "method": method,
+        "extra_headers": None if extra_headers is None else dict(extra_headers),
+        "dpop_nonce": dpop_nonce,
+    }
+    return request
 
 
 def _oauth_refresh_error_message(error: urllib.error.HTTPError) -> str:
@@ -1828,47 +1867,54 @@ def _refresh_guard_oauth_access_token(
             "refresh_token": refresh_token,
         }
     ).encode("utf-8")
-    request = urllib.request.Request(
-        token_endpoint,
-        data=request_body,
-        method="POST",
-        headers={
-            "Content-Type": "application/x-www-form-urlencoded",
-            "Accept": "application/json",
-            "User-Agent": _GUARD_SYNC_USER_AGENT,
-            "DPoP": _sign_guard_dpop_proof(
-                request_url=token_endpoint,
-                method="POST",
-                dpop_key_material=dpop_key_material,
+    dpop_nonce: str | None = None
+    while True:
+        request = urllib.request.Request(
+            token_endpoint,
+            data=request_body,
+            method="POST",
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+                "Accept": "application/json",
+                "User-Agent": _GUARD_SYNC_USER_AGENT,
+                "DPoP": _sign_guard_dpop_proof(
+                    request_url=token_endpoint,
+                    method="POST",
+                    dpop_key_material=dpop_key_material,
+                    nonce=dpop_nonce,
+                ),
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            challenge_nonce = _dpop_nonce_from_http_error(error)
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+                dpop_nonce = challenge_nonce
+                continue
+            refresh_error_message = _oauth_refresh_error_message(error)
+            if error.code in {400, 401, 403}:
+                raise GuardSyncAuthorizationExpiredError(
+                    f"{_guard_oauth_reauthorization_message()} {refresh_error_message}"
+                ) from error
+            raise RuntimeError(f"Guard OAuth token refresh failed: {refresh_error_message}") from error
+        except OSError as error:
+            raise RuntimeError(_sync_url_error_message(error)) from error
+        if not isinstance(payload, dict):
+            raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+        access_token = _optional_string(payload.get("access_token"))
+        token_type = _optional_string(payload.get("token_type"))
+        if access_token is None or token_type is None or token_type.lower() not in {"bearer", "dpop"}:
+            raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+        return {
+            "access_token": access_token,
+            "package_firewall_entitlement": build_oauth_package_firewall_entitlement(
+                payload,
+                now=datetime.now(timezone.utc),
             ),
-        },
-    )
-    try:
-        with urllib.request.urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        refresh_error_message = _oauth_refresh_error_message(error)
-        if error.code in {400, 401, 403}:
-            raise GuardSyncAuthorizationExpiredError(
-                f"{_guard_oauth_reauthorization_message()} {refresh_error_message}"
-            ) from error
-        raise RuntimeError(f"Guard OAuth token refresh failed: {refresh_error_message}") from error
-    except OSError as error:
-        raise RuntimeError(_sync_url_error_message(error)) from error
-    if not isinstance(payload, dict):
-        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-    access_token = _optional_string(payload.get("access_token"))
-    token_type = _optional_string(payload.get("token_type"))
-    if access_token is None or token_type is None or token_type.lower() not in {"bearer", "dpop"}:
-        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-    return {
-        "access_token": access_token,
-        "package_firewall_entitlement": build_oauth_package_firewall_entitlement(
-            payload,
-            now=datetime.now(timezone.utc),
-        ),
-        "refresh_token": _optional_string(payload.get("refresh_token")) or refresh_token,
-    }
+            "refresh_token": _optional_string(payload.get("refresh_token")) or refresh_token,
+        }
 
 
 def _oauth_sync_url_from_issuer(issuer: str) -> str:
@@ -2004,6 +2050,7 @@ def _guard_sync_headers(
     request_url: str,
     method: str,
     extra_headers: dict[str, str] | None = None,
+    dpop_nonce: str | None = None,
 ) -> dict[str, str]:
     access_token = str(auth_context["access_token"])
     headers = {
@@ -2014,16 +2061,62 @@ def _guard_sync_headers(
     }
     dpop_key_material = auth_context.get("dpop_key_material")
     if isinstance(dpop_key_material, GuardDpopKeyMaterial):
-        headers["DPoP"] = _sign_guard_dpop_proof(
+        dpop_header = _sign_guard_dpop_proof(
             request_url=request_url,
             method=method,
             dpop_key_material=dpop_key_material,
             access_token=access_token,
+            nonce=dpop_nonce,
         )
+        headers["DPoP"] = dpop_header
+        _GUARD_DPOP_REQUEST_CONTEXTS[dpop_header] = {
+            "auth_context": auth_context,
+            "request_url": request_url,
+            "method": method,
+            "extra_headers": None if extra_headers is None else dict(extra_headers),
+            "dpop_nonce": dpop_nonce,
+        }
     if isinstance(extra_headers, dict):
         headers.update(extra_headers)
     return headers
 
+
+def _guard_sync_request_with_nonce(
+    request: urllib.request.Request,
+    dpop_nonce: str,
+) -> urllib.request.Request | None:
+    request_context = getattr(request, "_guard_dpop_retry_context", None)
+    if not isinstance(request_context, dict):
+        current_dpop = request.get_header("DPoP")
+        if not isinstance(current_dpop, str):
+            for header_name, header_value in request.header_items():
+                if header_name.lower() == "dpop":
+                    current_dpop = header_value
+                    break
+        if not isinstance(current_dpop, str):
+            return None
+        request_context = _GUARD_DPOP_REQUEST_CONTEXTS.get(current_dpop)
+        if not isinstance(request_context, dict):
+            return None
+    auth_context = request_context.get("auth_context")
+    request_url = request_context.get("request_url")
+    method = request_context.get("method")
+    extra_headers = request_context.get("extra_headers")
+    current_dpop_nonce = request_context.get("dpop_nonce")
+    if not isinstance(auth_context, dict) or not isinstance(request_url, str) or not isinstance(method, str):
+        return None
+    if extra_headers is not None and not isinstance(extra_headers, dict):
+        return None
+    if current_dpop_nonce == dpop_nonce:
+        return None
+    return _guard_sync_request(
+        auth_context,
+        request_url=request_url,
+        method=method,
+        data=request.data,
+        extra_headers=None if extra_headers is None else {str(key): str(value) for key, value in extra_headers.items()},
+        dpop_nonce=dpop_nonce,
+    )
 
 def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     try:
@@ -2123,17 +2216,31 @@ def _urlopen_json_with_timeout_retry(
     timeout_seconds: int,
     retry_timeout_seconds: int,
 ) -> dict[str, object]:
-    try:
-        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    except OSError as error:
-        if not _is_timeout_error(error):
+    current_request = request
+    current_timeout_seconds = timeout_seconds
+    retried_timeout = False
+    while True:
+        try:
+            with urllib.request.urlopen(current_request, timeout=current_timeout_seconds) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        except urllib.error.HTTPError as error:
+            dpop_nonce = _dpop_nonce_from_http_error(error)
+            retry_request = None if dpop_nonce is None else _guard_sync_request_with_nonce(current_request, dpop_nonce)
+            if retry_request is not None:
+                current_request = retry_request
+                current_timeout_seconds = timeout_seconds
+                retried_timeout = False
+                continue
             raise
-        with urllib.request.urlopen(request, timeout=retry_timeout_seconds) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-    if not isinstance(payload, dict):
-        raise RuntimeError("Invalid sync response")
-    return payload
+        except OSError as error:
+            if not retried_timeout and _is_timeout_error(error):
+                current_timeout_seconds = retry_timeout_seconds
+                retried_timeout = True
+                continue
+            raise
+        if not isinstance(payload, dict):
+            raise RuntimeError("Guard Cloud sync returned an invalid response payload.")
+        return payload
 
 
 def _urlopen_with_timeout_retry(
@@ -2142,14 +2249,28 @@ def _urlopen_with_timeout_retry(
     timeout_seconds: int,
     retry_timeout_seconds: int,
 ) -> None:
-    try:
-        with urllib.request.urlopen(request, timeout=timeout_seconds):
-            return
-    except OSError as error:
-        if not _is_timeout_error(error):
+    current_request = request
+    current_timeout_seconds = timeout_seconds
+    retried_timeout = False
+    while True:
+        try:
+            with urllib.request.urlopen(current_request, timeout=current_timeout_seconds):
+                return
+        except urllib.error.HTTPError as error:
+            dpop_nonce = _dpop_nonce_from_http_error(error)
+            retry_request = None if dpop_nonce is None else _guard_sync_request_with_nonce(current_request, dpop_nonce)
+            if retry_request is not None:
+                current_request = retry_request
+                current_timeout_seconds = timeout_seconds
+                retried_timeout = False
+                continue
             raise
-        with urllib.request.urlopen(request, timeout=retry_timeout_seconds):
-            return
+        except OSError as error:
+            if not retried_timeout and _is_timeout_error(error):
+                current_timeout_seconds = retry_timeout_seconds
+                retried_timeout = True
+                continue
+            raise
 
 
 def _remote_harness(value: object, *, allow_wildcard: bool = True) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2118,6 +2118,7 @@ def _guard_sync_request_with_nonce(
         dpop_nonce=dpop_nonce,
     )
 
+
 def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     try:
         raw_body = error.read().decode("utf-8")

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1929,7 +1929,7 @@ def _refresh_guard_oauth_access_token(
             with urllib.request.urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
-            payload = _http_error_payload(error)
+            payload = _http_error_payload(error) if error.code in {400, 401} else None
             challenge_nonce = _dpop_nonce_from_http_error(error, payload)
             if challenge_nonce is not None and challenge_nonce != dpop_nonce and nonce_retry_count < 3:
                 dpop_nonce = challenge_nonce
@@ -2271,7 +2271,7 @@ def _urlopen_json_with_timeout_retry(
             with urllib.request.urlopen(current_request, timeout=current_timeout_seconds) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
-            error_payload = _http_error_payload(error)
+            error_payload = _http_error_payload(error) if error.code in {400, 401} else None
             dpop_nonce = _dpop_nonce_from_http_error(error, error_payload)
             retry_request = (
                 None
@@ -2311,7 +2311,7 @@ def _urlopen_with_timeout_retry(
             with urllib.request.urlopen(current_request, timeout=current_timeout_seconds):
                 return
         except urllib.error.HTTPError as error:
-            error_payload = _http_error_payload(error)
+            error_payload = _http_error_payload(error) if error.code in {400, 401} else None
             dpop_nonce = _dpop_nonce_from_http_error(error, error_payload)
             retry_request = (
                 None

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import hashlib
+import io
 import json
 import os
 import re
@@ -1767,19 +1768,57 @@ def _guard_http_header_value(response: object, header_name: str) -> str | None:
     if headers is None:
         return None
     value = headers.get(header_name)
+    if value is None:
+        header_items = getattr(headers, "items", None)
+        if callable(header_items):
+            target_header = header_name.lower()
+            for current_name, current_value in header_items():
+                if isinstance(current_name, str) and current_name.lower() == target_header:
+                    value = current_value
+                    break
     if not isinstance(value, str):
         return None
     normalized_value = value.strip()
     return normalized_value or None
 
 
-def _dpop_nonce_from_http_error(error: urllib.error.HTTPError) -> str | None:
+def _http_error_payload(error: urllib.error.HTTPError) -> object:
+    try:
+        raw_body = error.read()
+    except OSError:
+        raw_body = b""
+    error.fp = io.BytesIO(raw_body)
+    if not raw_body:
+        return None
+    try:
+        return json.loads(raw_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError):
+        return None
+
+
+def _dpop_nonce_from_http_error(error: urllib.error.HTTPError, payload: object) -> str | None:
     if error.code not in {400, 401}:
         return None
-    return _guard_http_header_value(error, "DPoP-Nonce")
+    nonce = _guard_http_header_value(error, "DPoP-Nonce")
+    if nonce is None:
+        return None
+    if isinstance(payload, dict):
+        oauth_error = str(payload.get("error") or "").strip()
+        if oauth_error and oauth_error not in {"use_dpop_nonce", "invalid_dpop_proof"}:
+            return None
+    return nonce
 
 
 _GUARD_DPOP_REQUEST_CONTEXTS: dict[str, dict[str, object]] = {}
+_GUARD_DPOP_REQUEST_CONTEXT_LIMIT = 1000
+
+
+def _remember_guard_dpop_request_context(dpop_header: str, context: dict[str, object]) -> None:
+    if len(_GUARD_DPOP_REQUEST_CONTEXTS) >= _GUARD_DPOP_REQUEST_CONTEXT_LIMIT:
+        oldest_header = next(iter(_GUARD_DPOP_REQUEST_CONTEXTS), None)
+        if isinstance(oldest_header, str):
+            _GUARD_DPOP_REQUEST_CONTEXTS.pop(oldest_header, None)
+    _GUARD_DPOP_REQUEST_CONTEXTS[dpop_header] = context
 
 
 def _guard_sync_request(
@@ -1868,6 +1907,7 @@ def _refresh_guard_oauth_access_token(
         }
     ).encode("utf-8")
     dpop_nonce: str | None = None
+    nonce_retry_count = 0
     while True:
         request = urllib.request.Request(
             token_endpoint,
@@ -1889,9 +1929,11 @@ def _refresh_guard_oauth_access_token(
             with urllib.request.urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
-            challenge_nonce = _dpop_nonce_from_http_error(error)
-            if challenge_nonce is not None and challenge_nonce != dpop_nonce:
+            payload = _http_error_payload(error)
+            challenge_nonce = _dpop_nonce_from_http_error(error, payload)
+            if challenge_nonce is not None and challenge_nonce != dpop_nonce and nonce_retry_count < 3:
                 dpop_nonce = challenge_nonce
+                nonce_retry_count += 1
                 continue
             refresh_error_message = _oauth_refresh_error_message(error)
             if error.code in {400, 401, 403}:
@@ -2069,13 +2111,16 @@ def _guard_sync_headers(
             nonce=dpop_nonce,
         )
         headers["DPoP"] = dpop_header
-        _GUARD_DPOP_REQUEST_CONTEXTS[dpop_header] = {
-            "auth_context": auth_context,
-            "request_url": request_url,
-            "method": method,
-            "extra_headers": None if extra_headers is None else dict(extra_headers),
-            "dpop_nonce": dpop_nonce,
-        }
+        _remember_guard_dpop_request_context(
+            dpop_header,
+            {
+                "auth_context": auth_context,
+                "request_url": request_url,
+                "method": method,
+                "extra_headers": None if extra_headers is None else dict(extra_headers),
+                "dpop_nonce": dpop_nonce,
+            },
+        )
     if isinstance(extra_headers, dict):
         headers.update(extra_headers)
     return headers
@@ -2220,14 +2265,21 @@ def _urlopen_json_with_timeout_retry(
     current_request = request
     current_timeout_seconds = timeout_seconds
     retried_timeout = False
+    nonce_retry_count = 0
     while True:
         try:
             with urllib.request.urlopen(current_request, timeout=current_timeout_seconds) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
-            dpop_nonce = _dpop_nonce_from_http_error(error)
-            retry_request = None if dpop_nonce is None else _guard_sync_request_with_nonce(current_request, dpop_nonce)
+            error_payload = _http_error_payload(error)
+            dpop_nonce = _dpop_nonce_from_http_error(error, error_payload)
+            retry_request = (
+                None
+                if dpop_nonce is None or nonce_retry_count >= 3
+                else _guard_sync_request_with_nonce(current_request, dpop_nonce)
+            )
             if retry_request is not None:
+                nonce_retry_count += 1
                 current_request = retry_request
                 current_timeout_seconds = timeout_seconds
                 retried_timeout = False
@@ -2253,14 +2305,21 @@ def _urlopen_with_timeout_retry(
     current_request = request
     current_timeout_seconds = timeout_seconds
     retried_timeout = False
+    nonce_retry_count = 0
     while True:
         try:
             with urllib.request.urlopen(current_request, timeout=current_timeout_seconds):
                 return
         except urllib.error.HTTPError as error:
-            dpop_nonce = _dpop_nonce_from_http_error(error)
-            retry_request = None if dpop_nonce is None else _guard_sync_request_with_nonce(current_request, dpop_nonce)
+            error_payload = _http_error_payload(error)
+            dpop_nonce = _dpop_nonce_from_http_error(error, error_payload)
+            retry_request = (
+                None
+                if dpop_nonce is None or nonce_retry_count >= 3
+                else _guard_sync_request_with_nonce(current_request, dpop_nonce)
+            )
             if retry_request is not None:
+                nonce_retry_count += 1
                 current_request = retry_request
                 current_timeout_seconds = timeout_seconds
                 retried_timeout = False

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -8,6 +8,8 @@ import urllib.request
 from datetime import datetime, timezone
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.cli import _build_parser
 from codex_plugin_scanner.guard.cli import commands as guard_commands
 from codex_plugin_scanner.guard.cli import connect_flow
@@ -1758,6 +1760,37 @@ def test_exchange_authorization_code_retries_with_dpop_nonce_challenge() -> None
     assert second_claims["nonce"] == challenge_nonce
     assert result.access_token == "access-123"
     assert result.refresh_token == "refresh-123"
+
+
+def test_exchange_authorization_code_limits_dpop_nonce_retries() -> None:
+    dpop_key_material = generate_dpop_key_pair()
+    captured_headers: list[dict[str, str]] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        captured_headers.append({str(key).lower(): str(value) for key, value in dict(request.header_items()).items()})
+        attempt = len(captured_headers)
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "Bad Request",
+            {"dpop-nonce": f"nonce-{attempt}"},
+            io.BytesIO(json.dumps({"error": "use_dpop_nonce"}).encode("utf-8")),
+        )
+
+    with pytest.raises(urllib.error.HTTPError):
+        connect_flow.exchange_guard_authorization_code(
+            token_endpoint="https://hol.org/api/guard/oauth/token",
+            client_id="guard-local-daemon",
+            code="auth-code-123",
+            redirect_uri="http://127.0.0.1:61234/oauth/callback",
+            code_verifier="verifier-123",
+            dpop_key_material=dpop_key_material,
+            urlopen=fake_urlopen,
+            now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        )
+
+    assert len(captured_headers) == 4
 
 
 def test_exchange_guard_device_code_retries_with_dpop_nonce_challenge() -> None:

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -17,6 +17,15 @@ from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.store import GuardStore, SystemKeyringSecretStore
 
 
+def _decode_connect_flow_jwt_segment(segment: str) -> dict[str, object]:
+    padding = "=" * (-len(segment) % 4)
+    return json.loads(base64.urlsafe_b64decode(f"{segment}{padding}".encode("ascii")).decode("utf-8"))
+
+
+def _decode_connect_flow_dpop_claims(proof: str) -> dict[str, object]:
+    return _decode_connect_flow_jwt_segment(proof.split(".")[1])
+
+
 class _FakeSystemKeyringModule:
     def __init__(self) -> None:
         self._secrets: dict[tuple[str, str], str] = {}
@@ -1689,3 +1698,178 @@ def test_connect_browser_reports_loopback_timeout_without_traceback(
     assert "Traceback" not in captured.err
     assert store.get_sync_credentials() is None
     assert store.get_oauth_local_credentials() is None
+
+
+def test_exchange_authorization_code_retries_with_dpop_nonce_challenge() -> None:
+    dpop_key_material = generate_dpop_key_pair()
+    challenge_nonce = "nonce-authorization"
+    captured_headers: list[dict[str, str]] = []
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": "access-123",
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                    "grant_id": "grant-123",
+                    "machine_id": "machine-123",
+                    "workspace_id": "workspace-123",
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        captured_headers.append({str(key).lower(): str(value) for key, value in dict(request.header_items()).items()})
+        if len(captured_headers) == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                400,
+                "Bad Request",
+                {"DPoP-Nonce": challenge_nonce},
+                io.BytesIO(json.dumps({"error": "use_dpop_nonce"}).encode("utf-8")),
+            )
+        return _Response()
+
+    result = connect_flow.exchange_guard_authorization_code(
+        token_endpoint="https://hol.org/api/guard/oauth/token",
+        client_id="guard-local-daemon",
+        code="auth-code-123",
+        redirect_uri="http://127.0.0.1:61234/oauth/callback",
+        code_verifier="verifier-123",
+        dpop_key_material=dpop_key_material,
+        urlopen=fake_urlopen,
+        now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+    first_claims = _decode_connect_flow_dpop_claims(captured_headers[0]["dpop"])
+    second_claims = _decode_connect_flow_dpop_claims(captured_headers[1]["dpop"])
+
+    assert len(captured_headers) == 2
+    assert "nonce" not in first_claims
+    assert second_claims["nonce"] == challenge_nonce
+    assert result.access_token == "access-123"
+    assert result.refresh_token == "refresh-123"
+
+
+def test_exchange_guard_device_code_retries_with_dpop_nonce_challenge() -> None:
+    dpop_key_material = generate_dpop_key_pair()
+    challenge_nonce = "nonce-device"
+    captured_headers: list[dict[str, str]] = []
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": "access-123",
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                    "grant_id": "grant-123",
+                    "machine_id": "machine-123",
+                    "workspace_id": "workspace-123",
+                }
+            ).encode("utf-8")
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        captured_headers.append({str(key).lower(): str(value) for key, value in dict(request.header_items()).items()})
+        if len(captured_headers) == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                400,
+                "Bad Request",
+                {"DPoP-Nonce": challenge_nonce},
+                io.BytesIO(json.dumps({"error": "use_dpop_nonce"}).encode("utf-8")),
+            )
+        return _Response()
+
+    result = connect_flow.exchange_guard_device_code(
+        token_endpoint="https://hol.org/api/guard/oauth/token",
+        client_id="guard-local-daemon",
+        device_code="device-code-123",
+        dpop_key_material=dpop_key_material,
+        interval_seconds=5,
+        expires_in_seconds=60,
+        urlopen=fake_urlopen,
+        now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+    first_claims = _decode_connect_flow_dpop_claims(captured_headers[0]["dpop"])
+    second_claims = _decode_connect_flow_dpop_claims(captured_headers[1]["dpop"])
+
+    assert len(captured_headers) == 2
+    assert "nonce" not in first_claims
+    assert second_claims["nonce"] == challenge_nonce
+    assert result.access_token == "access-123"
+    assert result.refresh_token == "refresh-123"
+
+
+def test_revoke_guard_self_oauth_grant_retries_with_dpop_nonce_challenge() -> None:
+    oauth_client = connect_flow.GuardOAuthClientConfig(
+        issuer="https://hol.org",
+        authorize_endpoint="https://hol.org/api/guard/oauth/authorize",
+        token_endpoint="https://hol.org/api/guard/oauth/token",
+        device_authorization_endpoint="https://hol.org/api/guard/oauth/device",
+        jwks_endpoint="https://hol.org/api/guard/oauth/jwks",
+        client_id="guard-local-daemon",
+    )
+    dpop_key_material = generate_dpop_key_pair()
+    challenge_nonce = "nonce-revoke"
+    captured_headers: list[dict[str, str]] = []
+
+    class _Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return b""
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        captured_headers.append({str(key).lower(): str(value) for key, value in dict(request.header_items()).items()})
+        if len(captured_headers) == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                401,
+                "Unauthorized",
+                {"DPoP-Nonce": challenge_nonce},
+                io.BytesIO(json.dumps({"error": "use_dpop_nonce"}).encode("utf-8")),
+            )
+        return _Response()
+
+    connect_flow.revoke_guard_self_oauth_grant(
+        oauth_client=oauth_client,
+        access_token="oauth-access-token-1",
+        workspace_id="workspace-123",
+        revoke_cloud_grant=True,
+        dpop_key_material=dpop_key_material,
+        urlopen=fake_urlopen,
+        now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+    first_claims = _decode_connect_flow_dpop_claims(captured_headers[0]["dpop"])
+    second_claims = _decode_connect_flow_dpop_claims(captured_headers[1]["dpop"])
+
+    assert len(captured_headers) == 2
+    assert "nonce" not in first_claims
+    assert second_claims["nonce"] == challenge_nonce
+    assert captured_headers[1]["authorization"] == "Bearer oauth-access-token-1"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -16184,6 +16184,7 @@ def test_sync_receipts_preserves_batch_metadata_and_reuses_device_metadata(tmp_p
 
 def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
     store.set_sync_credentials(
         "https://hol.org/api/guard/receipts/sync",
         "guard-live-token",
@@ -16216,6 +16217,11 @@ def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):
 
     payload = guard_runner_module.sync_runtime_session(
         store,
+        auth_context={
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "oauth-access-token-1",
+            "dpop_key_material": dpop_key_material,
+        },
         session={
             "session_id": "session-1",
             "harness": "hermes",
@@ -16238,6 +16244,7 @@ def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):
 
 def test_sync_runtime_session_retries_once_after_read_timeout(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
     store.set_sync_credentials(
         "https://hol.org/api/guard/receipts/sync",
         "guard-live-token",
@@ -16273,6 +16280,11 @@ def test_sync_runtime_session_retries_once_after_read_timeout(tmp_path, monkeypa
 
     payload = guard_runner_module.sync_runtime_session(
         store,
+        auth_context={
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "oauth-access-token-1",
+            "dpop_key_material": dpop_key_material,
+        },
         session={
             "session_id": "session-read-timeout",
             "harness": "hermes",
@@ -16535,6 +16547,7 @@ def test_sign_guard_dpop_proof_sets_access_token_hash_claim() -> None:
     expected_ath = guard_runner_module._base64url_encode(hashlib.sha256(access_token.encode("ascii")).digest())
 
     assert claims["ath"] == expected_ath
+
 
 def test_sync_receipts_uses_distinct_dpop_proofs_per_batch(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
@@ -17691,3 +17704,202 @@ def test_codex_read_only_source_inspection_rejects_malformed_chains(tmp_path: Pa
             command,
             cwd=workspace_dir,
         )
+
+
+def test_sign_guard_dpop_proof_sets_nonce_claim() -> None:
+    dpop_key_material = generate_dpop_key_pair()
+
+    proof = guard_runner_module._sign_guard_dpop_proof(
+        request_url="https://hol.org/api/guard/runtime/sessions/sync",
+        method="POST",
+        dpop_key_material=dpop_key_material,
+        nonce="nonce-123",
+        now=datetime(2026, 6, 1, tzinfo=timezone.utc),
+    )
+
+    claims = _decode_jwt_segment(proof.split(".")[1])
+
+    assert claims["nonce"] == "nonce-123"
+
+
+def test_sync_runtime_session_retries_with_dpop_nonce_challenge(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    captured_requests: list[urllib.request.Request] = []
+    challenge_nonce = "nonce-runtime"
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        del timeout
+        captured_requests.append(request)
+        if len(captured_requests) == 1:
+            raise urllib.error.HTTPError(
+                request.full_url,
+                401,
+                "Unauthorized",
+                {"DPoP-Nonce": challenge_nonce},
+                io.BytesIO(b"{}"),
+            )
+        assert request.full_url == "https://hol.org/api/guard/runtime/sessions/sync"
+        assert _request_header(request, "Authorization") == "Bearer oauth-access-token-1"
+        assert isinstance(_request_header(request, "DPoP"), str) and _request_header(request, "DPoP")
+        return _Response(
+            {
+                "generatedAt": "2026-06-01T00:00:10+00:00",
+                "items": [{"status": "accepted"}],
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = guard_runner_module.sync_runtime_session(
+        store,
+        auth_context={
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "oauth-access-token-1",
+            "dpop_key_material": dpop_key_material,
+        },
+        session={
+            "session_id": "session-oauth",
+            "harness": "codex",
+            "surface": "cli",
+            "status": "active",
+            "client_name": "Codex",
+            "client_title": "Codex CLI",
+            "client_version": "1.0.0",
+            "workspace": "prod",
+            "capabilities": ["chat"],
+            "started_at": "2026-06-01T00:00:00+00:00",
+            "updated_at": "2026-06-01T00:00:00+00:00",
+            "operations": [],
+        },
+    )
+
+    first_claims = _decode_jwt_segment(_request_header(captured_requests[0], "DPoP").split(".")[1])
+    second_claims = _decode_jwt_segment(_request_header(captured_requests[1], "DPoP").split(".")[1])
+
+    assert len(captured_requests) == 2
+    assert "nonce" not in first_claims
+    assert second_claims["nonce"] == challenge_nonce
+    assert payload["runtime_session_id"] == "session-oauth"
+
+
+def test_sync_runtime_session_refresh_retries_with_dpop_nonce_challenge(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    captured_requests: list[urllib.request.Request] = []
+    challenge_nonce = "nonce-refresh"
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        del timeout
+        captured_requests.append(request)
+        if request.full_url == "https://hol.org/api/guard/oauth/token":
+            if len([item for item in captured_requests if item.full_url == request.full_url]) == 1:
+                raise urllib.error.HTTPError(
+                    request.full_url,
+                    401,
+                    "Unauthorized",
+                    {"DPoP-Nonce": challenge_nonce},
+                    io.BytesIO(b"{}"),
+                )
+            body = urllib.parse.parse_qs(request.data.decode("utf-8"))
+            assert body["grant_type"] == ["refresh_token"]
+            assert body["client_id"] == ["guard-local-daemon"]
+            assert body["refresh_token"] == ["refresh-token-1"]
+            return _Response(
+                {
+                    "access_token": "oauth-access-token-1",
+                    "refresh_token": "refresh-token-2",
+                    "token_type": "DPoP",
+                    "expires_in": 3600,
+                }
+            )
+        assert request.full_url == "https://hol.org/api/guard/runtime/sessions/sync"
+        return _Response(
+            {
+                "generatedAt": "2026-06-01T00:00:10+00:00",
+                "items": [{"status": "accepted"}],
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    guard_runner_module.sync_runtime_session(
+        store,
+        session={
+            "session_id": "session-oauth",
+            "harness": "codex",
+            "surface": "cli",
+            "status": "active",
+            "client_name": "Codex",
+            "client_title": "Codex CLI",
+            "client_version": "1.0.0",
+            "workspace": "prod",
+            "capabilities": ["chat"],
+            "started_at": "2026-06-01T00:00:00+00:00",
+            "updated_at": "2026-06-01T00:00:00+00:00",
+            "operations": [],
+        },
+    )
+
+    refresh_requests = [
+        request for request in captured_requests if request.full_url == "https://hol.org/api/guard/oauth/token"
+    ]
+    assert len(refresh_requests) == 2
+    first_claims = _decode_jwt_segment(_request_header(refresh_requests[0], "DPoP").split(".")[1])
+    second_claims = _decode_jwt_segment(_request_header(refresh_requests[1], "DPoP").split(".")[1])
+    assert "nonce" not in first_claims
+    assert second_claims["nonce"] == challenge_nonce
+
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-token-2"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -17025,7 +17025,7 @@ def test_codex_read_only_source_inspection_allows_tilde_worktree_targets(tmp_pat
     _write_text(workspace_dir / "__tests__" / "agent-token-detail.test.ts", "expect(onRotated).toHaveBeenCalled();\n")
 
     command = (
-        "rg -n \"onRotated=|onRotated:|onRotated\\)|AgentTokenDetail\" "
+        'rg -n "onRotated=|onRotated:|onRotated\\)|AgentTokenDetail" '
         "~/CascadeProjects/hashgraph-online/hol-points-portal/.worktrees/guard-auth-phase-r-default-surfaces/app "
         "~/CascadeProjects/hashgraph-online/hol-points-portal/.worktrees/guard-auth-phase-r-default-surfaces/__tests__"
     )
@@ -17722,6 +17722,14 @@ def test_sign_guard_dpop_proof_sets_nonce_claim() -> None:
     assert claims["nonce"] == "nonce-123"
 
 
+def test_guard_http_header_value_matches_case_insensitive_mapping() -> None:
+    class _Response:
+        def __init__(self) -> None:
+            self.headers = {"dpop-nonce": "nonce-123"}
+
+    assert guard_runner_module._guard_http_header_value(_Response(), "DPoP-Nonce") == "nonce-123"
+
+
 def test_sync_runtime_session_retries_with_dpop_nonce_challenge(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     dpop_key_material = generate_dpop_key_pair()
@@ -17806,6 +17814,52 @@ def test_sync_runtime_session_retries_with_dpop_nonce_challenge(tmp_path, monkey
     assert "nonce" not in first_claims
     assert second_claims["nonce"] == challenge_nonce
     assert payload["runtime_session_id"] == "session-oauth"
+
+
+def test_sync_runtime_session_limits_dpop_nonce_retries(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    captured_requests: list[urllib.request.Request] = []
+
+    def _fake_urlopen(request, timeout):
+        del timeout
+        captured_requests.append(request)
+        attempt = len(captured_requests)
+        raise urllib.error.HTTPError(
+            request.full_url,
+            401,
+            "Unauthorized",
+            {"dpop-nonce": f"nonce-{attempt}"},
+            io.BytesIO(json.dumps({"error": "use_dpop_nonce"}).encode("utf-8")),
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    with pytest.raises(RuntimeError, match="HTTP Error 401: Unauthorized"):
+        guard_runner_module.sync_runtime_session(
+            store,
+            auth_context={
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+                "access_token": "oauth-access-token-1",
+                "dpop_key_material": dpop_key_material,
+            },
+            session={
+                "session_id": "session-oauth",
+                "harness": "codex",
+                "surface": "cli",
+                "status": "active",
+                "client_name": "Codex",
+                "client_title": "Codex CLI",
+                "client_version": "1.0.0",
+                "workspace": "prod",
+                "capabilities": ["chat"],
+                "started_at": "2026-06-01T00:00:00+00:00",
+                "updated_at": "2026-06-01T00:00:00+00:00",
+                "operations": [],
+            },
+        )
+
+    assert len(captured_requests) == 4
 
 
 def test_sync_runtime_session_refresh_retries_with_dpop_nonce_challenge(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- retry Guard OAuth device, authorization-code, refresh, revoke, and sync requests when the issuer returns a DPoP nonce challenge
- preserve reconnect guidance on expired OAuth refresh failures while keeping runtime DPoP retry coverage in place

## Testing
- `uv run pytest tests/test_guard_runtime.py -k 'nonce or refreshes_oauth_access_token_and_rotates_refresh_token or distinct_dpop_proofs_per_batch or sign_guard_dpop_proof_sets_access_token_hash_claim' -q`
- `uv run pytest tests/test_guard_oauth_device_connect.py -k 'nonce or exchange_authorization_code_posts_pkce_and_dpop_binding or disconnect' -q`
- `uv run pytest tests/test_guard_connect_flow.py tests/test_guard_oauth_device_connect.py tests/test_guard_runtime.py -q`
- `uv run pytest tests/test_guard_surface_server.py tests/test_guard_headless_daemon_api.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/connect_flow.py src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_oauth_device_connect.py tests/test_guard_runtime.py`
- `git diff --check`
