### PR TITLE
fix(guard): narrow dashboard session claims

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -85,7 +85,7 @@ from ..desktop_notifications import (
     ensure_desktop_notification_setup,
     macos_notification_guidance,
 )
-from ..local_dashboard_session import build_local_dashboard_session_token
+from ..local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE, build_local_dashboard_session_token
 from ..local_supply_chain import (
     build_local_supply_chain_posture,
     resolve_package_firewall_entitlement_with_refresh,
@@ -3078,6 +3078,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not secrets.compare_digest(signature, expected):
             return False
         claims = _decode_dashboard_session_payload(encoded_payload)
+        if self._optional_string(claims.get("aud")) != LOCAL_DASHBOARD_SESSION_AUDIENCE:
+            return False
         expires_at = claims.get("expires_at")
         if not isinstance(expires_at, str):
             return False
@@ -3102,8 +3104,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         action_path = self._optional_string(claims.get("action_path"))
         if action_path is None:
             return False
-        if path in {"/v1/capabilities", "/v1/harnesses", "/v1/inventory", "/v1/runtime"}:
-            return True
+        if self.command == "GET" and self._dashboard_session_scoped_read_path_is_allowed(claims, path):
+            return self._dashboard_session_scoped_nonce_matches_request(claims=claims, payload=payload)
         if (
             len(path_parts) == 3
             and path_parts[:2] == ["v1", "apps"]
@@ -3133,6 +3135,26 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 supply_chain_action=supply_chain_action,
             )
         return False
+
+    def _dashboard_session_scoped_read_path_is_allowed(self, claims: dict[str, object], path: str) -> bool:
+        allowed_read_paths = claims.get("allowed_read_paths")
+        if not isinstance(allowed_read_paths, list):
+            return False
+        return path in {item for item in allowed_read_paths if isinstance(item, str)}
+
+    def _dashboard_session_scoped_nonce_matches_request(
+        self,
+        *,
+        claims: dict[str, object],
+        payload: dict[str, object] | None,
+    ) -> bool:
+        claim_nonce = self._optional_string(claims.get("nonce"))
+        if claim_nonce is None:
+            return True
+        request_nonce = self._optional_string(self.headers.get("X-Guard-Dashboard-Nonce"))
+        if request_nonce is None and payload is not None:
+            request_nonce = self._optional_string(payload.get("dashboard_session_nonce"))
+        return request_nonce == claim_nonce
 
     def _local_surface_session_request_is_allowed(self, path: str, path_parts: list[str]) -> bool:
         if path in {

--- a/src/codex_plugin_scanner/guard/local_dashboard_session.py
+++ b/src/codex_plugin_scanner/guard/local_dashboard_session.py
@@ -11,8 +11,9 @@ from typing import Any
 
 LOCAL_DASHBOARD_SESSION_VERSION = "guard-local-daemon-session.v1"
 LOCAL_DASHBOARD_SESSION_PREFIX = "gld1"
+LOCAL_DASHBOARD_SESSION_AUDIENCE = "guard-local-daemon"
 DEFAULT_LOCAL_DASHBOARD_SESSION_TTL_SECONDS = 12 * 60 * 60
-_PROTECTED_LOCAL_DASHBOARD_SESSION_CLAIMS = frozenset({"version", "surface", "expires_at"})
+_PROTECTED_LOCAL_DASHBOARD_SESSION_CLAIMS = frozenset({"aud", "version", "surface", "expires_at"})
 
 
 def build_local_dashboard_session_token(
@@ -24,6 +25,7 @@ def build_local_dashboard_session_token(
 ) -> str:
     expires_at = datetime.now(timezone.utc) + timedelta(seconds=max(1, expires_in_seconds))
     payload_data: dict[str, Any] = {
+        "aud": LOCAL_DASHBOARD_SESSION_AUDIENCE,
         "version": LOCAL_DASHBOARD_SESSION_VERSION,
         "surface": surface,
         "expires_at": expires_at.isoformat(),

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -23,6 +23,7 @@ from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
+from codex_plugin_scanner.guard.local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
@@ -94,6 +95,7 @@ def _request(
 def _dashboard_token(auth_token: str) -> str:
     payload_json = json.dumps(
         {
+            "aud": LOCAL_DASHBOARD_SESSION_AUDIENCE,
             "version": "guard-local-daemon-session.v1",
             "expires_at": datetime(2099, 1, 1, tzinfo=timezone.utc).isoformat(),
             "surface": "approval-center",
@@ -109,6 +111,7 @@ def _dashboard_token(auth_token: str) -> str:
 def _dashboard_token_with_claims(auth_token: str, claims: dict[str, object]) -> str:
     payload_json = json.dumps(
         {
+            "aud": LOCAL_DASHBOARD_SESSION_AUDIENCE,
             "version": "guard-local-daemon-session.v1",
             "expires_at": datetime(2099, 1, 1, tzinfo=timezone.utc).isoformat(),
             **claims,
@@ -969,6 +972,59 @@ def test_supply_chain_dashboard_session_claims_scope_action_and_managers(tmp_pat
     assert allowed_payload["operation"] == "install"
     assert denied_status == 401
     assert denied_payload["error"] == "unauthorized"
+
+
+def test_action_scoped_dashboard_session_requires_exact_read_paths_and_matching_nonce(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        token = _dashboard_token_with_claims(
+            auth_token,
+            {
+                "action_path": "connect",
+                "allowed_read_paths": ["/v1/runtime"],
+                "nonce": "runtime-read-nonce",
+            },
+        )
+        allowed_status, allowed_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/runtime",
+                method="GET",
+                dashboard_session_token=token,
+                extra_headers={"X-Guard-Dashboard-Nonce": "runtime-read-nonce"},
+            ),
+        )
+        wrong_path_status, wrong_path_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/inventory",
+                method="GET",
+                dashboard_session_token=token,
+                extra_headers={"X-Guard-Dashboard-Nonce": "runtime-read-nonce"},
+            ),
+        )
+        wrong_nonce_status, wrong_nonce_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/runtime",
+                method="GET",
+                dashboard_session_token=token,
+                extra_headers={"X-Guard-Dashboard-Nonce": "wrong-nonce"},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert allowed_status == 200
+    assert isinstance(allowed_payload, dict)
+    assert wrong_path_status == 401
+    assert wrong_path_payload["error"] == "unauthorized"
+    assert wrong_nonce_status == 401
+    assert wrong_nonce_payload["error"] == "unauthorized"
 
 
 def test_headless_capabilities_rejects_dashboard_session_from_guard_token_header(tmp_path: Path) -> None:

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -1016,6 +1016,20 @@ def test_action_scoped_dashboard_session_requires_exact_read_paths_and_matching_
                 extra_headers={"X-Guard-Dashboard-Nonce": "wrong-nonce"},
             ),
         )
+        implicit_read_token = _dashboard_token_with_claims(
+            auth_token,
+            {
+                "action_path": "connect",
+            },
+        )
+        implicit_read_status, implicit_read_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/runtime",
+                method="GET",
+                dashboard_session_token=implicit_read_token,
+            ),
+        )
     finally:
         daemon.stop()
 
@@ -1025,6 +1039,8 @@ def test_action_scoped_dashboard_session_requires_exact_read_paths_and_matching_
     assert wrong_path_payload["error"] == "unauthorized"
     assert wrong_nonce_status == 401
     assert wrong_nonce_payload["error"] == "unauthorized"
+    assert implicit_read_status == 401
+    assert implicit_read_payload["error"] == "unauthorized"
 
 
 def test_headless_capabilities_rejects_dashboard_session_from_guard_token_header(tmp_path: Path) -> None:

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -21,6 +21,7 @@ from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
 from codex_plugin_scanner.guard.local_dashboard_session import (
+    LOCAL_DASHBOARD_SESSION_AUDIENCE,
     LOCAL_DASHBOARD_SESSION_VERSION,
     build_local_dashboard_session_token,
 )
@@ -76,6 +77,7 @@ class TestGuardSurfaceServer:
         claims = _decode_dashboard_session_claims(token)
 
         assert claims["version"] == LOCAL_DASHBOARD_SESSION_VERSION
+        assert claims["aud"] == LOCAL_DASHBOARD_SESSION_AUDIENCE
         assert claims["surface"] == "approval-center"
         assert claims["expires_at"] != "1970-01-01T00:00:00+00:00"
         assert claims["custom"] == "value"


### PR DESCRIPTION
## Summary
- require daemon-signed dashboard tokens to carry the local-daemon audience claim
- remove the broad implicit read access for action-scoped dashboard session tokens
- require exact `allowed_read_paths` for scoped GET access and support nonce binding for scoped requests
- add regression coverage for reserved claims, scoped reads, and nonce mismatches

## Verification
- uv run pytest tests/test_guard_headless_daemon_api.py -q -k "dashboard_session or capabilities_rejects_dashboard_session or exact_read_paths_and_matching_nonce"
- uv run pytest tests/test_guard_surface_server.py -q -k "local_dashboard_session_preserves_reserved_claims or guard_daemon_allows_private_network_preflight_for_hosted_dashboard"
- uv run ruff check src/codex_plugin_scanner/guard/local_dashboard_session.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py tests/test_guard_surface_server.py
- git diff --check