### PR TITLE
fix(evidence): surface actual commands, paths, and scanner risks in rows and detail

### DIFF
--- a/dashboard/src/evidence/app-tab.tsx
+++ b/dashboard/src/evidence/app-tab.tsx
@@ -10,7 +10,7 @@ import {
 } from "react-icons/hi2";
 import type { GuardReceipt } from "../guard-types";
 import { harnessDisplayName, isDisplayableHarness, formatRelativeTime } from "../approval-center-utils";
-import { plainEnglishDescription, resolveActionTitle, resolveActionType } from "./plain-english";
+import { plainEnglishDescription, resolveActionTitle, resolveActionType, resolveActionSubtitle } from "./plain-english";
 import { detectCategory, getCategoryInfo } from "./categories";
 import { guardAwareHref } from "../guard-api";
 import { Sparkline } from "./sparkline";
@@ -258,6 +258,7 @@ function AppTabRaw({ receipts }: AppTabProps) {
                     const catInfo = getCategoryInfo(category);
                     const actionTitle = resolveActionTitle(receipt);
                     const actionType = resolveActionType(receipt);
+                    const actionSubtitle = resolveActionSubtitle(receipt);
                     return (
                       <tr key={receipt.receipt_id} className="border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors">
                         <td className="px-3 py-2.5">
@@ -265,8 +266,8 @@ function AppTabRaw({ receipts }: AppTabProps) {
                         </td>
                         <td className="px-3 py-2.5">
                           <div className="flex flex-col min-w-0">
-                            <span className="text-sm font-medium text-brand-dark truncate block max-w-[200px]">{actionTitle}</span>
-                            <span className="text-[11px] text-slate-400 truncate block max-w-[200px]">{actionType}</span>
+                            <span className="text-sm font-medium text-brand-dark truncate block max-w-[260px]">{actionTitle}</span>
+                            <span className="text-[11px] text-slate-400 truncate block max-w-[260px]">{actionSubtitle ?? actionType}</span>
                           </div>
                         </td>
                         <td className="px-3 py-2.5 hidden md:table-cell">

--- a/dashboard/src/evidence/category-tab.tsx
+++ b/dashboard/src/evidence/category-tab.tsx
@@ -9,7 +9,7 @@ import {
 } from "react-icons/hi2";
 import type { GuardReceipt } from "../guard-types";
 import { groupByCategory, getCategoryInfo, type ReceiptCategory, CATEGORIES, detectCategory } from "./categories";
-import { plainEnglishDescription, resolveActionTitle, resolveActionType } from "./plain-english";
+import { plainEnglishDescription, resolveActionTitle, resolveActionType, resolveActionSubtitle } from "./plain-english";
 import { formatRelativeTime, harnessDisplayName } from "../approval-center-utils";
 import { DecisionBadge } from "./decision-badge";
 import { Badge } from "../approval-center-primitives";
@@ -179,6 +179,7 @@ function CategoryTabRaw({ receipts, onFilterCategory }: CategoryTabProps) {
                     const catInfo = getCategoryInfo(category);
                     const actionTitle = resolveActionTitle(receipt);
                     const actionType = resolveActionType(receipt);
+                    const actionSubtitle = resolveActionSubtitle(receipt);
                     return (
                       <tr key={receipt.receipt_id} className="border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors">
                         <td className="px-3 py-2.5">
@@ -186,8 +187,8 @@ function CategoryTabRaw({ receipts, onFilterCategory }: CategoryTabProps) {
                         </td>
                         <td className="px-3 py-2.5">
                           <div className="flex flex-col min-w-0">
-                            <span className="text-sm font-medium text-brand-dark truncate block max-w-[200px]">{actionTitle}</span>
-                            <span className="text-[11px] text-slate-400 truncate block max-w-[200px]">{actionType}</span>
+                            <span className="text-sm font-medium text-brand-dark truncate block max-w-[260px]">{actionTitle}</span>
+                            <span className="text-[11px] text-slate-400 truncate block max-w-[260px]">{actionSubtitle ?? actionType}</span>
                           </div>
                         </td>
                         <td className="px-3 py-2.5 hidden md:table-cell">

--- a/dashboard/src/evidence/evidence-action-detail.tsx
+++ b/dashboard/src/evidence/evidence-action-detail.tsx
@@ -15,7 +15,7 @@ import {
 import { useState } from "react";
 import type { GuardReceipt, RiskSignalV2 } from "../guard-types";
 import { harnessDisplayName, formatRelativeTime } from "../approval-center-utils";
-import { plainEnglishDescription, resolveActionTitle, resolveActionType } from "./plain-english";
+import { plainEnglishDescription, resolveActionTitle, resolveActionType, resolveActionSubtitle, resolveActionDetail } from "./plain-english";
 import { detectCategory, getCategoryInfo } from "./categories";
 import { SectionLabel } from "../approval-center-primitives";
 import { DecisionBadge } from "./decision-badge";
@@ -294,7 +294,10 @@ export function EvidenceActionDetail({
   const description = plainEnglishDescription(receipt);
   const actionTitle = resolveActionTitle(receipt);
   const actionType = resolveActionType(receipt);
+  const actionSubtitle = resolveActionSubtitle(receipt);
+  const actionDetail = resolveActionDetail(receipt);
   const signals = receipt.scanner_evidence ?? [];
+  const primarySignal = signals[0];
   let copyLabel = "Copy receipt ID";
   if (copied) {
     copyLabel = "Copied!";
@@ -349,10 +352,32 @@ export function EvidenceActionDetail({
 
         <p className="text-sm text-brand-dark leading-relaxed">{description}</p>
 
-        {receipt.capabilities_summary && (
-          <p className="text-xs text-slate-500 italic leading-relaxed">
-            {receipt.capabilities_summary}
-          </p>
+        {actionDetail && (
+          <div className="rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5">
+            <SectionLabel>{actionType}</SectionLabel>
+            <p className="mt-1 text-xs font-mono text-brand-dark break-all whitespace-pre-line leading-relaxed">
+              {actionDetail}
+            </p>
+          </div>
+        )}
+
+        {primarySignal && (
+          <div className="rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-3">
+            <div className="flex items-center gap-2">
+              <SeverityIcon severity={primarySignal.severity} />
+              <SectionLabel>Scanner finding</SectionLabel>
+              <SeverityBadge severity={primarySignal.severity} />
+            </div>
+            <p className="mt-1 text-sm font-medium text-brand-dark">{primarySignal.title}</p>
+            <p className="mt-1 text-xs text-brand-dark/80 leading-relaxed">
+              {primarySignal.plain_reason}
+            </p>
+            {primarySignal.false_positive_hint && (
+              <p className="mt-2 text-[11px] text-slate-500 italic">
+                Might be safe if: {primarySignal.false_positive_hint}
+              </p>
+            )}
+          </div>
         )}
 
         {receipt.provenance_summary && (

--- a/dashboard/src/evidence/evidence-action-list.tsx
+++ b/dashboard/src/evidence/evidence-action-list.tsx
@@ -11,7 +11,7 @@ import type { GuardReceipt } from "../guard-types";
 import type { EvidenceSortKey } from "./evidence-types";
 import { harnessDisplayName, formatRelativeTime } from "../approval-center-utils";
 import { detectCategory, getCategoryInfo } from "./categories";
-import { resolveActionTitle, resolveActionType } from "./plain-english";
+import { resolveActionTitle, resolveActionType, resolveActionSubtitle } from "./plain-english";
 import { hasMore } from "./evidence-pagination";
 import { SectionLabel } from "../approval-center-primitives";
 import { DecisionBadge } from "./decision-badge";
@@ -211,6 +211,7 @@ function ActionRow({
   const catInfo = getCategoryInfo(category);
   const actionTitle = resolveActionTitle(receipt);
   const actionType = resolveActionType(receipt);
+  const actionSubtitle = resolveActionSubtitle(receipt);
 
   const handleClick = useCallback(() => {
     onSelect(receipt.receipt_id);
@@ -260,11 +261,11 @@ function ActionRow({
       </td>
       <td className="px-3 py-2.5">
         <div className="flex flex-col min-w-0">
-          <span className="text-sm font-medium text-brand-dark truncate block max-w-[200px]">
+          <span className="text-sm font-medium text-brand-dark truncate block max-w-[260px]">
             {actionTitle}
           </span>
-          <span className="text-[11px] text-slate-400 truncate block max-w-[200px]">
-            {actionType}
+          <span className="text-[11px] text-slate-400 truncate block max-w-[260px]">
+            {actionSubtitle ?? actionType}
           </span>
         </div>
       </td>

--- a/dashboard/src/evidence/index.ts
+++ b/dashboard/src/evidence/index.ts
@@ -3,7 +3,7 @@ export { CategoryTab } from "./category-tab";
 export { AppTab } from "./app-tab";
 export { ExploreTab } from "./explore-tab";
 export { detectCategory, getCategoryInfo, groupByCategory, CATEGORIES } from "./categories";
-export { plainEnglishDescription, plainEnglishRequestTitle, whyPaused, humanFileName, resolveActionTitle, resolveActionType } from "./plain-english";
+export { plainEnglishDescription, plainEnglishRequestTitle, whyPaused, humanFileName, resolveActionTitle, resolveActionType, resolveActionSubtitle, resolveActionDetail } from "./plain-english";
 
 export type {
   EvidenceDecision,

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -1,9 +1,13 @@
-import type { GuardReceipt, GuardApprovalRequest } from "../guard-types";
+import type { GuardReceipt, GuardApprovalRequest, GuardActionEnvelope } from "../guard-types";
 import { harnessDisplayName } from "../approval-center-utils";
 import { detectCategory, type ReceiptCategory } from "./categories";
 
 function getArtifactType(receipt: GuardReceipt): string {
   return (receipt.artifact_type ?? "").toLowerCase();
+}
+
+function getEnvelope(receipt: GuardReceipt): GuardActionEnvelope | null {
+  return receipt.action_envelope_json ?? null;
 }
 
 export function humanFileName(artifactName: string | null | undefined): string {
@@ -19,8 +23,9 @@ export function humanFileName(artifactName: string | null | undefined): string {
 }
 
 export function resolveActionType(receipt: GuardReceipt): string {
+  const envelope = getEnvelope(receipt);
+  const actionType = (envelope?.action_type ?? "").toLowerCase();
   const artifactType = getArtifactType(receipt);
-  const actionType = ((receipt.action_envelope_json as { action_type?: string } | null | undefined)?.action_type ?? "").toLowerCase();
 
   if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command")) return "Shell command";
   if (actionType === "prompt" || artifactType === "prompt_request") return "Prompt";
@@ -36,59 +41,180 @@ export function resolveActionType(receipt: GuardReceipt): string {
   return "Action";
 }
 
-export function resolveActionTitle(receipt: GuardReceipt): string {
-  const artifactName = receipt.artifact_name?.trim();
-  if (artifactName && artifactName.length > 0 && !looksLikeId(artifactName)) {
-    return artifactName;
-  }
-
-  const caps = receipt.capabilities_summary?.trim();
-  if (caps && caps.length > 0 && !caps.startsWith("Guard local daemon completed")) {
-    return caps;
-  }
-
-  const signals = receipt.scanner_evidence ?? [];
-  if (signals.length > 0 && signals[0]?.title) {
-    return signals[0].title;
-  }
-
-  const provenance = receipt.provenance_summary?.trim();
-  if (provenance && provenance.length > 0 && !provenance.startsWith("hook event for")) {
-    return provenance;
-  }
-
-  const name = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
-  const type = resolveActionType(receipt);
-  if (name && name !== type.toLowerCase()) {
-    return `${type}: ${name}`;
-  }
-  return type;
-}
-
 function looksLikeId(text: string): boolean {
   if (/^\w+:[a-f0-9]{8,}$/i.test(text)) return true;
   if (/^[a-f0-9]{8,}$/i.test(text)) return true;
   return false;
 }
 
+export function resolveActionTitle(receipt: GuardReceipt): string {
+  const envelope = getEnvelope(receipt);
+  const type = resolveActionType(receipt);
+
+  // Shell command: show the actual command if available
+  const command = envelope?.command?.trim();
+  if (type === "Shell command" && command && command.length > 0) {
+    return truncate(command, 80);
+  }
+
+  // File access: show the actual path
+  const targetPath = envelope?.target_paths?.[0]?.trim();
+  if ((type === "File read" || type === "File write") && targetPath && targetPath.length > 0) {
+    return truncate(targetPath, 80);
+  }
+
+  // Prompt: show excerpt
+  const promptExcerpt = envelope?.prompt_excerpt?.trim();
+  if (type === "Prompt" && promptExcerpt && promptExcerpt.length > 0) {
+    return truncate(promptExcerpt, 80);
+  }
+
+  // Network: show host
+  const host = envelope?.network_hosts?.[0]?.trim();
+  if (type === "Network request" && host && host.length > 0) {
+    return host;
+  }
+
+  // MCP tool: show tool name
+  const mcpTool = envelope?.mcp_tool?.trim() ?? envelope?.tool_name?.trim();
+  if (type === "Tool call" && mcpTool && mcpTool.length > 0) {
+    return mcpTool;
+  }
+
+  // Package: show package name
+  const packageName = envelope?.package_name?.trim();
+  if (type === "Package" && packageName && packageName.length > 0) {
+    return packageName;
+  }
+
+  // Scanner evidence title is usually more descriptive than raw artifact_name
+  const signals = receipt.scanner_evidence ?? [];
+  if (signals.length > 0 && signals[0]?.title) {
+    return signals[0].title;
+  }
+
+  // artifact_name when it is human-readable
+  const artifactName = receipt.artifact_name?.trim();
+  if (artifactName && artifactName.length > 0 && !looksLikeId(artifactName)) {
+    return artifactName;
+  }
+
+  // capabilities_summary
+  const caps = receipt.capabilities_summary?.trim();
+  if (caps && caps.length > 0 && !caps.startsWith("Guard local daemon completed")) {
+    return caps;
+  }
+
+  // provenance_summary
+  const provenance = receipt.provenance_summary?.trim();
+  if (provenance && provenance.length > 0 && !provenance.startsWith("hook event for")) {
+    return provenance;
+  }
+
+  const name = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
+  if (name && name.toLowerCase() !== type.toLowerCase()) {
+    return `${type}: ${name}`;
+  }
+  return type;
+}
+
+export function resolveActionSubtitle(receipt: GuardReceipt): string | null {
+  const signals = receipt.scanner_evidence ?? [];
+  const firstSignal = signals[0];
+
+  // Highest priority: scanner plain_reason explains the actual risk
+  if (firstSignal?.plain_reason) {
+    return firstSignal.plain_reason;
+  }
+
+  // Fallback to a human-readable context string built from envelope + metadata
+  const envelope = getEnvelope(receipt);
+  const type = resolveActionType(receipt);
+  const parts: string[] = [];
+
+  if (type === "Shell command" && envelope?.command) {
+    // Already shown as title; subtitle can be empty or show tool_name
+    if (envelope.tool_name) parts.push(`via ${envelope.tool_name}`);
+  }
+
+  if ((type === "File read" || type === "File write") && envelope?.target_paths && envelope.target_paths.length > 1) {
+    parts.push(`${envelope.target_paths.length} paths`);
+  }
+
+  if (type === "Network request" && envelope?.network_hosts && envelope.network_hosts.length > 1) {
+    parts.push(`${envelope.network_hosts.length} hosts`);
+  }
+
+  if (receipt.capabilities_summary && receipt.capabilities_summary !== "hook artifact · codex") {
+    parts.push(receipt.capabilities_summary);
+  }
+
+  if (parts.length > 0) {
+    return parts.join(" · ");
+  }
+
+  return null;
+}
+
+export function resolveActionDetail(receipt: GuardReceipt): string | null {
+  const envelope = getEnvelope(receipt);
+  if (!envelope) return null;
+
+  const type = resolveActionType(receipt);
+
+  if (type === "Shell command" && envelope.command) {
+    return envelope.command;
+  }
+  if ((type === "File read" || type === "File write") && envelope.target_paths.length > 0) {
+    return envelope.target_paths.join("\n");
+  }
+  if (type === "Prompt" && (envelope.prompt_text || envelope.prompt_excerpt)) {
+    return (envelope.prompt_text || envelope.prompt_excerpt) as string;
+  }
+  if (type === "Network request" && envelope.network_hosts.length > 0) {
+    return envelope.network_hosts.join("\n");
+  }
+  if (type === "Tool call") {
+    const server = envelope.mcp_server ?? envelope.tool_name;
+    const tool = envelope.mcp_tool;
+    if (server && tool) return `${server} → ${tool}`;
+    if (tool) return tool;
+    if (server) return server;
+  }
+  if (type === "Package") {
+    const pm = envelope.package_manager;
+    const name = envelope.package_name;
+    if (pm && name) return `${pm} install ${name}`;
+    if (name) return name;
+  }
+  return null;
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + "…";
+}
+
 export function plainEnglishDescription(receipt: GuardReceipt): string {
   const app = harnessDisplayName(receipt.harness);
   const type = resolveActionType(receipt);
   const title = resolveActionTitle(receipt);
-  const signals = receipt.scanner_evidence ?? [];
-  const firstSignal = signals[0];
+  const subtitle = resolveActionSubtitle(receipt);
 
   if (receipt.policy_decision === "allow") {
     if (receipt.user_override !== null) {
-      return `${app} ${pastTenseVerb(type)} ${title}. You reviewed and allowed it.`;
+      return subtitle
+        ? `${app} ${pastTenseVerb(type)} ${title}. ${subtitle} You reviewed and allowed it.`
+        : `${app} ${pastTenseVerb(type)} ${title}. You reviewed and allowed it.`;
     }
-    return `${app} ${pastTenseVerb(type)} ${title}. Guard allowed it automatically.`;
+    return subtitle
+      ? `${app} ${pastTenseVerb(type)} ${title}. ${subtitle} Guard allowed it automatically.`
+      : `${app} ${pastTenseVerb(type)} ${title}. Guard allowed it automatically.`;
   }
 
-  if (firstSignal?.plain_reason) {
-    return `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it: ${firstSignal.plain_reason}`;
-  }
-  return `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it.`;
+  return subtitle
+    ? `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it: ${subtitle}`
+    : `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it.`;
 }
 
 function pastTenseVerb(type: string): string {

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -165,13 +165,13 @@ export function resolveActionDetail(receipt: GuardReceipt): string | null {
   if (type === "Shell command" && envelope.command) {
     return envelope.command;
   }
-  if ((type === "File read" || type === "File write") && envelope.target_paths.length > 0) {
+  if ((type === "File read" || type === "File write") && envelope.target_paths && envelope.target_paths.length > 0) {
     return envelope.target_paths.join("\n");
   }
   if (type === "Prompt" && (envelope.prompt_text || envelope.prompt_excerpt)) {
     return (envelope.prompt_text || envelope.prompt_excerpt) as string;
   }
-  if (type === "Network request" && envelope.network_hosts.length > 0) {
+  if (type === "Network request" && envelope.network_hosts && envelope.network_hosts.length > 0) {
     return envelope.network_hosts.join("\n");
   }
   if (type === "Tool call") {
@@ -190,6 +190,11 @@ export function resolveActionDetail(receipt: GuardReceipt): string | null {
   return null;
 }
 
+function formatSubtitle(subtitle: string): string {
+  if (subtitle.endsWith(".") || subtitle.endsWith("?") || subtitle.endsWith("!")) return subtitle + " ";
+  return subtitle + ". ";
+}
+
 function truncate(text: string, max: number): string {
   if (text.length <= max) return text;
   return text.slice(0, max - 1) + "…";
@@ -204,16 +209,16 @@ export function plainEnglishDescription(receipt: GuardReceipt): string {
   if (receipt.policy_decision === "allow") {
     if (receipt.user_override !== null) {
       return subtitle
-        ? `${app} ${pastTenseVerb(type)} ${title}. ${subtitle} You reviewed and allowed it.`
+        ? `${app} ${pastTenseVerb(type)} ${title}. ${formatSubtitle(subtitle)} You reviewed and allowed it.`
         : `${app} ${pastTenseVerb(type)} ${title}. You reviewed and allowed it.`;
     }
     return subtitle
-      ? `${app} ${pastTenseVerb(type)} ${title}. ${subtitle} Guard allowed it automatically.`
+      ? `${app} ${pastTenseVerb(type)} ${title}. ${formatSubtitle(subtitle)} Guard allowed it automatically.`
       : `${app} ${pastTenseVerb(type)} ${title}. Guard allowed it automatically.`;
   }
 
   return subtitle
-    ? `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it: ${subtitle}`
+    ? `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it: ${formatSubtitle(subtitle)}`
     : `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it.`;
 }
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16261,6 +16261,9 @@ function EvidenceFilterBar({
 function getArtifactType(receipt) {
   return (receipt.artifact_type ?? "").toLowerCase();
 }
+function getEnvelope(receipt) {
+  return receipt.action_envelope_json ?? null;
+}
 function humanFileName(artifactName) {
   if (!artifactName) return "a file";
   const name = artifactName.split("/").pop() ?? artifactName;
@@ -16273,8 +16276,9 @@ function humanFileName(artifactName) {
   return name;
 }
 function resolveActionType(receipt) {
+  const envelope = getEnvelope(receipt);
+  const actionType = (envelope?.action_type ?? "").toLowerCase();
   const artifactType = getArtifactType(receipt);
-  const actionType = (receipt.action_envelope_json?.action_type ?? "").toLowerCase();
   if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command")) return "Shell command";
   if (actionType === "prompt" || artifactType === "prompt_request") return "Prompt";
   if (actionType === "file_read" || artifactType === "file_read_request" || artifactType.includes("file_read")) return "File read";
@@ -16288,7 +16292,42 @@ function resolveActionType(receipt) {
   if (artifactType.includes("plugin")) return "Plugin";
   return "Action";
 }
+function looksLikeId(text) {
+  if (/^\w+:[a-f0-9]{8,}$/i.test(text)) return true;
+  if (/^[a-f0-9]{8,}$/i.test(text)) return true;
+  return false;
+}
 function resolveActionTitle(receipt) {
+  const envelope = getEnvelope(receipt);
+  const type = resolveActionType(receipt);
+  const command = envelope?.command?.trim();
+  if (type === "Shell command" && command && command.length > 0) {
+    return truncate(command, 80);
+  }
+  const targetPath = envelope?.target_paths?.[0]?.trim();
+  if ((type === "File read" || type === "File write") && targetPath && targetPath.length > 0) {
+    return truncate(targetPath, 80);
+  }
+  const promptExcerpt = envelope?.prompt_excerpt?.trim();
+  if (type === "Prompt" && promptExcerpt && promptExcerpt.length > 0) {
+    return truncate(promptExcerpt, 80);
+  }
+  const host = envelope?.network_hosts?.[0]?.trim();
+  if (type === "Network request" && host && host.length > 0) {
+    return host;
+  }
+  const mcpTool = envelope?.mcp_tool?.trim() ?? envelope?.tool_name?.trim();
+  if (type === "Tool call" && mcpTool && mcpTool.length > 0) {
+    return mcpTool;
+  }
+  const packageName = envelope?.package_name?.trim();
+  if (type === "Package" && packageName && packageName.length > 0) {
+    return packageName;
+  }
+  const signals = receipt.scanner_evidence ?? [];
+  if (signals.length > 0 && signals[0]?.title) {
+    return signals[0].title;
+  }
   const artifactName = receipt.artifact_name?.trim();
   if (artifactName && artifactName.length > 0 && !looksLikeId(artifactName)) {
     return artifactName;
@@ -16297,42 +16336,89 @@ function resolveActionTitle(receipt) {
   if (caps && caps.length > 0 && !caps.startsWith("Guard local daemon completed")) {
     return caps;
   }
-  const signals = receipt.scanner_evidence ?? [];
-  if (signals.length > 0 && signals[0]?.title) {
-    return signals[0].title;
-  }
   const provenance = receipt.provenance_summary?.trim();
   if (provenance && provenance.length > 0 && !provenance.startsWith("hook event for")) {
     return provenance;
   }
   const name = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
-  const type = resolveActionType(receipt);
-  if (name && name !== type.toLowerCase()) {
+  if (name && name.toLowerCase() !== type.toLowerCase()) {
     return `${type}: ${name}`;
   }
   return type;
 }
-function looksLikeId(text) {
-  if (/^\w+:[a-f0-9]{8,}$/i.test(text)) return true;
-  if (/^[a-f0-9]{8,}$/i.test(text)) return true;
-  return false;
+function resolveActionSubtitle(receipt) {
+  const signals = receipt.scanner_evidence ?? [];
+  const firstSignal = signals[0];
+  if (firstSignal?.plain_reason) {
+    return firstSignal.plain_reason;
+  }
+  const envelope = getEnvelope(receipt);
+  const type = resolveActionType(receipt);
+  const parts = [];
+  if (type === "Shell command" && envelope?.command) {
+    if (envelope.tool_name) parts.push(`via ${envelope.tool_name}`);
+  }
+  if ((type === "File read" || type === "File write") && envelope?.target_paths && envelope.target_paths.length > 1) {
+    parts.push(`${envelope.target_paths.length} paths`);
+  }
+  if (type === "Network request" && envelope?.network_hosts && envelope.network_hosts.length > 1) {
+    parts.push(`${envelope.network_hosts.length} hosts`);
+  }
+  if (receipt.capabilities_summary && receipt.capabilities_summary !== "hook artifact · codex") {
+    parts.push(receipt.capabilities_summary);
+  }
+  if (parts.length > 0) {
+    return parts.join(" · ");
+  }
+  return null;
+}
+function resolveActionDetail(receipt) {
+  const envelope = getEnvelope(receipt);
+  if (!envelope) return null;
+  const type = resolveActionType(receipt);
+  if (type === "Shell command" && envelope.command) {
+    return envelope.command;
+  }
+  if ((type === "File read" || type === "File write") && envelope.target_paths.length > 0) {
+    return envelope.target_paths.join("\n");
+  }
+  if (type === "Prompt" && (envelope.prompt_text || envelope.prompt_excerpt)) {
+    return envelope.prompt_text || envelope.prompt_excerpt;
+  }
+  if (type === "Network request" && envelope.network_hosts.length > 0) {
+    return envelope.network_hosts.join("\n");
+  }
+  if (type === "Tool call") {
+    const server = envelope.mcp_server ?? envelope.tool_name;
+    const tool = envelope.mcp_tool;
+    if (server && tool) return `${server} → ${tool}`;
+    if (tool) return tool;
+    if (server) return server;
+  }
+  if (type === "Package") {
+    const pm = envelope.package_manager;
+    const name = envelope.package_name;
+    if (pm && name) return `${pm} install ${name}`;
+    if (name) return name;
+  }
+  return null;
+}
+function truncate(text, max) {
+  if (text.length <= max) return text;
+  return text.slice(0, max - 1) + "…";
 }
 function plainEnglishDescription(receipt) {
   const app = harnessDisplayName(receipt.harness);
   const type = resolveActionType(receipt);
   const title = resolveActionTitle(receipt);
-  const signals = receipt.scanner_evidence ?? [];
-  const firstSignal = signals[0];
+  const subtitle = resolveActionSubtitle(receipt);
   if (receipt.policy_decision === "allow") {
     if (receipt.user_override !== null) {
-      return `${app} ${pastTenseVerb(type)} ${title}. You reviewed and allowed it.`;
+      return subtitle ? `${app} ${pastTenseVerb(type)} ${title}. ${subtitle} You reviewed and allowed it.` : `${app} ${pastTenseVerb(type)} ${title}. You reviewed and allowed it.`;
     }
-    return `${app} ${pastTenseVerb(type)} ${title}. Guard allowed it automatically.`;
+    return subtitle ? `${app} ${pastTenseVerb(type)} ${title}. ${subtitle} Guard allowed it automatically.` : `${app} ${pastTenseVerb(type)} ${title}. Guard allowed it automatically.`;
   }
-  if (firstSignal?.plain_reason) {
-    return `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it: ${firstSignal.plain_reason}`;
-  }
-  return `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it.`;
+  return subtitle ? `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it: ${subtitle}` : `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it.`;
 }
 function pastTenseVerb(type) {
   switch (type) {
@@ -16621,6 +16707,7 @@ function ActionRow({
   const catInfo = getCategoryInfo(category);
   const actionTitle = resolveActionTitle(receipt);
   const actionType = resolveActionType(receipt);
+  const actionSubtitle = resolveActionSubtitle(receipt);
   const handleClick = reactExports.useCallback(() => {
     onSelect(receipt.receipt_id);
   }, [receipt.receipt_id, onSelect]);
@@ -16659,8 +16746,8 @@ function ActionRow({
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `${catInfo.color}`, "aria-hidden": "true", children: catInfo.icon }) }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col min-w-0", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[200px]", children: actionTitle }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[11px] text-slate-400 truncate block max-w-[200px]", children: actionType })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[260px]", children: actionTitle }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[11px] text-slate-400 truncate block max-w-[260px]", children: actionSubtitle ?? actionType })
         ] }) }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden sm:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
           "button",
@@ -16905,7 +16992,10 @@ function EvidenceActionDetail({
   const description = plainEnglishDescription(receipt);
   const actionTitle = resolveActionTitle(receipt);
   const actionType = resolveActionType(receipt);
+  resolveActionSubtitle(receipt);
+  const actionDetail = resolveActionDetail(receipt);
   const signals = receipt.scanner_evidence ?? [];
+  const primarySignal = signals[0];
   let copyLabel = "Copy receipt ID";
   if (copied) {
     copyLabel = "Copied!";
@@ -16953,7 +17043,23 @@ function EvidenceActionDetail({
             /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: formatRelativeTime(receipt.timestamp) })
           ] }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark leading-relaxed", children: description }),
-          receipt.capabilities_summary && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500 italic leading-relaxed", children: receipt.capabilities_summary }),
+          actionDetail && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg border border-slate-200 bg-slate-50 px-3 py-2.5", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: actionType }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs font-mono text-brand-dark break-all whitespace-pre-line leading-relaxed", children: actionDetail })
+          ] }),
+          primarySignal && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-3 py-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(SeverityIcon, { severity: primarySignal.severity }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Scanner finding" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(SeverityBadge, { severity: primarySignal.severity })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm font-medium text-brand-dark", children: primarySignal.title }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-brand-dark/80 leading-relaxed", children: primarySignal.plain_reason }),
+            primarySignal.false_positive_hint && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-[11px] text-slate-500 italic", children: [
+              "Might be safe if: ",
+              primarySignal.false_positive_hint
+            ] })
+          ] }),
           receipt.provenance_summary && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-lg border border-slate-100 bg-slate-50/60 px-3 py-2.5", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Provenance" }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-700", children: receipt.provenance_summary })
@@ -17938,11 +18044,12 @@ function AppTabRaw({ receipts }) {
           const catInfo = getCategoryInfo(category);
           const actionTitle = resolveActionTitle(receipt);
           const actionType = resolveActionType(receipt);
+          const actionSubtitle = resolveActionSubtitle(receipt);
           return /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { className: "border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `${catInfo.color}`, "aria-hidden": "true", children: catInfo.icon }) }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col min-w-0", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[200px]", children: actionTitle }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[11px] text-slate-400 truncate block max-w-[200px]", children: actionType })
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[260px]", children: actionTitle }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[11px] text-slate-400 truncate block max-w-[260px]", children: actionSubtitle ?? actionType })
             ] }) }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden md:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: catInfo.label }) }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionBadge, { decision: receipt.policy_decision }) }),
@@ -18126,11 +18233,12 @@ function CategoryTabRaw({ receipts, onFilterCategory }) {
           const catInfo = getCategoryInfo(category);
           const actionTitle = resolveActionTitle(receipt);
           const actionType = resolveActionType(receipt);
+          const actionSubtitle = resolveActionSubtitle(receipt);
           return /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { className: "border-b border-slate-100 last:border-0 hover:bg-slate-50 transition-colors", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `${catInfo.color}`, "aria-hidden": "true", children: catInfo.icon }) }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col min-w-0", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[200px]", children: actionTitle }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[11px] text-slate-400 truncate block max-w-[200px]", children: actionType })
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark truncate block max-w-[260px]", children: actionTitle }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[11px] text-slate-400 truncate block max-w-[260px]", children: actionSubtitle ?? actionType })
             ] }) }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5 hidden md:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-500", children: harnessDisplayName(receipt.harness) }) }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-2.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx(DecisionBadge, { decision: receipt.policy_decision }) }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16379,13 +16379,13 @@ function resolveActionDetail(receipt) {
   if (type === "Shell command" && envelope.command) {
     return envelope.command;
   }
-  if ((type === "File read" || type === "File write") && envelope.target_paths.length > 0) {
+  if ((type === "File read" || type === "File write") && envelope.target_paths && envelope.target_paths.length > 0) {
     return envelope.target_paths.join("\n");
   }
   if (type === "Prompt" && (envelope.prompt_text || envelope.prompt_excerpt)) {
     return envelope.prompt_text || envelope.prompt_excerpt;
   }
-  if (type === "Network request" && envelope.network_hosts.length > 0) {
+  if (type === "Network request" && envelope.network_hosts && envelope.network_hosts.length > 0) {
     return envelope.network_hosts.join("\n");
   }
   if (type === "Tool call") {
@@ -16403,6 +16403,10 @@ function resolveActionDetail(receipt) {
   }
   return null;
 }
+function formatSubtitle(subtitle) {
+  if (subtitle.endsWith(".") || subtitle.endsWith("?") || subtitle.endsWith("!")) return subtitle + " ";
+  return subtitle + ". ";
+}
 function truncate(text, max) {
   if (text.length <= max) return text;
   return text.slice(0, max - 1) + "…";
@@ -16414,11 +16418,11 @@ function plainEnglishDescription(receipt) {
   const subtitle = resolveActionSubtitle(receipt);
   if (receipt.policy_decision === "allow") {
     if (receipt.user_override !== null) {
-      return subtitle ? `${app} ${pastTenseVerb(type)} ${title}. ${subtitle} You reviewed and allowed it.` : `${app} ${pastTenseVerb(type)} ${title}. You reviewed and allowed it.`;
+      return subtitle ? `${app} ${pastTenseVerb(type)} ${title}. ${formatSubtitle(subtitle)} You reviewed and allowed it.` : `${app} ${pastTenseVerb(type)} ${title}. You reviewed and allowed it.`;
     }
-    return subtitle ? `${app} ${pastTenseVerb(type)} ${title}. ${subtitle} Guard allowed it automatically.` : `${app} ${pastTenseVerb(type)} ${title}. Guard allowed it automatically.`;
+    return subtitle ? `${app} ${pastTenseVerb(type)} ${title}. ${formatSubtitle(subtitle)} Guard allowed it automatically.` : `${app} ${pastTenseVerb(type)} ${title}. Guard allowed it automatically.`;
   }
-  return subtitle ? `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it: ${subtitle}` : `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it.`;
+  return subtitle ? `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it: ${formatSubtitle(subtitle)}` : `${app} tried to ${infinitiveVerb(type)} ${title}. Guard stopped it.`;
 }
 function pastTenseVerb(type) {
   switch (type) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1155,6 +1155,10 @@
     max-width: 240px;
   }
 
+  .max-w-\[260px\] {
+    max-width: 260px;
+  }
+
   .max-w-lg {
     max-width: var(--container-lg);
   }
@@ -3385,6 +3389,10 @@
 
   .whitespace-nowrap {
     white-space: nowrap;
+  }
+
+  .whitespace-pre-line {
+    white-space: pre-line;
   }
 
   .whitespace-pre-wrap {


### PR DESCRIPTION
## Summary
- Surface the actual action payload in Evidence rows and detail: shell `command`, file `target_paths`, `prompt_excerpt`, `network_hosts`, MCP `tool_name`/`mcp_server`, and `package_name`.
- Prioritize scanner signal titles and `plain_reason` over generic `artifact_name` like "Bash" so rows show the real risk/action that was mitigated.
- Add `resolveActionSubtitle()` that returns the scanner plain_reason or envelope context, displayed under the action title in every table row.
- Prominently display the primary scanner finding + `plain_reason` above the fold in the detail panel, matching the Inbox quality bar.
- Show the raw command/path/prompt in a dedicated detail box so users can inspect exactly what Guard evaluated.
- Rebuild static dashboard assets.

## Testing
- `pnpm test` (all tests pass)
- `pnpm run build` (dashboard rebuilt successfully)
