### PR TITLE
fix(guard): sanitize CSV evidence exports

### DIFF
--- a/src/codex_plugin_scanner/guard/store_evidence.py
+++ b/src/codex_plugin_scanner/guard/store_evidence.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import csv
 import io
 import json
+import re
 import sqlite3
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
@@ -30,6 +31,7 @@ _EXPORT_COLUMNS: tuple[str, ...] = (
     "action_identity",
     "created_at",
 )
+_CSV_FORMULA_TRIGGER_PATTERN = re.compile(r"^[=+\-@\t\r]")
 
 
 def _now_iso() -> str:
@@ -298,8 +300,16 @@ def export_evidence_csv(
     for item in payload["items"]:
         if not isinstance(item, dict):
             continue
-        writer.writerow([item.get(column, "") for column in _EXPORT_COLUMNS])
+        writer.writerow([_sanitize_csv_formula_cell(item.get(column, "")) for column in _EXPORT_COLUMNS])
     return output.getvalue()
+
+
+def _sanitize_csv_formula_cell(value: object) -> object:
+    if not isinstance(value, str):
+        return value
+    if _CSV_FORMULA_TRIGGER_PATTERN.match(value):
+        return f"'{value}"
+    return value
 
 
 def clear_evidence(conn: sqlite3.Connection) -> int:

--- a/src/codex_plugin_scanner/guard/store_evidence.py
+++ b/src/codex_plugin_scanner/guard/store_evidence.py
@@ -31,7 +31,7 @@ _EXPORT_COLUMNS: tuple[str, ...] = (
     "action_identity",
     "created_at",
 )
-_CSV_FORMULA_TRIGGER_PATTERN = re.compile(r"^[=+\-@\t\r]")
+_CSV_FORMULA_TRIGGER_PATTERN = re.compile(r"^[=+\-@\t\r\n]")
 
 
 def _now_iso() -> str:

--- a/tests/test_guard_evidence_store.py
+++ b/tests/test_guard_evidence_store.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from codex_plugin_scanner.guard.store_evidence import (
     EvidenceRecord,
+    _sanitize_csv_formula_cell,
     compact_evidence,
     count_evidence,
     evidence_index_statements,
@@ -78,9 +79,7 @@ class TestSchema:
             conn.execute(stmt)
         names = [
             r[0]
-            for r in conn.execute(
-                "select name from sqlite_master where type='index' and name like 'idx_evidence%'"
-            )
+            for r in conn.execute("select name from sqlite_master where type='index' and name like 'idx_evidence%'")
         ]
         assert len(names) == len(set(names))
 
@@ -281,7 +280,7 @@ class TestExportEvidence:
             conn,
             _rec(
                 evidence_id="csv-formula-1",
-                summary="=HYPERLINK(\"https://evil.example\")",
+                summary='=HYPERLINK("https://evil.example")',
                 category="@formula",
                 signal_id="\tsecret-tab",
             ),
@@ -293,6 +292,12 @@ class TestExportEvidence:
         assert "'@formula" in exported
         assert "'\tsecret-tab" in exported
         assert ",=HYPERLINK(" not in exported
+        for dangerous_value in (
+            "+cmd",
+            "-cmd",
+            "\n=FORMULA()",
+        ):
+            assert f"'{dangerous_value}" == _sanitize_csv_formula_cell(dangerous_value)
 
 
 class TestCompactEvidence:

--- a/tests/test_guard_evidence_store.py
+++ b/tests/test_guard_evidence_store.py
@@ -275,6 +275,25 @@ class TestExportEvidence:
         assert "/Users/alice" not in exported
         assert "csv-1" in exported
 
+    def test_export_csv_sanitizes_formula_prefixed_cells(self, tmp_path: Path) -> None:
+        conn = _db(tmp_path)
+        store_evidence(
+            conn,
+            _rec(
+                evidence_id="csv-formula-1",
+                summary="=HYPERLINK(\"https://evil.example\")",
+                category="@formula",
+                signal_id="\tsecret-tab",
+            ),
+        )
+
+        exported = export_evidence_csv(conn)
+
+        assert "'=HYPERLINK(" in exported
+        assert "'@formula" in exported
+        assert "'\tsecret-tab" in exported
+        assert ",=HYPERLINK(" not in exported
+
 
 class TestCompactEvidence:
     def test_compact_removes_old(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- sanitize server-side CSV export cells that begin with spreadsheet formula trigger characters
- add regression coverage for formula-like summary/category/signal values

## Verification
- uv run pytest tests/test_guard_evidence_store.py -q
- uv run ruff check src/codex_plugin_scanner/guard/store_evidence.py tests/test_guard_evidence_store.py
- git diff --check