### PR TITLE
fix(package-firewall): unblock local recovery flows

### DIFF
--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1646,10 +1646,13 @@ function normalizePackageShimEntry(
   detail: Record<string, unknown> | null,
   pathStatus: PackageManagerProtection["path_status"],
 ): PackageShimEntry {
-  const installed = detail !== null && stringValue(detail.integrity) !== "missing";
+  const integrity = stringValue(detail?.integrity) ?? "uninstalled";
+  const installed = detail !== null && integrity !== "missing";
   const active = booleanValue(detail?.path_active);
   const activation_state = !installed
     ? "uninstalled"
+    : integrity === "tampered"
+    ? "repair_required"
     : active
     ? "protected"
     : pathStatus === "restart_required"
@@ -1659,7 +1662,7 @@ function normalizePackageShimEntry(
     active,
     activation_state,
     installed,
-    integrity: stringValue(detail?.integrity) ?? "uninstalled",
+    integrity,
     manager,
     path_index: numberValue(detail?.path_index),
     real_binary_found: booleanValue(detail?.real_binary_found),

--- a/dashboard/src/package-firewall-connect.test.tsx
+++ b/dashboard/src/package-firewall-connect.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from "react-dom/server";
-import { ConnectFlowCard, FreeUserView } from "./supply-chain-firewall-views";
+import { ConnectFlowCard, EntitlementNotice } from "./supply-chain-firewall-views";
 import type { PackageFirewallStatusResponse } from "./guard-types";
 
 function assert(condition: boolean, message: string): void {
@@ -67,7 +67,20 @@ const connectRequiredStatus: PackageFirewallStatusResponse = {
   status: "completed",
   supported_managers: ["npm", "pnpm"],
   protection: null,
-  package_shims: [],
+  package_shims: [
+    {
+      active: false,
+      activation_state: "repair_required",
+      installed: true,
+      integrity: "ok",
+      manager: "pnpm",
+      path_index: null,
+      real_binary_found: true,
+      real_binary_path: "/opt/homebrew/bin/pnpm",
+      real_binary_path_index: 2,
+      shim_path: "/guard-home/package-shims/bin/pnpm",
+    },
+  ],
   entitlement: {
     allowed: false,
     reason: "guard_cloud_connect_required",
@@ -100,7 +113,7 @@ const connectRequiredStatus: PackageFirewallStatusResponse = {
 };
 
 const freeViewMarkup = renderToStaticMarkup(
-  <FreeUserView
+  <EntitlementNotice
     connectError={null}
     connectStarting={false}
     data={connectRequiredStatus}
@@ -117,8 +130,8 @@ assert(
   "PF2: connect-required free view should not render upgrade upsell",
 );
 assert(
-  freeViewMarkup.includes("Protected after connect"),
-  "PF2: connect-required free view should explain coverage after connect",
+  freeViewMarkup.includes("Existing shims on this machine can still be fixed or removed locally."),
+  "PF2: connect-required view should explain that local recovery still works",
 );
 
 const upgradeRequiredStatus: PackageFirewallStatusResponse = {
@@ -142,7 +155,7 @@ const upgradeRequiredStatus: PackageFirewallStatusResponse = {
 };
 
 const upgradeMarkup = renderToStaticMarkup(
-  <FreeUserView
+  <EntitlementNotice
     connectError={null}
     connectStarting={false}
     data={upgradeRequiredStatus}
@@ -151,10 +164,10 @@ const upgradeMarkup = renderToStaticMarkup(
 );
 
 assert(
-  upgradeMarkup.includes("Would be protected"),
-  "PF3: upgrade-required free view should keep neutral supported-manager label",
-);
-assert(
   !upgradeMarkup.includes("Protected after connect"),
   "PF3: upgrade-required free view should not imply connect alone unlocks protection",
+);
+assert(
+  upgradeMarkup.includes("Upgrade to enable active protection"),
+  "PF3: upgrade-required view should render the upgrade CTA",
 );

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -290,10 +290,13 @@ export function resolvePackageManagerProtectionCopy(
     };
   }
   const pathInPath = protection.path_status === "in_path";
+  const installedButInactive = protection.installed_managers.length > 0;
   return {
     pathLabel: pathInPath ? "Guard shim directory is in PATH" : "Guard shim directory missing from PATH",
     pathDetail: pathInPath
       ? `Package manager commands are intercepted via ${protection.shim_dir}.`
+      : installedButInactive
+      ? `The shim directory (${protection.shim_dir}) is not on PATH yet. Use Fix PATH on an installed manager and Guard will update your shell profile automatically.`
       : `The shim directory (${protection.shim_dir}) is not on PATH. Install bypass is possible for package managers that are not otherwise protected.`,
     pathTone: pathInPath ? "green" : "attention",
     protectedList: protection.protected_managers,

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -19,7 +19,7 @@ import {
   runPackageSync,
   startPackageFirewallConnect,
 } from "./guard-api";
-import { FreeUserView, ActionResultPanel, ActivationSummary } from "./supply-chain-firewall-views";
+import { EntitlementNotice, ActionResultPanel, ActivationSummary } from "./supply-chain-firewall-views";
 import type { CompletedOp } from "./supply-chain-firewall-views";
 import { ManagerActionCard } from "./supply-chain-manager-card";
 import { useResolvedApprovalGate } from "./use-resolved-approval-gate";
@@ -157,12 +157,13 @@ function FailureBanner({ failed }: FailureBannerProps) {
   );
 }
 
-type PaidUserViewProps = {
+type FirewallControlsViewProps = {
   data: PackageFirewallStatusResponse;
   pendingOp: PendingOp | null;
   lastCompleted: CompletedOp | null;
   lastFailed: FailedOp | null;
   confirmRemoveManager: string | null;
+  showGlobalActions: boolean;
   onInstall: (manager: string) => void;
   onRepair: (manager: string) => void;
   onTest: (manager: string) => void;
@@ -174,12 +175,13 @@ type PaidUserViewProps = {
   onDismissResult: () => void;
 };
 
-function PaidUserView({
+function FirewallControlsView({
   data,
   pendingOp,
   lastCompleted,
   lastFailed,
   confirmRemoveManager,
+  showGlobalActions,
   onInstall,
   onRepair,
   onTest,
@@ -189,18 +191,20 @@ function PaidUserView({
   onAudit,
   onSync,
   onDismissResult,
-}: PaidUserViewProps) {
+}: FirewallControlsViewProps) {
   const anyPending = pendingOp !== null;
   return (
     <div className="space-y-4 px-4 py-4">
       <div className="flex flex-wrap items-center justify-between gap-2">
         <p className="text-sm font-medium text-brand-dark">Per-manager controls</p>
-        <GlobalActionsBar
-          anyPending={anyPending}
-          pendingOp={pendingOp}
-          onAudit={onAudit}
-          onSync={onSync}
-        />
+        {showGlobalActions && (
+          <GlobalActionsBar
+            anyPending={anyPending}
+            pendingOp={pendingOp}
+            onAudit={onAudit}
+            onSync={onSync}
+          />
+        )}
       </div>
 
       <ActivationSummary protection={data.protection} />
@@ -448,14 +452,25 @@ export function PackageFirewallPanel(props: {
         <ErrorBanner message={panelLoad.message} onRetry={handleRetry} />
       )}
 
-      {panelLoad.phase === "loaded" &&
-        (panelLoad.data.entitlement.allowed ? (
-          <PaidUserView
+      {panelLoad.phase === "loaded" && (
+        <>
+          {!panelLoad.data.entitlement.allowed && (
+            <div className="border-b border-slate-100">
+              <EntitlementNotice
+                connectError={connectError}
+                connectStarting={startingConnect}
+                data={panelLoad.data}
+                onStartConnect={handleStartConnect}
+              />
+            </div>
+          )}
+          <FirewallControlsView
             data={panelLoad.data}
             pendingOp={pendingOp}
             lastCompleted={lastCompleted}
             lastFailed={lastFailed}
             confirmRemoveManager={confirmRemoveManager}
+            showGlobalActions={panelLoad.data.entitlement.allowed}
             onInstall={handleInstall}
             onRepair={handleRepair}
             onTest={handleTest}
@@ -466,14 +481,8 @@ export function PackageFirewallPanel(props: {
             onSync={handleSync}
             onDismissResult={handleDismissResult}
           />
-        ) : (
-          <FreeUserView
-            connectError={connectError}
-            connectStarting={startingConnect}
-            data={panelLoad.data}
-            onStartConnect={handleStartConnect}
-          />
-        ))}
+        </>
+      )}
 
       {pendingApprovalOp !== null && (
         <ApprovalProofModal

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -54,6 +54,7 @@ type ConnectFlowCardProps = {
   connectError: string | null;
   connectStarting: boolean;
   connectFlow: NonNullable<PackageFirewallStatusResponse["connect_flow"]>;
+  localRecoveryHint?: string | null;
   mode: "connect" | "repair";
   onStartConnect: () => void;
 };
@@ -128,6 +129,7 @@ export function ConnectFlowCard({
   connectError,
   connectStarting,
   connectFlow,
+  localRecoveryHint,
   mode,
   onStartConnect,
 }: ConnectFlowCardProps) {
@@ -145,10 +147,10 @@ export function ConnectFlowCard({
   const statusLabel = mode === "repair" ? "Repair required" : "Connection required";
   const showManualLink = connectFlow.authorize_url !== null || running || failed;
   return (
-    <div className="rounded-[24px] border border-brand-blue/20 bg-gradient-to-br from-brand-blue/[0.05] via-white to-brand-purple/[0.04] px-4 py-4 shadow-[0_18px_45px_-34px_rgba(39,80,180,0.5)]">
+    <div className="space-y-4">
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-          <div className="space-y-2">
+        <div className="grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start">
+          <div className="space-y-2.5">
             <div className="flex flex-wrap items-center gap-2">
               <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-brand-blue">
                 HOL Guard Cloud
@@ -164,7 +166,7 @@ export function ConnectFlowCard({
               </p>
             </div>
           </div>
-          <div className="rounded-[18px] border border-slate-200 bg-white/85 px-3.5 py-3 sm:max-w-xs">
+          <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3">
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
               Security
             </p>
@@ -174,7 +176,7 @@ export function ConnectFlowCard({
           </div>
         </div>
 
-        <div className="grid gap-2.5 sm:grid-cols-3">
+        <div className="grid gap-2.5 md:grid-cols-3">
           {steps.map((step, index) => (
             <ConnectStep
               key={step.title}
@@ -186,6 +188,15 @@ export function ConnectFlowCard({
             />
           ))}
         </div>
+
+        {localRecoveryHint !== null && (
+          <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
+              Available now
+            </p>
+            <p className="mt-1 text-xs leading-relaxed text-slate-600">{localRecoveryHint}</p>
+          </div>
+        )}
 
         {connectError !== null && (
           <div className="rounded-[18px] border border-brand-attention/25 bg-brand-attention/[0.05] px-3.5 py-3">
@@ -240,24 +251,28 @@ export function CliFallback({ commands }: CliFallbackProps) {
   );
 }
 
-type FreeUserViewProps = {
+type EntitlementNoticeProps = {
   connectError: string | null;
   connectStarting: boolean;
   data: PackageFirewallStatusResponse;
   onStartConnect: () => void;
 };
 
-export function FreeUserView({
+export function EntitlementNotice({
   connectError,
   connectStarting,
   data,
   onStartConnect,
-}: FreeUserViewProps) {
+}: EntitlementNoticeProps) {
   const connectRequired =
     data.entitlement.reason === "guard_cloud_connect_required" ||
     data.entitlement.reason === "guard_cloud_reconnect_required";
   const connectMode = data.entitlement.reason === "guard_cloud_reconnect_required" ? "repair" : "connect";
-  const supportedManagersLabel = connectRequired ? "Protected after connect" : "Would be protected";
+  const localRecoveryHint = data.package_shims.some((shim) => shim.installed)
+    ? connectRequired
+      ? "Existing shims on this machine can still be fixed or removed locally. Connect is only needed for new installs and cloud-gated verification."
+      : null
+    : null;
   return (
     <div className="space-y-4 px-4 py-4">
       {connectRequired && data.connect_flow !== null ? (
@@ -265,31 +280,13 @@ export function FreeUserView({
           connectError={connectError}
           connectStarting={connectStarting}
           connectFlow={data.connect_flow}
+          localRecoveryHint={localRecoveryHint}
           mode={connectMode}
           onStartConnect={onStartConnect}
         />
       ) : (
         <UpgradeCta entitlement={data.entitlement} />
       )}
-      <div>
-        <p className="mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-400">
-          {supportedManagersLabel}
-        </p>
-        {data.supported_managers.length === 0 ? (
-          <p className="text-xs text-slate-500">No supported managers detected on this machine.</p>
-        ) : (
-          <div className="flex flex-wrap gap-1.5">
-            {data.supported_managers.map((mgr) => (
-              <span
-                key={mgr}
-                className="inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 font-mono text-xs text-slate-600"
-              >
-                {mgr}
-              </span>
-            ))}
-          </div>
-        )}
-      </div>
       {data.cli_fallback !== null && <CliFallback commands={data.cli_fallback} />}
     </div>
   );
@@ -299,7 +296,7 @@ function activationHeadline(protection: PackageManagerProtection | null): string
   if (protection === null) return "Activation status unavailable";
   if (protection.path_status === "in_path") return "Protection live now";
   if (protection.path_status === "restart_required") return "Restart shell or apps to finish activation";
-  return "PATH repair still needed";
+  return "Fix PATH to finish activation";
 }
 
 type ActivationSummaryProps = {

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -189,7 +189,7 @@ export function ConnectFlowCard({
           ))}
         </div>
 
-        {localRecoveryHint !== null && (
+        {localRecoveryHint != null && (
           <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3">
             <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
               Available now

--- a/dashboard/src/supply-chain-manager-card.tsx
+++ b/dashboard/src/supply-chain-manager-card.tsx
@@ -10,7 +10,11 @@ import {
   HiMiniExclamationTriangle,
 } from "react-icons/hi2";
 import { ActionButton, Tag } from "./approval-center-primitives";
-import type { PackageFirewallStatusResponse, PackageShimEntry } from "./guard-types";
+import type {
+  PackageFirewallActionState,
+  PackageFirewallStatusResponse,
+  PackageShimEntry,
+} from "./guard-types";
 
 type ShimStatusDotProps = {
   active: boolean;
@@ -75,6 +79,10 @@ function ActionBtn({ label, icon, variant, onClick, disabled }: ActionBtnProps) 
   );
 }
 
+function actionIsAvailable(state: PackageFirewallActionState | undefined): boolean {
+  return state === "available";
+}
+
 type ActionButtonRowProps = {
   shim: PackageShimEntry;
   actions: PackageFirewallStatusResponse["actions"];
@@ -98,16 +106,15 @@ function ActionButtonRow({
   const repairState = actions.repair ?? "disabled";
   const testState = actions.test ?? "disabled";
   const removeState = actions.remove ?? "disabled";
-  const installBlocked = installState === "paid_required" || installState === "reconnect_required";
-  const repairBlocked = repairState === "paid_required" || repairState === "reconnect_required";
-  const testBlocked = testState === "paid_required" || testState === "reconnect_required";
-  const removeBlocked = removeState === "paid_required" || removeState === "reconnect_required";
+  const installAvailable = actionIsAvailable(installState);
+  const repairAvailable = actionIsAvailable(repairState);
+  const testAvailable = actionIsAvailable(testState);
+  const removeAvailable = actionIsAvailable(removeState);
 
-  const showInstall = !shim.installed && installState !== "disabled";
-  const showRepair =
-    shim.installed && shim.activation_state !== "restart_required" && repairState !== "disabled";
-  const showTest = testState !== "disabled";
-  const showRemove = removeState !== "disabled" && shim.installed;
+  const showInstall = !shim.installed && installAvailable;
+  const showRepair = shim.installed && shim.activation_state === "repair_required" && repairAvailable;
+  const showTest = shim.installed && shim.activation_state === "protected" && testAvailable;
+  const showRemove = shim.installed && removeAvailable;
 
   return (
     <div className="flex flex-wrap gap-1.5">
@@ -117,16 +124,16 @@ function ActionButtonRow({
           icon={<HiMiniShieldCheck className="mr-1 h-3.5 w-3.5" aria-hidden="true" />}
           variant="primary"
           onClick={onInstall}
-          disabled={anyPending || installBlocked}
+          disabled={anyPending}
         />
       )}
       {showRepair && (
         <ActionBtn
-          label="Repair"
+          label="Fix PATH"
           icon={<HiMiniWrenchScrewdriver className="mr-1 h-3.5 w-3.5" aria-hidden="true" />}
-          variant="secondary"
+          variant="primary"
           onClick={onRepair}
-          disabled={anyPending || repairBlocked}
+          disabled={anyPending}
         />
       )}
       {showTest && (
@@ -135,7 +142,7 @@ function ActionButtonRow({
           icon={<HiMiniBeaker className="mr-1 h-3.5 w-3.5" aria-hidden="true" />}
           variant="outline"
           onClick={onTest}
-          disabled={anyPending || testBlocked}
+          disabled={anyPending}
         />
       )}
       {showRemove && (
@@ -144,7 +151,7 @@ function ActionButtonRow({
           icon={<HiMiniTrash className="mr-1 h-3.5 w-3.5" aria-hidden="true" />}
           variant="danger"
           onClick={onRemoveRequest}
-          disabled={anyPending || removeBlocked}
+          disabled={anyPending}
         />
       )}
     </div>
@@ -249,6 +256,12 @@ export function ManagerActionCard({
       {shim.activation_state === "restart_required" && (
         <p className="text-xs text-slate-500">
           Guard updated your shell profile. Open a new shell or restart AI apps to activate this shim.
+        </p>
+      )}
+
+      {shim.activation_state === "repair_required" && (
+        <p className="text-xs text-slate-500">
+          Guard can add the shim directory to your shell profile automatically, then this manager will be ready after a restart.
         </p>
       )}
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -118,7 +118,11 @@ from ..mcp_tool_calls import (
     evaluate_tool_call,
 )
 from ..models import SEVERITY_RANK, GuardArtifact, HarnessDetection, PolicyDecision
-from ..package_firewall_entitlement import package_firewall_block_details
+from ..package_firewall_entitlement import (
+    package_firewall_action_states,
+    package_firewall_available_actions,
+    package_firewall_block_details,
+)
 from ..policy.engine import SAFE_CHANGED_HASH_ACTION, VALID_GUARD_ACTIONS, build_decision_v2, guard_action_severity
 from ..protect import build_protect_payload
 from ..proxy import (
@@ -1153,27 +1157,6 @@ def _add_guard_cisco_mode_arg(parser: argparse.ArgumentParser) -> None:
     )
 
 
-def _package_firewall_action_states(entitlement: dict[str, object]) -> dict[str, str]:
-    allowed = bool(entitlement.get("allowed"))
-    reason = str(entitlement.get("reason") or "").strip().lower()
-    if allowed:
-        state = "available"
-    elif reason == "guard_cloud_connect_required":
-        state = "connect_required"
-    elif reason == "guard_cloud_reconnect_required":
-        state = "reconnect_required"
-    else:
-        state = "paid_required"
-    return {
-        "install": state,
-        "repair": state,
-        "test": state,
-        "audit": state,
-        "sync": state,
-        "remove": state,
-    }
-
-
 def _package_firewall_cli_gate_input(args: argparse.Namespace, guard_home: Path) -> ApprovalGateInput | None:
     password = getattr(args, "approval_password", None)
     totp_code = getattr(args, "approval_totp", None)
@@ -1187,13 +1170,17 @@ def _package_firewall_cli_gate_input(args: argparse.Namespace, guard_home: Path)
 def _package_firewall_block_payload(
     *,
     entitlement: dict[str, object],
+    has_installed_managers: bool,
     operation: str,
 ) -> tuple[int, dict[str, object]]:
     status, error_code, message = package_firewall_block_details(entitlement)
     return (
         status,
         {
-            "available_actions": ["status", "education", "cli_fallback"],
+            "available_actions": package_firewall_available_actions(
+                entitlement,
+                has_installed_managers=has_installed_managers,
+            ),
             "cli_fallback": {
                 "connect": "hol-guard connect",
                 "status": "hol-guard package-shims status --json",
@@ -2096,16 +2083,21 @@ def run_guard_command(
         )
         shim_command = getattr(args, "package_shims_command", "status")
         entitlement = resolve_package_firewall_entitlement_with_refresh(store)
+        current_status = package_shim_status(context)
         if shim_command == "status":
-            payload = package_shim_status(context)
-            payload["actions"] = _package_firewall_action_states(entitlement)
+            payload = current_status
+            payload["actions"] = package_firewall_action_states(
+                entitlement,
+                has_installed_managers=bool(current_status.get("installed_managers")),
+            )
             payload["entitlement"] = entitlement
             payload["generated_at"] = _now()
             _emit("package-shims", payload, getattr(args, "json", False))
             return 0
-        if not bool(entitlement["allowed"]):
+        if shim_command not in {"repair", "uninstall"} and not bool(entitlement["allowed"]):
             status, payload = _package_firewall_block_payload(
                 entitlement=entitlement,
+                has_installed_managers=bool(current_status.get("installed_managers")),
                 operation="remove" if shim_command == "uninstall" else shim_command,
             )
             payload["generated_at"] = _now()

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1822,9 +1822,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 manager for manager in tested_managers if manager in installed and manager not in protected
             ]
             return {
-                "blocked_execution": bool(tested_managers) and all(
-                    manager in protected for manager in tested_managers
-                ),
+                "blocked_execution": bool(tested_managers) and all(manager in protected for manager in tested_managers),
                 "missing_managers": [manager for manager in tested_managers if manager not in installed],
                 "package_shims": status,
                 "path_repair_required": path_repair_required,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -89,7 +89,11 @@ from ..local_supply_chain import (
     resolve_package_firewall_entitlement_with_refresh,
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
-from ..package_firewall_entitlement import package_firewall_block_details
+from ..package_firewall_entitlement import (
+    package_firewall_action_states,
+    package_firewall_available_actions,
+    package_firewall_block_details,
+)
 from ..receipts.manager import build_receipt
 from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
@@ -562,15 +566,6 @@ def _resolve_package_firewall_connect_flow(
         flow["poll_after_ms"] = None
         return flow
     return flow
-
-
-def _package_firewall_available_actions(entitlement: dict[str, object]) -> list[str]:
-    reason = str(entitlement.get("reason") or "").strip().lower()
-    actions = ["status"]
-    if reason in {"guard_cloud_connect_required", "guard_cloud_reconnect_required"}:
-        actions.append("connect")
-    actions.extend(["education", "cli_fallback"])
-    return actions
 
 
 def _finalize_daemon_guard_connect_payload(
@@ -1671,9 +1666,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         entitlement = self._supply_chain_entitlement()
         if not bool(entitlement["allowed"]):
             status, error_code, message = package_firewall_block_details(entitlement)
+            current_status = package_shim_status(self._supply_chain_context(payload))
             self._write_json(
                 {
-                    "available_actions": _package_firewall_available_actions(entitlement),
+                    "available_actions": package_firewall_available_actions(
+                        entitlement,
+                        has_installed_managers=bool(current_status.get("installed_managers")),
+                    ),
                     "entitlement": entitlement,
                     "error": error_code,
                     "message": message,
@@ -1723,7 +1722,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         status = package_shim_status(self._harness_context({}))
         self._write_json(
             {
-                "actions": self._supply_chain_action_states(entitlement),
+                "actions": package_firewall_action_states(
+                    entitlement,
+                    has_installed_managers=bool(status.get("installed_managers")),
+                ),
                 "cli_fallback": {
                     "connect": "hol-guard connect",
                     "install": "hol-guard package-shims install --json",
@@ -1745,11 +1747,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         operation = "remove" if action == "uninstall" else action
         entitlement = self._supply_chain_entitlement()
-        if not bool(entitlement["allowed"]):
+        context = self._supply_chain_context(payload)
+        current_status = package_shim_status(context)
+        if operation not in {"repair", "remove"} and not bool(entitlement["allowed"]):
             status, error_code, message = package_firewall_block_details(entitlement)
             self._write_json(
                 {
-                    "available_actions": _package_firewall_available_actions(entitlement),
+                    "available_actions": package_firewall_available_actions(
+                        entitlement,
+                        has_installed_managers=bool(current_status.get("installed_managers")),
+                    ),
                     "entitlement": entitlement,
                     "error": error_code,
                     "message": message,
@@ -1758,7 +1765,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 status=status,
             )
             return
-        context = self._supply_chain_context(payload)
         managers, manager_error = self._supply_chain_managers(payload)
         if manager_error is not None:
             self._write_json({"error": manager_error, "operation": operation}, status=400)
@@ -1810,10 +1816,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if operation == "test":
             status = package_shim_status(context)
             installed = {str(manager) for manager in status.get("installed_managers", []) if isinstance(manager, str)}
+            protected = {str(manager) for manager in status.get("protected_managers", []) if isinstance(manager, str)}
             tested_managers = list(managers or tuple(sorted(installed)))
+            path_repair_required = [
+                manager for manager in tested_managers if manager in installed and manager not in protected
+            ]
             return {
-                "blocked_execution": all(manager in installed for manager in tested_managers),
+                "blocked_execution": bool(tested_managers) and all(
+                    manager in protected for manager in tested_managers
+                ),
+                "missing_managers": [manager for manager in tested_managers if manager not in installed],
                 "package_shims": status,
+                "path_repair_required": path_repair_required,
                 "tested_managers": tested_managers,
             }
         if operation == "audit":
@@ -1852,27 +1866,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def _supply_chain_entitlement(self) -> dict[str, object]:
         return resolve_package_firewall_entitlement_with_refresh(self.server.store)  # type: ignore[attr-defined]
-
-    @staticmethod
-    def _supply_chain_action_states(entitlement: dict[str, object]) -> dict[str, str]:
-        allowed = bool(entitlement.get("allowed"))
-        reason = str(entitlement.get("reason") or "").strip().lower()
-        if allowed:
-            state = "available"
-        elif reason == "guard_cloud_connect_required":
-            state = "connect_required"
-        elif reason == "guard_cloud_reconnect_required":
-            state = "reconnect_required"
-        else:
-            state = "paid_required"
-        return {
-            "install": state,
-            "repair": state,
-            "test": state,
-            "audit": state,
-            "sync": state,
-            "remove": state,
-        }
 
     def _supply_chain_connect_flow(self, entitlement: dict[str, object]) -> dict[str, object] | None:
         return _resolve_package_firewall_connect_flow(server=self.server, entitlement=entitlement)  # type: ignore[arg-type]

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/runtime-overview.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/runtime-overview.js
@@ -93,9 +93,10 @@ function resolvePackageManagerProtectionCopy(protection) {
     };
   }
   const pathInPath = protection.path_status === "in_path";
+  const installedButInactive = protection.installed_managers.length > 0;
   return {
     pathLabel: pathInPath ? "Guard shim directory is in PATH" : "Guard shim directory missing from PATH",
-    pathDetail: pathInPath ? `Package manager commands are intercepted via ${protection.shim_dir}.` : `The shim directory (${protection.shim_dir}) is not on PATH. Install bypass is possible for package managers that are not otherwise protected.`,
+    pathDetail: pathInPath ? `Package manager commands are intercepted via ${protection.shim_dir}.` : installedButInactive ? `The shim directory (${protection.shim_dir}) is not on PATH yet. Use Fix PATH on an installed manager and Guard will update your shell profile automatically.` : `The shim directory (${protection.shim_dir}) is not on PATH. Install bypass is possible for package managers that are not otherwise protected.`,
     pathTone: pathInPath ? "green" : "attention",
     protectedList: protection.protected_managers,
     unprotectedList: protection.unprotected_managers

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -105,7 +105,7 @@ function ConnectFlowCard({
       },
       step.title
     )) }),
-    localRecoveryHint !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3", children: [
+    localRecoveryHint != null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.14em] text-slate-400", children: "Available now" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: localRecoveryHint })
     ] }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, g as HiMiniCheckCircle, ab as HiMiniArrowPath, b as HiMiniExclamationTriangle, T as Tag, A as ActionButton, H as HiMiniShieldCheck, ai as HiMiniArrowTopRightOnSquare, h as HiMiniXCircle, r as reactExports, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, ao as startPackageFirewallConnect, S as SectionLabel, E as EmptyState, ap as HiMiniBugAnt, a as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, T as Tag, A as ActionButton, ab as HiMiniArrowPath, H as HiMiniShieldCheck, ai as HiMiniArrowTopRightOnSquare, g as HiMiniCheckCircle, b as HiMiniExclamationTriangle, h as HiMiniXCircle, r as reactExports, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, ao as startPackageFirewallConnect, S as SectionLabel, E as EmptyState, ap as HiMiniBugAnt, a as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
 import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 import { b as resolvePackageManagerProtectionCopy } from "./runtime-overview.js";
 function UpgradeCta({ entitlement }) {
@@ -64,6 +64,7 @@ function ConnectFlowCard({
   connectError,
   connectStarting,
   connectFlow,
+  localRecoveryHint,
   mode,
   onStartConnect
 }) {
@@ -76,9 +77,9 @@ function ConnectFlowCard({
   const statusTone = mode === "repair" ? "attention" : "blue";
   const statusLabel = mode === "repair" ? "Repair required" : "Connection required";
   const showManualLink = connectFlow.authorize_url !== null || running || failed;
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-[24px] border border-brand-blue/20 bg-gradient-to-br from-brand-blue/[0.05] via-white to-brand-purple/[0.04] px-4 py-4 shadow-[0_18px_45px_-34px_rgba(39,80,180,0.5)]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2.5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-brand-blue", children: "HOL Guard Cloud" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: statusTone, children: statusLabel })
@@ -88,12 +89,12 @@ function ConnectFlowCard({
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "max-w-3xl text-sm leading-relaxed text-slate-500", children: connectFlow.detail })
         ] })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[18px] border border-slate-200 bg-white/85 px-3.5 py-3 sm:max-w-xs", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.14em] text-slate-400", children: "Security" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: "Guard does not change package-manager routing until this machine receives signed cloud access." })
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2.5 sm:grid-cols-3", children: steps.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2.5 md:grid-cols-3", children: steps.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       ConnectStep,
       {
         index: index + 1,
@@ -104,6 +105,10 @@ function ConnectFlowCard({
       },
       step.title
     )) }),
+    localRecoveryHint !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.14em] text-slate-400", children: "Available now" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: localRecoveryHint })
+    ] }),
     connectError !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[18px] border border-brand-attention/25 bg-brand-attention/[0.05] px-3.5 py-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Guard could not start local connect" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: connectError })
@@ -130,7 +135,7 @@ function CliFallback({ commands }) {
     ] }, label)) })
   ] });
 }
-function FreeUserView({
+function EntitlementNotice({
   connectError,
   connectStarting,
   data,
@@ -138,7 +143,7 @@ function FreeUserView({
 }) {
   const connectRequired = data.entitlement.reason === "guard_cloud_connect_required" || data.entitlement.reason === "guard_cloud_reconnect_required";
   const connectMode = data.entitlement.reason === "guard_cloud_reconnect_required" ? "repair" : "connect";
-  const supportedManagersLabel = connectRequired ? "Protected after connect" : "Would be protected";
+  const localRecoveryHint = data.package_shims.some((shim) => shim.installed) ? connectRequired ? "Existing shims on this machine can still be fixed or removed locally. Connect is only needed for new installs and cloud-gated verification." : null : null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-4 py-4", children: [
     connectRequired && data.connect_flow !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       ConnectFlowCard,
@@ -146,21 +151,11 @@ function FreeUserView({
         connectError,
         connectStarting,
         connectFlow: data.connect_flow,
+        localRecoveryHint,
         mode: connectMode,
         onStartConnect
       }
     ) : /* @__PURE__ */ jsxRuntimeExports.jsx(UpgradeCta, { entitlement: data.entitlement }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-2 text-xs font-semibold uppercase tracking-[0.15em] text-slate-400", children: supportedManagersLabel }),
-      data.supported_managers.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "No supported managers detected on this machine." }) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap gap-1.5", children: data.supported_managers.map((mgr) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "span",
-        {
-          className: "inline-flex items-center gap-1 rounded-full border border-slate-200 bg-slate-50 px-2.5 py-0.5 font-mono text-xs text-slate-600",
-          children: mgr
-        },
-        mgr
-      )) })
-    ] }),
     data.cli_fallback !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(CliFallback, { commands: data.cli_fallback })
   ] });
 }
@@ -168,7 +163,7 @@ function activationHeadline(protection) {
   if (protection === null) return "Activation status unavailable";
   if (protection.path_status === "in_path") return "Protection live now";
   if (protection.path_status === "restart_required") return "Restart shell or apps to finish activation";
-  return "PATH repair still needed";
+  return "Fix PATH to finish activation";
 }
 function ActivationSummary({ protection }) {
   if (protection === null) {
@@ -302,6 +297,9 @@ function ActionBtn({ label, icon, variant, onClick, disabled }) {
     label
   ] });
 }
+function actionIsAvailable(state) {
+  return state === "available";
+}
 function ActionButtonRow({
   shim,
   actions,
@@ -315,14 +313,14 @@ function ActionButtonRow({
   const repairState = actions.repair ?? "disabled";
   const testState = actions.test ?? "disabled";
   const removeState = actions.remove ?? "disabled";
-  const installBlocked = installState === "paid_required" || installState === "reconnect_required";
-  const repairBlocked = repairState === "paid_required" || repairState === "reconnect_required";
-  const testBlocked = testState === "paid_required" || testState === "reconnect_required";
-  const removeBlocked = removeState === "paid_required" || removeState === "reconnect_required";
-  const showInstall = !shim.installed && installState !== "disabled";
-  const showRepair = shim.installed && shim.activation_state !== "restart_required" && repairState !== "disabled";
-  const showTest = testState !== "disabled";
-  const showRemove = removeState !== "disabled" && shim.installed;
+  const installAvailable = actionIsAvailable(installState);
+  const repairAvailable = actionIsAvailable(repairState);
+  const testAvailable = actionIsAvailable(testState);
+  const removeAvailable = actionIsAvailable(removeState);
+  const showInstall = !shim.installed && installAvailable;
+  const showRepair = shim.installed && shim.activation_state === "repair_required" && repairAvailable;
+  const showTest = shim.installed && shim.activation_state === "protected" && testAvailable;
+  const showRemove = shim.installed && removeAvailable;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-1.5", children: [
     showInstall && /* @__PURE__ */ jsxRuntimeExports.jsx(
       ActionBtn,
@@ -331,17 +329,17 @@ function ActionButtonRow({
         icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mr-1 h-3.5 w-3.5", "aria-hidden": "true" }),
         variant: "primary",
         onClick: onInstall,
-        disabled: anyPending || installBlocked
+        disabled: anyPending
       }
     ),
     showRepair && /* @__PURE__ */ jsxRuntimeExports.jsx(
       ActionBtn,
       {
-        label: "Repair",
+        label: "Fix PATH",
         icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniWrenchScrewdriver, { className: "mr-1 h-3.5 w-3.5", "aria-hidden": "true" }),
-        variant: "secondary",
+        variant: "primary",
         onClick: onRepair,
-        disabled: anyPending || repairBlocked
+        disabled: anyPending
       }
     ),
     showTest && /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -351,7 +349,7 @@ function ActionButtonRow({
         icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "mr-1 h-3.5 w-3.5", "aria-hidden": "true" }),
         variant: "outline",
         onClick: onTest,
-        disabled: anyPending || testBlocked
+        disabled: anyPending
       }
     ),
     showRemove && /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -361,7 +359,7 @@ function ActionButtonRow({
         icon: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniTrash, { className: "mr-1 h-3.5 w-3.5", "aria-hidden": "true" }),
         variant: "danger",
         onClick: onRemoveRequest,
-        disabled: anyPending || removeBlocked
+        disabled: anyPending
       }
     )
   ] });
@@ -435,6 +433,7 @@ function ManagerActionCard({
       }
     ),
     shim.activation_state === "restart_required" && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Guard updated your shell profile. Open a new shell or restart AI apps to activate this shim." }),
+    shim.activation_state === "repair_required" && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Guard can add the shim directory to your shell profile automatically, then this manager will be ready after a restart." }),
     shim.shim_path !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "break-all font-mono text-[10px] text-slate-400", children: shim.shim_path })
   ] });
 }
@@ -536,12 +535,13 @@ function FailureBanner({ failed }) {
     }
   );
 }
-function PaidUserView({
+function FirewallControlsView({
   data,
   pendingOp,
   lastCompleted,
   lastFailed,
   confirmRemoveManager,
+  showGlobalActions,
   onInstall,
   onRepair,
   onTest,
@@ -556,7 +556,7 @@ function PaidUserView({
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-4 py-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-2", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Per-manager controls" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
+      showGlobalActions && /* @__PURE__ */ jsxRuntimeExports.jsx(
         GlobalActionsBar,
         {
           anyPending,
@@ -766,33 +766,37 @@ function PackageFirewallPanel(props) {
     ] }),
     panelLoad.phase === "loading" && /* @__PURE__ */ jsxRuntimeExports.jsx(LoadingSkeleton, {}),
     panelLoad.phase === "error" && /* @__PURE__ */ jsxRuntimeExports.jsx(ErrorBanner, { message: panelLoad.message, onRetry: handleRetry }),
-    panelLoad.phase === "loaded" && (panelLoad.data.entitlement.allowed ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-      PaidUserView,
-      {
-        data: panelLoad.data,
-        pendingOp,
-        lastCompleted,
-        lastFailed,
-        confirmRemoveManager,
-        onInstall: handleInstall,
-        onRepair: handleRepair,
-        onTest: handleTest,
-        onRemoveRequest: handleRemoveRequest,
-        onRemoveConfirm: handleRemoveConfirm,
-        onRemoveCancel: handleRemoveCancel,
-        onAudit: handleAudit,
-        onSync: handleSync,
-        onDismissResult: handleDismissResult
-      }
-    ) : /* @__PURE__ */ jsxRuntimeExports.jsx(
-      FreeUserView,
-      {
-        connectError,
-        connectStarting: startingConnect,
-        data: panelLoad.data,
-        onStartConnect: handleStartConnect
-      }
-    )),
+    panelLoad.phase === "loaded" && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      !panelLoad.data.entitlement.allowed && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "border-b border-slate-100", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        EntitlementNotice,
+        {
+          connectError,
+          connectStarting: startingConnect,
+          data: panelLoad.data,
+          onStartConnect: handleStartConnect
+        }
+      ) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        FirewallControlsView,
+        {
+          data: panelLoad.data,
+          pendingOp,
+          lastCompleted,
+          lastFailed,
+          confirmRemoveManager,
+          showGlobalActions: panelLoad.data.entitlement.allowed,
+          onInstall: handleInstall,
+          onRepair: handleRepair,
+          onTest: handleTest,
+          onRemoveRequest: handleRemoveRequest,
+          onRemoveConfirm: handleRemoveConfirm,
+          onRemoveCancel: handleRemoveCancel,
+          onAudit: handleAudit,
+          onSync: handleSync,
+          onDismissResult: handleDismissResult
+        }
+      )
+    ] }),
     pendingApprovalOp !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(
       ApprovalProofModal,
       {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13900,14 +13900,15 @@ function normalizePackageFirewallConnectFlow(value) {
   };
 }
 function normalizePackageShimEntry(manager, detail, pathStatus) {
-  const installed = detail !== null && stringValue(detail.integrity) !== "missing";
+  const integrity = stringValue(detail?.integrity) ?? "uninstalled";
+  const installed = detail !== null && integrity !== "missing";
   const active = booleanValue(detail?.path_active);
-  const activation_state = !installed ? "uninstalled" : active ? "protected" : pathStatus === "restart_required" ? "restart_required" : "repair_required";
+  const activation_state = !installed ? "uninstalled" : integrity === "tampered" ? "repair_required" : active ? "protected" : pathStatus === "restart_required" ? "restart_required" : "repair_required";
   return {
     active,
     activation_state,
     installed,
-    integrity: stringValue(detail?.integrity) ?? "uninstalled",
+    integrity,
     manager,
     path_index: numberValue(detail?.path_index),
     real_binary_found: booleanValue(detail?.real_binary_found),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -140,7 +140,6 @@
     --color-black: #000;
     --color-white: #fff;
     --spacing: .25rem;
-    --container-xs: 20rem;
     --container-sm: 24rem;
     --container-md: 28rem;
     --container-lg: 32rem;
@@ -1399,6 +1398,12 @@
     margin-block-end: calc(calc(var(--spacing) * 2) * calc(1 - var(--tw-space-y-reverse)));
   }
 
+  :where(.space-y-2\.5 > :not(:last-child)) {
+    --tw-space-y-reverse: 0;
+    margin-block-start: calc(calc(var(--spacing) * 2.5) * var(--tw-space-y-reverse));
+    margin-block-end: calc(calc(var(--spacing) * 2.5) * calc(1 - var(--tw-space-y-reverse)));
+  }
+
   :where(.space-y-3 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
     margin-block-start: calc(calc(var(--spacing) * 3) * var(--tw-space-y-reverse));
@@ -1515,10 +1520,6 @@
 
   .rounded-\[18px\] {
     border-radius: 18px;
-  }
-
-  .rounded-\[24px\] {
-    border-radius: 24px;
   }
 
   .rounded-full {
@@ -3035,20 +3036,6 @@
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
   }
 
-  .to-brand-purple\/\[0\.04\] {
-    --tw-gradient-to: var(--brand-purple);
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    .to-brand-purple\/\[0\.04\] {
-      --tw-gradient-to: color-mix(in oklab, var(--brand-purple) 4%, transparent);
-    }
-  }
-
-  .to-brand-purple\/\[0\.04\] {
-    --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
-  }
-
   .to-white {
     --tw-gradient-to: var(--color-white);
     --tw-gradient-stops: var(--tw-gradient-via-stops, var(--tw-gradient-position), var(--tw-gradient-from) var(--tw-gradient-from-position), var(--tw-gradient-to) var(--tw-gradient-to-position));
@@ -3796,11 +3783,6 @@
 
   .shadow-\[0_16px_40px_rgba\(63\,65\,116\,0\.10\)\] {
     --tw-shadow: 0 16px 40px var(--tw-shadow-color, #3f41741a);
-    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
-  }
-
-  .shadow-\[0_18px_45px_-34px_rgba\(39\,80\,180\,0\.5\)\] {
-    --tw-shadow: 0 18px 45px -34px var(--tw-shadow-color, #2750b480);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 
@@ -4610,10 +4592,6 @@
 
     .sm\:table-cell {
       display: table-cell;
-    }
-
-    .sm\:max-w-xs {
-      max-width: var(--container-xs);
     }
 
     .sm\:grid-cols-2 {

--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -213,6 +213,47 @@ def resolve_package_firewall_entitlement(
     return _connect_required_entitlement(store)
 
 
+def package_firewall_action_states(
+    entitlement: dict[str, object],
+    *,
+    has_installed_managers: bool,
+) -> dict[str, str]:
+    allowed = bool(entitlement.get("allowed"))
+    reason = str(entitlement.get("reason") or "").strip().lower()
+    if allowed:
+        blocked_state = "available"
+    elif reason == "guard_cloud_connect_required":
+        blocked_state = "connect_required"
+    elif reason == "guard_cloud_reconnect_required":
+        blocked_state = "reconnect_required"
+    else:
+        blocked_state = "paid_required"
+    local_recovery_state = "available" if has_installed_managers else "disabled"
+    return {
+        "install": blocked_state,
+        "repair": local_recovery_state,
+        "test": blocked_state,
+        "audit": blocked_state,
+        "sync": blocked_state,
+        "remove": local_recovery_state,
+    }
+
+
+def package_firewall_available_actions(
+    entitlement: dict[str, object],
+    *,
+    has_installed_managers: bool,
+) -> list[str]:
+    reason = str(entitlement.get("reason") or "").strip().lower()
+    actions = ["status"]
+    if reason in {"guard_cloud_connect_required", "guard_cloud_reconnect_required"}:
+        actions.append("connect")
+    if has_installed_managers:
+        actions.extend(["repair", "remove"])
+    actions.extend(["education", "cli_fallback"])
+    return actions
+
+
 def package_firewall_block_details(entitlement: dict[str, object]) -> tuple[int, str, str]:
     if entitlement.get("reason") == "guard_cloud_connect_required":
         return (

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.cli.connect_flow import GuardOAuthTokenExchangeResult
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -23,6 +24,7 @@ from codex_plugin_scanner.guard.daemon import server as daemon_server
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -124,6 +126,17 @@ def _dashboard_token_for(store: GuardStore) -> str:
     return _dashboard_token(auth_token)
 
 
+def _install_local_package_shim(store: GuardStore, home_dir: Path, manager: str) -> None:
+    install_package_shims(
+        HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=None,
+            guard_home=store.guard_home,
+        ),
+        managers=(manager,),
+    )
+
+
 def test_headless_capabilities_endpoint_reports_safe_action_contract(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -197,11 +210,11 @@ def test_supply_chain_package_firewall_status_reports_connect_gate_when_cloud_is
     assert payload["connect_flow"]["state"] == "idle"
     assert payload["actions"] == {
         "install": "connect_required",
-        "repair": "connect_required",
+        "repair": "disabled",
         "test": "connect_required",
         "audit": "connect_required",
         "sync": "connect_required",
-        "remove": "connect_required",
+        "remove": "disabled",
     }
 
 
@@ -396,6 +409,8 @@ def test_supply_chain_package_firewall_status_reports_reconnect_gate_for_expired
         "upgrade_cta": "Reconnect HOL Guard Cloud to refresh package firewall access.",
     }
     assert payload["actions"]["install"] == "reconnect_required"
+    assert payload["actions"]["repair"] == "disabled"
+    assert payload["actions"]["remove"] == "disabled"
 
 
 def test_supply_chain_package_firewall_install_requires_reconnect_when_cloud_auth_expired(
@@ -580,11 +595,11 @@ def test_supply_chain_package_firewall_status_accepts_paid_oauth_entitlement(tmp
     }
     assert payload["actions"] == {
         "install": "available",
-        "repair": "available",
+        "repair": "disabled",
         "test": "available",
         "audit": "available",
         "sync": "available",
-        "remove": "available",
+        "remove": "disabled",
     }
 
 
@@ -666,7 +681,101 @@ def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(
     assert test_payload["operation"] == "test"
     assert test_payload["status"] == "completed"
     assert test_payload["result"]["tested_managers"] == ["npm"]
-    assert test_payload["result"]["blocked_execution"] is True
+    assert test_payload["result"]["blocked_execution"] is False
+    assert test_payload["result"]["path_repair_required"] == ["npm"]
+
+
+def test_supply_chain_package_firewall_status_exposes_local_recovery_when_connect_is_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    store = GuardStore(tmp_path / "guard-home")
+    _install_local_package_shim(store, home_dir, "npm")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims",
+                method="GET",
+                token=token,
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["entitlement"]["reason"] == "guard_cloud_connect_required"
+    assert payload["actions"]["install"] == "connect_required"
+    assert payload["actions"]["repair"] == "available"
+    assert payload["actions"]["remove"] == "available"
+
+
+def test_supply_chain_package_firewall_repair_runs_without_guard_cloud_connect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    store = GuardStore(tmp_path / "guard-home")
+    _install_local_package_shim(store, home_dir, "npm")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/repair",
+                token=token,
+                payload={"managers": ["npm"]},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["entitlement"]["reason"] == "guard_cloud_connect_required"
+    assert payload["result"]["activation_state"] == "restart_required"
+    assert payload["result"]["profile"]["changed"] is True
+
+
+def test_supply_chain_package_firewall_remove_runs_without_guard_cloud_connect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    store = GuardStore(tmp_path / "guard-home")
+    _install_local_package_shim(store, home_dir, "npm")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/remove",
+                token=token,
+                payload={"managers": ["npm"]},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["entitlement"]["reason"] == "guard_cloud_connect_required"
+    assert payload["result"]["removed_managers"] == ["npm"]
 
 
 def test_audit_package_shim_path_remediation_requires_approval_gate_proof(tmp_path: Path) -> None:

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -9,7 +9,9 @@ import pytest
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
+from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -73,6 +75,17 @@ def _seed_retry_required_oauth_connect(home_dir: Path) -> None:
     )
 
 
+def _install_local_package_shim(guard_home: Path, home_dir: Path, manager: str) -> None:
+    install_package_shims(
+        HarnessContext(
+            home_dir=home_dir,
+            workspace_dir=None,
+            guard_home=guard_home,
+        ),
+        managers=(manager,),
+    )
+
+
 def test_package_shims_install_requires_guard_cloud_connect_first(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -90,6 +103,7 @@ def test_package_shims_install_requires_guard_cloud_connect_first(
         "tier": "unknown",
         "upgrade_cta": "Connect HOL Guard Cloud to check package firewall access and run package firewall actions.",
     }
+    assert payload["available_actions"] == ["status", "connect", "education", "cli_fallback"]
 
 
 def test_package_shims_status_reports_reconnect_required_when_cloud_auth_expired(
@@ -121,6 +135,8 @@ def test_package_shims_status_reports_reconnect_required_when_cloud_auth_expired
         "upgrade_cta": "Reconnect HOL Guard Cloud to refresh package firewall access.",
     }
     assert payload["actions"]["install"] == "reconnect_required"
+    assert payload["actions"]["repair"] == "disabled"
+    assert payload["actions"]["remove"] == "disabled"
 
 
 def test_package_shims_install_requires_reconnect_when_cloud_auth_expired(
@@ -222,6 +238,74 @@ def test_package_shims_status_reports_paid_oauth_entitlement(
         "upgrade_cta": None,
     }
     assert payload["actions"]["install"] == "available"
+    assert payload["actions"]["repair"] == "disabled"
+    assert payload["actions"]["remove"] == "disabled"
+
+
+def test_package_shims_status_allows_local_recovery_when_cloud_is_not_connected(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    guard_home = tmp_path / "guard-home"
+    _install_local_package_shim(guard_home, home_dir, "npm")
+
+    rc = main(["guard", "package-shims", "status", "--home", str(guard_home), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["entitlement"]["reason"] == "guard_cloud_connect_required"
+    assert payload["actions"]["install"] == "connect_required"
+    assert payload["actions"]["repair"] == "available"
+    assert payload["actions"]["remove"] == "available"
+
+
+def test_package_shims_repair_runs_without_guard_cloud_connect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    guard_home = tmp_path / "guard-home"
+    _install_local_package_shim(guard_home, home_dir, "npm")
+
+    rc = main(["guard", "package-shims", "repair", "--manager", "npm", "--home", str(guard_home), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["entitlement"]["reason"] == "guard_cloud_connect_required"
+    assert payload["activation_state"] == "restart_required"
+    assert payload["profile"]["changed"] is True
+    profile_path = Path(str(payload["profile"]["profile_path"]))
+    assert str(guard_home / "package-shims" / "bin") in profile_path.read_text(encoding="utf-8")
+
+
+def test_package_shims_uninstall_runs_without_guard_cloud_connect(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    guard_home = tmp_path / "guard-home"
+    _install_local_package_shim(guard_home, home_dir, "npm")
+
+    rc = main(["guard", "package-shims", "uninstall", "--manager", "npm", "--home", str(guard_home), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["entitlement"]["reason"] == "guard_cloud_connect_required"
+    assert payload["removed_managers"] == ["npm"]
+    assert not (guard_home / "package-shims" / "bin" / "npm").exists()
 
 
 def test_package_shims_install_requires_local_approval_gate_proof(


### PR DESCRIPTION
## Summary
- unblock local package-firewall recovery so existing shims can be repaired or removed even when Guard Cloud connect is still required
- flatten the supply-chain connect surface, hide dead-end test/install states, and clarify PATH recovery copy

## Testing
- `pnpm exec tsx src/package-firewall-connect.test.tsx`
- `pnpm exec tsx src/runtime-overview.test.ts`
- `pnpm exec tsx src/guard-api.test.ts`
- `pnpm run build`
- `uv run --extra dev python -m pytest -q tests/test_guard_package_shims_cli.py`
- `uv run --extra dev python -m pytest -q tests/test_guard_headless_daemon_api.py`
- `uv run --extra dev ruff check src/codex_plugin_scanner/guard/package_firewall_entitlement.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_package_shims_cli.py tests/test_guard_headless_daemon_api.py`

## Notes
- Live browser proof covered the real machine state on a patched daemon: `Fix PATH` and `Remove` were available while cloud connect was still required, and `Fix PATH` opened the local approval modal instead of dead-ending.
- Isolated approval-gated browser runs confirmed both `repair` and `remove` return the expected `403 approval_gate_required` first and then succeed after entering the local approval password.
