### PR TITLE
fix(cursor): install hooks globally only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ output/playwright/
 # IDE
 .idea/
 .vscode/
+.cursor/
 .codex/
 *.swp
 *.swo

--- a/scripts/e2e-cursor-hook-smoke.py
+++ b/scripts/e2e-cursor-hook-smoke.py
@@ -9,7 +9,7 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-HOOK_SCRIPT = REPO_ROOT / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
+HOOK_SCRIPT = Path.home() / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
 
 
 def main() -> int:

--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -58,8 +58,8 @@ class CursorHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _target_editor_config_path(context: HarnessContext) -> Path:
-        if context.workspace_dir is not None:
-            return context.workspace_dir / ".cursor" / "mcp.json"
+        """Managed Cursor editor installs always target the global config."""
+
         return context.home_dir / ".cursor" / "mcp.json"
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
@@ -218,13 +218,13 @@ class CursorHarnessAdapter(HarnessAdapter):
         target_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
         hooks_manifest = install_cursor_hooks(context)
         notes = [
-            "Guard Cursor editor MCP proxies added to the selected Cursor mcp.json config.",
-            "Guard native Cursor hooks installed for shell, MCP, and file-read interception.",
+            "Guard Cursor editor MCP proxies added to the global Cursor mcp.json config.",
+            "Guard native Cursor hooks installed globally for shell, MCP, and file-read interception.",
         ]
-        if context.workspace_dir is None:
+        if context.workspace_dir is not None:
             notes.append(
-                "No project workspace was detected; Guard used the global ~/.cursor config. "
-                "Run install from your repo root or pass --workspace <path> for project hooks."
+                "Workspace policy context uses the detected project directory; "
+                "Guard does not write project-local hook files."
             )
         return {
             "harness": self.harness,

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -106,16 +106,21 @@ def cursor_hook_should_block(*, policy_action: str) -> bool:
 
 
 def cursor_hooks_path(context: HarnessContext) -> Path:
-    if context.workspace_dir is not None:
-        return context.workspace_dir / ".cursor" / "hooks.json"
+    """Cursor hooks are always installed in the global Cursor config."""
+
     return context.home_dir / ".cursor" / "hooks.json"
 
 
 def cursor_hook_script_path(context: HarnessContext) -> Path:
-    hooks_path = cursor_hooks_path(context)
-    if context.workspace_dir is not None and hooks_path.is_relative_to(context.workspace_dir):
-        return context.workspace_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
     return context.home_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
+
+
+def _legacy_project_cursor_hooks_path(workspace_dir: Path) -> Path:
+    return workspace_dir / ".cursor" / "hooks.json"
+
+
+def _legacy_project_cursor_hook_script_path(workspace_dir: Path) -> Path:
+    return workspace_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
 
 
 def managed_hook_script_path(context: HarnessContext) -> Path:
@@ -169,6 +174,7 @@ def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
     payload["hooks"] = hooks
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
     hooks_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    _cleanup_legacy_project_cursor_hooks(context)
     return {
         "managed_hooks_path": str(hooks_path),
         "managed_hook_script_path": str(script_path),
@@ -181,10 +187,23 @@ def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
 def uninstall_cursor_hooks(context: HarnessContext) -> dict[str, object]:
     """Remove Guard-managed Cursor hooks and restore prior hooks.json."""
 
-    hooks_path = cursor_hooks_path(context)
+    return _uninstall_cursor_hooks_at_paths(
+        hooks_path=cursor_hooks_path(context),
+        script_path=cursor_hook_script_path(context),
+        context=context,
+        remove_managed_copy=True,
+    )
+
+
+def _uninstall_cursor_hooks_at_paths(
+    *,
+    hooks_path: Path,
+    script_path: Path,
+    context: HarnessContext,
+    remove_managed_copy: bool,
+) -> dict[str, object]:
     backup_path = _hooks_backup_path(hooks_path, context)
     state_path = _hooks_state_path(hooks_path, context)
-    script_path = cursor_hook_script_path(context)
     backup_payload = _backup_payload(backup_path)
     restored = False
     if backup_payload["readable"] is True:
@@ -201,16 +220,81 @@ def uninstall_cursor_hooks(context: HarnessContext) -> dict[str, object]:
         backup_path.unlink()
     if restored and state_path.is_file():
         state_path.unlink()
+    if (
+        not restored
+        and hooks_path.is_file()
+        and script_path.is_file()
+        and _is_managed_hook_script(script_path.read_text(encoding="utf-8"))
+    ):
+        hooks_path.unlink()
+        restored = True
+        if state_path.is_file():
+            state_path.unlink()
     if script_path.is_file() and _is_managed_hook_script(script_path.read_text(encoding="utf-8")):
         script_path.unlink()
-    managed_script_path = managed_hook_script_path(context)
-    if managed_script_path.is_file():
-        managed_script_path.unlink()
+    if remove_managed_copy:
+        managed_script_path = managed_hook_script_path(context)
+        if managed_script_path.is_file():
+            managed_script_path.unlink()
     return {
         "managed_hooks_path": str(hooks_path),
         "restored": restored,
         "removed_hook_script": not script_path.is_file(),
     }
+
+
+def _cleanup_legacy_project_cursor_hooks(context: HarnessContext) -> None:
+    if context.workspace_dir is None:
+        return
+    hooks_path = _legacy_project_cursor_hooks_path(context.workspace_dir)
+    script_path = _legacy_project_cursor_hook_script_path(context.workspace_dir)
+    if not hooks_path.is_file() and not script_path.is_file():
+        return
+    managed = script_path.is_file() and _is_managed_hook_script(script_path.read_text(encoding="utf-8"))
+    if hooks_path.is_file() and not managed:
+        try:
+            payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            payload = {}
+        hooks = payload.get("hooks")
+        if isinstance(hooks, dict):
+            for entries in hooks.values():
+                if not isinstance(entries, list):
+                    continue
+                for entry in entries:
+                    if _is_managed_hook_entry(entry, command=str(script_path.resolve())):
+                        managed = True
+                        break
+                if managed:
+                    break
+    if not managed:
+        return
+    _uninstall_cursor_hooks_at_paths(
+        hooks_path=hooks_path,
+        script_path=script_path,
+        context=context,
+        remove_managed_copy=False,
+    )
+    _prune_empty_project_cursor_dir(context.workspace_dir)
+
+
+def _prune_empty_project_cursor_dir(workspace_dir: Path) -> None:
+    hooks_dir = workspace_dir / ".cursor" / "hooks"
+    cursor_dir = workspace_dir / ".cursor"
+    if hooks_dir.is_dir():
+        try:
+            if not any(hooks_dir.iterdir()):
+                hooks_dir.rmdir()
+        except OSError:
+            return
+    if not cursor_dir.is_dir():
+        return
+    try:
+        remaining = list(cursor_dir.iterdir())
+    except OSError:
+        return
+    if not remaining:
+        cursor_dir.rmdir()
 
 
 def _resolve_guard_cli_command() -> list[str]:
@@ -237,8 +321,6 @@ def _embedded_guard_hook_argv(context: HarnessContext) -> list[str]:
     ]
     if context.home_dir.resolve() != Path.home().resolve():
         guard_argv.extend(["--home", str(context.home_dir)])
-    if context.workspace_dir is not None:
-        guard_argv.extend(["--workspace", str(context.workspace_dir)])
     return guard_argv
 
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -220,11 +220,14 @@ def _uninstall_cursor_hooks_at_paths(
         backup_path.unlink()
     if restored and state_path.is_file():
         state_path.unlink()
-    if not restored and hooks_path.is_file():
-        if _remove_managed_hook_entries(hooks_path=hooks_path, script_path=script_path):
-            restored = True
-            if state_path.is_file():
-                state_path.unlink()
+    if (
+        not restored
+        and hooks_path.is_file()
+        and _remove_managed_hook_entries(hooks_path=hooks_path, script_path=script_path)
+    ):
+        restored = True
+        if state_path.is_file():
+            state_path.unlink()
     if script_path.is_file():
         try:
             script_source = script_path.read_text(encoding="utf-8")

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -253,7 +253,12 @@ def _cleanup_legacy_project_cursor_hooks(context: HarnessContext) -> None:
     script_path = _legacy_project_cursor_hook_script_path(context.workspace_dir)
     if not hooks_path.is_file() and not script_path.is_file():
         return
-    managed = script_path.is_file() and _is_managed_hook_script(script_path.read_text(encoding="utf-8"))
+    managed = False
+    if script_path.is_file():
+        try:
+            managed = _is_managed_hook_script(script_path.read_text(encoding="utf-8"))
+        except OSError:
+            managed = False
     if hooks_path.is_file() and not managed:
         try:
             payload = json.loads(hooks_path.read_text(encoding="utf-8"))

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -220,18 +220,18 @@ def _uninstall_cursor_hooks_at_paths(
         backup_path.unlink()
     if restored and state_path.is_file():
         state_path.unlink()
-    if (
-        not restored
-        and hooks_path.is_file()
-        and script_path.is_file()
-        and _is_managed_hook_script(script_path.read_text(encoding="utf-8"))
-    ):
-        hooks_path.unlink()
-        restored = True
-        if state_path.is_file():
-            state_path.unlink()
-    if script_path.is_file() and _is_managed_hook_script(script_path.read_text(encoding="utf-8")):
-        script_path.unlink()
+    if not restored and hooks_path.is_file():
+        if _remove_managed_hook_entries(hooks_path=hooks_path, script_path=script_path):
+            restored = True
+            if state_path.is_file():
+                state_path.unlink()
+    if script_path.is_file():
+        try:
+            script_source = script_path.read_text(encoding="utf-8")
+        except OSError:
+            script_source = ""
+        if _is_managed_hook_script(script_source):
+            script_path.unlink()
     if remove_managed_copy:
         managed_script_path = managed_hook_script_path(context)
         if managed_script_path.is_file():
@@ -256,17 +256,18 @@ def _cleanup_legacy_project_cursor_hooks(context: HarnessContext) -> None:
             payload = json.loads(hooks_path.read_text(encoding="utf-8"))
         except (OSError, json.JSONDecodeError):
             payload = {}
-        hooks = payload.get("hooks")
-        if isinstance(hooks, dict):
-            for entries in hooks.values():
-                if not isinstance(entries, list):
-                    continue
-                for entry in entries:
-                    if _is_managed_hook_entry(entry, command=str(script_path.resolve())):
-                        managed = True
+        if isinstance(payload, dict):
+            hooks = payload.get("hooks")
+            if isinstance(hooks, dict):
+                for entries in hooks.values():
+                    if not isinstance(entries, list):
+                        continue
+                    for entry in entries:
+                        if _is_managed_hook_entry(entry, command=str(script_path.resolve())):
+                            managed = True
+                            break
+                    if managed:
                         break
-                if managed:
-                    break
     if not managed:
         return
     _uninstall_cursor_hooks_at_paths(
@@ -294,7 +295,48 @@ def _prune_empty_project_cursor_dir(workspace_dir: Path) -> None:
     except OSError:
         return
     if not remaining:
-        cursor_dir.rmdir()
+        try:
+            cursor_dir.rmdir()
+        except OSError:
+            return
+
+
+def _remove_managed_hook_entries(*, hooks_path: Path, script_path: Path) -> bool:
+    try:
+        payload = json.loads(hooks_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    hooks = payload.get("hooks")
+    has_managed_hooks = False
+    has_other_hooks = False
+    if not isinstance(hooks, dict):
+        return False
+    cleaned_hooks: dict[str, object] = {}
+    managed_command = str(script_path.resolve())
+    for event, entries in hooks.items():
+        if isinstance(entries, list):
+            filtered: list[object] = []
+            for entry in entries:
+                if _is_managed_hook_entry(entry, command=managed_command):
+                    has_managed_hooks = True
+                else:
+                    filtered.append(entry)
+            if filtered:
+                cleaned_hooks[str(event)] = filtered
+                has_other_hooks = True
+        else:
+            cleaned_hooks[str(event)] = entries
+            has_other_hooks = True
+    if not has_managed_hooks:
+        return False
+    if has_other_hooks:
+        payload["hooks"] = cleaned_hooks
+        hooks_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    else:
+        hooks_path.unlink()
+    return True
 
 
 def _resolve_guard_cli_command() -> list[str]:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -176,6 +176,36 @@ def test_cursor_editor_install_includes_native_hooks(tmp_path: Path) -> None:
     assert not (context.workspace_dir / ".cursor" / "hooks.json").exists()
 
 
+def test_legacy_cleanup_preserves_unrelated_hook_entries(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    assert context.workspace_dir is not None
+    legacy_hooks = context.workspace_dir / ".cursor" / "hooks.json"
+    legacy_script = context.workspace_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
+    legacy_hooks.parent.mkdir(parents=True, exist_ok=True)
+    legacy_script.parent.mkdir(parents=True, exist_ok=True)
+    legacy_script.write_text(f'"""Managed by HOL Guard."""\n{HOOK_SCRIPT_NAME}\n', encoding="utf-8")
+    legacy_hooks.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "hooks": {
+                    "afterFileEdit": [{"command": "./fmt.sh"}],
+                    "beforeShellExecution": [
+                        {"command": str(legacy_script.resolve()), "timeout": 35, "failClosed": True}
+                    ],
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    install_cursor_hooks(context)
+
+    payload = json.loads(legacy_hooks.read_text(encoding="utf-8"))
+    assert payload["hooks"] == {"afterFileEdit": [{"command": "./fmt.sh"}]}
+
+
 def test_install_cursor_hooks_removes_legacy_project_hooks(tmp_path: Path) -> None:
     context = _ctx(tmp_path)
     assert context.workspace_dir is not None

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -134,7 +134,8 @@ def test_install_cursor_hooks_writes_hooks_json_and_script(tmp_path: Path) -> No
     manifest = install_cursor_hooks(context)
     hooks_path = Path(str(manifest["managed_hooks_path"]))
     script_path = Path(str(manifest["managed_hook_script_path"]))
-    assert hooks_path == context.workspace_dir / ".cursor" / "hooks.json"
+    assert hooks_path == context.home_dir / ".cursor" / "hooks.json"
+    assert not (context.workspace_dir / ".cursor" / "hooks.json").exists()
     assert script_path.name == HOOK_SCRIPT_NAME
     assert script_path.is_file()
     assert script_path.stat().st_mode & stat.S_IXUSR
@@ -171,3 +172,35 @@ def test_cursor_editor_install_includes_native_hooks(tmp_path: Path) -> None:
     hooks_path = Path(str(manifest["managed_hooks_path"]))
     assert hooks_path.is_file()
     assert manifest["managed_hook_script_path"]
+    assert hooks_path == context.home_dir / ".cursor" / "hooks.json"
+    assert not (context.workspace_dir / ".cursor" / "hooks.json").exists()
+
+
+def test_install_cursor_hooks_removes_legacy_project_hooks(tmp_path: Path) -> None:
+    context = _ctx(tmp_path)
+    assert context.workspace_dir is not None
+    legacy_hooks = context.workspace_dir / ".cursor" / "hooks.json"
+    legacy_script = context.workspace_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
+    legacy_hooks.parent.mkdir(parents=True, exist_ok=True)
+    legacy_script.parent.mkdir(parents=True, exist_ok=True)
+    legacy_hooks.write_text(
+        json.dumps(
+            {
+                "version": 1,
+                "hooks": {
+                    "beforeShellExecution": [
+                        {"command": str(legacy_script.resolve()), "timeout": 35, "failClosed": True}
+                    ]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    legacy_script.write_text(f'"""Managed by HOL Guard."""\n{HOOK_SCRIPT_NAME}\n', encoding="utf-8")
+
+    install_cursor_hooks(context)
+
+    assert not legacy_hooks.exists()
+    assert not legacy_script.exists()
+    assert (context.home_dir / ".cursor" / "hooks.json").is_file()

--- a/tests/test_cursor_local_actions.py
+++ b/tests/test_cursor_local_actions.py
@@ -142,7 +142,8 @@ def test_cursor_editor_install_wraps_workspace_config_and_remove_restores(
     monkeypatch.setenv("PATH", str(tmp_path / "empty-bin"))
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    config_path = context.workspace_dir / ".cursor" / "mcp.json"
+    config_path = context.home_dir / ".cursor" / "mcp.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
     original_payload = {
         "mcpServers": {
             "filesystem": {
@@ -177,6 +178,7 @@ def test_cursor_editor_install_wraps_workspace_config_and_remove_restores(
     assert "node" in server["args"]
     assert "--arg=server.js" in server["args"]
     assert server["env"]["SAFE_FLAG"] == "1"
+    assert not (context.workspace_dir / ".cursor" / "hooks.json").exists()
 
     remove_payload = apply_managed_install(
         "uninstall",

--- a/tests/test_guard_install_workspace.py
+++ b/tests/test_guard_install_workspace.py
@@ -82,7 +82,7 @@ def test_resolve_guard_workspace_explicit_flag_wins(tmp_path: Path, monkeypatch:
     assert _resolve_guard_workspace(args, guard_home=guard_home) == other.resolve()
 
 
-def test_install_cursor_without_workspace_writes_project_hooks(
+def test_install_cursor_writes_global_hooks_not_project_hooks(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
@@ -108,8 +108,9 @@ def test_install_cursor_without_workspace_writes_project_hooks(
     output = json.loads(capsys.readouterr().out)
 
     assert rc == 0
-    hooks_path = repo / ".cursor" / "hooks.json"
+    hooks_path = home_dir / ".cursor" / "hooks.json"
     assert hooks_path.is_file()
+    assert not (repo / ".cursor" / "hooks.json").exists()
     managed_install = output["managed_install"]
     assert managed_install["harness"] == "cursor"
     assert Path(str(managed_install["workspace"])).resolve() == repo.resolve()
@@ -171,7 +172,7 @@ def test_install_cursor_hook_script_allows_benign_shell_command(
         ]
     )
     assert rc == 0
-    hook_script = repo / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
+    hook_script = home_dir / ".cursor" / "hooks" / "hol-guard-cursor-hook.py"
     assert hook_script.is_file()
     payload = json.dumps({"hook_event_name": "beforeShellExecution", "command": "echo guard-e2e"})
     env = os.environ.copy()


### PR DESCRIPTION
## Summary
- Install Cursor hooks and managed editor MCP proxies only in the global Cursor config (never project `.cursor/`).
- Remove legacy project-local Guard hook installs during `hol-guard install cursor`.
- Gitignore accidental project `.cursor/` directories and point hook smoke script at the global hook path.

## Testing
- `uv run pytest tests/test_cursor_hooks.py tests/test_cursor_local_actions.py tests/test_cursor_headless_fixtures.py -q`

## Notes
- Workspace policy context still comes from the detected project directory at hook runtime via `CURSOR_PROJECT_DIR`.
