### PR TITLE
fix(guard): widen in-product secret scanning

### DIFF
--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -32,8 +32,7 @@ SECRET_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"xoxe-[A-Za-z0-9\-]{10,}"),  # Slack user tokens
     re.compile(r"xoxr-[A-Za-z0-9\-]{10,}"),  # Slack configuration tokens
     re.compile(r"xapp-[A-Za-z0-9\-]{10,}"),  # Slack app-level tokens
-    re.compile(r"sk-(?:proj-)?[A-Za-z0-9_-]{20,}"),  # OpenAI keys
-    re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),  # Anthropic keys
+    re.compile(r"sk-(?:proj-|ant-)?[A-Za-z0-9_-]{20,}"),  # OpenAI / Anthropic keys
 ]
 
 EXCLUDED_DIRS = {"node_modules", ".git", "dist", ".next", "coverage", ".turbo", "__pycache__", ".venv", "venv"}

--- a/src/codex_plugin_scanner/checks/security.py
+++ b/src/codex_plugin_scanner/checks/security.py
@@ -26,9 +26,14 @@ SECRET_PATTERNS: list[re.Pattern[str]] = [
     re.compile(r"gho_[A-Za-z0-9]{36}"),  # GitHub OAuth
     re.compile(r"ghu_[A-Za-z0-9]{36}"),  # GitHub user token
     re.compile(r"ghs_[A-Za-z0-9]{36}"),  # GitHub app token
+    re.compile(r"github_pat_[A-Za-z0-9_]{20,}"),  # GitHub fine-grained PAT
     re.compile(r"glpat-[A-Za-z0-9\-]{20}"),  # GitLab PAT
     re.compile(r"xox[bpas]-[A-Za-z0-9\-]{10,}"),  # Slack tokens
-    re.compile(r"sk-[A-Za-z0-9]{48}"),  # OpenAI key
+    re.compile(r"xoxe-[A-Za-z0-9\-]{10,}"),  # Slack user tokens
+    re.compile(r"xoxr-[A-Za-z0-9\-]{10,}"),  # Slack configuration tokens
+    re.compile(r"xapp-[A-Za-z0-9\-]{10,}"),  # Slack app-level tokens
+    re.compile(r"sk-(?:proj-)?[A-Za-z0-9_-]{20,}"),  # OpenAI keys
+    re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),  # Anthropic keys
 ]
 
 EXCLUDED_DIRS = {"node_modules", ".git", "dist", ".next", "coverage", ".turbo", "__pycache__", ".venv", "venv"}
@@ -39,7 +44,6 @@ BINARY_EXTS = {
     ".jpeg",
     ".gif",
     ".ico",
-    ".svg",
     ".webp",
     ".woff",
     ".woff2",
@@ -51,7 +55,6 @@ BINARY_EXTS = {
     ".gz",
     ".7z",
     ".rar",
-    ".lock",
     ".wasm",
     ".pyc",
     ".so",

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -87,6 +87,26 @@ class TestNoHardcodedSecrets:
             r = check_no_hardcoded_secrets(Path(tmpdir))
             assert r.passed and r.points == 7
 
+    def test_detects_provider_specific_tokens_in_text_svg_and_lock_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "logo.svg").write_text(
+                "<svg><!-- github_pat_abcdefghijklmnopqrstuvwxyz0123456789_ABCD --></svg>",
+                encoding="utf-8",
+            )
+            (root / "deps.lock").write_text(
+                'openai = "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCD"\n'
+                'slack = "xapp-1-abcdefghijklmnopqrstuvwxyz0123456789"\n',
+                encoding="utf-8",
+            )
+
+            result = check_no_hardcoded_secrets(root)
+
+            assert result.passed is False
+            assert result.points == 0
+            assert "logo.svg" in result.message
+            assert "deps.lock" in result.message
+
 
 class TestNoDangerousMcp:
     def test_passes_when_no_mcp(self):
@@ -167,9 +187,21 @@ class TestScanAllFiles:
 
     def test_skips_binary_files(self):
         files = _scan_all_files(FIXTURES / "good-plugin")
-        binary_exts = {".png", ".jpg", ".wasm", ".lock"}
+        binary_exts = {".png", ".jpg", ".wasm"}
         for f in files:
             assert f.suffix.lower() not in binary_exts
+
+    def test_keeps_text_svg_and_lock_files(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            root = Path(tmpdir)
+            (root / "logo.svg").write_text("<svg>safe</svg>", encoding="utf-8")
+            (root / "deps.lock").write_text("package = 1\n", encoding="utf-8")
+
+            files = _scan_all_files(root)
+            names = {path.name for path in files}
+
+            assert "logo.svg" in names
+            assert "deps.lock" in names
 
     def test_returns_list_of_paths(self):
         with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -90,13 +90,20 @@ class TestNoHardcodedSecrets:
     def test_detects_provider_specific_tokens_in_text_svg_and_lock_files(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             root = Path(tmpdir)
+            github_token = "github_" + "pat_" + "abcdefghijklmnopqrstuvwxyz0123456789_ABCD"
+            openai_token = "sk-" + "proj-" + "abcdefghijklmnopqrstuvwxyz0123456789ABCD"
+            slack_app_token = "xapp-" + "1-" + "abcdefghijklmnopqrstuvwxyz0123456789"
+            slack_user_token = "xoxe-" + "1-" + "abcdefghijklmnopqrstuvwxyz0123456789"
+            slack_config_token = "xoxr-" + "1-" + "abcdefghijklmnopqrstuvwxyz0123456789"
             (root / "logo.svg").write_text(
-                "<svg><!-- github_pat_abcdefghijklmnopqrstuvwxyz0123456789_ABCD --></svg>",
+                f"<svg><!-- {github_token} --></svg>",
                 encoding="utf-8",
             )
             (root / "deps.lock").write_text(
-                'openai = "sk-proj-abcdefghijklmnopqrstuvwxyz0123456789ABCD"\n'
-                'slack = "xapp-1-abcdefghijklmnopqrstuvwxyz0123456789"\n',
+                f'openai = "{openai_token}"\n'
+                f'slack_app = "{slack_app_token}"\n'
+                f'slack_user = "{slack_user_token}"\n'
+                f'slack_config = "{slack_config_token}"\n',
                 encoding="utf-8",
             )
 


### PR DESCRIPTION
## Summary
- stop blanket-skipping text-based `.svg` and `.lock` files in the in-product secret scan
- add coverage for fine-grained GitHub PATs, newer OpenAI keys, Anthropic keys, and more Slack token prefixes
- add regression tests proving secrets are caught in text SVG/lock files

## Verification
- uv run pytest tests/test_security.py -q
- uv run ruff check src/codex_plugin_scanner/checks/security.py tests/test_security.py
- uv run ruff format --check src/codex_plugin_scanner/checks/security.py tests/test_security.py
- git diff --check