### PR TITLE
fix(guard): restore package firewall cloud connect flow

### DIFF
--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -12,6 +12,7 @@ import {
 	  parseActionEnvelope,
 	  parseDecisionV2,
 	  runPackageFirewallAction,
+	  startPackageFirewallConnect,
 	  runAuditRemediation,
 	  resolveRequestWithQueueResult,
 	  retryResume,
@@ -884,6 +885,55 @@ assert(
   firewallError instanceof GuardHarnessActionError && firewallError.payload?.error === "approval_gate_required",
   "L079db: runPackageFirewallAction preserves daemon error code for approval modal fallback"
 );
+
+installGuardWindow("?guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const connectCalls: RecordedFetch[] = [];
+globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+  const url = input instanceof Request ? input.url : String(input);
+  connectCalls.push({ url, init });
+  const path = new URL(url, "http://127.0.0.1:4174").pathname;
+  if (path === "/v1/initialize") {
+    return new Response(JSON.stringify({ auth_token: "fresh-connect-token" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+  if (path === "/v1/supply-chain/package-shims/connect") {
+    const token = headerValue(init, "X-Guard-Token");
+    if (token !== "fresh-connect-token") {
+      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
+    }
+    return new Response(JSON.stringify({
+      state: "running",
+      title: "Finish Guard Cloud sign-in in your browser",
+      detail: "HOL Guard opened the secure sign-in flow in your browser.",
+      action_label: "Connect HOL Guard Cloud",
+      connect_url: "https://hol.org/guard/connect",
+      authorize_url: "https://hol.org/mock-authorize",
+      browser_opened: true,
+      request_id: "guard-connect-1",
+      poll_after_ms: 1500
+    }), {
+      status: 202,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+  return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+};
+
+const connectFlow = await startPackageFirewallConnect();
+assert(connectCalls.length === 3, "L079dc: connect flow bootstraps token after 401 and retries");
+assert(
+  new URL(connectCalls[0].url).pathname === "/v1/supply-chain/package-shims/connect",
+  "L079dc: connect flow posts to daemon connect route"
+);
+assert(new URL(connectCalls[1].url).pathname === "/v1/initialize", "L079dc: connect flow refreshes token after unauthorized");
+assert(
+  headerValue(connectCalls[2].init, "X-Guard-Token") === "fresh-connect-token",
+  "L079dc: connect flow retries with refreshed Guard token"
+);
+assert(connectFlow?.state === "running", "L079dc: connect flow normalizes running daemon response");
+assert(connectFlow?.authorize_url === "https://hol.org/mock-authorize", "L079dc: connect flow preserves authorize URL");
 
 installGuardWindow("?guard-token=token-remediate-error&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
 globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1554,7 +1554,14 @@ function normalizePackageFirewallActions(
   if (!isRecord(value)) {
     return {};
   }
-  const allowedStates = new Set(["available", "paid_required", "reconnect_required", "pending", "disabled"]);
+  const allowedStates = new Set([
+    "available",
+    "connect_required",
+    "paid_required",
+    "reconnect_required",
+    "pending",
+    "disabled",
+  ]);
   const entries = Object.entries(value).filter(
     (entry): entry is [PackageFirewallActionType | PackageFirewallGlobalActionType, PackageFirewallActionState] =>
       typeof entry[1] === "string" && allowedStates.has(entry[1]),
@@ -1567,9 +1574,13 @@ function normalizePackageFirewallCliFallback(value: unknown): PackageFirewallCli
     return null;
   }
   const fallback: PackageFirewallCliFallback = {};
+  const connect = stringValue(value.connect);
   const install = stringValue(value.install);
   const status = stringValue(value.status);
   const remove = stringValue(value.remove);
+  if (connect !== null) {
+    fallback.connect = connect;
+  }
   if (install !== null) {
     fallback.install = install;
   }
@@ -1580,6 +1591,36 @@ function normalizePackageFirewallCliFallback(value: unknown): PackageFirewallCli
     fallback.remove = remove;
   }
   return Object.keys(fallback).length > 0 ? fallback : null;
+}
+
+function normalizePackageFirewallConnectFlow(
+  value: unknown,
+): PackageFirewallStatusResponse["connect_flow"] {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const state = value.state;
+  if (state !== "idle" && state !== "running" && state !== "failed") {
+    return null;
+  }
+  const title = stringValue(value.title);
+  const detail = stringValue(value.detail);
+  const actionLabel = stringValue(value.action_label);
+  const connectUrl = stringValue(value.connect_url);
+  if (title === null || detail === null || actionLabel === null || connectUrl === null) {
+    return null;
+  }
+  return {
+    state,
+    title,
+    detail,
+    action_label: actionLabel,
+    connect_url: connectUrl,
+    authorize_url: isStringOrNull(value.authorize_url) ? value.authorize_url : null,
+    browser_opened: value.browser_opened === true ? true : value.browser_opened === false ? false : null,
+    request_id: isStringOrNull(value.request_id) ? value.request_id : null,
+    poll_after_ms: numberValue(value.poll_after_ms),
+  };
 }
 
 function normalizePackageShimEntry(
@@ -1687,6 +1728,7 @@ function normalizePackageFirewallStatus(value: unknown): PackageFirewallStatusRe
   return {
     actions: normalizePackageFirewallActions(record.actions),
     cli_fallback: normalizePackageFirewallCliFallback(record.cli_fallback),
+    connect_flow: normalizePackageFirewallConnectFlow(record.connect_flow),
     entitlement: normalizePackageFirewallEntitlement(record.entitlement),
     operation: stringValue(record.operation) ?? "status",
     package_shims: packageShims,
@@ -1712,6 +1754,16 @@ function normalizePackageFirewallAction(value: unknown): PackageFirewallActionRe
 
 export async function fetchPackageFirewallStatus(): Promise<PackageFirewallStatusResponse> {
   return normalizePackageFirewallStatus(await readJson<unknown>("/v1/supply-chain/package-shims"));
+}
+
+export async function startPackageFirewallConnect(): Promise<PackageFirewallStatusResponse["connect_flow"]> {
+  return normalizePackageFirewallConnectFlow(
+    await readJson<unknown>("/v1/supply-chain/package-shims/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
 }
 
 export async function runPackageFirewallAction(

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -523,6 +523,7 @@ export type PackageFirewallGlobalActionType = (typeof PACKAGE_FIREWALL_GLOBAL_AC
 
 export type PackageFirewallActionState =
   | "available"
+  | "connect_required"
   | "paid_required"
   | "reconnect_required"
   | "pending"
@@ -557,9 +558,22 @@ export type PackageFirewallReceipt = {
 };
 
 export type PackageFirewallCliFallback = {
+  connect?: string;
   install?: string;
   status?: string;
   remove?: string;
+};
+
+export type PackageFirewallConnectFlow = {
+  state: "idle" | "running" | "failed";
+  title: string;
+  detail: string;
+  action_label: string;
+  connect_url: string;
+  authorize_url: string | null;
+  browser_opened: boolean | null;
+  request_id: string | null;
+  poll_after_ms: number | null;
 };
 
 export type PackageFirewallStatusResponse = {
@@ -571,6 +585,7 @@ export type PackageFirewallStatusResponse = {
   entitlement: PackageFirewallEntitlement;
   actions: Partial<Record<PackageFirewallActionType | PackageFirewallGlobalActionType, PackageFirewallActionState>>;
   cli_fallback: PackageFirewallCliFallback | null;
+  connect_flow: PackageFirewallConnectFlow | null;
 };
 
 export type PackageFirewallActionResponse = {

--- a/dashboard/src/package-firewall-connect.test.tsx
+++ b/dashboard/src/package-firewall-connect.test.tsx
@@ -1,0 +1,160 @@
+import { renderToStaticMarkup } from "react-dom/server";
+import { ConnectFlowCard, FreeUserView } from "./supply-chain-firewall-views";
+import type { PackageFirewallStatusResponse } from "./guard-types";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+Object.assign(globalThis, {
+  window: {
+    location: {
+      hash: "",
+      origin: "http://127.0.0.1:5474",
+      pathname: "/supply-chain",
+      search: "",
+    },
+    localStorage: {
+      getItem: () => null,
+      removeItem: () => undefined,
+      setItem: () => undefined,
+    },
+    sessionStorage: {
+      getItem: () => null,
+      removeItem: () => undefined,
+      setItem: () => undefined,
+    },
+  },
+});
+
+const runningMarkup = renderToStaticMarkup(
+  <ConnectFlowCard
+    connectError={null}
+    connectStarting={false}
+    connectFlow={{
+      state: "running",
+      title: "Finish Guard Cloud sign-in in your browser",
+      detail: "HOL Guard opened the secure sign-in flow in your browser.",
+      action_label: "Repair Guard Cloud access",
+      connect_url: "https://hol.org/guard/connect",
+      authorize_url: "https://hol.org/mock-authorize",
+      browser_opened: true,
+      request_id: "guard-connect-1",
+      poll_after_ms: 1500,
+    }}
+    mode="repair"
+    onStartConnect={() => undefined}
+  />,
+);
+
+assert(
+  runningMarkup.includes("Waiting for browser approval"),
+  "PF1: running connect card should show waiting button label",
+);
+assert(
+  runningMarkup.includes("Open sign-in page"),
+  "PF1: running connect card should keep manual sign-in fallback visible",
+);
+assert(
+  runningMarkup.includes("Repair required"),
+  "PF1: running reconnect card should show repair state badge",
+);
+
+const connectRequiredStatus: PackageFirewallStatusResponse = {
+  operation: "status",
+  status: "completed",
+  supported_managers: ["npm", "pnpm"],
+  protection: null,
+  package_shims: [],
+  entitlement: {
+    allowed: false,
+    reason: "guard_cloud_connect_required",
+    tier: "unknown",
+    upgrade_cta: "Connect HOL Guard Cloud to check package firewall access and run package firewall actions.",
+    upgrade_url: null,
+  },
+  actions: {
+    install: "connect_required",
+    repair: "connect_required",
+    test: "connect_required",
+    audit: "connect_required",
+    sync: "connect_required",
+    remove: "connect_required",
+  },
+  cli_fallback: {
+    connect: "hol-guard connect",
+  },
+  connect_flow: {
+    state: "idle",
+    title: "Connect HOL Guard Cloud to enable package firewall",
+    detail: "Connect HOL Guard Cloud here so the daemon can verify package-firewall access.",
+    action_label: "Connect HOL Guard Cloud",
+    connect_url: "https://hol.org/guard/connect",
+    authorize_url: null,
+    browser_opened: null,
+    request_id: null,
+    poll_after_ms: null,
+  },
+};
+
+const freeViewMarkup = renderToStaticMarkup(
+  <FreeUserView
+    connectError={null}
+    connectStarting={false}
+    data={connectRequiredStatus}
+    onStartConnect={() => undefined}
+  />,
+);
+
+assert(
+  freeViewMarkup.includes("Connect HOL Guard Cloud to enable package firewall"),
+  "PF2: connect-required free view should render connect guidance instead of upgrade copy",
+);
+assert(
+  !freeViewMarkup.includes("Upgrade to enable active protection"),
+  "PF2: connect-required free view should not render upgrade upsell",
+);
+assert(
+  freeViewMarkup.includes("Protected after connect"),
+  "PF2: connect-required free view should explain coverage after connect",
+);
+
+const upgradeRequiredStatus: PackageFirewallStatusResponse = {
+  ...connectRequiredStatus,
+  entitlement: {
+    allowed: false,
+    reason: "paid_guard_cloud_required",
+    tier: "free",
+    upgrade_cta: "Upgrade to HOL Guard Cloud to run package firewall actions.",
+    upgrade_url: "https://hol.org/guard/pricing",
+  },
+  actions: {
+    install: "paid_required",
+    repair: "paid_required",
+    test: "paid_required",
+    audit: "paid_required",
+    sync: "paid_required",
+    remove: "paid_required",
+  },
+  connect_flow: null,
+};
+
+const upgradeMarkup = renderToStaticMarkup(
+  <FreeUserView
+    connectError={null}
+    connectStarting={false}
+    data={upgradeRequiredStatus}
+    onStartConnect={() => undefined}
+  />,
+);
+
+assert(
+  upgradeMarkup.includes("Would be protected"),
+  "PF3: upgrade-required free view should keep neutral supported-manager label",
+);
+assert(
+  !upgradeMarkup.includes("Protected after connect"),
+  "PF3: upgrade-required free view should not imply connect alone unlocks protection",
+);

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -17,6 +17,7 @@ import {
   runPackageFirewallAction,
   runPackageAudit,
   runPackageSync,
+  startPackageFirewallConnect,
 } from "./guard-api";
 import { FreeUserView, ActionResultPanel, ActivationSummary } from "./supply-chain-firewall-views";
 import type { CompletedOp } from "./supply-chain-firewall-views";
@@ -271,6 +272,8 @@ export function PackageFirewallPanel(props: {
   const [pendingOp, setPendingOp] = useState<PendingOp | null>(null);
   const [lastCompleted, setLastCompleted] = useState<CompletedOp | null>(null);
   const [lastFailed, setLastFailed] = useState<FailedOp | null>(null);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [startingConnect, setStartingConnect] = useState(false);
   const [confirmRemoveManager, setConfirmRemoveManager] = useState<string | null>(null);
   const [pendingApprovalOp, setPendingApprovalOp] = useState<ApprovalOp | null>(null);
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(approvalGate);
@@ -302,6 +305,20 @@ export function PackageFirewallPanel(props: {
     }
   }, []);
 
+  useEffect(() => {
+    if (panelLoad.phase !== "loaded") {
+      return;
+    }
+    const flow = panelLoad.data.connect_flow;
+    if (flow === null || flow.state !== "running") {
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      void refreshAfterOp();
+    }, flow.poll_after_ms ?? 1500);
+    return () => window.clearTimeout(handle);
+  }, [panelLoad, refreshAfterOp]);
+
   const handleAction = useCallback(
     async (
       op: PackageFirewallActionType,
@@ -310,6 +327,7 @@ export function PackageFirewallPanel(props: {
     ) => {
       setPendingOp({ op, manager });
       setLastFailed(null);
+      setConnectError(null);
       try {
         const response = await runPackageFirewallAction(op, manager, credentials);
         setLastCompleted({ op, manager, response });
@@ -339,6 +357,7 @@ export function PackageFirewallPanel(props: {
     async (op: "audit" | "sync") => {
       setPendingOp({ op, manager: null });
       setLastFailed(null);
+      setConnectError(null);
       try {
         const response = op === "audit" ? await runPackageAudit() : await runPackageSync();
         setLastCompleted({ op, manager: null, response });
@@ -382,6 +401,21 @@ export function PackageFirewallPanel(props: {
   const handleSync = useCallback(() => void handleGlobalOp("sync"), [handleGlobalOp]);
   const handleDismissResult = useCallback(() => setLastCompleted(null), []);
   const handleRetry = useCallback(() => void load(), [load]);
+  const handleStartConnect = useCallback(async () => {
+    setStartingConnect(true);
+    setConnectError(null);
+    try {
+      await startPackageFirewallConnect();
+      await refreshAfterOp();
+      await onStateChanged?.();
+    } catch (error) {
+      setConnectError(
+        error instanceof Error ? error.message : "Unable to start Guard Cloud connect.",
+      );
+    } finally {
+      setStartingConnect(false);
+    }
+  }, [onStateChanged, refreshAfterOp]);
   const handleApprovalCancel = useCallback(() => setPendingApprovalOp(null), []);
   const handleApprovalConfirm = useCallback(
     (credentials: { approval_password?: string; approval_totp_code?: string }) => {
@@ -433,7 +467,12 @@ export function PackageFirewallPanel(props: {
             onDismissResult={handleDismissResult}
           />
         ) : (
-          <FreeUserView data={panelLoad.data} />
+          <FreeUserView
+            connectError={connectError}
+            connectStarting={startingConnect}
+            data={panelLoad.data}
+            onStartConnect={handleStartConnect}
+          />
         ))}
 
       {pendingApprovalOp !== null && (

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -6,7 +6,7 @@ import {
   HiMiniExclamationTriangle,
   HiMiniArrowPath,
 } from "react-icons/hi2";
-import { ActionButton } from "./approval-center-primitives";
+import { ActionButton, Tag } from "./approval-center-primitives";
 import type {
   PackageManagerProtection,
   PackageFirewallStatusResponse,
@@ -50,6 +50,171 @@ export function UpgradeCta({ entitlement }: UpgradeCtaProps) {
   );
 }
 
+type ConnectFlowCardProps = {
+  connectError: string | null;
+  connectStarting: boolean;
+  connectFlow: NonNullable<PackageFirewallStatusResponse["connect_flow"]>;
+  mode: "connect" | "repair";
+  onStartConnect: () => void;
+};
+
+type ConnectStepProps = {
+  body: string;
+  current: boolean;
+  done: boolean;
+  index: number;
+  title: string;
+};
+
+function ConnectStep({ body, current, done, index, title }: ConnectStepProps) {
+  const toneClass = done
+    ? "border-brand-green/20 bg-brand-green/[0.04]"
+    : current
+    ? "border-brand-blue/20 bg-brand-blue/[0.04]"
+    : "border-slate-200 bg-white/85";
+  const badgeClass = done
+    ? "bg-brand-green/10 text-brand-green"
+    : current
+    ? "bg-brand-blue/10 text-brand-blue"
+    : "bg-slate-100 text-slate-500";
+  return (
+    <div className={`rounded-[18px] border px-3.5 py-3 ${toneClass}`}>
+      <div className="flex items-start gap-3">
+        <span className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold ${badgeClass}`}>
+          {done ? <HiMiniCheckCircle className="h-3.5 w-3.5" aria-hidden="true" /> : index}
+        </span>
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-brand-dark">{title}</p>
+          <p className="mt-1 text-xs leading-relaxed text-slate-500">{body}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function resolveConnectSteps(
+  connectFlow: NonNullable<PackageFirewallStatusResponse["connect_flow"]>,
+): Array<{ body: string; current: boolean; done: boolean; title: string }> {
+  const running = connectFlow.state === "running";
+  const failed = connectFlow.state === "failed";
+  const browserOpened = connectFlow.browser_opened === true;
+  return [
+    {
+      title: "Start local connect",
+      body: failed
+        ? "Guard started the local connect flow, but it needs another attempt."
+        : "The local daemon opens a secure HOL Guard Cloud sign-in flow for this machine.",
+      done: running || failed,
+      current: !running && !failed,
+    },
+    {
+      title: "Approve in browser",
+      body: browserOpened
+        ? "Finish sign-in in the browser window Guard opened."
+        : "If your browser did not open automatically, use the manual sign-in link below.",
+      done: false,
+      current: running,
+    },
+    {
+      title: "Unlock firewall actions",
+      body: "Guard verifies package-firewall access before it changes package-manager routing.",
+      done: false,
+      current: false,
+    },
+  ];
+}
+
+export function ConnectFlowCard({
+  connectError,
+  connectStarting,
+  connectFlow,
+  mode,
+  onStartConnect,
+}: ConnectFlowCardProps) {
+  const manualHref = connectFlow.authorize_url ?? connectFlow.connect_url;
+  const running = connectFlow.state === "running";
+  const failed = connectFlow.state === "failed";
+  const primaryBusy = connectStarting || running;
+  const primaryLabel = running
+    ? "Waiting for browser approval"
+    : failed
+    ? "Try connect again"
+    : connectFlow.action_label;
+  const steps = resolveConnectSteps(connectFlow);
+  const statusTone = mode === "repair" ? "attention" : "blue";
+  const statusLabel = mode === "repair" ? "Repair required" : "Connection required";
+  const showManualLink = connectFlow.authorize_url !== null || running || failed;
+  return (
+    <div className="rounded-[24px] border border-brand-blue/20 bg-gradient-to-br from-brand-blue/[0.05] via-white to-brand-purple/[0.04] px-4 py-4 shadow-[0_18px_45px_-34px_rgba(39,80,180,0.5)]">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+          <div className="space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-brand-blue">
+                HOL Guard Cloud
+              </p>
+              <Tag tone={statusTone}>{statusLabel}</Tag>
+            </div>
+            <div className="space-y-1">
+              <p className="text-base font-semibold tracking-[-0.02em] text-brand-dark">
+                {connectFlow.title}
+              </p>
+              <p className="max-w-3xl text-sm leading-relaxed text-slate-500">
+                {connectFlow.detail}
+              </p>
+            </div>
+          </div>
+          <div className="rounded-[18px] border border-slate-200 bg-white/85 px-3.5 py-3 sm:max-w-xs">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+              Security
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-slate-600">
+              Guard does not change package-manager routing until this machine receives signed cloud access.
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-2.5 sm:grid-cols-3">
+          {steps.map((step, index) => (
+            <ConnectStep
+              key={step.title}
+              index={index + 1}
+              title={step.title}
+              body={step.body}
+              current={step.current}
+              done={step.done}
+            />
+          ))}
+        </div>
+
+        {connectError !== null && (
+          <div className="rounded-[18px] border border-brand-attention/25 bg-brand-attention/[0.05] px-3.5 py-3">
+            <p className="text-sm font-medium text-brand-dark">Guard could not start local connect</p>
+            <p className="mt-1 text-xs leading-relaxed text-slate-600">{connectError}</p>
+          </div>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <ActionButton variant="primary" onClick={onStartConnect} disabled={primaryBusy}>
+            {primaryBusy ? (
+              <HiMiniArrowPath className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <HiMiniShieldCheck className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+            )}
+            {primaryLabel}
+          </ActionButton>
+          {showManualLink && (
+            <ActionButton href={manualHref} variant="outline">
+              Open sign-in page
+              <HiMiniArrowTopRightOnSquare className="ml-1.5 h-3.5 w-3.5" aria-hidden="true" />
+            </ActionButton>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 type CliFallbackProps = {
   commands: NonNullable<PackageFirewallStatusResponse["cli_fallback"]>;
 };
@@ -57,11 +222,11 @@ type CliFallbackProps = {
 export function CliFallback({ commands }: CliFallbackProps) {
   const items = Object.entries(commands);
   return (
-    <div className="rounded-xl border border-slate-200 bg-slate-50 px-4 py-3">
-      <p className="mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
+    <details className="rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3">
+      <summary className="cursor-pointer list-none text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
         CLI fallback
-      </p>
-      <div className="space-y-1.5">
+      </summary>
+      <div className="mt-3 space-y-1.5">
         {items.map(([label, command]) => (
           <div key={label} className="min-w-0">
             <span className="mr-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
@@ -71,21 +236,44 @@ export function CliFallback({ commands }: CliFallbackProps) {
           </div>
         ))}
       </div>
-    </div>
+    </details>
   );
 }
 
 type FreeUserViewProps = {
+  connectError: string | null;
+  connectStarting: boolean;
   data: PackageFirewallStatusResponse;
+  onStartConnect: () => void;
 };
 
-export function FreeUserView({ data }: FreeUserViewProps) {
+export function FreeUserView({
+  connectError,
+  connectStarting,
+  data,
+  onStartConnect,
+}: FreeUserViewProps) {
+  const connectRequired =
+    data.entitlement.reason === "guard_cloud_connect_required" ||
+    data.entitlement.reason === "guard_cloud_reconnect_required";
+  const connectMode = data.entitlement.reason === "guard_cloud_reconnect_required" ? "repair" : "connect";
+  const supportedManagersLabel = connectRequired ? "Protected after connect" : "Would be protected";
   return (
     <div className="space-y-4 px-4 py-4">
-      <UpgradeCta entitlement={data.entitlement} />
+      {connectRequired && data.connect_flow !== null ? (
+        <ConnectFlowCard
+          connectError={connectError}
+          connectStarting={connectStarting}
+          connectFlow={data.connect_flow}
+          mode={connectMode}
+          onStartConnect={onStartConnect}
+        />
+      ) : (
+        <UpgradeCta entitlement={data.entitlement} />
+      )}
       <div>
         <p className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-400">
-          Would be protected
+          {supportedManagersLabel}
         </p>
         {data.supported_managers.length === 0 ? (
           <p className="text-xs text-slate-500">No supported managers detected on this machine.</p>

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1158,6 +1158,8 @@ def _package_firewall_action_states(entitlement: dict[str, object]) -> dict[str,
     reason = str(entitlement.get("reason") or "").strip().lower()
     if allowed:
         state = "available"
+    elif reason == "guard_cloud_connect_required":
+        state = "connect_required"
     elif reason == "guard_cloud_reconnect_required":
         state = "reconnect_required"
     else:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -53,6 +53,13 @@ from ..approvals import (
     apply_approval_resolution,
     build_runtime_snapshot,
 )
+from ..cli.connect_flow import (
+    _build_sync_auth_context,
+    exchange_guard_authorization_code,
+    resolve_connect_url,
+    resolve_guard_oauth_client_config,
+    start_guard_browser_session,
+)
 from ..cli.install_commands import (
     apply_managed_install,
     build_harness_setup_plan,
@@ -120,7 +127,9 @@ from .manager import (
 _HEADLESS_CLOUD_SYNC_STATE_LOCK = threading.Lock()
 _HEADLESS_CLOUD_SYNC_IN_FLIGHT: set[str] = set()
 _AUDIT_REMEDIATION_ACTIONS = {"package_shim_path"}
-_SUPPLY_CHAIN_PACKAGE_ACTIONS = {"install", "repair", "test", "audit", "sync", "remove", "uninstall"}
+_SUPPLY_CHAIN_PACKAGE_ACTIONS = {"install", "repair", "test", "audit", "sync", "remove", "uninstall", "connect"}
+_SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS = 1_500
+_SUPPLY_CHAIN_CONNECT_WAIT_TIMEOUT_SECONDS = 180
 
 
 class _HookPathValidationError(ValueError):
@@ -157,6 +166,8 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     start_monotonic: float
     active_stream_clients: int
     active_stream_clients_lock: threading.Lock
+    package_firewall_connect_state: dict[str, object] | None
+    package_firewall_connect_state_lock: threading.Lock
 
 
 _STATIC_DIR = Path(__file__).with_name("static")
@@ -449,6 +460,253 @@ def _maybe_queue_first_cloud_sync(*, store: GuardStore) -> dict[str, object] | N
     if str(latest_state.get("milestone") or "") != "first_sync_pending":
         return None
     return _queue_headless_cloud_sync(store=store)
+
+
+def _package_firewall_connect_url(store: GuardStore) -> str:
+    profile = store.get_cloud_sync_profile()
+    sync_url = profile.get("sync_url") if isinstance(profile, dict) else None
+    if isinstance(sync_url, str) and sync_url.strip():
+        parsed = urlparse(sync_url)
+        if parsed.scheme and parsed.netloc:
+            return f"{parsed.scheme}://{parsed.netloc}/guard/connect"
+    return "https://hol.org/guard/connect"
+
+
+def _package_firewall_connect_action_label(reason: str) -> str:
+    if reason == "guard_cloud_reconnect_required":
+        return "Repair Guard Cloud access"
+    return "Connect HOL Guard Cloud"
+
+
+def _copy_package_firewall_connect_state(server: _GuardDaemonHttpServer) -> dict[str, object] | None:
+    with server.package_firewall_connect_state_lock:
+        current = server.package_firewall_connect_state
+        return dict(current) if isinstance(current, dict) else None
+
+
+def _set_package_firewall_connect_state(server: _GuardDaemonHttpServer, state: dict[str, object] | None) -> None:
+    with server.package_firewall_connect_state_lock:
+        server.package_firewall_connect_state = dict(state) if isinstance(state, dict) else None
+
+
+def _default_package_firewall_connect_flow(
+    *,
+    store: GuardStore,
+    reason: str,
+) -> dict[str, object]:
+    connect_url = _package_firewall_connect_url(store)
+    action_label = _package_firewall_connect_action_label(reason)
+    if reason == "guard_cloud_reconnect_required":
+        title = "Repair Guard Cloud access to restore package firewall"
+        detail = (
+            "Guard has package-firewall coverage on your plan, but local cloud authorization on this machine is not "
+            "healthy. Repair it here and Guard will unlock the firewall again."
+        )
+    else:
+        title = "Connect HOL Guard Cloud to enable package firewall"
+        detail = (
+            "Guard keeps this machine protected locally. Connect HOL Guard Cloud here so the daemon can verify "
+            "package-firewall access before it changes package-manager routing."
+        )
+    return {
+        "state": "idle",
+        "title": title,
+        "detail": detail,
+        "action_label": action_label,
+        "connect_url": connect_url,
+        "authorize_url": None,
+        "browser_opened": None,
+        "request_id": None,
+        "poll_after_ms": None,
+    }
+
+
+def _resolve_package_firewall_connect_flow(
+    *,
+    server: _GuardDaemonHttpServer,
+    entitlement: dict[str, object],
+) -> dict[str, object] | None:
+    reason = str(entitlement.get("reason") or "").strip().lower()
+    if reason not in {"guard_cloud_connect_required", "guard_cloud_reconnect_required"}:
+        return None
+    current = _copy_package_firewall_connect_state(server)
+    if current is None:
+        return _default_package_firewall_connect_flow(store=server.store, reason=reason)
+    state = str(current.get("state") or "idle")
+    flow = {
+        **_default_package_firewall_connect_flow(store=server.store, reason=reason),
+        **current,
+    }
+    if state == "running":
+        flow["title"] = "Finish Guard Cloud sign-in in your browser"
+        browser_opened = flow.get("browser_opened") is True
+        flow["detail"] = (
+            "HOL Guard opened the secure sign-in flow in your browser. Finish sign-in there and this page will "
+            "unlock package-firewall controls automatically."
+            if browser_opened
+            else (
+                "HOL Guard is waiting for browser approval. Open the sign-in page below if your browser did "
+                "not open automatically."
+            )
+        )
+        flow["poll_after_ms"] = _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS
+        return flow
+    if state == "failed":
+        flow["title"] = "Guard Cloud sign-in needs attention"
+        flow["poll_after_ms"] = None
+        return flow
+    return flow
+
+
+def _package_firewall_available_actions(entitlement: dict[str, object]) -> list[str]:
+    reason = str(entitlement.get("reason") or "").strip().lower()
+    actions = ["status"]
+    if reason in {"guard_cloud_connect_required", "guard_cloud_reconnect_required"}:
+        actions.append("connect")
+    actions.extend(["education", "cli_fallback"])
+    return actions
+
+
+def _finalize_daemon_guard_connect_payload(
+    *,
+    store: GuardStore,
+    connect_url: str,
+    payload: dict[str, object],
+    now: str,
+) -> dict[str, object]:
+    sync_auth_context = payload.pop("_guard_sync_auth_context", None)
+    normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
+    sync_url = f"{allowed_origin}/api/guard/receipts/sync"
+    dashboard_url = f"{allowed_origin}/guard"
+    payload.setdefault("connect_url", normalized_connect_url)
+    payload.setdefault("sync_url", sync_url)
+    payload.setdefault("dashboard_url", dashboard_url)
+    payload.setdefault("inbox_url", f"{dashboard_url}/inbox")
+    payload.setdefault("fleet_url", f"{dashboard_url}/fleet")
+    if str(payload.get("status") or "") != "connected":
+        return payload
+    store.clear_cloud_sync_state_for_reconnect()
+    latest_state = store.record_guard_connect_pairing_completed(
+        sync_url=sync_url,
+        allowed_origin=allowed_origin,
+        now=now,
+    )
+    payload.update(
+        {
+            "status": str(latest_state.get("status") or payload.get("status") or "connected"),
+            "milestone": str(latest_state.get("milestone") or "first_sync_pending"),
+            "completed_at": latest_state.get("completed_at") or now,
+            "latest_connect_state": latest_state,
+        }
+    )
+    oauth_health = store.get_oauth_local_credential_health()
+    if str(oauth_health.get("state") or "") == "degraded":
+        repair_message = (
+            "Guard Cloud authorization did not persist locally. "
+            "Start Guard Cloud connect again to repair local sign-in."
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now=now,
+            reason=repair_message,
+        )
+        payload.update(
+            {
+                "status": "retry_required",
+                "milestone": "first_sync_failed",
+                "sync_succeeded": False,
+                "sync_error": repair_message,
+                "repair_message": repair_message,
+                "latest_connect_state": store.get_effective_guard_connect_state(now=now),
+            }
+        )
+        return payload
+    if store.get_cloud_sync_profile() is None:
+        payload["sync_attempted"] = False
+        return payload
+    payload["sync_attempted"] = True
+    try:
+        if isinstance(sync_auth_context, dict):
+            sync_payload = sync_local_guard_cloud_proof(store, auth_context=sync_auth_context)
+        else:
+            sync_payload = sync_local_guard_cloud_proof(store)
+    except GuardSyncNotAvailableError as error:
+        store.record_latest_guard_connect_sync_result(
+            status="connected",
+            milestone="sync_not_available",
+            now=now,
+            reason=str(error),
+        )
+        payload.update(
+            {
+                "milestone": "sync_not_available",
+                "sync_succeeded": False,
+                "sync_error": str(error),
+                "repair_message": str(error),
+                "latest_connect_state": store.get_latest_guard_connect_state(now=now),
+            }
+        )
+        return payload
+    except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
+        store.record_latest_guard_connect_sync_result(
+            status="retry_required",
+            milestone="first_sync_failed",
+            now=now,
+            reason=str(error),
+        )
+        payload.update(
+            {
+                "status": "retry_required",
+                "milestone": "first_sync_failed",
+                "sync_succeeded": False,
+                "sync_error": str(error),
+                "repair_message": "Run Guard Cloud connect again to refresh local authorization.",
+                "latest_connect_state": store.get_latest_guard_connect_state(now=now),
+            }
+        )
+        return payload
+    except RuntimeError as error:
+        repair_message = (
+            "Guard Cloud pairing finished, but the first proof sync is still pending. Local Guard will retry while "
+            "the daemon is running."
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="connected",
+            milestone="first_sync_pending",
+            now=now,
+            reason=str(error),
+        )
+        payload.update(
+            {
+                "status": "connected",
+                "milestone": "first_sync_pending",
+                "sync_succeeded": False,
+                "sync_error": str(error),
+                "repair_message": repair_message,
+                "latest_connect_state": store.get_latest_guard_connect_state(now=now),
+            }
+        )
+        return payload
+    latest_state = store.record_latest_guard_connect_sync_success(
+        sync_payload=sync_payload,
+        now=str(sync_payload.get("synced_at") or now),
+    )
+    payload.update(
+        {
+            "status": "connected",
+            "milestone": "first_sync_succeeded",
+            "sync_succeeded": True,
+            "sync": sync_payload,
+            "last_sync_at": sync_payload.get("synced_at"),
+            "latest_connect_state": latest_state or store.get_latest_guard_connect_state(now=now),
+        }
+    )
+    try:
+        payload["supply_chain"] = sync_supply_chain_bundle(store)
+    except (GuardSyncNotConfiguredError, GuardSyncNotAvailableError, RuntimeError) as error:
+        payload["supply_chain_error"] = str(error)
+    return payload
 
 
 class _GuardDaemonHandler(BaseHTTPRequestHandler):
@@ -1042,9 +1300,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     },
                 },
                 "package_firewall_api": {
-                    "operations": ["status", "install", "repair", "test", "audit", "sync", "remove"],
+                    "operations": ["status", "connect", "install", "repair", "test", "audit", "sync", "remove"],
                     "routes": {
                         "audit": "/v1/supply-chain/audit",
+                        "connect": "/v1/supply-chain/package-shims/connect",
                         "install": "/v1/supply-chain/package-shims/install",
                         "remove": "/v1/supply-chain/package-shims/remove",
                         "repair": "/v1/supply-chain/package-shims/repair",
@@ -1335,7 +1594,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             status, error_code, message = package_firewall_block_details(entitlement)
             self._write_json(
                 {
-                    "available_actions": ["status", "education", "cli_fallback"],
+                    "available_actions": _package_firewall_available_actions(entitlement),
                     "entitlement": entitlement,
                     "error": error_code,
                     "message": message,
@@ -1387,10 +1646,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             {
                 "actions": self._supply_chain_action_states(entitlement),
                 "cli_fallback": {
+                    "connect": "hol-guard connect",
                     "install": "hol-guard package-shims install --json",
                     "status": "hol-guard package-shims status --json",
                     "remove": "hol-guard package-shims uninstall --json",
                 },
+                "connect_flow": self._supply_chain_connect_flow(entitlement),
                 "entitlement": entitlement,
                 "operation": "status",
                 "status": "completed",
@@ -1400,13 +1661,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         )
 
     def _handle_supply_chain_package_firewall_action(self, action: str, payload: dict[str, object]) -> None:
+        if action == "connect":
+            self._handle_supply_chain_package_firewall_connect()
+            return
         operation = "remove" if action == "uninstall" else action
         entitlement = self._supply_chain_entitlement()
         if not bool(entitlement["allowed"]):
             status, error_code, message = package_firewall_block_details(entitlement)
             self._write_json(
                 {
-                    "available_actions": ["status", "education", "cli_fallback"],
+                    "available_actions": _package_firewall_available_actions(entitlement),
                     "entitlement": entitlement,
                     "error": error_code,
                     "message": message,
@@ -1516,6 +1780,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         reason = str(entitlement.get("reason") or "").strip().lower()
         if allowed:
             state = "available"
+        elif reason == "guard_cloud_connect_required":
+            state = "connect_required"
         elif reason == "guard_cloud_reconnect_required":
             state = "reconnect_required"
         else:
@@ -1528,6 +1794,183 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "sync": state,
             "remove": state,
         }
+
+    def _supply_chain_connect_flow(self, entitlement: dict[str, object]) -> dict[str, object] | None:
+        return _resolve_package_firewall_connect_flow(server=self.server, entitlement=entitlement)  # type: ignore[arg-type]
+
+    def _handle_supply_chain_package_firewall_connect(self) -> None:
+        entitlement = self._supply_chain_entitlement()
+        reason = str(entitlement.get("reason") or "").strip().lower()
+        if reason not in {"guard_cloud_connect_required", "guard_cloud_reconnect_required"}:
+            self._write_json(
+                {
+                    "error": "guard_cloud_connect_not_required",
+                    "entitlement": entitlement,
+                    "message": "Guard Cloud connect is not required for package firewall on this machine.",
+                },
+                status=409,
+            )
+            return
+        current = _copy_package_firewall_connect_state(self.server)  # type: ignore[arg-type]
+        if isinstance(current, dict) and str(current.get("state") or "") == "running":
+            self._write_json(current, status=202)
+            return
+        store = self.server.store  # type: ignore[attr-defined]
+        connect_url = _package_firewall_connect_url(store)
+        action_label = _package_firewall_connect_action_label(reason)
+        try:
+            device = store.get_device_metadata()
+            session = start_guard_browser_session(
+                connect_url=connect_url,
+                machine_id=str(device["installation_id"]),
+                machine_label=str(device["device_label"]),
+            )
+            browser_opened = bool(webbrowser.open(session.authorize_url))
+        except Exception as error:
+            failure = {
+                **_default_package_firewall_connect_flow(store=store, reason=reason),
+                "state": "failed",
+                "detail": str(error),
+                "browser_opened": False,
+                "poll_after_ms": None,
+            }
+            _set_package_firewall_connect_state(self.server, failure)  # type: ignore[arg-type]
+            self._write_json(failure, status=500)
+            return
+
+        request_id = f"guard-connect-{uuid.uuid4().hex}"
+        running_state = {
+            **_default_package_firewall_connect_flow(store=store, reason=reason),
+            "state": "running",
+            "title": "Finish Guard Cloud sign-in in your browser",
+            "detail": (
+                "HOL Guard opened the secure sign-in flow in your browser. Finish sign-in there and this page will "
+                "unlock package-firewall controls automatically."
+                if browser_opened
+                else (
+                    "HOL Guard is waiting for browser approval. Open the sign-in page below if your browser did "
+                    "not open automatically."
+                )
+            ),
+            "action_label": action_label,
+            "authorize_url": session.authorize_url,
+            "browser_opened": browser_opened,
+            "request_id": request_id,
+            "poll_after_ms": _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS,
+        }
+        _set_package_firewall_connect_state(self.server, running_state)  # type: ignore[arg-type]
+
+        def _complete_connect() -> None:
+            try:
+                _, allowed_origin = resolve_connect_url(connect_url)
+                oauth_client = resolve_guard_oauth_client_config(allowed_origin)
+                callback = session.wait_for_callback(_SUPPLY_CHAIN_CONNECT_WAIT_TIMEOUT_SECONDS)
+                token_result = exchange_guard_authorization_code(
+                    token_endpoint=oauth_client.token_endpoint,
+                    client_id=oauth_client.client_id,
+                    code=callback.code,
+                    redirect_uri=session.redirect_uri,
+                    code_verifier=session.pkce_verifier,
+                    dpop_key_material=session.dpop_key_material,
+                )
+                if token_result.refresh_token is None:
+                    raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
+                timestamp = _now()
+                store.set_oauth_local_credentials(
+                    issuer=oauth_client.issuer,
+                    client_id=oauth_client.client_id,
+                    refresh_token=token_result.refresh_token,
+                    dpop_private_key_pem=session.dpop_key_material.private_key_pem,
+                    dpop_public_jwk=session.dpop_key_material.public_jwk,
+                    dpop_public_jwk_thumbprint=session.dpop_key_material.public_jwk_thumbprint,
+                    grant_id=token_result.grant_id,
+                    machine_id=token_result.machine_id,
+                    supply_chain_entitlement_expires_at=(
+                        str(token_result.supply_chain_entitlement.get("supply_chain_entitlement_expires_at"))
+                        if isinstance(token_result.supply_chain_entitlement, dict)
+                        and isinstance(
+                            token_result.supply_chain_entitlement.get("supply_chain_entitlement_expires_at"),
+                            str,
+                        )
+                        else None
+                    ),
+                    supply_chain_firewall=(
+                        bool(token_result.supply_chain_entitlement.get("supply_chain_firewall"))
+                        if isinstance(token_result.supply_chain_entitlement, dict)
+                        and isinstance(token_result.supply_chain_entitlement.get("supply_chain_firewall"), bool)
+                        else None
+                    ),
+                    supply_chain_plan_id=(
+                        str(token_result.supply_chain_entitlement.get("supply_chain_plan_id"))
+                        if isinstance(token_result.supply_chain_entitlement, dict)
+                        and isinstance(token_result.supply_chain_entitlement.get("supply_chain_plan_id"), str)
+                        else None
+                    ),
+                    workspace_id=token_result.workspace_id,
+                    runtime_id="hol-guard",
+                    runtime_label="HOL Guard CLI",
+                    now=timestamp,
+                )
+                payload = _finalize_daemon_guard_connect_payload(
+                    store=store,
+                    connect_url=connect_url,
+                    payload={
+                        "status": "connected",
+                        "connect_mode": "browser_oauth",
+                        "browser_opened": browser_opened,
+                        "authorize_url": session.authorize_url,
+                        "redirect_uri": session.redirect_uri,
+                        "grant_id": token_result.grant_id,
+                        "machine_id": token_result.machine_id,
+                        "workspace_id": token_result.workspace_id,
+                        "connect_url": connect_url,
+                        "sync_url": f"{allowed_origin}/api/guard/receipts/sync",
+                        "_guard_sync_auth_context": _build_sync_auth_context(
+                            access_token=token_result.access_token,
+                            dpop_key_material=session.dpop_key_material,
+                            sync_url=f"{allowed_origin}/api/guard/receipts/sync",
+                        ),
+                    },
+                    now=timestamp,
+                )
+                resolved_entitlement = resolve_package_firewall_entitlement_with_refresh(store)
+                resolved_reason = str(resolved_entitlement.get("reason") or "")
+                if bool(resolved_entitlement.get("allowed")) or resolved_reason == "paid_guard_cloud_required":
+                    _set_package_firewall_connect_state(self.server, None)  # type: ignore[arg-type]
+                    return
+                repair_message = str(
+                    payload.get("repair_message") or payload.get("sync_error") or "Guard Cloud connect did not finish."
+                )
+                _set_package_firewall_connect_state(  # type: ignore[arg-type]
+                    self.server,
+                    {
+                        **running_state,
+                        "state": "failed",
+                        "title": "Guard Cloud sign-in needs attention",
+                        "detail": repair_message,
+                        "poll_after_ms": None,
+                    },
+                )
+            except Exception as error:
+                _set_package_firewall_connect_state(  # type: ignore[arg-type]
+                    self.server,
+                    {
+                        **running_state,
+                        "state": "failed",
+                        "title": "Guard Cloud sign-in needs attention",
+                        "detail": str(error),
+                        "poll_after_ms": None,
+                    },
+                )
+            finally:
+                session.close()
+
+        threading.Thread(
+            target=_complete_connect,
+            daemon=True,
+            name="guard-package-firewall-connect",
+        ).start()
+        self._write_json(running_state, status=202)
 
     @staticmethod
     def _policy_memory_payload(value: object) -> dict[str, object]:
@@ -3217,6 +3660,8 @@ class GuardDaemonServer:
         self._server.start_monotonic = time.monotonic()
         self._server.active_stream_clients = 0
         self._server.active_stream_clients_lock = threading.Lock()
+        self._server.package_firewall_connect_state = None
+        self._server.package_firewall_connect_state_lock = threading.Lock()
         self.port = int(self._server.server_address[1])
         self._bundle_refresh_backoff_seconds = bundle_refresh_backoff_seconds
         self._bundle_refresh_interval_seconds = bundle_refresh_interval_seconds

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -1,4 +1,4 @@
-import { r as reactExports, ap as runAuditRemediation, a9 as GuardHarnessActionError, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, b as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
+import { r as reactExports, aq as runAuditRemediation, a9 as GuardHarnessActionError, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, b as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
 import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 function deriveFrontendAuditResults(receipts, snapshot) {
   const results = [];

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, A as ActionButton, S as SectionLabel, b as HiMiniExclamationTriangle, ab as HiMiniArrowPath, g as HiMiniCheckCircle, aq as HiMiniSignal, h as HiMiniXCircle, ar as HiMiniClock, f as formatRelativeTime, B as Badge, T as Tag } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, A as ActionButton, S as SectionLabel, b as HiMiniExclamationTriangle, ab as HiMiniArrowPath, g as HiMiniCheckCircle, ar as HiMiniSignal, h as HiMiniXCircle, as as HiMiniClock, f as formatRelativeTime, B as Badge, T as Tag } from "../guard-dashboard.js";
 function resolveFeedSourceMode(cloudState) {
   if (cloudState === "local_only") return "sample";
   if (cloudState === "paired_waiting") return "full";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, g as HiMiniCheckCircle, ab as HiMiniArrowPath, b as HiMiniExclamationTriangle, H as HiMiniShieldCheck, A as ActionButton, ai as HiMiniArrowTopRightOnSquare, h as HiMiniXCircle, r as reactExports, T as Tag, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, S as SectionLabel, E as EmptyState, ao as HiMiniBugAnt, a as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, g as HiMiniCheckCircle, ab as HiMiniArrowPath, b as HiMiniExclamationTriangle, T as Tag, A as ActionButton, H as HiMiniShieldCheck, ai as HiMiniArrowTopRightOnSquare, h as HiMiniXCircle, r as reactExports, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, ao as startPackageFirewallConnect, S as SectionLabel, E as EmptyState, ap as HiMiniBugAnt, a as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
 import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 import { b as resolvePackageManagerProtectionCopy } from "./runtime-overview.js";
 function UpgradeCta({ entitlement }) {
@@ -24,21 +24,134 @@ function UpgradeCta({ entitlement }) {
     ] })
   ] });
 }
+function ConnectStep({ body, current, done, index, title }) {
+  const toneClass = done ? "border-brand-green/20 bg-brand-green/[0.04]" : current ? "border-brand-blue/20 bg-brand-blue/[0.04]" : "border-slate-200 bg-white/85";
+  const badgeClass = done ? "bg-brand-green/10 text-brand-green" : current ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-100 text-slate-500";
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `rounded-[18px] border px-3.5 py-3 ${toneClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold ${badgeClass}`, children: done ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : index }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: title }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-500", children: body })
+    ] })
+  ] }) });
+}
+function resolveConnectSteps(connectFlow) {
+  const running = connectFlow.state === "running";
+  const failed = connectFlow.state === "failed";
+  const browserOpened = connectFlow.browser_opened === true;
+  return [
+    {
+      title: "Start local connect",
+      body: failed ? "Guard started the local connect flow, but it needs another attempt." : "The local daemon opens a secure HOL Guard Cloud sign-in flow for this machine.",
+      done: running || failed,
+      current: !running && !failed
+    },
+    {
+      title: "Approve in browser",
+      body: browserOpened ? "Finish sign-in in the browser window Guard opened." : "If your browser did not open automatically, use the manual sign-in link below.",
+      done: false,
+      current: running
+    },
+    {
+      title: "Unlock firewall actions",
+      body: "Guard verifies package-firewall access before it changes package-manager routing.",
+      done: false,
+      current: false
+    }
+  ];
+}
+function ConnectFlowCard({
+  connectError,
+  connectStarting,
+  connectFlow,
+  mode,
+  onStartConnect
+}) {
+  const manualHref = connectFlow.authorize_url ?? connectFlow.connect_url;
+  const running = connectFlow.state === "running";
+  const failed = connectFlow.state === "failed";
+  const primaryBusy = connectStarting || running;
+  const primaryLabel = running ? "Waiting for browser approval" : failed ? "Try connect again" : connectFlow.action_label;
+  const steps = resolveConnectSteps(connectFlow);
+  const statusTone = mode === "repair" ? "attention" : "blue";
+  const statusLabel = mode === "repair" ? "Repair required" : "Connection required";
+  const showManualLink = connectFlow.authorize_url !== null || running || failed;
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-[24px] border border-brand-blue/20 bg-gradient-to-br from-brand-blue/[0.05] via-white to-brand-purple/[0.04] px-4 py-4 shadow-[0_18px_45px_-34px_rgba(39,80,180,0.5)]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-brand-blue", children: "HOL Guard Cloud" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: statusTone, children: statusLabel })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-base font-semibold tracking-[-0.02em] text-brand-dark", children: connectFlow.title }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "max-w-3xl text-sm leading-relaxed text-slate-500", children: connectFlow.detail })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[18px] border border-slate-200 bg-white/85 px-3.5 py-3 sm:max-w-xs", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.14em] text-slate-400", children: "Security" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: "Guard does not change package-manager routing until this machine receives signed cloud access." })
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2.5 sm:grid-cols-3", children: steps.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ConnectStep,
+      {
+        index: index + 1,
+        title: step.title,
+        body: step.body,
+        current: step.current,
+        done: step.done
+      },
+      step.title
+    )) }),
+    connectError !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[18px] border border-brand-attention/25 bg-brand-attention/[0.05] px-3.5 py-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Guard could not start local connect" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: connectError })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "primary", onClick: onStartConnect, disabled: primaryBusy, children: [
+        primaryBusy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mr-1.5 h-3.5 w-3.5 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mr-1.5 h-3.5 w-3.5", "aria-hidden": "true" }),
+        primaryLabel
+      ] }),
+      showManualLink && /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: manualHref, variant: "outline", children: [
+        "Open sign-in page",
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "ml-1.5 h-3.5 w-3.5", "aria-hidden": "true" })
+      ] })
+    ] })
+  ] }) });
+}
 function CliFallback({ commands }) {
   const items = Object.entries(commands);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-200 bg-slate-50 px-4 py-3", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-1.5 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400", children: "CLI fallback" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-1.5", children: items.map(([label, command]) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer list-none text-xs font-semibold uppercase tracking-[0.18em] text-slate-400", children: "CLI fallback" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 space-y-1.5", children: items.map(([label, command]) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mr-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400", children: label }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "break-all font-mono text-xs text-brand-dark", children: command })
     ] }, label)) })
   ] });
 }
-function FreeUserView({ data }) {
+function FreeUserView({
+  connectError,
+  connectStarting,
+  data,
+  onStartConnect
+}) {
+  const connectRequired = data.entitlement.reason === "guard_cloud_connect_required" || data.entitlement.reason === "guard_cloud_reconnect_required";
+  const connectMode = data.entitlement.reason === "guard_cloud_reconnect_required" ? "repair" : "connect";
+  const supportedManagersLabel = connectRequired ? "Protected after connect" : "Would be protected";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-4 py-4", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(UpgradeCta, { entitlement: data.entitlement }),
+    connectRequired && data.connect_flow !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ConnectFlowCard,
+      {
+        connectError,
+        connectStarting,
+        connectFlow: data.connect_flow,
+        mode: connectMode,
+        onStartConnect
+      }
+    ) : /* @__PURE__ */ jsxRuntimeExports.jsx(UpgradeCta, { entitlement: data.entitlement }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-400", children: "Would be protected" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-400", children: supportedManagersLabel }),
       data.supported_managers.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "No supported managers detected on this machine." }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap gap-1.5", children: data.supported_managers.map((mgr) => /* @__PURE__ */ jsxRuntimeExports.jsx(
         "span",
         {
@@ -506,6 +619,8 @@ function PackageFirewallPanel(props) {
   const [pendingOp, setPendingOp] = reactExports.useState(null);
   const [lastCompleted, setLastCompleted] = reactExports.useState(null);
   const [lastFailed, setLastFailed] = reactExports.useState(null);
+  const [connectError, setConnectError] = reactExports.useState(null);
+  const [startingConnect, setStartingConnect] = reactExports.useState(false);
   const [confirmRemoveManager, setConfirmRemoveManager] = reactExports.useState(null);
   const [pendingApprovalOp, setPendingApprovalOp] = reactExports.useState(null);
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(approvalGate);
@@ -531,10 +646,24 @@ function PackageFirewallPanel(props) {
       setPanelLoad({ phase: "error", message });
     }
   }, []);
+  reactExports.useEffect(() => {
+    if (panelLoad.phase !== "loaded") {
+      return;
+    }
+    const flow = panelLoad.data.connect_flow;
+    if (flow === null || flow.state !== "running") {
+      return;
+    }
+    const handle = window.setTimeout(() => {
+      void refreshAfterOp();
+    }, flow.poll_after_ms ?? 1500);
+    return () => window.clearTimeout(handle);
+  }, [panelLoad, refreshAfterOp]);
   const handleAction = reactExports.useCallback(
     async (op, manager, credentials) => {
       setPendingOp({ op, manager });
       setLastFailed(null);
+      setConnectError(null);
       try {
         const response = await runPackageFirewallAction(op, manager, credentials);
         setLastCompleted({ op, manager, response });
@@ -558,6 +687,7 @@ function PackageFirewallPanel(props) {
     async (op) => {
       setPendingOp({ op, manager: null });
       setLastFailed(null);
+      setConnectError(null);
       try {
         const response = op === "audit" ? await runPackageAudit() : await runPackageSync();
         setLastCompleted({ op, manager: null, response });
@@ -600,6 +730,21 @@ function PackageFirewallPanel(props) {
   const handleSync = reactExports.useCallback(() => void handleGlobalOp("sync"), [handleGlobalOp]);
   const handleDismissResult = reactExports.useCallback(() => setLastCompleted(null), []);
   const handleRetry = reactExports.useCallback(() => void load(), [load]);
+  const handleStartConnect = reactExports.useCallback(async () => {
+    setStartingConnect(true);
+    setConnectError(null);
+    try {
+      await startPackageFirewallConnect();
+      await refreshAfterOp();
+      await onStateChanged?.();
+    } catch (error) {
+      setConnectError(
+        error instanceof Error ? error.message : "Unable to start Guard Cloud connect."
+      );
+    } finally {
+      setStartingConnect(false);
+    }
+  }, [onStateChanged, refreshAfterOp]);
   const handleApprovalCancel = reactExports.useCallback(() => setPendingApprovalOp(null), []);
   const handleApprovalConfirm = reactExports.useCallback(
     (credentials) => {
@@ -639,7 +784,15 @@ function PackageFirewallPanel(props) {
         onSync: handleSync,
         onDismissResult: handleDismissResult
       }
-    ) : /* @__PURE__ */ jsxRuntimeExports.jsx(FreeUserView, { data: panelLoad.data })),
+    ) : /* @__PURE__ */ jsxRuntimeExports.jsx(
+      FreeUserView,
+      {
+        connectError,
+        connectStarting: startingConnect,
+        data: panelLoad.data,
+        onStartConnect: handleStartConnect
+      }
+    )),
     pendingApprovalOp !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(
       ApprovalProofModal,
       {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13824,7 +13824,14 @@ function normalizePackageFirewallActions(value) {
   if (!isRecord(value)) {
     return {};
   }
-  const allowedStates = /* @__PURE__ */ new Set(["available", "paid_required", "reconnect_required", "pending", "disabled"]);
+  const allowedStates = /* @__PURE__ */ new Set([
+    "available",
+    "connect_required",
+    "paid_required",
+    "reconnect_required",
+    "pending",
+    "disabled"
+  ]);
   const entries = Object.entries(value).filter(
     (entry) => typeof entry[1] === "string" && allowedStates.has(entry[1])
   );
@@ -13835,9 +13842,13 @@ function normalizePackageFirewallCliFallback(value) {
     return null;
   }
   const fallback = {};
+  const connect = stringValue(value.connect);
   const install = stringValue(value.install);
   const status = stringValue(value.status);
   const remove = stringValue(value.remove);
+  if (connect !== null) {
+    fallback.connect = connect;
+  }
   if (install !== null) {
     fallback.install = install;
   }
@@ -13848,6 +13859,33 @@ function normalizePackageFirewallCliFallback(value) {
     fallback.remove = remove;
   }
   return Object.keys(fallback).length > 0 ? fallback : null;
+}
+function normalizePackageFirewallConnectFlow(value) {
+  if (!isRecord(value)) {
+    return null;
+  }
+  const state = value.state;
+  if (state !== "idle" && state !== "running" && state !== "failed") {
+    return null;
+  }
+  const title = stringValue(value.title);
+  const detail = stringValue(value.detail);
+  const actionLabel = stringValue(value.action_label);
+  const connectUrl = stringValue(value.connect_url);
+  if (title === null || detail === null || actionLabel === null || connectUrl === null) {
+    return null;
+  }
+  return {
+    state,
+    title,
+    detail,
+    action_label: actionLabel,
+    connect_url: connectUrl,
+    authorize_url: isStringOrNull(value.authorize_url) ? value.authorize_url : null,
+    browser_opened: value.browser_opened === true ? true : value.browser_opened === false ? false : null,
+    request_id: isStringOrNull(value.request_id) ? value.request_id : null,
+    poll_after_ms: numberValue(value.poll_after_ms)
+  };
 }
 function normalizePackageShimEntry(manager, detail, pathStatus) {
   const installed = detail !== null && stringValue(detail.integrity) !== "missing";
@@ -13926,6 +13964,7 @@ function normalizePackageFirewallStatus(value) {
   return {
     actions: normalizePackageFirewallActions(record.actions),
     cli_fallback: normalizePackageFirewallCliFallback(record.cli_fallback),
+    connect_flow: normalizePackageFirewallConnectFlow(record.connect_flow),
     entitlement: normalizePackageFirewallEntitlement(record.entitlement),
     operation: stringValue(record.operation) ?? "status",
     package_shims: packageShims,
@@ -13949,6 +13988,15 @@ function normalizePackageFirewallAction(value) {
 }
 async function fetchPackageFirewallStatus() {
   return normalizePackageFirewallStatus(await readJson("/v1/supply-chain/package-shims"));
+}
+async function startPackageFirewallConnect() {
+  return normalizePackageFirewallConnectFlow(
+    await readJson("/v1/supply-chain/package-shims/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({})
+    })
+  );
 }
 async function runPackageFirewallAction(action, manager, credentials) {
   const payload = {
@@ -23159,10 +23207,11 @@ export {
   runPackageFirewallAction as al,
   runPackageAudit as am,
   runPackageSync as an,
-  HiMiniBugAnt as ao,
-  runAuditRemediation as ap,
-  HiMiniSignal as aq,
-  HiMiniClock as ar,
+  startPackageFirewallConnect as ao,
+  HiMiniBugAnt as ap,
+  runAuditRemediation as aq,
+  HiMiniSignal as ar,
+  HiMiniClock as as,
   HiMiniExclamationTriangle as b,
   HiMiniArrowRight as c,
   HiMiniChevronUp as d,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -140,6 +140,7 @@
     --color-black: #000;
     --color-white: #fff;
     --spacing: .25rem;
+    --container-xs: 20rem;
     --container-sm: 24rem;
     --container-md: 28rem;
     --container-lg: 32rem;
@@ -1512,6 +1513,14 @@
     border-radius: 1.35rem;
   }
 
+  .rounded-\[18px\] {
+    border-radius: 18px;
+  }
+
+  .rounded-\[24px\] {
+    border-radius: 24px;
+  }
+
   .rounded-full {
     border-radius: 3.40282e38px;
   }
@@ -2148,6 +2157,16 @@
     }
   }
 
+  .bg-brand-attention\/\[0\.05\] {
+    background-color: var(--brand-attention);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-brand-attention\/\[0\.05\] {
+      background-color: color-mix(in oklab, var(--brand-attention) 5%, transparent);
+    }
+  }
+
   .bg-brand-blue, .bg-brand-blue\/10 {
     background-color: var(--brand-blue);
   }
@@ -2690,6 +2709,16 @@
     }
   }
 
+  .bg-white\/85 {
+    background-color: #ffffffd9;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-white\/85 {
+      background-color: color-mix(in oklab, var(--color-white) 85%, transparent);
+    }
+  }
+
   .bg-white\/90 {
     background-color: #ffffffe6;
   }
@@ -3006,6 +3035,20 @@
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
 
+  .to-brand-purple\/\[0\.04\] {
+    --tw-gradient-to: var(--brand-purple);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .to-brand-purple\/\[0\.04\] {
+      --tw-gradient-to: color-mix(in oklab, var(--brand-purple) 4%, transparent);
+    }
+  }
+
+  .to-brand-purple\/\[0\.04\] {
+    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
+  }
+
   .to-white {
     --tw-gradient-to: var(--color-white);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
@@ -3069,6 +3112,10 @@
 
   .px-3 {
     padding-inline: calc(var(--spacing) * 3);
+  }
+
+  .px-3\.5 {
+    padding-inline: calc(var(--spacing) * 3.5);
   }
 
   .px-4 {
@@ -3327,6 +3374,11 @@
   .tracking-\[0\.12em\] {
     --tw-tracking: .12em;
     letter-spacing: .12em;
+  }
+
+  .tracking-\[0\.14em\] {
+    --tw-tracking: .14em;
+    letter-spacing: .14em;
   }
 
   .tracking-\[0\.15em\] {
@@ -3744,6 +3796,11 @@
 
   .shadow-\[0_16px_40px_rgba\(63\,65\,116\,0\.10\)\] {
     --tw-shadow: 0 16px 40px var(--tw-shadow-color, #3f41741a);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .shadow-\[0_18px_45px_-34px_rgba\(39\,80\,180\,0\.5\)\] {
+    --tw-shadow: 0 18px 45px -34px var(--tw-shadow-color, #2750b480);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 
@@ -4553,6 +4610,10 @@
 
     .sm\:table-cell {
       display: table-cell;
+    }
+
+    .sm\:max-w-xs {
+      max-width: var(--container-xs);
     }
 
     .sm\:grid-cols-2 {

--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -7,6 +7,9 @@ from datetime import datetime, timedelta, timezone
 from .store import GuardStore
 
 PACKAGE_FIREWALL_PAID_TIERS = frozenset({"paid", "premium", "pro", "team", "enterprise", "guard_cloud", "guard-cloud"})
+PACKAGE_FIREWALL_CONNECT_CTA = (
+    "Connect HOL Guard Cloud to check package firewall access and run package firewall actions."
+)
 PACKAGE_FIREWALL_RECONNECT_CTA = "Reconnect HOL Guard Cloud to refresh package firewall access."
 PACKAGE_FIREWALL_UPGRADE_CTA = "Upgrade to HOL Guard Cloud to run package firewall actions."
 _OAUTH_ENTITLEMENT_FALLBACK_TTL = timedelta(days=30)
@@ -150,6 +153,40 @@ def _connect_state_entitlement(store: GuardStore, *, now: datetime) -> dict[str,
     }
 
 
+def _connect_required_entitlement(store: GuardStore) -> dict[str, object]:
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    tier = "unknown"
+    if isinstance(oauth_payload, dict):
+        plan_id = _optional_string(oauth_payload.get("supply_chain_plan_id"))
+        if plan_id is not None:
+            tier = plan_id.lower()
+    return {
+        "allowed": False,
+        "reason": "guard_cloud_connect_required",
+        "tier": tier,
+        "upgrade_cta": PACKAGE_FIREWALL_CONNECT_CTA,
+    }
+
+
+def _requires_guard_cloud_connect(
+    store: GuardStore,
+    *,
+    bundle: dict[str, object] | None,
+    oauth: dict[str, object] | None,
+) -> bool:
+    oauth_health = store.get_oauth_local_credential_health()
+    oauth_configured = bool(oauth_health.get("configured")) if isinstance(oauth_health, dict) else False
+    oauth_state = _optional_string(oauth_health.get("state")) if isinstance(oauth_health, dict) else None
+    cloud_profile = store.get_cloud_sync_profile()
+    if oauth_configured and oauth_state == "healthy":
+        return False
+    if cloud_profile is not None:
+        return False
+    if oauth_configured:
+        return True
+    return not (bundle is not None and bool(bundle.get("allowed")))
+
+
 def resolve_package_firewall_entitlement(
     store: GuardStore,
     *,
@@ -167,19 +204,22 @@ def resolve_package_firewall_entitlement(
         return oauth
     if connect_state is not None:
         return connect_state
+    if _requires_guard_cloud_connect(store, bundle=bundle, oauth=oauth):
+        return _connect_required_entitlement(store)
     if bundle is not None:
         return bundle
     if oauth is not None:
         return oauth
-    return {
-        "allowed": False,
-        "reason": "paid_guard_cloud_required",
-        "tier": "free",
-        "upgrade_cta": PACKAGE_FIREWALL_UPGRADE_CTA,
-    }
+    return _connect_required_entitlement(store)
 
 
 def package_firewall_block_details(entitlement: dict[str, object]) -> tuple[int, str, str]:
+    if entitlement.get("reason") == "guard_cloud_connect_required":
+        return (
+            403,
+            "guard_cloud_connect_required",
+            "Connect HOL Guard Cloud on this machine before running package firewall actions.",
+        )
     if entitlement.get("reason") == "guard_cloud_reconnect_required":
         return (
             403,

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -172,6 +172,41 @@ def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path
     }
 
 
+def test_missing_cloud_connection_prefers_connect_over_false_paywall(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+
+    entitlement = resolve_package_firewall_entitlement(store)
+
+    assert entitlement == {
+        "allowed": False,
+        "reason": "guard_cloud_connect_required",
+        "tier": "unknown",
+        "upgrade_cta": "Connect HOL Guard Cloud to check package firewall access and run package firewall actions.",
+    }
+
+
+def test_paid_metadata_without_usable_local_auth_still_prefers_connect_over_upgrade(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        "oauth_local_credentials",
+        {
+            "workspace_id": "workspace-1",
+            "supply_chain_firewall": True,
+            "supply_chain_plan_id": "team",
+        },
+        "2026-06-05T01:39:51+00:00",
+    )
+
+    entitlement = resolve_package_firewall_entitlement(store)
+
+    assert entitlement == {
+        "allowed": False,
+        "reason": "guard_cloud_connect_required",
+        "tier": "team",
+        "upgrade_cta": "Connect HOL Guard Cloud to check package firewall access and run package firewall actions.",
+    }
+
+
 def test_retry_required_connect_state_prefers_reconnect_over_false_paywall(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.set_oauth_local_credentials(

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import json
 import threading
+import time
 import urllib.error
 import urllib.request
 from datetime import datetime, timezone
@@ -16,6 +17,7 @@ import pytest
 
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
+from codex_plugin_scanner.guard.cli.connect_flow import GuardOAuthTokenExchangeResult
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
@@ -145,6 +147,7 @@ def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: P
     ]
     assert payload["package_firewall_api"]["operations"] == [
         "status",
+        "connect",
         "install",
         "repair",
         "test",
@@ -152,6 +155,7 @@ def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: P
         "sync",
         "remove",
     ]
+    assert payload["package_firewall_api"]["routes"]["connect"] == "/v1/supply-chain/package-shims/connect"
     assert payload["package_firewall_api"]["routes"]["status"] == "/v1/supply-chain/package-shims"
     assert "codex" in payload["supported_harnesses"]
     assert payload["safe_failure_reasons"]["unsupported"] == "Harness is not supported by this daemon."
@@ -161,7 +165,9 @@ def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: P
     assert codex_item["status"] in {"inactive", "observed", "protected"}
 
 
-def test_supply_chain_package_firewall_status_reports_free_upgrade_gate(tmp_path: Path) -> None:
+def test_supply_chain_package_firewall_status_reports_connect_gate_when_cloud_is_not_connected(
+    tmp_path: Path,
+) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -182,22 +188,23 @@ def test_supply_chain_package_firewall_status_reports_free_upgrade_gate(tmp_path
     assert payload["operation"] == "status"
     assert payload["entitlement"] == {
         "allowed": False,
-        "reason": "paid_guard_cloud_required",
-        "tier": "free",
-        "upgrade_cta": "Upgrade to HOL Guard Cloud to run package firewall actions.",
+        "reason": "guard_cloud_connect_required",
+        "tier": "unknown",
+        "upgrade_cta": "Connect HOL Guard Cloud to check package firewall access and run package firewall actions.",
     }
     assert "npm" in payload["supported_managers"]
+    assert payload["connect_flow"]["state"] == "idle"
     assert payload["actions"] == {
-        "install": "paid_required",
-        "repair": "paid_required",
-        "test": "paid_required",
-        "audit": "paid_required",
-        "sync": "paid_required",
-        "remove": "paid_required",
+        "install": "connect_required",
+        "repair": "connect_required",
+        "test": "connect_required",
+        "audit": "connect_required",
+        "sync": "connect_required",
+        "remove": "connect_required",
     }
 
 
-def test_supply_chain_package_firewall_install_requires_paid_entitlement(tmp_path: Path) -> None:
+def test_supply_chain_package_firewall_install_requires_cloud_connect_first(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -214,11 +221,116 @@ def test_supply_chain_package_firewall_install_requires_paid_entitlement(tmp_pat
     finally:
         daemon.stop()
 
-    assert status == 402
-    assert payload["error"] == "paid_guard_cloud_required"
+    assert status == 403
+    assert payload["error"] == "guard_cloud_connect_required"
     assert payload["operation"] == "install"
-    assert payload["entitlement"]["tier"] == "free"
-    assert payload["available_actions"] == ["status", "education", "cli_fallback"]
+    assert payload["entitlement"]["tier"] == "unknown"
+    assert payload["available_actions"] == ["status", "connect", "education", "cli_fallback"]
+
+
+def test_supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_paid_access(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-old",
+        dpop_private_key_pem="private-key-old",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value-old", "y": "y-value-old"},
+        dpop_public_jwk_thumbprint="thumbprint-old",
+        grant_id="grant-old",
+        machine_id="machine-old",
+        supply_chain_entitlement_expires_at="2026-07-05T01:39:51+00:00",
+        supply_chain_firewall=True,
+        supply_chain_plan_id="team",
+        workspace_id="workspace-1",
+        now="2026-06-05T01:39:51+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    oauth_payload["credentials_sha256"] = "pbkdf2-sha256$" + ("0" * 64)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-05T01:40:00+00:00")
+
+    class _FakeSession:
+        authorize_url = "https://hol.org/mock-authorize"
+        redirect_uri = "http://127.0.0.1:53111/oauth/callback"
+        pkce_verifier = "pkce-verifier"
+        dpop_key_material = type(
+            "KeyMaterial",
+            (),
+            {
+                "private_key_pem": "private-key-new",
+                "public_jwk": {"kty": "EC", "crv": "P-256", "x": "x-value-new", "y": "y-value-new"},
+                "public_jwk_thumbprint": "thumbprint-new",
+            },
+        )()
+
+        def wait_for_callback(self, _timeout_seconds: float):
+            return type("Callback", (), {"code": "auth-code-1"})()
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(daemon_server, "start_guard_browser_session", lambda **_kwargs: _FakeSession())
+    monkeypatch.setattr(daemon_server.webbrowser, "open", lambda _url: False)
+    monkeypatch.setattr(
+        daemon_server,
+        "exchange_guard_authorization_code",
+        lambda **_kwargs: GuardOAuthTokenExchangeResult(
+            access_token="access-token-1",
+            refresh_token="refresh-token-new",
+            expires_in=300,
+            scope="guard:runtime.sync guard:offline_access",
+            token_type="Bearer",
+            grant_id="grant-new",
+            machine_id="machine-new",
+            supply_chain_entitlement={
+                "supply_chain_entitlement_expires_at": "2026-07-05T01:39:51+00:00",
+                "supply_chain_firewall": True,
+                "supply_chain_plan_id": "team",
+            },
+            workspace_id="workspace-1",
+        ),
+    )
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/connect",
+                token=token,
+                payload={},
+            ),
+        )
+        assert status == 202
+        assert payload["state"] == "running"
+        assert payload["authorize_url"] == "https://hol.org/mock-authorize"
+        for _ in range(20):
+            status, refreshed = _read_json_response(
+                _request(
+                    daemon.port,
+                    "/v1/supply-chain/package-shims",
+                    method="GET",
+                    token=token,
+                ),
+            )
+            if refreshed["entitlement"]["allowed"] is True:
+                assert status == 200
+                assert refreshed["entitlement"]["reason"] == "paid_oauth_entitlement_active"
+                assert refreshed["connect_flow"] is None
+                break
+            time.sleep(0.1)
+        else:
+            raise AssertionError("package firewall status never unlocked after local connect repair")
+    finally:
+        daemon.stop()
+
+    assert store.get_oauth_local_credential_health()["state"] == "healthy"
 
 
 def test_supply_chain_package_firewall_status_reports_reconnect_gate_for_expired_cloud_auth(

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -73,15 +73,23 @@ def _seed_retry_required_oauth_connect(home_dir: Path) -> None:
     )
 
 
-def test_package_shims_install_requires_paid_entitlement(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+def test_package_shims_install_requires_guard_cloud_connect_first(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
     guard_home = tmp_path / "guard-home"
 
     rc = main(["guard", "package-shims", "install", "--manager", "npm", "--home", str(guard_home), "--json"])
 
     payload = json.loads(capsys.readouterr().out)
     assert rc == 2
-    assert payload["error"] == "paid_guard_cloud_required"
-    assert payload["entitlement"]["tier"] == "free"
+    assert payload["error"] == "guard_cloud_connect_required"
+    assert payload["entitlement"] == {
+        "allowed": False,
+        "reason": "guard_cloud_connect_required",
+        "tier": "unknown",
+        "upgrade_cta": "Connect HOL Guard Cloud to check package firewall access and run package firewall actions.",
+    }
 
 
 def test_package_shims_status_reports_reconnect_required_when_cloud_auth_expired(


### PR DESCRIPTION
## Summary
- replace false package-firewall upgrade wall with a machine-local Guard Cloud connect flow in the supply-chain dashboard, CLI, and daemon
- add daemon-side connect/repair API wiring, calmer onboarding copy, and progressive CLI fallback disclosure for disconnected machines
- add regressions for connect-required entitlement detection, daemon connect repair, and dashboard connect POST token bootstrap

## Testing
- `uv run --extra dev python -m pytest -q tests/test_guard_connect_flow.py tests/test_guard_headless_daemon_api.py tests/test_guard_package_shims_cli.py`
- `uv run --extra dev ruff check src/codex_plugin_scanner/guard/package_firewall_entitlement.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_connect_flow.py tests/test_guard_headless_daemon_api.py tests/test_guard_package_shims_cli.py`
- `pnpm exec tsx src/guard-api.test.ts`
- `pnpm exec tsx src/package-firewall-connect.test.tsx`
- `pnpm run build`

## Notes
- live browser proof used both a real Guard home and a copied Guard home to verify the upgrade wall is gone, the dashboard starts `/v1/supply-chain/package-shims/connect`, and the UI transitions into waiting-for-browser-approval state
