### PR TITLE
fix(guard): harden ecosystem discovery paths

### DIFF
--- a/src/codex_plugin_scanner/ecosystems/base.py
+++ b/src/codex_plugin_scanner/ecosystems/base.py
@@ -91,6 +91,7 @@ def iter_safe_recursive_dirs(root: Path, base_dir: Path, pattern: str) -> tuple[
                 continue
             if fnmatchcase(entry.name, pattern):
                 matches.append(entry)
+                continue
             pending.append(entry)
     return tuple(sorted(matches, key=lambda path: str(path)))
 

--- a/src/codex_plugin_scanner/ecosystems/base.py
+++ b/src/codex_plugin_scanner/ecosystems/base.py
@@ -2,10 +2,97 @@
 
 from __future__ import annotations
 
+from fnmatch import fnmatchcase
 from pathlib import Path
 from typing import Protocol
 
+from ..path_support import resolves_within_root
 from .types import Ecosystem, NormalizedPackage, PackageCandidate
+
+IGNORED_ECOSYSTEM_DIRS = frozenset({"node_modules", ".git", ".venv", "venv", "dist", "__pycache__"})
+
+
+def iter_safe_recursive_files(root: Path, base_dir: Path, pattern: str) -> tuple[Path, ...]:
+    """Recursively enumerate in-root non-symlink files matching a glob name."""
+
+    try:
+        resolved_root = root.resolve()
+    except (OSError, RuntimeError):
+        return ()
+    if base_dir.is_symlink():
+        return ()
+    if not base_dir.is_dir() or not resolves_within_root(resolved_root, base_dir, require_exists=True):
+        return ()
+
+    matches: list[Path] = []
+    pending: list[Path] = [base_dir]
+    while pending:
+        current_dir = pending.pop()
+        try:
+            entries = sorted(current_dir.iterdir(), key=lambda path: path.name)
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.name in IGNORED_ECOSYSTEM_DIRS:
+                try:
+                    if entry.is_dir():
+                        continue
+                except OSError:
+                    continue
+            if entry.is_symlink():
+                continue
+            try:
+                if entry.is_dir():
+                    if resolves_within_root(resolved_root, entry, require_exists=True):
+                        pending.append(entry)
+                    continue
+                if not entry.is_file():
+                    continue
+            except OSError:
+                continue
+            if not resolves_within_root(resolved_root, entry, require_exists=True):
+                continue
+            if fnmatchcase(entry.name, pattern):
+                matches.append(entry)
+    return tuple(sorted(matches, key=lambda path: str(path)))
+
+
+def iter_safe_recursive_dirs(root: Path, base_dir: Path, pattern: str) -> tuple[Path, ...]:
+    """Recursively enumerate in-root non-symlink directories matching a glob name."""
+
+    try:
+        resolved_root = root.resolve()
+    except (OSError, RuntimeError):
+        return ()
+    if base_dir.is_symlink():
+        return ()
+    if not base_dir.is_dir() or not resolves_within_root(resolved_root, base_dir, require_exists=True):
+        return ()
+
+    matches: list[Path] = []
+    pending: list[Path] = [base_dir]
+    while pending:
+        current_dir = pending.pop()
+        try:
+            entries = sorted(current_dir.iterdir(), key=lambda path: path.name)
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_symlink():
+                continue
+            try:
+                if not entry.is_dir():
+                    continue
+            except OSError:
+                continue
+            if entry.name in IGNORED_ECOSYSTEM_DIRS:
+                continue
+            if not resolves_within_root(resolved_root, entry, require_exists=True):
+                continue
+            if fnmatchcase(entry.name, pattern):
+                matches.append(entry)
+            pending.append(entry)
+    return tuple(sorted(matches, key=lambda path: str(path)))
 
 
 class EcosystemAdapter(Protocol):

--- a/src/codex_plugin_scanner/ecosystems/claude.py
+++ b/src/codex_plugin_scanner/ecosystems/claude.py
@@ -74,9 +74,17 @@ class ClaudeAdapter:
             components["skills"] = tuple(
                 str(path.relative_to(root)) for path in iter_safe_recursive_files(root, skills_dir, "SKILL.md")
             )
-        if hooks_file.is_file() and resolves_within_root(root, hooks_file, require_exists=True):
+        if (
+            hooks_file.is_file()
+            and not hooks_file.is_symlink()
+            and resolves_within_root(root, hooks_file, require_exists=True)
+        ):
             components["hooks"] = (str(hooks_file.relative_to(root)),)
-        if mcp_file.is_file() and resolves_within_root(root, mcp_file, require_exists=True):
+        if (
+            mcp_file.is_file()
+            and not mcp_file.is_symlink()
+            and resolves_within_root(root, mcp_file, require_exists=True)
+        ):
             components["mcp_servers"] = (str(mcp_file.relative_to(root)),)
 
         strict_mode = manifest.get("strict")

--- a/src/codex_plugin_scanner/ecosystems/claude.py
+++ b/src/codex_plugin_scanner/ecosystems/claude.py
@@ -5,19 +5,9 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from ..path_support import resolves_within_root
+from .base import iter_safe_recursive_files
 from .types import Ecosystem, NormalizedPackage, PackageCandidate
-
-IGNORED_DIRS = {"node_modules", ".git", ".venv", "venv", "dist", "__pycache__"}
-
-
-def _iter_files(root: Path, pattern: str) -> list[Path]:
-    files: list[Path] = []
-    for path in root.rglob(pattern):
-        if any(part in IGNORED_DIRS for part in path.parts):
-            continue
-        if path.is_file():
-            files.append(path)
-    return files
 
 
 def _load_json(path: Path) -> dict[str, object]:
@@ -37,7 +27,7 @@ class ClaudeAdapter:
 
     def detect(self, root: Path) -> list[PackageCandidate]:
         candidates: list[PackageCandidate] = []
-        for manifest_path in _iter_files(root, "plugin.json"):
+        for manifest_path in iter_safe_recursive_files(root, root, "plugin.json"):
             if manifest_path.parent.name != ".claude-plugin":
                 continue
             candidates.append(
@@ -49,7 +39,7 @@ class ClaudeAdapter:
                     detection_reason="found .claude-plugin/plugin.json",
                 )
             )
-        for manifest_path in _iter_files(root, "marketplace.json"):
+        for manifest_path in iter_safe_recursive_files(root, root, "marketplace.json"):
             if manifest_path.parent.name != ".claude-plugin":
                 continue
             candidates.append(
@@ -74,19 +64,19 @@ class ClaudeAdapter:
         mcp_file = root / ".mcp.json"
         if commands_dir.is_dir():
             components["commands"] = tuple(
-                sorted(str(path.relative_to(root)) for path in commands_dir.rglob("*.md") if path.is_file())
+                str(path.relative_to(root)) for path in iter_safe_recursive_files(root, commands_dir, "*.md")
             )
         if agents_dir.is_dir():
             components["agents"] = tuple(
-                sorted(str(path.relative_to(root)) for path in agents_dir.rglob("*.md") if path.is_file())
+                str(path.relative_to(root)) for path in iter_safe_recursive_files(root, agents_dir, "*.md")
             )
         if skills_dir.is_dir():
             components["skills"] = tuple(
-                sorted(str(path.relative_to(root)) for path in skills_dir.rglob("SKILL.md") if path.is_file())
+                str(path.relative_to(root)) for path in iter_safe_recursive_files(root, skills_dir, "SKILL.md")
             )
-        if hooks_file.is_file():
+        if hooks_file.is_file() and resolves_within_root(root, hooks_file, require_exists=True):
             components["hooks"] = (str(hooks_file.relative_to(root)),)
-        if mcp_file.is_file():
+        if mcp_file.is_file() and resolves_within_root(root, mcp_file, require_exists=True):
             components["mcp_servers"] = (str(mcp_file.relative_to(root)),)
 
         strict_mode = manifest.get("strict")

--- a/src/codex_plugin_scanner/ecosystems/codex.py
+++ b/src/codex_plugin_scanner/ecosystems/codex.py
@@ -5,19 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from .base import iter_safe_recursive_files
 from .types import Ecosystem, NormalizedPackage, PackageCandidate
-
-IGNORED_DIRS = {"node_modules", ".git", ".venv", "venv", "dist", "__pycache__"}
-
-
-def _iter_files(root: Path, pattern: str) -> list[Path]:
-    files: list[Path] = []
-    for path in root.rglob(pattern):
-        if any(part in IGNORED_DIRS for part in path.parts):
-            continue
-        if path.is_file():
-            files.append(path)
-    return files
 
 
 def _load_json(path: Path) -> dict[str, object]:
@@ -37,7 +26,7 @@ class CodexAdapter:
 
     def detect(self, root: Path) -> list[PackageCandidate]:
         candidates: list[PackageCandidate] = []
-        for manifest_path in _iter_files(root, "plugin.json"):
+        for manifest_path in iter_safe_recursive_files(root, root, "plugin.json"):
             if manifest_path.parent.name != ".codex-plugin":
                 continue
             package_root = manifest_path.parent.parent
@@ -50,7 +39,7 @@ class CodexAdapter:
                     detection_reason="found .codex-plugin/plugin.json",
                 )
             )
-        for marketplace_path in _iter_files(root, "marketplace.json"):
+        for marketplace_path in iter_safe_recursive_files(root, root, "marketplace.json"):
             package_root = None
             if marketplace_path.parent.name == "plugins" and marketplace_path.parent.parent.name == ".agents":
                 package_root = marketplace_path.parent.parent.parent

--- a/src/codex_plugin_scanner/ecosystems/gemini.py
+++ b/src/codex_plugin_scanner/ecosystems/gemini.py
@@ -5,19 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from .base import iter_safe_recursive_files
 from .types import Ecosystem, NormalizedPackage, PackageCandidate
-
-IGNORED_DIRS = {"node_modules", ".git", ".venv", "venv", "dist", "__pycache__"}
-
-
-def _iter_files(root: Path, pattern: str) -> list[Path]:
-    files: list[Path] = []
-    for path in root.rglob(pattern):
-        if any(part in IGNORED_DIRS for part in path.parts):
-            continue
-        if path.is_file():
-            files.append(path)
-    return files
 
 
 def _load_json(path: Path) -> dict[str, object]:
@@ -37,7 +26,7 @@ class GeminiAdapter:
 
     def detect(self, root: Path) -> list[PackageCandidate]:
         candidates: list[PackageCandidate] = []
-        for manifest_path in _iter_files(root, "gemini-extension.json"):
+        for manifest_path in iter_safe_recursive_files(root, root, "gemini-extension.json"):
             candidates.append(
                 PackageCandidate(
                     ecosystem=Ecosystem.GEMINI,
@@ -56,7 +45,7 @@ class GeminiAdapter:
         components: dict[str, tuple[str, ...]] = {}
         if commands_dir.is_dir():
             components["commands"] = tuple(
-                sorted(str(path.relative_to(root)) for path in commands_dir.rglob("*.toml") if path.is_file())
+                str(path.relative_to(root)) for path in iter_safe_recursive_files(root, commands_dir, "*.toml")
             )
         mcp_servers = manifest.get("mcpServers")
         if isinstance(mcp_servers, dict):

--- a/src/codex_plugin_scanner/ecosystems/opencode.py
+++ b/src/codex_plugin_scanner/ecosystems/opencode.py
@@ -5,19 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from .base import iter_safe_recursive_dirs, iter_safe_recursive_files
 from .types import Ecosystem, NormalizedPackage, PackageCandidate
-
-IGNORED_DIRS = {"node_modules", ".git", ".venv", "venv", "dist", "__pycache__"}
-
-
-def _iter_files(root: Path, pattern: str) -> list[Path]:
-    files: list[Path] = []
-    for path in root.rglob(pattern):
-        if any(part in IGNORED_DIRS for part in path.parts):
-            continue
-        if path.is_file():
-            files.append(path)
-    return files
 
 
 def _strip_jsonc(text: str) -> str:
@@ -110,7 +99,7 @@ class OpenCodeAdapter:
         candidates: list[PackageCandidate] = []
         seen_roots: set[Path] = set()
         for config_name in ("opencode.json", "opencode.jsonc"):
-            for manifest_path in _iter_files(root, config_name):
+            for manifest_path in iter_safe_recursive_files(root, root, config_name):
                 package_root = manifest_path.parent
                 if package_root in seen_roots:
                     continue
@@ -125,9 +114,7 @@ class OpenCodeAdapter:
                     )
                 )
 
-        for opencode_dir in (path for path in root.rglob(".opencode") if path.is_dir()):
-            if any(part in IGNORED_DIRS for part in opencode_dir.parts):
-                continue
+        for opencode_dir in iter_safe_recursive_dirs(root, root, ".opencode"):
             package_root = opencode_dir.parent
             if package_root in seen_roots:
                 continue
@@ -153,14 +140,14 @@ class OpenCodeAdapter:
         plugins_dir = root / ".opencode" / "plugins"
         if commands_dir.is_dir():
             components["commands"] = tuple(
-                sorted(str(path.relative_to(root)) for path in commands_dir.rglob("*.md") if path.is_file())
+                str(path.relative_to(root)) for path in iter_safe_recursive_files(root, commands_dir, "*.md")
             )
         if plugins_dir.is_dir():
             components["plugin_modules"] = tuple(
                 sorted(
                     str(path.relative_to(root))
-                    for path in plugins_dir.rglob("*")
-                    if path.is_file() and path.suffix in {".js", ".ts", ".mjs", ".cjs"}
+                    for path in iter_safe_recursive_files(root, plugins_dir, "*")
+                    if path.suffix in {".js", ".ts", ".mjs", ".cjs"}
                 )
             )
         mcp_config = manifest.get("mcp")

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -116,6 +116,34 @@ def test_claude_parse_skips_symlinked_component_files_outside_root(tmp_path: Pat
     assert package.components["commands"] == ("commands/safe.md",)
 
 
+def test_opencode_detect_does_not_treat_nested_workspace_dirs_as_extra_packages(tmp_path: Path) -> None:
+    (tmp_path / ".opencode").mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".opencode" / "tools" / ".opencode").mkdir(parents=True, exist_ok=True)
+
+    packages = detect_packages(tmp_path, ecosystem=Ecosystem.OPENCODE)
+
+    assert len(packages) == 1
+    assert packages[0].root_path == tmp_path
+
+
+def test_claude_parse_skips_symlinked_hooks_and_mcp_files(tmp_path: Path) -> None:
+    manifest_path = tmp_path / ".claude-plugin" / "plugin.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text("{}", encoding="utf-8")
+    real_hooks = tmp_path / "real-hooks.json"
+    real_mcp = tmp_path / "real-mcp.json"
+    real_hooks.write_text('{"hook":"safe"}', encoding="utf-8")
+    real_mcp.write_text('{"mcpServers":{}}', encoding="utf-8")
+    _symlink_or_skip(tmp_path / "hooks" / "hooks.json", real_hooks)
+    _symlink_or_skip(tmp_path / ".mcp.json", real_mcp)
+
+    candidate = ClaudeAdapter().detect(tmp_path)[0]
+    package = ClaudeAdapter().parse(candidate)
+
+    assert "hooks" not in package.components
+    assert "mcp_servers" not in package.components
+
+
 def test_scan_claude_with_explicit_ecosystem() -> None:
     result = scan_plugin(
         FIXTURES / "claude-plugin-good",

--- a/tests/test_ecosystems.py
+++ b/tests/test_ecosystems.py
@@ -9,6 +9,7 @@ import pytest
 from codex_plugin_scanner.checks.gemini import check_context_and_mcp
 from codex_plugin_scanner.checks.opencode import check_opencode_config, check_opencode_plugins
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.ecosystems.claude import ClaudeAdapter
 from codex_plugin_scanner.ecosystems.detect import detect_packages
 from codex_plugin_scanner.ecosystems.opencode import OpenCodeAdapter
 from codex_plugin_scanner.ecosystems.types import Ecosystem, NormalizedPackage
@@ -16,6 +17,14 @@ from codex_plugin_scanner.models import ScanOptions
 from codex_plugin_scanner.scanner import scan_plugin
 
 FIXTURES = Path(__file__).parent / "fixtures"
+
+
+def _symlink_or_skip(link_path: Path, target: Path) -> None:
+    link_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        link_path.symlink_to(target, target_is_directory=target.is_dir())
+    except (NotImplementedError, OSError):
+        pytest.skip("symlinks are not supported in this environment")
 
 
 def test_detect_claude_package() -> None:
@@ -34,6 +43,77 @@ def test_detect_opencode_package() -> None:
     packages = detect_packages(FIXTURES / "opencode-good")
     ecosystems = {package.ecosystem for package in packages}
     assert Ecosystem.OPENCODE in ecosystems
+
+
+def test_detect_packages_skips_symlinked_manifest_files_outside_root(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-ecosystem-manifests"
+    shutil.rmtree(outside, ignore_errors=True)
+    outside.mkdir(parents=True, exist_ok=True)
+    (outside / "plugin.json").write_text("{}", encoding="utf-8")
+    (outside / "marketplace.json").write_text("{}", encoding="utf-8")
+    (outside / "gemini-extension.json").write_text("{}", encoding="utf-8")
+    (outside / "opencode.json").write_text("{}", encoding="utf-8")
+
+    _symlink_or_skip(tmp_path / "codex-plugin" / ".codex-plugin" / "plugin.json", outside / "plugin.json")
+    _symlink_or_skip(tmp_path / "claude-plugin" / ".claude-plugin" / "plugin.json", outside / "plugin.json")
+    _symlink_or_skip(tmp_path / "claude-market" / ".claude-plugin" / "marketplace.json", outside / "marketplace.json")
+    _symlink_or_skip(tmp_path / "gemini-ext" / "gemini-extension.json", outside / "gemini-extension.json")
+    _symlink_or_skip(tmp_path / "opencode-workspace" / "opencode.json", outside / "opencode.json")
+
+    assert detect_packages(tmp_path) == []
+
+
+def test_detect_packages_skips_nested_symlinked_directories_outside_root(tmp_path: Path) -> None:
+    outside = tmp_path.parent / "outside-ecosystem-dir"
+    shutil.rmtree(outside, ignore_errors=True)
+    (outside / "nested" / ".codex-plugin").mkdir(parents=True, exist_ok=True)
+    (outside / "nested" / ".codex-plugin" / "plugin.json").write_text("{}", encoding="utf-8")
+
+    _symlink_or_skip(tmp_path / "linked" / "outside", outside)
+
+    assert detect_packages(tmp_path) == []
+
+
+def test_detect_packages_ignores_unreadable_entries_without_crashing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    good_manifest = tmp_path / "good-plugin" / ".codex-plugin" / "plugin.json"
+    good_manifest.parent.mkdir(parents=True, exist_ok=True)
+    good_manifest.write_text("{}", encoding="utf-8")
+    blocked_dir = tmp_path / "blocked"
+    blocked_dir.mkdir()
+
+    original_iterdir = Path.iterdir
+
+    def _guarded_iterdir(self: Path):
+        if self == blocked_dir:
+            raise OSError("denied")
+        yield from original_iterdir(self)
+
+    monkeypatch.setattr(Path, "iterdir", _guarded_iterdir)
+
+    packages = detect_packages(tmp_path)
+
+    assert len(packages) == 1
+    assert packages[0].ecosystem == Ecosystem.CODEX
+
+
+def test_claude_parse_skips_symlinked_component_files_outside_root(tmp_path: Path) -> None:
+    manifest_path = tmp_path / ".claude-plugin" / "plugin.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text("{}", encoding="utf-8")
+    commands_dir = tmp_path / "commands"
+    commands_dir.mkdir()
+    (commands_dir / "safe.md").write_text("safe", encoding="utf-8")
+    outside = tmp_path.parent / "outside-command.md"
+    outside.write_text("secret", encoding="utf-8")
+    _symlink_or_skip(commands_dir / "escape.md", outside)
+
+    candidate = ClaudeAdapter().detect(tmp_path)[0]
+    package = ClaudeAdapter().parse(candidate)
+
+    assert package.components["commands"] == ("commands/safe.md",)
 
 
 def test_scan_claude_with_explicit_ecosystem() -> None:


### PR DESCRIPTION
## Summary
- harden ecosystem manifest discovery with shared in-root non-symlink recursive walkers
- stop traversing symlinked directories or accepting symlinked manifest/component files
- add unreadable-entry, nested-symlink, and component-escape regression coverage

## Verification
- uv run pytest tests/test_ecosystems.py -q
- uv run pytest tests/test_guard_claude_adapter.py tests/test_gemini_adapter.py tests/test_opencode_adapter.py -q
- uv run ruff check src/codex_plugin_scanner/ecosystems/base.py src/codex_plugin_scanner/ecosystems/claude.py src/codex_plugin_scanner/ecosystems/codex.py src/codex_plugin_scanner/ecosystems/gemini.py src/codex_plugin_scanner/ecosystems/opencode.py tests/test_ecosystems.py
- git diff --check