### PR TITLE
fix(guard): harden local secret storage

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -90,6 +90,7 @@ def _build_guard_product_payload(
         "guard_home": _redacted_path(context.guard_home, context.home_dir),
         "workspace": _redacted_path(context.workspace_dir, context.home_dir),
         "sync_configured": store.get_cloud_sync_profile() is not None,
+        "sync_storage_health": store.get_sync_credential_health(),
         "oauth_storage_health": store.get_oauth_local_credential_health(),
         "receipt_count": receipt_count,
         "pending_approvals": store.count_approval_requests(),

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -715,7 +715,8 @@ def _set_private_mode(path: Path, mode: int) -> None:
         return
     try:
         os.chmod(path, mode)
-    except OSError:
+    except OSError as exc:
+        _store_logger.debug("Could not set private mode %o on %s: %s", mode, path, exc)
         return
 
 
@@ -907,8 +908,8 @@ class GuardStore:
             connection.commit()
         finally:
             connection.close()
-            self._repair_store_permissions()
             elapsed_ms = (time.monotonic() - start) * 1000
+            self._repair_store_permissions()
             if elapsed_ms >= _SLOW_QUERY_THRESHOLD_MS:
                 log = _store_logger.warning if _should_warn_on_slow_store_transactions() else _store_logger.debug
                 log(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3534,7 +3534,10 @@ class GuardStore:
             self._sync_token_ref,
             expected_hash_value,
         )
-        if not secret_candidates:
+        if not any(
+            expected_hash_value is None or _secret_matches_hash(candidate, expected_hash_value)
+            for candidate in secret_candidates
+        ):
             health["state"] = "degraded"
             return health
         health["state"] = "healthy"

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -180,6 +180,8 @@ _SECRET_FINGERPRINT_PREFIX = "pbkdf2-sha256$"
 _SECRET_FINGERPRINT_SALT = b"hol-guard-secret-fingerprint:v1"
 _OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS = 30.0
 _OAUTH_REFRESH_LOCK_POLL_SECONDS = 0.05
+_GUARD_STORE_PRIVATE_DIR_MODE = 0o700
+_GUARD_STORE_PRIVATE_FILE_MODE = 0o600
 
 
 def _oauth_sync_url_from_issuer(issuer: str) -> str:
@@ -708,10 +710,22 @@ def _expand_keystream(*, key: bytes, nonce: bytes, length: int) -> bytes:
     return b"".join(chunks)[:length]
 
 
+def _set_private_mode(path: Path, mode: int) -> None:
+    if os.name == "nt":
+        return
+    try:
+        os.chmod(path, mode)
+    except OSError:
+        return
+
+
 def _build_secret_store(guard_home: Path) -> SecretStore:
     fallback_store = EncryptedFileSecretStore(guard_home)
     if KeychainSecretStore._is_available():
-        return FallbackSecretStore(fallback_store, KeychainSecretStore(service_name="hol-guard.sync"))
+        keychain_store = KeychainSecretStore(service_name="hol-guard.sync")
+        if sys.platform == "darwin":
+            return FallbackSecretStore(keychain_store, fallback_store)
+        return FallbackSecretStore(fallback_store, keychain_store)
     return fallback_store
 
 
@@ -758,6 +772,7 @@ class GuardStore:
     def __init__(self, guard_home: Path, *, guard_event_queue_limit: int = 1000) -> None:
         self.guard_home = guard_home
         self.guard_home.mkdir(parents=True, exist_ok=True)
+        _set_private_mode(self.guard_home, _GUARD_STORE_PRIVATE_DIR_MODE)
         self._secret_store = _build_secret_store(self.guard_home)
         self._oauth_secret_store = _build_oauth_secret_store(self.guard_home)
         self._sync_token_ref = self._build_scoped_secret_ref(_SYNC_TOKEN_REF)
@@ -871,6 +886,17 @@ class GuardStore:
             return []
         return [token]
 
+    def _repair_store_permissions(self) -> None:
+        _set_private_mode(self.guard_home, _GUARD_STORE_PRIVATE_DIR_MODE)
+        for candidate in (
+            self.path,
+            self.guard_home / "guard.db-journal",
+            self.guard_home / "guard.db-shm",
+            self.guard_home / "guard.db-wal",
+        ):
+            if candidate.exists():
+                _set_private_mode(candidate, _GUARD_STORE_PRIVATE_FILE_MODE)
+
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:
         connection = sqlite3.connect(self.path)
@@ -881,6 +907,7 @@ class GuardStore:
             connection.commit()
         finally:
             connection.close()
+            self._repair_store_permissions()
             elapsed_ms = (time.monotonic() - start) * 1000
             if elapsed_ms >= _SLOW_QUERY_THRESHOLD_MS:
                 log = _store_logger.warning if _should_warn_on_slow_store_transactions() else _store_logger.debug
@@ -3479,6 +3506,41 @@ class GuardStore:
             value = payload.get(key)
             if isinstance(value, str) and value:
                 health[key] = value
+        return health
+
+    def get_sync_credential_health(self) -> dict[str, object]:
+        payload = self.get_sync_payload("credentials")
+        health: dict[str, object] = {
+            "configured": isinstance(payload, dict),
+            "state": "not_configured",
+            "backend": _secret_store_backend_name(self._secret_store),
+            "fallback_backend": _secret_store_fallback_backend_name(self._secret_store),
+        }
+        if not isinstance(payload, dict):
+            return health
+        sync_url = payload.get("sync_url")
+        token_reference = payload.get("token_ref")
+        if not isinstance(sync_url, str) or not sync_url:
+            health["state"] = "degraded"
+            return health
+        if not isinstance(token_reference, str) or not token_reference or token_reference != self._sync_token_ref:
+            health["state"] = "degraded"
+            return health
+        expected_hash = payload.get(_SYNC_TOKEN_HASH_KEY)
+        expected_hash_value = expected_hash if isinstance(expected_hash, str) and expected_hash else None
+        secret_candidates = self._get_secret_candidates(
+            self._secret_store,
+            self._sync_token_ref,
+            expected_hash_value,
+        )
+        if not secret_candidates:
+            health["state"] = "degraded"
+            return health
+        health["state"] = "healthy"
+        health["sync_url"] = sync_url
+        workspace_id = payload.get("workspace_id")
+        if isinstance(workspace_id, str) and workspace_id:
+            health["workspace_id"] = workspace_id
         return health
 
     @staticmethod

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,8 @@ import os
 import sys
 from pathlib import Path
 
+import pytest
+
 SRC_PATH = Path(__file__).resolve().parents[1] / "src"
 
 if str(SRC_PATH) not in sys.path:
@@ -13,3 +15,10 @@ existing_pythonpath = os.environ.get("PYTHONPATH", "")
 pythonpath_entries = [entry for entry in existing_pythonpath.split(os.pathsep) if entry]
 if str(SRC_PATH) not in pythonpath_entries:
     os.environ["PYTHONPATH"] = os.pathsep.join([str(SRC_PATH), *pythonpath_entries])
+
+
+@pytest.fixture(autouse=True)
+def _disable_real_macos_keychain(monkeypatch: pytest.MonkeyPatch) -> None:
+    from codex_plugin_scanner.guard.store import KeychainSecretStore
+
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6491,9 +6491,8 @@ url = http://127.0.0.1:8787/guard-canary
                 "acknowledgements": [],
             },
         }
-        _SyncRequestHandler.response_payload["policyBundle"]["bundleHash"] = guard_runner_module._computed_policy_bundle_hash(
-            _SyncRequestHandler.response_payload["policyBundle"]
-        )
+        policy_bundle = _SyncRequestHandler.response_payload["policyBundle"]
+        policy_bundle["bundleHash"] = guard_runner_module._computed_policy_bundle_hash(policy_bundle)
 
         server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
         thread = threading.Thread(target=server.serve_forever, daemon=True)
@@ -6787,6 +6786,14 @@ url = http://127.0.0.1:8787/guard-canary
         status_output = json.loads(capsys.readouterr().out)
 
         assert status_rc == 0
+        assert status_output["sync_storage_health"] == {
+            "configured": True,
+            "state": "healthy",
+            "backend": "encrypted-file",
+            "fallback_backend": None,
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "workspace_id": "workspace-123",
+        }
         assert status_output["oauth_storage_health"] == {
             "configured": True,
             "state": "healthy",
@@ -8480,9 +8487,8 @@ url = http://127.0.0.1:8787/guard-canary
                 "auditTrail": [],
             },
         }
-        _SyncRequestHandler.response_payload["policyBundle"]["bundleHash"] = guard_runner_module._computed_policy_bundle_hash(
-            _SyncRequestHandler.response_payload["policyBundle"]
-        )
+        policy_bundle = _SyncRequestHandler.response_payload["policyBundle"]
+        policy_bundle["bundleHash"] = guard_runner_module._computed_policy_bundle_hash(policy_bundle)
 
         server = HTTPServer(("127.0.0.1", 0), _SyncRequestHandler)
         thread = threading.Thread(target=server.serve_forever, daemon=True)

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -66,6 +66,11 @@ def _install_fake_system_keyring(
     return module
 
 
+@pytest.fixture(autouse=True)
+def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
+
+
 def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch, usable_macos_keychain=False)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
@@ -395,15 +400,49 @@ def test_fallback_secret_store_logs_delete_failures(caplog):
     assert "guard-token" not in caplog.text
 
 
-def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available(tmp_path, monkeypatch):
+def _install_fake_sync_keychain(monkeypatch) -> dict[tuple[str, str], str]:
+    secrets: dict[tuple[str, str], str] = {}
+
+    monkeypatch.setattr(
+        KeychainSecretStore,
+        "set_secret",
+        lambda self, secret_id, value: secrets.__setitem__((self.service_name, secret_id), value),
+    )
+    monkeypatch.setattr(
+        KeychainSecretStore,
+        "get_secret",
+        lambda self, secret_id: secrets.get((self.service_name, secret_id)),
+    )
+    monkeypatch.setattr(
+        KeychainSecretStore,
+        "delete_secret",
+        lambda self, secret_id: secrets.pop((self.service_name, secret_id), None),
+    )
+    return secrets
+
+
+def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available_outside_macos(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
 
     secret_store = _build_secret_store(guard_home)
 
     assert isinstance(secret_store, FallbackSecretStore)
     assert isinstance(secret_store.primary, EncryptedFileSecretStore)
     assert isinstance(secret_store.fallback, KeychainSecretStore)
+
+
+def test_secret_store_prefers_keychain_backend_when_keychain_is_available_on_macos(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+
+    secret_store = _build_secret_store(guard_home)
+
+    assert isinstance(secret_store, FallbackSecretStore)
+    assert isinstance(secret_store.primary, KeychainSecretStore)
+    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
 def test_oauth_secret_store_prefers_system_keyring_backend_when_available(tmp_path, monkeypatch):
@@ -455,6 +494,50 @@ def test_sync_credentials_do_not_shell_out_to_keychain_when_file_store_is_availa
     GuardStore(guard_home)
 
 
+def test_sync_credentials_write_to_keychain_primary_on_macos(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    sync_keychain = _install_fake_sync_keychain(monkeypatch)
+    store = GuardStore(guard_home)
+
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "access-secret-value",
+        "2026-06-01T00:00:00+00:00",
+        workspace_id="workspace-123",
+    )
+
+    assert sync_keychain[( "hol-guard.sync", store._sync_token_ref)] == "access-secret-value"
+    assert store.get_sync_credentials() == {
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "token": "access-secret-value",
+    }
+
+
+def test_get_sync_credentials_promotes_legacy_file_secret_into_keychain_on_macos(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
+    legacy_store = GuardStore(guard_home)
+    legacy_store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "legacy-access-secret",
+        "2026-06-01T00:00:00+00:00",
+        workspace_id="workspace-123",
+    )
+
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    sync_keychain = _install_fake_sync_keychain(monkeypatch)
+    migrated_store = GuardStore(guard_home)
+
+    assert migrated_store.get_sync_credentials() == {
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "token": "legacy-access-secret",
+    }
+    assert sync_keychain[("hol-guard.sync", migrated_store._sync_token_ref)] == "legacy-access-secret"
+
+
 def test_oauth_local_credentials_do_not_shell_out_to_keychain_when_system_keyring_is_available(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     _install_fake_system_keyring(monkeypatch)
@@ -475,6 +558,73 @@ def test_oauth_local_credentials_do_not_shell_out_to_keychain_when_system_keyrin
     )
 
     assert store.get_oauth_local_credentials() is not None
+
+
+def test_guard_store_secures_guard_home_and_database_permissions(tmp_path):
+    if os.name == "nt":
+        pytest.skip("POSIX-only permission assertions")
+
+    store = GuardStore(tmp_path / "guard-home")
+
+    assert store.guard_home.stat().st_mode & 0o777 == 0o700
+    assert store.path.stat().st_mode & 0o777 == 0o600
+
+
+def test_guard_store_repairs_existing_guard_home_and_database_permissions(tmp_path):
+    if os.name == "nt":
+        pytest.skip("POSIX-only permission assertions")
+
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    os.chmod(guard_home, 0o755)
+    database_path = guard_home / "guard.db"
+    sqlite3.connect(database_path).close()
+    os.chmod(database_path, 0o644)
+    for name in ("guard.db-wal", "guard.db-shm", "guard.db-journal"):
+        sidecar = guard_home / name
+        sidecar.write_text("", encoding="utf-8")
+        os.chmod(sidecar, 0o666)
+
+    store = GuardStore(guard_home)
+
+    assert store.guard_home.stat().st_mode & 0o777 == 0o700
+    assert store.path.stat().st_mode & 0o777 == 0o600
+    for name in ("guard.db-wal", "guard.db-shm", "guard.db-journal"):
+        sidecar = guard_home / name
+        if sidecar.exists():
+            assert sidecar.stat().st_mode & 0o777 == 0o600
+
+
+def test_sync_credential_health_reports_backend_and_workspace(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+
+    assert store.get_sync_credential_health() == {
+        "configured": False,
+        "state": "not_configured",
+        "backend": "encrypted-file",
+        "fallback_backend": None,
+    }
+
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    sync_keychain = _install_fake_sync_keychain(monkeypatch)
+    keychain_store = GuardStore(tmp_path / "guard-home-keychain")
+    keychain_store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "access-secret-value",
+        "2026-06-01T00:00:00+00:00",
+        workspace_id="workspace-123",
+    )
+
+    assert sync_keychain[("hol-guard.sync", keychain_store._sync_token_ref)] == "access-secret-value"
+    assert keychain_store.get_sync_credential_health() == {
+        "configured": True,
+        "state": "healthy",
+        "backend": "keychain",
+        "fallback_backend": "encrypted-file",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "workspace_id": "workspace-123",
+    }
 
 
 def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -626,6 +626,14 @@ def test_sync_credential_health_reports_backend_and_workspace(tmp_path, monkeypa
         "workspace_id": "workspace-123",
     }
 
+    sync_keychain[("hol-guard.sync", keychain_store._sync_token_ref)] = "tampered-secret"
+    assert keychain_store.get_sync_credential_health() == {
+        "configured": True,
+        "state": "degraded",
+        "backend": "keychain",
+        "fallback_backend": "encrypted-file",
+    }
+
 
 def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):
     store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -508,7 +508,7 @@ def test_sync_credentials_write_to_keychain_primary_on_macos(tmp_path, monkeypat
         workspace_id="workspace-123",
     )
 
-    assert sync_keychain[( "hol-guard.sync", store._sync_token_ref)] == "access-secret-value"
+    assert sync_keychain[("hol-guard.sync", store._sync_token_ref)] == "access-secret-value"
     assert store.get_sync_credentials() == {
         "sync_url": "https://hol.org/api/guard/receipts/sync",
         "token": "access-secret-value",


### PR DESCRIPTION
## Summary
- harden Guard store permissions for guard home and SQLite files
- prefer macOS keychain for sync credentials and surface sync secret storage health

## Testing
- `uv run pytest tests/test_guard_store_migrations.py -q`
- `uv run pytest tests/test_guard_cli.py -q -k reports_oauth_key_storage_health`
- `uv run ruff check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/cli/product.py tests/conftest.py tests/test_guard_store_migrations.py tests/test_guard_cli.py`
- `git diff --check`
