### PR TITLE
fix(dashboard): renew stale local dashboard sessions

### DIFF
--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -1019,8 +1019,30 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   recoveryCalls.push({ url, init });
   const path = new URL(url, "http://127.0.0.1:4174").pathname;
   if (path === "/v1/requests/req-stale-token/approve") {
-    return new Response(JSON.stringify({ error: "unauthorized", message: "Guard session expired." }), {
-      status: 401,
+    if (recoveryCalls.length === 1) {
+      return new Response(JSON.stringify({ error: "unauthorized", message: "Guard session expired." }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        resolved: true,
+        item: { ...pageItem, request_id: "req-stale-token", status: "resolved" },
+        remaining_pending_count: 0,
+        next_selectable_request_id: null,
+        remaining_pending_summaries: [],
+        resolved_duplicate_ids: []
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }
+    );
+  }
+  if (path === "/v1/initialize") {
+    return new Response(JSON.stringify({ dashboard_session_token: "fresh-dashboard-session" }), {
+      status: 200,
       headers: { "Content-Type": "application/json" }
     });
   }
@@ -1038,15 +1060,24 @@ try {
 } catch (error) {
   recoveredResolutionError = error;
 }
-assert(recoveryCalls.length === 1, "L077b: stale dashboard session does not call initialize for root-token mint");
+assert(recoveryCalls.length === 3, "L077b: stale dashboard session refreshes and retries once");
 assert(
   headerValue(recoveryCalls[0].init, "X-Guard-Dashboard-Session") === "stale-resolve-token",
   "L077b: first resolve attempt uses dashboard session from current URL"
 );
 assert(
-  recoveredResolutionError instanceof Error && recoveredResolutionError.message.includes("Guard session expired"),
-  "L077b: stale dashboard session surfaces expiration error"
+  recoveryCalls[1].url === "http://127.0.0.1:4781/v1/initialize",
+  "L077b: stale dashboard session refresh calls initialize"
 );
+assert(
+  headerValue(recoveryCalls[1].init, "X-Guard-Dashboard-Session") === "stale-resolve-token",
+  "L077b: stale dashboard session refresh uses stale signed session"
+);
+assert(
+  headerValue(recoveryCalls[2].init, "X-Guard-Dashboard-Session") === "fresh-dashboard-session",
+  "L077b: stale dashboard session retry uses refreshed dashboard session"
+);
+assert(recoveredResolutionError === null, "L077b: stale dashboard session resolves after refresh");
 
 installGuardWindow("?guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
 const malformedRefreshCalls: RecordedFetch[] = [];
@@ -1206,18 +1237,56 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   retryResumeCalls.push({ url, init });
   const path = new URL(url, "http://127.0.0.1:4174").pathname;
   if (path === "/v1/requests/req-retry-resume/resume") {
-    return new Response(JSON.stringify({ error: "unauthorized" }), { status: 401, headers: { "Content-Type": "application/json" } });
+    if (retryResumeCalls.length === 1) {
+      return new Response(JSON.stringify({ error: "unauthorized" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+    return new Response(
+      JSON.stringify({
+        status: "sent",
+        supported: true,
+        attempt_count: 2,
+        request_id: "req-retry-resume",
+        operation_id: "op-3",
+        harness: "codex",
+        resolution_action: "allow",
+        strategy: "reply",
+        thread_id: "thread-retry",
+        reason: null,
+        message: null,
+        last_error: null,
+        created_at: null,
+        updated_at: null,
+        last_attempt_at: null,
+        sent_at: "2025-01-01T00:00:00Z"
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      }
+    );
+  }
+  if (path === "/v1/initialize") {
+    return new Response(JSON.stringify({ dashboard_session_token: "fresh-retry-resume-session" }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
   }
   return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
 };
 
-let retryResumeError: unknown = null;
-try {
-  await retryResume("req-retry-resume");
-} catch (error) {
-  retryResumeError = error;
-}
-assert(retryResumeCalls.length === 1, "L080: retryResume does not call initialize to mint replacement session");
-assert(retryResumeError instanceof Error && retryResumeError.message.includes("401"), "L080: retryResume surfaces unauthorized response");
+const retriedResume = await retryResume("req-retry-resume");
+assert(retryResumeCalls.length === 3, "L080: retryResume refreshes and retries once");
+assert(retriedResume.status === "sent", "L080: retryResume returns retried resume status");
+assert(
+  headerValue(retryResumeCalls[1].init, "X-Guard-Dashboard-Session") === "stale-retry-resume-token",
+  "L080: retryResume refresh uses stale signed session"
+);
+assert(
+  headerValue(retryResumeCalls[2].init, "X-Guard-Dashboard-Session") === "fresh-retry-resume-session",
+  "L080: retryResume retry uses refreshed dashboard session"
+);
 
 console.log("guard-api.test.ts: all tests passed");

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -61,6 +61,7 @@ import {
 
 const GUARD_TOKEN_PARAM = "guard-token";
 const GUARD_DAEMON_PARAM = "guardDaemon";
+const GUARD_SURFACE_PROTOCOL_VERSIONS = ["1.1", "1.0"] as const;
 let guardTokenOverride: string | null = null;
 let guardTokenLocationKey: string | null = null;
 
@@ -234,7 +235,17 @@ function withGuardAuthForToken(
 
 async function fetchWithGuardAuth(input: RequestInfo, init?: RequestInit): Promise<Response> {
   const requestInput = guardApiInput(input);
-  return fetch(requestInput, withGuardAuth(init));
+  const guardToken = readGuardToken();
+  const response = await fetch(requestInput, withGuardAuthForToken(init, guardToken));
+  if (response.status !== 401 || !guardToken || input instanceof Request) {
+    return response;
+  }
+  const refreshedGuardToken = await refreshGuardDashboardSession(guardToken);
+  if (!refreshedGuardToken || refreshedGuardToken === guardToken) {
+    return response;
+  }
+  saveGuardToken(refreshedGuardToken);
+  return fetch(requestInput, withGuardAuthForToken(init, refreshedGuardToken));
 }
 
 function guardAuthHeaders(): HeadersInit {
@@ -244,6 +255,37 @@ function guardAuthHeaders(): HeadersInit {
 
 function guardAuthHeadersForToken(guardToken: string | null): HeadersInit {
   return guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {};
+}
+
+function parseDashboardSessionToken(payload: unknown): string | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const dashboardSessionToken = payload["dashboard_session_token"];
+  return typeof dashboardSessionToken === "string" && dashboardSessionToken.trim() ? dashboardSessionToken : null;
+}
+
+async function refreshGuardDashboardSession(guardToken: string): Promise<string | null> {
+  try {
+    const response = await fetch(guardApiInput("/v1/initialize"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...guardAuthHeadersForToken(guardToken)
+      },
+      body: JSON.stringify({
+        client_name: "guard-dashboard-web",
+        surface: "dashboard",
+        supported_protocol_versions: [...GUARD_SURFACE_PROTOCOL_VERSIONS]
+      })
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return parseDashboardSessionToken(await response.json());
+  } catch {
+    return null;
+  }
 }
 
 export function guardAwareHref(href: string): string {

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -152,6 +152,7 @@ _SUPPLY_CHAIN_PACKAGE_ACTIONS = {
 }
 _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS = 1_500
 _SUPPLY_CHAIN_CONNECT_WAIT_TIMEOUT_SECONDS = 180
+_LOCAL_DASHBOARD_SESSION_REFRESH_GRACE_SECONDS = 7 * 24 * 60 * 60
 
 
 class _HookPathValidationError(ValueError):
@@ -2693,7 +2694,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError as error:
             self._write_json({"error": str(error)}, status=400)
             return
-        response["auth_token"] = self.server.auth_token  # type: ignore[attr-defined]
+        refreshed_session_token = self._refresh_dashboard_session_token(surface=surface)
+        if refreshed_session_token is not None:
+            response["dashboard_session_token"] = refreshed_session_token
         self._write_json(response)
 
     def _handle_client_attach(self, payload: dict[str, object]) -> None:
@@ -3081,29 +3084,71 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         return any(self._dashboard_session_token_matches(candidate, payload=payload) for candidate in candidates)
 
     def _dashboard_session_token_matches(self, token: str, *, payload: dict[str, object] | None = None) -> bool:
-        if not token.startswith("gld1."):
-            return False
-        parts = token.split(".")
-        if len(parts) != 3:
-            return False
-        prefix, encoded_payload, signature = parts
-        if prefix != "gld1" or not encoded_payload or not signature:
-            return False
-        expected = _dashboard_session_signature(encoded_payload, self.server.auth_token)  # type: ignore[attr-defined]
-        if not secrets.compare_digest(signature, expected):
-            return False
-        claims = _decode_dashboard_session_payload(encoded_payload)
-        if self._optional_string(claims.get("aud")) != LOCAL_DASHBOARD_SESSION_AUDIENCE:
-            return False
-        expires_at = claims.get("expires_at")
-        if not isinstance(expires_at, str):
-            return False
-        try:
-            if _parse_iso_timestamp(expires_at) <= time.time():
-                return False
-        except ValueError:
+        claims = self._dashboard_session_token_claims(token)
+        if claims is None:
             return False
         return self._dashboard_session_claims_authorize_request(claims, payload=payload)
+
+    def _dashboard_session_token_claims(
+        self,
+        token: str,
+        *,
+        allow_expired_within_seconds: float = 0.0,
+    ) -> dict[str, object] | None:
+        if not token.startswith("gld1."):
+            return None
+        parts = token.split(".")
+        if len(parts) != 3:
+            return None
+        prefix, encoded_payload, signature = parts
+        if prefix != "gld1" or not encoded_payload or not signature:
+            return None
+        expected = _dashboard_session_signature(encoded_payload, self.server.auth_token)  # type: ignore[attr-defined]
+        if not secrets.compare_digest(signature, expected):
+            return None
+        claims = _decode_dashboard_session_payload(encoded_payload)
+        if self._optional_string(claims.get("aud")) != LOCAL_DASHBOARD_SESSION_AUDIENCE:
+            return None
+        expires_at = claims.get("expires_at")
+        if not isinstance(expires_at, str):
+            return None
+        try:
+            expires_at_timestamp = _parse_iso_timestamp(expires_at)
+        except ValueError:
+            return None
+        if expires_at_timestamp + max(0.0, allow_expired_within_seconds) <= time.time():
+            return None
+        return claims
+
+    def _refresh_dashboard_session_token(self, *, surface: str) -> str | None:
+        if self._refreshable_dashboard_session_claims() is None:
+            return None
+        refreshed_surface = surface if surface in {"approval-center", "dashboard", "cloud-dashboard"} else "dashboard"
+        return build_local_dashboard_session_token(
+            auth_token=self.server.auth_token,  # type: ignore[attr-defined]
+            surface=refreshed_surface,
+        )
+
+    def _refreshable_dashboard_session_claims(self) -> dict[str, object] | None:
+        session_token = self.headers.get("X-Guard-Dashboard-Session")
+        authorization = self.headers.get("Authorization")
+        bearer_token = None
+        if isinstance(authorization, str) and authorization.lower().startswith("bearer "):
+            bearer_token = authorization[7:].strip()
+        candidates = [
+            candidate for candidate in (session_token, bearer_token) if isinstance(candidate, str) and candidate.strip()
+        ]
+        for candidate in candidates:
+            claims = self._dashboard_session_token_claims(
+                candidate,
+                allow_expired_within_seconds=_LOCAL_DASHBOARD_SESSION_REFRESH_GRACE_SECONDS,
+            )
+            if claims is None:
+                continue
+            surface = self._optional_string(claims.get("surface"))
+            if surface in {"approval-center", "dashboard", "cloud-dashboard"}:
+                return claims
+        return None
 
     def _dashboard_session_claims_authorize_request(
         self,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2693,6 +2693,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError as error:
             self._write_json({"error": str(error)}, status=400)
             return
+        response["auth_token"] = self.server.auth_token  # type: ignore[attr-defined]
         self._write_json(response)
 
     def _handle_client_attach(self, payload: dict[str, object]) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12703,6 +12703,7 @@ function getDemoDiff(artifactId, harness) {
 }
 const GUARD_TOKEN_PARAM = "guard-token";
 const GUARD_DAEMON_PARAM = "guardDaemon";
+const GUARD_SURFACE_PROTOCOL_VERSIONS = ["1.1", "1.0"];
 let guardTokenOverride = null;
 let guardTokenLocationKey = null;
 async function readJson(input, init) {
@@ -12768,6 +12769,10 @@ function readGuardToken() {
   }
   return window.sessionStorage.getItem(GUARD_TOKEN_PARAM);
 }
+function saveGuardToken(guardToken) {
+  guardTokenOverride = guardToken;
+  window.sessionStorage.setItem(GUARD_TOKEN_PARAM, guardToken);
+}
 function readGuardDaemonOrigin() {
   const rawDaemonUrl = guardParam(GUARD_DAEMON_PARAM);
   if (rawDaemonUrl) {
@@ -12817,7 +12822,17 @@ function withGuardAuthForToken(init, guardToken) {
 }
 async function fetchWithGuardAuth(input, init) {
   const requestInput = guardApiInput(input);
-  return fetch(requestInput, withGuardAuth(init));
+  const guardToken = readGuardToken();
+  const response = await fetch(requestInput, withGuardAuthForToken(init, guardToken));
+  if (response.status !== 401 || !guardToken || input instanceof Request) {
+    return response;
+  }
+  const refreshedGuardToken = await refreshGuardDashboardSession(guardToken);
+  if (!refreshedGuardToken || refreshedGuardToken === guardToken) {
+    return response;
+  }
+  saveGuardToken(refreshedGuardToken);
+  return fetch(requestInput, withGuardAuthForToken(init, refreshedGuardToken));
 }
 function guardAuthHeaders() {
   const guardToken = readGuardToken();
@@ -12825,6 +12840,35 @@ function guardAuthHeaders() {
 }
 function guardAuthHeadersForToken(guardToken) {
   return guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {};
+}
+function parseDashboardSessionToken(payload) {
+  if (!isRecord(payload)) {
+    return null;
+  }
+  const dashboardSessionToken = payload["dashboard_session_token"];
+  return typeof dashboardSessionToken === "string" && dashboardSessionToken.trim() ? dashboardSessionToken : null;
+}
+async function refreshGuardDashboardSession(guardToken) {
+  try {
+    const response = await fetch(guardApiInput("/v1/initialize"), {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...guardAuthHeadersForToken(guardToken)
+      },
+      body: JSON.stringify({
+        client_name: "guard-dashboard-web",
+        surface: "dashboard",
+        supported_protocol_versions: [...GUARD_SURFACE_PROTOCOL_VERSIONS]
+      })
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return parseDashboardSessionToken(await response.json());
+  } catch {
+    return null;
+  }
 }
 function guardAwareHref(href) {
   const guardToken = readGuardToken();

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1583,10 +1583,60 @@ class TestGuardSurfaceServer:
         assert initialize_payload["protocol"]["current_version"] == "1.1"
         assert initialize_payload["protocol"]["minimum_version"] == "1.0"
         assert initialize_payload["protocol"]["supported_versions"] == ["1.1", "1.0"]
-        assert isinstance(initialize_payload["auth_token"], str)
-        assert initialize_payload["auth_token"]
+        assert "auth_token" not in initialize_payload
+        assert "dashboard_session_token" not in initialize_payload
         assert unsupported_error is not None
         assert unsupported_error.code == 400
+
+    def test_initialize_refreshes_signed_dashboard_session_without_exposing_root_token(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        original_time = time.time()
+        stale_session_token = build_local_dashboard_session_token(
+            auth_token=daemon._server.auth_token,
+            surface="approval-center",
+            expires_in_seconds=1,
+        )
+        monkeypatch.setattr(daemon_server_module.time, "time", lambda: original_time + 5)
+
+        try:
+            initialize_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/initialize",
+                data=json.dumps(
+                    {
+                        "client_name": "guard-dashboard-web",
+                        "surface": "dashboard",
+                        "supported_protocol_versions": ["1.0", "1.1"],
+                    }
+                ).encode("utf-8"),
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Guard-Dashboard-Session": stale_session_token,
+                },
+                method="POST",
+            )
+            with urllib.request.urlopen(initialize_request, timeout=5) as response:
+                initialize_payload = json.loads(response.read().decode("utf-8"))
+            refreshed_token = initialize_payload["dashboard_session_token"]
+            with urllib.request.urlopen(
+                _guard_dashboard_session_get_request(daemon.port, "/v1/settings", refreshed_token),
+                timeout=5,
+            ) as settings_response:
+                settings_payload = json.loads(settings_response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert isinstance(refreshed_token, str)
+        assert refreshed_token
+        assert refreshed_token != stale_session_token
+        assert "auth_token" not in initialize_payload
+        assert settings_payload["guard_home"] == str(tmp_path / "guard-home")
 
     def test_surface_runtime_persists_sessions_operations_and_items(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
@@ -1786,8 +1836,7 @@ class TestGuardSurfaceServer:
             daemon.stop()
 
         assert initialize_payload["protocol_version"] == "1.1"
-        assert isinstance(initialize_payload["auth_token"], str)
-        assert initialize_payload["auth_token"]
+        assert "auth_token" not in initialize_payload
         assert "approval/list" in initialize_payload["server_capabilities"]["methods"]
         assert attach_payload["attached"] is True
         assert store.list_guard_client_attachments(surface="approval-center")

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1583,7 +1583,8 @@ class TestGuardSurfaceServer:
         assert initialize_payload["protocol"]["current_version"] == "1.1"
         assert initialize_payload["protocol"]["minimum_version"] == "1.0"
         assert initialize_payload["protocol"]["supported_versions"] == ["1.1", "1.0"]
-        assert "auth_token" not in initialize_payload
+        assert isinstance(initialize_payload["auth_token"], str)
+        assert initialize_payload["auth_token"]
         assert unsupported_error is not None
         assert unsupported_error.code == 400
 
@@ -1785,6 +1786,8 @@ class TestGuardSurfaceServer:
             daemon.stop()
 
         assert initialize_payload["protocol_version"] == "1.1"
+        assert isinstance(initialize_payload["auth_token"], str)
+        assert initialize_payload["auth_token"]
         assert "approval/list" in initialize_payload["server_capabilities"]["methods"]
         assert attach_payload["attached"] is True
         assert store.list_guard_client_attachments(surface="approval-center")


### PR DESCRIPTION
## Summary
- renew stale signed dashboard sessions on `401` instead of exposing daemon root auth from `/v1/initialize`
- return fresh `dashboard_session_token` only when initialize receives a refreshable signed dashboard session
- cover secure refresh path in daemon and dashboard tests, then rebuild dashboard static bundle

## Testing
- `uv run --extra dev python -m pytest -q tests/test_guard_surface_server.py -k 'surface_server_contract_is_exposed_during_initialize or initialize_refreshes_signed_dashboard_session_without_exposing_root_token or guard_daemon_initializes_surface_client_and_tracks_attachments'`
- `pnpm exec tsx src/guard-api.test.ts`
- `uv run --extra dev ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py`
- `pnpm run build`

## Notes
- live local browser proof against daemon on `127.0.0.1:5474` confirmed `/settings` and `/v1/requests?status=pending&limit=200` recover from stale signed dashboard sessions via `401 -> /v1/initialize -> 200 retry`
