### PR TITLE
refactor(evidence): normalize action envelope into runtime_receipt_envelopes table

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3429,9 +3429,8 @@ def run_guard_command(
                     if policy_action == "require-reapproval"
                     else "policy"
                 ),
-                action_envelope_json=action_envelope.to_dict() if action_envelope is not None else None,
             )
-            store.add_receipt(receipt)
+            store.add_receipt(receipt, action_envelope=action_envelope)
             response_payload = {
                 "recorded": True,
                 "harness": _canonical_harness_name(args.harness),
@@ -3843,9 +3842,8 @@ def run_guard_command(
                 source_scope=_coalesce_string(payload.get("source_scope"), "project"),
                 user_override=_optional_string(payload.get("user_override")),
                 approval_source=("inline" if _optional_string(payload.get("user_override")) is not None else "policy"),
-                action_envelope_json=action_envelope.to_dict() if action_envelope is not None else None,
             )
-            store.add_receipt(receipt)
+            store.add_receipt(receipt, action_envelope=action_envelope)
         _record_harness_usage_for_hook(
             store=store,
             action_envelope=action_envelope,

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -148,7 +148,7 @@ class GuardReceipt:
     source_scope: str | None = None
     diff_summary: str | None = None
     approval_source: str | None = None
-    action_envelope_json: dict[str, object] | None = None
+    approval_request_id: str | None = None
     scanner_evidence: tuple[dict[str, object], ...] = ()
 
     def to_dict(self) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/receipts/manager.py
+++ b/src/codex_plugin_scanner/guard/receipts/manager.py
@@ -7,6 +7,31 @@ from datetime import datetime, timezone
 from uuid import uuid4
 
 from ..models import GuardReceipt
+from ..runtime.actions import GuardActionEnvelope
+
+
+def _redacted_envelope_dict(envelope: GuardActionEnvelope) -> dict[str, object]:
+    """Return a cloud-safe redacted view of the action envelope."""
+    return {
+        "schema_version": envelope.schema_version,
+        "action_id": envelope.action_id,
+        "harness": envelope.harness,
+        "event_name": envelope.event_name,
+        "action_type": envelope.action_type,
+        "workspace_hash": envelope.workspace_hash,
+        "tool_name": envelope.tool_name,
+        "command_length": len(envelope.command) if envelope.command is not None else 0,
+        "target_paths_count": len(envelope.target_paths),
+        "network_hosts_count": len(envelope.network_hosts),
+        "mcp_server": envelope.mcp_server,
+        "mcp_tool": envelope.mcp_tool,
+        "package_manager": envelope.package_manager,
+        "package_name": envelope.package_name,
+        "package_intent_kind": envelope.package_intent_kind,
+        "package_targets_count": len(envelope.package_targets),
+        "pre_execution_result": envelope.pre_execution_result,
+        "script_name": envelope.script_name,
+    }
 
 
 def _auto_diff_summary(changed_capabilities: list[str]) -> str:
@@ -31,7 +56,7 @@ def build_receipt(
     scanner_evidence: Sequence[Mapping[str, object]] = (),
     diff_summary: str | None = None,
     approval_source: str | None = None,
-    action_envelope_json: Mapping[str, object] | None = None,
+    approval_request_id: str | None = None,
 ) -> GuardReceipt:
     """Create a runtime receipt."""
 
@@ -54,6 +79,6 @@ def build_receipt(
         source_scope=source_scope,
         diff_summary=resolved_diff_summary,
         approval_source=approval_source,
-        action_envelope_json=dict(action_envelope_json) if action_envelope_json is not None else None,
+        approval_request_id=approval_request_id,
         scanner_evidence=tuple(dict(item) for item in scanner_evidence),
     )

--- a/src/codex_plugin_scanner/guard/receipts/manager.py
+++ b/src/codex_plugin_scanner/guard/receipts/manager.py
@@ -26,7 +26,7 @@ def _redacted_envelope_dict(envelope: GuardActionEnvelope) -> dict[str, object]:
         "mcp_server": envelope.mcp_server,
         "mcp_tool": envelope.mcp_tool,
         "package_manager": envelope.package_manager,
-        "package_name": envelope.package_name,
+        "has_package_name": envelope.package_name is not None and len(envelope.package_name) > 0,
         "package_intent_kind": envelope.package_intent_kind,
         "package_targets_count": len(envelope.package_targets),
         "pre_execution_result": envelope.pre_execution_result,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3259,6 +3259,9 @@ def _cloud_sync_receipt_payload(
     publisher = _optional_string(receipt.get("publisher"))
     if publisher is not None:
         payload["publisher"] = publisher
+    redacted_envelope = receipt.get("envelope_redacted_json")
+    if isinstance(redacted_envelope, dict) and redacted_envelope:
+        payload["envelopeRedacted"] = redacted_envelope
     return payload
 
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -27,6 +27,7 @@ from .approval_gate import ApprovalGateGrant, require_policy_clear, require_poli
 from .cli.oauth_client import resolve_guard_oauth_client_config, validate_guard_sync_endpoint
 from .edge_events import build_receipt_event
 from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
+from .runtime.actions import GuardActionEnvelope
 from .runtime.scanner_cache import scanner_cache_key
 from .schemas.guard_event_v1 import GuardEventV1
 from .store_approvals import (
@@ -892,6 +893,13 @@ class GuardStore:
             )
             """,
             """
+            create table if not exists runtime_receipt_envelopes (
+              receipt_id text primary key references runtime_receipts(receipt_id) on delete cascade,
+              envelope_full_json text,
+              envelope_redacted_json text not null
+            )
+            """,
+            """
             create table if not exists publisher_cache (
               publisher_key text primary key,
               payload_json text not null,
@@ -1068,7 +1076,11 @@ class GuardStore:
             self._ensure_runtime_receipts_column(connection, "scanner_evidence_json", "text not null default '[]'")
             self._ensure_runtime_receipts_column(connection, "diff_summary", "text")
             self._ensure_runtime_receipts_column(connection, "approval_source", "text")
-            self._ensure_runtime_receipts_column(connection, "action_envelope_json", "text")
+            self._ensure_runtime_receipts_column(connection, "approval_request_id", "text")
+            self._ensure_runtime_receipt_envelopes_table(connection)
+            if not self._schema_version_applied(connection, version=5):
+                self._migrate_v5_receipt_envelopes(connection)
+                self._record_schema_version(connection, version=5)
             self._ensure_approval_column(connection, "artifact_type", "text not null default 'artifact'")
             self._ensure_approval_column(connection, "launch_target", "text")
             self._ensure_approval_column(connection, "transport", "text")
@@ -1117,6 +1129,37 @@ class GuardStore:
         if column_name in existing:
             return
         connection.execute(f"alter table runtime_receipts add column {column_name} {column_type}")
+
+    @staticmethod
+    def _ensure_runtime_receipt_envelopes_table(connection: sqlite3.Connection) -> None:
+        connection.execute(
+            """
+            create table if not exists runtime_receipt_envelopes (
+              receipt_id text primary key references runtime_receipts(receipt_id) on delete cascade,
+              envelope_full_json text,
+              envelope_redacted_json text not null
+            )
+            """
+        )
+
+    @staticmethod
+    def _migrate_v5_receipt_envelopes(connection: sqlite3.Connection) -> None:
+        rows = connection.execute("pragma table_info(runtime_receipts)").fetchall()
+        existing = {str(row["name"]) for row in rows}
+        if "action_envelope_json" not in existing:
+            return
+        connection.execute(
+            """
+            insert into runtime_receipt_envelopes (receipt_id, envelope_full_json, envelope_redacted_json)
+            select receipt_id, action_envelope_json, '{}'
+            from runtime_receipts
+            where action_envelope_json is not null
+              and not exists (
+                select 1 from runtime_receipt_envelopes where runtime_receipt_envelopes.receipt_id = runtime_receipts.receipt_id
+              )
+            """
+        )
+        connection.execute("alter table runtime_receipts drop column action_envelope_json")
 
     @staticmethod
     def _ensure_approval_column(connection: sqlite3.Connection, column_name: str, column_type: str) -> None:
@@ -1817,7 +1860,12 @@ class GuardStore:
         publisher = decision.publisher if decision.scope == "publisher" else None
         return artifact_id, artifact_hash, workspace, publisher
 
-    def add_receipt(self, receipt: GuardReceipt) -> None:
+    def add_receipt(
+        self,
+        receipt: GuardReceipt,
+        *,
+        action_envelope: GuardActionEnvelope | None = None,
+    ) -> None:
         with self._connect() as connection:
             connection.execute(
                 """
@@ -1825,7 +1873,7 @@ class GuardStore:
                   receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                   changed_capabilities_json,
                   provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                  diff_summary, approval_source, timestamp, action_envelope_json
+                  diff_summary, approval_source, approval_request_id, timestamp
                 )
                 values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
@@ -1844,10 +1892,24 @@ class GuardStore:
                     json.dumps(list(receipt.scanner_evidence), sort_keys=True),
                     receipt.diff_summary,
                     receipt.approval_source,
+                    receipt.approval_request_id,
                     receipt.timestamp,
-                    json.dumps(receipt.action_envelope_json) if receipt.action_envelope_json is not None else None,
                 ),
             )
+            if action_envelope is not None:
+                from .receipts.manager import _redacted_envelope_dict
+
+                connection.execute(
+                    """
+                    insert into runtime_receipt_envelopes (receipt_id, envelope_full_json, envelope_redacted_json)
+                    values (?, ?, ?)
+                    """,
+                    (
+                        receipt.receipt_id,
+                        json.dumps(action_envelope.to_dict()),
+                        json.dumps(_redacted_envelope_dict(action_envelope)),
+                    ),
+                )
             self._ensure_local_device(connection)
             row = connection.execute(
                 "select installation_id from guard_devices where device_key = ?",
@@ -1864,56 +1926,71 @@ class GuardStore:
                 ),
             )
 
+    @staticmethod
+    def _receipt_base_query(where_clause: str = "") -> str:
+        base = """
+            select
+              r.rowid as receipt_rowid,
+              r.receipt_id,
+              r.harness,
+              r.artifact_id,
+              r.artifact_hash,
+              r.policy_decision,
+              r.capabilities_summary,
+              r.changed_capabilities_json,
+              r.provenance_summary,
+              r.user_override,
+              r.artifact_name,
+              r.source_scope,
+              r.scanner_evidence_json,
+              r.diff_summary,
+              r.approval_source,
+              r.approval_request_id,
+              r.timestamp,
+              e.envelope_full_json as envelope_full_json,
+              e.envelope_redacted_json as envelope_redacted_json,
+              a.action_envelope_json as approval_envelope_json
+            from runtime_receipts r
+            left join runtime_receipt_envelopes e on e.receipt_id = r.receipt_id
+            left join approval_requests a on a.request_id = r.approval_request_id
+        """
+        return f"{base} {where_clause}".strip()
+
+    @staticmethod
+    def _receipt_dict_from_row(row: sqlite3.Row) -> dict[str, object]:
+        envelope = _json_object(row["envelope_full_json"]) or _json_object(row["approval_envelope_json"])
+        return {
+            "receipt_rowid": int(row["receipt_rowid"]),
+            "receipt_id": str(row["receipt_id"]),
+            "harness": str(row["harness"]),
+            "artifact_id": str(row["artifact_id"]),
+            "artifact_hash": str(row["artifact_hash"]),
+            "policy_decision": str(row["policy_decision"]),
+            "capabilities_summary": str(row["capabilities_summary"]),
+            "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
+            "provenance_summary": str(row["provenance_summary"]),
+            "user_override": row["user_override"],
+            "artifact_name": row["artifact_name"],
+            "source_scope": row["source_scope"],
+            "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
+            "diff_summary": row["diff_summary"],
+            "approval_source": row["approval_source"],
+            "approval_request_id": row["approval_request_id"],
+            "timestamp": str(row["timestamp"]),
+            "action_envelope_json": envelope,
+            "envelope_redacted_json": _json_object(row["envelope_redacted_json"]),
+        }
+
     def list_receipts(self, limit: int = 50, harness: str | None = None) -> list[dict[str, object]]:
         if harness is not None:
-            query = """
-                select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
-                       capabilities_summary,
-                       changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                       diff_summary, approval_source, timestamp, action_envelope_json
-                from runtime_receipts
-                where harness = ?
-                order by timestamp desc
-                limit ?
-                """
+            query = self._receipt_base_query("where r.harness = ? order by r.timestamp desc limit ?")
             params: tuple[object, ...] = (harness, limit)
         else:
-            query = """
-                select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
-                       capabilities_summary,
-                       changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                       diff_summary, approval_source, timestamp, action_envelope_json
-                from runtime_receipts
-                order by timestamp desc
-                limit ?
-                """
+            query = self._receipt_base_query("order by r.timestamp desc limit ?")
             params = (limit,)
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
-        return [
-            {
-                "receipt_rowid": int(row["receipt_rowid"]),
-                "receipt_id": str(row["receipt_id"]),
-                "harness": str(row["harness"]),
-                "artifact_id": str(row["artifact_id"]),
-                "artifact_hash": str(row["artifact_hash"]),
-                "policy_decision": str(row["policy_decision"]),
-                "capabilities_summary": str(row["capabilities_summary"]),
-                "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
-                "provenance_summary": str(row["provenance_summary"]),
-                "user_override": row["user_override"],
-                "artifact_name": row["artifact_name"],
-                "source_scope": row["source_scope"],
-                "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
-                "diff_summary": row["diff_summary"],
-                "approval_source": row["approval_source"],
-                "timestamp": str(row["timestamp"]),
-                "action_envelope_json": _json_object(row["action_envelope_json"]),
-            }
-            for row in rows
-        ]
+        return [self._receipt_dict_from_row(row) for row in rows]
 
     def list_receipts_since_rowid(
         self,
@@ -1923,57 +2000,18 @@ class GuardStore:
         harness: str | None = None,
     ) -> list[dict[str, object]]:
         if harness is not None:
-            query = """
-                select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
-                       capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
-                       artifact_name, source_scope, scanner_evidence_json, diff_summary, approval_source, timestamp,
-                       action_envelope_json
-                from runtime_receipts
-                where rowid > ? and harness = ?
-                order by rowid asc
-                limit ?
-                """
+            query = self._receipt_base_query("where r.rowid > ? and r.harness = ? order by r.rowid asc limit ?")
             params: tuple[object, ...] = (
                 after_rowid if after_rowid is not None else 0,
                 harness,
                 limit,
             )
         else:
-            query = """
-                select rowid as receipt_rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
-                       capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
-                       artifact_name, source_scope, scanner_evidence_json, diff_summary, approval_source, timestamp,
-                       action_envelope_json
-                from runtime_receipts
-                where rowid > ?
-                order by rowid asc
-                limit ?
-                """
+            query = self._receipt_base_query("where r.rowid > ? order by r.rowid asc limit ?")
             params = (after_rowid if after_rowid is not None else 0, limit)
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
-        return [
-            {
-                "receipt_rowid": int(row["receipt_rowid"]),
-                "receipt_id": str(row["receipt_id"]),
-                "harness": str(row["harness"]),
-                "artifact_id": str(row["artifact_id"]),
-                "artifact_hash": str(row["artifact_hash"]),
-                "policy_decision": str(row["policy_decision"]),
-                "capabilities_summary": str(row["capabilities_summary"]),
-                "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
-                "provenance_summary": str(row["provenance_summary"]),
-                "user_override": row["user_override"],
-                "artifact_name": row["artifact_name"],
-                "source_scope": row["source_scope"],
-                "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
-                "diff_summary": row["diff_summary"],
-                "approval_source": row["approval_source"],
-                "timestamp": str(row["timestamp"]),
-                "action_envelope_json": _json_object(row["action_envelope_json"]),
-            }
-            for row in rows
-        ]
+        return [self._receipt_dict_from_row(row) for row in rows]
 
     def latest_receipt_rowid(self, *, harness: str | None = None) -> int | None:
         query = "select max(rowid) as max_rowid from runtime_receipts"
@@ -1993,74 +2031,20 @@ class GuardStore:
         return None
 
     def get_receipt(self, receipt_id: str) -> dict[str, object] | None:
+        query = self._receipt_base_query("where r.receipt_id = ?")
         with self._connect() as connection:
-            row = connection.execute(
-                """
-                select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-                        changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                       diff_summary, approval_source, timestamp, action_envelope_json
-                from runtime_receipts
-                where receipt_id = ?
-                """,
-                (receipt_id,),
-            ).fetchone()
+            row = connection.execute(query, (receipt_id,)).fetchone()
         if row is None:
             return None
-        return {
-            "receipt_id": str(row["receipt_id"]),
-            "harness": str(row["harness"]),
-            "artifact_id": str(row["artifact_id"]),
-            "artifact_hash": str(row["artifact_hash"]),
-            "policy_decision": str(row["policy_decision"]),
-            "capabilities_summary": str(row["capabilities_summary"]),
-            "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
-            "provenance_summary": str(row["provenance_summary"]),
-            "user_override": row["user_override"],
-            "artifact_name": row["artifact_name"],
-            "source_scope": row["source_scope"],
-            "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
-            "diff_summary": row["diff_summary"],
-            "approval_source": row["approval_source"],
-            "timestamp": str(row["timestamp"]),
-            "action_envelope_json": _json_object(row["action_envelope_json"]),
-        }
+        return self._receipt_dict_from_row(row)
 
     def get_latest_receipt(self, harness: str, artifact_id: str) -> dict[str, object] | None:
+        query = self._receipt_base_query("where r.harness = ? and r.artifact_id = ? order by r.timestamp desc limit 1")
         with self._connect() as connection:
-            row = connection.execute(
-                """
-                select receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-                        changed_capabilities_json,
-                       provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                       diff_summary, approval_source, timestamp, action_envelope_json
-                from runtime_receipts
-                where harness = ? and artifact_id = ?
-                order by timestamp desc
-                limit 1
-                """,
-                (harness, artifact_id),
-            ).fetchone()
+            row = connection.execute(query, (harness, artifact_id)).fetchone()
         if row is None:
             return None
-        return {
-            "receipt_id": str(row["receipt_id"]),
-            "harness": str(row["harness"]),
-            "artifact_id": str(row["artifact_id"]),
-            "artifact_hash": str(row["artifact_hash"]),
-            "policy_decision": str(row["policy_decision"]),
-            "capabilities_summary": str(row["capabilities_summary"]),
-            "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
-            "provenance_summary": str(row["provenance_summary"]),
-            "user_override": row["user_override"],
-            "artifact_name": row["artifact_name"],
-            "source_scope": row["source_scope"],
-            "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
-            "diff_summary": row["diff_summary"],
-            "approval_source": row["approval_source"],
-            "timestamp": str(row["timestamp"]),
-            "action_envelope_json": _json_object(row["action_envelope_json"]),
-        }
+        return self._receipt_dict_from_row(row)
 
     def count_receipts(self, harness: str | None = None) -> int:
         query = "select count(*) as total from runtime_receipts"

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1155,7 +1155,8 @@ class GuardStore:
             from runtime_receipts
             where action_envelope_json is not null
               and not exists (
-                select 1 from runtime_receipt_envelopes where runtime_receipt_envelopes.receipt_id = runtime_receipts.receipt_id
+                select 1 from runtime_receipt_envelopes
+                where runtime_receipt_envelopes.receipt_id = runtime_receipts.receipt_id
               )
             """
         )

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2000,26 +2000,28 @@ class GuardStore:
         result: dict[str, object] = {}
         if include_rowid:
             result["receipt_rowid"] = int(row["receipt_rowid"])
-        result.update({
-            "receipt_id": str(row["receipt_id"]),
-            "harness": str(row["harness"]),
-            "artifact_id": str(row["artifact_id"]),
-            "artifact_hash": str(row["artifact_hash"]),
-            "policy_decision": str(row["policy_decision"]),
-            "capabilities_summary": str(row["capabilities_summary"]),
-            "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
-            "provenance_summary": str(row["provenance_summary"]),
-            "user_override": row["user_override"],
-            "artifact_name": row["artifact_name"],
-            "source_scope": row["source_scope"],
-            "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
-            "diff_summary": row["diff_summary"],
-            "approval_source": row["approval_source"],
-            "approval_request_id": row["approval_request_id"],
-            "timestamp": str(row["timestamp"]),
-            "action_envelope_json": envelope,
-            "envelope_redacted_json": _json_object(row["envelope_redacted_json"]),
-        })
+        result.update(
+            {
+                "receipt_id": str(row["receipt_id"]),
+                "harness": str(row["harness"]),
+                "artifact_id": str(row["artifact_id"]),
+                "artifact_hash": str(row["artifact_hash"]),
+                "policy_decision": str(row["policy_decision"]),
+                "capabilities_summary": str(row["capabilities_summary"]),
+                "changed_capabilities": json.loads(str(row["changed_capabilities_json"])),
+                "provenance_summary": str(row["provenance_summary"]),
+                "user_override": row["user_override"],
+                "artifact_name": row["artifact_name"],
+                "source_scope": row["source_scope"],
+                "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
+                "diff_summary": row["diff_summary"],
+                "approval_source": row["approval_source"],
+                "approval_request_id": row["approval_request_id"],
+                "timestamp": str(row["timestamp"]),
+                "action_envelope_json": envelope,
+                "envelope_redacted_json": _json_object(row["envelope_redacted_json"]),
+            }
+        )
         return result
 
     def list_receipts(self, limit: int = 50, harness: str | None = None) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1159,7 +1159,44 @@ class GuardStore:
               )
             """
         )
-        connection.execute("alter table runtime_receipts drop column action_envelope_json")
+        connection.execute(
+            """
+            create table runtime_receipts_new (
+              receipt_id text primary key,
+              harness text not null,
+              artifact_id text not null,
+              artifact_hash text not null,
+              policy_decision text not null,
+              capabilities_summary text not null default '',
+              changed_capabilities_json text not null,
+              provenance_summary text not null,
+              user_override text,
+              artifact_name text,
+              source_scope text,
+              scanner_evidence_json text not null default '[]',
+              timestamp text not null,
+              diff_summary text,
+              approval_source text,
+              approval_request_id text
+            )
+            """
+        )
+        connection.execute(
+            """
+            insert into runtime_receipts_new (
+              receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
+              changed_capabilities_json, provenance_summary, user_override, artifact_name, source_scope,
+              scanner_evidence_json, timestamp, diff_summary, approval_source, approval_request_id
+            )
+            select
+              receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
+              changed_capabilities_json, provenance_summary, user_override, artifact_name, source_scope,
+              scanner_evidence_json, timestamp, diff_summary, approval_source, null
+            from runtime_receipts
+            """
+        )
+        connection.execute("drop table runtime_receipts")
+        connection.execute("alter table runtime_receipts_new rename to runtime_receipts")
 
     @staticmethod
     def _ensure_approval_column(connection: sqlite3.Connection, column_name: str, column_type: str) -> None:
@@ -1957,10 +1994,12 @@ class GuardStore:
         return f"{base} {where_clause}".strip()
 
     @staticmethod
-    def _receipt_dict_from_row(row: sqlite3.Row) -> dict[str, object]:
+    def _receipt_dict_from_row(row: sqlite3.Row, *, include_rowid: bool = True) -> dict[str, object]:
         envelope = _json_object(row["envelope_full_json"]) or _json_object(row["approval_envelope_json"])
-        return {
-            "receipt_rowid": int(row["receipt_rowid"]),
+        result: dict[str, object] = {}
+        if include_rowid:
+            result["receipt_rowid"] = int(row["receipt_rowid"])
+        result.update({
             "receipt_id": str(row["receipt_id"]),
             "harness": str(row["harness"]),
             "artifact_id": str(row["artifact_id"]),
@@ -1979,7 +2018,8 @@ class GuardStore:
             "timestamp": str(row["timestamp"]),
             "action_envelope_json": envelope,
             "envelope_redacted_json": _json_object(row["envelope_redacted_json"]),
-        }
+        })
+        return result
 
     def list_receipts(self, limit: int = 50, harness: str | None = None) -> list[dict[str, object]]:
         if harness is not None:
@@ -2036,7 +2076,7 @@ class GuardStore:
             row = connection.execute(query, (receipt_id,)).fetchone()
         if row is None:
             return None
-        return self._receipt_dict_from_row(row)
+        return self._receipt_dict_from_row(row, include_rowid=False)
 
     def get_latest_receipt(self, harness: str, artifact_id: str) -> dict[str, object] | None:
         query = self._receipt_base_query("where r.harness = ? and r.artifact_id = ? order by r.timestamp desc limit 1")
@@ -2044,7 +2084,7 @@ class GuardStore:
             row = connection.execute(query, (harness, artifact_id)).fetchone()
         if row is None:
             return None
-        return self._receipt_dict_from_row(row)
+        return self._receipt_dict_from_row(row, include_rowid=False)
 
     def count_receipts(self, harness: str | None = None) -> int:
         query = "select count(*) as total from runtime_receipts"

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1160,6 +1160,7 @@ class GuardStore:
               )
             """
         )
+        connection.execute("drop table if exists runtime_receipts_new")
         connection.execute(
             """
             create table runtime_receipts_new (
@@ -1185,14 +1186,16 @@ class GuardStore:
         connection.execute(
             """
             insert into runtime_receipts_new (
-              receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-              changed_capabilities_json, provenance_summary, user_override, artifact_name, source_scope,
-              scanner_evidence_json, timestamp, diff_summary, approval_source, approval_request_id
+              rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+              capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
+              artifact_name, source_scope, scanner_evidence_json, timestamp, diff_summary,
+              approval_source, approval_request_id
             )
             select
-              receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
-              changed_capabilities_json, provenance_summary, user_override, artifact_name, source_scope,
-              scanner_evidence_json, timestamp, diff_summary, approval_source, null
+              rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+              capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
+              artifact_name, source_scope, scanner_evidence_json, timestamp, diff_summary,
+              approval_source, null
             from runtime_receipts
             """
         )

--- a/tests/test_guard_receipt_p5_fields.py
+++ b/tests/test_guard_receipt_p5_fields.py
@@ -246,6 +246,7 @@ class TestReceiptFieldRoundtrip:
         assert isinstance(result["envelope_redacted_json"], dict)
         assert result["envelope_redacted_json"]["command_length"] == len("ls -la")
         assert "command" not in result["envelope_redacted_json"]
+        assert "package_name" not in result["envelope_redacted_json"]
 
         receipts = store.list_receipts(harness="codex", limit=10)
         assert len(receipts) == 1

--- a/tests/test_guard_receipt_p5_fields.py
+++ b/tests/test_guard_receipt_p5_fields.py
@@ -41,7 +41,7 @@ def _make_receipt(
     diff_summary: str | None = None,
     approval_source: str | None = None,
     timestamp: str = "2025-01-01T00:00:00Z",
-    action_envelope_json: dict[str, object] | None = None,
+    approval_request_id: str | None = None,
 ) -> GuardReceipt:
     return GuardReceipt(
         receipt_id=receipt_id or str(uuid.uuid4()),
@@ -55,7 +55,7 @@ def _make_receipt(
         diff_summary=diff_summary,
         approval_source=approval_source,
         timestamp=timestamp,
-        action_envelope_json=action_envelope_json,
+        approval_request_id=approval_request_id,
     )
 
 
@@ -217,20 +217,86 @@ class TestReceiptFieldRoundtrip:
 
     def test_action_envelope_json_roundtrip(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
-        envelope: dict[str, object] = {"action_type": "shell_command", "command": "ls -la"}
-        receipt = _make_receipt(
-            receipt_id="r-env-01",
-            action_envelope_json=envelope,
+        from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+        envelope = GuardActionEnvelope(
+            schema_version=1,
+            action_id="action-01",
+            harness="codex",
+            event_name="PreToolUse",
+            action_type="shell_command",
+            workspace=None,
+            workspace_hash=None,
+            tool_name="bash",
+            command="ls -la",
+            prompt_excerpt=None,
+            prompt_text=None,
+            target_paths=(),
+            network_hosts=(),
+            mcp_server=None,
+            mcp_tool=None,
+            package_manager=None,
+            package_name=None,
         )
-        store.add_receipt(receipt)
+        receipt = _make_receipt(receipt_id="r-env-01")
+        store.add_receipt(receipt, action_envelope=envelope)
 
         result = store.get_receipt("r-env-01")
         assert result is not None
-        assert result["action_envelope_json"] == envelope
+        assert result["action_envelope_json"] == envelope.to_dict()
+        assert isinstance(result["envelope_redacted_json"], dict)
+        assert result["envelope_redacted_json"]["command_length"] == len("ls -la")
+        assert "command" not in result["envelope_redacted_json"]
 
         receipts = store.list_receipts(harness="codex", limit=10)
         assert len(receipts) == 1
-        assert receipts[0]["action_envelope_json"] == envelope
+        assert receipts[0]["action_envelope_json"] == envelope.to_dict()
+
+    def test_approval_request_id_joins_envelope_from_approval_table(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        from codex_plugin_scanner.guard.models import GuardApprovalRequest
+        from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+        envelope = GuardActionEnvelope(
+            schema_version=1,
+            action_id="action-02",
+            harness="codex",
+            event_name="PreToolUse",
+            action_type="shell_command",
+            workspace=None,
+            workspace_hash=None,
+            tool_name="bash",
+            command="rm -rf node_modules",
+            prompt_excerpt=None,
+            prompt_text=None,
+            target_paths=(),
+            network_hosts=(),
+            mcp_server=None,
+            mcp_tool=None,
+            package_manager=None,
+            package_name=None,
+        )
+        request = GuardApprovalRequest(
+            request_id="req-01",
+            harness="codex",
+            artifact_id="codex:project:bash",
+            artifact_name="Bash",
+            artifact_hash="sha256:abc",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("shell_command",),
+            source_scope="project",
+            config_path="/tmp",
+            review_command="Review",
+            approval_url="http://localhost/approvals/req-01",
+            action_envelope_json=envelope.to_dict(),
+        )
+        store.add_approval_request(request, now="2025-01-01T00:00:00Z")
+        receipt = _make_receipt(receipt_id="r-join-01", approval_request_id="req-01")
+        store.add_receipt(receipt)
+
+        result = store.get_receipt("r-join-01")
+        assert result is not None
+        assert result["approval_request_id"] == "req-01"
+        assert result["action_envelope_json"] == envelope.to_dict()
 
 
 class TestMapApprovalSource:

--- a/tests/test_guard_receipt_p5_fields.py
+++ b/tests/test_guard_receipt_p5_fields.py
@@ -12,6 +12,7 @@ Covers:
 
 from __future__ import annotations
 
+import sqlite3
 import uuid
 from pathlib import Path
 
@@ -298,6 +299,87 @@ class TestReceiptFieldRoundtrip:
         assert result is not None
         assert result["approval_request_id"] == "req-01"
         assert result["action_envelope_json"] == envelope.to_dict()
+
+
+class TestV5MigrationPreservesRowids:
+    def test_v5_migration_preserves_rowids_and_envelopes(self, tmp_path: Path) -> None:
+        db_path = tmp_path / "guard" / "guard.db"
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+        conn.execute(
+            "create table schema_migrations ("
+            "  version integer primary key,"
+            "  applied_at text not null"
+            ")"
+        )
+        conn.execute(
+            """
+            create table runtime_receipts (
+              receipt_id text primary key,
+              harness text not null,
+              artifact_id text not null,
+              artifact_hash text not null,
+              policy_decision text not null,
+              capabilities_summary text not null default '',
+              changed_capabilities_json text not null,
+              provenance_summary text not null,
+              user_override text,
+              artifact_name text,
+              source_scope text,
+              scanner_evidence_json text not null default '[]',
+              timestamp text not null,
+              diff_summary text,
+              approval_source text,
+              action_envelope_json text
+            )
+            """
+        )
+        conn.execute(
+            "insert into schema_migrations (version, applied_at) values (4, '2025-01-01T00:00:00Z')"
+        )
+        conn.execute(
+            """
+            insert into runtime_receipts (
+              rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+              changed_capabilities_json, provenance_summary, timestamp, action_envelope_json
+            ) values (10, 'r-10', 'codex', 'a', 'h', 'allow', '[]', 'npm', '2025-01-01T00:00:00Z', '{"command":"ls"}')
+            """
+        )
+        conn.execute(
+            """
+            insert into runtime_receipts (
+              rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+              changed_capabilities_json, provenance_summary, timestamp, action_envelope_json
+            ) values (25, 'r-25', 'codex', 'a', 'h', 'allow', '[]', 'npm', '2025-01-01T00:00:00Z', '{"command":"cat"}')
+            """
+        )
+        conn.execute(
+            """
+            insert into runtime_receipts (
+              rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
+              changed_capabilities_json, provenance_summary, timestamp
+            ) values (50, 'r-50', 'codex', 'a', 'h', 'allow', '[]', 'npm', '2025-01-01T00:00:00Z')
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        store = GuardStore(tmp_path / "guard")
+        rows = store.list_receipts_since_rowid(after_rowid=0, limit=10)
+        rowids = {r["receipt_rowid"] for r in rows}
+        assert rowids == {10, 25, 50}
+
+        since_10 = store.list_receipts_since_rowid(after_rowid=10, limit=10)
+        assert {r["receipt_rowid"] for r in since_10} == {25, 50}
+
+        r10 = store.get_receipt("r-10")
+        assert r10 is not None
+        assert r10["action_envelope_json"] == {"command": "ls"}
+
+        r50 = store.get_receipt("r-50")
+        assert r50 is not None
+        assert r50["action_envelope_json"] is None
 
 
 class TestMapApprovalSource:


### PR DESCRIPTION
## Problem

The previous fix (#624) stored the full `action_envelope_json` directly on `runtime_receipts`. That worked for showing commands in Evidence, but it:

1. Duplicated envelope data between `runtime_receipts` and `approval_requests`.
2. Blew up receipt row size with full command text / paths / prompts.
3. Gave cloud sync no clean place to read a redacted, compliance-safe envelope.

## Changes

- Schema
  - Dropped `action_envelope_json` from `runtime_receipts`.
  - Added `approval_request_id` (text, nullable) to `runtime_receipts` for future request-linked optimization.
  - Added `runtime_receipt_envelopes` table:
    - `receipt_id` PK / FK to `runtime_receipts`
    - `envelope_full_json` — local UI use ( Evidence detail, row titles )
    - `envelope_redacted_json` — cloud-sync use only
  - Added schema v5 migration that moves any existing `action_envelope_json` rows into the new table before dropping the old column.

- Models / receipt builder
  - `GuardReceipt` no longer carries `action_envelope_json`; carries `approval_request_id` instead.
  - `build_receipt()` no longer accepts an envelope dict.
  - Added `_redacted_envelope_dict()` in `receipts/manager.py` to produce a cloud-safe envelope with counts and metadata only (no raw command, paths, hosts, or prompt text).

- Store
  - `add_receipt()` now takes an optional `action_envelope:` kwarg and writes both full and redacted envelopes to `runtime_receipt_envelopes`.
  - All receipt getters (`list_receipts`, `list_receipts_since_rowid`, `get_receipt`, `get_latest_receipt`) now LEFT JOIN `runtime_receipt_envelopes` and `approval_requests` and surface `action_envelope_json` from whichever source has it.

- Cloud sync
  - `_cloud_sync_receipt_payload()` now includes `envelopeRedacted` when a redacted envelope exists.
  - Full envelope never leaves the local device.

- Hook handlers
  - Updated generic hook and runtime artifact receipt creation in `cli/commands.py` to pass `action_envelope=action_envelope` to `store.add_receipt()`.

- Tests
  - Updated `test_guard_receipt_p5_fields.py` helpers and added coverage for:
    - Full envelope + redacted envelope roundtrip
    - Redacted envelope drops sensitive fields
    - `approval_request_id` JOIN correctly resolves envelope from `approval_requests.action_envelope_json`

## Verification

- `pytest tests/test_guard_receipt_p5_fields.py -v` — 44 passed
- `pytest tests/test_guard_receipt_persistence.py -v` — 19 passed
- `pytest tests/test_guard_event_schema_v1.py -v` — 9 passed
- `pytest tests/test_guard_runtime.py -v -k receipt` — 20 passed
- `pytest tests/test_guard_cli.py -v -k "bash or shell or destructive"` — 1 passed
- `pnpm run build` ✅
- `pnpm test` (dashboard full suite) ✅

## Design note

Receipts and their envelopes are now 1:1 in `runtime_receipt_envelopes`. `approval_requests` still keeps its own envelope for Inbox use; unifying those two envelope stores is left for a follow-up so this PR stays focused on the receipt-side normalization and cloud redaction.