### PR TITLE
fix: remove initialize root-token bootstrap

### DIFF
--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -660,7 +660,10 @@ assert(approvalUrl.searchParams.get("harness") === "copilot", "L078: fetchApprov
 assert(approvalUrl.searchParams.get("search") === "plugin secret", "L078: fetchApprovalPage forwards search filter");
 assert(approvalUrl.searchParams.get("cursor") === "cursor-one", "L078: fetchApprovalPage forwards cursor");
 assert(approvalUrl.searchParams.get("limit") === "25", "L078: fetchApprovalPage forwards limit");
-assert(headerValue(fetchApprovalCalls[0].init, "X-Guard-Token") === "token-queue", "L078: fetchApprovalPage sends Guard token");
+assert(
+  headerValue(fetchApprovalCalls[0].init, "X-Guard-Dashboard-Session") === "token-queue",
+  "L078: fetchApprovalPage sends dashboard session token"
+);
 assert(approvalPage.items[0].action_envelope_json?.action_id === "act-abc123", "L078: fetchApprovalPage normalizes action envelope");
 assert(approvalPage.items[0].decision_v2_json?.user_title === "Wants to read a credential file", "L078: fetchApprovalPage normalizes decision v2");
 assert(approvalPage.next_cursor === "cursor-two", "L078: fetchApprovalPage returns next cursor");
@@ -757,7 +760,10 @@ const clearQueueResult = await clearReviewQueue({
 });
 const clearQueueBody = JSON.parse(String(clearQueueCalls[0].init?.body)) as Record<string, unknown>;
 assert(clearQueueCalls[0].url === "http://127.0.0.1:4781/v1/requests/clear", "L079b: clearReviewQueue posts to clear route");
-assert(headerValue(clearQueueCalls[0].init, "X-Guard-Token") === "token-clear-queue", "L079b: clearReviewQueue sends Guard token");
+assert(
+  headerValue(clearQueueCalls[0].init, "X-Guard-Dashboard-Session") === "token-clear-queue",
+  "L079b: clearReviewQueue sends dashboard session token"
+);
 assert(clearQueueBody["status"] === "pending", "L079b: clearReviewQueue clears pending reviews");
 const clearQueueGate = clearQueueBody["approval_gate"] as Record<string, unknown>;
 assert(clearQueueGate["password"] === "local-password", "L079b: clearReviewQueue sends approval password");
@@ -785,7 +791,10 @@ assert(
   remediationCalls[0].url === "http://127.0.0.1:4781/v1/audit/remediations/package_shim_path",
   "L079c: runAuditRemediation posts to daemon remediation route"
 );
-assert(headerValue(remediationCalls[0].init, "X-Guard-Token") === "token-remediate", "L079c: runAuditRemediation sends Guard token");
+assert(
+  headerValue(remediationCalls[0].init, "X-Guard-Dashboard-Session") === "token-remediate",
+  "L079c: runAuditRemediation sends dashboard session token"
+);
 assert(remediationBody["manager"] === "pnpm", "L079c: runAuditRemediation sends manager");
 assert(remediationBody["approval_password"] === "local-password", "L079c: runAuditRemediation sends approval password");
 assert(remediationBody["approval_totp_code"] === "123456", "L079c: runAuditRemediation sends approval TOTP code");
@@ -797,42 +806,29 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   const url = input instanceof Request ? input.url : String(input);
   remediationBootstrapCalls.push({ url, init });
   const path = new URL(url, "http://127.0.0.1:4174").pathname;
-  if (path === "/v1/initialize") {
-    return new Response(JSON.stringify({ auth_token: "fresh-remediate-token" }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
-  }
   if (path === "/v1/audit/remediations/package_shim_path") {
-    const token = headerValue(init, "X-Guard-Token");
-    if (token !== "fresh-remediate-token") {
-      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
-    }
-    return new Response(JSON.stringify({
-      entitlement: { allowed: true },
-      operation: "package_shim_path",
-      receipt: null,
-      result: { manager: "pnpm" },
-      status: "completed"
-    }), {
-      status: 200,
+    return new Response(JSON.stringify({ error: "unauthorized", message: "Guard session missing." }), {
+      status: 401,
       headers: { "Content-Type": "application/json" }
     });
   }
   return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
 };
 
-const remediationBootstrap = await runAuditRemediation({
-  action: "package_shim_path",
-  manager: "pnpm",
-});
-assert(remediationBootstrapCalls.length === 3, "L079d: remediation bootstraps token after 401 and retries");
-assert(new URL(remediationBootstrapCalls[1].url).pathname === "/v1/initialize", "L079d: remediation calls initialize after unauthorized");
+let remediationBootstrapError: unknown = null;
+try {
+  await runAuditRemediation({
+    action: "package_shim_path",
+    manager: "pnpm",
+  });
+} catch (error) {
+  remediationBootstrapError = error;
+}
+assert(remediationBootstrapCalls.length === 1, "L079d: remediation does not call initialize to mint a new local session");
 assert(
-  headerValue(remediationBootstrapCalls[2].init, "X-Guard-Token") === "fresh-remediate-token",
-  "L079d: remediation retries with refreshed Guard token"
+  remediationBootstrapError instanceof GuardHarnessActionError && remediationBootstrapError.status === 401,
+  "L079d: remediation surfaces missing dashboard session as 401"
 );
-assert(remediationBootstrap.operation === "package_shim_path", "L079d: remediation succeeds after token bootstrap");
 
 installGuardWindow("?guard-token=token-firewall&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
 const firewallCalls = installFetchStub({
@@ -853,7 +849,10 @@ assert(
   firewallCalls[0].url === "http://127.0.0.1:4781/v1/supply-chain/package-shims/install",
   "L079da: runPackageFirewallAction posts to the install route"
 );
-assert(headerValue(firewallCalls[0].init, "X-Guard-Token") === "token-firewall", "L079da: runPackageFirewallAction sends Guard token");
+assert(
+  headerValue(firewallCalls[0].init, "X-Guard-Dashboard-Session") === "token-firewall",
+  "L079da: runPackageFirewallAction sends dashboard session token"
+);
 assert(Array.isArray(firewallBody["managers"]) && (firewallBody["managers"] as unknown[])[0] === "pnpm", "L079da: runPackageFirewallAction sends selected manager");
 assert(firewallBody["approval_password"] === "local-password", "L079da: runPackageFirewallAction sends approval password");
 assert(firewallBody["approval_totp_code"] === "123456", "L079da: runPackageFirewallAction sends approval TOTP code");
@@ -892,48 +891,30 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   const url = input instanceof Request ? input.url : String(input);
   connectCalls.push({ url, init });
   const path = new URL(url, "http://127.0.0.1:4174").pathname;
-  if (path === "/v1/initialize") {
-    return new Response(JSON.stringify({ auth_token: "fresh-connect-token" }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
-  }
   if (path === "/v1/supply-chain/package-shims/connect") {
-    const token = headerValue(init, "X-Guard-Token");
-    if (token !== "fresh-connect-token") {
-      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
-    }
-    return new Response(JSON.stringify({
-      state: "running",
-      title: "Finish Guard Cloud sign-in in your browser",
-      detail: "HOL Guard opened the secure sign-in flow in your browser.",
-      action_label: "Connect HOL Guard Cloud",
-      connect_url: "https://hol.org/guard/connect",
-      authorize_url: "https://hol.org/mock-authorize",
-      browser_opened: true,
-      request_id: "guard-connect-1",
-      poll_after_ms: 1500
-    }), {
-      status: 202,
+    return new Response(JSON.stringify({ error: "unauthorized", message: "Guard session missing." }), {
+      status: 401,
       headers: { "Content-Type": "application/json" }
     });
   }
   return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
 };
 
-const connectFlow = await startPackageFirewallConnect();
-assert(connectCalls.length === 3, "L079dc: connect flow bootstraps token after 401 and retries");
+let connectFlowError: unknown = null;
+try {
+  await startPackageFirewallConnect();
+} catch (error) {
+  connectFlowError = error;
+}
+assert(connectCalls.length === 1, "L079dc: connect flow does not mint local session from unauthenticated initialize");
 assert(
   new URL(connectCalls[0].url).pathname === "/v1/supply-chain/package-shims/connect",
   "L079dc: connect flow posts to daemon connect route"
 );
-assert(new URL(connectCalls[1].url).pathname === "/v1/initialize", "L079dc: connect flow refreshes token after unauthorized");
 assert(
-  headerValue(connectCalls[2].init, "X-Guard-Token") === "fresh-connect-token",
-  "L079dc: connect flow retries with refreshed Guard token"
+  connectFlowError instanceof Error && connectFlowError.message.includes("Guard session missing"),
+  "L079dc: connect flow surfaces missing dashboard session"
 );
-assert(connectFlow?.state === "running", "L079dc: connect flow normalizes running daemon response");
-assert(connectFlow?.authorize_url === "https://hol.org/mock-authorize", "L079dc: connect flow preserves authorize URL");
 
 installGuardWindow("?guard-token=token-remediate-error&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
 globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
@@ -994,7 +975,10 @@ const resolution = await resolveRequestWithQueueResult({
 const resolveBody = JSON.parse(String(fetchResolveCalls[0].init?.body)) as Record<string, unknown>;
 
 assert(fetchResolveCalls[0].url === "http://127.0.0.1:4781/v1/requests/req-active/approve", "L077: resolveRequestWithQueueResult posts to approve route");
-assert(headerValue(fetchResolveCalls[0].init, "X-Guard-Token") === "token-resolve", "L077: resolveRequestWithQueueResult sends Guard token");
+assert(
+  headerValue(fetchResolveCalls[0].init, "X-Guard-Dashboard-Session") === "token-resolve",
+  "L077: resolveRequestWithQueueResult sends dashboard session token"
+);
 assert(resolveBody["scope"] === "artifact", "L077: resolveRequestWithQueueResult sends scope");
 assert(resolveBody["workspace"] === "/workspace", "L077: resolveRequestWithQueueResult sends workspace");
 assert(resolveBody["reason"] === "reviewed", "L077: resolveRequestWithQueueResult sends reason");
@@ -1034,80 +1018,34 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   const url = input instanceof Request ? input.url : String(input);
   recoveryCalls.push({ url, init });
   const path = new URL(url, "http://127.0.0.1:4174").pathname;
-  if (path === "/v1/initialize") {
-    return new Response(JSON.stringify({ auth_token: "fresh-resolve-token" }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
-  }
   if (path === "/v1/requests/req-stale-token/approve") {
-    const token = headerValue(init, "X-Guard-Token");
-    if (token !== "fresh-resolve-token") {
-      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
-    }
-    return new Response(JSON.stringify({
-      resolved: true,
-      item: null,
-      resolved_request: null,
-      remaining_pending_count: 0,
-      next_selectable_request_id: null,
-      remaining_pending_summaries: [],
-      resolved_duplicate_ids: [],
-      resolution_summary: "Decision saved.",
-      retry_hint: null,
-      copy: null
-    }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
-  }
-  if (path === "/v1/requests/req-next-after-refresh/approve") {
-    const token = headerValue(init, "X-Guard-Token");
-    return new Response(JSON.stringify({
-      resolved: token === "fresh-resolve-token",
-      item: null,
-      resolved_request: null,
-      remaining_pending_count: 0,
-      next_selectable_request_id: null,
-      remaining_pending_summaries: [],
-      resolved_duplicate_ids: [],
-      resolution_summary: "Decision saved.",
-      retry_hint: null,
-      copy: null
-    }), {
-      status: token === "fresh-resolve-token" ? 200 : 401,
+    return new Response(JSON.stringify({ error: "unauthorized", message: "Guard session expired." }), {
+      status: 401,
       headers: { "Content-Type": "application/json" }
     });
   }
   return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
 };
 
-const recoveredResolution = await resolveRequestWithQueueResult({
-  requestId: "req-stale-token",
-  action: "allow",
-  scope: "global",
-  reason: "reviewed"
-});
-assert(recoveredResolution.resolved === true, "L077b: resolve retries after refreshing stale local token");
-assert(recoveryCalls.length === 3, "L077b: resolve retry makes approve, initialize, approve calls");
+let recoveredResolutionError: unknown = null;
+try {
+  await resolveRequestWithQueueResult({
+    requestId: "req-stale-token",
+    action: "allow",
+    scope: "global",
+    reason: "reviewed"
+  });
+} catch (error) {
+  recoveredResolutionError = error;
+}
+assert(recoveryCalls.length === 1, "L077b: stale dashboard session does not call initialize for root-token mint");
 assert(
-  headerValue(recoveryCalls[0].init, "X-Guard-Token") === "stale-resolve-token",
-  "L077b: first resolve attempt uses token from current URL"
+  headerValue(recoveryCalls[0].init, "X-Guard-Dashboard-Session") === "stale-resolve-token",
+  "L077b: first resolve attempt uses dashboard session from current URL"
 );
-assert(new URL(recoveryCalls[1].url).pathname === "/v1/initialize", "L077b: stale token recovery calls initialize");
 assert(
-  headerValue(recoveryCalls[2].init, "X-Guard-Token") === "fresh-resolve-token",
-  "L077b: retry uses refreshed Guard token"
-);
-await resolveRequestWithQueueResult({
-  requestId: "req-next-after-refresh",
-  action: "allow",
-  scope: "global",
-  reason: "reviewed"
-});
-assert(
-  headerValue(recoveryCalls[3].init, "X-Guard-Token") === "fresh-resolve-token",
-  "L077b: later requests keep using refreshed Guard token instead of stale URL token"
+  recoveredResolutionError instanceof Error && recoveredResolutionError.message.includes("Guard session expired"),
+  "L077b: stale dashboard session surfaces expiration error"
 );
 
 installGuardWindow("?guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
@@ -1115,13 +1053,6 @@ const malformedRefreshCalls: RecordedFetch[] = [];
 globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
   const url = input instanceof Request ? input.url : String(input);
   malformedRefreshCalls.push({ url, init });
-  const path = new URL(url, "http://127.0.0.1:4174").pathname;
-  if (path === "/v1/initialize") {
-    return new Response("<html>not json</html>", {
-      status: 200,
-      headers: { "Content-Type": "text/html" }
-    });
-  }
   return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
 };
 
@@ -1135,9 +1066,12 @@ try {
   throw new Error("expected malformed token refresh to preserve the 401 failure");
 } catch (error) {
   assert(error instanceof Error, "L077c: malformed refresh returns an Error");
+  if (!(error instanceof Error)) {
+    throw error;
+  }
   assert(error.message.includes("401"), "L077c: malformed refresh preserves original 401 status");
 }
-assert(malformedRefreshCalls.length === 2, "L077c: malformed refresh does not retry without a parsed token");
+assert(malformedRefreshCalls.length === 1, "L077c: malformed refresh does not retry or bootstrap without a token");
 
 installGuardWindow("?guard-token=token-codex-resolve&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
 const fetchCodexResolveCalls = installFetchStub({
@@ -1271,43 +1205,19 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   const url = input instanceof Request ? input.url : String(input);
   retryResumeCalls.push({ url, init });
   const path = new URL(url, "http://127.0.0.1:4174").pathname;
-  if (path === "/v1/initialize") {
-    return new Response(JSON.stringify({ auth_token: "fresh-retry-resume-token" }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
-  }
   if (path === "/v1/requests/req-retry-resume/resume") {
-    const token = new Headers(init?.headers).get("X-Guard-Token");
-    if (token !== "fresh-retry-resume-token") {
-      return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401 });
-    }
-    return new Response(JSON.stringify({
-      status: "sent",
-      supported: true,
-      attempt_count: 2,
-      request_id: "req-retry-resume",
-      operation_id: null,
-      harness: "codex",
-      resolution_action: "allow",
-      strategy: "reply",
-      thread_id: "thread-retry",
-      reason: null,
-      message: null,
-      last_error: null,
-      created_at: null,
-      updated_at: null,
-      last_attempt_at: null,
-      sent_at: "2025-01-01T00:01:00Z"
-    }), { status: 200, headers: { "Content-Type": "application/json" } });
+    return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401, headers: { "Content-Type": "application/json" } });
   }
   return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
 };
 
-const retryResult = await retryResume("req-retry-resume");
-assert(retryResumeCalls.length === 3, "L080: retryResume calls initialize then retries with fresh token");
-assert(retryResult.status === "sent", "L080: retryResume returns normalized codex_resume on success");
-assert(retryResult.thread_id === "thread-retry", "L080: retryResume normalizes thread_id");
-assert(retryResult.attempt_count === 2, "L080: retryResume normalizes attempt_count");
+let retryResumeError: unknown = null;
+try {
+  await retryResume("req-retry-resume");
+} catch (error) {
+  retryResumeError = error;
+}
+assert(retryResumeCalls.length === 1, "L080: retryResume does not call initialize to mint replacement session");
+assert(retryResumeError instanceof Error && retryResumeError.message.includes("401"), "L080: retryResume surfaces unauthorized response");
 
 console.log("guard-api.test.ts: all tests passed");

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -29,6 +29,7 @@ import type {
   GuardHarnessAction,
   GuardHarnessActionErrorPayload,
   GuardHarnessActionResult,
+  GuardManagedInstall,
   GuardNotificationSetupResult,
   GuardPolicyDecision,
   PackageManagerProtection,
@@ -176,42 +177,6 @@ function saveGuardToken(guardToken: string): void {
   window.sessionStorage.setItem(GUARD_TOKEN_PARAM, guardToken);
 }
 
-function parseAuthToken(payload: unknown): string | null {
-  if (!isRecord(payload)) {
-    return null;
-  }
-  const authToken = payload["auth_token"];
-  return typeof authToken === "string" && authToken.trim() ? authToken : null;
-}
-
-async function refreshGuardToken(): Promise<string | null> {
-  const response = await fetch(guardApiInput("/v1/initialize"), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      client_name: "guard-dashboard",
-      client_title: "HOL Guard dashboard",
-      surface: "dashboard",
-      capabilities: ["approval-resolution"],
-      supported_protocol_versions: [1]
-    })
-  });
-  if (!response.ok) {
-    return null;
-  }
-  let payload: unknown;
-  try {
-    payload = await response.json();
-  } catch {
-    return null;
-  }
-  const authToken = parseAuthToken(payload);
-  if (authToken !== null) {
-    saveGuardToken(authToken);
-  }
-  return authToken;
-}
-
 function readGuardDaemonOrigin(): string | null {
   const rawDaemonUrl = guardParam(GUARD_DAEMON_PARAM);
   if (rawDaemonUrl) {
@@ -260,7 +225,7 @@ function withGuardAuthForToken(
     return init;
   }
   const headers = new Headers(init?.headers);
-  headers.set("X-Guard-Token", guardToken);
+  headers.set("X-Guard-Dashboard-Session", guardToken);
   return {
     ...init,
     headers
@@ -269,24 +234,16 @@ function withGuardAuthForToken(
 
 async function fetchWithGuardAuth(input: RequestInfo, init?: RequestInit): Promise<Response> {
   const requestInput = guardApiInput(input);
-  let response = await fetch(requestInput, withGuardAuth(init));
-  if (response.status !== 401) {
-    return response;
-  }
-  const refreshedToken = await refreshGuardToken();
-  if (refreshedToken === null) {
-    return response;
-  }
-  return fetch(requestInput, withGuardAuthForToken(init, refreshedToken));
+  return fetch(requestInput, withGuardAuth(init));
 }
 
 function guardAuthHeaders(): HeadersInit {
   const guardToken = readGuardToken();
-  return guardToken ? { "X-Guard-Token": guardToken } : {};
+  return guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {};
 }
 
 function guardAuthHeadersForToken(guardToken: string | null): HeadersInit {
-  return guardToken ? { "X-Guard-Token": guardToken } : {};
+  return guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {};
 }
 
 export function guardAwareHref(href: string): string {

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -102,6 +102,7 @@ from ..desktop_notifications import (
 )
 from ..harness_usage import record_harness_usage_events
 from ..incident import build_incident_context
+from ..local_dashboard_session import build_local_dashboard_session_token
 from ..local_supply_chain import (
     build_local_supply_chain_posture,
     build_supply_chain_explain_payload,
@@ -1748,6 +1749,7 @@ def _guard_cloud_app_urls(
     browser_url = _browser_url_with_guard_params(
         public_url,
         auth_token=auth_token,
+        surface="cloud-dashboard",
         daemon_url=daemon_url,
     )
     return public_url, browser_url
@@ -6257,13 +6259,14 @@ def _open_approval_center(
 def _approval_center_browser_url(approval_center_url: str, auth_token: str | None) -> str | None:
     if auth_token is None:
         return None
-    return _browser_url_with_guard_params(approval_center_url, auth_token=auth_token)
+    return _browser_url_with_guard_params(approval_center_url, auth_token=auth_token, surface="approval-center")
 
 
 def _browser_url_with_guard_params(
     url: str,
     *,
     auth_token: str,
+    surface: str,
     daemon_url: str | None = None,
 ) -> str:
     parsed = urllib.parse.urlparse(url)
@@ -6274,7 +6277,12 @@ def _browser_url_with_guard_params(
     ]
     if daemon_url:
         fragment_pairs.append(("guardDaemon", daemon_url))
-    fragment_pairs.append(("guard-token", auth_token))
+    fragment_pairs.append(
+        (
+            "guard-token",
+            build_local_dashboard_session_token(auth_token=auth_token, surface=surface),
+        )
+    )
     return urllib.parse.urlunparse(parsed._replace(fragment=urllib.parse.urlencode(fragment_pairs)))
 
 

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -255,29 +255,9 @@ def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> dict[str, 
             raw_payload = response.read().decode("utf-8")
             if response.status != 200 or not _healthz_payload_is_current(raw_payload):
                 return None
-        request = urllib.request.Request(
-            f"{url}/v1/initialize",
-            data=json.dumps(
-                {
-                    "client_name": "guard-daemon-manager",
-                    "client_title": "HOL Guard daemon manager",
-                    "surface": "cli",
-                    "capabilities": ["daemon-adoption"],
-                    "supported_protocol_versions": [1],
-                }
-            ).encode("utf-8"),
-            headers={"Content-Type": "application/json"},
-            method="POST",
-        )
-        with urllib.request.urlopen(request, timeout=2) as response:
-            if response.status != 200:
-                return None
-            payload = json.loads(response.read().decode("utf-8"))
     except (OSError, ValueError, json.JSONDecodeError, urllib.error.URLError):
         return None
-    if not isinstance(payload, dict):
-        return None
-    auth_token = payload.get("auth_token")
+    auth_token = load_guard_daemon_auth_token(guard_home)
     if not isinstance(auth_token, str) or not auth_token.strip():
         return None
     details_payload = _daemon_healthz_details_payload(url, auth_token)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2986,9 +2986,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if isinstance(authorization, str) and authorization.lower().startswith("bearer "):
             bearer_token = authorization[7:].strip()
         candidates = [
-            candidate
-            for candidate in (session_token, bearer_token)
-            if isinstance(candidate, str) and candidate.strip()
+            candidate for candidate in (session_token, bearer_token) if isinstance(candidate, str) and candidate.strip()
         ]
         return any(self._dashboard_session_token_matches(candidate, payload=payload) for candidate in candidates)
 
@@ -3107,16 +3105,26 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             if len(path_parts) == 4 and path_parts[:2] == ["v1", "sessions"] and path_parts[3] == "resume":
                 return True
         if self.command == "POST":
-            if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {
-                "approve",
-                "block",
-                "resume",
-            }:
+            if (
+                len(path_parts) == 4
+                and path_parts[:2] == ["v1", "requests"]
+                and path_parts[3]
+                in {
+                    "approve",
+                    "block",
+                    "resume",
+                }
+            ):
                 return True
-            if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] in {
-                "items",
-                "status",
-            }:
+            if (
+                len(path_parts) == 4
+                and path_parts[:2] == ["v1", "operations"]
+                and path_parts[3]
+                in {
+                    "items",
+                    "status",
+                }
+            ):
                 return True
         return False
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -84,6 +84,7 @@ from ..desktop_notifications import (
     ensure_desktop_notification_setup,
     macos_notification_guidance,
 )
+from ..local_dashboard_session import build_local_dashboard_session_token
 from ..local_supply_chain import (
     build_local_supply_chain_posture,
     resolve_package_firewall_entitlement_with_refresh,
@@ -2603,7 +2604,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError as error:
             self._write_json({"error": str(error)}, status=400)
             return
-        response["auth_token"] = self.server.auth_token  # type: ignore[attr-defined]
         self._write_json(response)
 
     def _handle_client_attach(self, payload: dict[str, object]) -> None:
@@ -2975,7 +2975,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         path = urlparse(self.path).path
         path_parts = [part for part in path.split("/") if part]
         return self._tokens_match(token) or (
-            self._is_hosted_dashboard_api_path(path, path_parts)
+            self._path_supports_dashboard_session(path, path_parts)
             and self._dashboard_session_token_is_valid(payload=payload)
         )
 
@@ -2986,7 +2986,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if isinstance(authorization, str) and authorization.lower().startswith("bearer "):
             bearer_token = authorization[7:].strip()
         candidates = [
-            candidate for candidate in (session_token, bearer_token) if isinstance(candidate, str) and candidate.strip()
+            candidate
+            for candidate in (session_token, bearer_token)
+            if isinstance(candidate, str) and candidate.strip()
         ]
         return any(self._dashboard_session_token_matches(candidate, payload=payload) for candidate in candidates)
 
@@ -3019,11 +3021,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         *,
         payload: dict[str, object] | None,
     ) -> bool:
-        action_path = self._optional_string(claims.get("action_path"))
-        if action_path is None:
-            return True
+        surface = self._optional_string(claims.get("surface"))
         path = urlparse(self.path).path
         path_parts = [part for part in path.split("/") if part]
+        if surface in {"approval-center", "dashboard", "cloud-dashboard"}:
+            return self._path_supports_dashboard_session(path, path_parts)
+        action_path = self._optional_string(claims.get("action_path"))
+        if action_path is None:
+            return False
         if path in {"/v1/capabilities", "/v1/harnesses", "/v1/inventory", "/v1/runtime"}:
             return True
         if (
@@ -3055,6 +3060,71 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 supply_chain_action=supply_chain_action,
             )
         return False
+
+    def _local_surface_session_request_is_allowed(self, path: str, path_parts: list[str]) -> bool:
+        if path in {
+            "/v1/capabilities",
+            "/v1/sessions",
+            "/v1/runtime",
+            "/v1/harnesses",
+            "/v1/inventory",
+            "/v1/settings",
+            "/v1/settings/export",
+            "/v1/events",
+            "/v1/events/stream",
+            "/v1/requests",
+            "/v1/receipts",
+            "/v1/receipts/latest",
+            "/v1/policy",
+            "/v1/evidence",
+            "/v1/evidence/export",
+            "/v1/clients/attach",
+            "/v1/clients/heartbeat",
+            "/v1/sessions/start",
+            "/v1/operations/start",
+            "/v1/operations/block",
+            "/v1/requests/clear",
+            "/v1/settings/import",
+            "/v1/settings/reset",
+            "/v1/policy/clear",
+            "/v1/approval-gate/cooldown/revoke",
+            "/v1/approval-gate/totp/enroll",
+            "/v1/approval-gate/totp/verify",
+            "/v1/approval-gate/totp/disable",
+            "/v1/daemon/repair",
+            "/v1/notifications/setup",
+        }:
+            return True
+        if len(path_parts) >= 2 and path_parts[:2] == ["v1", "supply-chain"]:
+            return True
+        if self.command == "GET":
+            if len(path_parts) == 3 and path_parts[:2] in (
+                ["v1", "requests"],
+                ["v1", "receipts"],
+                ["v1", "operations"],
+            ):
+                return True
+            if len(path_parts) == 4 and path_parts[:2] == ["v1", "sessions"] and path_parts[3] == "resume":
+                return True
+        if self.command == "POST":
+            if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] in {
+                "approve",
+                "block",
+                "resume",
+            }:
+                return True
+            if len(path_parts) == 4 and path_parts[:2] == ["v1", "operations"] and path_parts[3] in {
+                "items",
+                "status",
+            }:
+                return True
+        return False
+
+    def _path_supports_dashboard_session(self, path: str, path_parts: list[str]) -> bool:
+        return self._is_hosted_dashboard_api_path(path, path_parts) or self._local_surface_session_request_is_allowed(
+            path,
+            path_parts,
+        )
 
     def _supply_chain_dashboard_claims_authorize(
         self,
@@ -3887,7 +3957,12 @@ def _approval_center_browser_url(approval_center_url: str, auth_token: str) -> s
     fragment_pairs = [
         (key, value) for key, value in parse_qsl(parsed.fragment, keep_blank_values=True) if key != "guard-token"
     ]
-    fragment_pairs.append(("guard-token", auth_token))
+    fragment_pairs.append(
+        (
+            "guard-token",
+            build_local_dashboard_session_token(auth_token=auth_token, surface="approval-center"),
+        )
+    )
     return urlunparse(parsed._replace(fragment=urlencode(fragment_pairs)))
 
 

--- a/src/codex_plugin_scanner/guard/local_dashboard_session.py
+++ b/src/codex_plugin_scanner/guard/local_dashboard_session.py
@@ -12,6 +12,7 @@ from typing import Any
 LOCAL_DASHBOARD_SESSION_VERSION = "guard-local-daemon-session.v1"
 LOCAL_DASHBOARD_SESSION_PREFIX = "gld1"
 DEFAULT_LOCAL_DASHBOARD_SESSION_TTL_SECONDS = 12 * 60 * 60
+_PROTECTED_LOCAL_DASHBOARD_SESSION_CLAIMS = frozenset({"version", "surface", "expires_at"})
 
 
 def build_local_dashboard_session_token(
@@ -28,7 +29,13 @@ def build_local_dashboard_session_token(
         "expires_at": expires_at.isoformat(),
     }
     if extra_claims:
-        payload_data.update(extra_claims)
+        payload_data.update(
+            {
+                key: value
+                for key, value in extra_claims.items()
+                if key not in _PROTECTED_LOCAL_DASHBOARD_SESSION_CLAIMS
+            }
+        )
     payload_json = json.dumps(payload_data, separators=(",", ":"))
     encoded_payload = base64.urlsafe_b64encode(payload_json.encode("utf-8")).decode("ascii").rstrip("=")
     signature = hmac.new(auth_token.encode("utf-8"), encoded_payload.encode("utf-8"), hashlib.sha256).digest()

--- a/src/codex_plugin_scanner/guard/local_dashboard_session.py
+++ b/src/codex_plugin_scanner/guard/local_dashboard_session.py
@@ -1,0 +1,36 @@
+"""Signed local browser session tokens for Guard daemon surfaces."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+LOCAL_DASHBOARD_SESSION_VERSION = "guard-local-daemon-session.v1"
+LOCAL_DASHBOARD_SESSION_PREFIX = "gld1"
+DEFAULT_LOCAL_DASHBOARD_SESSION_TTL_SECONDS = 12 * 60 * 60
+
+
+def build_local_dashboard_session_token(
+    *,
+    auth_token: str,
+    surface: str,
+    expires_in_seconds: int = DEFAULT_LOCAL_DASHBOARD_SESSION_TTL_SECONDS,
+    extra_claims: dict[str, Any] | None = None,
+) -> str:
+    expires_at = datetime.now(timezone.utc) + timedelta(seconds=max(1, expires_in_seconds))
+    payload_data: dict[str, Any] = {
+        "version": LOCAL_DASHBOARD_SESSION_VERSION,
+        "surface": surface,
+        "expires_at": expires_at.isoformat(),
+    }
+    if extra_claims:
+        payload_data.update(extra_claims)
+    payload_json = json.dumps(payload_data, separators=(",", ":"))
+    encoded_payload = base64.urlsafe_b64encode(payload_json.encode("utf-8")).decode("ascii").rstrip("=")
+    signature = hmac.new(auth_token.encode("utf-8"), encoded_payload.encode("utf-8"), hashlib.sha256).digest()
+    encoded_signature = base64.urlsafe_b64encode(signature).decode("ascii").rstrip("=")
+    return f"{LOCAL_DASHBOARD_SESSION_PREFIX}.{encoded_payload}.{encoded_signature}"

--- a/src/codex_plugin_scanner/guard/local_dashboard_session.py
+++ b/src/codex_plugin_scanner/guard/local_dashboard_session.py
@@ -30,11 +30,7 @@ def build_local_dashboard_session_token(
     }
     if extra_claims:
         payload_data.update(
-            {
-                key: value
-                for key, value in extra_claims.items()
-                if key not in _PROTECTED_LOCAL_DASHBOARD_SESSION_CLAIMS
-            }
+            {key: value for key, value in extra_claims.items() if key not in _PROTECTED_LOCAL_DASHBOARD_SESSION_CLAIMS}
         )
     payload_json = json.dumps(payload_data, separators=(",", ":"))
     encoded_payload = base64.urlsafe_b64encode(payload_json.encode("utf-8")).decode("ascii").rstrip("=")

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -8085,7 +8085,9 @@ url = http://127.0.0.1:8787/guard-canary
         )
 
         assert browser_url is not None
-        assert "guard-token=secret-token" in browser_url
+        parsed = urllib.parse.urlparse(browser_url)
+        fragment = urllib.parse.parse_qs(parsed.fragment)
+        assert fragment["guard-token"][0].startswith("gld1.")
         assert "guard-token=" not in guard_commands_module._public_approval_center_url(browser_url)
 
     def test_guard_connect_pending_output_uses_product_copy_for_sign_in_gap(self, capsys):

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -76,21 +76,21 @@ def test_daemon_rejects_legacy_connect_pairing_endpoints(tmp_path: Path) -> None
     daemon.start()
 
     try:
-        initialize_payload = _initialize_daemon(daemon)
+        _initialize_daemon(daemon)
         request_status, request_payload = _post_legacy_connect_endpoint(
             daemon=daemon,
             path="/v1/connect/requests",
-            token=initialize_payload["auth_token"],
+            token=daemon._server.auth_token,
         )
         complete_status, complete_payload = _post_legacy_connect_endpoint(
             daemon=daemon,
             path="/v1/connect/complete",
-            token=initialize_payload["auth_token"],
+            token=daemon._server.auth_token,
         )
         result_status, result_payload = _post_legacy_connect_endpoint(
             daemon=daemon,
             path="/v1/connect/result",
-            token=initialize_payload["auth_token"],
+            token=daemon._server.auth_token,
         )
     finally:
         daemon.stop()

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -421,11 +421,12 @@ def test_apps_connect_opens_guard_cloud_app_page(
     payload = json.loads(capsys.readouterr().out)
     assert payload["cloud_app"]["browser_opened"] is True
     assert payload["cloud_app"]["app_url"] == "https://hol.org/guard/apps/codex"
-    assert opened_urls == [
-        "https://hol.org/guard/apps/codex"
-        "#guardDaemon=http%3A%2F%2F127.0.0.1%3A5474"
-        "&guard-token=local-daemon-token-1234567890"
-    ]
+    assert len(opened_urls) == 1
+    opened_url = urllib.parse.urlparse(opened_urls[0])
+    opened_fragment = urllib.parse.parse_qs(opened_url.fragment)
+    assert f"{opened_url.scheme}://{opened_url.netloc}{opened_url.path}" == "https://hol.org/guard/apps/codex"
+    assert opened_fragment["guardDaemon"] == ["http://127.0.0.1:5474"]
+    assert opened_fragment["guard-token"][0].startswith("gld1.")
     assert "local-daemon-token-1234567890" not in json.dumps(payload)
 
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -96,6 +96,7 @@ def _dashboard_token(auth_token: str) -> str:
         {
             "version": "guard-local-daemon-session.v1",
             "expires_at": datetime(2099, 1, 1, tzinfo=timezone.utc).isoformat(),
+            "surface": "approval-center",
         },
         separators=(",", ":"),
     )

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1566,7 +1566,8 @@ def test_daemon_rejects_legacy_pairing_request_endpoint(tmp_path: Path) -> None:
             method="POST",
         )
         with urllib.request.urlopen(initialize_request, timeout=5) as response:
-            initialize_payload = json.loads(response.read().decode("utf-8"))
+            response.read()
+        auth_token = daemon._server.auth_token
 
         results: dict[str, tuple[int, dict[str, object]]] = {}
         for path, method in (
@@ -1587,7 +1588,7 @@ def test_daemon_rejects_legacy_pairing_request_endpoint(tmp_path: Path) -> None:
                 else None,
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method=method,
             )

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import json
 import os
 import time
@@ -19,7 +20,10 @@ from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
-from codex_plugin_scanner.guard.local_dashboard_session import build_local_dashboard_session_token
+from codex_plugin_scanner.guard.local_dashboard_session import (
+    LOCAL_DASHBOARD_SESSION_VERSION,
+    build_local_dashboard_session_token,
+)
 from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, PolicyDecision
 from codex_plugin_scanner.guard.runtime.surface_server import GuardSurfaceRuntime
 from codex_plugin_scanner.guard.schemas import build_surface_server_contract
@@ -49,7 +53,33 @@ def _approval_center_session_token(daemon: GuardDaemonServer) -> str:
     )
 
 
+def _decode_dashboard_session_claims(token: str) -> dict[str, object]:
+    _prefix, encoded_payload, _signature = token.split(".")
+    padding = "=" * (-len(encoded_payload) % 4)
+    return json.loads(base64.urlsafe_b64decode(f"{encoded_payload}{padding}").decode("utf-8"))
+
+
 class TestGuardSurfaceServer:
+    def test_local_dashboard_session_preserves_reserved_claims(self) -> None:
+        token = build_local_dashboard_session_token(
+            auth_token="daemon-auth-token",
+            surface="approval-center",
+            expires_in_seconds=60,
+            extra_claims={
+                "surface": "cli",
+                "version": "override-version",
+                "expires_at": "1970-01-01T00:00:00+00:00",
+                "custom": "value",
+            },
+        )
+
+        claims = _decode_dashboard_session_claims(token)
+
+        assert claims["version"] == LOCAL_DASHBOARD_SESSION_VERSION
+        assert claims["surface"] == "approval-center"
+        assert claims["expires_at"] != "1970-01-01T00:00:00+00:00"
+        assert claims["custom"] == "value"
+
     def test_guard_daemon_serves_dashboard_shell_for_home_and_section_routes(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -19,6 +19,7 @@ from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
+from codex_plugin_scanner.guard.local_dashboard_session import build_local_dashboard_session_token
 from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, PolicyDecision
 from codex_plugin_scanner.guard.runtime.surface_server import GuardSurfaceRuntime
 from codex_plugin_scanner.guard.schemas import build_surface_server_contract
@@ -30,6 +31,21 @@ def _guard_get_request(port: int, path: str, auth_token: str) -> urllib.request.
         f"http://127.0.0.1:{port}{path}",
         headers={"X-Guard-Token": auth_token},
         method="GET",
+    )
+
+
+def _guard_dashboard_session_get_request(port: int, path: str, session_token: str) -> urllib.request.Request:
+    return urllib.request.Request(
+        f"http://127.0.0.1:{port}{path}",
+        headers={"X-Guard-Dashboard-Session": session_token},
+        method="GET",
+    )
+
+
+def _approval_center_session_token(daemon: GuardDaemonServer) -> str:
+    return build_local_dashboard_session_token(
+        auth_token=daemon._server.auth_token,
+        surface="approval-center",
     )
 
 
@@ -1516,6 +1532,7 @@ class TestGuardSurfaceServer:
         assert initialize_payload["protocol"]["current_version"] == "1.1"
         assert initialize_payload["protocol"]["minimum_version"] == "1.0"
         assert initialize_payload["protocol"]["supported_versions"] == ["1.1", "1.0"]
+        assert "auth_token" not in initialize_payload
         assert unsupported_error is not None
         assert unsupported_error.code == 400
 
@@ -1695,6 +1712,7 @@ class TestGuardSurfaceServer:
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
                 initialize_payload = json.loads(response.read().decode("utf-8"))
+            session_token = _approval_center_session_token(daemon)
 
             attach_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/clients/attach",
@@ -1706,7 +1724,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Dashboard-Session": session_token,
                 },
                 method="POST",
             )
@@ -1740,6 +1758,7 @@ class TestGuardSurfaceServer:
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
                 initialize_payload = json.loads(response.read().decode("utf-8"))
+            session_token = _approval_center_session_token(daemon)
 
             session_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/sessions/start",
@@ -1753,7 +1772,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Dashboard-Session": session_token,
                 },
                 method="POST",
             )
@@ -1771,7 +1790,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Dashboard-Session": session_token,
                 },
                 method="POST",
             )
@@ -1779,10 +1798,10 @@ class TestGuardSurfaceServer:
                 attach_payload = json.loads(response.read().decode("utf-8"))
 
             with urllib.request.urlopen(
-                _guard_get_request(
+                _guard_dashboard_session_get_request(
                     daemon.port,
                     f"/v1/sessions/{session_payload['session_id']}/resume",
-                    initialize_payload["auth_token"],
+                    session_token,
                 ),
                 timeout=5,
             ) as response:
@@ -1800,7 +1819,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Dashboard-Session": session_token,
                 },
                 method="POST",
             )
@@ -1808,10 +1827,10 @@ class TestGuardSurfaceServer:
                 operation_payload = json.loads(response.read().decode("utf-8"))
 
             with urllib.request.urlopen(
-                _guard_get_request(
+                _guard_dashboard_session_get_request(
                     daemon.port,
                     f"/v1/sessions/{session_payload['session_id']}/resume",
-                    initialize_payload["auth_token"],
+                    session_token,
                 ),
                 timeout=5,
             ) as response:
@@ -1846,6 +1865,7 @@ class TestGuardSurfaceServer:
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
                 initialize_payload = json.loads(response.read().decode("utf-8"))
+            session_token = _approval_center_session_token(daemon)
 
             attach_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/clients/attach",
@@ -1858,7 +1878,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Dashboard-Session": session_token,
                 },
                 method="POST",
             )
@@ -1897,7 +1917,8 @@ class TestGuardSurfaceServer:
                 method="POST",
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
-                initialize_payload = json.loads(response.read().decode("utf-8"))
+                response.read()
+            auth_token = daemon._server.auth_token
 
             session_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/sessions/start",
@@ -1914,7 +1935,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -1933,7 +1954,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -1950,7 +1971,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -1967,7 +1988,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -1979,7 +2000,7 @@ class TestGuardSurfaceServer:
                 data=json.dumps({"status": "completed"}).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -2014,7 +2035,8 @@ class TestGuardSurfaceServer:
                 method="POST",
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
-                initialize_payload = json.loads(response.read().decode("utf-8"))
+                response.read()
+            auth_token = daemon._server.auth_token
 
             item_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/operations/missing-operation/items",
@@ -2026,7 +2048,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -2064,7 +2086,8 @@ class TestGuardSurfaceServer:
                 method="POST",
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
-                initialize_payload = json.loads(response.read().decode("utf-8"))
+                response.read()
+            auth_token = daemon._server.auth_token
 
             operation_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/operations/start",
@@ -2078,7 +2101,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -2116,14 +2139,15 @@ class TestGuardSurfaceServer:
                 method="POST",
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
-                initialize_payload = json.loads(response.read().decode("utf-8"))
+                response.read()
+            auth_token = daemon._server.auth_token
 
             status_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/operations/missing-operation/status",
                 data=json.dumps({"status": "completed"}).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -2164,7 +2188,8 @@ class TestGuardSurfaceServer:
                 method="POST",
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
-                initialize_payload = json.loads(response.read().decode("utf-8"))
+                response.read()
+            auth_token = daemon._server.auth_token
 
             session_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/sessions/start",
@@ -2178,7 +2203,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -2231,7 +2256,7 @@ class TestGuardSurfaceServer:
                 data=json.dumps(block_payload).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -2243,7 +2268,7 @@ class TestGuardSurfaceServer:
                 data=json.dumps(block_payload).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -2268,7 +2293,8 @@ class TestGuardSurfaceServer:
 
         assert len(opened_urls) == 1
         assert f"{opened_url.scheme}://{opened_url.netloc}{opened_url.path}" == f"http://127.0.0.1:{daemon.port}"
-        assert opened_fragment["guard-token"] == [initialize_payload["auth_token"]]
+        assert opened_fragment["guard-token"][0].startswith("gld1.")
+        assert opened_fragment["guard-token"] != [daemon._server.auth_token]
 
     def test_guard_daemon_rejects_legacy_browser_connect_pairing_endpoint(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
@@ -2289,7 +2315,8 @@ class TestGuardSurfaceServer:
                 method="POST",
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
-                initialize_payload = json.loads(response.read().decode("utf-8"))
+                response.read()
+            auth_token = daemon._server.auth_token
 
             legacy_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/connect/requests",
@@ -2301,7 +2328,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Token": auth_token,
                 },
                 method="POST",
             )
@@ -2467,6 +2494,7 @@ class TestGuardSurfaceServer:
             )
             with urllib.request.urlopen(initialize_request, timeout=5) as response:
                 initialize_payload = json.loads(response.read().decode("utf-8"))
+            session_token = _approval_center_session_token(daemon)
 
             attach_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/clients/attach",
@@ -2479,7 +2507,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Dashboard-Session": session_token,
                 },
                 method="POST",
             )
@@ -2497,7 +2525,7 @@ class TestGuardSurfaceServer:
                 ).encode("utf-8"),
                 headers={
                     "Content-Type": "application/json",
-                    "X-Guard-Token": initialize_payload["auth_token"],
+                    "X-Guard-Dashboard-Session": session_token,
                 },
                 method="POST",
             )


### PR DESCRIPTION
## Summary
- stop `/v1/initialize` from returning the root daemon auth token
- mint signed local dashboard session tokens for approval-center/cloud-dashboard browser entrypoints
- remove dashboard-side initialize/bootstrap retry logic and adopt existing daemons from the local auth-token file instead

## Verification
- `pnpm exec tsx src/guard-api.test.ts`
- `uv run pytest tests/test_guard_surface_server.py tests/test_guard_connect_flow.py tests/test_guard_oauth_device_connect.py -q`
- `uv run pytest tests/test_guard_headless_daemon_api.py -q`
- `uv run pytest tests/test_guard_daemon_manager.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/local_dashboard_session.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/daemon/manager.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_surface_server.py tests/test_guard_connect_flow.py tests/test_guard_oauth_device_connect.py tests/test_guard_headless_daemon_api.py`
- `git diff --check`

## Security impact
- browser bootstrap no longer mints or rehydrates the root daemon token through `/v1/initialize`
- local dashboard/browser traffic uses scoped signed `gld1` session tokens
- root daemon token stays in the local token file / trusted local process path only
