### PR TITLE
fix(guard): restore codex approval links and skip broken keychains

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3859,25 +3859,28 @@ def run_guard_command(
             or _decision_v2_harness_message(payload)
             or payload.get("permission_decision_reason")
         )
+        approval_context = _native_approval_center_context(payload, harness=args.harness)
         if _should_emit_native_hook_exit_block(args, event_name=hook_event_name, policy_action=policy_action):
             _emit_native_hook_block_stderr(
                 _native_hook_reason_for_harness(
                     args.harness,
                     incoming_reason,
-                    _native_approval_center_context(payload, harness=args.harness),
+                    approval_context,
                 )
             )
             return 2
-        if _canonical_harness_name(args.harness) == "codex" and hook_event_name == "UserPromptSubmit":
+        if _canonical_harness_name(args.harness) == "codex" and (
+            hook_event_name == "UserPromptSubmit" or approval_context is not None
+        ):
             reason = _native_hook_reason(
                 incoming_reason,
-                _native_approval_center_context(payload, harness=args.harness),
+                approval_context,
             )
         else:
             reason = _native_hook_reason_for_harness(
                 args.harness,
                 incoming_reason,
-                _native_approval_center_context(payload, harness=args.harness),
+                approval_context,
             )
         if _should_emit_claude_native_pretooluse_notice(
             args,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3853,15 +3853,32 @@ def run_guard_command(
                 output_stream=output_stream,
             )
             return 0
+        _localize_pending_approval_copy(payload, harness=args.harness)
         incoming_reason = (
             daemon_failure_reason
             or _decision_v2_harness_message(payload)
             or payload.get("permission_decision_reason")
         )
         if _should_emit_native_hook_exit_block(args, event_name=hook_event_name, policy_action=policy_action):
-            _emit_native_hook_block_stderr(_native_hook_reason_for_harness(args.harness, incoming_reason))
+            _emit_native_hook_block_stderr(
+                _native_hook_reason_for_harness(
+                    args.harness,
+                    incoming_reason,
+                    _native_approval_center_context(payload, harness=args.harness),
+                )
+            )
             return 2
-        reason = _native_hook_reason_for_harness(args.harness, incoming_reason)
+        if _canonical_harness_name(args.harness) == "codex" and hook_event_name == "UserPromptSubmit":
+            reason = _native_hook_reason(
+                incoming_reason,
+                _native_approval_center_context(payload, harness=args.harness),
+            )
+        else:
+            reason = _native_hook_reason_for_harness(
+                args.harness,
+                incoming_reason,
+                _native_approval_center_context(payload, harness=args.harness),
+            )
         if _should_emit_claude_native_pretooluse_notice(
             args,
             event_name=hook_event_name,
@@ -3876,12 +3893,18 @@ def run_guard_command(
             output_stream=output_stream,
         ):
             system_message = None
+            canonical_harness = _canonical_harness_name(args.harness)
             if (
-                _canonical_harness_name(args.harness) == "claude-code"
+                canonical_harness == "claude-code"
                 and hook_event_name in {"UserPromptSubmit", "PreToolUse"}
                 and policy_action in {"block", "sandbox-required", "require-reapproval"}
             ):
                 system_message = _ensure_terminal_punctuation(reason)
+            elif canonical_harness == "codex" and hook_event_name == "UserPromptSubmit":
+                system_message = _codex_prompt_block_system_message(
+                    policy_action=policy_action,
+                    native_reason=reason,
+                )
             _emit_native_hook_response(
                 harness=args.harness,
                 policy_action=policy_action,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -9,6 +9,7 @@ import logging
 import os
 import sqlite3
 import subprocess
+import sys
 import time
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
@@ -334,6 +335,34 @@ class SystemKeyringSecretStore:
     def _load_keyring_module():
         return importlib.import_module("keyring")
 
+    @staticmethod
+    def _macos_default_keychain_path() -> Path | None:
+        if sys.platform != "darwin":
+            return None
+        security_path = Path("/usr/bin/security")
+        if not security_path.exists():
+            return None
+        try:
+            result = subprocess.run(
+                [str(security_path), "default-keychain"],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+        except Exception:
+            return None
+        if result.returncode != 0:
+            return None
+        raw_path = result.stdout.strip().strip('"').strip("'")
+        if not raw_path:
+            return None
+        return Path(raw_path).expanduser()
+
+    @classmethod
+    def _macos_default_keychain_is_usable(cls) -> bool:
+        path = cls._macos_default_keychain_path()
+        return path is not None and path.exists()
+
     @classmethod
     def _is_available(cls) -> bool:
         try:
@@ -345,7 +374,11 @@ class SystemKeyringSecretStore:
         if backend_name == "failkeyring":
             return False
         priority = getattr(backend, "priority", None)
-        return not (isinstance(priority, (int, float)) and priority <= 0)
+        if isinstance(priority, (int, float)) and priority <= 0:
+            return False
+        if sys.platform == "darwin" and not cls._macos_default_keychain_is_usable():
+            return False
+        return True
 
     def set_secret(self, secret_id: str, value: str) -> None:
         keyring_module = self._load_keyring_module()

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -14,6 +14,7 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
+from functools import lru_cache
 from hashlib import pbkdf2_hmac, sha256
 from pathlib import Path
 from typing import Protocol
@@ -336,6 +337,7 @@ class SystemKeyringSecretStore:
         return importlib.import_module("keyring")
 
     @staticmethod
+    @lru_cache(maxsize=1)
     def _macos_default_keychain_path() -> Path | None:
         if sys.platform != "darwin":
             return None
@@ -348,6 +350,7 @@ class SystemKeyringSecretStore:
                 check=False,
                 capture_output=True,
                 text=True,
+                timeout=5,
             )
         except Exception:
             return None

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4328,6 +4328,49 @@ clearer UX and an implementation plan with technical references.
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert output["hookSpecificOutput"]["permissionDecisionReason"] == message
 
+    def test_guard_hook_codex_native_block_appends_approval_url_for_precomputed_payload(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "hook_event_name": "PreToolUse",
+            "artifact_id": "codex:project:dangerous-command",
+            "artifact_name": "dangerous-command",
+            "policy_action": "block",
+            "permission_decision_reason": "This command sends local secret to network host.",
+            "approval_center_url": "http://127.0.0.1:4455",
+            "approval_requests": [{"approval_url": "http://127.0.0.1:4455/approvals/request-1"}],
+            "changed_capabilities": ["command"],
+            "provenance_summary": "project artifact defined at .codex/config.toml",
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "codex",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
+        assert "Open HOL Guard to approve or keep this blocked" in reason
+        assert "http://127.0.0.1:4455/approvals/request-1" in reason
+
     def test_guard_hook_fallback_artifact_id_uses_scope(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4370,6 +4370,7 @@ clearer UX and an implementation plan with technical references.
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "Open HOL Guard to approve or keep this blocked" in reason
         assert "http://127.0.0.1:4455/approvals/request-1" in reason
+        assert "Approve it in HOL Guard, then retry." not in reason
 
     def test_guard_hook_fallback_artifact_id_uses_scope(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -56,6 +56,21 @@ def _install_fake_system_keyring(monkeypatch) -> _FakeSystemKeyringModule:
     return module
 
 
+def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_macos_default_keychain_path",
+        staticmethod(lambda: None),
+    )
+
+    secret_store = _build_oauth_secret_store(tmp_path / "guard-home")
+
+    assert SystemKeyringSecretStore._is_available() is False
+    assert isinstance(secret_store, EncryptedFileSecretStore)
+
+
 def test_windows_oauth_refresh_lock_wraps_permission_error_as_blocking(monkeypatch):
     class _FakeHandle:
         def seek(self, _offset: int) -> None:


### PR DESCRIPTION
## Summary
- stop treating a broken macOS default-keychain state as a usable OAuth keyring backend, so Guard falls back to encrypted local storage instead of repeatedly triggering keychain popups
- restore Codex native block responses that come through precomputed payload paths so they include the live HOL Guard approval URL and Codex prompt messaging again

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py -k 'oauth_local_credentials or validated_keychain or macos_default_keychain or system_keyring' -q`
- `python3 -m pytest tests/test_guard_oauth_device_connect.py -k 'keychain or headless_connect_avoids' -q`
- `python3 -m pytest tests/test_guard_runtime.py -k 'codex_native_block_appends_approval_url_for_precomputed_payload or codex_user_prompt_submit_secret_read_includes_approval_url or codex_queues_approval_before_native_deny_output' -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_store_migrations.py tests/test_guard_runtime.py tests/test_guard_oauth_device_connect.py`
- `PYTHONPATH=src python3 - <<'PY' ... codex-link-smoke:ok ... PY`
- `PYTHONPATH=src python3 - <<'PY' ... keychain-fallback-smoke:ok ... PY`
