### PR TITLE
fix(guard): migrate git pipx installs to PyPI when releases are newer

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1262,6 +1262,11 @@ def _render_update(console: Console, payload: dict[str, object]) -> None:
     if isinstance(command, list) and command:
         body.add_row("Command", " ".join(str(part) for part in command))
     body.add_row("Dry run", _bool_label(bool(payload.get("dry_run"))))
+    version_check = payload.get("version_check")
+    if isinstance(version_check, dict):
+        latest_version = version_check.get("latest_version")
+        if isinstance(latest_version, str) and latest_version.strip():
+            body.add_row("Latest PyPI version", latest_version.strip())
     if payload.get("resulting_version"):
         body.add_row("Resulting version", str(payload.get("resulting_version")))
     if payload.get("editable_install") is not None:
@@ -1274,6 +1279,7 @@ def _render_update(console: Console, payload: dict[str, object]) -> None:
     border_style = {
         "planned": "blue",
         "current": "blue",
+        "stale": "yellow",
         "updated": "green",
         "skipped": "yellow",
         "failed": "red",

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -16,6 +16,7 @@ import sysconfig
 import urllib.error
 import urllib.request
 from pathlib import Path
+from urllib.parse import unquote, urlparse
 
 from packaging.version import InvalidVersion, Version
 
@@ -43,7 +44,20 @@ def run_guard_update(
 ) -> tuple[dict[str, object], int]:
     current_version = _current_version()
     installer = _installer_kind()
-    command = _update_command(installer)
+    direct_url = _direct_url_payload()
+    local_source_install = _local_source_install_payload(direct_url)
+    vcs_install = _vcs_install_payload(direct_url)
+    version_check = _version_check_payload(current_version)
+    use_pypi = _should_upgrade_from_pypi(
+        version_check=version_check,
+        vcs_install=vcs_install,
+        local_source_install=local_source_install,
+    )
+    command = _update_command(
+        installer,
+        use_pypi=use_pypi,
+        local_source_install=local_source_install,
+    )
     payload: dict[str, object] = {
         "current_version": current_version,
         "installer": installer,
@@ -51,12 +65,18 @@ def run_guard_update(
         "retry_command": _shell_command(command),
         "binary_diagnostics": _binary_diagnostics(command, installer),
         "dry_run": dry_run,
+        "version_check": version_check,
     }
-    direct_url = _direct_url_payload()
     if direct_url is not None:
         payload["direct_url"] = direct_url
         is_editable = bool(direct_url.get("dir_info", {}).get("editable"))
         payload["editable_install"] = is_editable
+        if local_source_install is not None:
+            payload["source_install"] = local_source_install
+        if vcs_install is not None:
+            payload["vcs_install"] = vcs_install
+        if use_pypi:
+            payload["upgrade_source"] = "pypi"
         if is_editable:
             payload["status"] = "skipped"
             payload["changed"] = False
@@ -64,11 +84,19 @@ def run_guard_update(
                 "Automatic update is disabled for editable installs. Re-run your local install workflow instead."
             )
             return payload, 0
+        if local_source_install is not None and bool(local_source_install.get("path_exists")):
+            payload["status"] = "skipped"
+            payload["changed"] = False
+            payload["error"] = (
+                "Automatic update is disabled for local source installs. Re-run your local install workflow instead."
+            )
+            return payload, 0
+        if local_source_install is not None and not bool(local_source_install.get("path_exists")):
+            payload["recovery_source_install"] = True
     if dry_run:
-        payload["version_check"] = _version_check_payload(current_version)
         payload["status"] = "planned"
         payload["changed"] = False
-        payload["message"] = "Review the planned installer command before updating."
+        payload["message"] = _planned_update_message(version_check=version_check, use_pypi=use_pypi)
         return payload, 0
     try:
         result = subprocess.run(
@@ -93,12 +121,15 @@ def run_guard_update(
         payload["changed"] = False
         payload["message"] = "HOL Guard update failed."
         return payload, 1
+    payload["version_check"] = _version_check_payload(str(payload.get("resulting_version") or current_version))
     payload["status"] = _success_status(payload)
     payload["changed"] = payload["status"] == "updated"
     payload["message"] = _success_message(
         status=str(payload["status"]),
         current_version=current_version,
         resulting_version=str(payload.get("resulting_version") or ""),
+        version_check=payload.get("version_check"),
+        retry_command=str(payload.get("retry_command") or ""),
     )
     notes = _success_notes(payload)
     if notes:
@@ -187,6 +218,10 @@ def _success_status(payload: dict[str, object]) -> str:
         and current_version != resulting_version
     ):
         return "updated"
+    version_check = payload.get("version_check")
+    if isinstance(version_check, dict) and version_check.get("update_available") is True:
+        if payload.get("vcs_install") is not None or payload.get("upgrade_source") == "pypi":
+            return "stale"
     output_text = str(payload.get("stdout") or "").lower()
     if any(hint in output_text for hint in _ALREADY_CURRENT_HINTS):
         return "current"
@@ -195,9 +230,35 @@ def _success_status(payload: dict[str, object]) -> str:
     return "updated"
 
 
-def _success_message(*, status: str, current_version: str, resulting_version: str) -> str:
+def _success_message(
+    *,
+    status: str,
+    current_version: str,
+    resulting_version: str,
+    version_check: object = None,
+    retry_command: str = "",
+) -> str:
+    if status == "stale":
+        latest_version = None
+        if isinstance(version_check, dict):
+            latest = version_check.get("latest_version")
+            if isinstance(latest, str) and latest.strip():
+                latest_version = latest.strip()
+        installed_version = resulting_version or current_version
+        if latest_version and installed_version not in {"", "unknown"}:
+            message = (
+                f"HOL Guard {installed_version} is behind PyPI {latest_version}. "
+                "The installed package source is not tracking PyPI releases."
+            )
+        else:
+            message = "HOL Guard is behind the latest PyPI release."
+        if retry_command:
+            return f"{message} Run: {retry_command}"
+        return message
     if status == "current":
         return "HOL Guard is already current."
+    if status == "updated" and current_version == resulting_version:
+        return "HOL Guard source was repaired successfully."
     if (
         current_version
         and resulting_version
@@ -207,6 +268,16 @@ def _success_message(*, status: str, current_version: str, resulting_version: st
     ):
         return f"Updated HOL Guard from {current_version} to {resulting_version}."
     return "HOL Guard update completed successfully."
+
+
+def _planned_update_message(*, version_check: dict[str, object], use_pypi: bool) -> str:
+    if use_pypi and version_check.get("update_available") is True:
+        latest_version = version_check.get("latest_version")
+        if isinstance(latest_version, str) and latest_version.strip():
+            return (
+                f"Review the planned PyPI install command to update to {latest_version.strip()}."
+            )
+    return "Review the planned installer command before updating."
 
 
 def _success_notes(payload: dict[str, object]) -> list[str]:
@@ -294,12 +365,91 @@ def _installer_kind() -> str:
     return "pip"
 
 
-def _update_command(installer: str) -> list[str]:
+def _should_upgrade_from_pypi(
+    *,
+    version_check: dict[str, object],
+    vcs_install: dict[str, object] | None,
+    local_source_install: dict[str, object] | None,
+) -> bool:
+    if version_check.get("update_available") is not True:
+        return False
+    if vcs_install is not None:
+        return True
+    if local_source_install is not None and not bool(local_source_install.get("path_exists")):
+        return True
+    return False
+
+
+def _update_command(
+    installer: str,
+    *,
+    use_pypi: bool = False,
+    local_source_install: dict[str, object] | None = None,
+) -> list[str]:
+    if use_pypi:
+        if installer == "uv":
+            return ["uv", "tool", "install", "--force", "hol-guard"]
+        if installer == "pipx":
+            return ["pipx", "install", "--force", "hol-guard"]
+        return [sys.executable, "-m", "pip", "install", "--upgrade", "hol-guard"]
+    if (
+        installer == "pipx"
+        and local_source_install is not None
+        and not bool(local_source_install.get("path_exists"))
+    ):
+        return ["pipx", "install", "--force", "hol-guard"]
     if installer == "uv":
         return ["uv", "tool", "upgrade", "hol-guard"]
     if installer == "pipx":
         return ["pipx", "upgrade", "hol-guard"]
     return [sys.executable, "-m", "pip", "install", "--upgrade", "hol-guard"]
+
+
+def _vcs_install_payload(direct_url: dict[str, object] | None) -> dict[str, object] | None:
+    if not isinstance(direct_url, dict):
+        return None
+    vcs_info = direct_url.get("vcs_info")
+    if not isinstance(vcs_info, dict):
+        return None
+    vcs = vcs_info.get("vcs")
+    if not isinstance(vcs, str) or not vcs.strip():
+        return None
+    payload: dict[str, object] = {"kind": "vcs", "vcs": vcs.strip()}
+    raw_url = direct_url.get("url")
+    if isinstance(raw_url, str) and raw_url.strip():
+        payload["url"] = raw_url.strip()
+    requested_revision = vcs_info.get("requested_revision")
+    if isinstance(requested_revision, str) and requested_revision.strip():
+        payload["requested_revision"] = requested_revision.strip()
+    commit_id = vcs_info.get("commit_id")
+    if isinstance(commit_id, str) and commit_id.strip():
+        payload["commit_id"] = commit_id.strip()
+    return payload
+
+
+def _local_source_install_payload(direct_url: dict[str, object] | None) -> dict[str, object] | None:
+    if not isinstance(direct_url, dict):
+        return None
+    if isinstance(direct_url.get("vcs_info"), dict):
+        return None
+    raw_url = direct_url.get("url")
+    if not isinstance(raw_url, str) or not raw_url.strip():
+        return None
+    parsed = urlparse(raw_url)
+    if parsed.scheme != "file":
+        return None
+    raw_path = urllib.request.url2pathname(unquote(parsed.path))
+    if not raw_path:
+        return None
+    source_path = Path(raw_path).expanduser()
+    if not source_path.is_absolute():
+        source_path = Path.cwd() / source_path
+    return {
+        "kind": "local_path",
+        "url": raw_url,
+        "path": str(source_path.resolve(strict=False)),
+        "path_exists": source_path.exists(),
+    }
 
 
 def _direct_url_payload() -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -47,21 +47,10 @@ def run_guard_update(
     direct_url = _direct_url_payload()
     local_source_install = _local_source_install_payload(direct_url)
     vcs_install = _vcs_install_payload(direct_url)
-    version_check = _version_check_payload(current_version)
-    use_pypi = _should_upgrade_from_pypi(
-        version_check=version_check,
-        vcs_install=vcs_install,
-        local_source_install=local_source_install,
-    )
-    command = _update_command(installer, use_pypi=use_pypi)
     payload: dict[str, object] = {
         "current_version": current_version,
         "installer": installer,
-        "command": command,
-        "retry_command": _shell_command(command),
-        "binary_diagnostics": _binary_diagnostics(command, installer),
         "dry_run": dry_run,
-        "version_check": version_check,
     }
     if direct_url is not None:
         payload["direct_url"] = direct_url
@@ -71,8 +60,6 @@ def run_guard_update(
             payload["source_install"] = local_source_install
         if vcs_install is not None:
             payload["vcs_install"] = vcs_install
-        if use_pypi:
-            payload["upgrade_source"] = "pypi"
         if is_editable:
             payload["status"] = "skipped"
             payload["changed"] = False
@@ -89,6 +76,24 @@ def run_guard_update(
             return payload, 0
         if local_source_install is not None and not bool(local_source_install.get("path_exists")):
             payload["recovery_source_install"] = True
+    version_check = _version_check_payload(current_version)
+    use_pypi = _should_upgrade_from_pypi(
+        current_version=current_version,
+        version_check=version_check,
+        vcs_install=vcs_install,
+        local_source_install=local_source_install,
+    )
+    command = _update_command(installer, use_pypi=use_pypi)
+    payload.update(
+        {
+            "command": command,
+            "retry_command": _shell_command(command),
+            "binary_diagnostics": _binary_diagnostics(command, installer),
+            "version_check": version_check,
+        }
+    )
+    if use_pypi:
+        payload["upgrade_source"] = "pypi"
     if dry_run:
         payload["status"] = "planned"
         payload["changed"] = False
@@ -117,7 +122,10 @@ def run_guard_update(
         payload["changed"] = False
         payload["message"] = "HOL Guard update failed."
         return payload, 1
-    payload["version_check"] = _version_check_payload(str(payload.get("resulting_version") or current_version))
+    initial_version_check = payload.get("version_check")
+    post_version_check = _version_check_payload(str(payload.get("resulting_version") or current_version))
+    payload["post_version_check"] = post_version_check
+    payload["version_check"] = _merge_version_checks(initial_version_check, post_version_check)
     payload["status"] = _success_status(payload)
     payload["changed"] = payload["status"] == "updated"
     payload["message"] = _success_message(
@@ -204,6 +212,8 @@ def _output_lines(value: str) -> list[str]:
 
 
 def _success_status(payload: dict[str, object]) -> str:
+    if _is_stale_install(payload):
+        return "stale"
     current_version = str(payload.get("current_version") or "").strip()
     resulting_version = str(payload.get("resulting_version") or "").strip()
     if (
@@ -214,19 +224,41 @@ def _success_status(payload: dict[str, object]) -> str:
         and current_version != resulting_version
     ):
         return "updated"
-    version_check = payload.get("version_check")
-    if (
-        isinstance(version_check, dict)
-        and version_check.get("update_available") is True
-        and (payload.get("vcs_install") is not None or payload.get("upgrade_source") == "pypi")
-    ):
-        return "stale"
     output_text = str(payload.get("stdout") or "").lower()
     if any(hint in output_text for hint in _ALREADY_CURRENT_HINTS):
         return "current"
     if "requirement already satisfied: hol-guard" in output_text or "hol-guard is already installed" in output_text:
         return "current"
     return "updated"
+
+
+def _is_stale_install(payload: dict[str, object]) -> bool:
+    if payload.get("vcs_install") is None and payload.get("upgrade_source") != "pypi":
+        return False
+    version_check = payload.get("version_check")
+    return (
+        isinstance(version_check, dict)
+        and version_check.get("update_available") is True
+    )
+
+
+def _merge_version_checks(
+    initial_version_check: object,
+    post_version_check: object,
+) -> dict[str, object]:
+    if isinstance(post_version_check, dict) and post_version_check.get("update_available") is not None:
+        return post_version_check
+    if isinstance(initial_version_check, dict):
+        return initial_version_check
+    if isinstance(post_version_check, dict):
+        return post_version_check
+    return {
+        "source": "pypi",
+        "status": "unavailable",
+        "current_version": None,
+        "latest_version": None,
+        "update_available": None,
+    }
 
 
 def _success_message(
@@ -274,9 +306,7 @@ def _planned_update_message(*, version_check: dict[str, object], use_pypi: bool)
         if version_check.get("update_available") is True:
             latest_version = version_check.get("latest_version")
             if isinstance(latest_version, str) and latest_version.strip():
-                return (
-                    f"Review the planned PyPI install command to update to {latest_version.strip()}."
-                )
+                return f"Review the planned PyPI install command to update to {latest_version.strip()}."
         return "Review the planned PyPI install command to repair the install source."
     return "Review the planned installer command before updating."
 
@@ -368,11 +398,17 @@ def _installer_kind() -> str:
 
 def _should_upgrade_from_pypi(
     *,
+    current_version: str,
     version_check: dict[str, object],
     vcs_install: dict[str, object] | None,
     local_source_install: dict[str, object] | None,
 ) -> bool:
     if local_source_install is not None and not bool(local_source_install.get("path_exists")):
+        latest_version = version_check.get("latest_version")
+        if isinstance(latest_version, str) and latest_version.strip():
+            newer_than_pypi = _is_newer_version(current_version, latest_version.strip())
+            if newer_than_pypi is True:
+                return False
         return True
     if version_check.get("update_available") is not True:
         return False
@@ -419,6 +455,8 @@ def _local_source_install_payload(direct_url: dict[str, object] | None) -> dict[
     if not isinstance(direct_url, dict):
         return None
     if isinstance(direct_url.get("vcs_info"), dict):
+        return None
+    if isinstance(direct_url.get("archive_info"), dict):
         return None
     raw_url = direct_url.get("url")
     if not isinstance(raw_url, str) or not raw_url.strip():

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -123,17 +123,22 @@ def run_guard_update(
         payload["message"] = "HOL Guard update failed."
         return payload, 1
     initial_version_check = payload.get("version_check")
-    post_version_check = _version_check_payload(str(payload.get("resulting_version") or current_version))
+    resulting_version = str(payload.get("resulting_version") or current_version)
+    post_version_check = _version_check_payload(resulting_version)
     payload["post_version_check"] = post_version_check
-    payload["version_check"] = _merge_version_checks(initial_version_check, post_version_check)
+    payload["version_check"] = _merge_version_checks(
+        initial_version_check,
+        post_version_check,
+        resulting_version,
+    )
     payload["status"] = _success_status(payload)
     payload["changed"] = payload["status"] == "updated"
     payload["message"] = _success_message(
         status=str(payload["status"]),
         current_version=current_version,
-        resulting_version=str(payload.get("resulting_version") or ""),
+        resulting_version=resulting_version,
         version_check=payload.get("version_check"),
-        retry_command=str(payload.get("retry_command") or ""),
+        retry_command=_stale_retry_command(payload),
     )
     notes = _success_notes(payload)
     if notes:
@@ -242,11 +247,22 @@ def _is_stale_install(payload: dict[str, object]) -> bool:
 def _merge_version_checks(
     initial_version_check: object,
     post_version_check: object,
+    resulting_version: str,
 ) -> dict[str, object]:
     if isinstance(post_version_check, dict) and post_version_check.get("update_available") is not None:
         return post_version_check
     if isinstance(initial_version_check, dict):
-        return initial_version_check
+        merged = dict(initial_version_check)
+        latest_version = merged.get("latest_version")
+        if isinstance(latest_version, str) and latest_version.strip() and resulting_version not in {"", "unknown"}:
+            try:
+                if Version(resulting_version) >= Version(latest_version.strip()):
+                    merged["update_available"] = False
+                    merged["status"] = "current"
+                    merged["current_version"] = resulting_version
+            except InvalidVersion:
+                pass
+        return merged
     if isinstance(post_version_check, dict):
         return post_version_check
     return {
@@ -256,6 +272,19 @@ def _merge_version_checks(
         "latest_version": None,
         "update_available": None,
     }
+
+
+def _stale_retry_command(payload: dict[str, object]) -> str:
+    if payload.get("vcs_install") is not None or payload.get("upgrade_source") == "pypi":
+        installer = str(payload.get("installer") or "pip")
+        return _shell_command(_update_command(installer, use_pypi=True))
+    retry_command = payload.get("retry_command")
+    if isinstance(retry_command, str) and retry_command.strip():
+        return retry_command.strip()
+    command = payload.get("command")
+    if isinstance(command, list) and command:
+        return _shell_command(command)
+    return ""
 
 
 def _success_message(
@@ -418,7 +447,7 @@ def _update_command(installer: str, *, use_pypi: bool = False) -> list[str]:
             return ["uv", "tool", "install", "--force", "hol-guard"]
         if installer == "pipx":
             return ["pipx", "install", "--force", "hol-guard"]
-        return [sys.executable, "-m", "pip", "install", "--upgrade", "hol-guard"]
+        return [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall", "hol-guard"]
     if installer == "uv":
         return ["uv", "tool", "upgrade", "hol-guard"]
     if installer == "pipx":

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -236,10 +236,7 @@ def _is_stale_install(payload: dict[str, object]) -> bool:
     if payload.get("vcs_install") is None and payload.get("upgrade_source") != "pypi":
         return False
     version_check = payload.get("version_check")
-    return (
-        isinstance(version_check, dict)
-        and version_check.get("update_available") is True
-    )
+    return isinstance(version_check, dict) and version_check.get("update_available") is True
 
 
 def _merge_version_checks(

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -16,7 +16,7 @@ import sysconfig
 import urllib.error
 import urllib.request
 from pathlib import Path
-from urllib.parse import unquote, urlparse
+from urllib.parse import urlparse
 
 from packaging.version import InvalidVersion, Version
 
@@ -53,11 +53,7 @@ def run_guard_update(
         vcs_install=vcs_install,
         local_source_install=local_source_install,
     )
-    command = _update_command(
-        installer,
-        use_pypi=use_pypi,
-        local_source_install=local_source_install,
-    )
+    command = _update_command(installer, use_pypi=use_pypi)
     payload: dict[str, object] = {
         "current_version": current_version,
         "installer": installer,
@@ -219,9 +215,12 @@ def _success_status(payload: dict[str, object]) -> str:
     ):
         return "updated"
     version_check = payload.get("version_check")
-    if isinstance(version_check, dict) and version_check.get("update_available") is True:
-        if payload.get("vcs_install") is not None or payload.get("upgrade_source") == "pypi":
-            return "stale"
+    if (
+        isinstance(version_check, dict)
+        and version_check.get("update_available") is True
+        and (payload.get("vcs_install") is not None or payload.get("upgrade_source") == "pypi")
+    ):
+        return "stale"
     output_text = str(payload.get("stdout") or "").lower()
     if any(hint in output_text for hint in _ALREADY_CURRENT_HINTS):
         return "current"
@@ -271,12 +270,14 @@ def _success_message(
 
 
 def _planned_update_message(*, version_check: dict[str, object], use_pypi: bool) -> str:
-    if use_pypi and version_check.get("update_available") is True:
-        latest_version = version_check.get("latest_version")
-        if isinstance(latest_version, str) and latest_version.strip():
-            return (
-                f"Review the planned PyPI install command to update to {latest_version.strip()}."
-            )
+    if use_pypi:
+        if version_check.get("update_available") is True:
+            latest_version = version_check.get("latest_version")
+            if isinstance(latest_version, str) and latest_version.strip():
+                return (
+                    f"Review the planned PyPI install command to update to {latest_version.strip()}."
+                )
+        return "Review the planned PyPI install command to repair the install source."
     return "Review the planned installer command before updating."
 
 
@@ -371,33 +372,20 @@ def _should_upgrade_from_pypi(
     vcs_install: dict[str, object] | None,
     local_source_install: dict[str, object] | None,
 ) -> bool:
-    if version_check.get("update_available") is not True:
-        return False
-    if vcs_install is not None:
-        return True
     if local_source_install is not None and not bool(local_source_install.get("path_exists")):
         return True
-    return False
+    if version_check.get("update_available") is not True:
+        return False
+    return vcs_install is not None
 
 
-def _update_command(
-    installer: str,
-    *,
-    use_pypi: bool = False,
-    local_source_install: dict[str, object] | None = None,
-) -> list[str]:
+def _update_command(installer: str, *, use_pypi: bool = False) -> list[str]:
     if use_pypi:
         if installer == "uv":
             return ["uv", "tool", "install", "--force", "hol-guard"]
         if installer == "pipx":
             return ["pipx", "install", "--force", "hol-guard"]
         return [sys.executable, "-m", "pip", "install", "--upgrade", "hol-guard"]
-    if (
-        installer == "pipx"
-        and local_source_install is not None
-        and not bool(local_source_install.get("path_exists"))
-    ):
-        return ["pipx", "install", "--force", "hol-guard"]
     if installer == "uv":
         return ["uv", "tool", "upgrade", "hol-guard"]
     if installer == "pipx":
@@ -438,7 +426,7 @@ def _local_source_install_payload(direct_url: dict[str, object] | None) -> dict[
     parsed = urlparse(raw_url)
     if parsed.scheme != "file":
         return None
-    raw_path = urllib.request.url2pathname(unquote(parsed.path))
+    raw_path = urllib.request.url2pathname(parsed.path)
     if not raw_path:
         return None
     source_path = Path(raw_path).expanduser()

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3796,6 +3796,7 @@ args = ["workspace-skill.js", "--changed"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.36")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.36")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.36")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -216,7 +216,15 @@ def test_update_repairs_missing_pip_local_source_install(monkeypatch: pytest.Mon
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands[0] == ["/opt/guard/bin/python", "-m", "pip", "install", "--upgrade", "hol-guard"]
+    assert captured_commands[0] == [
+        "/opt/guard/bin/python",
+        "-m",
+        "pip",
+        "install",
+        "--upgrade",
+        "--force-reinstall",
+        "hol-guard",
+    ]
     assert payload["recovery_source_install"] is True
     assert payload["upgrade_source"] == "pypi"
 
@@ -372,6 +380,40 @@ def test_update_marks_git_install_stale_when_pypi_upgrade_leaves_old_version(mon
     assert payload["status"] == "stale"
     assert "behind PyPI 2.0.489" in str(payload["message"])
     assert "pipx install --force hol-guard" in str(payload["message"])
+
+
+def test_update_reports_current_after_successful_pypi_repair_when_post_check_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.489")
+    call_count = {"count": 0}
+
+    def fake_latest() -> str | None:
+        call_count["count"] += 1
+        return "2.0.489" if call_count["count"] == 1 else None
+
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", fake_latest)
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {
+            "url": "https://github.com/hashgraph-online/hol-guard.git",
+            "vcs_info": {"vcs": "git", "requested_revision": "main", "commit_id": "abc"},
+        },
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.489", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert payload["status"] == "updated"
+    assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.489."
 
 
 def test_install_aliases_resolve_to_native_contracts() -> None:

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -131,6 +131,146 @@ def test_update_binary_diagnostics_treats_pipx_shim_as_healthy(monkeypatch: pyte
     assert payload["binary_diagnostics"]["expected_script_dir"] is None
 
 
+def test_update_skips_existing_local_source_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    source_dir = tmp_path / "src-install"
+    source_dir.mkdir()
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {"dir_info": {}, "url": source_dir.as_uri()},
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert payload["status"] == "skipped"
+    assert payload["changed"] is False
+    assert "disabled for local source installs" in str(payload["error"])
+    assert payload["source_install"]["path_exists"] is True
+
+
+def test_update_repairs_missing_pipx_local_source_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    missing_dir = tmp_path / "missing-src-install"
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.489")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.489")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {"dir_info": {}, "url": missing_dir.as_uri()},
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    captured_commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured_commands.append(command)
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard"]
+    assert payload["recovery_source_install"] is True
+    assert payload["source_install"]["path_exists"] is False
+    assert payload["status"] == "updated"
+    assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.489."
+
+
+def test_update_switches_git_install_to_pypi_when_release_is_newer(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.489")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.489")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {
+            "url": "https://github.com/hashgraph-online/hol-guard.git",
+            "vcs_info": {
+                "commit_id": "ea81cb21edf6fbf2c83658299a81043e9fe37c57",
+                "requested_revision": "main",
+                "vcs": "git",
+            },
+        },
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    captured_commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured_commands.append(command)
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.489", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard"]
+    assert payload["upgrade_source"] == "pypi"
+    assert payload["status"] == "updated"
+    assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.489."
+
+
+def test_update_marks_git_install_stale_when_pypi_upgrade_leaves_old_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.489")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {
+            "url": "https://github.com/hashgraph-online/hol-guard.git",
+            "vcs_info": {
+                "commit_id": "ea81cb21edf6fbf2c83658299a81043e9fe37c57",
+                "requested_revision": "main",
+                "vcs": "git",
+            },
+        },
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+
+    captured_commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured_commands.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            "hol-guard is already at latest version 2.0.345",
+            "upgrading hol-guard from spec 'git+https://github.com/hashgraph-online/hol-guard.git@main'...",
+        )
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard"]
+    assert payload["status"] == "stale"
+    assert "behind PyPI 2.0.489" in str(payload["message"])
+    assert "pipx install --force hol-guard" in str(payload["message"])
+
+
 def test_install_aliases_resolve_to_native_contracts() -> None:
     aliases = {
         "claude": "claude-code",

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -254,6 +254,7 @@ def test_update_does_not_skip_local_wheel_install(monkeypatch: pytest.MonkeyPatc
     wheel = tmp_path / "hol-guard.whl"
     wheel.write_bytes(b"fake-wheel")
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.345")
     monkeypatch.setattr(
         update_commands,
         "_direct_url_payload",

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -220,6 +220,79 @@ def test_update_repairs_missing_pip_local_source_install(monkeypatch: pytest.Mon
     assert payload["upgrade_source"] == "pypi"
 
 
+def test_update_skips_pypi_recovery_when_missing_local_source_is_newer_than_pypi(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    missing_dir = tmp_path / "missing-dev-install"
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.1.0.dev0")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.489")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {"dir_info": {}, "url": missing_dir.as_uri()},
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["command"] == ["pipx", "upgrade", "hol-guard"]
+    assert payload.get("upgrade_source") is None
+
+
+def test_update_does_not_skip_local_wheel_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    wheel = tmp_path / "hol-guard.whl"
+    wheel.write_bytes(b"fake-wheel")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {
+            "url": wheel.as_uri(),
+            "archive_info": {"hash": "sha256:abc", "hashes": {"sha256": "abc"}},
+        },
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["status"] == "planned"
+    assert payload.get("source_install") is None
+
+
+def test_update_marks_partial_pypi_repair_as_stale(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.400")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.489")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {
+            "url": "https://github.com/hashgraph-online/hol-guard.git",
+            "vcs_info": {
+                "commit_id": "ea81cb21edf6fbf2c83658299a81043e9fe37c57",
+                "requested_revision": "main",
+                "vcs": "git",
+            },
+        },
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.400", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert payload["status"] == "stale"
+    assert payload["resulting_version"] == "2.0.400"
+    assert "behind PyPI 2.0.489" in str(payload["message"])
+
+
 def test_update_switches_git_install_to_pypi_when_release_is_newer(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
     monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.489")

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -154,6 +154,7 @@ def test_update_skips_existing_local_source_install(monkeypatch: pytest.MonkeyPa
     assert payload["changed"] is False
     assert "disabled for local source installs" in str(payload["error"])
     assert payload["source_install"]["path_exists"] is True
+    assert "version_check" not in payload
 
 
 def test_update_repairs_missing_pipx_local_source_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -191,6 +191,35 @@ def test_update_repairs_missing_pipx_local_source_install(monkeypatch: pytest.Mo
     assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.489."
 
 
+def test_update_repairs_missing_pip_local_source_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    missing_dir = tmp_path / "missing-src-install"
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.489")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.489")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.489")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {"dir_info": {}, "url": missing_dir.as_uri()},
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
+    monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard/bin/python")
+
+    captured_commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured_commands.append(command)
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert captured_commands[0] == ["/opt/guard/bin/python", "-m", "pip", "install", "--upgrade", "hol-guard"]
+    assert payload["recovery_source_install"] is True
+    assert payload["upgrade_source"] == "pypi"
+
+
 def test_update_switches_git_install_to_pypi_when_release_is_newer(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
     monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.489")


### PR DESCRIPTION
## Summary
- Detect when hol-guard was installed from a VCS source (e.g. `git+https://github.com/hashgraph-online/hol-guard.git@main`) and PyPI has a newer release than the installed version.
- Switch `hol-guard update` to run `pipx install --force hol-guard` (or the uv/pip equivalent) instead of `pipx upgrade`, which only refreshes the original git spec.
- Surface a `stale` update status with the latest PyPI version when a git-sourced install remains behind after update, and recover missing local source installs the same way.
- Show latest PyPI version in the update panel during dry-run and after update.

## Context
pipx remembers the original install URL. Users who installed from git `@main` saw `hol-guard update` report "already current" at 2.0.345 while PyPI had 2.0.489, because git `main`'s `pyproject.toml` version lagged published releases. This is an installer/source-tracking issue, not an intentional security mode.

## Test plan
- [x] `pytest tests/test_guard_phase03_local_install.py -q`
- [x] `pytest tests/test_guard_cli.py -k guard_update -q` (20/21 pass; one pre-existing macOS keychain flake unrelated to this change)
- [ ] `hol-guard update --dry-run` on a git-sourced pipx install shows PyPI version and `pipx install --force hol-guard`
- [ ] `hol-guard update` on a git-sourced pipx install upgrades to latest PyPI release