### PR TITLE
fix(guard): stabilize supply-chain approval and cloud proof sync

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -118,6 +118,19 @@ function parseRequestId(pathname: string): string | null {
 
 type AppView = "home" | "inbox" | "fleet" | "evidence" | "settings" | "app-detail" | "supply-chain" | "audit" | "policy" | "feed-health";
 
+export function viewTitle(view: AppView): string {
+  if (view === "home") return "Home";
+  if (view === "inbox") return "Inbox";
+  if (view === "fleet") return "Protect";
+  if (view === "evidence") return "Evidence";
+  if (view === "settings") return "Settings";
+  if (view === "supply-chain") return "Supply Chain";
+  if (view === "audit") return "Audit";
+  if (view === "policy") return "Policy";
+  if (view === "feed-health") return "Feed Health";
+  return "App detail";
+}
+
 export function parseAppDetail(pathname: string): string | null {
   if (!pathname.startsWith("/apps/")) {
     return null;
@@ -647,7 +660,7 @@ export function App() {
         Skip to content
       </a>
       <div aria-live="polite" aria-atomic="true" className="sr-only">
-        {view === "home" ? "Home" : view === "inbox" ? "Inbox" : view === "fleet" ? "Protect" : view === "evidence" ? "Evidence" : view === "settings" ? "Settings" : view === "supply-chain" || view === "audit" || view === "policy" || view === "feed-health" ? "Trust Center" : "App detail"}
+        {viewTitle(view)}
       </div>
     <ApprovalCenterLayout
       view={view}

--- a/dashboard/src/approval-proof-modal.tsx
+++ b/dashboard/src/approval-proof-modal.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useState } from "react";
+import type { ChangeEvent } from "react";
+import { ActionButton, SectionLabel } from "./approval-center-primitives";
+import type { GuardApprovalGatePublicConfig } from "./guard-types";
+
+type ApprovalProofModalProps = {
+  title: string;
+  detail: string;
+  confirmLabel: string;
+  approvalGate: GuardApprovalGatePublicConfig | null;
+  onCancel: () => void;
+  onConfirm: (credentials: { approval_password?: string; approval_totp_code?: string }) => void;
+};
+
+export function ApprovalProofModal(props: ApprovalProofModalProps) {
+  const { title, detail, confirmLabel, approvalGate, onCancel, onConfirm } = props;
+  const [password, setPassword] = useState("");
+  const [totpCode, setTotpCode] = useState("");
+
+  const handlePasswordChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setPassword(event.target.value);
+  }, []);
+
+  const handleTotpChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setTotpCode(event.target.value);
+  }, []);
+
+  const handleConfirm = useCallback(() => {
+    onConfirm({
+      approval_password: password,
+      ...(approvalGate?.totp_enabled === true ? { approval_totp_code: totpCode } : {}),
+    });
+  }, [approvalGate, onConfirm, password, totpCode]);
+
+  const confirmDisabled =
+    password.trim() === "" || (approvalGate?.totp_enabled === true && totpCode.trim() === "");
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4">
+      <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl">
+        <SectionLabel>Approval required</SectionLabel>
+        <h2 className="mt-2 text-base font-semibold text-brand-dark">{title}</h2>
+        <p className="mt-1 text-sm text-slate-500">{detail}</p>
+        <label className="mt-4 block">
+          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+            Approval password
+          </span>
+          <input
+            type="password"
+            value={password}
+            onChange={handlePasswordChange}
+            autoComplete="current-password"
+            className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          />
+        </label>
+        {approvalGate?.totp_enabled === true && (
+          <label className="mt-3 block">
+            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
+              Authenticator code
+            </span>
+            <input
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              value={totpCode}
+              onChange={handleTotpChange}
+              className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+            />
+          </label>
+        )}
+        <div className="mt-5 flex justify-end gap-2">
+          <ActionButton variant="outline" onClick={onCancel}>
+            Cancel
+          </ActionButton>
+          <ActionButton onClick={handleConfirm} disabled={confirmDisabled}>
+            {confirmLabel}
+          </ActionButton>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo } from "react";
+import { useState, useCallback, useMemo, useEffect } from "react";
 import type { ChangeEvent } from "react";
 import {
   HiMiniExclamationTriangle,
@@ -13,8 +13,9 @@ import {
   HiMiniWrenchScrewdriver,
 } from "react-icons/hi2";
 import { SectionLabel, Badge, Tag, ActionButton, EmptyState } from "./approval-center-primitives";
+import { ApprovalProofModal } from "./approval-proof-modal";
 import { formatRelativeTime, harnessDisplayName } from "./approval-center-utils";
-import { GuardHarnessActionError, runAuditRemediation } from "./guard-api";
+import { fetchSettings, GuardHarnessActionError, runAuditRemediation } from "./guard-api";
 import type { AuditRemediationAction } from "./guard-api";
 import type { GuardApprovalGatePublicConfig, GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
 
@@ -219,6 +220,26 @@ export function AuditWorkspace({ snapshot, receipts, approvalGate }: AuditWorksp
   const [pendingRemediation, setPendingRemediation] = useState<AuditResult | null>(null);
   const [runningRemediationId, setRunningRemediationId] = useState<string | null>(null);
   const [remediationMessages, setRemediationMessages] = useState<Record<string, string>>({});
+  const [resolvedApprovalGate, setResolvedApprovalGate] =
+    useState<GuardApprovalGatePublicConfig | null>(approvalGate);
+
+  useEffect(() => {
+    setResolvedApprovalGate(approvalGate);
+  }, [approvalGate]);
+
+  const resolveApprovalGate = useCallback(async () => {
+    if (resolvedApprovalGate !== null) {
+      return resolvedApprovalGate;
+    }
+    try {
+      const payload = await fetchSettings();
+      const gate = payload.settings.approval_gate ?? null;
+      setResolvedApprovalGate(gate);
+      return gate;
+    } catch {
+      return null;
+    }
+  }, [resolvedApprovalGate]);
 
   const handleSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setFilter((f) => ({ ...f, searchQuery: e.target.value }));
@@ -261,10 +282,9 @@ export function AuditWorkspace({ snapshot, receipts, approvalGate }: AuditWorksp
         if (
           credentials === undefined &&
           error instanceof GuardHarnessActionError &&
-          error.payload?.error === "approval_gate_required" &&
-          approvalGate?.enabled === true &&
-          approvalGate.configured === true
+          error.payload?.error === "approval_gate_required"
         ) {
+          await resolveApprovalGate();
           setPendingRemediation(result);
           setRemediationMessages((prev) => {
             const next = { ...prev };
@@ -279,7 +299,7 @@ export function AuditWorkspace({ snapshot, receipts, approvalGate }: AuditWorksp
         setRunningRemediationId(null);
       }
     },
-    [approvalGate],
+    [resolveApprovalGate],
   );
 
   const handleRunRemediation = useCallback(
@@ -349,8 +369,7 @@ export function AuditWorkspace({ snapshot, receipts, approvalGate }: AuditWorksp
     <div className="space-y-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-lg font-semibold text-brand-dark">Audit</h1>
-          <p className="mt-0.5 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             Workspace audit results, open issues, and remediation queue.
           </p>
         </div>
@@ -461,7 +480,7 @@ export function AuditWorkspace({ snapshot, receipts, approvalGate }: AuditWorksp
       {pendingRemediation !== null && (
         <RemediationApprovalModal
           result={pendingRemediation}
-          approvalGate={approvalGate}
+          approvalGate={resolvedApprovalGate}
           onCancel={handleCancelRemediationGate}
           onConfirm={handleConfirmRemediationGate}
         />
@@ -557,61 +576,14 @@ function RemediationApprovalModal(props: {
   onConfirm: (credentials: { approval_password?: string; approval_totp_code?: string }) => void;
 }) {
   const { approvalGate, onCancel, onConfirm, result } = props;
-  const [password, setPassword] = useState("");
-  const [totpCode, setTotpCode] = useState("");
-  const handlePasswordChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setPassword(event.target.value);
-  }, []);
-  const handleTotpChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setTotpCode(event.target.value);
-  }, []);
-  const handleConfirm = useCallback(() => {
-    onConfirm({
-      approval_password: password,
-      ...(approvalGate?.totp_enabled === true ? { approval_totp_code: totpCode } : {}),
-    });
-  }, [approvalGate, onConfirm, password, totpCode]);
-  const confirmDisabled = password.trim() === "" || (approvalGate?.totp_enabled === true && totpCode.trim() === "");
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4">
-      <div className="w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl">
-        <SectionLabel>Approval required</SectionLabel>
-        <h2 className="mt-2 text-base font-semibold text-brand-dark">{result.remediationAction?.label}</h2>
-        <p className="mt-1 text-sm text-slate-500">
-          Enter local approval proof before Guard changes package-manager protection on this device.
-        </p>
-        <label className="mt-4 block">
-          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Approval password</span>
-          <input
-            type="password"
-            value={password}
-            onChange={handlePasswordChange}
-            autoComplete="current-password"
-            className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-          />
-        </label>
-        {approvalGate?.totp_enabled === true && (
-          <label className="mt-3 block">
-            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">Authenticator code</span>
-            <input
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              value={totpCode}
-              onChange={handleTotpChange}
-              className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-            />
-          </label>
-        )}
-        <div className="mt-5 flex justify-end gap-2">
-          <ActionButton variant="outline" onClick={onCancel}>
-            Cancel
-          </ActionButton>
-          <ActionButton onClick={handleConfirm} disabled={confirmDisabled}>
-            Run remediation
-          </ActionButton>
-        </div>
-      </div>
-    </div>
+    <ApprovalProofModal
+      title={result.remediationAction?.label ?? "Run remediation"}
+      detail="Enter local approval proof before Guard changes package-manager protection on this device."
+      confirmLabel="Run remediation"
+      approvalGate={approvalGate}
+      onCancel={onCancel}
+      onConfirm={onConfirm}
+    />
   );
 }

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo, useEffect } from "react";
+import { useState, useCallback, useMemo } from "react";
 import type { ChangeEvent } from "react";
 import {
   HiMiniExclamationTriangle,
@@ -15,9 +15,10 @@ import {
 import { SectionLabel, Badge, Tag, ActionButton, EmptyState } from "./approval-center-primitives";
 import { ApprovalProofModal } from "./approval-proof-modal";
 import { formatRelativeTime, harnessDisplayName } from "./approval-center-utils";
-import { fetchSettings, GuardHarnessActionError, runAuditRemediation } from "./guard-api";
+import { GuardHarnessActionError, runAuditRemediation } from "./guard-api";
 import type { AuditRemediationAction } from "./guard-api";
 import type { GuardApprovalGatePublicConfig, GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
+import { useResolvedApprovalGate } from "./use-resolved-approval-gate";
 
 export type AuditSeverity = "critical" | "high" | "medium" | "low" | "info";
 
@@ -220,26 +221,7 @@ export function AuditWorkspace({ snapshot, receipts, approvalGate }: AuditWorksp
   const [pendingRemediation, setPendingRemediation] = useState<AuditResult | null>(null);
   const [runningRemediationId, setRunningRemediationId] = useState<string | null>(null);
   const [remediationMessages, setRemediationMessages] = useState<Record<string, string>>({});
-  const [resolvedApprovalGate, setResolvedApprovalGate] =
-    useState<GuardApprovalGatePublicConfig | null>(approvalGate);
-
-  useEffect(() => {
-    setResolvedApprovalGate(approvalGate);
-  }, [approvalGate]);
-
-  const resolveApprovalGate = useCallback(async () => {
-    if (resolvedApprovalGate !== null) {
-      return resolvedApprovalGate;
-    }
-    try {
-      const payload = await fetchSettings();
-      const gate = payload.settings.approval_gate ?? null;
-      setResolvedApprovalGate(gate);
-      return gate;
-    } catch {
-      return null;
-    }
-  }, [resolvedApprovalGate]);
+  const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(approvalGate);
 
   const handleSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setFilter((f) => ({ ...f, searchQuery: e.target.value }));

--- a/dashboard/src/feed-health-workspace.tsx
+++ b/dashboard/src/feed-health-workspace.tsx
@@ -107,8 +107,7 @@ export function FeedHealthWorkspace({ snapshot, onOpenSettings }: FeedHealthWork
     <div className="space-y-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-lg font-semibold text-brand-dark">Feed Health</h1>
-          <p className="mt-0.5 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             Intel feed source mode, freshness, and cloud sync status.
           </p>
         </div>

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -11,6 +11,7 @@ import {
 	  normalizeApprovalRequest,
 	  parseActionEnvelope,
 	  parseDecisionV2,
+	  runPackageFirewallAction,
 	  runAuditRemediation,
 	  resolveRequestWithQueueResult,
 	  retryResume,
@@ -825,6 +826,58 @@ assert(
   "L079d: remediation retries with refreshed Guard token"
 );
 assert(remediationBootstrap.operation === "package_shim_path", "L079d: remediation succeeds after token bootstrap");
+
+installGuardWindow("?guard-token=token-firewall&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const firewallCalls = installFetchStub({
+  "/v1/supply-chain/package-shims/install": {
+    entitlement: { allowed: true },
+    operation: "install",
+    receipt: null,
+    result: { manager: "pnpm" },
+    status: "completed"
+  }
+});
+const firewallAction = await runPackageFirewallAction("install", "pnpm", {
+  approval_password: "local-password",
+  approval_totp_code: "123456"
+});
+const firewallBody = JSON.parse(String(firewallCalls[0].init?.body)) as Record<string, unknown>;
+assert(
+  firewallCalls[0].url === "http://127.0.0.1:4781/v1/supply-chain/package-shims/install",
+  "L079da: runPackageFirewallAction posts to the install route"
+);
+assert(headerValue(firewallCalls[0].init, "X-Guard-Token") === "token-firewall", "L079da: runPackageFirewallAction sends Guard token");
+assert(Array.isArray(firewallBody["managers"]) && (firewallBody["managers"] as unknown[])[0] === "pnpm", "L079da: runPackageFirewallAction sends selected manager");
+assert(firewallBody["approval_password"] === "local-password", "L079da: runPackageFirewallAction sends approval password");
+assert(firewallBody["approval_totp_code"] === "123456", "L079da: runPackageFirewallAction sends approval TOTP code");
+assert(firewallAction.operation === "install", "L079da: runPackageFirewallAction normalizes response");
+
+installGuardWindow("?guard-token=token-firewall-error&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
+  const url = input instanceof Request ? input.url : String(input);
+  const parsed = new URL(url, "http://127.0.0.1:4174");
+  if (parsed.pathname === "/v1/supply-chain/package-shims/install") {
+    return new Response(
+      JSON.stringify({
+        error: "approval_gate_required",
+        message: "Approval password is required."
+      }),
+      { status: 403, headers: { "Content-Type": "application/json" } }
+    );
+  }
+  return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+};
+let firewallError: unknown = null;
+try {
+  await runPackageFirewallAction("install", "pnpm");
+} catch (error) {
+  firewallError = error;
+}
+assert(firewallError instanceof GuardHarnessActionError, "L079db: runPackageFirewallAction throws GuardHarnessActionError on structured failures");
+assert(
+  firewallError instanceof GuardHarnessActionError && firewallError.payload?.error === "approval_gate_required",
+  "L079db: runPackageFirewallAction preserves daemon error code for approval modal fallback"
+);
 
 installGuardWindow("?guard-token=token-remediate-error&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
 globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1661,9 +1661,18 @@ export async function fetchPackageFirewallStatus(): Promise<PackageFirewallStatu
 export async function runPackageFirewallAction(
   action: PackageFirewallActionType,
   manager: string | null,
+  credentials?: { approval_password?: string; approval_totp_code?: string },
 ): Promise<PackageFirewallActionResponse> {
-  const payload = manager !== null ? { managers: [manager] } : {};
-  const response = await readJson<unknown>(
+  const payload = {
+    ...(manager !== null ? { managers: [manager] } : {}),
+    ...(credentials?.approval_password !== undefined
+      ? { approval_password: credentials.approval_password }
+      : {}),
+    ...(credentials?.approval_totp_code !== undefined
+      ? { approval_totp_code: credentials.approval_totp_code }
+      : {}),
+  };
+  const response = await fetchGuardApi(
     `/v1/supply-chain/package-shims/${action}`,
     {
       method: "POST",
@@ -1674,7 +1683,14 @@ export async function runPackageFirewallAction(
       body: JSON.stringify(payload),
     },
   );
-  return normalizePackageFirewallAction(response);
+  const payloadBody = (await response.json().catch(() => null)) as unknown;
+  if (!response.ok) {
+    throw new GuardHarnessActionError(
+      response.status,
+      isGuardHarnessActionErrorPayload(payloadBody) ? payloadBody : null,
+    );
+  }
+  return normalizePackageFirewallAction(payloadBody);
 }
 
 export type AuditRemediationAction = "package_shim_path";

--- a/dashboard/src/policy-workspace.tsx
+++ b/dashboard/src/policy-workspace.tsx
@@ -180,8 +180,7 @@ export function PolicyWorkspace({
     <div className="space-y-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-lg font-semibold text-brand-dark">Policy</h1>
-          <p className="mt-0.5 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             Guard rules, exceptions, and remembered decisions.
           </p>
         </div>

--- a/dashboard/src/scrg171-172.test.ts
+++ b/dashboard/src/scrg171-172.test.ts
@@ -1,4 +1,5 @@
-import { resolveView } from "./app";
+import { resolveView, viewTitle } from "./app";
+import { hubTitleForTab } from "./supply-chain-hub-workspace";
 import {
   buildDemoRuntimeSnapshot,
   loadStatusPage,
@@ -227,6 +228,22 @@ assert(
 assert(
   resolveView("/feed") !== "feed-health",
   "SCRG171-H: /feed does not match feed-health view",
+);
+
+assert(
+  viewTitle("supply-chain") === "Supply Chain" &&
+    viewTitle("audit") === "Audit" &&
+    viewTitle("policy") === "Policy" &&
+    viewTitle("feed-health") === "Feed Health",
+  "SCRG171-H2: route titles stay specific inside Trust Center views",
+);
+
+assert(
+  hubTitleForTab("supply-chain") === "Supply Chain" &&
+    hubTitleForTab("audit") === "Audit" &&
+    hubTitleForTab("policy") === "Policy" &&
+    hubTitleForTab("feed-health") === "Feed Health",
+  "SCRG171-H3: hub header mirrors active Trust Center tab",
 );
 
 assert(

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -12,7 +12,6 @@ import type {
   PackageFirewallActionType,
 } from "./guard-types";
 import {
-  fetchSettings,
   fetchPackageFirewallStatus,
   GuardHarnessActionError,
   runPackageFirewallAction,
@@ -22,6 +21,7 @@ import {
 import { FreeUserView, ActionResultPanel } from "./supply-chain-firewall-views";
 import type { CompletedOp } from "./supply-chain-firewall-views";
 import { ManagerActionCard } from "./supply-chain-manager-card";
+import { useResolvedApprovalGate } from "./use-resolved-approval-gate";
 
 type PanelLoadState =
   | { phase: "loading" }
@@ -270,12 +270,7 @@ export function PackageFirewallPanel(props: {
   const [lastFailed, setLastFailed] = useState<FailedOp | null>(null);
   const [confirmRemoveManager, setConfirmRemoveManager] = useState<string | null>(null);
   const [pendingApprovalOp, setPendingApprovalOp] = useState<ApprovalOp | null>(null);
-  const [resolvedApprovalGate, setResolvedApprovalGate] =
-    useState<GuardApprovalGatePublicConfig | null>(approvalGate);
-
-  useEffect(() => {
-    setResolvedApprovalGate(approvalGate);
-  }, [approvalGate]);
+  const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(approvalGate);
 
   const load = useCallback(async () => {
     setPanelLoad({ phase: "loading" });
@@ -303,20 +298,6 @@ export function PackageFirewallPanel(props: {
       setPanelLoad({ phase: "error", message });
     }
   }, []);
-
-  const resolveApprovalGate = useCallback(async () => {
-    if (resolvedApprovalGate !== null) {
-      return resolvedApprovalGate;
-    }
-    try {
-      const payload = await fetchSettings();
-      const gate = payload.settings.approval_gate ?? null;
-      setResolvedApprovalGate(gate);
-      return gate;
-    } catch {
-      return null;
-    }
-  }, [resolvedApprovalGate]);
 
   const handleAction = useCallback(
     async (

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -4,13 +4,17 @@ import {
   HiMiniBugAnt,
   HiMiniExclamationTriangle,
 } from "react-icons/hi2";
+import { ApprovalProofModal } from "./approval-proof-modal";
 import { SectionLabel, ActionButton, EmptyState } from "./approval-center-primitives";
 import type {
+  GuardApprovalGatePublicConfig,
   PackageFirewallStatusResponse,
   PackageFirewallActionType,
 } from "./guard-types";
 import {
+  fetchSettings,
   fetchPackageFirewallStatus,
+  GuardHarnessActionError,
   runPackageFirewallAction,
   runPackageAudit,
   runPackageSync,
@@ -35,6 +39,11 @@ type FailedOp = {
   op: OpKey;
   manager: string | null;
   message: string;
+};
+
+type ApprovalOp = {
+  op: PackageFirewallActionType;
+  manager: string;
 };
 
 type LoadingRowProps = { width: string };
@@ -251,12 +260,22 @@ function RefreshButton({ disabled, spinning, onRefresh }: RefreshButtonProps) {
   );
 }
 
-export function PackageFirewallPanel() {
+export function PackageFirewallPanel(props: {
+  approvalGate: GuardApprovalGatePublicConfig | null;
+}) {
+  const { approvalGate } = props;
   const [panelLoad, setPanelLoad] = useState<PanelLoadState>({ phase: "loading" });
   const [pendingOp, setPendingOp] = useState<PendingOp | null>(null);
   const [lastCompleted, setLastCompleted] = useState<CompletedOp | null>(null);
   const [lastFailed, setLastFailed] = useState<FailedOp | null>(null);
   const [confirmRemoveManager, setConfirmRemoveManager] = useState<string | null>(null);
+  const [pendingApprovalOp, setPendingApprovalOp] = useState<ApprovalOp | null>(null);
+  const [resolvedApprovalGate, setResolvedApprovalGate] =
+    useState<GuardApprovalGatePublicConfig | null>(approvalGate);
+
+  useEffect(() => {
+    setResolvedApprovalGate(approvalGate);
+  }, [approvalGate]);
 
   const load = useCallback(async () => {
     setPanelLoad({ phase: "loading" });
@@ -285,22 +304,50 @@ export function PackageFirewallPanel() {
     }
   }, []);
 
+  const resolveApprovalGate = useCallback(async () => {
+    if (resolvedApprovalGate !== null) {
+      return resolvedApprovalGate;
+    }
+    try {
+      const payload = await fetchSettings();
+      const gate = payload.settings.approval_gate ?? null;
+      setResolvedApprovalGate(gate);
+      return gate;
+    } catch {
+      return null;
+    }
+  }, [resolvedApprovalGate]);
+
   const handleAction = useCallback(
-    async (op: PackageFirewallActionType, manager: string | null) => {
+    async (
+      op: PackageFirewallActionType,
+      manager: string | null,
+      credentials?: { approval_password?: string; approval_totp_code?: string },
+    ) => {
       setPendingOp({ op, manager });
       setLastFailed(null);
       try {
-        const response = await runPackageFirewallAction(op, manager);
+        const response = await runPackageFirewallAction(op, manager, credentials);
         setLastCompleted({ op, manager, response });
         await refreshAfterOp();
       } catch (err) {
+        if (
+          credentials === undefined &&
+          manager !== null &&
+          err instanceof GuardHarnessActionError &&
+          err.payload?.error === "approval_gate_required"
+        ) {
+          await resolveApprovalGate();
+          setPendingApprovalOp({ op, manager });
+          return;
+        }
         const message = err instanceof Error ? err.message : "Action failed.";
         setLastFailed({ op, manager, message });
       } finally {
         setPendingOp(null);
       }
     },
-    [refreshAfterOp],
+    [refreshAfterOp, resolveApprovalGate],
   );
 
   const handleGlobalOp = useCallback(
@@ -349,9 +396,18 @@ export function PackageFirewallPanel() {
   const handleSync = useCallback(() => void handleGlobalOp("sync"), [handleGlobalOp]);
   const handleDismissResult = useCallback(() => setLastCompleted(null), []);
   const handleRetry = useCallback(() => void load(), [load]);
+  const handleApprovalCancel = useCallback(() => setPendingApprovalOp(null), []);
+  const handleApprovalConfirm = useCallback(
+    (credentials: { approval_password?: string; approval_totp_code?: string }) => {
+      const pendingApproval = pendingApprovalOp;
+      if (pendingApproval === null) return;
+      setPendingApprovalOp(null);
+      void handleAction(pendingApproval.op, pendingApproval.manager, credentials);
+    },
+    [handleAction, pendingApprovalOp],
+  );
 
   const anyPending = pendingOp !== null;
-
   return (
     <div className="rounded-2xl border border-slate-100 bg-white shadow-sm">
       <div className="flex flex-wrap items-center justify-between gap-2 border-b border-slate-100 px-4 py-3">
@@ -393,6 +449,21 @@ export function PackageFirewallPanel() {
         ) : (
           <FreeUserView data={panelLoad.data} />
         ))}
+
+      {pendingApprovalOp !== null && (
+        <ApprovalProofModal
+          title={`${actionLabel(pendingApprovalOp.op)} ${pendingApprovalOp.manager}`}
+          detail="Enter local approval proof before Guard changes package-manager protection on this device."
+          confirmLabel={actionLabel(pendingApprovalOp.op)}
+          approvalGate={resolvedApprovalGate}
+          onCancel={handleApprovalCancel}
+          onConfirm={handleApprovalConfirm}
+        />
+      )}
     </div>
   );
+}
+
+function actionLabel(op: PackageFirewallActionType): string {
+  return op.charAt(0).toUpperCase() + op.slice(1);
 }

--- a/dashboard/src/supply-chain-hub-workspace.tsx
+++ b/dashboard/src/supply-chain-hub-workspace.tsx
@@ -24,6 +24,10 @@ const hubTabs: Array<{ value: HubTab; label: string }> = [
   { value: "feed-health", label: "Feed Health" },
 ];
 
+export function hubTitleForTab(tab: HubTab): string {
+  return hubTabs.find((item) => item.value === tab)?.label ?? "Supply Chain";
+}
+
 function viewToTab(view: string): HubTab {
   if (view === "supply-chain" || view === "audit" || view === "policy" || view === "feed-health") {
     return view;
@@ -55,12 +59,19 @@ export function SupplyChainHubWorkspace(props: {
   return (
     <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <h1 className="text-2xl font-semibold tracking-tight text-brand-dark">Trust Center</h1>
+        <div className="space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Trust Center</p>
+          <h1 className="text-2xl font-semibold tracking-tight text-brand-dark">{hubTitleForTab(tab)}</h1>
+        </div>
         <TabBar tabs={hubTabs} active={tab} onChange={handleTabChange} />
       </div>
       <Suspense fallback={<LazyFallback />}>
         {tab === "supply-chain" && (
-          <SupplyChainWorkspace snapshot={props.snapshot} onGoHome={props.onGoHome} />
+          <SupplyChainWorkspace
+            snapshot={props.snapshot}
+            approvalGate={props.approvalGate}
+            onGoHome={props.onGoHome}
+          />
 	        )}
 	        {tab === "audit" && (
 	          <AuditWorkspace snapshot={props.snapshot} receipts={props.receipts} approvalGate={props.approvalGate} />

--- a/dashboard/src/supply-chain-workspace.tsx
+++ b/dashboard/src/supply-chain-workspace.tsx
@@ -12,7 +12,12 @@ import {
 } from "react-icons/hi2";
 import { SectionLabel, Badge, Tag, ActionButton, EmptyState } from "./approval-center-primitives";
 import { harnessDisplayName, formatRelativeTime } from "./approval-center-utils";
-import type { GuardManagedInstall, GuardRuntimeSnapshot, PackageManagerProtection } from "./guard-types";
+import type {
+  GuardApprovalGatePublicConfig,
+  GuardManagedInstall,
+  GuardRuntimeSnapshot,
+  PackageManagerProtection,
+} from "./guard-types";
 import { resolvePackageManagerProtectionCopy } from "./runtime-overview";
 import { PackageFirewallPanel } from "./supply-chain-firewall-panel";
 
@@ -136,10 +141,11 @@ function AppFirewallRow({ install, protection }: AppFirewallRowProps) {
 
 type SupplyChainWorkspaceProps = {
   snapshot: GuardRuntimeSnapshot;
+  approvalGate: GuardApprovalGatePublicConfig | null;
   onGoHome: () => void;
 };
 
-export function SupplyChainWorkspace({ snapshot, onGoHome }: SupplyChainWorkspaceProps) {
+export function SupplyChainWorkspace({ snapshot, approvalGate, onGoHome }: SupplyChainWorkspaceProps) {
   const [filter, setFilter] = useState<SupplyChainFilterState>({
     statusFilter: "all",
     managerFilter: "",
@@ -186,8 +192,7 @@ export function SupplyChainWorkspace({ snapshot, onGoHome }: SupplyChainWorkspac
     <div className="space-y-6">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <h1 className="text-lg font-semibold text-brand-dark">Supply Chain</h1>
-          <p className="mt-0.5 text-sm text-slate-500">
+          <p className="text-sm text-slate-500">
             Package manager firewall status, prevented installs, and feed health.
           </p>
         </div>
@@ -203,7 +208,7 @@ export function SupplyChainWorkspace({ snapshot, onGoHome }: SupplyChainWorkspac
         <StatCard label="Unprotected managers" value={stats.unprotectedManagers} tone={stats.unprotectedManagers > 0 ? "attention" : "slate"} />
       </div>
 
-      <PackageFirewallPanel />
+      <PackageFirewallPanel approvalGate={approvalGate} />
 
       <div className="rounded-2xl border border-slate-100 bg-white shadow-sm">
         <div className="border-b border-slate-100 px-4 py-3">

--- a/dashboard/src/use-resolved-approval-gate.ts
+++ b/dashboard/src/use-resolved-approval-gate.ts
@@ -1,0 +1,28 @@
+import { useCallback, useEffect, useState } from "react";
+import { fetchSettings } from "./guard-api";
+import type { GuardApprovalGatePublicConfig } from "./guard-types";
+
+export function useResolvedApprovalGate(initialGate: GuardApprovalGatePublicConfig | null) {
+  const [resolvedApprovalGate, setResolvedApprovalGate] =
+    useState<GuardApprovalGatePublicConfig | null>(initialGate);
+
+  useEffect(() => {
+    setResolvedApprovalGate(initialGate);
+  }, [initialGate]);
+
+  const resolveApprovalGate = useCallback(async () => {
+    if (resolvedApprovalGate !== null) {
+      return resolvedApprovalGate;
+    }
+    try {
+      const payload = await fetchSettings();
+      const gate = payload.settings.approval_gate ?? null;
+      setResolvedApprovalGate(gate);
+      return gate;
+    } catch {
+      return null;
+    }
+  }, [resolvedApprovalGate]);
+
+  return { resolvedApprovalGate, resolveApprovalGate };
+}

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -577,6 +577,7 @@ def _build_runtime_cloud_context(
         bool(oauth_storage_health.get("configured")) and oauth_storage_health.get("state") == "degraded"
     )
     connect_retry_required = _connect_retry_required(latest_connect_state)
+    connect_retry_refresh_race = _connect_retry_refresh_race(latest_connect_state)
     sync_url = cloud_profile["sync_url"] if cloud_profile is not None else None
     sync_summary = store.get_sync_payload("sync_summary") or {}
     remote_policy = store.get_sync_payload("policy") or {}
@@ -595,6 +596,7 @@ def _build_runtime_cloud_context(
         cloud_state,
         oauth_repair_required=oauth_repair_required,
         connect_retry_required=connect_retry_required,
+        connect_retry_refresh_race=connect_retry_refresh_race,
     )
     return {
         "sync_configured": cloud_profile is not None,
@@ -604,6 +606,7 @@ def _build_runtime_cloud_context(
             cloud_state,
             oauth_repair_required=oauth_repair_required,
             connect_retry_required=connect_retry_required,
+            connect_retry_refresh_race=connect_retry_refresh_race,
         ),
         "cloud_sync_health": sync_health,
         "cloud_pairing_state": {
@@ -613,6 +616,7 @@ def _build_runtime_cloud_context(
                 cloud_state,
                 oauth_repair_required=oauth_repair_required,
                 connect_retry_required=connect_retry_required,
+                connect_retry_refresh_race=connect_retry_refresh_race,
             ),
             "sync_configured": cloud_profile is not None,
             "dashboard_url": dashboard_url,
@@ -679,6 +683,7 @@ def _build_runtime_proof_status(latest_state: dict[str, object] | None) -> dict[
     status = _runtime_proof_status_name(
         status=_optional_string(latest_state.get("status")),
         milestone=_optional_string(latest_state.get("milestone")),
+        reason=_optional_string(latest_state.get("reason")),
         proof=proof,
     )
     return _runtime_proof_status_payload(
@@ -711,6 +716,7 @@ def _runtime_proof_status_name(
     *,
     status: str | None,
     milestone: str | None,
+    reason: str | None,
     proof: Mapping[str, object],
 ) -> str:
     if milestone == "first_sync_succeeded" or proof.get("first_synced_at"):
@@ -718,6 +724,8 @@ def _runtime_proof_status_name(
     if milestone == "sync_not_available":
         return "sync_unavailable"
     if status == "retry_required" or milestone == "first_sync_failed":
+        if _connect_retry_refresh_race_from_reason(reason):
+            return "stalled"
         return "failed"
     if milestone == "first_sync_pending":
         return "pending"
@@ -733,6 +741,7 @@ def _runtime_proof_status_label(state: str) -> str:
         "synced": "First proof synced",
         "sync_unavailable": "Local connected, cloud sync gated",
         "failed": "First proof needs retry",
+        "stalled": "First proof stalled",
         "pending": "First proof pending",
         "expired": "Sign-in expired",
         "waiting": "Waiting for browser sign-in",
@@ -746,6 +755,10 @@ def _runtime_proof_status_detail(state: str) -> str:
         "synced": "This device completed its first Guard Cloud proof sync.",
         "sync_unavailable": "Local Guard is connected. Shared cloud sync needs a paid Guard plan.",
         "failed": "Guard Cloud sign-in on this machine needs repair. Run hol-guard connect again.",
+        "stalled": (
+            "Local protection stays active. The first shared Guard Cloud proof stalled after a refresh-token race. "
+            "Run hol-guard connect once on this machine when you want shared proof restored."
+        ),
         "pending": (
             "Browser sign-in finished. Local Guard will retry the first proof sync automatically "
             "while the daemon is running, or you can run hol-guard sync now."
@@ -765,6 +778,16 @@ def _connect_retry_required(latest_state: dict[str, object] | None) -> bool:
     return status == "retry_required" or milestone == "first_sync_failed"
 
 
+def _connect_retry_refresh_race(latest_state: dict[str, object] | None) -> bool:
+    if latest_state is None or not _connect_retry_required(latest_state):
+        return False
+    return _connect_retry_refresh_race_from_reason(_optional_string(latest_state.get("reason")))
+
+
+def _connect_retry_refresh_race_from_reason(reason: str | None) -> bool:
+    return isinstance(reason, str) and "already consumed" in reason.lower()
+
+
 def _build_cloud_sync_health(
     store: GuardStore,
     sync_configured: bool,
@@ -772,6 +795,7 @@ def _build_cloud_sync_health(
     *,
     oauth_repair_required: bool = False,
     connect_retry_required: bool = False,
+    connect_retry_refresh_race: bool = False,
 ) -> dict[str, object]:
     pending_events = store.count_guard_events_v1(uploaded=False)
     event_summary = store.get_sync_payload("guard_events_v1_summary") or {}
@@ -808,6 +832,7 @@ def _build_cloud_sync_health(
             pending_events=pending_events,
             oauth_repair_required=oauth_repair_required,
             connect_retry_required=connect_retry_required,
+            connect_retry_refresh_race=connect_retry_refresh_race,
         ),
         "pending_events": pending_events,
         "last_synced_at": last_synced_at,
@@ -863,10 +888,16 @@ def _cloud_sync_health_detail(
     pending_events: int,
     oauth_repair_required: bool = False,
     connect_retry_required: bool = False,
+    connect_retry_refresh_race: bool = False,
 ) -> str:
     if state == "healthy":
         return "Guard Cloud has the latest local proof from this machine."
     if state == "failed":
+        if connect_retry_refresh_race:
+            return (
+                "Local protection is active. The first shared Guard Cloud proof stalled after a refresh-token race. "
+                "Run hol-guard connect once to mint a fresh Cloud refresh token."
+            )
         if oauth_repair_required or connect_retry_required:
             return (
                 "Guard Cloud authorization on this machine needs repair. Run hol-guard connect again to restore sync."
@@ -910,11 +941,18 @@ def _runtime_cloud_state_detail(
     *,
     oauth_repair_required: bool = False,
     connect_retry_required: bool = False,
+    connect_retry_refresh_race: bool = False,
 ) -> str:
     if oauth_repair_required:
         return (
             "Guard Cloud sign-in on this machine is incomplete. "
             "Run hol-guard connect again to repair local authorization and resume sync."
+        )
+    if connect_retry_refresh_race:
+        return (
+            "This machine stays locally protected. "
+            "The first shared Guard Cloud proof stalled after a refresh-token race. "
+            "Run hol-guard connect once when you want shared proof restored."
         )
     if connect_retry_required:
         return (

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -195,6 +195,7 @@ from .approval_commands import (
 from .approval_gate_prompt import approval_gate_cli_payload, prompt_for_approval_gate
 from .bootstrap import DEFAULT_ALIAS_NAME, build_guard_bootstrap_payload
 from .connect_flow import (
+    CONNECT_SYNC_AUTH_CONTEXT_KEY,
     DEFAULT_GUARD_CONNECT_URL,
     DEFAULT_GUARD_SYNC_URL,
     build_connect_status_payload,
@@ -9392,6 +9393,7 @@ def _finalize_guard_connect_payload(
     payload: dict[str, object],
     now: str,
 ) -> dict[str, object]:
+    sync_auth_context = payload.pop(CONNECT_SYNC_AUTH_CONTEXT_KEY, None)
     urls = _guard_cloud_urls_for_connect(connect_url)
     for key in ("connect_url", "sync_url", "dashboard_url", "inbox_url", "fleet_url"):
         payload.setdefault(key, urls[key])
@@ -9440,7 +9442,10 @@ def _finalize_guard_connect_payload(
         return payload
     payload["sync_attempted"] = True
     try:
-        sync_payload = sync_local_guard_cloud_proof(store)
+        if isinstance(sync_auth_context, dict):
+            sync_payload = sync_local_guard_cloud_proof(store, auth_context=sync_auth_context)
+        else:
+            sync_payload = sync_local_guard_cloud_proof(store)
     except GuardSyncNotAvailableError as error:
         store.record_latest_guard_connect_sync_result(
             status="connected",
@@ -9557,6 +9562,7 @@ def _run_guard_device_connect_flow(
         open_browser=open_browser,
         ci_safe=ci_safe,
         machine_label=machine_label,
+        include_sync_auth_context=True,
     )
 
 
@@ -9570,6 +9576,7 @@ def _run_guard_browser_connect_flow(
         store=store,
         connect_url=connect_url,
         wait_timeout_seconds=wait_timeout_seconds,
+        include_sync_auth_context=True,
     )
 
 

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -47,6 +47,7 @@ CONNECT_STATUS_COMMAND = "hol-guard connect status"
 CONNECT_REPAIR_COMMAND = "hol-guard connect repair"
 DISCONNECT_COMMAND = "hol-guard disconnect"
 HEADLESS_CONNECT_COMMAND = "hol-guard connect --headless"
+CONNECT_SYNC_AUTH_CONTEXT_KEY = "_guard_sync_auth_context"
 DEVICE_CODE_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:device_code"
 DEVICE_CODE_SLOW_DOWN_SECONDS = 5
 HEADLESS_RUNTIME_ID = "hol-guard"
@@ -342,6 +343,19 @@ def resolve_connect_url(connect_url: str) -> tuple[str, str]:
 def _oauth_sync_url_from_issuer(issuer: str) -> str:
     oauth_client = resolve_guard_oauth_client_config(issuer)
     return f"{oauth_client.issuer}/api/guard/receipts/sync"
+
+
+def _build_sync_auth_context(
+    *,
+    access_token: str,
+    dpop_key_material: GuardDpopKeyMaterial,
+    sync_url: str,
+) -> dict[str, object]:
+    return {
+        "access_token": access_token,
+        "dpop_key_material": dpop_key_material,
+        "sync_url": sync_url,
+    }
 
 
 def build_device_authorization_request_body(
@@ -844,6 +858,7 @@ def run_guard_device_connect_command(
     open_browser=None,
     ci_safe: bool = False,
     machine_label: str | None = None,
+    include_sync_auth_context: bool = False,
 ) -> dict[str, object]:
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
@@ -906,6 +921,7 @@ def run_guard_device_connect_command(
         runtime_label=HEADLESS_RUNTIME_LABEL,
         now=timestamp,
     )
+    sync_url = _oauth_sync_url_from_issuer(oauth_client.issuer)
     payload.update(
         {
             "status": "connected",
@@ -913,12 +929,18 @@ def run_guard_device_connect_command(
             "machine_id": token_result.machine_id,
             "workspace_id": token_result.workspace_id,
             "connect_url": connect_url,
-            "sync_url": _oauth_sync_url_from_issuer(oauth_client.issuer),
+            "sync_url": sync_url,
             "connect_command": CONNECT_COMMAND,
             "connect_status_command": CONNECT_STATUS_COMMAND,
             "connect_repair_command": CONNECT_REPAIR_COMMAND,
         }
     )
+    if include_sync_auth_context:
+        payload[CONNECT_SYNC_AUTH_CONTEXT_KEY] = _build_sync_auth_context(
+            access_token=token_result.access_token,
+            dpop_key_material=dpop_key_material,
+            sync_url=sync_url,
+        )
     return payload
 
 
@@ -931,6 +953,7 @@ def run_guard_browser_connect_command(
     exchange_authorization_code=exchange_guard_authorization_code,
     now: str | None = None,
     wait_timeout_seconds: float = 180,
+    include_sync_auth_context: bool = False,
 ) -> dict[str, object]:
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
@@ -971,7 +994,8 @@ def run_guard_browser_connect_command(
         runtime_label=HEADLESS_RUNTIME_LABEL,
         now=timestamp,
     )
-    return {
+    sync_url = _oauth_sync_url_from_issuer(oauth_client.issuer)
+    payload: dict[str, object] = {
         "status": "connected",
         "connect_mode": "browser_oauth",
         "browser_opened": browser_opened,
@@ -981,11 +1005,18 @@ def run_guard_browser_connect_command(
         "machine_id": token_result.machine_id,
         "workspace_id": token_result.workspace_id,
         "connect_url": connect_url,
-        "sync_url": _oauth_sync_url_from_issuer(oauth_client.issuer),
+        "sync_url": sync_url,
         "connect_command": CONNECT_COMMAND,
         "connect_status_command": CONNECT_STATUS_COMMAND,
         "connect_repair_command": CONNECT_REPAIR_COMMAND,
     }
+    if include_sync_auth_context:
+        payload[CONNECT_SYNC_AUTH_CONTEXT_KEY] = _build_sync_auth_context(
+            access_token=token_result.access_token,
+            dpop_key_material=session.dpop_key_material,
+            sync_url=sync_url,
+        )
+    return payload
 
 
 def build_connect_status_payload(

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -246,6 +246,7 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
     last_sync_at = _optional_string(sync_summary.get("synced_at"))
     latest_connect_state = store.get_effective_guard_connect_state(now=_now())
     connect_retry_required = _connect_retry_required(latest_connect_state)
+    connect_retry_refresh_race = _connect_retry_refresh_race(latest_connect_state)
     remote_payload_active = bool(advisories or alert_preferences or remote_policy or team_policy_pack)
     cloud_state = _resolve_cloud_state(
         sync_configured=cloud_profile is not None,
@@ -261,6 +262,7 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
             dashboard_url,
             oauth_repair_required=oauth_repair_required,
             connect_retry_required=connect_retry_required,
+            connect_retry_refresh_race=connect_retry_refresh_race,
         ),
         "sync_url": sync_url,
         "dashboard_url": dashboard_url,
@@ -474,11 +476,17 @@ def _cloud_state_detail(
     *,
     oauth_repair_required: bool = False,
     connect_retry_required: bool = False,
+    connect_retry_refresh_race: bool = False,
 ) -> str:
     if oauth_repair_required:
         return (
             "Guard Cloud sign-in on this machine is incomplete. "
             f"Run `{GUARD_COMMAND} connect` or reopen {connect_url} to repair local authorization and resume sync."
+        )
+    if connect_retry_refresh_race:
+        return (
+            "This machine stays locally protected. The first shared Guard Cloud proof stalled after a refresh-token "
+            f"race. Run `{GUARD_COMMAND} connect` or reopen {connect_url} when you want shared proof restored."
         )
     if connect_retry_required:
         return (
@@ -512,6 +520,13 @@ def _connect_retry_required(latest_state: dict[str, object] | None) -> bool:
     status = _optional_string(latest_state.get("status"))
     milestone = _optional_string(latest_state.get("milestone"))
     return status == "retry_required" or milestone == "first_sync_failed"
+
+
+def _connect_retry_refresh_race(latest_state: dict[str, object] | None) -> bool:
+    if latest_state is None or not _connect_retry_required(latest_state):
+        return False
+    reason = _optional_string(latest_state.get("reason"))
+    return isinstance(reason, str) and "already consumed" in reason.lower()
 
 
 def _advisory_headline(advisories: list[dict[str, object]]) -> str | None:

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -6,9 +6,9 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
-from ..approvals import _connect_retry_refresh_race_from_reason
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
+from ..approvals import _connect_retry_refresh_race_from_reason
 from ..config import GuardConfig
 from ..consumer import detect_all
 from ..consumer.service import diff_artifact

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
+from ..approvals import _connect_retry_refresh_race_from_reason
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
@@ -525,8 +526,7 @@ def _connect_retry_required(latest_state: dict[str, object] | None) -> bool:
 def _connect_retry_refresh_race(latest_state: dict[str, object] | None) -> bool:
     if latest_state is None or not _connect_retry_required(latest_state):
         return False
-    reason = _optional_string(latest_state.get("reason"))
-    return isinstance(reason, str) and "already consumed" in reason.lower()
+    return _connect_retry_refresh_race_from_reason(_optional_string(latest_state.get("reason")))
 
 
 def _advisory_headline(advisories: list[dict[str, object]]) -> str | None:

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/approval-proof-modal.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/approval-proof-modal.js
@@ -1,0 +1,58 @@
+import { r as reactExports, j as jsxRuntimeExports, S as SectionLabel, A as ActionButton } from "../guard-dashboard.js";
+function ApprovalProofModal(props) {
+  const { title, detail, confirmLabel, approvalGate, onCancel, onConfirm } = props;
+  const [password, setPassword] = reactExports.useState("");
+  const [totpCode, setTotpCode] = reactExports.useState("");
+  const handlePasswordChange = reactExports.useCallback((event) => {
+    setPassword(event.target.value);
+  }, []);
+  const handleTotpChange = reactExports.useCallback((event) => {
+    setTotpCode(event.target.value);
+  }, []);
+  const handleConfirm = reactExports.useCallback(() => {
+    onConfirm({
+      approval_password: password,
+      ...approvalGate?.totp_enabled === true ? { approval_totp_code: totpCode } : {}
+    });
+  }, [approvalGate, onConfirm, password, totpCode]);
+  const confirmDisabled = password.trim() === "" || approvalGate?.totp_enabled === true && totpCode.trim() === "";
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Approval required" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "mt-2 text-base font-semibold text-brand-dark", children: title }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: detail }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-4 block", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.15em] text-slate-500", children: "Approval password" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "password",
+          value: password,
+          onChange: handlePasswordChange,
+          autoComplete: "current-password",
+          className: "mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+        }
+      )
+    ] }),
+    approvalGate?.totp_enabled === true && /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-3 block", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.15em] text-slate-500", children: "Authenticator code" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "text",
+          inputMode: "numeric",
+          pattern: "[0-9]*",
+          value: totpCode,
+          onChange: handleTotpChange,
+          className: "mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex justify-end gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onCancel, children: "Cancel" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleConfirm, disabled: confirmDisabled, children: confirmLabel })
+    ] })
+  ] }) });
+}
+export {
+  ApprovalProofModal as A
+};

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -1,5 +1,5 @@
-import { r as reactExports, D as fetchSettings, ap as runAuditRemediation, a9 as GuardHarnessActionError, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, a as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
-import { A as ApprovalProofModal } from "./approval-proof-modal.js";
+import { r as reactExports, ap as runAuditRemediation, a9 as GuardHarnessActionError, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, a as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
+import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 function deriveFrontendAuditResults(receipts, snapshot) {
   const results = [];
   const protection = snapshot.supply_chain?.package_manager_protection;
@@ -125,23 +125,7 @@ function AuditWorkspace({ snapshot, receipts, approvalGate }) {
   const [pendingRemediation, setPendingRemediation] = reactExports.useState(null);
   const [runningRemediationId, setRunningRemediationId] = reactExports.useState(null);
   const [remediationMessages, setRemediationMessages] = reactExports.useState({});
-  const [resolvedApprovalGate, setResolvedApprovalGate] = reactExports.useState(approvalGate);
-  reactExports.useEffect(() => {
-    setResolvedApprovalGate(approvalGate);
-  }, [approvalGate]);
-  const resolveApprovalGate = reactExports.useCallback(async () => {
-    if (resolvedApprovalGate !== null) {
-      return resolvedApprovalGate;
-    }
-    try {
-      const payload = await fetchSettings();
-      const gate = payload.settings.approval_gate ?? null;
-      setResolvedApprovalGate(gate);
-      return gate;
-    } catch {
-      return null;
-    }
-  }, [resolvedApprovalGate]);
+  const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(approvalGate);
   const handleSearchChange = reactExports.useCallback((e) => {
     setFilter((f) => ({ ...f, searchQuery: e.target.value }));
   }, []);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -1,4 +1,5 @@
-import { r as reactExports, ap as runAuditRemediation, a9 as GuardHarnessActionError, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, a as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
+import { r as reactExports, D as fetchSettings, ap as runAuditRemediation, a9 as GuardHarnessActionError, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, a as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
+import { A as ApprovalProofModal } from "./approval-proof-modal.js";
 function deriveFrontendAuditResults(receipts, snapshot) {
   const results = [];
   const protection = snapshot.supply_chain?.package_manager_protection;
@@ -124,6 +125,23 @@ function AuditWorkspace({ snapshot, receipts, approvalGate }) {
   const [pendingRemediation, setPendingRemediation] = reactExports.useState(null);
   const [runningRemediationId, setRunningRemediationId] = reactExports.useState(null);
   const [remediationMessages, setRemediationMessages] = reactExports.useState({});
+  const [resolvedApprovalGate, setResolvedApprovalGate] = reactExports.useState(approvalGate);
+  reactExports.useEffect(() => {
+    setResolvedApprovalGate(approvalGate);
+  }, [approvalGate]);
+  const resolveApprovalGate = reactExports.useCallback(async () => {
+    if (resolvedApprovalGate !== null) {
+      return resolvedApprovalGate;
+    }
+    try {
+      const payload = await fetchSettings();
+      const gate = payload.settings.approval_gate ?? null;
+      setResolvedApprovalGate(gate);
+      return gate;
+    } catch {
+      return null;
+    }
+  }, [resolvedApprovalGate]);
   const handleSearchChange = reactExports.useCallback((e) => {
     setFilter((f) => ({ ...f, searchQuery: e.target.value }));
   }, []);
@@ -155,7 +173,8 @@ function AuditWorkspace({ snapshot, receipts, approvalGate }) {
           [result.id]: "Remediation completed. Restart your shell before retrying package installs."
         }));
       } catch (error) {
-        if (credentials === void 0 && error instanceof GuardHarnessActionError && error.payload?.error === "approval_gate_required" && approvalGate?.enabled === true && approvalGate.configured === true) {
+        if (credentials === void 0 && error instanceof GuardHarnessActionError && error.payload?.error === "approval_gate_required") {
+          await resolveApprovalGate();
           setPendingRemediation(result);
           setRemediationMessages((prev) => {
             const next = { ...prev };
@@ -170,7 +189,7 @@ function AuditWorkspace({ snapshot, receipts, approvalGate }) {
         setRunningRemediationId(null);
       }
     },
-    [approvalGate]
+    [resolveApprovalGate]
   );
   const handleRunRemediation = reactExports.useCallback(
     (result) => {
@@ -216,10 +235,7 @@ function AuditWorkspace({ snapshot, receipts, approvalGate }) {
   );
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-lg font-semibold text-brand-dark", children: "Audit" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-sm text-slate-500", children: "Workspace audit results, open issues, and remediation queue." })
-      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "Workspace audit results, open issues, and remediation queue." }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
         criticalCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs(Badge, { tone: "destructive", children: [
           criticalCount,
@@ -309,7 +325,7 @@ function AuditWorkspace({ snapshot, receipts, approvalGate }) {
       RemediationApprovalModal,
       {
         result: pendingRemediation,
-        approvalGate,
+        approvalGate: resolvedApprovalGate,
         onCancel: handleCancelRemediationGate,
         onConfirm: handleConfirmRemediationGate
       }
@@ -366,57 +382,17 @@ function RemediationQueueActions(props) {
 }
 function RemediationApprovalModal(props) {
   const { approvalGate, onCancel, onConfirm, result } = props;
-  const [password, setPassword] = reactExports.useState("");
-  const [totpCode, setTotpCode] = reactExports.useState("");
-  const handlePasswordChange = reactExports.useCallback((event) => {
-    setPassword(event.target.value);
-  }, []);
-  const handleTotpChange = reactExports.useCallback((event) => {
-    setTotpCode(event.target.value);
-  }, []);
-  const handleConfirm = reactExports.useCallback(() => {
-    onConfirm({
-      approval_password: password,
-      ...approvalGate?.totp_enabled === true ? { approval_totp_code: totpCode } : {}
-    });
-  }, [approvalGate, onConfirm, password, totpCode]);
-  const confirmDisabled = password.trim() === "" || approvalGate?.totp_enabled === true && totpCode.trim() === "";
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "fixed inset-0 z-50 flex items-center justify-center bg-slate-950/40 px-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "w-full max-w-md rounded-xl border border-slate-200 bg-white p-5 shadow-xl", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Approval required" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "mt-2 text-base font-semibold text-brand-dark", children: result.remediationAction?.label }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Enter local approval proof before Guard changes package-manager protection on this device." }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-4 block", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.15em] text-slate-500", children: "Approval password" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "input",
-        {
-          type: "password",
-          value: password,
-          onChange: handlePasswordChange,
-          autoComplete: "current-password",
-          className: "mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-        }
-      )
-    ] }),
-    approvalGate?.totp_enabled === true && /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-3 block", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-semibold uppercase tracking-[0.15em] text-slate-500", children: "Authenticator code" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "input",
-        {
-          type: "text",
-          inputMode: "numeric",
-          pattern: "[0-9]*",
-          value: totpCode,
-          onChange: handleTotpChange,
-          className: "mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-        }
-      )
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex justify-end gap-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onCancel, children: "Cancel" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleConfirm, disabled: confirmDisabled, children: "Run remediation" })
-    ] })
-  ] }) });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    ApprovalProofModal,
+    {
+      title: result.remediationAction?.label ?? "Run remediation",
+      detail: "Enter local approval proof before Guard changes package-manager protection on this device.",
+      confirmLabel: "Run remediation",
+      approvalGate,
+      onCancel,
+      onConfirm
+    }
+  );
 }
 export {
   AuditWorkspace,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
@@ -57,10 +57,7 @@ function FeedHealthWorkspace({ snapshot, onOpenSettings }) {
   const cloudDetail = snapshot.cloud_state_detail;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-lg font-semibold text-brand-dark", children: "Feed Health" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-sm text-slate-500", children: "Intel feed source mode, freshness, and cloud sync status." })
-      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "Intel feed source mode, freshness, and cloud sync status." }) }),
       onOpenSettings && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onOpenSettings, children: "Open Settings" })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-100 bg-white p-5 shadow-sm space-y-4", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
@@ -99,10 +99,7 @@ function PolicyWorkspace({
   reactExports.useMemo(() => groupPoliciesByHarness(policies), [policies]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-lg font-semibold text-brand-dark", children: "Policy" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-sm text-slate-500", children: "Guard rules, exceptions, and remembered decisions." })
-      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "Guard rules, exceptions, and remembered decisions." }) }),
       onOpenSettings && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onOpenSettings, children: "Open Settings" })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -1,4 +1,4 @@
-const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/chunks/supply-chain-workspace.js","assets/guard-dashboard.js","assets/index.css","assets/chunks/runtime-overview.js","assets/chunks/approval-proof-modal.js","assets/chunks/audit-workspace.js","assets/chunks/policy-workspace.js","assets/chunks/feed-health-workspace.js"])))=>i.map(i=>d[i]);
+const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/chunks/supply-chain-workspace.js","assets/guard-dashboard.js","assets/index.css","assets/chunks/runtime-overview.js","assets/chunks/use-resolved-approval-gate.js","assets/chunks/audit-workspace.js","assets/chunks/policy-workspace.js","assets/chunks/feed-health-workspace.js"])))=>i.map(i=>d[i]);
 import { r as reactExports, j as jsxRuntimeExports, ag as TabBar, ah as __vitePreload } from "../guard-dashboard.js";
 const SupplyChainWorkspace = reactExports.lazy(
   () => __vitePreload(() => import("./supply-chain-workspace.js"), true ? __vite__mapDeps([0,1,2,3,4]) : void 0).then((m) => ({ default: m.SupplyChainWorkspace }))

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -1,16 +1,16 @@
-const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/chunks/supply-chain-workspace.js","assets/guard-dashboard.js","assets/index.css","assets/chunks/runtime-overview.js","assets/chunks/audit-workspace.js","assets/chunks/policy-workspace.js","assets/chunks/feed-health-workspace.js"])))=>i.map(i=>d[i]);
+const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/chunks/supply-chain-workspace.js","assets/guard-dashboard.js","assets/index.css","assets/chunks/runtime-overview.js","assets/chunks/approval-proof-modal.js","assets/chunks/audit-workspace.js","assets/chunks/policy-workspace.js","assets/chunks/feed-health-workspace.js"])))=>i.map(i=>d[i]);
 import { r as reactExports, j as jsxRuntimeExports, ag as TabBar, ah as __vitePreload } from "../guard-dashboard.js";
 const SupplyChainWorkspace = reactExports.lazy(
-  () => __vitePreload(() => import("./supply-chain-workspace.js"), true ? __vite__mapDeps([0,1,2,3]) : void 0).then((m) => ({ default: m.SupplyChainWorkspace }))
+  () => __vitePreload(() => import("./supply-chain-workspace.js"), true ? __vite__mapDeps([0,1,2,3,4]) : void 0).then((m) => ({ default: m.SupplyChainWorkspace }))
 );
 const AuditWorkspace = reactExports.lazy(
-  () => __vitePreload(() => import("./audit-workspace.js"), true ? __vite__mapDeps([4,1,2]) : void 0).then((m) => ({ default: m.AuditWorkspace }))
+  () => __vitePreload(() => import("./audit-workspace.js"), true ? __vite__mapDeps([5,1,2,4]) : void 0).then((m) => ({ default: m.AuditWorkspace }))
 );
 const PolicyWorkspace = reactExports.lazy(
-  () => __vitePreload(() => import("./policy-workspace.js"), true ? __vite__mapDeps([5,1,2]) : void 0).then((m) => ({ default: m.PolicyWorkspace }))
+  () => __vitePreload(() => import("./policy-workspace.js"), true ? __vite__mapDeps([6,1,2]) : void 0).then((m) => ({ default: m.PolicyWorkspace }))
 );
 const FeedHealthWorkspace = reactExports.lazy(
-  () => __vitePreload(() => import("./feed-health-workspace.js"), true ? __vite__mapDeps([6,1,2]) : void 0).then((m) => ({ default: m.FeedHealthWorkspace }))
+  () => __vitePreload(() => import("./feed-health-workspace.js"), true ? __vite__mapDeps([7,1,2]) : void 0).then((m) => ({ default: m.FeedHealthWorkspace }))
 );
 const hubTabs = [
   { value: "supply-chain", label: "Supply Chain" },
@@ -18,6 +18,9 @@ const hubTabs = [
   { value: "policy", label: "Policy" },
   { value: "feed-health", label: "Feed Health" }
 ];
+function hubTitleForTab(tab) {
+  return hubTabs.find((item) => item.value === tab)?.label ?? "Supply Chain";
+}
 function viewToTab(view) {
   if (view === "supply-chain" || view === "audit" || view === "policy" || view === "feed-health") {
     return view;
@@ -35,11 +38,21 @@ function SupplyChainHubWorkspace(props) {
   );
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-2xl font-semibold tracking-tight text-brand-dark", children: "Trust Center" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-slate-400", children: "Trust Center" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-2xl font-semibold tracking-tight text-brand-dark", children: hubTitleForTab(tab) })
+      ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(TabBar, { tabs: hubTabs, active: tab, onChange: handleTabChange })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(reactExports.Suspense, { fallback: /* @__PURE__ */ jsxRuntimeExports.jsx(LazyFallback, {}), children: [
-      tab === "supply-chain" && /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainWorkspace, { snapshot: props.snapshot, onGoHome: props.onGoHome }),
+      tab === "supply-chain" && /* @__PURE__ */ jsxRuntimeExports.jsx(
+        SupplyChainWorkspace,
+        {
+          snapshot: props.snapshot,
+          approvalGate: props.approvalGate,
+          onGoHome: props.onGoHome
+        }
+      ),
       tab === "audit" && /* @__PURE__ */ jsxRuntimeExports.jsx(AuditWorkspace, { snapshot: props.snapshot, receipts: props.receipts, approvalGate: props.approvalGate }),
       tab === "policy" && /* @__PURE__ */ jsxRuntimeExports.jsx(
         PolicyWorkspace,
@@ -58,5 +71,6 @@ function LazyFallback() {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex min-h-[200px] items-center justify-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "guard-skeleton h-8 w-48" }) });
 }
 export {
-  SupplyChainHubWorkspace
+  SupplyChainHubWorkspace,
+  hubTitleForTab
 };

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,5 +1,6 @@
-import { j as jsxRuntimeExports, g as HiMiniCheckCircle, a as HiMiniExclamationTriangle, H as HiMiniShieldCheck, A as ActionButton, ai as HiMiniArrowTopRightOnSquare, h as HiMiniXCircle, r as reactExports, ab as HiMiniArrowPath, T as Tag, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, al as runPackageFirewallAction, am as runPackageAudit, an as runPackageSync, S as SectionLabel, E as EmptyState, ao as HiMiniBugAnt, b as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, g as HiMiniCheckCircle, a as HiMiniExclamationTriangle, H as HiMiniShieldCheck, A as ActionButton, ai as HiMiniArrowTopRightOnSquare, h as HiMiniXCircle, r as reactExports, ab as HiMiniArrowPath, T as Tag, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, D as fetchSettings, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, S as SectionLabel, E as EmptyState, ao as HiMiniBugAnt, b as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
 import { b as resolvePackageManagerProtectionCopy } from "./runtime-overview.js";
+import { A as ApprovalProofModal } from "./approval-proof-modal.js";
 function UpgradeCta({ entitlement }) {
   const reconnectRequired = entitlement.reason === "guard_cloud_reconnect_required";
   const upgradeUrl = reconnectRequired ? "https://hol.org/guard/connect" : entitlement.upgrade_url ?? "https://hol.org/guard/pricing";
@@ -470,12 +471,18 @@ function RefreshButton({ disabled, spinning, onRefresh }) {
     }
   );
 }
-function PackageFirewallPanel() {
+function PackageFirewallPanel(props) {
+  const { approvalGate } = props;
   const [panelLoad, setPanelLoad] = reactExports.useState({ phase: "loading" });
   const [pendingOp, setPendingOp] = reactExports.useState(null);
   const [lastCompleted, setLastCompleted] = reactExports.useState(null);
   const [lastFailed, setLastFailed] = reactExports.useState(null);
   const [confirmRemoveManager, setConfirmRemoveManager] = reactExports.useState(null);
+  const [pendingApprovalOp, setPendingApprovalOp] = reactExports.useState(null);
+  const [resolvedApprovalGate, setResolvedApprovalGate] = reactExports.useState(approvalGate);
+  reactExports.useEffect(() => {
+    setResolvedApprovalGate(approvalGate);
+  }, [approvalGate]);
   const load = reactExports.useCallback(async () => {
     setPanelLoad({ phase: "loading" });
     try {
@@ -498,22 +505,40 @@ function PackageFirewallPanel() {
       setPanelLoad({ phase: "error", message });
     }
   }, []);
+  const resolveApprovalGate = reactExports.useCallback(async () => {
+    if (resolvedApprovalGate !== null) {
+      return resolvedApprovalGate;
+    }
+    try {
+      const payload = await fetchSettings();
+      const gate = payload.settings.approval_gate ?? null;
+      setResolvedApprovalGate(gate);
+      return gate;
+    } catch {
+      return null;
+    }
+  }, [resolvedApprovalGate]);
   const handleAction = reactExports.useCallback(
-    async (op, manager) => {
+    async (op, manager, credentials) => {
       setPendingOp({ op, manager });
       setLastFailed(null);
       try {
-        const response = await runPackageFirewallAction(op, manager);
+        const response = await runPackageFirewallAction(op, manager, credentials);
         setLastCompleted({ op, manager, response });
         await refreshAfterOp();
       } catch (err) {
+        if (credentials === void 0 && manager !== null && err instanceof GuardHarnessActionError && err.payload?.error === "approval_gate_required") {
+          await resolveApprovalGate();
+          setPendingApprovalOp({ op, manager });
+          return;
+        }
         const message = err instanceof Error ? err.message : "Action failed.";
         setLastFailed({ op, manager, message });
       } finally {
         setPendingOp(null);
       }
     },
-    [refreshAfterOp]
+    [refreshAfterOp, resolveApprovalGate]
   );
   const handleGlobalOp = reactExports.useCallback(
     async (op) => {
@@ -560,6 +585,16 @@ function PackageFirewallPanel() {
   const handleSync = reactExports.useCallback(() => void handleGlobalOp("sync"), [handleGlobalOp]);
   const handleDismissResult = reactExports.useCallback(() => setLastCompleted(null), []);
   const handleRetry = reactExports.useCallback(() => void load(), [load]);
+  const handleApprovalCancel = reactExports.useCallback(() => setPendingApprovalOp(null), []);
+  const handleApprovalConfirm = reactExports.useCallback(
+    (credentials) => {
+      const pendingApproval = pendingApprovalOp;
+      if (pendingApproval === null) return;
+      setPendingApprovalOp(null);
+      void handleAction(pendingApproval.op, pendingApproval.manager, credentials);
+    },
+    [handleAction, pendingApprovalOp]
+  );
   const anyPending = pendingOp !== null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-100 bg-white shadow-sm", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-2 border-b border-slate-100 px-4 py-3", children: [
@@ -589,8 +624,22 @@ function PackageFirewallPanel() {
         onSync: handleSync,
         onDismissResult: handleDismissResult
       }
-    ) : /* @__PURE__ */ jsxRuntimeExports.jsx(FreeUserView, { data: panelLoad.data }))
+    ) : /* @__PURE__ */ jsxRuntimeExports.jsx(FreeUserView, { data: panelLoad.data })),
+    pendingApprovalOp !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ApprovalProofModal,
+      {
+        title: `${actionLabel(pendingApprovalOp.op)} ${pendingApprovalOp.manager}`,
+        detail: "Enter local approval proof before Guard changes package-manager protection on this device.",
+        confirmLabel: actionLabel(pendingApprovalOp.op),
+        approvalGate: resolvedApprovalGate,
+        onCancel: handleApprovalCancel,
+        onConfirm: handleApprovalConfirm
+      }
+    )
   ] });
+}
+function actionLabel(op) {
+  return op.charAt(0).toUpperCase() + op.slice(1);
 }
 function buildSupplyChainStats(snapshot) {
   const managedInstalls = snapshot.managed_installs ?? [];
@@ -654,7 +703,7 @@ function AppFirewallRow({ install, protection }) {
     ] })
   ] });
 }
-function SupplyChainWorkspace({ snapshot, onGoHome }) {
+function SupplyChainWorkspace({ snapshot, approvalGate, onGoHome }) {
   const [filter, setFilter] = reactExports.useState({
     statusFilter: "all",
     managerFilter: ""
@@ -687,10 +736,7 @@ function SupplyChainWorkspace({ snapshot, onGoHome }) {
   );
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-lg font-semibold text-brand-dark", children: "Supply Chain" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-sm text-slate-500", children: "Package manager firewall status, prevented installs, and feed health." })
-      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "Package manager firewall status, prevented installs, and feed health." }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "ghost", onClick: onGoHome, children: "Back to Home" })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2 lg:grid-cols-4", children: [
@@ -699,7 +745,7 @@ function SupplyChainWorkspace({ snapshot, onGoHome }) {
       /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Protected managers", value: stats.protectedManagers, tone: "green" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Unprotected managers", value: stats.unprotectedManagers, tone: stats.unprotectedManagers > 0 ? "attention" : "slate" })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(PackageFirewallPanel, {}),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(PackageFirewallPanel, { approvalGate }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-100 bg-white shadow-sm", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-b border-slate-100 px-4 py-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,6 +1,6 @@
-import { j as jsxRuntimeExports, g as HiMiniCheckCircle, a as HiMiniExclamationTriangle, H as HiMiniShieldCheck, A as ActionButton, ai as HiMiniArrowTopRightOnSquare, h as HiMiniXCircle, r as reactExports, ab as HiMiniArrowPath, T as Tag, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, D as fetchSettings, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, S as SectionLabel, E as EmptyState, ao as HiMiniBugAnt, b as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, g as HiMiniCheckCircle, a as HiMiniExclamationTriangle, H as HiMiniShieldCheck, A as ActionButton, ai as HiMiniArrowTopRightOnSquare, h as HiMiniXCircle, r as reactExports, ab as HiMiniArrowPath, T as Tag, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, S as SectionLabel, E as EmptyState, ao as HiMiniBugAnt, b as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
 import { b as resolvePackageManagerProtectionCopy } from "./runtime-overview.js";
-import { A as ApprovalProofModal } from "./approval-proof-modal.js";
+import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 function UpgradeCta({ entitlement }) {
   const reconnectRequired = entitlement.reason === "guard_cloud_reconnect_required";
   const upgradeUrl = reconnectRequired ? "https://hol.org/guard/connect" : entitlement.upgrade_url ?? "https://hol.org/guard/pricing";
@@ -479,10 +479,7 @@ function PackageFirewallPanel(props) {
   const [lastFailed, setLastFailed] = reactExports.useState(null);
   const [confirmRemoveManager, setConfirmRemoveManager] = reactExports.useState(null);
   const [pendingApprovalOp, setPendingApprovalOp] = reactExports.useState(null);
-  const [resolvedApprovalGate, setResolvedApprovalGate] = reactExports.useState(approvalGate);
-  reactExports.useEffect(() => {
-    setResolvedApprovalGate(approvalGate);
-  }, [approvalGate]);
+  const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(approvalGate);
   const load = reactExports.useCallback(async () => {
     setPanelLoad({ phase: "loading" });
     try {
@@ -505,19 +502,6 @@ function PackageFirewallPanel(props) {
       setPanelLoad({ phase: "error", message });
     }
   }, []);
-  const resolveApprovalGate = reactExports.useCallback(async () => {
-    if (resolvedApprovalGate !== null) {
-      return resolvedApprovalGate;
-    }
-    try {
-      const payload = await fetchSettings();
-      const gate = payload.settings.approval_gate ?? null;
-      setResolvedApprovalGate(gate);
-      return gate;
-    } catch {
-      return null;
-    }
-  }, [resolvedApprovalGate]);
   const handleAction = reactExports.useCallback(
     async (op, manager, credentials) => {
       setPendingOp({ op, manager });

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/use-resolved-approval-gate.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/use-resolved-approval-gate.js
@@ -1,4 +1,4 @@
-import { r as reactExports, j as jsxRuntimeExports, S as SectionLabel, A as ActionButton } from "../guard-dashboard.js";
+import { r as reactExports, j as jsxRuntimeExports, S as SectionLabel, A as ActionButton, D as fetchSettings } from "../guard-dashboard.js";
 function ApprovalProofModal(props) {
   const { title, detail, confirmLabel, approvalGate, onCancel, onConfirm } = props;
   const [password, setPassword] = reactExports.useState("");
@@ -53,6 +53,27 @@ function ApprovalProofModal(props) {
     ] })
   ] }) });
 }
+function useResolvedApprovalGate(initialGate) {
+  const [resolvedApprovalGate, setResolvedApprovalGate] = reactExports.useState(initialGate);
+  reactExports.useEffect(() => {
+    setResolvedApprovalGate(initialGate);
+  }, [initialGate]);
+  const resolveApprovalGate = reactExports.useCallback(async () => {
+    if (resolvedApprovalGate !== null) {
+      return resolvedApprovalGate;
+    }
+    try {
+      const payload = await fetchSettings();
+      const gate = payload.settings.approval_gate ?? null;
+      setResolvedApprovalGate(gate);
+      return gate;
+    } catch {
+      return null;
+    }
+  }, [resolvedApprovalGate]);
+  return { resolvedApprovalGate, resolveApprovalGate };
+}
 export {
-  ApprovalProofModal as A
+  ApprovalProofModal as A,
+  useResolvedApprovalGate as u
 };

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13920,9 +13920,13 @@ function normalizePackageFirewallAction(value) {
 async function fetchPackageFirewallStatus() {
   return normalizePackageFirewallStatus(await readJson("/v1/supply-chain/package-shims"));
 }
-async function runPackageFirewallAction(action, manager) {
-  const payload = manager !== null ? { managers: [manager] } : {};
-  const response = await readJson(
+async function runPackageFirewallAction(action, manager, credentials) {
+  const payload = {
+    ...manager !== null ? { managers: [manager] } : {},
+    ...credentials?.approval_password !== void 0 ? { approval_password: credentials.approval_password } : {},
+    ...credentials?.approval_totp_code !== void 0 ? { approval_totp_code: credentials.approval_totp_code } : {}
+  };
+  const response = await fetchGuardApi(
     `/v1/supply-chain/package-shims/${action}`,
     {
       method: "POST",
@@ -13933,7 +13937,14 @@ async function runPackageFirewallAction(action, manager) {
       body: JSON.stringify(payload)
     }
   );
-  return normalizePackageFirewallAction(response);
+  const payloadBody = await response.json().catch(() => null);
+  if (!response.ok) {
+    throw new GuardHarnessActionError(
+      response.status,
+      isGuardHarnessActionErrorPayload(payloadBody) ? payloadBody : null
+    );
+  }
+  return normalizePackageFirewallAction(payloadBody);
 }
 async function runAuditRemediation(input) {
   if (isGuardDemoMode()) {
@@ -15152,6 +15163,7 @@ function TabBar(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "tablist", className: "flex flex-wrap gap-1 rounded-lg border border-slate-200 bg-slate-50 p-0.5", children: props.tabs.map((tab) => /* @__PURE__ */ jsxRuntimeExports.jsx(
     "button",
     {
+      id: tab.id ?? tab.value,
       type: "button",
       role: "tab",
       "aria-selected": props.active === tab.value,
@@ -15897,7 +15909,7 @@ function EvidenceHeader({
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-0.5 min-w-0", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-lg font-semibold text-brand-dark", children: "Evidence" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Every action Guard reviewed on this machine." }),
-      lastActivityLabel && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "flex items-center gap-1 text-[11px] text-slate-400", children: [
+      lastActivityLabel && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-[11px] text-slate-400", children: [
         "Last activity: ",
         lastActivityLabel
       ] })
@@ -16346,6 +16358,14 @@ function DecisionChip({ decision }) {
     "Reviewed"
   ] });
 }
+const SORT_TOGGLE_MAP = {
+  newest: "oldest",
+  oldest: "newest",
+  artifact: "artifact",
+  app: "app",
+  category: "category",
+  decision: "decision"
+};
 function SortHeader({
   label,
   active,
@@ -16357,6 +16377,7 @@ function SortHeader({
     "th",
     {
       scope: "col",
+      "aria-sort": active ? ascending ? "ascending" : "descending" : "none",
       className: `px-3 py-2.5 text-left text-[11px] font-semibold uppercase tracking-wider text-slate-500 ${className}`,
       children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
@@ -16390,10 +16411,8 @@ function EvidenceActionList({
   const showLoadMore = hasMore(page, pageSize, receipts.length);
   const handleSort = reactExports.useCallback(
     (key) => {
-      if (sort === key && key === "newest") {
-        onSortChange("oldest");
-      } else if (sort === key && key === "oldest") {
-        onSortChange("newest");
+      if (sort === key) {
+        onSortChange(SORT_TOGGLE_MAP[key]);
       } else {
         onSortChange(key);
       }
@@ -16420,7 +16439,7 @@ function EvidenceActionList({
           {
             label: "Artifact",
             active: sort === "artifact",
-            ascending: true,
+            ascending: sort === "artifact",
             onClick: () => handleSort("artifact"),
             className: "min-w-[180px]"
           }
@@ -16430,7 +16449,7 @@ function EvidenceActionList({
           {
             label: "App",
             active: sort === "app",
-            ascending: true,
+            ascending: sort === "app",
             onClick: () => handleSort("app"),
             className: "hidden sm:table-cell"
           }
@@ -16440,7 +16459,7 @@ function EvidenceActionList({
           {
             label: "Category",
             active: sort === "category",
-            ascending: true,
+            ascending: sort === "category",
             onClick: () => handleSort("category"),
             className: "hidden md:table-cell"
           }
@@ -16450,7 +16469,7 @@ function EvidenceActionList({
           {
             label: "Decision",
             active: sort === "decision",
-            ascending: true,
+            ascending: sort === "decision",
             onClick: () => handleSort("decision")
           }
         ),
@@ -16459,7 +16478,7 @@ function EvidenceActionList({
           {
             label: "Time",
             active: sort === "newest" || sort === "oldest",
-            ascending: sort === "newest",
+            ascending: sort === "oldest",
             onClick: () => handleSort("newest"),
             className: "hidden lg:table-cell"
           }
@@ -16528,7 +16547,6 @@ function ActionRow({
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "tr",
     {
-      role: "button",
       tabIndex: 0,
       onClick: handleClick,
       onKeyDown: handleKeyDown,
@@ -16704,8 +16722,7 @@ function TechnicalSection({ receipt }) {
           value: (receipt.changed_capabilities ?? []).join(", ")
         }
       ),
-      receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Capabilities", value: receipt.capabilities_summary }),
-      receipt.diff_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Diff summary", value: receipt.diff_summary })
+      receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx(DetailRow, { label: "Capabilities", value: receipt.capabilities_summary })
     ] })
   ] });
 }
@@ -18127,7 +18144,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }) {
       }
     );
   }
-  const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label }));
+  const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label, id: t.key }));
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       EvidenceHeader,
@@ -22265,6 +22282,18 @@ function parseRequestId(pathname) {
   }
   return null;
 }
+function viewTitle(view) {
+  if (view === "home") return "Home";
+  if (view === "inbox") return "Inbox";
+  if (view === "fleet") return "Protect";
+  if (view === "evidence") return "Evidence";
+  if (view === "settings") return "Settings";
+  if (view === "supply-chain") return "Supply Chain";
+  if (view === "audit") return "Audit";
+  if (view === "policy") return "Policy";
+  if (view === "feed-health") return "Feed Health";
+  return "App detail";
+}
 function parseAppDetail(pathname) {
   if (!pathname.startsWith("/apps/")) {
     return null;
@@ -22729,7 +22758,7 @@ function App() {
         children: "Skip to content"
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { "aria-live": "polite", "aria-atomic": "true", className: "sr-only", children: view === "home" ? "Home" : view === "inbox" ? "Inbox" : view === "fleet" ? "Protect" : view === "evidence" ? "Evidence" : view === "settings" ? "Settings" : view === "supply-chain" || view === "audit" || view === "policy" || view === "feed-health" ? "Trust Center" : "App detail" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { "aria-live": "polite", "aria-atomic": "true", className: "sr-only", children: viewTitle(view) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       ApprovalCenterLayout,
       {

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1543,20 +1543,24 @@ def _local_guard_runtime_session() -> dict[str, object]:
     }
 
 
-def sync_local_guard_cloud_proof(store: GuardStore) -> dict[str, object]:
+def sync_local_guard_cloud_proof(
+    store: GuardStore,
+    *,
+    auth_context: dict[str, object] | None = None,
+) -> dict[str, object]:
     """Publish the local Guard runtime session before syncing receipts."""
 
-    auth_context = _resolve_guard_sync_auth_context(store)
+    resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
     runtime_summary = sync_runtime_session(
         store,
         session=_local_guard_runtime_session(),
-        auth_context=auth_context,
+        auth_context=resolved_auth_context,
     )
     receipts_summary = sync_receipts(
         store,
         persist_sync_summary=False,
         persist_connect_state=False,
-        auth_context=auth_context,
+        auth_context=resolved_auth_context,
     )
     summary = dict(receipts_summary)
     summary.update(
@@ -1945,57 +1949,58 @@ def _persist_rotated_oauth_refresh_token(
 
 
 def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
-    oauth_health = store.get_oauth_local_credential_health()
-    oauth_credentials = store.get_oauth_local_credentials()
-    if oauth_credentials is not None:
-        issuer = _optional_string(oauth_credentials.get("issuer"))
-        client_id = _optional_string(oauth_credentials.get("client_id"))
-        refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
-        if issuer is None or client_id is None or refresh_token is None:
-            raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-        dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
-        try:
-            oauth_client = resolve_guard_oauth_client_config(issuer)
-        except ValueError as error:
-            raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
-        refreshed = _refresh_guard_oauth_access_token(
-            token_endpoint=oauth_client.token_endpoint,
-            client_id=client_id,
-            refresh_token=refresh_token,
-            dpop_key_material=dpop_key_material,
-        )
-        rotated_refresh_token = str(refreshed["refresh_token"])
-        package_firewall_entitlement = (
-            refreshed["package_firewall_entitlement"]
-            if isinstance(refreshed.get("package_firewall_entitlement"), dict)
-            else None
-        )
-        if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None:
-            _persist_rotated_oauth_refresh_token(
-                store=store,
-                credentials=oauth_credentials,
-                package_firewall_entitlement=package_firewall_entitlement,
-                refresh_token=rotated_refresh_token,
+    with store.hold_oauth_refresh_lock():
+        oauth_health = store.get_oauth_local_credential_health()
+        oauth_credentials = store.get_oauth_local_credentials()
+        if oauth_credentials is not None:
+            issuer = _optional_string(oauth_credentials.get("issuer"))
+            client_id = _optional_string(oauth_credentials.get("client_id"))
+            refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
+            if issuer is None or client_id is None or refresh_token is None:
+                raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+            dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
+            try:
+                oauth_client = resolve_guard_oauth_client_config(issuer)
+            except ValueError as error:
+                raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
+            refreshed = _refresh_guard_oauth_access_token(
+                token_endpoint=oauth_client.token_endpoint,
+                client_id=client_id,
+                refresh_token=refresh_token,
+                dpop_key_material=dpop_key_material,
             )
-        sync_url = _validate_guard_sync_url(
-            _oauth_sync_url_from_issuer(oauth_client.issuer),
-            issuer=oauth_client.issuer,
-        )
+            rotated_refresh_token = str(refreshed["refresh_token"])
+            package_firewall_entitlement = (
+                refreshed["package_firewall_entitlement"]
+                if isinstance(refreshed.get("package_firewall_entitlement"), dict)
+                else None
+            )
+            if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None:
+                _persist_rotated_oauth_refresh_token(
+                    store=store,
+                    credentials=oauth_credentials,
+                    package_firewall_entitlement=package_firewall_entitlement,
+                    refresh_token=rotated_refresh_token,
+                )
+            sync_url = _validate_guard_sync_url(
+                _oauth_sync_url_from_issuer(oauth_client.issuer),
+                issuer=oauth_client.issuer,
+            )
+            return {
+                "sync_url": sync_url,
+                "access_token": str(refreshed["access_token"]),
+                "dpop_key_material": dpop_key_material,
+            }
+        if bool(oauth_health.get("configured")):
+            raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+        credentials = store.get_sync_credentials()
+        if credentials is None:
+            raise GuardSyncNotConfiguredError("Guard is not logged in.")
         return {
-            "sync_url": sync_url,
-            "access_token": str(refreshed["access_token"]),
-            "dpop_key_material": dpop_key_material,
+            "sync_url": _validate_guard_sync_url(str(credentials["sync_url"])),
+            "access_token": str(credentials["token"]),
+            "dpop_key_material": None,
         }
-    if bool(oauth_health.get("configured")):
-        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-    credentials = store.get_sync_credentials()
-    if credentials is None:
-        raise GuardSyncNotConfiguredError("Guard is not logged in.")
-    return {
-        "sync_url": _validate_guard_sync_url(str(credentials["sync_url"])),
-        "access_token": str(credentials["token"]),
-        "dpop_key_material": None,
-    }
 
 
 def _guard_sync_headers(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -10,7 +10,6 @@ import re
 import socket
 import subprocess
 import threading
-import time
 import urllib.error
 import urllib.parse
 import urllib.request

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2056,9 +2056,7 @@ def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
             try:
                 oauth_client = resolve_guard_oauth_client_config(issuer)
             except ValueError as error:
-                raise GuardSyncAuthorizationExpiredError(
-                    f"{_guard_oauth_reauthorization_message()} {error}"
-                ) from error
+                raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
             refreshed = _refresh_guard_oauth_access_token(
                 token_endpoint=oauth_client.token_endpoint,
                 client_id=client_id,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -208,12 +208,12 @@ def _acquire_advisory_file_lock(handle) -> None:
     if os.name == "nt":
         import msvcrt
 
-        handle.seek(0)
-        if not handle.read(1):
-            handle.write(b"0")
-            handle.flush()
-        handle.seek(0)
         try:
+            handle.seek(0)
+            if not handle.read(1):
+                handle.write(b"0")
+                handle.flush()
+            handle.seek(0)
             msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
         except OSError as error:
             raise BlockingIOError from error

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -11,7 +11,7 @@ import sqlite3
 import subprocess
 import time
 from collections.abc import Iterator
-from contextlib import contextmanager
+from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
 from hashlib import pbkdf2_hmac, sha256
 from pathlib import Path
@@ -165,6 +165,8 @@ _POLICY_SCOPES = frozenset({"artifact", "workspace", "publisher", "harness", "gl
 _SLOW_STORE_WARNING_ENV = "HOL_GUARD_WARN_SLOW_STORE"
 _SECRET_FINGERPRINT_PREFIX = "pbkdf2-sha256$"
 _SECRET_FINGERPRINT_SALT = b"hol-guard-secret-fingerprint:v1"
+_OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS = 30.0
+_OAUTH_REFRESH_LOCK_POLL_SECONDS = 0.05
 
 
 def _oauth_sync_url_from_issuer(issuer: str) -> str:
@@ -200,6 +202,42 @@ def _secret_matches_hash(value: str, expected_hash: str) -> bool:
     if expected_hash.startswith(_SECRET_FINGERPRINT_PREFIX):
         return _secret_fingerprint(value) == expected_hash
     return _legacy_secret_sha256(value) == expected_hash
+
+
+def _acquire_advisory_file_lock(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        if not handle.read(1):
+            handle.write(b"0")
+            handle.flush()
+        handle.seek(0)
+        try:
+            msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+        except OSError as error:
+            raise BlockingIOError from error
+        return
+
+    import fcntl
+
+    try:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except OSError as error:
+        raise BlockingIOError from error
+
+
+def _release_advisory_file_lock(handle) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        handle.seek(0)
+        msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
 
 
 class SecretStore(Protocol):
@@ -669,6 +707,29 @@ class GuardStore:
                     "Guard store slow transaction (%.0fms); consider indexing hot query paths.",
                     elapsed_ms,
                 )
+
+    @contextmanager
+    def hold_oauth_refresh_lock(
+        self,
+        *,
+        timeout_seconds: float = _OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS,
+    ) -> Iterator[None]:
+        lock_path = self.guard_home / "oauth-refresh.lock"
+        deadline = time.monotonic() + max(timeout_seconds, 0.0)
+        with lock_path.open("a+b") as handle:
+            while True:
+                try:
+                    _acquire_advisory_file_lock(handle)
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("Timed out waiting for Guard OAuth refresh lock.") from None
+                    time.sleep(_OAUTH_REFRESH_LOCK_POLL_SECONDS)
+            try:
+                yield
+            finally:
+                with suppress(OSError):
+                    _release_advisory_file_lock(handle)
 
     def _initialize(self) -> None:
         statements = (

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.cli.connect_flow import CONNECT_SYNC_AUTH_CONTEXT_KEY
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
@@ -49,6 +50,63 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sy
     assert isinstance(latest_state, dict)
     assert latest_state["status"] == "connected"
     assert latest_state["milestone"] == "first_sync_pending"
+
+
+def test_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_url = "https://hol.org/guard/connect"
+    now = "2026-06-04T12:00:00+00:00"
+    sync_calls: list[dict[str, object] | None] = []
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": True, "state": "healthy"},
+    )
+
+    def _fake_sync(
+        _store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        sync_calls.append(auth_context)
+        return {
+            "synced_at": "2026-06-04T12:00:05+00:00",
+            "runtime_session_id": "session-1",
+            "runtime_session_synced_at": "2026-06-04T12:00:05+00:00",
+            "runtime_sessions_visible": 1,
+            "receipts_stored": 0,
+        }
+
+    monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", _fake_sync)
+
+    payload = guard_commands_module._finalize_guard_connect_payload(
+        store=store,
+        connect_url=connect_url,
+        payload={
+            "status": "connected",
+            CONNECT_SYNC_AUTH_CONTEXT_KEY: {
+                "access_token": "access-token-1",
+                "dpop_key_material": "dpop",
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+            },
+        },
+        now=now,
+    )
+
+    assert sync_calls == [
+        {
+            "access_token": "access-token-1",
+            "dpop_key_material": "dpop",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        }
+    ]
+    assert CONNECT_SYNC_AUTH_CONTEXT_KEY not in payload
 
 
 def test_guard_daemon_runtime_request_queues_pending_first_sync(tmp_path, monkeypatch) -> None:

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -468,12 +468,66 @@ args = ["workspace-skill.js", "--changed"]
         assert "connect      Pair this machine to Guard Cloud" in output
         assert "doctor       Run local diagnostics" in output
         assert "Use status for Home posture" in output
-        assert "Use apps for Protect install, repair, status, and first protected action proof" in output
-        assert "Use approvals for Inbox decisions and receipts for Evidence" in output
-        assert "Use doctor for setup and runtime probes" in output
-        assert "Use diff for changed artifacts" in output
-        assert "Use explain for detailed artifact evidence" in output
-        assert "Use events for the local timeline" in output
+
+    def test_guard_status_softens_refresh_race_copy_when_local_protection_stays_active(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        guard_home = home_dir / ".hol-guard"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        store = GuardStore(guard_home)
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            supply_chain_entitlement_expires_at="2026-07-04T18:30:00+00:00",
+            supply_chain_firewall=True,
+            supply_chain_plan_id="team",
+            workspace_id="workspace-123",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        store.record_guard_connect_pairing_completed(
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            allowed_origin="https://hol.org",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now="2026-06-04T18:31:00+00:00",
+            reason="Guard authorization expired. The grant is missing, expired, or already consumed.",
+        )
+
+        rc = main(
+            [
+                "guard",
+                "status",
+                "--home",
+                str(home_dir),
+                "--guard-home",
+                str(guard_home),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["cloud_state"] == "paired_waiting"
+        assert "stays locally protected" in output["cloud_state_detail"]
+        assert "needs repair before the first shared proof can land" not in output["cloud_state_detail"]
 
     def test_guard_start_human_output_highlights_guard_loop(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -16,6 +16,7 @@ import threading
 import urllib.error
 import urllib.request
 from base64 import urlsafe_b64decode
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
@@ -16516,6 +16517,97 @@ def test_sync_runtime_session_refreshes_oauth_access_token_and_rotates_refresh_t
     assert payload["runtime_session_id"] == "session-oauth"
     assert credentials is not None
     assert credentials["refresh_token"] == "refresh-token-2"
+
+
+def test_resolve_guard_sync_auth_context_serializes_refresh_token_rotation(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        supply_chain_entitlement_expires_at="2026-07-01T00:00:00+00:00",
+        supply_chain_firewall=True,
+        supply_chain_plan_id="team",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    refresh_lock = threading.Lock()
+    first_refresh_started = threading.Event()
+    allow_first_refresh = threading.Event()
+    observed_refresh_tokens: list[str] = []
+
+    @contextmanager
+    def _fake_refresh_lock(*, timeout_seconds: float = 30.0):
+        del timeout_seconds
+        with refresh_lock:
+            yield
+
+    def _fake_refresh(
+        *,
+        token_endpoint: str,
+        client_id: str,
+        refresh_token: str,
+        dpop_key_material,
+    ) -> dict[str, object]:
+        del token_endpoint, client_id, dpop_key_material
+        observed_refresh_tokens.append(refresh_token)
+        if refresh_token == "refresh-token-1":
+            first_refresh_started.set()
+            assert allow_first_refresh.wait(timeout=3)
+            return {
+                "access_token": "access-token-1",
+                "refresh_token": "refresh-token-2",
+                "package_firewall_entitlement": {
+                    "supply_chain_entitlement_expires_at": "2026-07-05T00:00:00+00:00",
+                    "supply_chain_firewall": True,
+                    "supply_chain_plan_id": "team",
+                },
+            }
+        if refresh_token == "refresh-token-2":
+            return {
+                "access_token": "access-token-2",
+                "refresh_token": "refresh-token-3",
+                "package_firewall_entitlement": {
+                    "supply_chain_entitlement_expires_at": "2026-07-05T00:00:00+00:00",
+                    "supply_chain_firewall": True,
+                    "supply_chain_plan_id": "team",
+                },
+            }
+        raise AssertionError(f"Unexpected refresh token: {refresh_token}")
+
+    monkeypatch.setattr(store, "hold_oauth_refresh_lock", _fake_refresh_lock)
+    monkeypatch.setattr(guard_runner_module, "_refresh_guard_oauth_access_token", _fake_refresh)
+
+    results: list[dict[str, object]] = []
+    errors: list[Exception] = []
+
+    def _worker() -> None:
+        try:
+            results.append(guard_runner_module._resolve_guard_sync_auth_context(store))
+        except Exception as error:  # pragma: no cover - asserted below
+            errors.append(error)
+
+    first = threading.Thread(target=_worker)
+    second = threading.Thread(target=_worker)
+    first.start()
+    assert first_refresh_started.wait(timeout=1)
+    second.start()
+    allow_first_refresh.set()
+    first.join()
+    second.join()
+
+    assert errors == []
+    assert observed_refresh_tokens == ["refresh-token-1", "refresh-token-2"]
+    assert [result["access_token"] for result in results] == ["access-token-1", "access-token-2"]
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-token-3"
 
 
 def test_sign_guard_dpop_proof_sets_access_token_hash_claim() -> None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -8,9 +8,12 @@ import logging
 import os
 import sqlite3
 import subprocess
+import sys
+import types
 
 import pytest
 
+from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.models import GuardReceipt
 from codex_plugin_scanner.guard.store import (
     EncryptedFileSecretStore,
@@ -51,6 +54,34 @@ def _install_fake_system_keyring(monkeypatch) -> _FakeSystemKeyringModule:
     module = _FakeSystemKeyringModule()
     monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
     return module
+
+
+def test_windows_oauth_refresh_lock_wraps_permission_error_as_blocking(monkeypatch):
+    class _FakeHandle:
+        def seek(self, _offset: int) -> None:
+            return None
+
+        def read(self, _size: int) -> bytes:
+            raise PermissionError("locked")
+
+        def write(self, _payload: bytes) -> int:
+            return 0
+
+        def flush(self) -> None:
+            return None
+
+        def fileno(self) -> int:
+            return 1
+
+    fake_msvcrt = types.SimpleNamespace(
+        LK_NBLCK=1,
+        locking=lambda _fd, _mode, _size: None,
+    )
+    monkeypatch.setattr(guard_store_module.os, "name", "nt", raising=False)
+    monkeypatch.setitem(sys.modules, "msvcrt", fake_msvcrt)
+
+    with pytest.raises(BlockingIOError):
+        guard_store_module._acquire_advisory_file_lock(_FakeHandle())
 
 
 def test_sync_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1047,6 +1047,64 @@ class TestGuardSurfaceServer:
         assert payload["cloud_sync_health"]["state"] == "failed"
         assert "Run hol-guard connect again to restore sync." in payload["cloud_sync_health"]["detail"]
 
+    def test_guard_daemon_runtime_snapshot_softens_refresh_race_copy_when_local_protection_stays_active(
+        self,
+        tmp_path,
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            supply_chain_entitlement_expires_at="2026-07-04T18:30:00+00:00",
+            supply_chain_firewall=True,
+            supply_chain_plan_id="team",
+            workspace_id="workspace-123",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        store.record_guard_connect_pairing_completed(
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            allowed_origin="https://hol.org",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now="2026-06-04T18:31:00+00:00",
+            reason="Guard authorization expired. The grant is missing, expired, or already consumed.",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert payload["cloud_state"] == "paired_waiting"
+        assert "stays locally protected" in payload["cloud_state_detail"]
+        assert payload["cloud_pairing_state"]["detail"] == payload["cloud_state_detail"]
+        assert payload["proof_status"]["state"] == "stalled"
+        assert payload["proof_status"]["detail"].startswith("Local protection stays active.")
+        assert payload["cloud_sync_health"]["state"] == "failed"
+        assert payload["cloud_sync_health"]["detail"].startswith("Local protection is active.")
+
     def test_guard_daemon_runtime_snapshot_keeps_failed_sync_copy_distinct_from_oauth_repair(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         store.set_oauth_local_credentials(


### PR DESCRIPTION
## Summary
- fix Trust Center supply-chain navigation so `View supply chain` lands on a route-specific Supply Chain view instead of reading like Protect
- route package-firewall install actions through an approval-proof modal on `/supply-chain` and `/audit`, including direct-route fallback when approval-gate settings arrive late
- harden first Guard Cloud proof sync to avoid refresh-token races after connect and soften stale first-sync copy while local protection remains active

## Testing
- `pnpm exec tsx src/guard-api.test.ts`
- `pnpm exec tsx src/scrg171-172.test.ts`
- `pnpm run build`
- `uv run --extra dev python -m pytest -q tests/test_guard_auto_first_sync.py tests/test_guard_connect_flow.py tests/test_guard_runtime.py tests/test_guard_product_flow.py tests/test_guard_surface_server.py -k 'finalize_guard_connect_payload or browser_connect_caches_paid_package_firewall_entitlement or retry_required_connect_state_prefers_reconnect_over_false_paywall or refreshes_oauth_access_token_and_rotates_refresh_token or serializes_refresh_token_rotation or softens_refresh_race_copy'`

## Notes
- live browser proof on `http://127.0.0.1:5474/` confirmed `View supply chain` lands on `/supply-chain`, package-firewall `Protect` opens an approval-proof modal instead of a reconnect wall, and direct `/supply-chain` loads fetch approval-gate settings on demand before retry
