### PR TITLE
fix(evidence): persist action envelope in receipts so actual commands show; relabel Trust Center -> Supply chain; fix home package manager CTA route

### DIFF
--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -143,7 +143,7 @@ const sidebarLinks = [
   { href: "/inbox", label: "Inbox", view: "inbox", icon: HiMiniInbox },
   { href: "/fleet", label: "Protect", view: "fleet", icon: HiMiniShieldCheck },
   { href: "/evidence", label: "Evidence", view: "evidence", icon: HiMiniDocumentText },
-  { href: "/supply-chain", label: "Trust Center", view: "supply-chain", icon: HiMiniSquares2X2 },
+  { href: "/supply-chain", label: "Supply chain", view: "supply-chain", icon: HiMiniSquares2X2 },
   { href: "/settings", label: "Settings", view: "settings", icon: HiMiniAdjustmentsHorizontal }
 ] as const;
 

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -94,8 +94,19 @@ export function resolveActionTitle(receipt: GuardReceipt): string {
     return signals[0].title;
   }
 
-  // artifact_name when it is human-readable
+  // provenance_summary for hook events is more descriptive than a generic tool name like "Bash"
+  const provenance = receipt.provenance_summary?.trim();
   const artifactName = receipt.artifact_name?.trim();
+  if (
+    provenance &&
+    provenance.toLowerCase().startsWith("hook event for") &&
+    artifactName &&
+    provenance.toLowerCase().endsWith(artifactName.toLowerCase())
+  ) {
+    return provenance;
+  }
+
+  // artifact_name when it is human-readable
   if (artifactName && artifactName.length > 0 && !looksLikeId(artifactName)) {
     return artifactName;
   }
@@ -106,9 +117,8 @@ export function resolveActionTitle(receipt: GuardReceipt): string {
     return caps;
   }
 
-  // provenance_summary for hook events is more descriptive than the raw tool name
-  const provenance = receipt.provenance_summary?.trim();
-  if (provenance && provenance.toLowerCase().startsWith("hook event for")) {
+  // provenance_summary when it is descriptive
+  if (provenance && provenance.length > 0 && !provenance.toLowerCase().startsWith("hook event for")) {
     return provenance;
   }
 
@@ -153,7 +163,7 @@ export function resolveActionSubtitle(receipt: GuardReceipt): string | null {
 
   if (isCapsUseful) {
     parts.push(caps);
-  } else if (isProvenanceUseful && provenance?.toLowerCase() !== caps?.toLowerCase()) {
+  } else if (isProvenanceUseful && provenance?.toLowerCase() !== caps?.toLowerCase() && provenance !== resolveActionTitle(receipt)) {
     parts.push(provenance);
   }
 

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -28,7 +28,11 @@ export function resolveActionType(receipt: GuardReceipt): string {
   const artifactType = getArtifactType(receipt);
   const artifactName = (receipt.artifact_name ?? "").toLowerCase();
 
-  if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command") || artifactName === "bash") return "Shell command";
+  if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command")) return "Shell command";
+  if (
+    artifactName === "bash" &&
+    receipt.provenance_summary?.trim().toLowerCase().startsWith("hook event for")
+  ) return "Shell command";
   if (actionType === "prompt" || artifactType === "prompt_request") return "Prompt";
   if (actionType === "file_read" || artifactType === "file_read_request" || artifactType.includes("file_read")) return "File read";
   if (actionType === "file_write" || artifactType.includes("file_write") || artifactType.includes("write")) return "File write";

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -26,8 +26,9 @@ export function resolveActionType(receipt: GuardReceipt): string {
   const envelope = getEnvelope(receipt);
   const actionType = (envelope?.action_type ?? "").toLowerCase();
   const artifactType = getArtifactType(receipt);
+  const artifactName = (receipt.artifact_name ?? "").toLowerCase();
 
-  if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command")) return "Shell command";
+  if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command") || artifactName === "bash") return "Shell command";
   if (actionType === "prompt" || artifactType === "prompt_request") return "Prompt";
   if (actionType === "file_read" || artifactType === "file_read_request" || artifactType.includes("file_read")) return "File read";
   if (actionType === "file_write" || artifactType.includes("file_write") || artifactType.includes("write")) return "File write";
@@ -105,9 +106,9 @@ export function resolveActionTitle(receipt: GuardReceipt): string {
     return caps;
   }
 
-  // provenance_summary
+  // provenance_summary for hook events is more descriptive than the raw tool name
   const provenance = receipt.provenance_summary?.trim();
-  if (provenance && provenance.length > 0 && !provenance.startsWith("hook event for")) {
+  if (provenance && provenance.toLowerCase().startsWith("hook event for")) {
     return provenance;
   }
 
@@ -145,8 +146,12 @@ export function resolveActionSubtitle(receipt: GuardReceipt): string | null {
     parts.push(`${envelope.network_hosts.length} hosts`);
   }
 
-  if (receipt.capabilities_summary && receipt.capabilities_summary !== "hook artifact · codex") {
-    parts.push(receipt.capabilities_summary);
+  const caps = receipt.capabilities_summary?.trim();
+  const provenance = receipt.provenance_summary?.trim();
+  if (caps && caps !== "hook artifact · codex" && !caps.toLowerCase().startsWith("guard local daemon completed")) {
+    parts.push(caps);
+  } else if (provenance && provenance.toLowerCase() !== caps?.toLowerCase()) {
+    parts.push(provenance);
   }
 
   if (parts.length > 0) {

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -148,9 +148,12 @@ export function resolveActionSubtitle(receipt: GuardReceipt): string | null {
 
   const caps = receipt.capabilities_summary?.trim();
   const provenance = receipt.provenance_summary?.trim();
-  if (caps && caps !== "hook artifact · codex" && !caps.toLowerCase().startsWith("guard local daemon completed")) {
+  const isCapsUseful = caps && caps !== "hook artifact · codex" && !caps.toLowerCase().startsWith("guard local daemon completed");
+  const isProvenanceUseful = provenance && provenance !== "hook artifact · codex" && !provenance.toLowerCase().startsWith("guard local daemon completed");
+
+  if (isCapsUseful) {
     parts.push(caps);
-  } else if (provenance && provenance.toLowerCase() !== caps?.toLowerCase()) {
+  } else if (isProvenanceUseful && provenance?.toLowerCase() !== caps?.toLowerCase()) {
     parts.push(provenance);
   }
 

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1029,12 +1029,30 @@ export async function fetchRequest(requestId: string): Promise<GuardApprovalRequ
   return normalizeApprovalRequest(payload);
 }
 
+type RawGuardReceipt = Omit<GuardReceipt, "action_envelope_json"> & {
+  action_envelope_json?: unknown;
+};
+
+function normalizeReceipt(item: RawGuardReceipt): GuardReceipt {
+  return {
+    ...item,
+    action_envelope_json: parseActionEnvelope(item.action_envelope_json)
+  };
+}
+
+function normalizeReceipts(items: RawGuardReceipt[] | null | undefined): GuardReceipt[] {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.map(normalizeReceipt);
+}
+
 export async function fetchReceipts(): Promise<GuardReceipt[]> {
   if (isGuardDemoMode()) {
     return getDemoReceipts();
   }
-  const payload = await readJson<{ items: GuardReceipt[] }>("/v1/receipts");
-  return payload.items;
+  const payload = await readJson<{ items: RawGuardReceipt[] }>("/v1/receipts");
+  return normalizeReceipts(payload.items);
 }
 
 export async function fetchLatestReceipt(
@@ -1053,7 +1071,7 @@ export async function fetchLatestReceipt(
   if (!response.ok) {
     throw new Error(`Receipt request failed with ${response.status}`);
   }
-  return (await response.json()) as GuardReceipt;
+  return normalizeReceipt((await response.json()) as RawGuardReceipt);
 }
 
 export async function fetchPolicy(harness: string): Promise<GuardPolicyDecision[]> {

--- a/dashboard/src/home-protection-module.tsx
+++ b/dashboard/src/home-protection-module.tsx
@@ -179,7 +179,7 @@ export function HomeProtectionModule({
 
           {(status === "unprotected" || status === "unknown") && (
             <div className="flex items-center gap-3">
-              <ActionButton onClick={onOpenFleet} variant="secondary">
+              <ActionButton onClick={onOpenSupplyChain ?? onOpenFleet} variant="secondary">
                 Set up protection
                 <HiMiniArrowRight className="ml-1.5 h-3.5 w-3.5" aria-hidden="true" />
               </ActionButton>

--- a/dashboard/src/supply-chain-hub-workspace.tsx
+++ b/dashboard/src/supply-chain-hub-workspace.tsx
@@ -61,7 +61,7 @@ export function SupplyChainHubWorkspace(props: {
     <div className="space-y-6">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Trust Center</p>
+          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Supply chain</p>
           <h1 className="text-2xl font-semibold tracking-tight text-brand-dark">{hubTitleForTab(tab)}</h1>
         </div>
         <TabBar tabs={hubTabs} active={tab} onChange={handleTabChange} />

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3429,6 +3429,7 @@ def run_guard_command(
                     if policy_action == "require-reapproval"
                     else "policy"
                 ),
+                action_envelope_json=action_envelope.to_dict() if action_envelope is not None else None,
             )
             store.add_receipt(receipt)
             response_payload = {
@@ -3842,6 +3843,7 @@ def run_guard_command(
                 source_scope=_coalesce_string(payload.get("source_scope"), "project"),
                 user_override=_optional_string(payload.get("user_override")),
                 approval_source=("inline" if _optional_string(payload.get("user_override")) is not None else "policy"),
+                action_envelope_json=action_envelope.to_dict() if action_envelope is not None else None,
             )
             store.add_receipt(receipt)
         _record_harness_usage_for_hook(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-dashboard.js
@@ -96,7 +96,7 @@ function HomeProtectionModule({
             ] })
           ] }),
           (status === "unprotected" || status === "unknown") && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-3", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { onClick: onOpenFleet, variant: "secondary", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { onClick: onOpenSupplyChain ?? onOpenFleet, variant: "secondary", children: [
               "Set up protection",
               /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowRight, { className: "ml-1.5 h-3.5 w-3.5", "aria-hidden": "true" })
             ] }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -39,7 +39,7 @@ function SupplyChainHubWorkspace(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-slate-400", children: "Trust Center" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.18em] text-slate-400", children: "Supply chain" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("h1", { className: "text-2xl font-semibold tracking-tight text-brand-dark", children: hubTitleForTab(tab) })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(TabBar, { tabs: hubTabs, active: tab, onChange: handleTabChange })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13451,12 +13451,24 @@ async function fetchRequest(requestId) {
   const payload = await readJson(`/v1/requests/${requestId}`);
   return normalizeApprovalRequest(payload);
 }
+function normalizeReceipt(item) {
+  return {
+    ...item,
+    action_envelope_json: parseActionEnvelope(item.action_envelope_json)
+  };
+}
+function normalizeReceipts(items) {
+  if (!Array.isArray(items)) {
+    return [];
+  }
+  return items.map(normalizeReceipt);
+}
 async function fetchReceipts() {
   if (isGuardDemoMode()) {
     return getDemoReceipts();
   }
   const payload = await readJson("/v1/receipts");
-  return payload.items;
+  return normalizeReceipts(payload.items);
 }
 async function fetchLatestReceipt(artifactId, harness) {
   if (isGuardDemoMode()) {
@@ -13471,7 +13483,7 @@ async function fetchLatestReceipt(artifactId, harness) {
   if (!response.ok) {
     throw new Error(`Receipt request failed with ${response.status}`);
   }
-  return await response.json();
+  return normalizeReceipt(await response.json());
 }
 async function fetchPolicy(harness) {
   if (isGuardDemoMode()) {
@@ -14883,7 +14895,7 @@ const sidebarLinks = [
   { href: "/inbox", label: "Inbox", view: "inbox", icon: HiMiniInbox },
   { href: "/fleet", label: "Protect", view: "fleet", icon: HiMiniShieldCheck },
   { href: "/evidence", label: "Evidence", view: "evidence", icon: HiMiniDocumentText },
-  { href: "/supply-chain", label: "Trust Center", view: "supply-chain", icon: HiMiniSquares2X2 },
+  { href: "/supply-chain", label: "Supply chain", view: "supply-chain", icon: HiMiniSquares2X2 },
   { href: "/settings", label: "Settings", view: "settings", icon: HiMiniAdjustmentsHorizontal }
 ];
 function ShellSidebar(props) {
@@ -16309,7 +16321,8 @@ function resolveActionType(receipt) {
   const envelope = getEnvelope(receipt);
   const actionType = (envelope?.action_type ?? "").toLowerCase();
   const artifactType = getArtifactType(receipt);
-  if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command")) return "Shell command";
+  const artifactName = (receipt.artifact_name ?? "").toLowerCase();
+  if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command") || artifactName === "bash") return "Shell command";
   if (actionType === "prompt" || artifactType === "prompt_request") return "Prompt";
   if (actionType === "file_read" || artifactType === "file_read_request" || artifactType.includes("file_read")) return "File read";
   if (actionType === "file_write" || artifactType.includes("file_write") || artifactType.includes("write")) return "File write";
@@ -16367,7 +16380,7 @@ function resolveActionTitle(receipt) {
     return caps;
   }
   const provenance = receipt.provenance_summary?.trim();
-  if (provenance && provenance.length > 0 && !provenance.startsWith("hook event for")) {
+  if (provenance && provenance.toLowerCase().startsWith("hook event for")) {
     return provenance;
   }
   const name = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
@@ -16394,8 +16407,12 @@ function resolveActionSubtitle(receipt) {
   if (type === "Network request" && envelope?.network_hosts && envelope.network_hosts.length > 1) {
     parts.push(`${envelope.network_hosts.length} hosts`);
   }
-  if (receipt.capabilities_summary && receipt.capabilities_summary !== "hook artifact · codex") {
-    parts.push(receipt.capabilities_summary);
+  const caps = receipt.capabilities_summary?.trim();
+  const provenance = receipt.provenance_summary?.trim();
+  if (caps && caps !== "hook artifact · codex" && !caps.toLowerCase().startsWith("guard local daemon completed")) {
+    parts.push(caps);
+  } else if (provenance && provenance.toLowerCase() !== caps?.toLowerCase()) {
+    parts.push(provenance);
   }
   if (parts.length > 0) {
     return parts.join(" · ");

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16322,7 +16322,8 @@ function resolveActionType(receipt) {
   const actionType = (envelope?.action_type ?? "").toLowerCase();
   const artifactType = getArtifactType(receipt);
   const artifactName = (receipt.artifact_name ?? "").toLowerCase();
-  if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command") || artifactName === "bash") return "Shell command";
+  if (actionType === "shell_command" || artifactType.includes("shell") || artifactType.includes("command")) return "Shell command";
+  if (artifactName === "bash" && receipt.provenance_summary?.trim().toLowerCase().startsWith("hook event for")) return "Shell command";
   if (actionType === "prompt" || artifactType === "prompt_request") return "Prompt";
   if (actionType === "file_read" || artifactType === "file_read_request" || artifactType.includes("file_read")) return "File read";
   if (actionType === "file_write" || artifactType.includes("file_write") || artifactType.includes("write")) return "File write";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16371,7 +16371,11 @@ function resolveActionTitle(receipt) {
   if (signals.length > 0 && signals[0]?.title) {
     return signals[0].title;
   }
+  const provenance = receipt.provenance_summary?.trim();
   const artifactName = receipt.artifact_name?.trim();
+  if (provenance && provenance.toLowerCase().startsWith("hook event for") && artifactName && provenance.toLowerCase().endsWith(artifactName.toLowerCase())) {
+    return provenance;
+  }
   if (artifactName && artifactName.length > 0 && !looksLikeId(artifactName)) {
     return artifactName;
   }
@@ -16379,8 +16383,7 @@ function resolveActionTitle(receipt) {
   if (caps && caps.length > 0 && !caps.startsWith("Guard local daemon completed")) {
     return caps;
   }
-  const provenance = receipt.provenance_summary?.trim();
-  if (provenance && provenance.toLowerCase().startsWith("hook event for")) {
+  if (provenance && provenance.length > 0 && !provenance.toLowerCase().startsWith("hook event for")) {
     return provenance;
   }
   const name = humanFileName(receipt.artifact_name ?? receipt.artifact_id);
@@ -16413,7 +16416,7 @@ function resolveActionSubtitle(receipt) {
   const isProvenanceUseful = provenance && provenance !== "hook artifact · codex" && !provenance.toLowerCase().startsWith("guard local daemon completed");
   if (isCapsUseful) {
     parts.push(caps);
-  } else if (isProvenanceUseful && provenance?.toLowerCase() !== caps?.toLowerCase()) {
+  } else if (isProvenanceUseful && provenance?.toLowerCase() !== caps?.toLowerCase() && provenance !== resolveActionTitle(receipt)) {
     parts.push(provenance);
   }
   if (parts.length > 0) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16409,9 +16409,11 @@ function resolveActionSubtitle(receipt) {
   }
   const caps = receipt.capabilities_summary?.trim();
   const provenance = receipt.provenance_summary?.trim();
-  if (caps && caps !== "hook artifact · codex" && !caps.toLowerCase().startsWith("guard local daemon completed")) {
+  const isCapsUseful = caps && caps !== "hook artifact · codex" && !caps.toLowerCase().startsWith("guard local daemon completed");
+  const isProvenanceUseful = provenance && provenance !== "hook artifact · codex" && !provenance.toLowerCase().startsWith("guard local daemon completed");
+  if (isCapsUseful) {
     parts.push(caps);
-  } else if (provenance && provenance.toLowerCase() !== caps?.toLowerCase()) {
+  } else if (isProvenanceUseful && provenance?.toLowerCase() !== caps?.toLowerCase()) {
     parts.push(provenance);
   }
   if (parts.length > 0) {

--- a/src/codex_plugin_scanner/guard/receipts/manager.py
+++ b/src/codex_plugin_scanner/guard/receipts/manager.py
@@ -31,6 +31,7 @@ def build_receipt(
     scanner_evidence: Sequence[Mapping[str, object]] = (),
     diff_summary: str | None = None,
     approval_source: str | None = None,
+    action_envelope_json: Mapping[str, object] | None = None,
 ) -> GuardReceipt:
     """Create a runtime receipt."""
 
@@ -53,5 +54,6 @@ def build_receipt(
         source_scope=source_scope,
         diff_summary=resolved_diff_summary,
         approval_source=approval_source,
+        action_envelope_json=dict(action_envelope_json) if action_envelope_json is not None else None,
         scanner_evidence=tuple(dict(item) for item in scanner_evidence),
     )

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -30,6 +30,7 @@ from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRunt
 from .runtime.scanner_cache import scanner_cache_key
 from .schemas.guard_event_v1 import GuardEventV1
 from .store_approvals import (
+    _json_object,
     _json_object_list,
     approval_index_statements,
     approval_schema_statement,
@@ -1058,6 +1059,7 @@ class GuardStore:
             self._ensure_runtime_receipts_column(connection, "scanner_evidence_json", "text not null default '[]'")
             self._ensure_runtime_receipts_column(connection, "diff_summary", "text")
             self._ensure_runtime_receipts_column(connection, "approval_source", "text")
+            self._ensure_runtime_receipts_column(connection, "action_envelope_json", "text")
             self._ensure_approval_column(connection, "artifact_type", "text not null default 'artifact'")
             self._ensure_approval_column(connection, "launch_target", "text")
             self._ensure_approval_column(connection, "transport", "text")
@@ -1812,9 +1814,9 @@ class GuardStore:
                   receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                   changed_capabilities_json,
                   provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                  diff_summary, approval_source, timestamp
+                  diff_summary, approval_source, timestamp, action_envelope_json
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     receipt.receipt_id,
@@ -1832,6 +1834,7 @@ class GuardStore:
                     receipt.diff_summary,
                     receipt.approval_source,
                     receipt.timestamp,
+                    json.dumps(receipt.action_envelope_json) if receipt.action_envelope_json is not None else None,
                 ),
             )
             self._ensure_local_device(connection)
@@ -1857,7 +1860,7 @@ class GuardStore:
                        capabilities_summary,
                        changed_capabilities_json,
                        provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                       diff_summary, approval_source, timestamp
+                       diff_summary, approval_source, timestamp, action_envelope_json
                 from runtime_receipts
                 where harness = ?
                 order by timestamp desc
@@ -1870,7 +1873,7 @@ class GuardStore:
                        capabilities_summary,
                        changed_capabilities_json,
                        provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                       diff_summary, approval_source, timestamp
+                       diff_summary, approval_source, timestamp, action_envelope_json
                 from runtime_receipts
                 order by timestamp desc
                 limit ?
@@ -1896,6 +1899,7 @@ class GuardStore:
                 "diff_summary": row["diff_summary"],
                 "approval_source": row["approval_source"],
                 "timestamp": str(row["timestamp"]),
+                "action_envelope_json": _json_object(row["action_envelope_json"]),
             }
             for row in rows
         ]
@@ -1911,7 +1915,8 @@ class GuardStore:
             query = """
                 select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
                        capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
-                       artifact_name, source_scope, scanner_evidence_json, diff_summary, approval_source, timestamp
+                       artifact_name, source_scope, scanner_evidence_json, diff_summary, approval_source, timestamp,
+                       action_envelope_json
                 from runtime_receipts
                 where rowid > ? and harness = ?
                 order by rowid asc
@@ -1926,7 +1931,8 @@ class GuardStore:
             query = """
                 select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
                        capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
-                       artifact_name, source_scope, scanner_evidence_json, diff_summary, approval_source, timestamp
+                       artifact_name, source_scope, scanner_evidence_json, diff_summary, approval_source, timestamp,
+                       action_envelope_json
                 from runtime_receipts
                 where rowid > ?
                 order by rowid asc
@@ -1953,6 +1959,7 @@ class GuardStore:
                 "diff_summary": row["diff_summary"],
                 "approval_source": row["approval_source"],
                 "timestamp": str(row["timestamp"]),
+                "action_envelope_json": _json_object(row["action_envelope_json"]),
             }
             for row in rows
         ]
@@ -1981,7 +1988,7 @@ class GuardStore:
                 select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                         changed_capabilities_json,
                        provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                       diff_summary, approval_source, timestamp
+                       diff_summary, approval_source, timestamp, action_envelope_json
                 from runtime_receipts
                 where receipt_id = ?
                 """,
@@ -2005,6 +2012,7 @@ class GuardStore:
             "diff_summary": row["diff_summary"],
             "approval_source": row["approval_source"],
             "timestamp": str(row["timestamp"]),
+            "action_envelope_json": _json_object(row["action_envelope_json"]),
         }
 
     def get_latest_receipt(self, harness: str, artifact_id: str) -> dict[str, object] | None:
@@ -2014,7 +2022,7 @@ class GuardStore:
                 select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                         changed_capabilities_json,
                        provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                       diff_summary, approval_source, timestamp
+                       diff_summary, approval_source, timestamp, action_envelope_json
                 from runtime_receipts
                 where harness = ? and artifact_id = ?
                 order by timestamp desc
@@ -2040,6 +2048,7 @@ class GuardStore:
             "diff_summary": row["diff_summary"],
             "approval_source": row["approval_source"],
             "timestamp": str(row["timestamp"]),
+            "action_envelope_json": _json_object(row["action_envelope_json"]),
         }
 
     def count_receipts(self, harness: str | None = None) -> int:

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -585,6 +585,16 @@ def _safe_json_list(value: object) -> list[object]:
     return list(parsed) if isinstance(parsed, list) else []
 
 
+def _json_object(value: object) -> dict[str, object] | None:
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(str(value))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    return dict(parsed) if isinstance(parsed, dict) else None
+
+
 def _json_object_list(value: object) -> list[dict[str, object]]:
     if value is None:
         return []

--- a/tests/test_guard_receipt_p5_fields.py
+++ b/tests/test_guard_receipt_p5_fields.py
@@ -41,6 +41,7 @@ def _make_receipt(
     diff_summary: str | None = None,
     approval_source: str | None = None,
     timestamp: str = "2025-01-01T00:00:00Z",
+    action_envelope_json: dict[str, object] | None = None,
 ) -> GuardReceipt:
     return GuardReceipt(
         receipt_id=receipt_id or str(uuid.uuid4()),
@@ -54,6 +55,7 @@ def _make_receipt(
         diff_summary=diff_summary,
         approval_source=approval_source,
         timestamp=timestamp,
+        action_envelope_json=action_envelope_json,
     )
 
 
@@ -212,6 +214,23 @@ class TestReceiptFieldRoundtrip:
         assert len(receipts) == 1
         assert receipts[0]["diff_summary"] == "1 change(s): removed"
         assert receipts[0]["approval_source"] == "policy"
+
+    def test_action_envelope_json_roundtrip(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        envelope: dict[str, object] = {"action_type": "shell_command", "command": "ls -la"}
+        receipt = _make_receipt(
+            receipt_id="r-env-01",
+            action_envelope_json=envelope,
+        )
+        store.add_receipt(receipt)
+
+        result = store.get_receipt("r-env-01")
+        assert result is not None
+        assert result["action_envelope_json"] == envelope
+
+        receipts = store.list_receipts(harness="codex", limit=10)
+        assert len(receipts) == 1
+        assert receipts[0]["action_envelope_json"] == envelope
 
 
 class TestMapApprovalSource:


### PR DESCRIPTION
## Problem

1. The 'Set up protection' button in the Home 'Package manager protection' card routed to the Protect (/fleet) view instead of the Supply Chain view.
2. 'Trust Center' was an unclear label for end users; the route covers supply-chain/package-manager concerns.
3. Evidence rows for bash/shell commands showed only 'Bash' with subtitle 'hook artifact · codex' and the detail panel never surfaced the actual command. The data was available at receipt creation time but was not persisted in runtime_receipts, so the frontend had nothing to render.

## Changes

- Home
  - `home-protection-module.tsx`: 'Set up protection' button now uses `onOpenSupplyChain` (falls back to `onOpenFleet`).
  - `approval-center-primitives.tsx`: sidebar label changed from 'Trust Center' to 'Supply chain'.
  - `supply-chain-hub-workspace.tsx`: hub header subtitle changed from 'Trust Center' to 'Supply chain'.

- Backend
  - Added `action_envelope_json` column to `runtime_receipts` via `_ensure_runtime_receipts_column`.
  - `build_receipt()` accepts optional `action_envelope_json` and forwards it to `GuardReceipt`.
  - `GuardStore.add_receipt/list_receipts/list_receipts_since_rowid/get_receipt/get_latest_receipt` persist and return `action_envelope_json`.
  - Added `_json_object()` helper in `store_approvals.py` for safe dict parsing.
  - Hook and runtime receipt creation in `cli/commands.py` now passes the parsed action envelope.

- Frontend
  - `guard-api.ts`: `fetchReceipts()` and `fetchLatestReceipt()` normalize raw `action_envelope_json` through `parseActionEnvelope()` so the envelope is a typed object instead of a raw JSON string/dict.
  - `plain-english.ts`:
    - `resolveActionType()` detects 'Bash' artifact_name as shell command even when no envelope is present.
    - `resolveActionTitle()` falls back to 'hook event for ...' provenance when artifact_name is just a generic tool name.
    - `resolveActionSubtitle()` uses provenance when capabilities_summary is the generic 'hook artifact · codex' string.

- Tests
  - Added `test_action_envelope_json_roundtrip` in `test_guard_receipt_p5_fields.py` covering `get_receipt` and `list_receipts`.

## Verification

- Dashboard build: `pnpm run build` ✅
- Frontend tests: `pnpm test` (filtered evidence + home + scr171/172 suites) ✅
- Python receipt tests: `pytest tests/test_guard_receipt_p5_fields.py -v` ✅ (43 passed)
- Python runtime receipt tests: `pytest tests/test_guard_runtime.py -v -k receipt` ✅ (16 passed)
- Python CLI bash tests: `pytest tests/test_guard_cli.py -v -k 'bash or shell or destructive'` ✅ (1 passed)

## Note on existing data

Receipts created before this change will not retroactively gain `action_envelope_json`, so very old bash rows may still show the provenance fallback ('hook event for Bash') rather than the exact command. New receipts from Codex hook events will show the actual command/path/prompt text.