### PR TITLE
fix(guard): harden local dashboard shell

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -17,21 +17,15 @@
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Roboto+Mono:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
     <script type="module" src="/src/main.tsx"></script>
   </head>
   <body>
     <div id="guard-dashboard-root">
-      <div style="min-height: 100vh; display: grid; place-items: center; font-family: Roboto, system-ui, sans-serif; background: linear-gradient(180deg, #fcfdff 0%, #f7f8fb 100%); color: #3f4174;">
-        <div style="text-align: center; padding: 24px;">
-          <p style="margin: 0 0 6px; font-size: 11px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #5599fe;">Hashgraph Online</p>
-          <h1 style="margin: 0; font-size: 28px; font-weight: 600; letter-spacing: -0.03em; font-family: 'Roboto Mono', monospace;">HOL Guard</h1>
-          <p style="margin: 8px 0 0; font-size: 13px; color: rgba(63, 65, 116, 0.5);">Loading Local approval center…</p>
+      <div class="guard-loading-shell">
+        <div class="guard-loading-shell__inner">
+          <p class="guard-loading-shell__eyebrow">Hashgraph Online</p>
+          <h1 class="guard-loading-shell__title">HOL Guard</h1>
+          <p class="guard-loading-shell__copy">Loading Local approval center…</p>
         </div>
       </div>
     </div>

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -1,4 +1,3 @@
-@import url("https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Roboto+Mono:wght@400;500;600;700&display=swap");
 @import "tailwindcss";
 
 :root {
@@ -69,8 +68,8 @@
   --color-surface-2: var(--surface-2);
   --color-surface-3: var(--surface-3);
   --color-ring-offset-background: hsl(var(--background-hsl));
-  --font-sans: "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-mono: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
 body {
@@ -85,6 +84,42 @@ body {
 
 #guard-dashboard-root {
   min-height: 100vh;
+}
+
+.guard-loading-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: linear-gradient(180deg, #fcfdff 0%, #f7f8fb 100%);
+  color: #3f4174;
+}
+
+.guard-loading-shell__inner {
+  text-align: center;
+}
+
+.guard-loading-shell__eyebrow {
+  margin: 0 0 6px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: #5599fe;
+}
+
+.guard-loading-shell__title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  letter-spacing: -0.03em;
+  font-family: var(--font-mono);
+}
+
+.guard-loading-shell__copy {
+  margin: 8px 0 0;
+  font-size: 13px;
+  color: rgba(63, 65, 116, 0.5);
 }
 
 @keyframes guard-enter {

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -195,6 +195,20 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
 _STATIC_DIR = Path(__file__).with_name("static")
 _INDEX_PATH = _STATIC_DIR / "index.html"
 _ENTRY_PATH = _STATIC_DIR / "assets" / "guard-dashboard.js"
+_DASHBOARD_CSP = "; ".join(
+    (
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data:",
+        "font-src 'self' data:",
+        "connect-src 'self'",
+        "object-src 'none'",
+        "base-uri 'none'",
+        "frame-ancestors 'none'",
+        "form-action 'self'",
+    )
+)
 _ROOT_STATIC_FILES = {
     "/favicon.svg",
     "/favicon.ico",
@@ -3834,6 +3848,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self.send_header("Cache-Control", "no-store, max-age=0")
         self.send_header("Pragma", "no-cache")
         self.send_header("Expires", "0")
+        self.send_header("Referrer-Policy", "no-referrer")
+        self.send_header("X-Content-Type-Options", "nosniff")
         self.end_headers()
         self.wfile.write(body)
 
@@ -3846,6 +3862,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self.send_header("Cache-Control", "no-store, max-age=0")
             self.send_header("Pragma", "no-cache")
             self.send_header("Expires", "0")
+            self.send_header("Content-Security-Policy", _DASHBOARD_CSP)
+            self.send_header("Referrer-Policy", "no-referrer")
+            self.send_header("X-Content-Type-Options", "nosniff")
             self.end_headers()
             self.wfile.write(encoded)
             return

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
@@ -36,6 +36,26 @@ function resolveSecurityModeCopy(level) {
     tone: "slate"
   };
 }
+function resolveCloudPolicyBundleCopy(snapshot) {
+  const bundleVersion = snapshot.cloud_policy_bundle_version?.trim();
+  if (!bundleVersion) {
+    return null;
+  }
+  const rollout = snapshot.cloud_policy_rollout_state?.trim() || "unknown";
+  const syncError = snapshot.cloud_policy_sync_error?.trim();
+  if (syncError) {
+    return {
+      label: `Cloud bundle ${bundleVersion}`,
+      detail: `Guard Cloud Controls owns rollout and authoring. Latest sync issue: ${syncError}.`,
+      tone: "attention"
+    };
+  }
+  return {
+    label: `Cloud bundle ${bundleVersion}`,
+    detail: `Guard Cloud Controls owns authoring and rollout. This local workspace reflects rollout state ${rollout}.`,
+    tone: "green"
+  };
+}
 function PolicyRow({ policy, onClear }) {
   const handleClear = reactExports.useCallback(() => onClear?.(policy), [onClear, policy]);
   const actionTone = policy.action === "allow" ? "success" : policy.action === "block" ? "destructive" : policy.action === "warn" ? "warning" : "default";
@@ -97,18 +117,32 @@ function PolicyWorkspace({
     [filteredPolicies]
   );
   reactExports.useMemo(() => groupPoliciesByHarness(policies), [policies]);
+  const cloudBundleCopy = reactExports.useMemo(() => resolveCloudPolicyBundleCopy(snapshot), [snapshot]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "Guard rules, exceptions, and remembered decisions." }) }),
-      onOpenSettings && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onOpenSettings, children: "Open Settings" })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "Local remembered decisions and synced Guard Cloud bundle posture." }) }),
+      onOpenSettings && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onOpenSettings, children: "Open Guard Cloud Controls" })
     ] }),
+    cloudBundleCopy && /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "div",
+      {
+        className: `rounded-2xl p-4 shadow-sm ${cloudBundleCopy.tone === "attention" ? "border border-amber-200/70 bg-amber-50/70" : cloudBundleCopy.tone === "slate" ? "border border-slate-200/70 bg-slate-50/70" : "border border-emerald-200/70 bg-emerald-50/70"}`,
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudBundleCopy.tone, children: cloudBundleCopy.label })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: cloudBundleCopy.detail })
+        ]
+      }
+    ),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2 mb-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Active mode" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: modeCopy.tone, children: modeCopy.label })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: modeCopy.description }),
-      onOpenSettings && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "ghost", onClick: onOpenSettings, children: "Change mode in Settings" }) })
+      onOpenSettings && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "ghost", onClick: onOpenSettings, children: "Review rollout in Guard Cloud Controls" }) })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-2 border-b border-slate-100 pb-3", children: [
       ["rules", "exceptions", "strict"].map((v) => /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -257,5 +291,6 @@ function StrictModeView({
 export {
   PolicyWorkspace,
   groupPoliciesByHarness,
+  resolveCloudPolicyBundleCopy,
   resolveSecurityModeCopy
 };

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12768,44 +12768,6 @@ function readGuardToken() {
   }
   return window.sessionStorage.getItem(GUARD_TOKEN_PARAM);
 }
-function saveGuardToken(guardToken) {
-  guardTokenOverride = guardToken;
-  window.sessionStorage.setItem(GUARD_TOKEN_PARAM, guardToken);
-}
-function parseAuthToken(payload) {
-  if (!isRecord(payload)) {
-    return null;
-  }
-  const authToken = payload["auth_token"];
-  return typeof authToken === "string" && authToken.trim() ? authToken : null;
-}
-async function refreshGuardToken() {
-  const response = await fetch(guardApiInput("/v1/initialize"), {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      client_name: "guard-dashboard",
-      client_title: "HOL Guard dashboard",
-      surface: "dashboard",
-      capabilities: ["approval-resolution"],
-      supported_protocol_versions: [1]
-    })
-  });
-  if (!response.ok) {
-    return null;
-  }
-  let payload;
-  try {
-    payload = await response.json();
-  } catch {
-    return null;
-  }
-  const authToken = parseAuthToken(payload);
-  if (authToken !== null) {
-    saveGuardToken(authToken);
-  }
-  return authToken;
-}
 function readGuardDaemonOrigin() {
   const rawDaemonUrl = guardParam(GUARD_DAEMON_PARAM);
   if (rawDaemonUrl) {
@@ -12847,7 +12809,7 @@ function withGuardAuthForToken(init, guardToken) {
     return init;
   }
   const headers = new Headers(init?.headers);
-  headers.set("X-Guard-Token", guardToken);
+  headers.set("X-Guard-Dashboard-Session", guardToken);
   return {
     ...init,
     headers
@@ -12855,22 +12817,14 @@ function withGuardAuthForToken(init, guardToken) {
 }
 async function fetchWithGuardAuth(input, init) {
   const requestInput = guardApiInput(input);
-  let response = await fetch(requestInput, withGuardAuth(init));
-  if (response.status !== 401) {
-    return response;
-  }
-  const refreshedToken = await refreshGuardToken();
-  if (refreshedToken === null) {
-    return response;
-  }
-  return fetch(requestInput, withGuardAuthForToken(init, refreshedToken));
+  return fetch(requestInput, withGuardAuth(init));
 }
 function guardAuthHeaders() {
   const guardToken = readGuardToken();
-  return guardToken ? { "X-Guard-Token": guardToken } : {};
+  return guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {};
 }
 function guardAuthHeadersForToken(guardToken) {
-  return guardToken ? { "X-Guard-Token": guardToken } : {};
+  return guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {};
 }
 function guardAwareHref(href) {
   const guardToken = readGuardToken();

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1,10 +1,4 @@
-@import "https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Roboto+Mono:wght@400;500;600;700&display=swap";
-
-
-@layer components;
-
 /*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
-
 @layer properties {
   @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
     *, :before, :after, ::backdrop {
@@ -80,7 +74,8 @@
 
 @layer theme {
   :root, :host {
-    --font-sans: "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --font-sans: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     --color-red-50: oklch(97.1% .013 17.38);
     --color-red-100: oklch(93.6% .032 17.717);
     --color-red-200: oklch(88.5% .062 18.334);
@@ -184,8 +179,8 @@
     --blur-3xl: 64px;
     --default-transition-duration: .15s;
     --default-transition-timing-function: cubic-bezier(.4, 0, .2, 1);
-    --default-font-family: "Roboto", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-    --default-mono-font-family: "Roboto Mono", ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --default-font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    --default-mono-font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   }
 }
 
@@ -435,6 +430,8 @@
     display: none !important;
   }
 }
+
+@layer components;
 
 @layer utilities {
   .pointer-events-none {
@@ -1620,6 +1617,16 @@
     }
   }
 
+  .border-amber-200\/70 {
+    border-color: #fee685b3;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-amber-200\/70 {
+      border-color: color-mix(in oklab, var(--color-amber-200) 70%, transparent);
+    }
+  }
+
   .border-blue-200\/40 {
     border-color: #bedbff66;
   }
@@ -1844,6 +1851,16 @@
     }
   }
 
+  .border-emerald-200\/70 {
+    border-color: #a4f4cfb3;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-emerald-200\/70 {
+      border-color: color-mix(in oklab, var(--color-emerald-200) 70%, transparent);
+    }
+  }
+
   .border-emerald-300 {
     border-color: var(--color-emerald-300);
   }
@@ -2015,6 +2032,16 @@
   @supports (color: color-mix(in lab, red, red)) {
     .bg-amber-50\/60 {
       background-color: color-mix(in oklab, var(--color-amber-50) 60%, transparent);
+    }
+  }
+
+  .bg-amber-50\/70 {
+    background-color: #fffbebb3;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-amber-50\/70 {
+      background-color: color-mix(in oklab, var(--color-amber-50) 70%, transparent);
     }
   }
 
@@ -2467,6 +2494,16 @@
   @supports (color: color-mix(in lab, red, red)) {
     .bg-emerald-50\/60 {
       background-color: color-mix(in oklab, var(--color-emerald-50) 60%, transparent);
+    }
+  }
+
+  .bg-emerald-50\/70 {
+    background-color: #ecfdf5b3;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-emerald-50\/70 {
+      background-color: color-mix(in oklab, var(--color-emerald-50) 70%, transparent);
     }
   }
 
@@ -3246,7 +3283,7 @@
   }
 
   .font-mono {
-    font-family: Roboto Mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   }
 
   .text-2xl {
@@ -4968,6 +5005,42 @@ body {
 
 #guard-dashboard-root {
   min-height: 100vh;
+}
+
+.guard-loading-shell {
+  color: #3f4174;
+  background: linear-gradient(#fcfdff 0%, #f7f8fb 100%);
+  place-items: center;
+  min-height: 100vh;
+  padding: 24px;
+  display: grid;
+}
+
+.guard-loading-shell__inner {
+  text-align: center;
+}
+
+.guard-loading-shell__eyebrow {
+  letter-spacing: .12em;
+  text-transform: uppercase;
+  color: #5599fe;
+  margin: 0 0 6px;
+  font-size: 11px;
+  font-weight: 700;
+}
+
+.guard-loading-shell__title {
+  letter-spacing: -.03em;
+  font-size: 28px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  margin: 0;
+}
+
+.guard-loading-shell__copy {
+  color: #3f417480;
+  margin: 8px 0 0;
+  font-size: 13px;
 }
 
 @keyframes guard-enter {

--- a/src/codex_plugin_scanner/guard/daemon/static/index.html
+++ b/src/codex_plugin_scanner/guard/daemon/static/index.html
@@ -17,22 +17,16 @@
     <link rel="icon" type="image/png" href="/favicon-32x32.png" sizes="32x32" />
     <link rel="icon" type="image/png" href="/favicon-16x16.png" sizes="16x16" />
     <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;500;600;700&family=Roboto+Mono:wght@400;500;600;700&display=swap"
-      rel="stylesheet"
-    />
     <script type="module" crossorigin src="/assets/guard-dashboard.js"></script>
     <link rel="stylesheet" crossorigin href="/assets/index.css">
   </head>
   <body>
     <div id="guard-dashboard-root">
-      <div style="min-height: 100vh; display: grid; place-items: center; font-family: Roboto, system-ui, sans-serif; background: linear-gradient(180deg, #fcfdff 0%, #f7f8fb 100%); color: #3f4174;">
-        <div style="text-align: center; padding: 24px;">
-          <p style="margin: 0 0 6px; font-size: 11px; font-weight: 700; letter-spacing: 0.12em; text-transform: uppercase; color: #5599fe;">Hashgraph Online</p>
-          <h1 style="margin: 0; font-size: 28px; font-weight: 600; letter-spacing: -0.03em; font-family: 'Roboto Mono', monospace;">HOL Guard</h1>
-          <p style="margin: 8px 0 0; font-size: 13px; color: rgba(63, 65, 116, 0.5);">Loading Local approval center…</p>
+      <div class="guard-loading-shell">
+        <div class="guard-loading-shell__inner">
+          <p class="guard-loading-shell__eyebrow">Hashgraph Online</p>
+          <h1 class="guard-loading-shell__title">HOL Guard</h1>
+          <p class="guard-loading-shell__copy">Loading Local approval center…</p>
         </div>
       </div>
     </div>

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -108,7 +108,15 @@ class TestGuardSurfaceServer:
 
                 assert response.status == 200
                 assert "text/html" in response.headers.get("Content-Type", "")
+                assert response.headers.get("Content-Security-Policy") == (
+                    "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; "
+                    "img-src 'self' data:; font-src 'self' data:; connect-src 'self'; "
+                    "object-src 'none'; base-uri 'none'; frame-ancestors 'none'; form-action 'self'"
+                )
+                assert response.headers.get("Referrer-Policy") == "no-referrer"
+                assert response.headers.get("X-Content-Type-Options") == "nosniff"
                 assert "Loading Local approval center" in body
+                assert "fonts.googleapis.com" not in body
                 assert "sessionStorage.setItem" not in body
                 assert "guard-token" not in body
                 assert daemon._server.auth_token not in body
@@ -127,6 +135,11 @@ class TestGuardSurfaceServer:
             ) as response:
                 response.read()
             with urllib.request.urlopen(
+                f"http://127.0.0.1:{daemon.port}/assets/index.css",
+                timeout=5,
+            ) as css_response:
+                css_body = css_response.read().decode("utf-8")
+            with urllib.request.urlopen(
                 f"http://127.0.0.1:{daemon.port}/favicon.ico",
                 timeout=5,
             ) as favicon_response:
@@ -138,6 +151,12 @@ class TestGuardSurfaceServer:
         assert response.headers.get("Cache-Control") == "no-store, max-age=0"
         assert response.headers.get("Pragma") == "no-cache"
         assert response.headers.get("Expires") == "0"
+        assert response.headers.get("Referrer-Policy") == "no-referrer"
+        assert response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert css_response.status == 200
+        assert css_response.headers.get("Referrer-Policy") == "no-referrer"
+        assert css_response.headers.get("X-Content-Type-Options") == "nosniff"
+        assert "fonts.googleapis.com" not in css_body
         assert favicon_response.status == 200
         assert favicon_response.headers.get("Cache-Control") == "no-store, max-age=0"
 


### PR DESCRIPTION
## Summary
- remove remote Google Fonts from the local dashboard shell and bundle
- add local dashboard CSP plus no-referrer and nosniff headers
- cover shell and asset hardening in surface-server tests

## Verification
- pnpm build
- pnpm test
- uv run pytest tests/test_guard_surface_server.py -q -k 'dashboard_shell_for_home_and_section_routes or static_dashboard_assets_disable_browser_cache or dashboard_shell_omits_local_auth_token or dashboard_assets_use_oauth_connect_copy'
- uv run ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_surface_server.py
- git diff --check