### PR TITLE
fix(guard): serialize concurrent oauth refresh

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -65,6 +65,8 @@ _APPROVAL_METADATA_KEYS = (
 
 _DEFAULT_DETECTOR_REGISTRY: tuple[Callable[[], tuple[Any, ...]], DetectorRegistry] | None = None
 _DEFAULT_DETECTOR_REGISTRY_LOCK = threading.Lock()
+_GUARD_SYNC_AUTH_LOCKS_LOCK = threading.Lock()
+_GUARD_SYNC_AUTH_LOCKS: dict[str, threading.RLock] = {}
 
 
 def _get_default_detector_registry() -> DetectorRegistry:
@@ -79,6 +81,16 @@ def _get_default_detector_registry() -> DetectorRegistry:
             cached = (factory, DetectorRegistry(factory()))
             _DEFAULT_DETECTOR_REGISTRY = cached
     return cached[1]
+
+
+def _guard_sync_auth_lock(store: GuardStore) -> threading.RLock:
+    store_key = str(store.guard_home.expanduser().resolve())
+    with _GUARD_SYNC_AUTH_LOCKS_LOCK:
+        lock = _GUARD_SYNC_AUTH_LOCKS.get(store_key)
+        if lock is None:
+            lock = threading.RLock()
+            _GUARD_SYNC_AUTH_LOCKS[store_key] = lock
+        return lock
 
 
 _PAIN_SIGNAL_EVENTS = frozenset(
@@ -1945,57 +1957,58 @@ def _persist_rotated_oauth_refresh_token(
 
 
 def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
-    oauth_health = store.get_oauth_local_credential_health()
-    oauth_credentials = store.get_oauth_local_credentials()
-    if oauth_credentials is not None:
-        issuer = _optional_string(oauth_credentials.get("issuer"))
-        client_id = _optional_string(oauth_credentials.get("client_id"))
-        refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
-        if issuer is None or client_id is None or refresh_token is None:
-            raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-        dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
-        try:
-            oauth_client = resolve_guard_oauth_client_config(issuer)
-        except ValueError as error:
-            raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
-        refreshed = _refresh_guard_oauth_access_token(
-            token_endpoint=oauth_client.token_endpoint,
-            client_id=client_id,
-            refresh_token=refresh_token,
-            dpop_key_material=dpop_key_material,
-        )
-        rotated_refresh_token = str(refreshed["refresh_token"])
-        package_firewall_entitlement = (
-            refreshed["package_firewall_entitlement"]
-            if isinstance(refreshed.get("package_firewall_entitlement"), dict)
-            else None
-        )
-        if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None:
-            _persist_rotated_oauth_refresh_token(
-                store=store,
-                credentials=oauth_credentials,
-                package_firewall_entitlement=package_firewall_entitlement,
-                refresh_token=rotated_refresh_token,
+    with _guard_sync_auth_lock(store):
+        oauth_health = store.get_oauth_local_credential_health()
+        oauth_credentials = store.get_oauth_local_credentials()
+        if oauth_credentials is not None:
+            issuer = _optional_string(oauth_credentials.get("issuer"))
+            client_id = _optional_string(oauth_credentials.get("client_id"))
+            refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
+            if issuer is None or client_id is None or refresh_token is None:
+                raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+            dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
+            try:
+                oauth_client = resolve_guard_oauth_client_config(issuer)
+            except ValueError as error:
+                raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
+            refreshed = _refresh_guard_oauth_access_token(
+                token_endpoint=oauth_client.token_endpoint,
+                client_id=client_id,
+                refresh_token=refresh_token,
+                dpop_key_material=dpop_key_material,
             )
-        sync_url = _validate_guard_sync_url(
-            _oauth_sync_url_from_issuer(oauth_client.issuer),
-            issuer=oauth_client.issuer,
-        )
+            rotated_refresh_token = str(refreshed["refresh_token"])
+            package_firewall_entitlement = (
+                refreshed["package_firewall_entitlement"]
+                if isinstance(refreshed.get("package_firewall_entitlement"), dict)
+                else None
+            )
+            if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None:
+                _persist_rotated_oauth_refresh_token(
+                    store=store,
+                    credentials=oauth_credentials,
+                    package_firewall_entitlement=package_firewall_entitlement,
+                    refresh_token=rotated_refresh_token,
+                )
+            sync_url = _validate_guard_sync_url(
+                _oauth_sync_url_from_issuer(oauth_client.issuer),
+                issuer=oauth_client.issuer,
+            )
+            return {
+                "sync_url": sync_url,
+                "access_token": str(refreshed["access_token"]),
+                "dpop_key_material": dpop_key_material,
+            }
+        if bool(oauth_health.get("configured")):
+            raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+        credentials = store.get_sync_credentials()
+        if credentials is None:
+            raise GuardSyncNotConfiguredError("Guard is not logged in.")
         return {
-            "sync_url": sync_url,
-            "access_token": str(refreshed["access_token"]),
-            "dpop_key_material": dpop_key_material,
+            "sync_url": _validate_guard_sync_url(str(credentials["sync_url"])),
+            "access_token": str(credentials["token"]),
+            "dpop_key_material": None,
         }
-    if bool(oauth_health.get("configured")):
-        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    return {
-        "sync_url": _validate_guard_sync_url(str(credentials["sync_url"])),
-        "access_token": str(credentials["token"]),
-        "dpop_key_material": None,
-    }
 
 
 def _guard_sync_headers(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -9,15 +9,16 @@ import re
 import socket
 import subprocess
 import threading
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
 from base64 import urlsafe_b64encode
 from collections.abc import Callable
-from contextlib import suppress
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any
+from typing import Any, BinaryIO
 from uuid import uuid4
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -66,7 +67,8 @@ _APPROVAL_METADATA_KEYS = (
 _DEFAULT_DETECTOR_REGISTRY: tuple[Callable[[], tuple[Any, ...]], DetectorRegistry] | None = None
 _DEFAULT_DETECTOR_REGISTRY_LOCK = threading.Lock()
 _GUARD_SYNC_AUTH_LOCKS_LOCK = threading.Lock()
-_GUARD_SYNC_AUTH_LOCKS: dict[str, threading.RLock] = {}
+_GUARD_SYNC_AUTH_LOCKS: dict[str, threading.Lock] = {}
+_GUARD_SYNC_AUTH_LOCK_POLL_INTERVAL_SECONDS = 0.05
 
 
 def _get_default_detector_registry() -> DetectorRegistry:
@@ -83,14 +85,57 @@ def _get_default_detector_registry() -> DetectorRegistry:
     return cached[1]
 
 
-def _guard_sync_auth_lock(store: GuardStore) -> threading.RLock:
-    store_key = str(store.guard_home.expanduser().resolve())
+@contextmanager
+def _guard_sync_auth_lock(store: GuardStore):
+    guard_home = store.guard_home.expanduser().resolve()
+    store_key = str(guard_home)
     with _GUARD_SYNC_AUTH_LOCKS_LOCK:
         lock = _GUARD_SYNC_AUTH_LOCKS.get(store_key)
         if lock is None:
-            lock = threading.RLock()
+            lock = threading.Lock()
             _GUARD_SYNC_AUTH_LOCKS[store_key] = lock
-        return lock
+    with lock:
+        lock_path = guard_home / "oauth-refresh.lock"
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        with lock_path.open("a+b") as handle:
+            _lock_guard_sync_auth_file(handle)
+            try:
+                yield
+            finally:
+                _unlock_guard_sync_auth_file(handle)
+
+
+def _lock_guard_sync_auth_file(handle: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        if os.fstat(handle.fileno()).st_size == 0:
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        while True:
+            try:
+                msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                return
+            except OSError:
+                time.sleep(_GUARD_SYNC_AUTH_LOCK_POLL_INTERVAL_SECONDS)
+        return
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+
+
+def _unlock_guard_sync_auth_file(handle: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 _PAIN_SIGNAL_EVENTS = frozenset(
@@ -1957,58 +2002,64 @@ def _persist_rotated_oauth_refresh_token(
 
 
 def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
-    with _guard_sync_auth_lock(store):
-        oauth_health = store.get_oauth_local_credential_health()
-        oauth_credentials = store.get_oauth_local_credentials()
-        if oauth_credentials is not None:
-            issuer = _optional_string(oauth_credentials.get("issuer"))
-            client_id = _optional_string(oauth_credentials.get("client_id"))
-            refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
-            if issuer is None or client_id is None or refresh_token is None:
-                raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-            dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
-            try:
-                oauth_client = resolve_guard_oauth_client_config(issuer)
-            except ValueError as error:
-                raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
-            refreshed = _refresh_guard_oauth_access_token(
-                token_endpoint=oauth_client.token_endpoint,
-                client_id=client_id,
-                refresh_token=refresh_token,
-                dpop_key_material=dpop_key_material,
-            )
-            rotated_refresh_token = str(refreshed["refresh_token"])
-            package_firewall_entitlement = (
-                refreshed["package_firewall_entitlement"]
-                if isinstance(refreshed.get("package_firewall_entitlement"), dict)
-                else None
-            )
-            if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None:
-                _persist_rotated_oauth_refresh_token(
-                    store=store,
-                    credentials=oauth_credentials,
-                    package_firewall_entitlement=package_firewall_entitlement,
-                    refresh_token=rotated_refresh_token,
+    oauth_health = store.get_oauth_local_credential_health()
+    oauth_credentials = store.get_oauth_local_credentials()
+    if oauth_credentials is not None:
+        with _guard_sync_auth_lock(store):
+            oauth_credentials = store.get_oauth_local_credentials()
+            if oauth_credentials is None:
+                oauth_health = store.get_oauth_local_credential_health()
+            else:
+                issuer = _optional_string(oauth_credentials.get("issuer"))
+                client_id = _optional_string(oauth_credentials.get("client_id"))
+                refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
+                if issuer is None or client_id is None or refresh_token is None:
+                    raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+                dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
+                try:
+                    oauth_client = resolve_guard_oauth_client_config(issuer)
+                except ValueError as error:
+                    raise GuardSyncAuthorizationExpiredError(
+                        f"{_guard_oauth_reauthorization_message()} {error}"
+                    ) from error
+                refreshed = _refresh_guard_oauth_access_token(
+                    token_endpoint=oauth_client.token_endpoint,
+                    client_id=client_id,
+                    refresh_token=refresh_token,
+                    dpop_key_material=dpop_key_material,
                 )
-            sync_url = _validate_guard_sync_url(
-                _oauth_sync_url_from_issuer(oauth_client.issuer),
-                issuer=oauth_client.issuer,
-            )
-            return {
-                "sync_url": sync_url,
-                "access_token": str(refreshed["access_token"]),
-                "dpop_key_material": dpop_key_material,
-            }
-        if bool(oauth_health.get("configured")):
-            raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-        credentials = store.get_sync_credentials()
-        if credentials is None:
-            raise GuardSyncNotConfiguredError("Guard is not logged in.")
-        return {
-            "sync_url": _validate_guard_sync_url(str(credentials["sync_url"])),
-            "access_token": str(credentials["token"]),
-            "dpop_key_material": None,
-        }
+                rotated_refresh_token = str(refreshed["refresh_token"])
+                package_firewall_entitlement = (
+                    refreshed["package_firewall_entitlement"]
+                    if isinstance(refreshed.get("package_firewall_entitlement"), dict)
+                    else None
+                )
+                if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None:
+                    _persist_rotated_oauth_refresh_token(
+                        store=store,
+                        credentials=oauth_credentials,
+                        package_firewall_entitlement=package_firewall_entitlement,
+                        refresh_token=rotated_refresh_token,
+                    )
+                sync_url = _validate_guard_sync_url(
+                    _oauth_sync_url_from_issuer(oauth_client.issuer),
+                    issuer=oauth_client.issuer,
+                )
+                return {
+                    "sync_url": sync_url,
+                    "access_token": str(refreshed["access_token"]),
+                    "dpop_key_material": dpop_key_material,
+                }
+    if bool(oauth_health.get("configured")):
+        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+    credentials = store.get_sync_credentials()
+    if credentials is None:
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
+    return {
+        "sync_url": _validate_guard_sync_url(str(credentials["sync_url"])),
+        "access_token": str(credentials["token"]),
+        "dpop_key_material": None,
+    }
 
 
 def _guard_sync_headers(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -16720,6 +16720,112 @@ def test_sync_local_guard_cloud_proof_refreshes_oauth_once(tmp_path, monkeypatch
     assert payload["runtime_session_id"] == expected_session_id
 
 
+def test_sync_local_guard_cloud_proof_serializes_concurrent_oauth_refresh(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    token_refreshes: list[str] = []
+    sync_errors: list[Exception] = []
+    sync_results: list[dict[str, object]] = []
+    start_barrier = threading.Barrier(2)
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        del timeout
+        if request.full_url == "https://hol.org/api/guard/oauth/token":
+            body = urllib.parse.parse_qs(request.data.decode("utf-8"))
+            refresh_token = body["refresh_token"][0]
+            token_refreshes.append(refresh_token)
+            threading.Event().wait(0.05)
+            rotated_refresh_token = {
+                "refresh-token-1": "refresh-token-2",
+                "refresh-token-2": "refresh-token-3",
+            }.get(refresh_token)
+            if rotated_refresh_token is None:
+                raise AssertionError(f"unexpected refresh token: {refresh_token}")
+            return _Response(
+                {
+                    "access_token": f"oauth-access-token-for-{refresh_token}",
+                    "refresh_token": rotated_refresh_token,
+                    "token_type": "Bearer",
+                    "expires_in": 3600,
+                }
+            )
+        if request.full_url == "https://hol.org/api/guard/runtime/sessions/sync":
+            return _Response(
+                {
+                    "syncedAt": "2026-06-01T00:00:05+00:00",
+                    "items": [{"sessionId": "runtime-session-1"}],
+                }
+            )
+        if request.full_url == "https://hol.org/api/guard/receipts/sync":
+            return _Response(
+                {
+                    "syncedAt": "2026-06-01T00:00:06+00:00",
+                    "receiptsStored": 0,
+                    "advisories": [],
+                    "policy": {},
+                    "alertPreferences": {},
+                    "teamPolicyPack": {},
+                    "exceptions": [],
+                }
+            )
+        if request.full_url == "https://hol.org/api/v1/guard/events":
+            return _Response(
+                {
+                    "syncedAt": "2026-06-01T00:00:07+00:00",
+                    "accepted": 1,
+                    "events": 1,
+                }
+            )
+        raise AssertionError(f"unexpected request: {request.full_url}")
+
+    def _run_sync() -> None:
+        try:
+            start_barrier.wait(timeout=5)
+            sync_results.append(guard_runner_module.sync_local_guard_cloud_proof(store))
+        except Exception as error:  # pragma: no cover - assertion captured below
+            sync_errors.append(error)
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    threads = [threading.Thread(target=_run_sync) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=5)
+
+    assert sync_errors == []
+    assert len(sync_results) == 2
+    assert token_refreshes == ["refresh-token-1", "refresh-token-2"]
+    stored_credentials = store.get_oauth_local_credentials()
+    assert isinstance(stored_credentials, dict)
+    assert stored_credentials["refresh_token"] == "refresh-token-3"
+
+
 def test_sync_pain_signals_raises_when_oauth_refresh_is_revoked(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     dpop_key_material = generate_dpop_key_pair()


### PR DESCRIPTION
## Summary
- serialize Guard OAuth refresh-token rotation per Guard home during cloud sync auth resolution
- prevent the first proof sync from reusing the same refresh token family when CLI connect and daemon sync overlap
- add a regression that starts two proof-sync callers concurrently and proves token rotation advances instead of reusing v1

## Verification
- python3 -m pytest tests/test_guard_runtime.py -q -k 'sync_local_guard_cloud_proof_refreshes_oauth_once or sync_local_guard_cloud_proof_serializes_concurrent_oauth_refresh or sync_pain_signals_raises_when_oauth_refresh_is_revoked'
- python3 -m pytest tests/test_guard_auto_first_sync.py -q
- python3 -m ruff check src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_runtime.py
