### PR TITLE
fix(opencode): install global root config and harden pretool hook

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -399,10 +399,13 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         context: HarnessContext,
         server: ManagedMcpServer,
         existing_workspace_server_names: set[str],
+        for_companion: bool = False,
     ) -> bool:
         if context.workspace_dir is None:
             return False
         if server.source_scope == "project":
+            return False
+        if for_companion and server.source_scope == "global":
             return False
         return server.name in existing_workspace_server_names
 
@@ -712,6 +715,7 @@ def _persisted_mcp_with_guard_companions(
             context=context,
             server=server,
             existing_workspace_server_names=existing_workspace_server_names,
+            for_companion=True,
         ):
             continue
         companion_name = _guard_mcp_companion_name(server.name)

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -35,7 +35,6 @@ from .opencode_artifacts import (
 from .opencode_pretool import install_pretool_plugin, remove_pretool_plugin
 
 _OPENCODE_SCHEMA = "https://opencode.ai/config.json"
-_GUARD_PRETOOL_PLUGIN_REF = "./plugins/hol-guard-pretool.ts"
 _GUARD_MCP_COMPANION_PREFIX = "hol-guard::"
 _DEFAULT_BASH_PERMISSION: dict[str, object] = {
     "*": "allow",
@@ -237,7 +236,8 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             "Guard installed an OpenCode pretool plugin that reviews bash and shell commands through "
             "hol-guard hook before execution.",
             "Guard updated the global OpenCode root config at ~/.config/opencode/opencode.json with "
-            "pretool plugin registration, baseline bash permission rules, and hol-guard:: MCP companion servers.",
+            "baseline bash permission rules and hol-guard:: MCP companion servers, and installed the "
+            "pretool plugin under ~/.config/opencode/plugins/.",
             "Guard added an OpenCode runtime overlay that keeps managed MCP tools on native ask and routes "
             "managed local MCP servers through Guard runtime interception when you launch through Guard.",
             "Use hol-guard:: MCP servers in OpenCode for Guard-proxied tools, or launch through guard-opencode "
@@ -385,7 +385,13 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             if not server.enabled:
                 continue
             rules[f"{server.name}_*"] = "ask"
+            if server.source_scope != "project":
+                rules[f"{_guard_mcp_companion_name(server.name)}_*"] = "ask"
         return rules
+
+    @staticmethod
+    def _skip_global_managed_server(server: ManagedMcpServer) -> bool:
+        return server.source_scope == "project"
 
     @staticmethod
     def _should_skip_workspace_override(
@@ -615,30 +621,29 @@ __all__ = ["OpenCodeHarnessAdapter"]
 
 def _apply_install_baseline(payload: dict[str, object]) -> None:
     payload.setdefault("$schema", _OPENCODE_SCHEMA)
-    _register_guard_pretool_plugin(payload)
-
-
-def _register_guard_pretool_plugin(payload: dict[str, object]) -> None:
-    for key in ("plugin", "plugins"):
-        existing = payload.get(key)
-        if isinstance(existing, list):
-            if not any("hol-guard-pretool" in str(item) for item in existing):
-                existing.append(_GUARD_PRETOOL_PLUGIN_REF)
-            payload[key] = existing
-            return
-    payload["plugin"] = [_GUARD_PRETOOL_PLUGIN_REF]
 
 
 def _merge_default_bash_permission(permission: dict[str, object]) -> dict[str, object]:
     bash = permission.get("bash")
+    if isinstance(bash, str):
+        merged_bash = dict(_DEFAULT_BASH_PERMISSION)
+        merged_bash["*"] = bash
+        permission["bash"] = merged_bash
+        return permission
     if isinstance(bash, dict):
         merged_bash = dict(_DEFAULT_BASH_PERMISSION)
         for key, value in bash.items():
             if isinstance(key, str):
                 merged_bash[key] = value
         permission["bash"] = merged_bash
-    else:
-        permission["bash"] = dict(_DEFAULT_BASH_PERMISSION)
+        return permission
+    wildcard = permission.get("*")
+    if isinstance(wildcard, str):
+        merged_bash = dict(_DEFAULT_BASH_PERMISSION)
+        merged_bash["*"] = wildcard
+        permission["bash"] = merged_bash
+        return permission
+    permission["bash"] = dict(_DEFAULT_BASH_PERMISSION)
     return permission
 
 
@@ -654,6 +659,8 @@ def _ensure_native_mcp_entries(
     context: HarnessContext,
 ) -> None:
     for server in servers:
+        if OpenCodeHarnessAdapter._skip_global_managed_server(server):
+            continue
         if OpenCodeHarnessAdapter._should_skip_workspace_override(
             context=context,
             server=server,
@@ -662,11 +669,14 @@ def _ensure_native_mcp_entries(
             continue
         if server.name in persisted or not server.command:
             continue
-        persisted[server.name] = {
+        entry: dict[str, object] = {
             "type": "local",
             "command": [server.command, *server.args],
             "enabled": server.enabled,
         }
+        if server.env:
+            entry["environment"] = dict(server.env)
+        persisted[server.name] = entry
 
 
 def _persisted_mcp_with_guard_companions(
@@ -683,7 +693,9 @@ def _persisted_mcp_with_guard_companions(
         existing_workspace_server_names=existing_workspace_server_names,
         context=context,
     )
-    managed_names = {server.name for server in servers}
+    managed_names = {
+        server.name for server in servers if not OpenCodeHarnessAdapter._skip_global_managed_server(server)
+    }
     stale_companions = [
         name
         for name in persisted
@@ -694,6 +706,8 @@ def _persisted_mcp_with_guard_companions(
     for name in stale_companions:
         persisted.pop(name, None)
     for server in servers:
+        if OpenCodeHarnessAdapter._skip_global_managed_server(server):
+            continue
         if OpenCodeHarnessAdapter._should_skip_workspace_override(
             context=context,
             server=server,
@@ -710,7 +724,7 @@ def _persisted_mcp_with_guard_companions(
                     guard_home=str(context.guard_home),
                     server=server,
                     home=str(context.home_dir) if context.home_dir.resolve() != Path.home().resolve() else None,
-                    workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
+                    workspace=None,
                 ),
             ],
             "enabled": server.enabled,

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -34,6 +34,23 @@ from .opencode_artifacts import (
 )
 from .opencode_pretool import install_pretool_plugin, remove_pretool_plugin
 
+_OPENCODE_SCHEMA = "https://opencode.ai/config.json"
+_GUARD_PRETOOL_PLUGIN_REF = "./plugins/hol-guard-pretool.ts"
+_GUARD_MCP_COMPANION_PREFIX = "hol-guard::"
+_DEFAULT_BASH_PERMISSION: dict[str, object] = {
+    "*": "allow",
+    "git checkout *": "deny",
+    "git checkout": "deny",
+    "git revert *": "deny",
+    "git revert": "deny",
+    "git restore *": "deny",
+    "git restore": "deny",
+    "git reset *": "deny",
+    "git reset": "deny",
+    "rm -rf *": "deny",
+    "rm -r *": "deny",
+}
+
 
 class OpenCodeHarnessAdapter(HarnessAdapter):
     """Discover OpenCode config, commands, plugins, and skills."""
@@ -147,7 +164,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         detection = self.detect(context)
         managed_servers = managed_stdio_servers(detection)
         skipped_servers = skipped_stdio_server_names(detection)
-        target_config_path = self._target_config_path(context)
+        target_config_path = self._managed_install_config_path(context)
         original_text = None
         if target_config_path.is_file():
             original_text = target_config_path.read_text(encoding="utf-8")
@@ -177,13 +194,19 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         if parse_error or not isinstance(target_payload, dict):
             target_payload = {}
         existing_workspace_server_names = self._workspace_server_names(context)
+        _apply_install_baseline(target_payload)
         target_payload["permission"] = self._managed_permission_payload(
             target_payload.get("permission"),
             context=context,
             servers=managed_servers,
             existing_workspace_server_names=existing_workspace_server_names,
         )
-        target_payload["mcp"] = _persisted_mcp_payload(target_payload.get("mcp"))
+        target_payload["mcp"] = _persisted_mcp_with_guard_companions(
+            target_payload.get("mcp"),
+            context=context,
+            servers=managed_servers,
+            existing_workspace_server_names=existing_workspace_server_names,
+        )
         target_config_path.parent.mkdir(parents=True, exist_ok=True)
         target_config_path.write_text(json.dumps(target_payload, indent=2) + "\n", encoding="utf-8")
         shim_manifest = install_guard_shim(self.harness, context)
@@ -213,10 +236,12 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             *list(shim_manifest.get("notes", [])),
             "Guard installed an OpenCode pretool plugin that reviews bash and shell commands through "
             "hol-guard hook before execution.",
+            "Guard updated the global OpenCode root config at ~/.config/opencode/opencode.json with "
+            "pretool plugin registration, baseline bash permission rules, and hol-guard:: MCP companion servers.",
             "Guard added an OpenCode runtime overlay that keeps managed MCP tools on native ask and routes "
             "managed local MCP servers through Guard runtime interception when you launch through Guard.",
-            "Launch OpenCode through guard-opencode or hol-guard run opencode when you also want "
-            "pre-launch artifact checks and the runtime skill overlay.",
+            "Use hol-guard:: MCP servers in OpenCode for Guard-proxied tools, or launch through guard-opencode "
+            "or hol-guard run opencode for pre-launch artifact checks and the runtime skill overlay.",
         ]
         return {
             "harness": self.harness,
@@ -406,6 +431,12 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             return configured_path
         if workspace_dir is not None:
             return workspace_dir / CONFIG_FILENAMES[0]
+        return OpenCodeHarnessAdapter._managed_install_config_path(context)
+
+    @staticmethod
+    def _managed_install_config_path(context: HarnessContext) -> Path:
+        """Managed OpenCode installs always target the global root config."""
+
         global_dir = context.home_dir / ".config" / "opencode"
         for name in CONFIG_FILENAMES:
             candidate = global_dir / name
@@ -415,7 +446,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _backup_path(context: HarnessContext) -> Path:
-        target_path = str(OpenCodeHarnessAdapter._target_config_path(context).resolve())
+        target_path = str(OpenCodeHarnessAdapter._managed_install_config_path(context).resolve())
         digest = hashlib.sha256(target_path.encode("utf-8")).hexdigest()[:12]
         return context.guard_home / "managed" / "opencode" / f"{digest}.backup.json"
 
@@ -428,7 +459,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
     @classmethod
     def _state_entry(cls, context: HarnessContext) -> tuple[Path, dict[str, str]]:
         state_dir = context.guard_home / "managed" / "opencode"
-        target_config_path = cls._target_config_path(context)
+        target_config_path = cls._managed_install_config_path(context)
         preferred_path = cls._state_path(context, target_config_path)
         current_workspace = str(context.workspace_dir.resolve()) if context.workspace_dir is not None else None
         candidate_entries: list[tuple[Path, dict[str, str]]] = []
@@ -478,7 +509,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         managed_config_path = state_payload.get("managed_config_path")
         if isinstance(managed_config_path, str):
             return Path(managed_config_path)
-        return cls._target_config_path(context)
+        return cls._managed_install_config_path(context)
 
     @classmethod
     def _backup_path_from_state(
@@ -567,7 +598,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
                 existing_workspace_server_names=existing_workspace_server_names,
             )
         )
-        return permission
+        return _merge_default_bash_permission(permission)
 
     @staticmethod
     def _coerce_permission_payload(current_permission: object) -> dict[str, object]:
@@ -580,6 +611,115 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
 
 
 __all__ = ["OpenCodeHarnessAdapter"]
+
+
+def _apply_install_baseline(payload: dict[str, object]) -> None:
+    payload.setdefault("$schema", _OPENCODE_SCHEMA)
+    _register_guard_pretool_plugin(payload)
+
+
+def _register_guard_pretool_plugin(payload: dict[str, object]) -> None:
+    for key in ("plugin", "plugins"):
+        existing = payload.get(key)
+        if isinstance(existing, list):
+            if not any("hol-guard-pretool" in str(item) for item in existing):
+                existing.append(_GUARD_PRETOOL_PLUGIN_REF)
+            payload[key] = existing
+            return
+    payload["plugin"] = [_GUARD_PRETOOL_PLUGIN_REF]
+
+
+def _merge_default_bash_permission(permission: dict[str, object]) -> dict[str, object]:
+    bash = permission.get("bash")
+    if isinstance(bash, dict):
+        merged_bash = dict(_DEFAULT_BASH_PERMISSION)
+        for key, value in bash.items():
+            if isinstance(key, str):
+                merged_bash[key] = value
+        permission["bash"] = merged_bash
+    else:
+        permission["bash"] = dict(_DEFAULT_BASH_PERMISSION)
+    return permission
+
+
+def _guard_mcp_companion_name(server_name: str) -> str:
+    return f"{_GUARD_MCP_COMPANION_PREFIX}{server_name}"
+
+
+def _ensure_native_mcp_entries(
+    persisted: dict[str, object],
+    *,
+    servers: tuple[ManagedMcpServer, ...],
+    existing_workspace_server_names: set[str],
+    context: HarnessContext,
+) -> None:
+    for server in servers:
+        if OpenCodeHarnessAdapter._should_skip_workspace_override(
+            context=context,
+            server=server,
+            existing_workspace_server_names=existing_workspace_server_names,
+        ):
+            continue
+        if server.name in persisted or not server.command:
+            continue
+        persisted[server.name] = {
+            "type": "local",
+            "command": [server.command, *server.args],
+            "enabled": server.enabled,
+        }
+
+
+def _persisted_mcp_with_guard_companions(
+    current_mcp: object,
+    *,
+    context: HarnessContext,
+    servers: tuple[ManagedMcpServer, ...],
+    existing_workspace_server_names: set[str],
+) -> dict[str, object]:
+    persisted = _persisted_mcp_payload(current_mcp)
+    _ensure_native_mcp_entries(
+        persisted,
+        servers=servers,
+        existing_workspace_server_names=existing_workspace_server_names,
+        context=context,
+    )
+    managed_names = {server.name for server in servers}
+    stale_companions = [
+        name
+        for name in persisted
+        if isinstance(name, str)
+        and name.startswith(_GUARD_MCP_COMPANION_PREFIX)
+        and name.removeprefix(_GUARD_MCP_COMPANION_PREFIX) not in managed_names
+    ]
+    for name in stale_companions:
+        persisted.pop(name, None)
+    for server in servers:
+        if OpenCodeHarnessAdapter._should_skip_workspace_override(
+            context=context,
+            server=server,
+            existing_workspace_server_names=existing_workspace_server_names,
+        ):
+            continue
+        companion_name = _guard_mcp_companion_name(server.name)
+        entry: dict[str, object] = {
+            "type": "local",
+            "command": [
+                str(resolve_guard_hook_python(context)),
+                *proxy_cli_args(
+                    proxy_command="opencode-mcp-proxy",
+                    guard_home=str(context.guard_home),
+                    server=server,
+                    home=str(context.home_dir) if context.home_dir.resolve() != Path.home().resolve() else None,
+                    workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
+                ),
+            ],
+            "enabled": server.enabled,
+        }
+        environment = merge_guard_launcher_env(proxy_process_env(getattr(server, "env", {})))
+        if environment:
+            entry["environment"] = environment
+        persisted[companion_name] = entry
+    return persisted
 
 
 def _restore_local_server_from_guard_proxy(server_config: dict[str, object]) -> dict[str, object] | None:
@@ -617,12 +757,14 @@ def _restore_local_server_from_guard_proxy(server_config: dict[str, object]) -> 
 
 
 def _persisted_mcp_payload(current_mcp: object) -> dict[str, object]:
-    """Keep user MCP servers on disk; Guard proxies belong in the runtime overlay only."""
+    """Keep native MCP servers on disk; strip legacy in-place proxy wrappers."""
 
     payload = _object_dict(current_mcp) or {}
     persisted: dict[str, object] = {}
     for name, entry in payload.items():
         if not isinstance(name, str) or not isinstance(entry, dict):
+            continue
+        if name.startswith(_GUARD_MCP_COMPANION_PREFIX):
             continue
         restored = _restore_local_server_from_guard_proxy(entry)
         if restored is not None:

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -376,11 +376,14 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
     ) -> dict[str, object]:
         rules: dict[str, object] = {}
         for server in servers:
-            if OpenCodeHarnessAdapter._should_skip_workspace_override(
+            shadowed = OpenCodeHarnessAdapter._should_skip_workspace_override(
                 context=context,
                 server=server,
                 existing_workspace_server_names=existing_workspace_server_names,
-            ):
+            )
+            if shadowed:
+                if server.enabled and server.source_scope != "project":
+                    rules[f"{_guard_mcp_companion_name(server.name)}_*"] = "ask"
                 continue
             if not server.enabled:
                 continue
@@ -654,6 +657,19 @@ def _guard_mcp_companion_name(server_name: str) -> str:
     return f"{_GUARD_MCP_COMPANION_PREFIX}{server_name}"
 
 
+def _source_mcp_server_config(server: ManagedMcpServer) -> dict[str, object] | None:
+    from ...ecosystems.opencode import _load_json_or_jsonc
+
+    payload, parse_error, _ = _load_json_or_jsonc(Path(server.config_path))
+    if parse_error or not isinstance(payload, dict):
+        return None
+    mcp = payload.get("mcp")
+    if not isinstance(mcp, dict):
+        return None
+    entry = mcp.get(server.name)
+    return entry if isinstance(entry, dict) else None
+
+
 def _ensure_native_mcp_entries(
     persisted: dict[str, object],
     *,
@@ -672,11 +688,11 @@ def _ensure_native_mcp_entries(
             continue
         if server.name in persisted or not server.command:
             continue
-        entry: dict[str, object] = {
-            "type": "local",
-            "command": [server.command, *server.args],
-            "enabled": server.enabled,
-        }
+        source_entry = _source_mcp_server_config(server) or {}
+        entry: dict[str, object] = dict(source_entry)
+        entry["type"] = entry.get("type", "local")
+        entry["command"] = [server.command, *server.args]
+        entry["enabled"] = server.enabled
         if server.env:
             entry["environment"] = dict(server.env)
         persisted[server.name] = entry

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -151,7 +151,9 @@ def _pretool_hook_launcher_code(*, package_root: str) -> str:
     trusted_entries = _trusted_pythonpath_entries(package_root)
     return (
         "import json,os,sys;"
-        f"sys.path[:0]={json.dumps(trusted_entries)};"
+        f"trusted={json.dumps(trusted_entries)};"
+        "sys.path=[entry for entry in sys.path if entry and entry != os.getcwd()];"
+        "sys.path[:0]=trusted;"
         "from codex_plugin_scanner.cli import main;"
         f"raise SystemExit(main(json.loads(os.environ[{_HOOK_ARGV_ENV!r}])))"
     )
@@ -159,9 +161,10 @@ def _pretool_hook_launcher_code(*, package_root: str) -> str:
 
 def _pretool_hook_env(*, package_root: str) -> dict[str, str]:
     entries = _trusted_pythonpath_entries(package_root)
-    if not entries:
-        return {}
-    return {"PYTHONPATH": os.pathsep.join(entries)}
+    env = {"PYTHONSAFEPATH": "1", "PYTHONNOUSERSITE": "1"}
+    if entries:
+        env["PYTHONPATH"] = os.pathsep.join(entries)
+    return env
 
 
 def managed_plugin_path(context: HarnessContext) -> Path:
@@ -234,7 +237,9 @@ def opencode_config_uses_guard_proxy(config_path: Path) -> bool:
     mcp = payload.get("mcp")
     if not isinstance(mcp, dict):
         return False
-    for server in mcp.values():
+    for name, server in mcp.items():
+        if isinstance(name, str) and name.startswith("hol-guard::"):
+            return True
         if not isinstance(server, dict):
             continue
         command = server.get("command")

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -152,7 +152,7 @@ def _pretool_hook_launcher_code(*, package_root: str) -> str:
     return (
         "import json,os,sys;"
         f"trusted={json.dumps(trusted_entries)};"
-        "sys.path=[entry for entry in sys.path if entry and entry != os.getcwd()];"
+        "sys.path=[entry for entry in sys.path if entry and os.path.realpath(entry) != os.path.realpath(os.getcwd())];"
         "sys.path[:0]=trusted;"
         "from codex_plugin_scanner.cli import main;"
         f"raise SystemExit(main(json.loads(os.environ[{_HOOK_ARGV_ENV!r}])))"
@@ -238,11 +238,15 @@ def opencode_config_uses_guard_proxy(config_path: Path) -> bool:
     if not isinstance(mcp, dict):
         return False
     for name, server in mcp.items():
-        if isinstance(name, str) and name.startswith("hol-guard::"):
-            return True
-        if not isinstance(server, dict):
+        if not isinstance(name, str) or not isinstance(server, dict):
             continue
         command = server.get("command")
+        if name.startswith("hol-guard::"):
+            if isinstance(command, list) and any("opencode-mcp-proxy" in str(part) for part in command):
+                return True
+            if isinstance(command, str) and "opencode-mcp-proxy" in command:
+                return True
+            continue
         if isinstance(command, list) and any("opencode-mcp-proxy" in str(part) for part in command):
             return True
         if isinstance(command, str) and "opencode-mcp-proxy" in command:

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -226,6 +226,14 @@ def opencode_config_has_mcp_servers(config_path: Path) -> bool:
     return isinstance(mcp, dict) and bool(mcp)
 
 
+def _mcp_command_uses_guard_proxy(command: object) -> bool:
+    if isinstance(command, list):
+        return any("opencode-mcp-proxy" in str(part) for part in command)
+    if isinstance(command, str):
+        return "opencode-mcp-proxy" in command
+    return False
+
+
 def opencode_config_uses_guard_proxy(config_path: Path) -> bool:
     from ...ecosystems.opencode import _load_json_or_jsonc
 
@@ -237,21 +245,24 @@ def opencode_config_uses_guard_proxy(config_path: Path) -> bool:
     mcp = payload.get("mcp")
     if not isinstance(mcp, dict):
         return False
+    native_servers: dict[str, dict] = {}
+    companions: dict[str, dict] = {}
     for name, server in mcp.items():
         if not isinstance(name, str) or not isinstance(server, dict):
             continue
-        command = server.get("command")
         if name.startswith("hol-guard::"):
-            if isinstance(command, list) and any("opencode-mcp-proxy" in str(part) for part in command):
-                return True
-            if isinstance(command, str) and "opencode-mcp-proxy" in command:
-                return True
+            companions[name] = server
+        else:
+            native_servers[name] = server
+    if not native_servers:
+        return any(_mcp_command_uses_guard_proxy(server.get("command")) for server in companions.values())
+    for name, server in native_servers.items():
+        if _mcp_command_uses_guard_proxy(server.get("command")):
             continue
-        if isinstance(command, list) and any("opencode-mcp-proxy" in str(part) for part in command):
-            return True
-        if isinstance(command, str) and "opencode-mcp-proxy" in command:
-            return True
-    return False
+        companion = companions.get(f"hol-guard::{name}")
+        if companion is None or not _mcp_command_uses_guard_proxy(companion.get("command")):
+            return False
+    return True
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -219,29 +219,65 @@ def uninstall_confirmation_token(harness: str) -> str:
     return f"disconnect-{harness}"
 
 
+def _native_mcp_server_names(config_path: Path) -> set[str]:
+    from ...ecosystems.opencode import _load_json_or_jsonc
+
+    payload, parse_error, _ = _load_json_or_jsonc(config_path)
+    if parse_error or not isinstance(payload, dict):
+        return set()
+    mcp = payload.get("mcp")
+    if not isinstance(mcp, dict):
+        return set()
+    return {
+        name
+        for name in mcp
+        if isinstance(name, str) and not name.startswith("hol-guard::")
+    }
+
+
 def _opencode_protection_checks(context: HarnessContext, store: GuardStore | None) -> dict[str, object]:
     from ..adapters.opencode import OpenCodeHarnessAdapter
+    from ..adapters.opencode_artifacts import runtime_config_path
     from ..adapters.opencode_pretool import (
         global_plugin_path,
         opencode_config_has_mcp_servers,
         opencode_config_uses_guard_proxy,
     )
 
-    from ..adapters.opencode_artifacts import runtime_config_path
-
+    adapter = OpenCodeHarnessAdapter()
     managed = store.get_managed_install("opencode") if store is not None else None
-    config_path = OpenCodeHarnessAdapter()._managed_install_config_path(context)
+    config_path = adapter._managed_install_config_path(context)
     shim_path = context.guard_home / "bin" / "guard-opencode"
     plugin_path = global_plugin_path(context)
-    mcp_proxy_configured = opencode_config_uses_guard_proxy(config_path)
-    runtime_overlay_path = runtime_config_path(context)
-    if not mcp_proxy_configured and runtime_overlay_path.is_file():
-        try:
-            runtime_payload = json.loads(runtime_overlay_path.read_text(encoding="utf-8"))
-        except (OSError, json.JSONDecodeError):
-            runtime_payload = {}
-        runtime_mcp = runtime_payload.get("mcp")
-        mcp_proxy_configured = isinstance(runtime_mcp, dict) and bool(runtime_mcp)
+    loaded_config_paths = [
+        Path(path)
+        for path in adapter.detect(context).config_paths
+        if Path(path).is_file()
+    ] or ([config_path] if config_path.is_file() else [])
+    has_loaded_mcp = any(opencode_config_has_mcp_servers(path) for path in loaded_config_paths)
+    if not has_loaded_mcp:
+        mcp_proxy_configured = False
+    else:
+        mcp_proxy_configured = all(
+            (not opencode_config_has_mcp_servers(path)) or opencode_config_uses_guard_proxy(path)
+            for path in loaded_config_paths
+        )
+        runtime_overlay_path = runtime_config_path(context)
+        if not mcp_proxy_configured and runtime_overlay_path.is_file():
+            try:
+                runtime_payload = json.loads(runtime_overlay_path.read_text(encoding="utf-8"))
+            except (OSError, json.JSONDecodeError):
+                runtime_payload = {}
+            runtime_mcp = runtime_payload.get("mcp")
+            if isinstance(runtime_mcp, dict) and runtime_mcp:
+                managed_server_names = {
+                    name
+                    for path in loaded_config_paths
+                    if opencode_config_has_mcp_servers(path)
+                    for name in _native_mcp_server_names(path)
+                }
+                mcp_proxy_configured = managed_server_names.issubset(set(runtime_mcp))
+    has_unproxied_mcp = has_loaded_mcp and not mcp_proxy_configured
     warnings: list[str] = []
     if not (managed and managed.get("active")):
         warnings.append("Run `hol-guard install opencode` to activate Guard-managed OpenCode protection.")
@@ -253,7 +289,7 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         warnings.append(
             "OpenCode root config is missing at ~/.config/opencode/opencode.json. Re-run `hol-guard install opencode`."
         )
-    if opencode_config_has_mcp_servers(config_path) and not mcp_proxy_configured:
+    if has_unproxied_mcp:
         warnings.append(
             "OpenCode MCP servers are not routed through hol-guard companion servers or the runtime overlay. "
             "Re-run `hol-guard install opencode`."

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -228,11 +228,7 @@ def _native_mcp_server_names(config_path: Path) -> set[str]:
     mcp = payload.get("mcp")
     if not isinstance(mcp, dict):
         return set()
-    return {
-        name
-        for name in mcp
-        if isinstance(name, str) and not name.startswith("hol-guard::")
-    }
+    return {name for name in mcp if isinstance(name, str) and not name.startswith("hol-guard::")}
 
 
 def _opencode_protection_checks(context: HarnessContext, store: GuardStore | None) -> dict[str, object]:
@@ -249,11 +245,9 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
     config_path = adapter._managed_install_config_path(context)
     shim_path = context.guard_home / "bin" / "guard-opencode"
     plugin_path = global_plugin_path(context)
-    loaded_config_paths = [
-        Path(path)
-        for path in adapter.detect(context).config_paths
-        if Path(path).is_file()
-    ] or ([config_path] if config_path.is_file() else [])
+    loaded_config_paths = [Path(path) for path in adapter.detect(context).config_paths if Path(path).is_file()] or (
+        [config_path] if config_path.is_file() else []
+    )
     has_loaded_mcp = any(opencode_config_has_mcp_servers(path) for path in loaded_config_paths)
     if not has_loaded_mcp:
         mcp_proxy_configured = False

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import glob as globlib
+import json
 from pathlib import Path
 
 from ..adapters import get_adapter, list_adapters
@@ -226,11 +227,21 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         opencode_config_uses_guard_proxy,
     )
 
+    from ..adapters.opencode_artifacts import runtime_config_path
+
     managed = store.get_managed_install("opencode") if store is not None else None
-    config_path = OpenCodeHarnessAdapter()._target_config_path(context)
+    config_path = OpenCodeHarnessAdapter()._managed_install_config_path(context)
     shim_path = context.guard_home / "bin" / "guard-opencode"
     plugin_path = global_plugin_path(context)
     mcp_proxy_configured = opencode_config_uses_guard_proxy(config_path)
+    runtime_overlay_path = runtime_config_path(context)
+    if not mcp_proxy_configured and runtime_overlay_path.is_file():
+        try:
+            runtime_payload = json.loads(runtime_overlay_path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            runtime_payload = {}
+        runtime_mcp = runtime_payload.get("mcp")
+        mcp_proxy_configured = isinstance(runtime_mcp, dict) and bool(runtime_mcp)
     warnings: list[str] = []
     if not (managed and managed.get("active")):
         warnings.append("Run `hol-guard install opencode` to activate Guard-managed OpenCode protection.")
@@ -238,8 +249,15 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         warnings.append(
             "OpenCode pretool plugin is missing from ~/.config/opencode/plugins/. Re-run `hol-guard install opencode`."
         )
+    if not config_path.is_file():
+        warnings.append(
+            "OpenCode root config is missing at ~/.config/opencode/opencode.json. Re-run `hol-guard install opencode`."
+        )
     if opencode_config_has_mcp_servers(config_path) and not mcp_proxy_configured:
-        warnings.append("OpenCode MCP servers are not routed through hol-guard. Re-run `hol-guard install opencode`.")
+        warnings.append(
+            "OpenCode MCP servers are not routed through hol-guard companion servers or the runtime overlay. "
+            "Re-run `hol-guard install opencode`."
+        )
     if not shim_path.is_file():
         warnings.append(
             f"guard-opencode launcher shim is missing. Add {context.guard_home / 'bin'} to PATH or launch with "

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3008,17 +3008,18 @@ args = ["workspace-skill.js", "--changed"]
         assert runtime_payload["mcp"]["danger_lab"]["command"][3] == "guard"
         assert runtime_payload["mcp"]["danger_lab"]["command"][4] == "opencode-mcp-proxy"
         assert runtime_payload["mcp"]["danger_lab"]["environment"]["API_BASE"] == "https://hol.org"
-        assert manifest["managed_config_path"] == str(home_dir / ".config" / "opencode" / "opencode.json")
+        global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
+        assert manifest["managed_config_path"] == str(global_config_path)
         assert Path(str(manifest["backup_path"])).is_file()
-        assert managed_payload["permission"]["danger_lab_*"] == "ask"
         assert "danger_lab" not in managed_payload.get("mcp", {})
-        assert (workspace_dir / "opencode.json").read_text(encoding="utf-8") != ""
+        assert managed_payload["permission"]["bash"]["rm -rf *"] == "deny"
+        assert json.loads((workspace_dir / "opencode.json").read_text(encoding="utf-8"))["name"] == "workspace-opencode"
 
     def test_guard_reinstall_does_not_double_wrap_opencode_mcp_proxies(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _write_json(
-            workspace_dir / "opencode.json",
+            home_dir / ".config" / "opencode" / "opencode.json",
             {
                 "mcp": {
                     "danger_lab": {
@@ -3064,15 +3065,16 @@ args = ["workspace-skill.js", "--changed"]
 
         assert first_rc == 0
         assert second_rc == 0
-        assert "danger_lab" not in managed_payload.get("mcp", {})
+        assert managed_payload["mcp"]["danger_lab"]["command"] == ["python3", "danger-server.py"]
+        assert "opencode-mcp-proxy" in json.dumps(managed_payload["mcp"]["hol-guard::danger_lab"])
         assert proxy_command.count("opencode-mcp-proxy") == 1
         assert proxy_command[proxy_command.index("--command") + 1] == "python3"
         assert "--arg=danger-server.py" in proxy_command
 
-    def test_guard_install_prefers_existing_opencode_jsonc_target(self, tmp_path, capsys):
+    def test_guard_install_uses_global_jsonc_when_present(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
-        jsonc_path = workspace_dir / "opencode.jsonc"
+        jsonc_path = home_dir / ".config" / "opencode" / "opencode.jsonc"
         jsonc_text = (
             "{\n"
             "  // keep jsonc target\n"
@@ -3102,11 +3104,12 @@ args = ["workspace-skill.js", "--changed"]
         managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
 
         assert rc == 0
-        assert managed_config_path == home_dir / ".config" / "opencode" / "opencode.json"
-        assert "openai" in jsonc_path.read_text(encoding="utf-8")
-        assert managed_payload["permission"]["danger_lab_*"] == "ask"
+        assert managed_config_path == jsonc_path
+        assert managed_payload["provider"] == {"openai": {}}
+        assert managed_payload["mcp"]["danger_lab"]["command"] == ["python3", "danger-server.py"]
+        assert "hol-guard::danger_lab" in managed_payload["mcp"]
 
-    def test_guard_install_prefers_opencode_environment_config_target(self, monkeypatch, tmp_path, capsys):
+    def test_guard_install_ignores_opencode_config_for_managed_target(self, monkeypatch, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         custom_config_path = workspace_dir / "custom" / "guard-opencode.jsonc"
@@ -3133,11 +3136,14 @@ args = ["workspace-skill.js", "--changed"]
         assert managed_config_path == home_dir / ".config" / "opencode" / "opencode.json"
         assert json.loads(custom_config_path.read_text(encoding="utf-8"))["provider"] == {"openrouter": {}}
 
-    def test_guard_install_prefers_workspace_target_over_existing_global_opencode_config(self, tmp_path, capsys):
+    def test_guard_install_targets_global_even_with_workspace_config(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
+        workspace_config_path = workspace_dir / "opencode.json"
+        workspace_text = '{\n  "provider": {"anthropic": {}}\n}\n'
         global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
         global_text = '{\n  "provider": {"openai": {}}\n}\n'
+        _write_text(workspace_config_path, workspace_text)
         _write_text(global_config_path, global_text)
 
         rc = main(
@@ -3158,7 +3164,8 @@ args = ["workspace-skill.js", "--changed"]
         assert rc == 0
         assert managed_config_path == global_config_path
         assert managed_config_path.exists() is True
-        assert global_config_path.read_text(encoding="utf-8") != global_text
+        assert json.loads(global_config_path.read_text(encoding="utf-8"))["provider"] == {"openai": {}}
+        assert workspace_config_path.read_text(encoding="utf-8") == workspace_text
 
     def test_guard_uninstall_restores_opencode_project_config(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -3175,6 +3182,7 @@ args = ["workspace-skill.js", "--changed"]
         }
         _write_json(workspace_dir / "opencode.json", original_payload)
         original_text = (workspace_dir / "opencode.json").read_text(encoding="utf-8")
+        global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
 
         install_rc = main(
             [
@@ -3209,6 +3217,7 @@ args = ["workspace-skill.js", "--changed"]
         assert uninstall_rc == 0
         assert uninstall_output["managed_install"]["active"] is False
         assert (workspace_dir / "opencode.json").read_text(encoding="utf-8") == original_text
+        assert global_config_path.exists() is False
         assert backup_path.exists() is False
 
     def test_guard_install_keeps_pythonpath_in_opencode_runtime_overlay(self, tmp_path, capsys, monkeypatch):
@@ -3328,8 +3337,10 @@ args = ["workspace-skill.js", "--changed"]
 
         assert install_rc == 0
         assert uninstall_rc == 0
-        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(home_dir / ".config" / "opencode" / "opencode.json")
+        global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
+        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(global_config_path)
         assert custom_config_path.read_text(encoding="utf-8") == original_text
+        assert global_config_path.exists() is False
         assert backup_path.exists() is False
         assert state_path.exists() is False
 
@@ -3337,8 +3348,11 @@ args = ["workspace-skill.js", "--changed"]
         home_dir = tmp_path / "home"
         workspace_a = tmp_path / "workspace-a"
         workspace_b = tmp_path / "workspace-b"
+        global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
+        original_global = '{\n  "provider": {"openai": {}}\n}\n'
         original_a = '{\n  "provider": {"openai": {}}\n}\n'
         original_b = '{\n  "provider": {"openrouter": {}}\n}\n'
+        _write_text(global_config_path, original_global)
         _write_text(workspace_a / "opencode.json", original_a)
         _write_text(workspace_b / "opencode.json", original_b)
 
@@ -3372,7 +3386,7 @@ args = ["workspace-skill.js", "--changed"]
         install_b_output = json.loads(capsys.readouterr().out)
         state_b_path = Path(str(install_b_output["managed_install"]["manifest"]["state_path"]))
 
-        uninstall_a_rc = main(
+        uninstall_b_rc = main(
             [
                 "guard",
                 "uninstall",
@@ -3380,27 +3394,30 @@ args = ["workspace-skill.js", "--changed"]
                 "--home",
                 str(home_dir),
                 "--workspace",
-                str(workspace_a),
+                str(workspace_b),
                 "--json",
             ]
         )
-        uninstall_a_output = json.loads(capsys.readouterr().out)
+        uninstall_b_output = json.loads(capsys.readouterr().out)
 
         assert install_a_rc == 0
         assert install_b_rc == 0
-        assert uninstall_a_rc == 0
-        global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
-        assert uninstall_a_output["managed_install"]["manifest"]["managed_config_path"] == str(global_config_path)
+        assert uninstall_b_rc == 0
+        assert uninstall_b_output["managed_install"]["manifest"]["managed_config_path"] == str(global_config_path)
         assert (workspace_a / "opencode.json").read_text(encoding="utf-8") == original_a
         assert (workspace_b / "opencode.json").read_text(encoding="utf-8") == original_b
+        assert global_config_path.read_text(encoding="utf-8") == original_global
         assert state_a_path == state_b_path
-        assert state_a_path.exists() is False
+        assert state_b_path.exists() is False
 
     def test_guard_uninstall_uses_single_global_state_without_opencode_config(self, monkeypatch, tmp_path, capsys):
         home_dir = tmp_path / "home"
         custom_config_path = home_dir / "custom" / "opencode.jsonc"
+        global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
         original_text = '{\n  "provider": {"openrouter": {}}\n}\n'
-        _write_text(custom_config_path, original_text)
+        custom_text = '{\n  "provider": {"anthropic": {}}\n}\n'
+        _write_text(global_config_path, original_text)
+        _write_text(custom_config_path, custom_text)
         monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config_path))
 
         install_rc = main(
@@ -3431,8 +3448,9 @@ args = ["workspace-skill.js", "--changed"]
 
         assert install_rc == 0
         assert uninstall_rc == 0
-        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(home_dir / ".config" / "opencode" / "opencode.json")
-        assert custom_config_path.read_text(encoding="utf-8") == original_text
+        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(global_config_path)
+        assert global_config_path.read_text(encoding="utf-8") == original_text
+        assert custom_config_path.read_text(encoding="utf-8") == custom_text
         assert state_path.exists() is False
 
     def test_guard_uninstall_keeps_config_when_backup_metadata_is_unreadable(self, tmp_path, capsys):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3008,13 +3008,11 @@ args = ["workspace-skill.js", "--changed"]
         assert runtime_payload["mcp"]["danger_lab"]["command"][3] == "guard"
         assert runtime_payload["mcp"]["danger_lab"]["command"][4] == "opencode-mcp-proxy"
         assert runtime_payload["mcp"]["danger_lab"]["environment"]["API_BASE"] == "https://hol.org"
-        assert manifest["managed_config_path"] == str(workspace_dir / "opencode.json")
+        assert manifest["managed_config_path"] == str(home_dir / ".config" / "opencode" / "opencode.json")
         assert Path(str(manifest["backup_path"])).is_file()
         assert managed_payload["permission"]["danger_lab_*"] == "ask"
-        assert managed_payload["mcp"]["danger_lab"]["type"] == "local"
-        assert managed_payload["mcp"]["danger_lab"]["command"] == ["python3", "danger-server.py"]
-        assert managed_payload["mcp"]["danger_lab"]["environment"]["API_BASE"] == "https://hol.org"
-        assert "opencode-mcp-proxy" not in json.dumps(managed_payload["mcp"]["danger_lab"])
+        assert "danger_lab" not in managed_payload.get("mcp", {})
+        assert (workspace_dir / "opencode.json").read_text(encoding="utf-8") != ""
 
     def test_guard_reinstall_does_not_double_wrap_opencode_mcp_proxies(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -3066,7 +3064,7 @@ args = ["workspace-skill.js", "--changed"]
 
         assert first_rc == 0
         assert second_rc == 0
-        assert managed_payload["mcp"]["danger_lab"]["command"] == ["python3", "danger-server.py"]
+        assert "danger_lab" not in managed_payload.get("mcp", {})
         assert proxy_command.count("opencode-mcp-proxy") == 1
         assert proxy_command[proxy_command.index("--command") + 1] == "python3"
         assert "--arg=danger-server.py" in proxy_command
@@ -3104,8 +3102,8 @@ args = ["workspace-skill.js", "--changed"]
         managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
 
         assert rc == 0
-        assert managed_config_path == jsonc_path
-        assert managed_payload["provider"] == {"openai": {}}
+        assert managed_config_path == home_dir / ".config" / "opencode" / "opencode.json"
+        assert "openai" in jsonc_path.read_text(encoding="utf-8")
         assert managed_payload["permission"]["danger_lab_*"] == "ask"
 
     def test_guard_install_prefers_opencode_environment_config_target(self, monkeypatch, tmp_path, capsys):
@@ -3132,8 +3130,8 @@ args = ["workspace-skill.js", "--changed"]
         managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
 
         assert rc == 0
-        assert managed_config_path == custom_config_path
-        assert managed_payload["provider"] == {"openrouter": {}}
+        assert managed_config_path == home_dir / ".config" / "opencode" / "opencode.json"
+        assert json.loads(custom_config_path.read_text(encoding="utf-8"))["provider"] == {"openrouter": {}}
 
     def test_guard_install_prefers_workspace_target_over_existing_global_opencode_config(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -3158,9 +3156,9 @@ args = ["workspace-skill.js", "--changed"]
         managed_config_path = Path(str(output["managed_install"]["manifest"]["managed_config_path"]))
 
         assert rc == 0
-        assert managed_config_path == workspace_dir / "opencode.json"
+        assert managed_config_path == global_config_path
         assert managed_config_path.exists() is True
-        assert global_config_path.read_text(encoding="utf-8") == global_text
+        assert global_config_path.read_text(encoding="utf-8") != global_text
 
     def test_guard_uninstall_restores_opencode_project_config(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -3330,7 +3328,7 @@ args = ["workspace-skill.js", "--changed"]
 
         assert install_rc == 0
         assert uninstall_rc == 0
-        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(custom_config_path)
+        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(home_dir / ".config" / "opencode" / "opencode.json")
         assert custom_config_path.read_text(encoding="utf-8") == original_text
         assert backup_path.exists() is False
         assert state_path.exists() is False
@@ -3391,13 +3389,12 @@ args = ["workspace-skill.js", "--changed"]
         assert install_a_rc == 0
         assert install_b_rc == 0
         assert uninstall_a_rc == 0
-        assert uninstall_a_output["managed_install"]["manifest"]["managed_config_path"] == str(
-            workspace_a / "opencode.json"
-        )
+        global_config_path = home_dir / ".config" / "opencode" / "opencode.json"
+        assert uninstall_a_output["managed_install"]["manifest"]["managed_config_path"] == str(global_config_path)
         assert (workspace_a / "opencode.json").read_text(encoding="utf-8") == original_a
-        assert (workspace_b / "opencode.json").read_text(encoding="utf-8") != original_b
+        assert (workspace_b / "opencode.json").read_text(encoding="utf-8") == original_b
+        assert state_a_path == state_b_path
         assert state_a_path.exists() is False
-        assert state_b_path.exists() is True
 
     def test_guard_uninstall_uses_single_global_state_without_opencode_config(self, monkeypatch, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -3434,7 +3431,7 @@ args = ["workspace-skill.js", "--changed"]
 
         assert install_rc == 0
         assert uninstall_rc == 0
-        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(custom_config_path)
+        assert uninstall_output["managed_install"]["manifest"]["managed_config_path"] == str(home_dir / ".config" / "opencode" / "opencode.json")
         assert custom_config_path.read_text(encoding="utf-8") == original_text
         assert state_path.exists() is False
 
@@ -3626,8 +3623,8 @@ args = ["workspace-skill.js", "--changed"]
         assert uninstall_rc == 0
         assert config_a_path.read_text(encoding="utf-8") == config_a_before_uninstall
         assert config_b_path.read_text(encoding="utf-8") == config_b_before_uninstall
-        assert state_a_path.exists() is True
-        assert state_b_path.exists() is True
+        assert state_a_path == state_b_path
+        assert state_a_path.exists() is False
 
     def test_guard_install_keeps_disabled_opencode_servers_disabled(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -348,7 +348,7 @@ class TestOpenCodeInstall:
         runtime_chrome = runtime_config["mcp"]["chrome-devtools"]
         assert "opencode-mcp-proxy" in json.dumps(runtime_chrome)
 
-    def test_install_promotes_workspace_mcp_servers_to_global_config(self, tmp_path: Path) -> None:
+    def test_install_does_not_promote_project_mcp_to_global_config(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=True)
         assert ctx.workspace_dir is not None
         workspace_config = ctx.workspace_dir / "opencode.json"
@@ -359,8 +359,17 @@ class TestOpenCodeInstall:
         global_config = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         OpenCodeHarnessAdapter().install(ctx)
         managed_config = json.loads(global_config.read_text(encoding="utf-8"))
-        assert managed_config["mcp"]["project-mcp"]["command"] == ["node", "project-mcp.js"]
-        assert "hol-guard::project-mcp" in managed_config["mcp"]
+        assert "project-mcp" not in managed_config.get("mcp", {})
+        assert "hol-guard::project-mcp" not in managed_config.get("mcp", {})
+
+    def test_install_preserves_explicit_bash_ask_permission(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_text(json.dumps({"permission": {"bash": "ask"}}), encoding="utf-8")
+        OpenCodeHarnessAdapter().install(ctx)
+        managed_config = json.loads(target.read_text(encoding="utf-8"))
+        assert managed_config["permission"]["bash"]["*"] == "ask"
 
     def test_install_writes_global_root_config_even_with_workspace(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=True)
@@ -376,9 +385,6 @@ class TestOpenCodeInstall:
         assert Path(str(result["managed_config_path"])) == global_config
         managed_config = json.loads(global_config.read_text(encoding="utf-8"))
         assert managed_config["$schema"] == "https://opencode.ai/config.json"
-        assert "./plugins/hol-guard-pretool.ts" in json.dumps(
-            managed_config.get("plugin", managed_config.get("plugins"))
-        )
         assert managed_config["permission"]["bash"]["rm -rf *"] == "deny"
         assert "hol-guard::chrome-devtools" in managed_config["mcp"]
         assert workspace_config.read_text(encoding="utf-8") == '{"mcp": {}}'
@@ -519,8 +525,9 @@ class TestOpenCodePermissionRules:
         managed = managed_stdio_servers(detection)
         rules = OpenCodeHarnessAdapter._proxy_permission_rules(ctx, managed, set())
         target_rule_keys = [k for k in rules if "target-srv" in k]
-        assert len(target_rule_keys) == 1
-        assert rules[target_rule_keys[0]] == "ask"
+        assert len(target_rule_keys) == 2
+        assert rules["target-srv_*"] == "ask"
+        assert rules["hol-guard::target-srv_*"] == "ask"
 
 
 class TestOpenCodeLaunchEnvironment:

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -362,6 +362,23 @@ class TestOpenCodeInstall:
         assert "project-mcp" not in managed_config.get("mcp", {})
         assert "hol-guard::project-mcp" not in managed_config.get("mcp", {})
 
+    def test_install_keeps_global_companion_when_workspace_shadows_name(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        assert ctx.workspace_dir is not None
+        global_config = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
+        _write_mcp_config(
+            global_config,
+            {"shared-lab": {"type": "local", "command": ["node", "global-shared-lab.js"]}},
+        )
+        _write_mcp_config(
+            ctx.workspace_dir / "opencode.json",
+            {"shared-lab": {"type": "local", "command": ["node", "project-shared-lab.js"]}},
+        )
+        OpenCodeHarnessAdapter().install(ctx)
+        managed_config = json.loads(global_config.read_text(encoding="utf-8"))
+        assert managed_config["mcp"]["shared-lab"]["command"] == ["node", "global-shared-lab.js"]
+        assert "hol-guard::shared-lab" in managed_config["mcp"]
+
     def test_install_preserves_explicit_bash_ask_permission(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
         target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -211,23 +211,25 @@ class TestOpenCodeConfigPrecedence:
         assert "workspace-only" in names
         assert "global-only" in names
 
-    def test_target_config_path_prefers_existing_workspace_file(self, tmp_path: Path) -> None:
+    def test_target_config_path_prefers_existing_global_file(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=True)
         assert ctx.workspace_dir is not None
-        existing = ctx.workspace_dir / "opencode.json"
+        ctx.workspace_dir.joinpath("opencode.json").write_text("{}", encoding="utf-8")
+        existing = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        existing.parent.mkdir(parents=True, exist_ok=True)
         existing.write_text("{}", encoding="utf-8")
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         assert target == existing
 
-    def test_target_config_path_uses_first_filename_for_new_workspace(self, tmp_path: Path) -> None:
+    def test_target_config_path_uses_global_dir_for_new_install(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=True)
         assert ctx.workspace_dir is not None
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
-        assert target == ctx.workspace_dir / CONFIG_FILENAMES[0]
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
+        assert target == ctx.home_dir / ".config" / "opencode" / CONFIG_FILENAMES[0]
 
     def test_target_config_path_uses_global_dir_when_no_workspace(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=False)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         assert target.is_relative_to(ctx.home_dir)
 
 
@@ -272,7 +274,7 @@ class TestOpenCodeInstall:
 
     def test_install_backup_preserves_original_content(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         target.parent.mkdir(parents=True, exist_ok=True)
         original = '{"model": "gpt-4"}'
         target.write_text(original, encoding="utf-8")
@@ -297,7 +299,7 @@ class TestOpenCodeInstall:
 
     def test_install_with_existing_mcp_adds_permission_rules(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         target.parent.mkdir(parents=True, exist_ok=True)
         _write_mcp_config(target, {"my-server": {"type": "local", "command": ["node", "s.js"]}})
         OpenCodeHarnessAdapter().install(ctx)
@@ -317,7 +319,7 @@ class TestOpenCodeInstall:
 
     def test_install_keeps_original_mcp_servers_on_disk(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         target.parent.mkdir(parents=True, exist_ok=True)
         _write_mcp_config(
             target,
@@ -340,13 +342,50 @@ class TestOpenCodeInstall:
         assert chrome["command"] == ["npx", "-y", "chrome-devtools-mcp@latest"]
         assert "opencode-mcp-proxy" not in json.dumps(chrome)
         assert managed_config["mcp"]["my-remote"]["url"] == "https://example.com/mcp"
+        companion = managed_config["mcp"]["hol-guard::chrome-devtools"]
+        assert "opencode-mcp-proxy" in json.dumps(companion)
         runtime_config = json.loads(Path(result["runtime_config_path"]).read_text(encoding="utf-8"))
         runtime_chrome = runtime_config["mcp"]["chrome-devtools"]
         assert "opencode-mcp-proxy" in json.dumps(runtime_chrome)
 
+    def test_install_promotes_workspace_mcp_servers_to_global_config(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        assert ctx.workspace_dir is not None
+        workspace_config = ctx.workspace_dir / "opencode.json"
+        _write_mcp_config(
+            workspace_config,
+            {"project-mcp": {"type": "local", "command": ["node", "project-mcp.js"]}},
+        )
+        global_config = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
+        OpenCodeHarnessAdapter().install(ctx)
+        managed_config = json.loads(global_config.read_text(encoding="utf-8"))
+        assert managed_config["mcp"]["project-mcp"]["command"] == ["node", "project-mcp.js"]
+        assert "hol-guard::project-mcp" in managed_config["mcp"]
+
+    def test_install_writes_global_root_config_even_with_workspace(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        assert ctx.workspace_dir is not None
+        workspace_config = ctx.workspace_dir / "opencode.json"
+        workspace_config.write_text('{"mcp": {}}', encoding="utf-8")
+        global_config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        _write_mcp_config(
+            global_config,
+            {"chrome-devtools": {"type": "local", "command": ["npx", "-y", "chrome-devtools-mcp@latest"]}},
+        )
+        result = OpenCodeHarnessAdapter().install(ctx)
+        assert Path(str(result["managed_config_path"])) == global_config
+        managed_config = json.loads(global_config.read_text(encoding="utf-8"))
+        assert managed_config["$schema"] == "https://opencode.ai/config.json"
+        assert "./plugins/hol-guard-pretool.ts" in json.dumps(
+            managed_config.get("plugin", managed_config.get("plugins"))
+        )
+        assert managed_config["permission"]["bash"]["rm -rf *"] == "deny"
+        assert "hol-guard::chrome-devtools" in managed_config["mcp"]
+        assert workspace_config.read_text(encoding="utf-8") == '{"mcp": {}}'
+
     def test_install_restores_prior_persisted_proxy_wrappers(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         target.parent.mkdir(parents=True, exist_ok=True)
         _write_mcp_config(
             target,
@@ -392,7 +431,7 @@ class TestOpenCodeInstall:
 class TestOpenCodeUninstall:
     def test_uninstall_restores_original_content(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         target.parent.mkdir(parents=True, exist_ok=True)
         original = '{"model": "gpt-4"}'
         target.write_text(original, encoding="utf-8")
@@ -403,7 +442,7 @@ class TestOpenCodeUninstall:
     def test_uninstall_removes_file_when_no_prior_config_existed(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
         OpenCodeHarnessAdapter().install(ctx)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         OpenCodeHarnessAdapter().uninstall(ctx)
         assert not target.is_file()
 
@@ -666,7 +705,7 @@ class TestOpenCodeScopeDetection:
 
     def test_install_and_uninstall_are_inverse_for_new_config(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         assert not target.exists()
         OpenCodeHarnessAdapter().install(ctx)
         assert target.is_file()
@@ -675,7 +714,7 @@ class TestOpenCodeScopeDetection:
 
     def test_install_and_uninstall_are_inverse_for_existing_config(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         target.parent.mkdir(parents=True, exist_ok=True)
         original_text = '{"model": "claude-3"}'
         target.write_text(original_text, encoding="utf-8")
@@ -696,7 +735,7 @@ class TestOpenCodeScopeDetection:
         adapter = get_adapter("opencode")
         assert adapter.harness == "opencode"
 
-    def test_target_config_path_uses_opencode_config_env_var(
+    def test_managed_install_ignores_opencode_config_env_var(
         self, tmp_path: Path, monkeypatch
     ) -> None:
         ctx = _ctx(tmp_path, workspace=False)
@@ -704,8 +743,8 @@ class TestOpenCodeScopeDetection:
         custom_config.parent.mkdir(parents=True, exist_ok=True)
         custom_config.touch()
         monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config))
-        target = OpenCodeHarnessAdapter._target_config_path(ctx)
-        assert target == custom_config
+        target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
+        assert target == ctx.home_dir / ".config" / "opencode" / CONFIG_FILENAMES[0]
 
 
 

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -166,6 +166,28 @@ def test_opencode_config_uses_guard_proxy_parses_jsonc_comments(tmp_path: Path) 
     assert opencode_config_uses_guard_proxy(config) is True
 
 
+def test_opencode_config_uses_guard_proxy_rejects_invalid_companion_command(tmp_path: Path) -> None:
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "hol-guard::chrome-devtools": {
+                        "type": "local",
+                        "command": ["node", "not-a-proxy.js"],
+                    },
+                    "chrome-devtools": {
+                        "type": "local",
+                        "command": ["npx", "-y", "chrome-devtools-mcp@latest"],
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert opencode_config_uses_guard_proxy(config) is False
+
+
 def test_opencode_config_uses_guard_proxy_detects_companion_server_name(tmp_path: Path) -> None:
     config = tmp_path / "opencode.json"
     config.write_text(

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -101,6 +101,24 @@ def test_pretool_hook_launcher_ignores_workspace_package_hijack(
     assert completed.returncode != 99
 
 
+def test_pretool_hook_env_blocks_workspace_import_shadowing(tmp_path: Path) -> None:
+    ctx = _ctx(tmp_path)
+    guard_python = resolve_guard_hook_python(ctx)
+    package_root = package_root_from_python(guard_python)
+    env = _pretool_hook_env(package_root=package_root)
+    assert env["PYTHONSAFEPATH"] == "1"
+    assert env["PYTHONNOUSERSITE"] == "1"
+    assert package_root in env["PYTHONPATH"]
+
+
+def test_pretool_plugin_source_does_not_spawn_python_m_module(tmp_path: Path) -> None:
+    source = pretool_plugin_source(_ctx(tmp_path))
+    spawn_block = source.split("Bun.spawn(", 1)[1].split("});", 1)[0]
+    assert "codex_plugin_scanner.cli" not in spawn_block
+    assert '"-c"' in spawn_block or "'-c'" in spawn_block or "-c" in spawn_block
+    assert "GUARD_HOOK_LAUNCHER" in spawn_block
+
+
 def test_install_pretool_plugin_writes_managed_and_global_copies(tmp_path: Path) -> None:
     ctx = _ctx(tmp_path)
     manifest = install_pretool_plugin(ctx)
@@ -148,6 +166,24 @@ def test_opencode_config_uses_guard_proxy_parses_jsonc_comments(tmp_path: Path) 
     assert opencode_config_uses_guard_proxy(config) is True
 
 
+def test_opencode_config_uses_guard_proxy_detects_companion_server_name(tmp_path: Path) -> None:
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "hol-guard::chrome-devtools": {
+                        "type": "local",
+                        "command": ["python", "-m", "codex_plugin_scanner.cli", "guard", "opencode-mcp-proxy"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert opencode_config_uses_guard_proxy(config) is True
+
+
 def test_opencode_config_uses_guard_proxy_detects_managed_command(tmp_path: Path) -> None:
     config = tmp_path / "opencode.json"
     config.write_text(
@@ -183,6 +219,41 @@ def test_opencode_verification_ready_without_mcp_servers(tmp_path: Path) -> None
     assert verification["pretool_plugin_installed"] is True
     assert verification["mcp_proxy_configured"] is False
     assert opencode_config_has_mcp_servers(config) is False
+    assert verification["ready"] is True
+    assert not verification["warnings"]
+
+
+def test_opencode_verification_ready_with_guard_companion_servers(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    ctx = _ctx(tmp_path)
+    config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+    config.parent.mkdir(parents=True, exist_ok=True)
+    config.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "chrome-devtools": {
+                        "type": "local",
+                        "command": ["npx", "-y", "chrome-devtools-mcp@latest"],
+                    },
+                    "hol-guard::chrome-devtools": {
+                        "type": "local",
+                        "command": ["python", "-m", "codex_plugin_scanner.cli", "guard", "opencode-mcp-proxy"],
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    install_pretool_plugin(ctx)
+    (ctx.guard_home / "bin").mkdir(parents=True, exist_ok=True)
+    (ctx.guard_home / "bin" / "guard-opencode").write_text("#!/bin/sh\n", encoding="utf-8")
+    store = GuardStore(ctx.guard_home)
+    store.set_managed_install("opencode", True, None, {}, "2026-06-04T00:00:00+00:00")
+    payload = install_commands_module.build_harness_verification("opencode", ctx, store=store)
+    verification = payload["verification"]
+    assert verification["mcp_proxy_configured"] is True
     assert verification["ready"] is True
     assert not verification["warnings"]
 

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -224,6 +224,28 @@ def test_opencode_config_uses_guard_proxy_detects_managed_command(tmp_path: Path
     assert opencode_config_uses_guard_proxy(config) is True
 
 
+def test_opencode_config_uses_guard_proxy_requires_companion_for_each_native_server(tmp_path: Path) -> None:
+    config = tmp_path / "opencode.json"
+    config.write_text(
+        json.dumps(
+            {
+                "mcp": {
+                    "hol-guard::old-server": {
+                        "type": "local",
+                        "command": ["python", "-m", "codex_plugin_scanner.cli", "guard", "opencode-mcp-proxy"],
+                    },
+                    "new-server": {
+                        "type": "local",
+                        "command": ["node", "new-server.js"],
+                    },
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert opencode_config_uses_guard_proxy(config) is False
+
+
 def test_opencode_verification_ready_without_mcp_servers(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.store import GuardStore
 


### PR DESCRIPTION
## Summary
- Install OpenCode protection against the global root config at ~/.config/opencode/opencode.json instead of project opencode.json
- Register pretool plugin, baseline bash permission rules, and hol-guard:: MCP companion servers on disk
- Harden pretool hook: trusted inline launcher, cwd=GUARD_HOME, PYTHONSAFEPATH, workspace sys.path stripping

## Testing
- `uv run pytest tests/test_opencode_adapter.py tests/test_opencode_pretool.py tests/test_opencode_hook_python.py -q --tb=short`

## Notes
- Addresses workspace import-shadowing on OpenCode pretool hooks (no python -m with workspace cwd)
- After merge, run `hol-guard install opencode` on each machine to regenerate the pretool plugin
