### PR TITLE
fix(guard): pin OpenCode pretool import path

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -14,6 +14,15 @@ _INTERCEPT_TOOLS = ("bash", "shell", "sh", "zsh", "terminal")
 _PLUGIN_TEMPLATE = """// Managed by HOL Guard. Re-run `hol-guard install opencode` after moving Guard home.
 const GUARD_HOME = __GUARD_HOME__;
 const GUARD_PYTHON = __GUARD_PYTHON__;
+const TRUSTED_PACKAGE_ROOT = __TRUSTED_PACKAGE_ROOT__;
+const GUARD_LAUNCHER =
+  "import os,sys;" +
+  "trusted_root=sys.argv.pop(1);" +
+  "cwd=os.getcwd();" +
+  "blocked=('','.',os.curdir,cwd,trusted_root);" +
+  "sys.path=[trusted_root,*[entry for entry in sys.path if entry not in blocked]];" +
+  "from codex_plugin_scanner.cli import main;" +
+  "raise SystemExit(main(sys.argv[1:]))";
 const INTERCEPT_TOOLS = new Set(__INTERCEPT_TOOLS__);
 
 async function runGuardHook(directory: string, payload: Record<string, unknown>) {
@@ -21,8 +30,9 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
   const proc = Bun.spawn(
     [
       GUARD_PYTHON,
-      "-m",
-      "codex_plugin_scanner.cli",
+      "-c",
+      GUARD_LAUNCHER,
+      TRUSTED_PACKAGE_ROOT,
       "guard",
       "hook",
       "--guard-home",
@@ -130,6 +140,7 @@ def pretool_plugin_source(context: HarnessContext) -> str:
     return (
         _PLUGIN_TEMPLATE.replace("__GUARD_HOME__", json.dumps(str(context.guard_home.resolve())))
         .replace("__GUARD_PYTHON__", json.dumps(str(Path(sys.executable).resolve())))
+        .replace("__TRUSTED_PACKAGE_ROOT__", json.dumps(str(Path(__file__).resolve().parents[3])))
         .replace("__INTERCEPT_TOOLS__", json.dumps(list(_INTERCEPT_TOOLS)))
     )
 

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -40,6 +40,10 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     assert "stdoutPromise" in source
     assert "try {" in source
     assert 'source_scope: directory?.trim() ? "project" : "global"' in source
+    assert '"-c"' in source
+    assert '"-m"' not in source
+    assert "TRUSTED_PACKAGE_ROOT" in source
+    assert "sys.path=[trusted_root" in source
     assert "codex_plugin_scanner.cli" in source
     assert "guard" in source
 


### PR DESCRIPTION
### Motivation
- The OpenCode pretool plugin previously launched the Guard CLI with `python -m codex_plugin_scanner.cli` and set the subprocess `cwd` to the workspace, allowing an attacker-controlled repository to shadow the installed Guard package on `sys.path` and execute arbitrary code before review. 
- The change aims to fail-closed on this import-shadowing vector by ensuring the subprocess imports Guard from a pinned, trusted package root instead of relying on the untrusted workspace. 

### Description
- Replace the generated `python -m codex_plugin_scanner.cli` invocation with an inline, trusted Python launcher executed via `-c` that sanitizes `sys.path` and imports the CLI from a pinned trusted package root. 
- Embed `TRUSTED_PACKAGE_ROOT` into the generated OpenCode plugin source and pass it to the inline launcher so the Guard package root is prepended and the workspace cannot shadow imports. 
- Keep the subprocess working directory set to the OpenCode workspace to preserve behavior while changing only how the Guard CLI is imported. 
- Update tests to assert the generated plugin uses `-c` (and not `-m`), includes `TRUSTED_PACKAGE_ROOT`, and contains the `sys.path` sanitization snippet. 

### Testing
- The modified files successfully compile with `python -m compileall -q src/codex_plugin_scanner/guard/adapters/opencode_pretool.py tests/test_opencode_pretool.py`. 
- Static checks passed with `ruff check src/codex_plugin_scanner/guard/adapters/opencode_pretool.py tests/test_opencode_pretool.py`. 
- Running `pytest -q tests/test_opencode_pretool.py` in the base interpreter could not be completed because the `cryptography` dependency was not installed in the environment. 
- Attempts to run the test suite via `uv run pytest -q` failed to fetch external dependencies from PyPI due to network/tunnel errors, so full integration test runs could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20fa56bdac832d874003ee4a12301a)