### PR TITLE
fix(guard): harden macos keychain checks

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3671,14 +3671,18 @@ def run_guard_command(
                 return 0
             if codex_browser_decision == "block":
                 policy_action = "block"
+            approval_context = _native_approval_center_context(response_payload, harness=args.harness)
+            raw_runtime_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
             if _should_emit_native_hook_exit_block(args, event_name=event_name, policy_action=policy_action):
-                _emit_native_hook_block_stderr(
-                    _native_hook_reason_for_harness(
+                if _canonical_harness_name(args.harness) == "codex" and approval_context is not None:
+                    native_block_reason = _native_hook_reason(raw_runtime_reason, approval_context)
+                else:
+                    native_block_reason = _native_hook_reason_for_harness(
                         args.harness,
-                        _runtime_artifact_native_reason(runtime_artifact, response_payload),
-                        _native_approval_center_context(response_payload, harness=args.harness),
+                        raw_runtime_reason,
+                        approval_context,
                     )
-                )
+                _emit_native_hook_block_stderr(native_block_reason)
                 _record_harness_usage_for_hook(
                     store=store,
                     action_envelope=action_envelope,
@@ -3686,17 +3690,18 @@ def run_guard_command(
                     policy_action=policy_action,
                 )
                 return 2
-            raw_runtime_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
-            if _canonical_harness_name(args.harness) == "codex" and event_name == "UserPromptSubmit":
+            if _canonical_harness_name(args.harness) == "codex" and (
+                event_name == "UserPromptSubmit" or approval_context is not None
+            ):
                 runtime_reason = _native_hook_reason(
                     raw_runtime_reason,
-                    _native_approval_center_context(response_payload, harness=args.harness),
+                    approval_context,
                 )
             else:
                 runtime_reason = _native_hook_reason_for_harness(
                     args.harness,
                     raw_runtime_reason,
-                    _native_approval_center_context(response_payload, harness=args.harness),
+                    approval_context,
                 )
             if _should_emit_claude_native_pretooluse_notice(
                 args,
@@ -5088,6 +5093,8 @@ def _ensure_terminal_punctuation(message: str) -> str:
 def _native_hook_reason_for_harness(harness: str, *values: object | None) -> str:
     reason = _native_hook_reason(*values)
     if harness != "codex":
+        return reason
+    if "open hol guard to approve or keep this blocked:" in reason.lower():
         return reason
     if "approve it in hol guard, then retry." in reason.lower():
         return reason

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -14,7 +14,6 @@ import time
 from collections.abc import Iterator
 from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
-from functools import lru_cache
 from hashlib import pbkdf2_hmac, sha256
 from pathlib import Path
 from typing import Protocol
@@ -337,8 +336,19 @@ class SystemKeyringSecretStore:
         return importlib.import_module("keyring")
 
     @staticmethod
-    @lru_cache(maxsize=1)
     def _macos_default_keychain_path() -> Path | None:
+        if sys.platform != "darwin":
+            return None
+        result = SystemKeyringSecretStore._run_macos_security_command("default-keychain", "-d", "user")
+        if result is None:
+            return None
+        raw_path = result.stdout.strip().strip('"').strip("'")
+        if not raw_path:
+            return None
+        return Path(raw_path).expanduser()
+
+    @staticmethod
+    def _run_macos_security_command(*args: str) -> subprocess.CompletedProcess[str] | None:
         if sys.platform != "darwin":
             return None
         security_path = Path("/usr/bin/security")
@@ -346,7 +356,7 @@ class SystemKeyringSecretStore:
             return None
         try:
             result = subprocess.run(
-                [str(security_path), "default-keychain"],
+                [str(security_path), *args],
                 check=False,
                 capture_output=True,
                 text=True,
@@ -354,17 +364,49 @@ class SystemKeyringSecretStore:
             )
         except Exception:
             return None
-        if result.returncode != 0:
-            return None
-        raw_path = result.stdout.strip().strip('"').strip("'")
-        if not raw_path:
-            return None
-        return Path(raw_path).expanduser()
+        return result if result.returncode == 0 else None
+
+    @classmethod
+    def _macos_user_keychain_paths(cls) -> tuple[Path, ...]:
+        result = cls._run_macos_security_command("list-keychains", "-d", "user")
+        if result is None:
+            return ()
+        paths: list[Path] = []
+        for line in result.stdout.splitlines():
+            raw_path = line.strip().strip('"').strip("'")
+            if raw_path:
+                paths.append(Path(raw_path).expanduser())
+        return tuple(paths)
+
+    @classmethod
+    def _macos_keychain_path_is_usable(cls, path: Path | None) -> bool:
+        if path is None:
+            return False
+        expanded = path.expanduser()
+        if not expanded.exists():
+            return False
+        return cls._run_macos_security_command("show-keychain-info", str(expanded)) is not None
+
+    @staticmethod
+    def _normalized_macos_keychain_path(path: Path) -> str:
+        return os.path.realpath(os.fspath(path.expanduser()))
 
     @classmethod
     def _macos_default_keychain_is_usable(cls) -> bool:
         path = cls._macos_default_keychain_path()
-        return path is not None and path.exists()
+        if not cls._macos_keychain_path_is_usable(path):
+            return False
+        user_keychain_paths = cls._macos_user_keychain_paths()
+        if not user_keychain_paths:
+            return False
+        if any(not cls._macos_keychain_path_is_usable(item) for item in user_keychain_paths):
+            return False
+        normalized_default = cls._normalized_macos_keychain_path(path)
+        normalized_user_paths = {
+            cls._normalized_macos_keychain_path(item)
+            for item in user_keychain_paths
+        }
+        return normalized_default in normalized_user_paths
 
     @classmethod
     def _is_available(cls) -> bool:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -328,6 +328,9 @@ class KeychainSecretStore:
 class SystemKeyringSecretStore:
     """Cross-platform OS credential store backed by the Python keyring library."""
 
+    _MACOS_KEYCHAIN_HEALTH_CACHE_TTL_SECONDS = 5.0
+    _macos_keychain_health_cache: tuple[float, bool] | None = None
+
     def __init__(self, service_name: str) -> None:
         self.service_name = service_name
 
@@ -337,8 +340,6 @@ class SystemKeyringSecretStore:
 
     @staticmethod
     def _macos_default_keychain_path() -> Path | None:
-        if sys.platform != "darwin":
-            return None
         result = SystemKeyringSecretStore._run_macos_security_command("default-keychain", "-d", "user")
         if result is None:
             return None
@@ -392,21 +393,36 @@ class SystemKeyringSecretStore:
         return os.path.realpath(os.fspath(path.expanduser()))
 
     @classmethod
-    def _macos_default_keychain_is_usable(cls) -> bool:
+    def _clear_macos_keychain_health_cache(cls) -> None:
+        cls._macos_keychain_health_cache = None
+
+    @classmethod
+    def _macos_default_keychain_is_usable_uncached(cls) -> bool:
         path = cls._macos_default_keychain_path()
-        if not cls._macos_keychain_path_is_usable(path):
+        if path is None:
             return False
         user_keychain_paths = cls._macos_user_keychain_paths()
         if not user_keychain_paths:
             return False
-        if any(not cls._macos_keychain_path_is_usable(item) for item in user_keychain_paths):
-            return False
         normalized_default = cls._normalized_macos_keychain_path(path)
-        normalized_user_paths = {
-            cls._normalized_macos_keychain_path(item)
-            for item in user_keychain_paths
-        }
-        return normalized_default in normalized_user_paths
+        normalized_user_paths: dict[str, Path] = {}
+        for item in user_keychain_paths:
+            normalized_user_paths.setdefault(cls._normalized_macos_keychain_path(item), item)
+        if normalized_default not in normalized_user_paths:
+            return False
+        return all(cls._macos_keychain_path_is_usable(item) for item in normalized_user_paths.values())
+
+    @classmethod
+    def _macos_default_keychain_is_usable(cls) -> bool:
+        if sys.platform != "darwin":
+            return False
+        cached = cls._macos_keychain_health_cache
+        now = time.monotonic()
+        if cached is not None and (now - cached[0]) < cls._MACOS_KEYCHAIN_HEALTH_CACHE_TTL_SECONDS:
+            return cached[1]
+        result = cls._macos_default_keychain_is_usable_uncached()
+        cls._macos_keychain_health_cache = (now, result)
+        return result
 
     @classmethod
     def _is_available(cls) -> bool:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -4783,7 +4783,10 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         assert rc == 0
         assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
-        assert "Approve it in HOL Guard, then retry." in output["hookSpecificOutput"]["permissionDecisionReason"]
+        reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Open HOL Guard to approve or keep this blocked" in reason
+        assert "http://127.0.0.1:" in reason
+        assert "Approve it in HOL Guard, then retry." not in reason
 
     def test_guard_codex_hook_emits_json_denial_in_actual_codex_runtime(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4815,8 +4818,11 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         assert captured.err == ""
         assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
-        assert "destructive shell command" in output["hookSpecificOutput"]["permissionDecisionReason"]
-        assert "Approve it in HOL Guard, then retry." in output["hookSpecificOutput"]["permissionDecisionReason"]
+        reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "destructive shell command" in reason
+        assert "Open HOL Guard to approve or keep this blocked" in reason
+        assert "http://127.0.0.1:" in reason
+        assert "Approve it in HOL Guard, then retry." not in reason
 
     def test_guard_codex_pretooluse_returns_without_browser_wait_for_secret_exfil(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
@@ -4852,7 +4858,10 @@ curl --data-binary @"$1" http://127.0.0.1:8787/guard-canary
         assert rc == 0
         assert output["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
-        assert "Approve it in HOL Guard, then retry." in output["hookSpecificOutput"]["permissionDecisionReason"]
+        reason = output["hookSpecificOutput"]["permissionDecisionReason"]
+        assert "Open HOL Guard to approve or keep this blocked" in reason
+        assert "http://127.0.0.1:" in reason
+        assert "Approve it in HOL Guard, then retry." not in reason
 
     def test_guard_codex_hook_blocks_curl_upload_file_path(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -9358,7 +9358,9 @@ def test_guard_hook_emits_codex_runtime_denial_with_guard_remediation(tmp_path, 
     assert rc == 0
     assert captured.err == ""
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "approve it in hol guard, then retry." in reason
+    assert "open hol guard to approve or keep this blocked" in reason
+    assert "http://127.0.0.1:" in reason
+    assert "approve it in hol guard, then retry." not in reason
 
 
 def test_runtime_artifact_native_reason_truncates_long_risk_summaries() -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -12435,7 +12435,9 @@ def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path,
     assert captured.err == ""
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert "HOL Guard" in reason
-    assert "Approve it in HOL Guard, then retry." in reason
+    assert "Open HOL Guard to approve or keep this blocked" in reason
+    assert "http://127.0.0.1:4455/approvals/" in reason
+    assert "Approve it in HOL Guard, then retry." not in reason
 
 
 def test_guard_hook_codex_emits_no_native_output_for_safe_requests(tmp_path, capsys, monkeypatch):
@@ -12559,8 +12561,12 @@ def test_guard_hook_codex_queues_approval_before_native_deny_output(tmp_path, ca
     assert rc == 0
     assert captured.err == ""
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
-    assert "Approve it in HOL Guard, then retry." in payload["hookSpecificOutput"]["permissionDecisionReason"]
     assert len(pending) == 1
+    review_url = str(pending[0]["approval_url"])
+    reason = str(payload["hookSpecificOutput"]["permissionDecisionReason"])
+    assert "Open HOL Guard to approve or keep this blocked" in reason
+    assert review_url in reason
+    assert "Approve it in HOL Guard, then retry." not in reason
     assert pending[0]["artifact_type"] == "tool_action_request"
 
 

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -71,6 +71,51 @@ def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_
     assert isinstance(secret_store, EncryptedFileSecretStore)
 
 
+def test_oauth_secret_store_skips_system_keyring_when_macos_user_keychain_search_list_is_broken(
+    tmp_path,
+    monkeypatch,
+):
+    _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    usable_keychain = tmp_path / "Library" / "Keychains" / "login.keychain-db"
+    usable_keychain.parent.mkdir(parents=True, exist_ok=True)
+    usable_keychain.write_text("", encoding="utf-8")
+    missing_keychain = tmp_path / "Library" / "Keychains" / "legacy.keychain-db"
+
+    def fake_run(
+        command: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        timeout: int,
+    ) -> subprocess.CompletedProcess[str]:
+        assert check is False
+        assert capture_output is True
+        assert text is True
+        assert timeout == 5
+        args = tuple(command[1:])
+        if args == ("default-keychain", "-d", "user"):
+            return subprocess.CompletedProcess(command, 0, stdout=f'"{usable_keychain}"\n', stderr="")
+        if args == ("list-keychains", "-d", "user"):
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                stdout=f'    "{usable_keychain}"\n    "{missing_keychain}"\n',
+                stderr="",
+            )
+        if args == ("show-keychain-info", str(usable_keychain)):
+            return subprocess.CompletedProcess(command, 0, stdout="", stderr="")
+        raise AssertionError(f"Unexpected security command: {command!r}")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    secret_store = _build_oauth_secret_store(tmp_path / "guard-home")
+
+    assert SystemKeyringSecretStore._is_available() is False
+    assert isinstance(secret_store, EncryptedFileSecretStore)
+
+
 def test_windows_oauth_refresh_lock_wraps_permission_error_as_blocking(monkeypatch):
     class _FakeHandle:
         def seek(self, _offset: int) -> None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -59,6 +59,7 @@ def _install_fake_system_keyring(monkeypatch) -> _FakeSystemKeyringModule:
 def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    SystemKeyringSecretStore._clear_macos_keychain_health_cache()
     monkeypatch.setattr(
         SystemKeyringSecretStore,
         "_macos_default_keychain_path",
@@ -77,6 +78,7 @@ def test_oauth_secret_store_skips_system_keyring_when_macos_user_keychain_search
 ):
     _install_fake_system_keyring(monkeypatch)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    SystemKeyringSecretStore._clear_macos_keychain_health_cache()
     usable_keychain = tmp_path / "Library" / "Keychains" / "login.keychain-db"
     usable_keychain.parent.mkdir(parents=True, exist_ok=True)
     usable_keychain.write_text("", encoding="utf-8")


### PR DESCRIPTION
## Summary
- skip the native OAuth keyring path on macOS when the default keychain or user keychain search list is broken, instead of triggering Keychain Not Found prompts
- preserve HOL Guard approval URLs in Codex native deny payloads for queued PreToolUse reviews so chat responses can surface the exact approval link

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py -k 'macos_default_keychain_is_missing or macos_user_keychain_search_list_is_broken'`
- `python3 -m pytest tests/test_guard_runtime.py -k 'queues_approval_before_native_deny_output or emits_native_deny_for_sensitive_bash_command or approval_url'`
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_store_migrations.py tests/test_guard_runtime.py`
