### PR TITLE
fix(guard): add MCP proxy timeouts

### DIFF
--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -31,7 +31,14 @@ from ..runtime.package_intent import build_package_request_artifact, extract_pac
 from ..runtime.signals import RiskSignalV2
 from ..runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from ..store import GuardStore
-from .stdio import _blocked_tool_response, _redact_json
+from .stdio import (
+    _blocked_tool_response,
+    _is_timeout_response,
+    _quarantine_process,
+    _readline_with_timeout,
+    _redact_json,
+    _timeout_response,
+)
 
 _PACKAGE_POLICY_ACTION_RANK = {
     "allow": 0,
@@ -94,6 +101,22 @@ class RuntimeMcpGuardProxy:
         self._tool_catalog: dict[str, dict[str, object]] = {}
         self._tool_catalog_pending: dict[str, dict[str, object]] | None = None
         self._tool_catalog_generation = 0
+        self._active_process: subprocess.Popen[str] | None = None
+
+    def _child_response_timeout_seconds(self) -> float:
+        configured = getattr(self.config, "approval_wait_timeout_seconds", None)
+        if isinstance(configured, (int, float)) and configured > 0:
+            return min(float(configured), 30.0)
+        return 30.0
+
+    def _nested_request_timeout_seconds(self) -> float:
+        return self._child_response_timeout_seconds()
+
+    def _inline_approval_timeout_seconds(self) -> float:
+        configured = getattr(self.config, "approval_wait_timeout_seconds", None)
+        if isinstance(configured, (int, float)) and configured > 0:
+            return float(configured)
+        return 120.0
 
     def run_session(
         self,
@@ -104,6 +127,7 @@ class RuntimeMcpGuardProxy:
         process = self._start_process()
         responses: list[dict[str, Any]] = []
         events: list[dict[str, Any]] = []
+        self._active_process = process
         try:
             assert process.stdin is not None
             assert process.stdout is not None
@@ -118,10 +142,14 @@ class RuntimeMcpGuardProxy:
                 )
                 if response is not None:
                     responses.append(response)
+                    if _is_timeout_response(response):
+                        events.append(event)
+                        break
                 events.append(event)
             process.stdin.close()
             process.wait(timeout=5)
         finally:
+            self._active_process = None
             if process.poll() is None:
                 process.terminate()
                 process.wait(timeout=5)
@@ -136,6 +164,7 @@ class RuntimeMcpGuardProxy:
         input_stream = stdin or sys.stdin
         output_stream = stdout or sys.stdout
         process = self._start_process()
+        self._active_process = process
         try:
             assert process.stdin is not None
             assert process.stdout is not None
@@ -161,10 +190,13 @@ class RuntimeMcpGuardProxy:
                 if response is not None:
                     output_stream.write(json.dumps(response) + "\n")
                     output_stream.flush()
+                    if _is_timeout_response(response):
+                        break
             process.stdin.close()
             process.wait(timeout=5)
             return int(process.returncode or 0)
         finally:
+            self._active_process = None
             if process.poll() is None:
                 process.terminate()
                 process.wait(timeout=5)
@@ -224,6 +256,8 @@ class RuntimeMcpGuardProxy:
                     request_cursor=list_cursor,
                     request_generation=list_generation,
                 )
+            if _is_timeout_response(response):
+                event["decision"] = "timeout"
             return response, event
 
         tool_name = str(params.get("name") or "unknown")
@@ -540,7 +574,7 @@ class RuntimeMcpGuardProxy:
             return response, {
                 "method": "tools/call",
                 "tool_name": tool_name,
-                "decision": f"package-{queue_policy_action}",
+                "decision": "timeout" if _is_timeout_response(response) else f"package-{queue_policy_action}",
                 "redacted_params": _redact_json(params),
             }
         approval_center_url = ensure_guard_daemon(self.context.guard_home)
@@ -683,7 +717,7 @@ class RuntimeMcpGuardProxy:
         return response, {
             "method": "tools/call",
             "tool_name": params.get("name"),
-            "decision": decision_source,
+            "decision": "timeout" if _is_timeout_response(response) else decision_source,
             "redacted_params": _redact_json(params),
         }
 
@@ -708,7 +742,19 @@ class RuntimeMcpGuardProxy:
             buffered_response = self._pop_buffered_child_response(request_id)
             if buffered_response is not None:
                 return buffered_response
-            line = child_stdout.readline()
+            timeout_seconds = self._child_response_timeout_seconds()
+            try:
+                line = _readline_with_timeout(child_stdout, timeout_seconds, source="child_response")
+            except TimeoutError:
+                active_process = self._active_process
+                if active_process is not None:
+                    _quarantine_process(active_process)
+                return _timeout_response(
+                    request_id,
+                    source="child_response",
+                    timeout_seconds=timeout_seconds,
+                    message="Guard runtime MCP proxy timed out waiting for the MCP server.",
+                )
             if not line:
                 raise RuntimeError("Guard stdio proxy did not receive a response from the MCP server.")
             payload = json.loads(line)
@@ -787,7 +833,20 @@ class RuntimeMcpGuardProxy:
             if buffered_response is not None:
                 self._forward_notification(buffered_response, child_stdin)
                 return
-            line = client_input.readline()
+            timeout_seconds = self._nested_request_timeout_seconds()
+            try:
+                line = _readline_with_timeout(client_input, timeout_seconds, source="nested_client_response")
+            except TimeoutError:
+                self._forward_notification(
+                    _timeout_response(
+                        request_id,
+                        source="nested_client_response",
+                        timeout_seconds=timeout_seconds,
+                        message="Guard runtime MCP proxy timed out waiting for the client response.",
+                    ),
+                    child_stdin,
+                )
+                return
             if not line:
                 raise RuntimeError("Guard runtime MCP proxy lost the client while waiting for a server response.")
             message = json.loads(line)
@@ -834,7 +893,11 @@ class RuntimeMcpGuardProxy:
             buffered_response = self._pop_buffered_client_response(request_id)
             if buffered_response is not None:
                 return _approval_payload(buffered_response)
-            line = input_stream.readline()
+            timeout_seconds = self._inline_approval_timeout_seconds()
+            try:
+                line = _readline_with_timeout(input_stream, timeout_seconds, source="inline_approval")
+            except TimeoutError:
+                return {"action": "cancel", "reason": "timeout"}
             if not line:
                 return {"action": "cancel"}
             payload = json.loads(line)

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -32,6 +32,7 @@ from ..runtime.signals import RiskSignalV2
 from ..runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from ..store import GuardStore
 from .stdio import (
+    ProxyIoTimeoutError,
     _blocked_tool_response,
     _is_timeout_response,
     _quarantine_process,
@@ -745,7 +746,7 @@ class RuntimeMcpGuardProxy:
             timeout_seconds = self._child_response_timeout_seconds()
             try:
                 line = _readline_with_timeout(child_stdout, timeout_seconds, source="child_response")
-            except TimeoutError:
+            except ProxyIoTimeoutError:
                 active_process = self._active_process
                 if active_process is not None:
                     _quarantine_process(active_process)
@@ -835,8 +836,13 @@ class RuntimeMcpGuardProxy:
                 return
             timeout_seconds = self._nested_request_timeout_seconds()
             try:
-                line = _readline_with_timeout(client_input, timeout_seconds, source="nested_client_response")
-            except TimeoutError:
+                line = _readline_with_timeout(
+                    client_input,
+                    timeout_seconds,
+                    source="nested_client_response",
+                    allow_background_wait=False,
+                )
+            except ProxyIoTimeoutError:
                 self._forward_notification(
                     _timeout_response(
                         request_id,
@@ -895,8 +901,13 @@ class RuntimeMcpGuardProxy:
                 return _approval_payload(buffered_response)
             timeout_seconds = self._inline_approval_timeout_seconds()
             try:
-                line = _readline_with_timeout(input_stream, timeout_seconds, source="inline_approval")
-            except TimeoutError:
+                line = _readline_with_timeout(
+                    input_stream,
+                    timeout_seconds,
+                    source="inline_approval",
+                    allow_background_wait=False,
+                )
+            except ProxyIoTimeoutError:
                 return {"action": "cancel", "reason": "timeout"}
             if not line:
                 return {"action": "cancel"}

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import subprocess
+import threading
+from contextlib import suppress
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -16,6 +19,16 @@ from ..models import HarnessDetection
 from ..receipts import build_receipt
 from ..runtime.secret_file_requests import build_file_read_request_artifact, extract_sensitive_file_read_request
 from ..store import GuardStore
+
+_DEFAULT_PROXY_RESPONSE_TIMEOUT_SECONDS = 30.0
+_PROXY_TERMINATION_TIMEOUT_SECONDS = 1.0
+
+
+class ProxyIoTimeoutError(TimeoutError):
+    def __init__(self, *, source: str, timeout_seconds: float) -> None:
+        super().__init__(f"timeout waiting for {source}")
+        self.source = source
+        self.timeout_seconds = timeout_seconds
 
 
 def _redact_scalar(value: str) -> str:
@@ -69,6 +82,69 @@ def _blocked_tool_response(
     return payload
 
 
+def _timeout_response(
+    message_id: Any,
+    *,
+    source: str,
+    timeout_seconds: float,
+    message: str,
+) -> dict[str, Any]:
+    return {
+        "jsonrpc": "2.0",
+        "id": message_id,
+        "error": {
+            "code": -32002,
+            "message": message,
+            "data": {
+                "source": source,
+                "timeout_seconds": timeout_seconds,
+            },
+        },
+    }
+
+
+def _is_timeout_response(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    error = payload.get("error")
+    return isinstance(error, dict) and error.get("code") == -32002
+
+
+def _readline_with_timeout(stream: Any, timeout_seconds: float, *, source: str) -> str:
+    result_queue: queue.Queue[tuple[bool, object]] = queue.Queue(maxsize=1)
+
+    def _reader() -> None:
+        try:
+            result_queue.put((True, stream.readline()))
+        except BaseException as exc:  # pragma: no cover - surfaced through queue
+            result_queue.put((False, exc))
+
+    threading.Thread(target=_reader, daemon=True).start()
+    try:
+        ok, result = result_queue.get(timeout=timeout_seconds)
+    except queue.Empty as exc:
+        raise ProxyIoTimeoutError(source=source, timeout_seconds=timeout_seconds) from exc
+    if ok:
+        return result if isinstance(result, str) else ""
+    raise result
+
+
+def _quarantine_process(process: subprocess.Popen[str]) -> None:
+    if process.poll() is not None:
+        return
+    with suppress(Exception):
+        process.terminate()
+    try:
+        process.wait(timeout=_PROXY_TERMINATION_TIMEOUT_SECONDS)
+        return
+    except Exception:
+        pass
+    with suppress(Exception):
+        process.kill()
+    with suppress(Exception):
+        process.wait(timeout=_PROXY_TERMINATION_TIMEOUT_SECONDS)
+
+
 class StdioGuardProxy:
     """Proxy JSON-RPC traffic to a stdio subprocess while recording metadata-only events."""
 
@@ -91,6 +167,12 @@ class StdioGuardProxy:
         self.approval_center_url = approval_center_url
         self.harness = harness
         self.env = env or {}
+
+    def _response_timeout_seconds(self) -> float:
+        configured = getattr(self.guard_config, "approval_wait_timeout_seconds", None)
+        if isinstance(configured, (int, float)) and configured > 0:
+            return min(float(configured), _DEFAULT_PROXY_RESPONSE_TIMEOUT_SECONDS)
+        return _DEFAULT_PROXY_RESPONSE_TIMEOUT_SECONDS
 
     def run_session(self, messages: list[dict[str, Any]]) -> dict[str, Any]:
         responses, events, return_code = self._run_messages(messages)
@@ -124,6 +206,8 @@ class StdioGuardProxy:
                 if response is not None:
                     output_stream.write(json.dumps(response, separators=(",", ":")) + "\n")
                     output_stream.flush()
+                    if _is_timeout_response(response):
+                        break
             assert process.stdin is not None
             process.stdin.close()
             process.wait(timeout=5)
@@ -149,6 +233,8 @@ class StdioGuardProxy:
                     events=events,
                     output_stream=None,
                 )
+                if responses and _is_timeout_response(responses[-1]):
+                    break
             assert process.stdin is not None
             process.stdin.close()
             process.wait(timeout=5)
@@ -322,6 +408,8 @@ class StdioGuardProxy:
         )
         if response is None:
             return None
+        if _is_timeout_response(response):
+            event["decision"] = "timeout"
         responses.append(response)
         events.append(event)
         return response
@@ -337,7 +425,17 @@ class StdioGuardProxy:
             return None
         assert process.stdout is not None
         while True:
-            line = process.stdout.readline()
+            timeout_seconds = self._response_timeout_seconds()
+            try:
+                line = _readline_with_timeout(process.stdout, timeout_seconds, source="child_response")
+            except ProxyIoTimeoutError:
+                _quarantine_process(process)
+                return _timeout_response(
+                    message_id,
+                    source="child_response",
+                    timeout_seconds=timeout_seconds,
+                    message="Guard stdio proxy timed out waiting for the MCP server.",
+                )
             if not line:
                 raise RuntimeError("Guard stdio proxy did not receive a response from the MCP server.")
             response = json.loads(line)

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import io
 import json
 import os
 import queue
+import select
 import subprocess
 import threading
 from contextlib import suppress
@@ -22,6 +24,7 @@ from ..store import GuardStore
 
 _DEFAULT_PROXY_RESPONSE_TIMEOUT_SECONDS = 30.0
 _PROXY_TERMINATION_TIMEOUT_SECONDS = 1.0
+_GUARD_PROXY_TIMEOUT_ERROR_CODE = -32800
 
 
 class ProxyIoTimeoutError(TimeoutError):
@@ -93,9 +96,10 @@ def _timeout_response(
         "jsonrpc": "2.0",
         "id": message_id,
         "error": {
-            "code": -32002,
+            "code": _GUARD_PROXY_TIMEOUT_ERROR_CODE,
             "message": message,
             "data": {
+                "guard_timeout": True,
                 "source": source,
                 "timeout_seconds": timeout_seconds,
             },
@@ -107,10 +111,41 @@ def _is_timeout_response(payload: object) -> bool:
     if not isinstance(payload, dict):
         return False
     error = payload.get("error")
-    return isinstance(error, dict) and error.get("code") == -32002
+    if not isinstance(error, dict):
+        return False
+    data = error.get("data")
+    return error.get("code") == _GUARD_PROXY_TIMEOUT_ERROR_CODE and isinstance(data, dict) and data.get(
+        "guard_timeout"
+    ) is True
 
 
-def _readline_with_timeout(stream: Any, timeout_seconds: float, *, source: str) -> str:
+def _stream_fileno(stream: Any) -> int | None:
+    try:
+        fileno = stream.fileno()
+    except (AttributeError, OSError, ValueError, io.UnsupportedOperation):
+        return None
+    return fileno if isinstance(fileno, int) and fileno >= 0 else None
+
+
+def _readline_with_timeout(
+    stream: Any,
+    timeout_seconds: float,
+    *,
+    source: str,
+    allow_background_wait: bool = True,
+) -> str:
+    fileno = None if allow_background_wait else _stream_fileno(stream)
+    if fileno is not None:
+        try:
+            ready, _, _ = select.select([fileno], [], [], timeout_seconds)
+        except (OSError, ValueError):
+            ready = None
+        else:
+            if not ready:
+                raise ProxyIoTimeoutError(source=source, timeout_seconds=timeout_seconds)
+            return stream.readline()
+    if not allow_background_wait:
+        return stream.readline()
     result_queue: queue.Queue[tuple[bool, object]] = queue.Queue(maxsize=1)
 
     def _reader() -> None:

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -140,14 +140,15 @@ def _readline_with_timeout(
     if fileno is not None:
         try:
             ready, _, _ = select.select([fileno], [], [], timeout_seconds)
-        except (OSError, ValueError):
-            ready = None
-        else:
-            if not ready:
-                raise ProxyIoTimeoutError(source=source, timeout_seconds=timeout_seconds)
-            return stream.readline()
-    if not allow_background_wait:
+        except (OSError, ValueError) as exc:
+            raise ProxyIoTimeoutError(source=source, timeout_seconds=timeout_seconds) from exc
+        if not ready:
+            raise ProxyIoTimeoutError(source=source, timeout_seconds=timeout_seconds)
         return stream.readline()
+    if not allow_background_wait:
+        if isinstance(stream, io.StringIO):
+            return stream.readline()
+        raise ProxyIoTimeoutError(source=source, timeout_seconds=timeout_seconds)
     result_queue: queue.Queue[tuple[bool, object]] = queue.Queue(maxsize=1)
 
     def _reader() -> None:

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -114,9 +114,11 @@ def _is_timeout_response(payload: object) -> bool:
     if not isinstance(error, dict):
         return False
     data = error.get("data")
-    return error.get("code") == _GUARD_PROXY_TIMEOUT_ERROR_CODE and isinstance(data, dict) and data.get(
-        "guard_timeout"
-    ) is True
+    return (
+        error.get("code") == _GUARD_PROXY_TIMEOUT_ERROR_CODE
+        and isinstance(data, dict)
+        and data.get("guard_timeout") is True
+    )
 
 
 def _stream_fileno(stream: Any) -> int | None:

--- a/tests/test_guard_codex_proxy.py
+++ b/tests/test_guard_codex_proxy.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sys
+import time
 from io import StringIO
 from pathlib import Path
 
@@ -214,6 +215,35 @@ def _nested_request_child_command_with_risky_tool(marker_path: Path) -> list[str
             ]
         ),
     ]
+
+
+def _hung_response_child_command() -> list[str]:
+    return [
+        sys.executable,
+        "-u",
+        "-c",
+        "\n".join(
+            [
+                "import json",
+                "import sys",
+                "import time",
+                "for line in sys.stdin:",
+                "    message = json.loads(line)",
+                "    if message.get('id') is None:",
+                "        continue",
+                "    time.sleep(60)",
+            ]
+        ),
+    ]
+
+
+class _BlockingInput:
+    def __init__(self, sleep_seconds: float = 0.2) -> None:
+        self.sleep_seconds = sleep_seconds
+
+    def readline(self) -> str:
+        time.sleep(self.sleep_seconds)
+        return ""
 
 
 def _context(tmp_path: Path) -> HarnessContext:
@@ -1404,3 +1434,87 @@ def test_codex_guard_proxy_invalidates_catalog_on_server_list_changed_notificati
     assert response["id"] == 7
     assert proxy._tool_catalog == {}
     assert proxy._tool_catalog_pending is None
+
+
+def test_codex_guard_proxy_returns_timeout_error_when_child_server_hangs(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace_skill",
+        command=_hung_response_child_command(),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    monkeypatch.setattr(proxy, "_child_response_timeout_seconds", lambda: 0.05)
+
+    result = proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}},
+        ]
+    )
+
+    assert result["responses"][0]["error"]["code"] == -32002
+    assert result["events"][0]["decision"] == "timeout"
+    assert result["responses"][0]["error"]["data"]["source"] == "child_response"
+
+
+def test_codex_guard_proxy_returns_timeout_error_to_child_for_nested_request_timeout(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace_skill",
+        command=_nested_request_child_command(),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    monkeypatch.setattr(proxy, "_nested_request_timeout_seconds", lambda: 0.05)
+    child_stdin = StringIO()
+    server_output = StringIO()
+
+    proxy._proxy_child_request(
+        payload={"jsonrpc": "2.0", "id": "child-sampling-timeout", "method": "sampling/createMessage", "params": {}},
+        child_stdin=child_stdin,
+        child_stdout=StringIO(),
+        client_input=_BlockingInput(),
+        server_output=server_output,
+    )
+
+    child_reply = json.loads(child_stdin.getvalue().splitlines()[0])
+    assert json.loads(server_output.getvalue().splitlines()[0])["id"] == "child-sampling-timeout"
+    assert child_reply["id"] == "child-sampling-timeout"
+    assert child_reply["error"]["code"] == -32002
+    assert child_reply["error"]["data"]["source"] == "nested_client_response"
+
+
+def test_codex_guard_proxy_cancels_inline_approval_after_timeout(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    proxy = CodexMcpGuardProxy(
+        server_name="workspace_skill",
+        command=_child_command(tmp_path / "dangerous-call.json"),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / ".codex" / "config.toml"),
+    )
+    monkeypatch.setattr(proxy, "_inline_approval_timeout_seconds", lambda: 0.05)
+
+    result = proxy._request_inline_approval(
+        {"jsonrpc": "2.0", "id": "guard-elicitation-timeout", "method": "elicitation/create", "params": {}},
+        input_stream=_BlockingInput(),
+        output_stream=StringIO(),
+        child_stdin=StringIO(),
+        child_stdout=StringIO(),
+    )
+
+    assert result == {"action": "cancel", "reason": "timeout"}

--- a/tests/test_guard_codex_proxy.py
+++ b/tests/test_guard_codex_proxy.py
@@ -14,6 +14,8 @@ from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.mcp_tool_calls import ToolCallDecision, build_tool_call_artifact, build_tool_call_hash
 from codex_plugin_scanner.guard.proxy import CodexMcpGuardProxy
 from codex_plugin_scanner.guard.proxy import runtime_mcp as runtime_mcp_module
+from codex_plugin_scanner.guard.proxy import stdio as stdio_module
+from codex_plugin_scanner.guard.proxy.stdio import ProxyIoTimeoutError, _readline_with_timeout
 from codex_plugin_scanner.guard.runtime.mcp_protection import build_mcp_tool_identity
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -252,6 +254,11 @@ class _BlockingPipeInput:
     def close(self) -> None:
         self._reader.close()
         os.close(self._writer_fd)
+
+
+class _NoFilenoBlockingInput:
+    def readline(self) -> str:
+        raise AssertionError("shared stream should fail closed before blocking readline()")
 
 
 def _context(tmp_path: Path) -> HarnessContext:
@@ -1541,3 +1548,32 @@ def test_codex_guard_proxy_cancels_inline_approval_after_timeout(tmp_path, monke
         blocking_input.close()
 
     assert result == {"action": "cancel", "reason": "timeout"}
+
+
+def test_readline_with_timeout_rejects_shared_stream_without_fileno() -> None:
+    with pytest.raises(ProxyIoTimeoutError):
+        _readline_with_timeout(
+            _NoFilenoBlockingInput(),
+            0.05,
+            source="inline_approval",
+            allow_background_wait=False,
+        )
+
+
+def test_readline_with_timeout_rejects_shared_stream_when_select_fails(monkeypatch) -> None:
+    blocking_input = _BlockingPipeInput()
+    try:
+        monkeypatch.setattr(
+            stdio_module.select,
+            "select",
+            lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("select unavailable")),
+        )
+        with pytest.raises(ProxyIoTimeoutError):
+            _readline_with_timeout(
+                blocking_input,
+                0.05,
+                source="nested_client_response",
+                allow_background_wait=False,
+            )
+    finally:
+        blocking_input.close()

--- a/tests/test_guard_codex_proxy.py
+++ b/tests/test_guard_codex_proxy.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
 import sys
-import time
 from io import StringIO
 from pathlib import Path
 
@@ -237,13 +237,21 @@ def _hung_response_child_command() -> list[str]:
     ]
 
 
-class _BlockingInput:
-    def __init__(self, sleep_seconds: float = 0.2) -> None:
-        self.sleep_seconds = sleep_seconds
+class _BlockingPipeInput:
+    def __init__(self) -> None:
+        read_fd, write_fd = os.pipe()
+        self._reader = os.fdopen(read_fd, "r", encoding="utf-8")
+        self._writer_fd = write_fd
+
+    def fileno(self) -> int:
+        return self._reader.fileno()
 
     def readline(self) -> str:
-        time.sleep(self.sleep_seconds)
-        return ""
+        return self._reader.readline()
+
+    def close(self) -> None:
+        self._reader.close()
+        os.close(self._writer_fd)
 
 
 def _context(tmp_path: Path) -> HarnessContext:
@@ -1457,7 +1465,8 @@ def test_codex_guard_proxy_returns_timeout_error_when_child_server_hangs(tmp_pat
         ]
     )
 
-    assert result["responses"][0]["error"]["code"] == -32002
+    assert result["responses"][0]["error"]["code"] == -32800
+    assert result["responses"][0]["error"]["data"]["guard_timeout"] is True
     assert result["events"][0]["decision"] == "timeout"
     assert result["responses"][0]["error"]["data"]["source"] == "child_response"
 
@@ -1478,19 +1487,29 @@ def test_codex_guard_proxy_returns_timeout_error_to_child_for_nested_request_tim
     monkeypatch.setattr(proxy, "_nested_request_timeout_seconds", lambda: 0.05)
     child_stdin = StringIO()
     server_output = StringIO()
+    blocking_input = _BlockingPipeInput()
 
-    proxy._proxy_child_request(
-        payload={"jsonrpc": "2.0", "id": "child-sampling-timeout", "method": "sampling/createMessage", "params": {}},
-        child_stdin=child_stdin,
-        child_stdout=StringIO(),
-        client_input=_BlockingInput(),
-        server_output=server_output,
-    )
+    try:
+        proxy._proxy_child_request(
+            payload={
+                "jsonrpc": "2.0",
+                "id": "child-sampling-timeout",
+                "method": "sampling/createMessage",
+                "params": {},
+            },
+            child_stdin=child_stdin,
+            child_stdout=StringIO(),
+            client_input=blocking_input,
+            server_output=server_output,
+        )
+    finally:
+        blocking_input.close()
 
     child_reply = json.loads(child_stdin.getvalue().splitlines()[0])
     assert json.loads(server_output.getvalue().splitlines()[0])["id"] == "child-sampling-timeout"
     assert child_reply["id"] == "child-sampling-timeout"
-    assert child_reply["error"]["code"] == -32002
+    assert child_reply["error"]["code"] == -32800
+    assert child_reply["error"]["data"]["guard_timeout"] is True
     assert child_reply["error"]["data"]["source"] == "nested_client_response"
 
 
@@ -1509,12 +1528,16 @@ def test_codex_guard_proxy_cancels_inline_approval_after_timeout(tmp_path, monke
     )
     monkeypatch.setattr(proxy, "_inline_approval_timeout_seconds", lambda: 0.05)
 
-    result = proxy._request_inline_approval(
-        {"jsonrpc": "2.0", "id": "guard-elicitation-timeout", "method": "elicitation/create", "params": {}},
-        input_stream=_BlockingInput(),
-        output_stream=StringIO(),
-        child_stdin=StringIO(),
-        child_stdout=StringIO(),
-    )
+    blocking_input = _BlockingPipeInput()
+    try:
+        result = proxy._request_inline_approval(
+            {"jsonrpc": "2.0", "id": "guard-elicitation-timeout", "method": "elicitation/create", "params": {}},
+            input_stream=blocking_input,
+            output_stream=StringIO(),
+            child_stdin=StringIO(),
+            child_stdout=StringIO(),
+        )
+    finally:
+        blocking_input.close()
 
     assert result == {"action": "cancel", "reason": "timeout"}

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15080,7 +15080,8 @@ def test_stdio_proxy_returns_timeout_error_when_child_server_hangs(monkeypatch):
         ]
     )
 
-    assert result["responses"][0]["error"]["code"] == -32002
+    assert result["responses"][0]["error"]["code"] == -32800
+    assert result["responses"][0]["error"]["data"]["guard_timeout"] is True
     assert result["responses"][0]["error"]["data"]["source"] == "child_response"
     assert result["events"][0]["decision"] == "timeout"
     assert isinstance(result["return_code"], int)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -15054,6 +15054,39 @@ def test_stdio_proxy_blocks_disallowed_tools_and_redacts_headers():
     assert blocked["events"][0]["decision"] == "block"
 
 
+def test_stdio_proxy_returns_timeout_error_when_child_server_hangs(monkeypatch):
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
+                [
+                    "import json, sys, time",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    if message.get('id') is None:",
+                    "        continue",
+                    "    time.sleep(60)",
+                ]
+            ),
+        ],
+    )
+    monkeypatch.setattr(proxy, "_response_timeout_seconds", lambda: 0.05)
+
+    result = proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {}},
+        ]
+    )
+
+    assert result["responses"][0]["error"]["code"] == -32002
+    assert result["responses"][0]["error"]["data"]["source"] == "child_response"
+    assert result["events"][0]["decision"] == "timeout"
+    assert isinstance(result["return_code"], int)
+    assert result["return_code"] != 0
+
+
 def test_stdio_proxy_waits_for_matching_response_id():
     proxy = StdioGuardProxy(
         command=[
@@ -16964,7 +16997,8 @@ def test_sync_receipts_uploads_policy_bundle_acknowledgement_to_sync_route(tmp_p
             self.end_headers()
             self.wfile.write(encoded)
 
-        def log_message(self, format, *args):
+        def log_message(self, format_string, *args):
+            del format_string, args
             return
 
     server = HTTPServer(("127.0.0.1", 0), _AckSyncHandler)


### PR DESCRIPTION
## Summary
- add hard MCP proxy timeouts for child replies, nested client replies, and inline approval waits
- return JSON-RPC timeout errors and quarantine timed-out child servers while expanding hung-proxy regression coverage

## Testing
- `uv run pytest tests/test_guard_codex_proxy.py -q`
- `uv run pytest tests/test_guard_opencode_proxy.py tests/test_guard_mcp_package_proxy_phase14.py -q`
- `uv run pytest tests/test_guard_runtime.py -q -k "stdio_proxy_"`
- `uv run ruff check src/codex_plugin_scanner/guard/proxy/stdio.py src/codex_plugin_scanner/guard/proxy/runtime_mcp.py tests/test_guard_codex_proxy.py tests/test_guard_runtime.py`
- `git diff --check`
