### PR TITLE
fix(package-firewall): repair post-connect auth and activation ux

### DIFF
--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1822,6 +1822,25 @@ export async function runPackageFirewallAction(
   return normalizePackageFirewallAction(payloadBody);
 }
 
+export async function openPackageFirewallShell(): Promise<void> {
+  const response = await fetchGuardApi("/v1/supply-chain/package-shims/open-shell", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...guardAuthHeaders(),
+    },
+    body: JSON.stringify({}),
+  });
+  if (response.ok) {
+    return;
+  }
+  const payloadBody = (await response.json().catch(() => null)) as unknown;
+  if (isRecord(payloadBody) && typeof payloadBody.message === "string" && payloadBody.message.trim()) {
+    throw new Error(payloadBody.message);
+  }
+  throw new Error("Unable to open a new shell.");
+}
+
 export type AuditRemediationAction = "package_shim_path";
 
 export type AuditRemediationInput = {

--- a/dashboard/src/package-firewall-connect.test.tsx
+++ b/dashboard/src/package-firewall-connect.test.tsx
@@ -31,6 +31,7 @@ Object.assign(globalThis, {
 
 const runningMarkup = renderToStaticMarkup(
   <ConnectFlowCard
+    compact
     connectError={null}
     connectStarting={false}
     connectFlow={{
@@ -58,8 +59,12 @@ assert(
   "PF1: running connect card should keep manual sign-in fallback visible",
 );
 assert(
-  runningMarkup.includes("Repair required"),
-  "PF1: running reconnect card should show repair state badge",
+  runningMarkup.includes("Waiting for approval"),
+  "PF1: running reconnect card should show waiting state badge",
+);
+assert(
+  !runningMarkup.includes("Security"),
+  "PF1: compact connect state should not render the nested security card",
 );
 
 const connectRequiredStatus: PackageFirewallStatusResponse = {
@@ -133,6 +138,14 @@ assert(
   freeViewMarkup.includes("Existing shims on this machine can still be fixed or removed locally."),
   "PF2: connect-required view should explain that local recovery still works",
 );
+assert(
+  !freeViewMarkup.includes("AVAILABLE NOW"),
+  "PF2: staged local recovery view should stay compact instead of nesting extra helper cards",
+);
+assert(
+  !freeViewMarkup.includes("SECURITY"),
+  "PF2: staged local recovery view should not render the large nested security card",
+);
 
 const upgradeRequiredStatus: PackageFirewallStatusResponse = {
   ...connectRequiredStatus,
@@ -170,4 +183,26 @@ assert(
 assert(
   upgradeMarkup.includes("Upgrade to enable active protection"),
   "PF3: upgrade-required view should render the upgrade CTA",
+);
+
+const reconnectLikeStatus: PackageFirewallStatusResponse = {
+  ...connectRequiredStatus,
+  entitlement: {
+    ...connectRequiredStatus.entitlement,
+    tier: "team",
+  },
+};
+
+const reconnectLikeMarkup = renderToStaticMarkup(
+  <EntitlementNotice
+    connectError={null}
+    connectStarting={false}
+    data={reconnectLikeStatus}
+    onStartConnect={() => undefined}
+  />,
+);
+
+assert(
+  reconnectLikeMarkup.includes("Repair required"),
+  "PF4: broken post-connect local auth should render repair guidance instead of a first-connect badge",
 );

--- a/dashboard/src/package-firewall-connect.test.tsx
+++ b/dashboard/src/package-firewall-connect.test.tsx
@@ -146,6 +146,11 @@ assert(
   !freeViewMarkup.includes("SECURITY"),
   "PF2: staged local recovery view should not render the large nested security card",
 );
+const routingCopy = "Guard changes routing only after this machine receives signed cloud access.";
+assert(
+  freeViewMarkup.split(routingCopy).length - 1 === 1,
+  "PF2: compact staged recovery view should not duplicate the shared routing hint",
+);
 
 const upgradeRequiredStatus: PackageFirewallStatusResponse = {
   ...connectRequiredStatus,

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -14,6 +14,7 @@ import type {
 import {
   fetchPackageFirewallStatus,
   GuardHarnessActionError,
+  openPackageFirewallShell,
   runPackageFirewallAction,
   runPackageAudit,
   runPackageSync,
@@ -158,6 +159,8 @@ function FailureBanner({ failed }: FailureBannerProps) {
 }
 
 type FirewallControlsViewProps = {
+  activationAssistError: string | null;
+  openingShell: boolean;
   data: PackageFirewallStatusResponse;
   pendingOp: PendingOp | null;
   lastCompleted: CompletedOp | null;
@@ -173,9 +176,13 @@ type FirewallControlsViewProps = {
   onAudit: () => void;
   onSync: () => void;
   onDismissResult: () => void;
+  onOpenShell: () => void;
+  onRefreshStatus: () => void;
 };
 
 function FirewallControlsView({
+  activationAssistError,
+  openingShell,
   data,
   pendingOp,
   lastCompleted,
@@ -191,6 +198,8 @@ function FirewallControlsView({
   onAudit,
   onSync,
   onDismissResult,
+  onOpenShell,
+  onRefreshStatus,
 }: FirewallControlsViewProps) {
   const anyPending = pendingOp !== null;
   return (
@@ -207,7 +216,13 @@ function FirewallControlsView({
         )}
       </div>
 
-      <ActivationSummary protection={data.protection} />
+      <ActivationSummary
+        activationAssistError={activationAssistError}
+        openingShell={openingShell}
+        onOpenShell={onOpenShell}
+        onRefreshStatus={onRefreshStatus}
+        protection={data.protection}
+      />
 
       {lastFailed !== null && <FailureBanner failed={lastFailed} />}
 
@@ -277,7 +292,9 @@ export function PackageFirewallPanel(props: {
   const [lastCompleted, setLastCompleted] = useState<CompletedOp | null>(null);
   const [lastFailed, setLastFailed] = useState<FailedOp | null>(null);
   const [connectError, setConnectError] = useState<string | null>(null);
+  const [activationAssistError, setActivationAssistError] = useState<string | null>(null);
   const [startingConnect, setStartingConnect] = useState(false);
+  const [openingShell, setOpeningShell] = useState(false);
   const [confirmRemoveManager, setConfirmRemoveManager] = useState<string | null>(null);
   const [pendingApprovalOp, setPendingApprovalOp] = useState<ApprovalOp | null>(null);
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(approvalGate);
@@ -332,6 +349,7 @@ export function PackageFirewallPanel(props: {
       setPendingOp({ op, manager });
       setLastFailed(null);
       setConnectError(null);
+      setActivationAssistError(null);
       try {
         const response = await runPackageFirewallAction(op, manager, credentials);
         setLastCompleted({ op, manager, response });
@@ -362,6 +380,7 @@ export function PackageFirewallPanel(props: {
       setPendingOp({ op, manager: null });
       setLastFailed(null);
       setConnectError(null);
+      setActivationAssistError(null);
       try {
         const response = op === "audit" ? await runPackageAudit() : await runPackageSync();
         setLastCompleted({ op, manager: null, response });
@@ -408,6 +427,7 @@ export function PackageFirewallPanel(props: {
   const handleStartConnect = useCallback(async () => {
     setStartingConnect(true);
     setConnectError(null);
+    setActivationAssistError(null);
     try {
       await startPackageFirewallConnect();
       await refreshAfterOp();
@@ -420,6 +440,17 @@ export function PackageFirewallPanel(props: {
       setStartingConnect(false);
     }
   }, [onStateChanged, refreshAfterOp]);
+  const handleOpenShell = useCallback(async () => {
+    setOpeningShell(true);
+    setActivationAssistError(null);
+    try {
+      await openPackageFirewallShell();
+    } catch (error) {
+      setActivationAssistError(error instanceof Error ? error.message : "Unable to open a new shell.");
+    } finally {
+      setOpeningShell(false);
+    }
+  }, []);
   const handleApprovalCancel = useCallback(() => setPendingApprovalOp(null), []);
   const handleApprovalConfirm = useCallback(
     (credentials: { approval_password?: string; approval_totp_code?: string }) => {
@@ -480,6 +511,10 @@ export function PackageFirewallPanel(props: {
             onAudit={handleAudit}
             onSync={handleSync}
             onDismissResult={handleDismissResult}
+            onOpenShell={handleOpenShell}
+            onRefreshStatus={handleRetry}
+            openingShell={openingShell}
+            activationAssistError={activationAssistError}
           />
         </>
       )}

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -51,6 +51,7 @@ export function UpgradeCta({ entitlement }: UpgradeCtaProps) {
 }
 
 type ConnectFlowCardProps = {
+  compact?: boolean;
   connectError: string | null;
   connectStarting: boolean;
   connectFlow: NonNullable<PackageFirewallStatusResponse["connect_flow"]>;
@@ -126,6 +127,7 @@ function resolveConnectSteps(
 }
 
 export function ConnectFlowCard({
+  compact = false,
   connectError,
   connectStarting,
   connectFlow,
@@ -143,9 +145,69 @@ export function ConnectFlowCard({
     ? "Try connect again"
     : connectFlow.action_label;
   const steps = resolveConnectSteps(connectFlow);
-  const statusTone = mode === "repair" ? "attention" : "blue";
-  const statusLabel = mode === "repair" ? "Repair required" : "Connection required";
+  const statusTone = running ? "blue" : mode === "repair" ? "attention" : "blue";
+  const statusLabel = running ? "Waiting for approval" : mode === "repair" ? "Repair required" : "Connection required";
   const showManualLink = connectFlow.authorize_url !== null || running || failed;
+  const hintCopy = localRecoveryHint ?? "Guard changes routing only after this machine receives signed cloud access.";
+  if (compact) {
+    return (
+      <div className="space-y-3">
+        <div className="space-y-2">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-brand-blue">
+              HOL Guard Cloud
+            </p>
+            <Tag tone={statusTone}>{statusLabel}</Tag>
+          </div>
+          <div className="space-y-1">
+            <p className="text-base font-semibold tracking-[-0.02em] text-brand-dark">
+              {connectFlow.title}
+            </p>
+            <p className="max-w-3xl text-sm leading-relaxed text-slate-500">
+              {connectFlow.detail}
+            </p>
+          </div>
+        </div>
+
+        <div className="grid gap-2 text-xs leading-relaxed text-slate-500 md:grid-cols-3">
+          {steps.map((step, index) => (
+            <div key={step.title} className="min-w-0">
+              <p className="font-semibold text-brand-dark">
+                {index + 1}. {step.title}
+              </p>
+              <p className="mt-0.5">{step.body}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs leading-relaxed text-slate-500">
+          <span>{hintCopy}</span>
+          <span>Guard changes routing only after this machine receives signed cloud access.</span>
+        </div>
+
+        {connectError !== null && (
+          <p className="text-xs leading-relaxed text-brand-attention">{connectError}</p>
+        )}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <ActionButton variant="primary" onClick={onStartConnect} disabled={primaryBusy}>
+            {primaryBusy ? (
+              <HiMiniArrowPath className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+            ) : (
+              <HiMiniShieldCheck className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+            )}
+            {primaryLabel}
+          </ActionButton>
+          {showManualLink && (
+            <ActionButton href={manualHref} variant="outline">
+              Open sign-in page
+              <HiMiniArrowTopRightOnSquare className="ml-1.5 h-3.5 w-3.5" aria-hidden="true" />
+            </ActionButton>
+          )}
+        </div>
+      </div>
+    );
+  }
   return (
     <div className="space-y-4">
       <div className="flex flex-col gap-4">
@@ -267,16 +329,24 @@ export function EntitlementNotice({
   const connectRequired =
     data.entitlement.reason === "guard_cloud_connect_required" ||
     data.entitlement.reason === "guard_cloud_reconnect_required";
-  const connectMode = data.entitlement.reason === "guard_cloud_reconnect_required" ? "repair" : "connect";
+  const reconnectLikeState =
+    data.entitlement.reason === "guard_cloud_reconnect_required" ||
+    (data.entitlement.reason === "guard_cloud_connect_required" &&
+      (data.entitlement.tier !== "unknown" || data.package_shims.some((shim) => shim.installed)));
+  const connectMode = reconnectLikeState ? "repair" : "connect";
   const localRecoveryHint = data.package_shims.some((shim) => shim.installed)
     ? connectRequired
       ? "Existing shims on this machine can still be fixed or removed locally. Connect is only needed for new installs and cloud-gated verification."
       : null
     : null;
+  const compactConnectNotice =
+    data.package_shims.some((shim) => shim.installed) ||
+    data.protection?.path_status === "restart_required";
   return (
     <div className="space-y-4 px-4 py-4">
       {connectRequired && data.connect_flow !== null ? (
         <ConnectFlowCard
+          compact={compactConnectNotice}
           connectError={connectError}
           connectStarting={connectStarting}
           connectFlow={data.connect_flow}
@@ -300,10 +370,20 @@ function activationHeadline(protection: PackageManagerProtection | null): string
 }
 
 type ActivationSummaryProps = {
+  activationAssistError: string | null;
+  openingShell: boolean;
+  onOpenShell: () => void;
+  onRefreshStatus: () => void;
   protection: PackageManagerProtection | null;
 };
 
-export function ActivationSummary({ protection }: ActivationSummaryProps) {
+export function ActivationSummary({
+  activationAssistError,
+  openingShell,
+  onOpenShell,
+  onRefreshStatus,
+  protection,
+}: ActivationSummaryProps) {
   if (protection === null) {
     return null;
   }
@@ -326,6 +406,11 @@ export function ActivationSummary({ protection }: ActivationSummaryProps) {
       : protection.path_status === "restart_required"
       ? "text-brand-blue"
       : "text-brand-attention";
+  const canOpenShell =
+    protection.path_status === "restart_required" &&
+    protection.shell_profile_configured &&
+    typeof navigator !== "undefined" &&
+    navigator.platform.toLowerCase().includes("mac");
   return (
     <div className={`rounded-xl border px-4 py-3 ${toneClass}`}>
       <div className="flex items-start gap-2.5">
@@ -333,6 +418,21 @@ export function ActivationSummary({ protection }: ActivationSummaryProps) {
         <div className="min-w-0">
           <p className="text-sm font-medium text-brand-dark">{activationHeadline(protection)}</p>
           <p className="mt-0.5 text-xs text-slate-600">{copy.pathDetail}</p>
+          {protection.path_status === "restart_required" && (
+            <div className="mt-3 flex flex-wrap items-center gap-2">
+              {canOpenShell && (
+                <ActionButton variant="primary" onClick={onOpenShell} disabled={openingShell}>
+                  {openingShell ? "Opening shell…" : "Open new shell"}
+                </ActionButton>
+              )}
+              <ActionButton variant="outline" onClick={onRefreshStatus} disabled={openingShell}>
+                Refresh after restart
+              </ActionButton>
+            </div>
+          )}
+          {activationAssistError !== null && (
+            <p className="mt-2 text-xs text-brand-attention">{activationAssistError}</p>
+          )}
         </div>
       </div>
     </div>

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -60,6 +60,12 @@ type ConnectFlowCardProps = {
   onStartConnect: () => void;
 };
 
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: {
+    platform?: string;
+  };
+};
+
 type ConnectStepProps = {
   body: string;
   current: boolean;
@@ -126,6 +132,16 @@ function resolveConnectSteps(
   ];
 }
 
+function isMacClient(): boolean {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  const navigatorWithUserAgentData = navigator as NavigatorWithUserAgentData;
+  const platformHint =
+    navigatorWithUserAgentData.userAgentData?.platform ?? navigator.userAgent ?? navigator.platform;
+  return platformHint.toLowerCase().includes("mac");
+}
+
 export function ConnectFlowCard({
   compact = false,
   connectError,
@@ -148,7 +164,6 @@ export function ConnectFlowCard({
   const statusTone = running ? "blue" : mode === "repair" ? "attention" : "blue";
   const statusLabel = running ? "Waiting for approval" : mode === "repair" ? "Repair required" : "Connection required";
   const showManualLink = connectFlow.authorize_url !== null || running || failed;
-  const hintCopy = localRecoveryHint ?? "Guard changes routing only after this machine receives signed cloud access.";
   if (compact) {
     return (
       <div className="space-y-3">
@@ -181,7 +196,7 @@ export function ConnectFlowCard({
         </div>
 
         <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs leading-relaxed text-slate-500">
-          <span>{hintCopy}</span>
+          {localRecoveryHint !== null && <span>{localRecoveryHint}</span>}
           <span>Guard changes routing only after this machine receives signed cloud access.</span>
         </div>
 
@@ -409,8 +424,7 @@ export function ActivationSummary({
   const canOpenShell =
     protection.path_status === "restart_required" &&
     protection.shell_profile_configured &&
-    typeof navigator !== "undefined" &&
-    navigator.platform.toLowerCase().includes("mac");
+    isMacClient();
   return (
     <div className={`rounded-xl border px-4 py-3 ${toneClass}`}>
       <div className="flex items-start gap-2.5">

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -9480,7 +9480,7 @@ def _finalize_guard_connect_payload(
     payload: dict[str, object],
     now: str,
 ) -> dict[str, object]:
-    sync_auth_context = payload.pop(CONNECT_SYNC_AUTH_CONTEXT_KEY, None)
+    payload.pop(CONNECT_SYNC_AUTH_CONTEXT_KEY, None)
     urls = _guard_cloud_urls_for_connect(connect_url)
     for key in ("connect_url", "sync_url", "dashboard_url", "inbox_url", "fleet_url"):
         payload.setdefault(key, urls[key])
@@ -9529,10 +9529,7 @@ def _finalize_guard_connect_payload(
         return payload
     payload["sync_attempted"] = True
     try:
-        if isinstance(sync_auth_context, dict):
-            sync_payload = sync_local_guard_cloud_proof(store, auth_context=sync_auth_context)
-        else:
-            sync_payload = sync_local_guard_cloud_proof(store)
+        sync_payload = sync_local_guard_cloud_proof(store)
     except GuardSyncNotAvailableError as error:
         store.record_latest_guard_connect_sync_result(
             status="connected",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -12,6 +12,7 @@ import mimetypes
 import os
 import platform
 import secrets
+import subprocess
 import threading
 import time
 import uuid
@@ -137,7 +138,17 @@ from .manager import (
 _HEADLESS_CLOUD_SYNC_STATE_LOCK = threading.Lock()
 _HEADLESS_CLOUD_SYNC_IN_FLIGHT: set[str] = set()
 _AUDIT_REMEDIATION_ACTIONS = {"package_shim_path"}
-_SUPPLY_CHAIN_PACKAGE_ACTIONS = {"install", "repair", "test", "audit", "sync", "remove", "uninstall", "connect"}
+_SUPPLY_CHAIN_PACKAGE_ACTIONS = {
+    "install",
+    "repair",
+    "test",
+    "audit",
+    "sync",
+    "remove",
+    "uninstall",
+    "connect",
+    "open-shell",
+}
 _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS = 1_500
 _SUPPLY_CHAIN_CONNECT_WAIT_TIMEOUT_SECONDS = 180
 
@@ -482,8 +493,15 @@ def _package_firewall_connect_url(store: GuardStore) -> str:
     return "https://hol.org/guard/connect"
 
 
-def _package_firewall_connect_action_label(reason: str) -> str:
+def _package_firewall_connect_needs_repair(store: GuardStore, reason: str) -> bool:
     if reason == "guard_cloud_reconnect_required":
+        return True
+    oauth_health = store.get_oauth_local_credential_health()
+    return bool(oauth_health.get("configured"))
+
+
+def _package_firewall_connect_action_label(reason: str, *, repair_copy: bool = False) -> str:
+    if reason == "guard_cloud_reconnect_required" or repair_copy:
         return "Repair Guard Cloud access"
     return "Connect HOL Guard Cloud"
 
@@ -505,12 +523,13 @@ def _default_package_firewall_connect_flow(
     reason: str,
 ) -> dict[str, object]:
     connect_url = _package_firewall_connect_url(store)
-    action_label = _package_firewall_connect_action_label(reason)
-    if reason == "guard_cloud_reconnect_required":
+    repair_copy = _package_firewall_connect_needs_repair(store, reason)
+    action_label = _package_firewall_connect_action_label(reason, repair_copy=repair_copy)
+    if repair_copy:
         title = "Repair Guard Cloud access to restore package firewall"
         detail = (
-            "Guard has package-firewall coverage on your plan, but local cloud authorization on this machine is not "
-            "healthy. Repair it here and Guard will unlock the firewall again."
+            "Guard already has package-firewall coverage for this machine, but the local cloud authorization is not "
+            "usable right now. Repair it here and Guard will unlock the firewall again."
         )
     else:
         title = "Connect HOL Guard Cloud to enable package firewall"
@@ -529,6 +548,58 @@ def _default_package_firewall_connect_flow(
         "request_id": None,
         "poll_after_ms": None,
     }
+
+
+def _open_package_firewall_activation_shell() -> tuple[int, dict[str, object]]:
+    system_name = platform.system().lower()
+    if system_name != "darwin":
+        return (
+            501,
+            {
+                "error": "activation_shell_unsupported",
+                "message": "Opening a new shell from the dashboard is only supported on macOS right now.",
+            },
+        )
+    osascript_path = Path("/usr/bin/osascript")
+    if not osascript_path.exists():
+        return (
+            500,
+            {
+                "error": "activation_shell_unavailable",
+                "message": "macOS automation support is unavailable on this machine.",
+            },
+        )
+    command = [
+        str(osascript_path),
+        "-e",
+        'tell application "Terminal" to do script ""',
+        "-e",
+        'tell application "Terminal" to activate',
+    ]
+    try:
+        subprocess.Popen(
+            command,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    except OSError as error:
+        return (
+            500,
+            {
+                "error": "activation_shell_launch_failed",
+                "message": f"Guard could not open a new shell automatically. {error}",
+            },
+        )
+    return (
+        200,
+        {
+            "status": "opened",
+            "message": "Opened a new Terminal window with a fresh shell session.",
+            "platform": "macos",
+        },
+    )
 
 
 def _resolve_package_firewall_connect_flow(
@@ -575,7 +646,7 @@ def _finalize_daemon_guard_connect_payload(
     payload: dict[str, object],
     now: str,
 ) -> dict[str, object]:
-    sync_auth_context = payload.pop("_guard_sync_auth_context", None)
+    payload.pop("_guard_sync_auth_context", None)
     normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
     sync_url = f"{allowed_origin}/api/guard/receipts/sync"
     dashboard_url = f"{allowed_origin}/guard"
@@ -628,10 +699,7 @@ def _finalize_daemon_guard_connect_payload(
         return payload
     payload["sync_attempted"] = True
     try:
-        if isinstance(sync_auth_context, dict):
-            sync_payload = sync_local_guard_cloud_proof(store, auth_context=sync_auth_context)
-        else:
-            sync_payload = sync_local_guard_cloud_proof(store)
+        sync_payload = sync_local_guard_cloud_proof(store)
     except GuardSyncNotAvailableError as error:
         store.record_latest_guard_connect_sync_result(
             status="connected",
@@ -1745,6 +1813,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if action == "connect":
             self._handle_supply_chain_package_firewall_connect()
             return
+        if action == "open-shell":
+            status, response = _open_package_firewall_activation_shell()
+            self._write_json(response, status=status)
+            return
         operation = "remove" if action == "uninstall" else action
         entitlement = self._supply_chain_entitlement()
         context = self._supply_chain_context(payload)
@@ -1887,7 +1959,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         store = self.server.store  # type: ignore[attr-defined]
         connect_url = _package_firewall_connect_url(store)
-        action_label = _package_firewall_connect_action_label(reason)
+        action_label = _package_firewall_connect_action_label(
+            reason,
+            repair_copy=_package_firewall_connect_needs_repair(store, reason),
+        )
         try:
             device = store.get_device_metadata()
             session = start_guard_browser_session(
@@ -3095,7 +3170,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return "supply_chain_entitlement"
         if len(path_parts) == 4 and path_parts[:3] == ["v1", "supply-chain", "package-shims"]:
             action = "remove" if path_parts[3] == "uninstall" else path_parts[3]
-            if action in {"install", "repair", "test", "remove"}:
+            if action in {"install", "repair", "test", "remove", "open-shell"}:
                 return f"package_shims_{action}"
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "supply-chain"] and path_parts[2] in {"audit", "sync"}:
             return f"package_shims_{path_parts[2]}"

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -1,4 +1,4 @@
-import { r as reactExports, aq as runAuditRemediation, a9 as GuardHarnessActionError, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, b as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
+import { r as reactExports, ar as runAuditRemediation, a9 as GuardHarnessActionError, j as jsxRuntimeExports, B as Badge, S as SectionLabel, W as HiMiniMagnifyingGlass, E as EmptyState, g as HiMiniCheckCircle, h as HiMiniXCircle, b as HiMiniExclamationTriangle, i as harnessDisplayName, f as formatRelativeTime, s as HiMiniChevronRight, A as ActionButton, v as HiMiniWrenchScrewdriver } from "../guard-dashboard.js";
 import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 function deriveFrontendAuditResults(receipts, snapshot) {
   const results = [];

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, A as ActionButton, S as SectionLabel, b as HiMiniExclamationTriangle, ab as HiMiniArrowPath, g as HiMiniCheckCircle, ar as HiMiniSignal, h as HiMiniXCircle, as as HiMiniClock, f as formatRelativeTime, B as Badge, T as Tag } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, A as ActionButton, S as SectionLabel, b as HiMiniExclamationTriangle, ab as HiMiniArrowPath, g as HiMiniCheckCircle, as as HiMiniSignal, h as HiMiniXCircle, at as HiMiniClock, f as formatRelativeTime, B as Badge, T as Tag } from "../guard-dashboard.js";
 function resolveFeedSourceMode(cloudState) {
   if (cloudState === "local_only") return "sample";
   if (cloudState === "paired_waiting") return "full";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -60,6 +60,14 @@ function resolveConnectSteps(connectFlow) {
     }
   ];
 }
+function isMacClient() {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+  const navigatorWithUserAgentData = navigator;
+  const platformHint = navigatorWithUserAgentData.userAgentData?.platform ?? navigator.userAgent ?? navigator.platform;
+  return platformHint.toLowerCase().includes("mac");
+}
 function ConnectFlowCard({
   compact = false,
   connectError,
@@ -78,7 +86,6 @@ function ConnectFlowCard({
   const statusTone = running ? "blue" : mode === "repair" ? "attention" : "blue";
   const statusLabel = running ? "Waiting for approval" : mode === "repair" ? "Repair required" : "Connection required";
   const showManualLink = connectFlow.authorize_url !== null || running || failed;
-  const hintCopy = localRecoveryHint ?? "Guard changes routing only after this machine receives signed cloud access.";
   if (compact) {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
@@ -100,7 +107,7 @@ function ConnectFlowCard({
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5", children: step.body })
       ] }, step.title)) }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-x-4 gap-y-1 text-xs leading-relaxed text-slate-500", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: hintCopy }),
+        localRecoveryHint !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: localRecoveryHint }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Guard changes routing only after this machine receives signed cloud access." })
       ] }),
       connectError !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-brand-attention", children: connectError }),
@@ -221,7 +228,7 @@ function ActivationSummary({
   const Icon = protection.path_status === "in_path" ? HiMiniCheckCircle : protection.path_status === "restart_required" ? HiMiniArrowPath : HiMiniExclamationTriangle;
   const toneClass = protection.path_status === "in_path" ? "border-brand-green/20 bg-brand-green/[0.04]" : protection.path_status === "restart_required" ? "border-brand-blue/20 bg-brand-blue/[0.04]" : "border-brand-attention/20 bg-brand-attention/[0.04]";
   const iconClass = protection.path_status === "in_path" ? "text-brand-green" : protection.path_status === "restart_required" ? "text-brand-blue" : "text-brand-attention";
-  const canOpenShell = protection.path_status === "restart_required" && protection.shell_profile_configured && typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac");
+  const canOpenShell = protection.path_status === "restart_required" && protection.shell_profile_configured && isMacClient();
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `rounded-xl border px-4 py-3 ${toneClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2.5", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: `mt-0.5 h-4 w-4 shrink-0 ${iconClass}`, "aria-hidden": "true" }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, T as Tag, A as ActionButton, ab as HiMiniArrowPath, H as HiMiniShieldCheck, ai as HiMiniArrowTopRightOnSquare, g as HiMiniCheckCircle, b as HiMiniExclamationTriangle, h as HiMiniXCircle, r as reactExports, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, ao as startPackageFirewallConnect, S as SectionLabel, E as EmptyState, ap as HiMiniBugAnt, a as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, T as Tag, A as ActionButton, ab as HiMiniArrowPath, H as HiMiniShieldCheck, ai as HiMiniArrowTopRightOnSquare, g as HiMiniCheckCircle, b as HiMiniExclamationTriangle, h as HiMiniXCircle, r as reactExports, v as HiMiniWrenchScrewdriver, aj as HiMiniBeaker, ac as HiMiniTrash, ak as fetchPackageFirewallStatus, al as runPackageFirewallAction, a9 as GuardHarnessActionError, am as runPackageAudit, an as runPackageSync, ao as startPackageFirewallConnect, ap as openPackageFirewallShell, S as SectionLabel, E as EmptyState, aq as HiMiniBugAnt, a as HiMiniInformationCircle, i as harnessDisplayName, B as Badge, d as HiMiniChevronUp, e as HiMiniChevronDown, f as formatRelativeTime } from "../guard-dashboard.js";
 import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 import { b as resolvePackageManagerProtectionCopy } from "./runtime-overview.js";
 function UpgradeCta({ entitlement }) {
@@ -61,6 +61,7 @@ function resolveConnectSteps(connectFlow) {
   ];
 }
 function ConnectFlowCard({
+  compact = false,
   connectError,
   connectStarting,
   connectFlow,
@@ -74,9 +75,47 @@ function ConnectFlowCard({
   const primaryBusy = connectStarting || running;
   const primaryLabel = running ? "Waiting for browser approval" : failed ? "Try connect again" : connectFlow.action_label;
   const steps = resolveConnectSteps(connectFlow);
-  const statusTone = mode === "repair" ? "attention" : "blue";
-  const statusLabel = mode === "repair" ? "Repair required" : "Connection required";
+  const statusTone = running ? "blue" : mode === "repair" ? "attention" : "blue";
+  const statusLabel = running ? "Waiting for approval" : mode === "repair" ? "Repair required" : "Connection required";
   const showManualLink = connectFlow.authorize_url !== null || running || failed;
+  const hintCopy = localRecoveryHint ?? "Guard changes routing only after this machine receives signed cloud access.";
+  if (compact) {
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-brand-blue", children: "HOL Guard Cloud" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: statusTone, children: statusLabel })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-base font-semibold tracking-[-0.02em] text-brand-dark", children: connectFlow.title }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "max-w-3xl text-sm leading-relaxed text-slate-500", children: connectFlow.detail })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2 text-xs leading-relaxed text-slate-500 md:grid-cols-3", children: steps.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "font-semibold text-brand-dark", children: [
+          index + 1,
+          ". ",
+          step.title
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5", children: step.body })
+      ] }, step.title)) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-x-4 gap-y-1 text-xs leading-relaxed text-slate-500", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: hintCopy }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Guard changes routing only after this machine receives signed cloud access." })
+      ] }),
+      connectError !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-brand-attention", children: connectError }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "primary", onClick: onStartConnect, disabled: primaryBusy, children: [
+          primaryBusy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mr-1.5 h-3.5 w-3.5 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mr-1.5 h-3.5 w-3.5", "aria-hidden": "true" }),
+          primaryLabel
+        ] }),
+        showManualLink && /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: manualHref, variant: "outline", children: [
+          "Open sign-in page",
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "ml-1.5 h-3.5 w-3.5", "aria-hidden": "true" })
+        ] })
+      ] })
+    ] });
+  }
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-3 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2.5", children: [
@@ -142,12 +181,15 @@ function EntitlementNotice({
   onStartConnect
 }) {
   const connectRequired = data.entitlement.reason === "guard_cloud_connect_required" || data.entitlement.reason === "guard_cloud_reconnect_required";
-  const connectMode = data.entitlement.reason === "guard_cloud_reconnect_required" ? "repair" : "connect";
+  const reconnectLikeState = data.entitlement.reason === "guard_cloud_reconnect_required" || data.entitlement.reason === "guard_cloud_connect_required" && (data.entitlement.tier !== "unknown" || data.package_shims.some((shim) => shim.installed));
+  const connectMode = reconnectLikeState ? "repair" : "connect";
   const localRecoveryHint = data.package_shims.some((shim) => shim.installed) ? connectRequired ? "Existing shims on this machine can still be fixed or removed locally. Connect is only needed for new installs and cloud-gated verification." : null : null;
+  const compactConnectNotice = data.package_shims.some((shim) => shim.installed) || data.protection?.path_status === "restart_required";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-4 py-4", children: [
     connectRequired && data.connect_flow !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       ConnectFlowCard,
       {
+        compact: compactConnectNotice,
         connectError,
         connectStarting,
         connectFlow: data.connect_flow,
@@ -165,7 +207,13 @@ function activationHeadline(protection) {
   if (protection.path_status === "restart_required") return "Restart shell or apps to finish activation";
   return "Fix PATH to finish activation";
 }
-function ActivationSummary({ protection }) {
+function ActivationSummary({
+  activationAssistError,
+  openingShell,
+  onOpenShell,
+  onRefreshStatus,
+  protection
+}) {
   if (protection === null) {
     return null;
   }
@@ -173,11 +221,17 @@ function ActivationSummary({ protection }) {
   const Icon = protection.path_status === "in_path" ? HiMiniCheckCircle : protection.path_status === "restart_required" ? HiMiniArrowPath : HiMiniExclamationTriangle;
   const toneClass = protection.path_status === "in_path" ? "border-brand-green/20 bg-brand-green/[0.04]" : protection.path_status === "restart_required" ? "border-brand-blue/20 bg-brand-blue/[0.04]" : "border-brand-attention/20 bg-brand-attention/[0.04]";
   const iconClass = protection.path_status === "in_path" ? "text-brand-green" : protection.path_status === "restart_required" ? "text-brand-blue" : "text-brand-attention";
+  const canOpenShell = protection.path_status === "restart_required" && protection.shell_profile_configured && typeof navigator !== "undefined" && navigator.platform.toLowerCase().includes("mac");
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `rounded-xl border px-4 py-3 ${toneClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2.5", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: `mt-0.5 h-4 w-4 shrink-0 ${iconClass}`, "aria-hidden": "true" }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: activationHeadline(protection) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs text-slate-600", children: copy.pathDetail })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs text-slate-600", children: copy.pathDetail }),
+      protection.path_status === "restart_required" && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex flex-wrap items-center gap-2", children: [
+        canOpenShell && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "primary", onClick: onOpenShell, disabled: openingShell, children: openingShell ? "Opening shell…" : "Open new shell" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onRefreshStatus, disabled: openingShell, children: "Refresh after restart" })
+      ] }),
+      activationAssistError !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-brand-attention", children: activationAssistError })
     ] })
   ] }) });
 }
@@ -536,6 +590,8 @@ function FailureBanner({ failed }) {
   );
 }
 function FirewallControlsView({
+  activationAssistError,
+  openingShell,
   data,
   pendingOp,
   lastCompleted,
@@ -550,7 +606,9 @@ function FirewallControlsView({
   onRemoveCancel,
   onAudit,
   onSync,
-  onDismissResult
+  onDismissResult,
+  onOpenShell,
+  onRefreshStatus
 }) {
   const anyPending = pendingOp !== null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-4 py-4", children: [
@@ -566,7 +624,16 @@ function FirewallControlsView({
         }
       )
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(ActivationSummary, { protection: data.protection }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      ActivationSummary,
+      {
+        activationAssistError,
+        openingShell,
+        onOpenShell,
+        onRefreshStatus,
+        protection: data.protection
+      }
+    ),
     lastFailed !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(FailureBanner, { failed: lastFailed }),
     lastCompleted !== null && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionResultPanel, { completed: lastCompleted, onDismiss: onDismissResult }),
     data.package_shims.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -620,7 +687,9 @@ function PackageFirewallPanel(props) {
   const [lastCompleted, setLastCompleted] = reactExports.useState(null);
   const [lastFailed, setLastFailed] = reactExports.useState(null);
   const [connectError, setConnectError] = reactExports.useState(null);
+  const [activationAssistError, setActivationAssistError] = reactExports.useState(null);
   const [startingConnect, setStartingConnect] = reactExports.useState(false);
+  const [openingShell, setOpeningShell] = reactExports.useState(false);
   const [confirmRemoveManager, setConfirmRemoveManager] = reactExports.useState(null);
   const [pendingApprovalOp, setPendingApprovalOp] = reactExports.useState(null);
   const { resolvedApprovalGate, resolveApprovalGate } = useResolvedApprovalGate(approvalGate);
@@ -664,6 +733,7 @@ function PackageFirewallPanel(props) {
       setPendingOp({ op, manager });
       setLastFailed(null);
       setConnectError(null);
+      setActivationAssistError(null);
       try {
         const response = await runPackageFirewallAction(op, manager, credentials);
         setLastCompleted({ op, manager, response });
@@ -688,6 +758,7 @@ function PackageFirewallPanel(props) {
       setPendingOp({ op, manager: null });
       setLastFailed(null);
       setConnectError(null);
+      setActivationAssistError(null);
       try {
         const response = op === "audit" ? await runPackageAudit() : await runPackageSync();
         setLastCompleted({ op, manager: null, response });
@@ -733,6 +804,7 @@ function PackageFirewallPanel(props) {
   const handleStartConnect = reactExports.useCallback(async () => {
     setStartingConnect(true);
     setConnectError(null);
+    setActivationAssistError(null);
     try {
       await startPackageFirewallConnect();
       await refreshAfterOp();
@@ -745,6 +817,17 @@ function PackageFirewallPanel(props) {
       setStartingConnect(false);
     }
   }, [onStateChanged, refreshAfterOp]);
+  const handleOpenShell = reactExports.useCallback(async () => {
+    setOpeningShell(true);
+    setActivationAssistError(null);
+    try {
+      await openPackageFirewallShell();
+    } catch (error) {
+      setActivationAssistError(error instanceof Error ? error.message : "Unable to open a new shell.");
+    } finally {
+      setOpeningShell(false);
+    }
+  }, []);
   const handleApprovalCancel = reactExports.useCallback(() => setPendingApprovalOp(null), []);
   const handleApprovalConfirm = reactExports.useCallback(
     (credentials) => {
@@ -793,7 +876,11 @@ function PackageFirewallPanel(props) {
           onRemoveCancel: handleRemoveCancel,
           onAudit: handleAudit,
           onSync: handleSync,
-          onDismissResult: handleDismissResult
+          onDismissResult: handleDismissResult,
+          onOpenShell: handleOpenShell,
+          onRefreshStatus: handleRetry,
+          openingShell,
+          activationAssistError
         }
       )
     ] }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14037,6 +14037,24 @@ async function runPackageFirewallAction(action, manager, credentials) {
   }
   return normalizePackageFirewallAction(payloadBody);
 }
+async function openPackageFirewallShell() {
+  const response = await fetchGuardApi("/v1/supply-chain/package-shims/open-shell", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...guardAuthHeaders()
+    },
+    body: JSON.stringify({})
+  });
+  if (response.ok) {
+    return;
+  }
+  const payloadBody = await response.json().catch(() => null);
+  if (isRecord(payloadBody) && typeof payloadBody.message === "string" && payloadBody.message.trim()) {
+    throw new Error(payloadBody.message);
+  }
+  throw new Error("Unable to open a new shell.");
+}
 async function runAuditRemediation(input) {
   if (isGuardDemoMode()) {
     return {
@@ -23232,10 +23250,11 @@ export {
   runPackageAudit as am,
   runPackageSync as an,
   startPackageFirewallConnect as ao,
-  HiMiniBugAnt as ap,
-  runAuditRemediation as aq,
-  HiMiniSignal as ar,
-  HiMiniClock as as,
+  openPackageFirewallShell as ap,
+  HiMiniBugAnt as aq,
+  runAuditRemediation as ar,
+  HiMiniSignal as as,
+  HiMiniClock as at,
   HiMiniExclamationTriangle as b,
   HiMiniArrowRight as c,
   HiMiniChevronUp as d,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2470,11 +2470,7 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
         if isinstance(refreshed.get("package_firewall_entitlement"), dict)
         else None
     )
-    if (
-        rotated_refresh_token != refresh_token
-        or package_firewall_entitlement is not None
-        or persist_recovered_secret
-    ):
+    if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None or persist_recovered_secret:
         _persist_rotated_oauth_refresh_token(
             store=store,
             credentials=oauth_credentials,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2442,50 +2442,70 @@ def _persist_rotated_oauth_refresh_token(
     )
 
 
+def _resolve_guard_sync_auth_context_from_oauth_credentials(
+    store: GuardStore,
+    oauth_credentials: dict[str, object],
+    *,
+    persist_recovered_secret: bool = False,
+) -> dict[str, object]:
+    issuer = _optional_string(oauth_credentials.get("issuer"))
+    client_id = _optional_string(oauth_credentials.get("client_id"))
+    refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
+    if issuer is None or client_id is None or refresh_token is None:
+        raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+    dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
+    try:
+        oauth_client = resolve_guard_oauth_client_config(issuer)
+    except ValueError as error:
+        raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
+    refreshed = _refresh_guard_oauth_access_token(
+        token_endpoint=oauth_client.token_endpoint,
+        client_id=client_id,
+        refresh_token=refresh_token,
+        dpop_key_material=dpop_key_material,
+    )
+    rotated_refresh_token = str(refreshed["refresh_token"])
+    package_firewall_entitlement = (
+        refreshed["package_firewall_entitlement"]
+        if isinstance(refreshed.get("package_firewall_entitlement"), dict)
+        else None
+    )
+    if (
+        rotated_refresh_token != refresh_token
+        or package_firewall_entitlement is not None
+        or persist_recovered_secret
+    ):
+        _persist_rotated_oauth_refresh_token(
+            store=store,
+            credentials=oauth_credentials,
+            package_firewall_entitlement=package_firewall_entitlement,
+            refresh_token=rotated_refresh_token,
+        )
+    sync_url = _validate_guard_sync_url(
+        _oauth_sync_url_from_issuer(oauth_client.issuer),
+        issuer=oauth_client.issuer,
+    )
+    return {
+        "sync_url": sync_url,
+        "access_token": str(refreshed["access_token"]),
+        "dpop_key_material": dpop_key_material,
+    }
+
+
 def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
     with _guard_sync_auth_lock(store):
         oauth_health = store.get_oauth_local_credential_health()
         oauth_credentials = store.get_oauth_local_credentials()
         if oauth_credentials is not None:
-            issuer = _optional_string(oauth_credentials.get("issuer"))
-            client_id = _optional_string(oauth_credentials.get("client_id"))
-            refresh_token = _optional_string(oauth_credentials.get("refresh_token"))
-            if issuer is None or client_id is None or refresh_token is None:
-                raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-            dpop_key_material = _oauth_dpop_key_material(oauth_credentials)
-            try:
-                oauth_client = resolve_guard_oauth_client_config(issuer)
-            except ValueError as error:
-                raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
-            refreshed = _refresh_guard_oauth_access_token(
-                token_endpoint=oauth_client.token_endpoint,
-                client_id=client_id,
-                refresh_token=refresh_token,
-                dpop_key_material=dpop_key_material,
-            )
-            rotated_refresh_token = str(refreshed["refresh_token"])
-            package_firewall_entitlement = (
-                refreshed["package_firewall_entitlement"]
-                if isinstance(refreshed.get("package_firewall_entitlement"), dict)
-                else None
-            )
-            if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None:
-                _persist_rotated_oauth_refresh_token(
-                    store=store,
-                    credentials=oauth_credentials,
-                    package_firewall_entitlement=package_firewall_entitlement,
-                    refresh_token=rotated_refresh_token,
-                )
-            sync_url = _validate_guard_sync_url(
-                _oauth_sync_url_from_issuer(oauth_client.issuer),
-                issuer=oauth_client.issuer,
-            )
-            return {
-                "sync_url": sync_url,
-                "access_token": str(refreshed["access_token"]),
-                "dpop_key_material": dpop_key_material,
-            }
+            return _resolve_guard_sync_auth_context_from_oauth_credentials(store, oauth_credentials)
         if bool(oauth_health.get("configured")):
+            recoverable_credentials = store.get_recoverable_oauth_local_credentials()
+            if recoverable_credentials is not None:
+                return _resolve_guard_sync_auth_context_from_oauth_credentials(
+                    store,
+                    recoverable_credentials,
+                    persist_recovered_secret=True,
+                )
             raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
         credentials = store.get_sync_credentials()
         if credentials is None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -143,6 +143,7 @@ _SYNC_TOKEN_HASH_KEY = "token_sha256"
 _OAUTH_LOCAL_CREDENTIALS_STATE_KEY = "oauth_local_credentials"
 _OAUTH_LOCAL_CREDENTIALS_HASH_KEY = "credentials_sha256"
 _OAUTH_LOCAL_CREDENTIALS_REF_KEY = "credentials_ref"
+_OAUTH_PRIMARY_SECRET_TIMEOUT_SECONDS = 2.0
 _GUARD_CLOUD_RESET_STATE_KEYS = (
     "credentials",
     "sync_summary",
@@ -461,6 +462,35 @@ class SystemKeyringSecretStore:
         value = keyring_module.get_password(self.service_name, secret_id)
         return value if isinstance(value, str) and value else None
 
+    def get_secret_with_timeout(self, secret_id: str, *, timeout_seconds: float) -> str | None:
+        if sys.platform != "darwin":
+            return self.get_secret(secret_id)
+        security_path = Path("/usr/bin/security")
+        if not security_path.exists():
+            return None
+        try:
+            result = subprocess.run(
+                [
+                    str(security_path),
+                    "find-generic-password",
+                    "-a",
+                    secret_id,
+                    "-s",
+                    self.service_name,
+                    "-w",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds,
+            )
+        except Exception:
+            return None
+        if result.returncode != 0:
+            return None
+        value = result.stdout.rstrip("\r\n")
+        return value if value else None
+
     def delete_secret(self, secret_id: str) -> None:
         keyring_module = self._load_keyring_module()
         try:
@@ -767,20 +797,64 @@ class GuardStore:
             )
             return
 
+    def _assert_oauth_secret_persisted(self, secret_id: str, value: str) -> None:
+        secret_store = self._oauth_secret_store
+        if isinstance(secret_store, FallbackSecretStore) and isinstance(
+            secret_store.fallback,
+            EncryptedFileSecretStore,
+        ):
+            fallback_value = self._get_secret_from_store(secret_store.fallback, secret_id)
+            if fallback_value == value:
+                return
+            raise RuntimeError(
+                "Guard could not persist local Guard Cloud authorization into the encrypted local store."
+            )
+        persisted_value = self._get_secret_from_store(secret_store, secret_id)
+        if persisted_value == value:
+            return
+        raise RuntimeError("Guard could not persist local Guard Cloud authorization securely.")
+
     def _get_secret_from_store(self, store: SecretStore, secret_id: str) -> str | None:
         try:
             return store.get_secret(secret_id)
         except Exception:
             return None
 
+    def _get_secret_from_primary_store(self, store: SecretStore, secret_id: str) -> str | None:
+        if isinstance(store, SystemKeyringSecretStore):
+            return store.get_secret_with_timeout(
+                secret_id,
+                timeout_seconds=_OAUTH_PRIMARY_SECRET_TIMEOUT_SECONDS,
+            )
+        return self._get_secret_from_store(store, secret_id)
+
     def _get_secret_candidates(
         self,
         secret_store: SecretStore,
         secret_id: str,
         expected_hash_value: str | None,
+        *,
+        prefer_fallback_first: bool = False,
     ) -> list[str]:
         if isinstance(secret_store, FallbackSecretStore):
-            primary_token = self._get_secret_from_store(secret_store.primary, secret_id)
+            if prefer_fallback_first and isinstance(secret_store.fallback, EncryptedFileSecretStore):
+                fallback_token = self._get_secret_from_store(secret_store.fallback, secret_id)
+                if fallback_token is not None and (
+                    expected_hash_value is None or _secret_matches_hash(fallback_token, expected_hash_value)
+                ):
+                    return [fallback_token]
+                primary_token = self._get_secret_from_primary_store(secret_store.primary, secret_id)
+                if primary_token is not None and (
+                    expected_hash_value is None or _secret_matches_hash(primary_token, expected_hash_value)
+                ):
+                    return [primary_token]
+                if fallback_token is not None and expected_hash_value is not None:
+                    return []
+            primary_token = (
+                self._get_secret_from_primary_store(secret_store.primary, secret_id)
+                if prefer_fallback_first
+                else self._get_secret_from_store(secret_store.primary, secret_id)
+            )
             if primary_token is not None:
                 if expected_hash_value is None or _secret_matches_hash(primary_token, expected_hash_value):
                     return [primary_token]
@@ -3327,6 +3401,7 @@ class GuardStore:
             payload["runtime_label"] = runtime_label
         self._oauth_secret_store.set_secret(self._oauth_local_credentials_ref, secret_json)
         self._mirror_oauth_secret_to_fallback(self._oauth_local_credentials_ref, secret_json)
+        self._assert_oauth_secret_persisted(self._oauth_local_credentials_ref, secret_json)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
 
     def get_oauth_local_credentials(self) -> dict[str, object] | None:
@@ -3337,6 +3412,18 @@ class GuardStore:
         if metadata is None:
             return None
         secret_payload = self._load_oauth_secret_payload(payload)
+        if secret_payload is None:
+            return None
+        return self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload)
+
+    def get_recoverable_oauth_local_credentials(self) -> dict[str, object] | None:
+        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        if not isinstance(payload, dict):
+            return None
+        metadata = self._oauth_local_credentials_metadata(payload)
+        if metadata is None:
+            return None
+        secret_payload = self._load_oauth_fallback_secret_payload(payload)
         if secret_payload is None:
             return None
         return self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload)
@@ -3414,7 +3501,12 @@ class GuardStore:
             return None
         if not isinstance(secret_hash, str) or not secret_hash:
             return None
-        for candidate in self._get_secret_candidates(self._oauth_secret_store, secret_ref, secret_hash):
+        for candidate in self._get_secret_candidates(
+            self._oauth_secret_store,
+            secret_ref,
+            secret_hash,
+            prefer_fallback_first=True,
+        ):
             if not _secret_matches_hash(candidate, secret_hash):
                 continue
             try:
@@ -3428,6 +3520,33 @@ class GuardStore:
                 self._mirror_oauth_secret_to_fallback(secret_ref, candidate)
             return secret_payload
         return None
+
+    def _load_oauth_fallback_secret_payload(self, payload: dict[str, object]) -> dict[str, object] | None:
+        secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)
+        if not isinstance(secret_ref, str) or not secret_ref:
+            return None
+        secret_store = self._oauth_secret_store
+        fallback_store: EncryptedFileSecretStore | None
+        if isinstance(secret_store, FallbackSecretStore):
+            fallback_store = (
+                secret_store.fallback
+                if isinstance(secret_store.fallback, EncryptedFileSecretStore)
+                else None
+            )
+        elif isinstance(secret_store, EncryptedFileSecretStore):
+            fallback_store = secret_store
+        else:
+            fallback_store = None
+        if fallback_store is None:
+            return None
+        secret_json = self._get_secret_from_store(fallback_store, secret_ref)
+        if not isinstance(secret_json, str) or not secret_json:
+            return None
+        try:
+            secret_payload = json.loads(secret_json)
+        except json.JSONDecodeError:
+            return None
+        return secret_payload if isinstance(secret_payload, dict) else None
 
     @staticmethod
     def _build_oauth_local_credentials_result(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3529,9 +3529,7 @@ class GuardStore:
         fallback_store: EncryptedFileSecretStore | None
         if isinstance(secret_store, FallbackSecretStore):
             fallback_store = (
-                secret_store.fallback
-                if isinstance(secret_store.fallback, EncryptedFileSecretStore)
-                else None
+                secret_store.fallback if isinstance(secret_store.fallback, EncryptedFileSecretStore) else None
             )
         elif isinstance(secret_store, EncryptedFileSecretStore):
             fallback_store = secret_store

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -99,13 +99,7 @@ def test_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(tmp_p
         now=now,
     )
 
-    assert sync_calls == [
-        {
-            "access_token": "access-token-1",
-            "dpop_key_material": "dpop",
-            "sync_url": "https://hol.org/api/guard/receipts/sync",
-        }
-    ]
+    assert sync_calls == [None]
     assert CONNECT_SYNC_AUTH_CONTEXT_KEY not in payload
 
 

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -7,6 +7,8 @@ import urllib.error
 import urllib.request
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.cli.connect_flow import (
     GuardOAuthLoopbackCallback,
     GuardOAuthTokenExchangeResult,
@@ -16,6 +18,7 @@ from codex_plugin_scanner.guard.cli.connect_flow import (
 from codex_plugin_scanner.guard.cli.oauth_client import GuardDpopKeyMaterial
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.package_firewall_entitlement import resolve_package_firewall_entitlement
+from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -205,6 +208,94 @@ def test_paid_metadata_without_usable_local_auth_still_prefers_connect_over_upgr
         "tier": "team",
         "upgrade_cta": "Connect HOL Guard Cloud to check package firewall access and run package firewall actions.",
     }
+
+
+def test_sync_local_guard_cloud_proof_repairs_degraded_oauth_from_encrypted_fallback(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-old",
+        dpop_private_key_pem="private-key-old",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value-old", "y": "y-value-old"},
+        dpop_public_jwk_thumbprint="thumbprint-old",
+        grant_id="grant-old",
+        machine_id="machine-old",
+        supply_chain_entitlement_expires_at="2026-07-05T01:39:51+00:00",
+        supply_chain_firewall=True,
+        supply_chain_plan_id="team",
+        workspace_id="workspace-1",
+        now="2026-06-05T01:39:51+00:00",
+    )
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-05T01:39:51+00:00",
+        request_id="connect-1",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    oauth_payload["credentials_sha256"] = "pbkdf2-sha256$" + ("0" * 64)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-05T01:40:00+00:00")
+
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_refresh_guard_oauth_access_token",
+        lambda **_kwargs: {
+            "access_token": "access-token-1",
+            "refresh_token": "refresh-token-new",
+            "package_firewall_entitlement": {
+                "supply_chain_entitlement_expires_at": "2026-07-05T01:39:51+00:00",
+                "supply_chain_firewall": True,
+                "supply_chain_plan_id": "team",
+            },
+        },
+    )
+    monkeypatch.setattr(
+        guard_runner_module,
+        "sync_runtime_session",
+        lambda *_args, **_kwargs: {
+            "runtime_session_id": "runtime-session-1",
+            "runtime_session_synced_at": "2026-06-05T01:40:15+00:00",
+            "runtime_sessions_visible": 1,
+            "local_guard_online_at": "2026-06-05T01:40:15+00:00",
+            "runtime_harness": "hol-guard",
+            "runtime_surface": "local",
+            "runtime_workspace": "workspace-1",
+            "runtime_device_id": "machine-old",
+        },
+    )
+    monkeypatch.setattr(
+        guard_runner_module,
+        "sync_receipts",
+        lambda *_args, **_kwargs: {
+            "synced_at": "2026-06-05T01:40:20+00:00",
+            "receipts_stored": 4,
+            "inventory_tracked": 2,
+            "local_guard_online_at": "2026-06-05T01:40:20+00:00",
+        },
+    )
+
+    summary = guard_runner_module.sync_local_guard_cloud_proof(store)
+
+    assert summary["synced_at"] == "2026-06-05T01:40:20+00:00"
+    assert store.get_oauth_local_credential_health()["state"] == "healthy"
+    repaired_credentials = store.get_oauth_local_credentials()
+    assert repaired_credentials is not None
+    assert repaired_credentials["refresh_token"] == "refresh-token-new"
+    entitlement = resolve_package_firewall_entitlement(store)
+    assert entitlement == {
+        "allowed": True,
+        "reason": "paid_oauth_entitlement_active",
+        "tier": "team",
+        "upgrade_cta": None,
+    }
+    latest_state = store.get_latest_guard_connect_state(now="2026-06-05T01:40:25+00:00")
+    assert latest_state is not None
+    assert latest_state["milestone"] == "first_sync_succeeded"
 
 
 def test_retry_required_connect_state_prefers_reconnect_over_false_paywall(tmp_path: Path) -> None:

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -603,6 +603,36 @@ def test_supply_chain_package_firewall_status_accepts_paid_oauth_entitlement(tmp
     }
 
 
+def test_supply_chain_package_firewall_open_shell_endpoint_returns_activation_launch_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    monkeypatch.setattr(
+        daemon_server,
+        "_open_package_firewall_activation_shell",
+        lambda: (200, {"status": "opened", "message": "Opened a new Terminal window with a fresh shell session."}),
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/open-shell",
+                token=token,
+                payload={},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["status"] == "opened"
+    assert "fresh shell session" in payload["message"]
+
+
 def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -53,6 +53,11 @@ class _FakeSystemKeyringModule:
 def _install_fake_system_keyring(monkeypatch) -> _FakeSystemKeyringModule:
     module = _FakeSystemKeyringModule()
     monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_macos_default_keychain_is_usable",
+        classmethod(lambda cls: True),
+    )
     return module
 
 
@@ -707,6 +712,156 @@ def test_oauth_local_credentials_mirror_secret_into_encrypted_fallback_store(tmp
     assert headless_store.get_oauth_local_credential_health()["state"] == "healthy"
 
 
+def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before_keyring(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    def fail_primary_lookup(secret_id: str) -> str | None:
+        raise AssertionError(f"primary keyring lookup should not run for {secret_id}")
+
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret", fail_primary_lookup)
+
+    credentials = store.get_oauth_local_credentials()
+
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-secret-value"
+
+
+def test_get_oauth_local_credentials_fails_closed_when_fallback_hash_is_stale(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    oauth_payload["credentials_sha256"] = "pbkdf2-sha256$" + ("0" * 64)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-01T00:01:00+00:00")
+
+    def fail_primary_lookup(_secret_id: str, *, timeout_seconds: float) -> str | None:
+        assert timeout_seconds > 0
+        return None
+
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", fail_primary_lookup)
+
+    assert store.get_oauth_local_credentials() is None
+    assert store.get_oauth_local_credential_health()["state"] == "degraded"
+
+
+def test_get_oauth_local_credentials_recovers_from_timed_primary_lookup_when_fallback_hash_is_stale(
+    tmp_path,
+    monkeypatch,
+):
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    secret_id = str(oauth_payload["credentials_ref"])
+    original_secret = fake_keyring.get_password("hol-guard.oauth", secret_id)
+    assert isinstance(original_secret, str)
+    updated_secret_payload = json.loads(original_secret)
+    assert isinstance(updated_secret_payload, dict)
+    updated_secret_payload["refresh_token"] = "refresh-secret-value-rotated"
+    updated_secret = json.dumps(updated_secret_payload)
+    fake_keyring.set_password("hol-guard.oauth", secret_id, updated_secret)
+    oauth_payload["credentials_sha256"] = guard_store_module._secret_fingerprint(updated_secret)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-01T00:01:00+00:00")
+
+    assert isinstance(store._oauth_secret_store.primary, SystemKeyringSecretStore)
+    primary_secret = fake_keyring.get_password("hol-guard.oauth", secret_id)
+    assert isinstance(primary_secret, str)
+    monkeypatch.setattr(
+        store._oauth_secret_store.primary,
+        "get_secret",
+        lambda _secret_id: (_ for _ in ()).throw(AssertionError("plain primary lookup should not run")),
+    )
+    monkeypatch.setattr(
+        store._oauth_secret_store.primary,
+        "get_secret_with_timeout",
+        lambda _secret_id, *, timeout_seconds: primary_secret,
+    )
+
+    credentials = store.get_oauth_local_credentials()
+
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-secret-value-rotated"
+    assert store.get_oauth_local_credential_health()["state"] == "healthy"
+
+
+def test_get_recoverable_oauth_local_credentials_uses_encrypted_fallback_when_hash_is_stale(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    oauth_payload["credentials_sha256"] = "pbkdf2-sha256$" + ("0" * 64)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-01T00:01:00+00:00")
+
+    assert store.get_oauth_local_credentials() is None
+
+    recoverable = store.get_recoverable_oauth_local_credentials()
+
+    assert recoverable is not None
+    assert recoverable["refresh_token"] == "refresh-secret-value"
+    assert recoverable["workspace_id"] == "workspace-123"
+
+
 def test_set_oauth_local_credentials_does_not_use_generic_secret_promotion(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
     guard_home = tmp_path / "guard-home"
@@ -737,7 +892,7 @@ def test_set_oauth_local_credentials_does_not_use_generic_secret_promotion(tmp_p
     assert headless_store.get_oauth_local_credentials() is not None
 
 
-def test_set_oauth_local_credentials_logs_when_fallback_mirror_fails(tmp_path, monkeypatch, caplog):
+def test_set_oauth_local_credentials_rejects_incomplete_fallback_mirror(tmp_path, monkeypatch, caplog):
     _install_fake_system_keyring(monkeypatch)
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
@@ -749,20 +904,26 @@ def test_set_oauth_local_credentials_logs_when_fallback_mirror_fails(tmp_path, m
     monkeypatch.setattr(store._oauth_secret_store.fallback, "set_secret", fail_fallback_set_secret)
     caplog.set_level(logging.WARNING, logger="codex_plugin_scanner.guard.store")
 
-    store.set_oauth_local_credentials(
-        issuer="https://hol.org",
-        client_id="guard-local-daemon",
-        refresh_token="refresh-secret-value",
-        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
-        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
-        dpop_public_jwk_thumbprint="thumbprint-123",
-        grant_id="grant-123",
-        machine_id="machine-123",
-        workspace_id="workspace-123",
-        now="2026-06-01T00:00:00+00:00",
-    )
+    try:
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            workspace_id="workspace-123",
+            now="2026-06-01T00:00:00+00:00",
+        )
+    except RuntimeError as error:
+        assert str(error) == "Guard could not persist local Guard Cloud authorization into the encrypted local store."
+    else:
+        raise AssertionError("OAuth persistence should fail when the encrypted fallback mirror is missing")
 
-    assert store.get_oauth_local_credentials() is not None
+    assert store.get_sync_payload("oauth_local_credentials") is None
+    assert store.get_oauth_local_credentials() is None
     assert "Failed to mirror OAuth credentials into encrypted fallback store" in caplog.text
 
 

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -50,19 +50,24 @@ class _FakeSystemKeyringModule:
         self._secrets.pop((service_name, secret_id), None)
 
 
-def _install_fake_system_keyring(monkeypatch) -> _FakeSystemKeyringModule:
+def _install_fake_system_keyring(
+    monkeypatch,
+    *,
+    usable_macos_keychain: bool = True,
+) -> _FakeSystemKeyringModule:
     module = _FakeSystemKeyringModule()
     monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
-    monkeypatch.setattr(
-        SystemKeyringSecretStore,
-        "_macos_default_keychain_is_usable",
-        classmethod(lambda cls: True),
-    )
+    if usable_macos_keychain:
+        monkeypatch.setattr(
+            SystemKeyringSecretStore,
+            "_macos_default_keychain_is_usable",
+            classmethod(lambda cls: True),
+        )
     return module
 
 
 def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing(tmp_path, monkeypatch):
-    _install_fake_system_keyring(monkeypatch)
+    _install_fake_system_keyring(monkeypatch, usable_macos_keychain=False)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
     SystemKeyringSecretStore._clear_macos_keychain_health_cache()
     monkeypatch.setattr(
@@ -81,7 +86,7 @@ def test_oauth_secret_store_skips_system_keyring_when_macos_user_keychain_search
     tmp_path,
     monkeypatch,
 ):
-    _install_fake_system_keyring(monkeypatch)
+    _install_fake_system_keyring(monkeypatch, usable_macos_keychain=False)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
     SystemKeyringSecretStore._clear_macos_keychain_health_cache()
     usable_keychain = tmp_path / "Library" / "Keychains" / "login.keychain-db"
@@ -1012,7 +1017,6 @@ def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_wr
         "machine_id": "machine-old",
         "workspace_id": "workspace-old",
     }
-
 
 
 def test_validated_keychain_fallback_reads_are_migrated_into_encrypted_file_store(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- repair package-firewall post-connect auth persistence and sync recovery
- compact the reconnect surface in Supply Chain and add actionable restart assistance

## Testing
- `uv run --extra dev python -m pytest -q tests/test_guard_store_migrations.py -k 'oauth_local_credentials_prefers_validated_encrypted_fallback_before_keyring or oauth_local_credentials_fails_closed_when_fallback_hash_is_stale or oauth_local_credentials_recovers_from_timed_primary_lookup_when_fallback_hash_is_stale or recoverable_oauth_local_credentials or set_oauth_local_credentials_rejects_incomplete_fallback_mirror'`
- `uv run --extra dev python -m pytest -q tests/test_guard_connect_flow.py -k 'sync_local_guard_cloud_proof_repairs_degraded_oauth_from_encrypted_fallback or paid_metadata_without_usable_local_auth_still_prefers_connect_over_upgrade'`
- `uv run --extra dev python -m pytest -q tests/test_guard_headless_daemon_api.py -k 'supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_paid_access or supply_chain_package_firewall_status_accepts_paid_oauth_entitlement or supply_chain_package_firewall_open_shell_endpoint_returns_activation_launch_status'`
- `uv run --extra dev ruff check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_store_migrations.py tests/test_guard_connect_flow.py`
- `pnpm exec tsx src/package-firewall-connect.test.tsx`
- `pnpm run build`

## Notes
- Live validation covered the local daemon package-firewall API against a production-backed HOL auth state and verified the reconnect flow is presented as repair guidance when prior machine auth is degraded.
