### PR TITLE
fix(guard): harden low-level temp and CLI defaults

### DIFF
--- a/docs/guard/release-checklist.md
+++ b/docs/guard/release-checklist.md
@@ -8,3 +8,11 @@ Before each Guard harness release:
 - In release notes, call out that `hol-guard connect` is the canonical Guard Cloud sign-in flow and `hol-guard connect --headless` is the canonical SSH/CI flow.
 - In release notes, call out that pasted `--token` login and legacy bearer setup are retired.
 - Attach smoke evidence to the release notes or pull request before publishing.
+
+When running Guard scans against untrusted content in a container, keep the runtime sandboxed:
+
+- mount the target workspace read-only when possible
+- disable outbound network access with `--network=none`
+- drop ambient privileges with `--cap-drop=ALL` and `--security-opt=no-new-privileges`
+- set explicit `--memory`, `--cpus`, and `--pids-limit` caps
+- use a writable `tmpfs` only for the minimal paths the scan needs, such as `/tmp`

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -63,7 +63,7 @@ def _add_common_policy_args(parser: argparse.ArgumentParser) -> None:
     parser.add_argument("--config", help="Path to a scanner config file such as .plugin-scanner.toml")
     parser.add_argument("--baseline", help="Path to baseline suppression file")
     parser.add_argument("--strict", action="store_true", help="Fail if any finding is present")
-    parser.add_argument("--diff-base", help="Reserved for future diff-aware gating")
+    parser.add_argument("--diff-base", help="Not implemented yet. Guard exits with an error if this flag is used.")
 
 
 def _is_guard_program(program_name: str) -> bool:
@@ -508,6 +508,8 @@ def main(argv: list[str] | None = None) -> int:
         for ecosystem in list_supported_ecosystems():
             print(ecosystem)
         return 0
+    if getattr(args, "diff_base", None):
+        parser.error("--diff-base is not implemented yet. Remove the flag and rerun without diff-aware gating.")
     if args.command in {None, "scan"}:
         return _run_scan(args)
     if args.command == "lint":

--- a/src/codex_plugin_scanner/guard/totp.py
+++ b/src/codex_plugin_scanner/guard/totp.py
@@ -7,6 +7,7 @@ import hashlib
 import hmac
 import os
 import secrets
+import tempfile
 import urllib.parse
 from pathlib import Path
 
@@ -76,20 +77,28 @@ class TotpSecretStore:
     @staticmethod
     def _atomic_write_bytes(path: Path, payload: bytes, mode: int) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
-        tmp_path.write_bytes(payload)
-        os.chmod(tmp_path, mode)
-        tmp_path.replace(path)
-        os.chmod(path, mode)
+        tmp_path = _temporary_atomic_path(path)
+        try:
+            tmp_path.write_bytes(payload)
+            os.chmod(tmp_path, mode)
+            tmp_path.replace(path)
+            os.chmod(path, mode)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
 
     @staticmethod
     def _atomic_write_text(path: Path, payload: str, mode: int) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_suffix(path.suffix + ".tmp")
-        tmp_path.write_text(payload, encoding="utf-8")
-        os.chmod(tmp_path, mode)
-        tmp_path.replace(path)
-        os.chmod(path, mode)
+        tmp_path = _temporary_atomic_path(path)
+        try:
+            tmp_path.write_text(payload, encoding="utf-8")
+            os.chmod(tmp_path, mode)
+            tmp_path.replace(path)
+            os.chmod(path, mode)
+        finally:
+            if tmp_path.exists():
+                tmp_path.unlink()
 
 
 def generate_totp_secret() -> str:
@@ -153,3 +162,11 @@ def _normalize_base32(value: str) -> str:
     normalized = value.strip().replace(" ", "").replace("-", "").upper()
     padding = "=" * ((8 - len(normalized) % 8) % 8)
     return normalized + padding
+
+
+def _temporary_atomic_path(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    prefix = f"{path.name}."
+    fd, raw_path = tempfile.mkstemp(prefix=prefix, suffix=".tmp", dir=path.parent)
+    os.close(fd)
+    return Path(raw_path)

--- a/src/codex_plugin_scanner/guard/totp.py
+++ b/src/codex_plugin_scanner/guard/totp.py
@@ -84,8 +84,7 @@ class TotpSecretStore:
             tmp_path.replace(path)
             os.chmod(path, mode)
         finally:
-            if tmp_path.exists():
-                tmp_path.unlink()
+            tmp_path.unlink(missing_ok=True)
 
     @staticmethod
     def _atomic_write_text(path: Path, payload: str, mode: int) -> None:
@@ -97,8 +96,7 @@ class TotpSecretStore:
             tmp_path.replace(path)
             os.chmod(path, mode)
         finally:
-            if tmp_path.exists():
-                tmp_path.unlink()
+            tmp_path.unlink(missing_ok=True)
 
 
 def generate_totp_secret() -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -118,6 +118,13 @@ class TestMain:
 
         assert args.cisco_mcp_scan == "on"
 
+    def test_diff_base_fails_loudly_until_implemented(self, capsys):
+        with pytest.raises(SystemExit) as error:
+            main(["scan", str(FIXTURES / "good-plugin"), "--diff-base", "HEAD~1"])
+
+        assert error.value.code == 2
+        assert "--diff-base is not implemented yet" in capsys.readouterr().err
+
     def test_scan_help_explains_cisco_mcp_extra_requirement(self, capsys):
         parser = cli_module._build_parser("plugin-scanner", program_mode="scanner")
 

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -45,7 +45,7 @@ from codex_plugin_scanner.guard.proxy import runtime_mcp as runtime_mcp_module
 from codex_plugin_scanner.guard.proxy.runtime_mcp import RuntimeMcpGuardProxy
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
-from codex_plugin_scanner.guard.totp import TotpSecretStore, totp_code_at_counter
+from codex_plugin_scanner.guard.totp import TotpSecretStore, _temporary_atomic_path, totp_code_at_counter
 
 PASSWORD = "correct-password"
 WRONG_PASSWORD = "wrong-password"
@@ -152,6 +152,23 @@ def _enable_totp(store: GuardStore, *, now: str) -> str:
         now=now,
     )
     return secret
+
+
+def test_totp_atomic_temp_paths_are_random(tmp_path: Path) -> None:
+    target_path = tmp_path / "guard-home" / "totp-secrets" / "seed.secret"
+    first = _temporary_atomic_path(target_path)
+    second = _temporary_atomic_path(target_path)
+    try:
+        assert first != second
+        assert first.parent == target_path.parent
+        assert second.parent == target_path.parent
+        assert first.name != f"{target_path.name}.tmp"
+        assert second.name != f"{target_path.name}.tmp"
+    finally:
+        if first.exists():
+            first.unlink()
+        if second.exists():
+            second.unlink()
 
 
 def test_approval_gate_missing_password_fails_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- replace deterministic TOTP temp filenames with random per-write temp paths
- make `--diff-base` fail loudly instead of pretending to be implemented
- document minimum container sandbox flags for untrusted scans in the release checklist
- add focused regressions for the CLI error and temp-path randomization

## Verification
- uv run pytest tests/test_cli.py -q -k "diff_base_fails_loudly_until_implemented"
- uv run pytest tests/test_guard_approval_gate.py -q -k "totp_atomic_temp_paths_are_random"
- uv run ruff check src/codex_plugin_scanner/guard/totp.py src/codex_plugin_scanner/cli.py tests/test_cli.py tests/test_guard_approval_gate.py
- git diff --check