### PR TITLE
fix(guard): harden bridge daemon auth

### DIFF
--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import re
 import subprocess
@@ -196,7 +197,14 @@ def _validate_webhook_url(url: str) -> str:
         raise ValueError("Guard Bridge webhook URL must include a host.")
     if parsed.username or parsed.password:
         raise ValueError("Guard Bridge webhook URL must not embed credentials.")
-    if parsed.hostname.lower() in {"127.0.0.1", "localhost", "::1"}:
+    hostname = parsed.hostname.lower()
+    if hostname in {"localhost", "0.0.0.0", "169.254.169.254"}:
+        raise ValueError("Guard Bridge webhook URL must not target loopback.")
+    try:
+        address = ipaddress.ip_address(hostname)
+    except ValueError:
+        return parsed.geturl()
+    if address.is_loopback or address.is_link_local:
         raise ValueError("Guard Bridge webhook URL must not target loopback.")
     return parsed.geturl()
 
@@ -220,6 +228,7 @@ class GuardBridge:
         """Fetch pending requests from Guard daemon."""
         auth_token = load_guard_daemon_auth_token(self.store.guard_home)
         if auth_token is None:
+            print("[Guard Bridge] No daemon auth token found - skipping poll.", file=sys.stderr)
             return []
         try:
             resp = requests.get(

--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -10,6 +10,7 @@ import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 
@@ -119,12 +120,19 @@ class TelegramBackend(NotificationBackend):
 class WebhookBackend(NotificationBackend):
     """Send notifications via HTTP webhook."""
 
-    def __init__(self, url: str):
-        self.url = url
+    def __init__(self, url: str, *, include_artifact_details: bool = False):
+        self.url = _validate_webhook_url(url)
+        self.include_artifact_details = include_artifact_details
 
     def send_notification(self, request: PendingRequest, message: str) -> bool:
+        payload = {
+            "text": "HOL Guard approval pending. Review locally to see artifact details.",
+            "request_id": request.request_id,
+        }
+        if self.include_artifact_details:
+            payload["text"] = message
         try:
-            resp = requests.post(self.url, json={"text": message, "request_id": request.request_id}, timeout=10)
+            resp = requests.post(self.url, json=payload, timeout=10)
             return resp.status_code in (200, 201)
         except Exception:
             return False
@@ -180,6 +188,19 @@ def _format_notification(request: PendingRequest) -> str:
     return "\n".join(lines)
 
 
+def _validate_webhook_url(url: str) -> str:
+    parsed = urlparse(url)
+    if parsed.scheme != "https":
+        raise ValueError("Guard Bridge webhook URL must use https.")
+    if not parsed.hostname:
+        raise ValueError("Guard Bridge webhook URL must include a host.")
+    if parsed.username or parsed.password:
+        raise ValueError("Guard Bridge webhook URL must not embed credentials.")
+    if parsed.hostname.lower() in {"127.0.0.1", "localhost", "::1"}:
+        raise ValueError("Guard Bridge webhook URL must not target loopback.")
+    return parsed.geturl()
+
+
 class GuardBridge:
     """Bridge daemon that polls Guard daemon and sends notifications."""
 
@@ -197,8 +218,15 @@ class GuardBridge:
 
     def _fetch_pending_requests(self, guard_url: str) -> list[PendingRequest]:
         """Fetch pending requests from Guard daemon."""
+        auth_token = load_guard_daemon_auth_token(self.store.guard_home)
+        if auth_token is None:
+            return []
         try:
-            resp = requests.get(f"{guard_url}/v1/requests", timeout=10)
+            resp = requests.get(
+                f"{guard_url}/v1/requests",
+                headers={"X-Guard-Token": auth_token},
+                timeout=10,
+            )
             if resp.status_code != 200:
                 return []
             data = resp.json()

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1044,6 +1044,11 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     bridge_parser.add_argument("--telegram-token", help="Telegram bot token for notifications")
     bridge_parser.add_argument("--telegram-chat-id", help="Telegram chat ID for notifications")
     bridge_parser.add_argument("--webhook-url", help="Webhook URL for notifications")
+    bridge_parser.add_argument(
+        "--webhook-include-artifact-details",
+        action="store_true",
+        help="Include artifact details in webhook notifications",
+    )
     bridge_parser.add_argument("--hermes-chat-id", help="Hermes chat ID for notifications")
     bridge_parser.add_argument("--dry-run", action="store_true", help="Log notifications without sending")
     _add_guard_common_args(bridge_parser)
@@ -2635,12 +2640,16 @@ def run_guard_command(
         telegram_token = getattr(args, "telegram_token", None)
         telegram_chat_id = getattr(args, "telegram_chat_id", None)
         webhook_url = getattr(args, "webhook_url", None)
+        webhook_include_artifact_details = getattr(args, "webhook_include_artifact_details", False)
         hermes_chat_id = getattr(args, "hermes_chat_id", None)
 
         if telegram_token and telegram_chat_id:
             backend = TelegramBackend(telegram_token, telegram_chat_id)
         elif webhook_url:
-            backend = WebhookBackend(webhook_url)
+            backend = WebhookBackend(
+                webhook_url,
+                include_artifact_details=webhook_include_artifact_details,
+            )
         elif hermes_chat_id:
             backend = HermesBackend(hermes_chat_id)
 

--- a/tests/test_guard_bridge.py
+++ b/tests/test_guard_bridge.py
@@ -1,0 +1,155 @@
+"""Security tests for Guard Bridge daemon integration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import bridge as guard_bridge_module
+from codex_plugin_scanner.guard.bridge import BridgeConfig, GuardBridge, PendingRequest, WebhookBackend
+from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _build_pending_request() -> PendingRequest:
+    return PendingRequest(
+        request_id="req-bridge",
+        artifact_id="artifact-123",
+        artifact_name=".env",
+        artifact_type="file",
+        policy_action="block",
+        harness="codex",
+        source_scope="project",
+        risk_summary={"overall_risk_level": "high"},
+        created_at="2026-06-05T00:00:00+00:00",
+    )
+
+
+def test_guard_bridge_fetch_pending_requests_sends_guard_token_header(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    token_path = store.guard_home / "daemon-auth-token"
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text("bridge-token", encoding="utf-8")
+    bridge = GuardBridge(
+        config=BridgeConfig(guard_url="http://127.0.0.1:4455", dry_run=False),
+        store=store,
+    )
+    get_calls: list[tuple[str, dict[str, str], int]] = []
+
+    def fake_get(url: str, *, headers: dict[str, str], timeout: int):
+        get_calls.append((url, headers, timeout))
+        return SimpleNamespace(
+            status_code=200,
+            json=lambda: {
+                "items": [
+                    {
+                        "request_id": "req-bridge",
+                        "artifact_id": "artifact-123",
+                        "artifact_name": ".env",
+                        "artifact_type": "file",
+                        "policy_action": "block",
+                        "harness": "codex",
+                        "source_scope": "project",
+                        "risk_summary": {"overall_risk_level": "high"},
+                        "created_at": "2026-06-05T00:00:00+00:00",
+                    }
+                ]
+            },
+        )
+
+    monkeypatch.setattr(guard_bridge_module.requests, "get", fake_get)
+
+    requests_list = bridge._fetch_pending_requests("http://127.0.0.1:4455")
+
+    assert [request.request_id for request in requests_list] == ["req-bridge"]
+    assert get_calls == [
+        (
+            "http://127.0.0.1:4455/v1/requests",
+            {"X-Guard-Token": "bridge-token"},
+            10,
+        )
+    ]
+
+
+def test_guard_bridge_fetch_pending_requests_fails_closed_without_daemon_token(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    bridge = GuardBridge(
+        config=BridgeConfig(guard_url="http://127.0.0.1:4455", dry_run=False),
+        store=store,
+    )
+    called = False
+
+    def fake_get(*args, **kwargs):
+        nonlocal called
+        called = True
+        raise AssertionError("requests.get should not run without daemon auth token")
+
+    monkeypatch.setattr(guard_bridge_module.requests, "get", fake_get)
+
+    requests_list = bridge._fetch_pending_requests("http://127.0.0.1:4455")
+
+    assert requests_list == []
+    assert called is False
+
+
+def test_webhook_backend_rejects_non_https_urls():
+    with pytest.raises(ValueError, match="https"):
+        WebhookBackend("http://hooks.example.test/guard")
+
+
+def test_webhook_backend_redacts_artifact_details_by_default(monkeypatch):
+    backend = WebhookBackend("https://hooks.example.test/guard")
+    request = _build_pending_request()
+    post_calls: list[tuple[str, dict[str, object], int]] = []
+
+    def fake_post(url: str, *, json: dict[str, object], timeout: int):
+        post_calls.append((url, json, timeout))
+        return SimpleNamespace(status_code=200)
+
+    monkeypatch.setattr(guard_bridge_module.requests, "post", fake_post)
+
+    sent = backend.send_notification(request, "raw notification with artifact details")
+
+    assert sent is True
+    assert post_calls == [
+        (
+            "https://hooks.example.test/guard",
+            {
+                "text": "HOL Guard approval pending. Review locally to see artifact details.",
+                "request_id": "req-bridge",
+            },
+            10,
+        )
+    ]
+
+
+def test_guard_bridge_cli_can_opt_into_artifact_details(tmp_path, monkeypatch):
+    captured: dict[str, object] = {}
+
+    class _FakeGuardBridge:
+        def __init__(self, *, config, store, backend):
+            captured["backend"] = backend
+
+        def run(self) -> None:
+            return
+
+    monkeypatch.setattr(guard_commands_module, "GuardBridge", _FakeGuardBridge)
+
+    rc = main(
+        [
+            "guard",
+            "bridge",
+            "--home",
+            str(tmp_path / "guard-home"),
+            "--webhook-url",
+            "https://hooks.example.test/guard",
+            "--webhook-include-artifact-details",
+            "--dry-run",
+        ]
+    )
+
+    assert rc == 0
+    assert isinstance(captured["backend"], WebhookBackend)
+    assert captured["backend"].include_artifact_details is True

--- a/tests/test_guard_bridge.py
+++ b/tests/test_guard_bridge.py
@@ -73,7 +73,7 @@ def test_guard_bridge_fetch_pending_requests_sends_guard_token_header(tmp_path, 
     ]
 
 
-def test_guard_bridge_fetch_pending_requests_fails_closed_without_daemon_token(tmp_path, monkeypatch):
+def test_guard_bridge_fetch_pending_requests_fails_closed_without_daemon_token(tmp_path, monkeypatch, capsys):
     store = GuardStore(tmp_path / "guard-home")
     bridge = GuardBridge(
         config=BridgeConfig(guard_url="http://127.0.0.1:4455", dry_run=False),
@@ -92,11 +92,23 @@ def test_guard_bridge_fetch_pending_requests_fails_closed_without_daemon_token(t
 
     assert requests_list == []
     assert called is False
+    assert "No daemon auth token found" in capsys.readouterr().err
 
 
-def test_webhook_backend_rejects_non_https_urls():
-    with pytest.raises(ValueError, match="https"):
-        WebhookBackend("http://hooks.example.test/guard")
+@pytest.mark.parametrize(
+    ("scheme", "host", "path"),
+    [
+        ("http", "hooks.example.test", "/guard"),
+        ("https", "127.0.0.1", "/guard"),
+        ("https", "[0:0:0:0:0:0:0:1]", "/guard"),
+        ("https", "[::ffff:127.0.0.1]", "/guard"),
+        ("https", "169.254.169.254", "/guard"),
+    ],
+)
+def test_webhook_backend_rejects_unsafe_urls(scheme: str, host: str, path: str):
+    url = f"{scheme}:{'//'}{host}{path}"
+    with pytest.raises(ValueError):
+        WebhookBackend(url)
 
 
 def test_webhook_backend_redacts_artifact_details_by_default(monkeypatch):


### PR DESCRIPTION
## Summary
- require daemon auth when Guard Bridge polls pending approval requests
- harden webhook notifications with HTTPS-only targets and redacted default payloads
- add focused bridge regression coverage and CLI opt-in for artifact-detail webhook payloads

## Testing
- `uv run pytest tests/test_guard_bridge.py tests/test_guard_approvals.py -k guard_bridge -q`
- `uv run pytest tests/test_guard_config_paths.py -k run_bridge_uses_resolved_guard_home_by_default -q`
- `uv run ruff check src/codex_plugin_scanner/guard/bridge/__init__.py src/codex_plugin_scanner/guard/cli/commands.py tests/test_guard_bridge.py`
- `git diff --check`
