### PR TITLE
fix(cursor): scope approval links to harness and add inbox copy

### DIFF
--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -10,6 +10,7 @@ import {
   buildRecommendation,
   scopeLabel,
   buildCodexResumeUx,
+  resolveApprovalShareUrl,
 } from "./approval-center-utils";
 import type { GuardActionEnvelope, GuardApprovalRequest, GuardCodexResumeResult } from "./guard-types";
 
@@ -336,5 +337,14 @@ assert(uxFailedDefault.body !== null, "C13: failed has non-null body even withou
 const uxSkipped = buildCodexResumeUx(makeResume("skipped"));
 assert(uxSkipped.showRetry === false, "C13: skipped status has showRetry false");
 assert(uxSkipped.body !== null && uxSkipped.body.toLowerCase().includes("codex"), "C13: skipped body mentions Codex");
+
+assert(
+  resolveApprovalShareUrl({
+    ...BASE_REQUEST,
+    request_id: "cursor-share-req",
+    approval_url: "http://127.0.0.1:4781/approvals/legacy-req"
+  }) === "/requests/cursor-share-req",
+  "T498: resolveApprovalShareUrl prefers request_id and canonical /requests/ route"
+);
 
 console.log("approval-center-layout.test.ts: all tests passed");

--- a/dashboard/src/approval-center-layout.test.ts
+++ b/dashboard/src/approval-center-layout.test.ts
@@ -343,7 +343,7 @@ assert(
     ...BASE_REQUEST,
     request_id: "cursor-share-req",
     approval_url: "http://127.0.0.1:4781/approvals/legacy-req"
-  }) === "/requests/cursor-share-req",
+  }) === "http://127.0.0.1:4781/requests/cursor-share-req",
   "T498: resolveApprovalShareUrl prefers request_id and canonical /requests/ route"
 );
 

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, MouseEvent } from "react";
+import type { ReactNode, MouseEvent, KeyboardEvent } from "react";
 import { useState, useEffect, useCallback, useMemo, useRef, type ChangeEvent } from "react";
 import {
   HiMiniChevronDown,
@@ -845,6 +845,7 @@ function QueueCardRow(props: {
 function QueueApprovalShareButton(props: { item: GuardApprovalRequest }) {
   const [shareState, setShareState] = useState<"idle" | "copied" | "failed">("idle");
   const approvalUrl = resolveApprovalShareUrl(props.item);
+  const timeoutRef = useRef<number | null>(null);
   const handleCopy = useCallback(
     async (event: MouseEvent<HTMLButtonElement>) => {
       event.stopPropagation();
@@ -852,17 +853,28 @@ function QueueApprovalShareButton(props: { item: GuardApprovalRequest }) {
       if (approvalUrl === null) {
         return;
       }
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
       try {
         await navigator.clipboard.writeText(approvalUrl);
         setShareState("copied");
-        window.setTimeout(() => setShareState("idle"), 1800);
+        timeoutRef.current = window.setTimeout(() => setShareState("idle"), 1800);
       } catch {
         setShareState("failed");
-        window.setTimeout(() => setShareState("idle"), 2400);
+        timeoutRef.current = window.setTimeout(() => setShareState("idle"), 2400);
       }
     },
     [approvalUrl]
   );
+
+  useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
 
   if (approvalUrl === null) {
     return null;
@@ -887,19 +899,32 @@ function QueueCard(props: { item: GuardApprovalRequest; duplicateCount: number; 
   const fileReadPath = resolveFileReadPath(props.item);
   const isBlocked = props.item.policy_action === "block";
   const statusDotClass = queueCardStatusDotClass(props.active, isBlocked);
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        props.onClick();
+      }
+    },
+    [props.onClick]
+  );
   return (
-    <button
-      type="button"
-      onClick={props.onClick}
-      aria-pressed={props.active}
-      className={`group/item w-full cursor-pointer border-l-4 px-4 py-3.5 text-left transition-all duration-150 hover:bg-brand-blue/[0.035] ${
+    <div
+      className={`group/item w-full border-l-4 px-4 py-3.5 transition-all duration-150 hover:bg-brand-blue/[0.035] ${
         props.active
           ? "border-brand-blue bg-brand-blue/[0.06]"
           : "border-transparent bg-white/70"
       }`}
     >
       <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 items-start gap-3">
+        <div
+          role="button"
+          tabIndex={0}
+          onClick={props.onClick}
+          onKeyDown={handleKeyDown}
+          aria-pressed={props.active}
+          className="flex min-w-0 flex-1 cursor-pointer items-start gap-3 text-left"
+        >
            <span
              className={`mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full transition-colors ${
                statusDotClass
@@ -917,14 +942,16 @@ function QueueCard(props: { item: GuardApprovalRequest; duplicateCount: number; 
             )}
           </div>
         </div>
-        {props.duplicateCount > 0 && (
-          <span className="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground">
-            +{props.duplicateCount}
-          </span>
-        )}
-        <QueueApprovalShareButton item={props.item} />
+        <div className="flex shrink-0 items-start gap-2">
+          {props.duplicateCount > 0 && (
+            <span className="rounded-full bg-slate-100 px-2 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground">
+              +{props.duplicateCount}
+            </span>
+          )}
+          <QueueApprovalShareButton item={props.item} />
+        </div>
       </div>
-    </button>
+    </div>
   );
 }
 

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { ReactNode, MouseEvent } from "react";
 import { useState, useEffect, useCallback, useMemo, useRef, type ChangeEvent } from "react";
 import {
   HiMiniChevronDown,
@@ -54,6 +54,7 @@ import {
   displayArtifactName,
   resolveTerminalLabel,
   resolveFileReadPath,
+  resolveApprovalShareUrl,
   scopeLabel,
   STALE_REQUEST_COPY,
   QUEUE_CONNECTION_ERROR_HEADLINE,
@@ -841,6 +842,46 @@ function QueueCardRow(props: {
   );
 }
 
+function QueueApprovalShareButton(props: { item: GuardApprovalRequest }) {
+  const [shareState, setShareState] = useState<"idle" | "copied" | "failed">("idle");
+  const approvalUrl = resolveApprovalShareUrl(props.item);
+  const handleCopy = useCallback(
+    async (event: MouseEvent<HTMLButtonElement>) => {
+      event.stopPropagation();
+      event.preventDefault();
+      if (approvalUrl === null) {
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(approvalUrl);
+        setShareState("copied");
+        window.setTimeout(() => setShareState("idle"), 1800);
+      } catch {
+        setShareState("failed");
+        window.setTimeout(() => setShareState("idle"), 2400);
+      }
+    },
+    [approvalUrl]
+  );
+
+  if (approvalUrl === null) {
+    return null;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-brand-blue/80 transition-colors hover:bg-brand-blue/[0.06] hover:text-brand-blue"
+      aria-label="Copy approval link"
+      title={copyApprovalUrlLabel(shareState)}
+    >
+      <HiMiniClipboard className="h-3.5 w-3.5" aria-hidden="true" />
+      <span className="hidden sm:inline">{copyApprovalUrlLabel(shareState)}</span>
+    </button>
+  );
+}
+
 function QueueCard(props: { item: GuardApprovalRequest; duplicateCount: number; active: boolean; onClick: () => void }) {
   const summary = buildQueueSummary(props.item);
   const fileReadPath = resolveFileReadPath(props.item);
@@ -881,6 +922,7 @@ function QueueCard(props: { item: GuardApprovalRequest; duplicateCount: number; 
             +{props.duplicateCount}
           </span>
         )}
+        <QueueApprovalShareButton item={props.item} />
       </div>
     </button>
   );
@@ -1874,7 +1916,7 @@ function BlockedActionCard(props: { item: GuardApprovalRequest }) {
     isMcpTool && envelope !== null
       ? resolveMcpInputSummary(envelope.raw_payload_redacted)
       : null;
-  const approvalUrl = props.item.approval_url ? guardAwareHref(props.item.approval_url) : null;
+  const approvalUrl = resolveApprovalShareUrl(props.item);
   const toggleCommand = useCallback(() => {
     setShowCommand((visible) => !visible);
   }, []);

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -619,14 +619,31 @@ export function buildApprovalSharePath(item: GuardApprovalRequest): string | nul
 }
 
 export function resolveApprovalShareUrl(item: GuardApprovalRequest): string | null {
-  const path = buildApprovalSharePath(item);
-  if (path === null) {
-    return null;
+  const requestId = item.request_id?.trim();
+  const stored = item.approval_url?.trim();
+  let absolute: string | null = null;
+  if (stored) {
+    absolute = stored.replace("/approvals/", "/requests/");
+    if (requestId) {
+      absolute = absolute.replace(/\/(?:approvals|requests)\/[^/?#]+/, `/requests/${requestId}`);
+    }
+  } else if (requestId && typeof window !== "undefined") {
+    absolute = `${window.location.origin}/requests/${requestId}`;
+  }
+  if (absolute === null) {
+    const path = buildApprovalSharePath(item);
+    if (path === null) {
+      return null;
+    }
+    if (typeof window === "undefined") {
+      return path;
+    }
+    absolute = `${window.location.origin}${path}`;
   }
   if (typeof window === "undefined") {
-    return path;
+    return absolute;
   }
-  return guardAwareHref(path);
+  return guardAwareHref(absolute);
 }
 
 export function resolveTerminalLabel(item: GuardApprovalRequest): string {

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -6,6 +6,7 @@ import type {
   GuardReceipt,
   RiskSignalV2
 } from "./guard-types";
+import { guardAwareHref } from "./guard-api";
 
 export const EMPTY_QUEUE_TITLE = "No blocked actions";
 export const STALE_REQUEST_COPY = "This request was already decided.";
@@ -597,6 +598,35 @@ export function resolveFileReadPath(item: GuardApprovalRequest): string | null {
   const paths = item.action_envelope_json?.target_paths ?? [];
   if (paths.length > 0) return paths[0];
   return item.launch_target ?? null;
+}
+
+export function buildApprovalSharePath(item: GuardApprovalRequest): string | null {
+  const requestId = item.request_id?.trim();
+  if (requestId) {
+    return `/requests/${requestId}`;
+  }
+  const stored = item.approval_url?.trim();
+  if (!stored) {
+    return null;
+  }
+  try {
+    const parsed = new URL(stored, "http://guard.local");
+    parsed.pathname = parsed.pathname.replace("/approvals/", "/requests/");
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return stored.replace("/approvals/", "/requests/");
+  }
+}
+
+export function resolveApprovalShareUrl(item: GuardApprovalRequest): string | null {
+  const path = buildApprovalSharePath(item);
+  if (path === null) {
+    return null;
+  }
+  if (typeof window === "undefined") {
+    return path;
+  }
+  return guardAwareHref(path);
 }
 
 export function resolveTerminalLabel(item: GuardApprovalRequest): string {

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -493,26 +493,30 @@ def _cursor_read_file_permission(permission: str) -> str:
 
 def _cursor_reason(guard_payload: dict[str, object]) -> str:
     primary_url = guard_payload.get("primary_approval_url")
-    if isinstance(primary_url, str) and primary_url.strip():
-        for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
-            value = guard_payload.get(key)
-            if isinstance(value, str) and value.strip():
-                reason = value.strip()
-                if primary_url.strip() in reason:
-                    return reason
-                return f"{reason} Review: {primary_url.strip()}"
-        return f"HOL Guard needs approval for this Cursor action. Review it at {primary_url.strip()}."
+    reason: str | None = None
     for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
         value = guard_payload.get(key)
         if isinstance(value, str) and value.strip():
-            return value.strip()
-    decision = guard_payload.get("decision_v2_json")
-    if isinstance(decision, Mapping):
-        for key in ("harness_message", "retry_instruction", "user_body", "user_title"):
-            value = decision.get(key)
-            if isinstance(value, str) and value.strip():
-                return value.strip()
-    return "HOL Guard blocked this Cursor action."
+            reason = value.strip()
+            break
+    if reason is None:
+        decision = guard_payload.get("decision_v2_json")
+        if isinstance(decision, Mapping):
+            for key in ("harness_message", "retry_instruction", "user_body", "user_title"):
+                value = decision.get(key)
+                if isinstance(value, str) and value.strip():
+                    reason = value.strip()
+                    break
+    if reason is None:
+        if isinstance(primary_url, str) and primary_url.strip():
+            return f"HOL Guard needs approval for this Cursor action. Review it at {primary_url.strip()}."
+        return "HOL Guard blocked this Cursor action."
+    if isinstance(primary_url, str) and primary_url.strip():
+        url_str = primary_url.strip()
+        if url_str in reason:
+            return reason
+        return f"{reason} Review: {url_str}"
+    return reason
 
 
 def _emit_cursor_response(

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -492,6 +492,16 @@ def _cursor_read_file_permission(permission: str) -> str:
 
 
 def _cursor_reason(guard_payload: dict[str, object]) -> str:
+    primary_url = guard_payload.get("primary_approval_url")
+    if isinstance(primary_url, str) and primary_url.strip():
+        for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
+            value = guard_payload.get(key)
+            if isinstance(value, str) and value.strip():
+                reason = value.strip()
+                if primary_url.strip() in reason:
+                    return reason
+                return f"{reason} Review: {primary_url.strip()}"
+        return f"HOL Guard needs approval for this Cursor action. Review it at {primary_url.strip()}."
     for key in ("review_hint", "risk_summary", "why_now", "risk_headline"):
         value = guard_payload.get(key)
         if isinstance(value, str) and value.strip():

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -96,7 +96,7 @@ def primary_approval_url(
         return None
     approval_url = request.get("approval_url")
     if isinstance(approval_url, str) and approval_url.strip():
-        return approval_url.strip()
+        return approval_url.strip().replace("/approvals/", "/requests/")
     request_id = request.get("request_id")
     if isinstance(request_id, str) and request_id.strip() and isinstance(approval_center_url, str):
         center = approval_center_url.strip()
@@ -396,11 +396,14 @@ def approval_center_hint(
     flow = approval_prompt_flow(harness, managed_install=managed_install)
     count = len(queued)
     risk_summary = _queue_risk_summary(queued)
-    review_url = primary_approval_url(
-        queued,
-        harness=harness,
-        approval_center_url=approval_center_url,
-    ) or approval_center_url
+    review_url = (
+        primary_approval_url(
+            queued,
+            harness=harness,
+            approval_center_url=approval_center_url,
+        )
+        or approval_center_url
+    )
     return (
         f"Guard queued {count} approval request{'s' if count != 1 else ''} for {harness}. "
         f"{flow['summary']} "

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -47,6 +47,64 @@ class ApprovalRequestAlreadyResolvedError(ValueError):
     """Raised when an approval request was already resolved."""
 
 
+def build_approval_request_url(approval_center_url: str, request_id: str) -> str:
+    """Build the canonical local dashboard deep link for one approval request."""
+
+    return f"{approval_center_url.rstrip('/')}/requests/{request_id.strip()}"
+
+
+def _normalize_harness_slug(harness: str | None) -> str | None:
+    if not isinstance(harness, str):
+        return None
+    normalized = harness.strip().lower()
+    if normalized in {"claude", "claude-code"}:
+        return "claude-code"
+    return normalized or None
+
+
+def primary_approval_request(
+    queued: Sequence[object],
+    *,
+    harness: str | None = None,
+) -> dict[str, object] | None:
+    """Return the approval request dict that best matches the current harness action."""
+
+    normalized_harness = _normalize_harness_slug(harness)
+    matched: dict[str, object] | None = None
+    fallback: dict[str, object] | None = None
+    for item in reversed(tuple(queued)):
+        if not isinstance(item, Mapping):
+            continue
+        request = dict(item)
+        if fallback is None:
+            fallback = request
+        item_harness = _normalize_harness_slug(str(request.get("harness") or ""))
+        if normalized_harness is not None and item_harness == normalized_harness:
+            matched = request
+            break
+    return matched or fallback
+
+
+def primary_approval_url(
+    queued: Sequence[object],
+    *,
+    harness: str | None = None,
+    approval_center_url: str | None = None,
+) -> str | None:
+    request = primary_approval_request(queued, harness=harness)
+    if request is None:
+        return None
+    approval_url = request.get("approval_url")
+    if isinstance(approval_url, str) and approval_url.strip():
+        return approval_url.strip()
+    request_id = request.get("request_id")
+    if isinstance(request_id, str) and request_id.strip() and isinstance(approval_center_url, str):
+        center = approval_center_url.strip()
+        if center:
+            return build_approval_request_url(center, request_id.strip())
+    return None
+
+
 def queue_blocked_approvals(
     *,
     detection: HarnessDetection,
@@ -99,7 +157,7 @@ def queue_blocked_approvals(
             launch_target=launch_target,
             transport=artifact.transport if artifact is not None else None,
             review_command=f"{GUARD_COMMAND} approvals approve {request_id}",
-            approval_url=f"{approval_center_url.rstrip('/')}/approvals/{request_id}",
+            approval_url=build_approval_request_url(approval_center_url, request_id),
             workspace=_workspace_scope_target(item, artifact),
             publisher=artifact.publisher if artifact is not None else None,
             risk_summary=risk_summary,
@@ -120,7 +178,7 @@ def queue_blocked_approvals(
                 request,
                 request_id=persisted_request_id,
                 review_command=f"{GUARD_COMMAND} approvals approve {persisted_request_id}",
-                approval_url=f"{approval_center_url.rstrip('/')}/approvals/{persisted_request_id}",
+                approval_url=build_approval_request_url(approval_center_url, persisted_request_id),
             )
         _notify_pending_approval(store=store, request=request)
         queued.append(request.to_dict())
@@ -338,8 +396,11 @@ def approval_center_hint(
     flow = approval_prompt_flow(harness, managed_install=managed_install)
     count = len(queued)
     risk_summary = _queue_risk_summary(queued)
-    approval_url = first_approval_url(queued)
-    review_url = approval_url or approval_center_url
+    review_url = primary_approval_url(
+        queued,
+        harness=harness,
+        approval_center_url=approval_center_url,
+    ) or approval_center_url
     return (
         f"Guard queued {count} approval request{'s' if count != 1 else ''} for {harness}. "
         f"{flow['summary']} "
@@ -349,14 +410,17 @@ def approval_center_hint(
     )
 
 
-def first_approval_url(queued: Sequence[object]) -> str | None:
-    for item in queued:
-        if not isinstance(item, Mapping):
-            continue
-        approval_url = item.get("approval_url")
-        if isinstance(approval_url, str) and approval_url.strip():
-            return approval_url.strip()
-    return None
+def first_approval_url(
+    queued: Sequence[object],
+    *,
+    harness: str | None = None,
+    approval_center_url: str | None = None,
+) -> str | None:
+    return primary_approval_url(
+        queued,
+        harness=harness,
+        approval_center_url=approval_center_url,
+    )
 
 
 def build_runtime_snapshot(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3086,7 +3086,7 @@ def run_guard_command(
             response_payload["approval_requests"] = queued
             _attach_primary_approval_link(
                 response_payload,
-                harness=args.harness,
+                harness=_optional_string(args.harness) or args.harness,
                 approval_center_url=approval_center_url,
             )
             response_payload["approval_center_url"] = approval_center_url
@@ -3628,7 +3628,7 @@ def run_guard_command(
                     response_payload["approval_requests"] = queued
                     _attach_primary_approval_link(
                         response_payload,
-                        harness=args.harness,
+                        harness=_optional_string(args.harness) or args.harness,
                         approval_center_url=approval_center_url,
                     )
                     response_payload["approval_center_url"] = approval_center_url

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -50,6 +50,8 @@ from ..approvals import (
     approval_delivery_payload,
     approval_prompt_flow,
     first_approval_url,
+    primary_approval_request,
+    primary_approval_url,
     queue_blocked_approvals,
     wait_for_approval_requests,
 )
@@ -3082,6 +3084,11 @@ def run_guard_command(
                     else []
                 )
             response_payload["approval_requests"] = queued
+            _attach_primary_approval_link(
+                response_payload,
+                harness=args.harness,
+                approval_center_url=approval_center_url,
+            )
             response_payload["approval_center_url"] = approval_center_url
             response_payload["review_hint"] = approval_center_hint(
                 context=context,
@@ -3619,6 +3626,11 @@ def run_guard_command(
                         )
                         response_payload["operation_id"] = str(operation["operation_id"])
                     response_payload["approval_requests"] = queued
+                    _attach_primary_approval_link(
+                        response_payload,
+                        harness=args.harness,
+                        approval_center_url=approval_center_url,
+                    )
                     response_payload["approval_center_url"] = approval_center_url
                     response_payload["review_hint"] = approval_center_hint(
                         context=context,
@@ -4157,9 +4169,44 @@ def _codex_pretooluse_live_wait_candidate(payload: Mapping[str, object] | None) 
     )
 
 
+def _attach_primary_approval_link(
+    response_payload: dict[str, object],
+    *,
+    harness: str,
+    approval_center_url: str | None,
+) -> None:
+    queued = response_payload.get("approval_requests")
+    if not isinstance(queued, list):
+        return
+    primary = primary_approval_request(queued, harness=harness)
+    if primary is None:
+        return
+    request_id = primary.get("request_id")
+    if isinstance(request_id, str) and request_id.strip():
+        response_payload["primary_approval_request_id"] = request_id.strip()
+    review_url = primary_approval_url(
+        queued,
+        harness=harness,
+        approval_center_url=approval_center_url,
+    )
+    if review_url is not None:
+        response_payload["primary_approval_url"] = review_url
+
+
 def _open_codex_live_approval(response_payload: Mapping[str, object]) -> None:
     queued = response_payload.get("approval_requests")
-    review_url = first_approval_url(queued) if isinstance(queued, list) else None
+    review_url = (
+        _optional_string(response_payload.get("primary_approval_url"))
+        or (
+            first_approval_url(
+                queued,
+                harness=_optional_string(response_payload.get("harness")),
+                approval_center_url=_optional_string(response_payload.get("approval_center_url")),
+            )
+            if isinstance(queued, list)
+            else None
+        )
+    )
     if not review_url:
         approval_center_url = response_payload.get("approval_center_url")
         review_url = approval_center_url.strip() if isinstance(approval_center_url, str) else None
@@ -5113,8 +5160,19 @@ def _native_approval_center_context(response_payload: dict[str, object], *, harn
     if not isinstance(approval_center_url, str) or not approval_center_url.strip():
         return None
     queued = response_payload.get("approval_requests")
-    review_url = first_approval_url(queued) if isinstance(queued, list) else None
-    review_url = review_url or approval_center_url.strip()
+    review_url = (
+        _optional_string(response_payload.get("primary_approval_url"))
+        or (
+            first_approval_url(
+                queued,
+                harness=harness,
+                approval_center_url=approval_center_url.strip(),
+            )
+            if isinstance(queued, list)
+            else None
+        )
+        or approval_center_url.strip()
+    )
     harness_label = {
         "claude-code": "Claude Code",
         "codex": "Codex",
@@ -5132,7 +5190,18 @@ def _localize_pending_approval_copy(response_payload: dict[str, object], *, harn
     if review_context is None:
         return
     queued = response_payload.get("approval_requests")
-    review_url = first_approval_url(queued) if isinstance(queued, list) else None
+    review_url = (
+        _optional_string(response_payload.get("primary_approval_url"))
+        or (
+            first_approval_url(
+                queued,
+                harness=harness,
+                approval_center_url=_optional_string(response_payload.get("approval_center_url")),
+            )
+            if isinstance(queued, list)
+            else None
+        )
+    )
     approval_center_url = response_payload.get("approval_center_url")
     if review_url is None and isinstance(approval_center_url, str) and approval_center_url.strip():
         review_url = approval_center_url.strip()

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -494,7 +494,7 @@ function requireReact_production() {
   react_production.useTransition = function() {
     return ReactSharedInternals.H.useTransition();
   };
-  react_production.version = "19.2.5";
+  react_production.version = "19.2.7";
   return react_production;
 }
 var hasRequiredReact;
@@ -516,7 +516,7 @@ var hasRequiredScheduler_production;
 function requireScheduler_production() {
   if (hasRequiredScheduler_production) return scheduler_production;
   hasRequiredScheduler_production = 1;
-  (function(exports$1) {
+  (function(exports) {
     function push(heap, node) {
       var index = heap.length;
       heap.push(node);
@@ -550,15 +550,15 @@ function requireScheduler_production() {
       var diff = a.sortIndex - b.sortIndex;
       return 0 !== diff ? diff : a.id - b.id;
     }
-    exports$1.unstable_now = void 0;
+    exports.unstable_now = void 0;
     if ("object" === typeof performance && "function" === typeof performance.now) {
       var localPerformance = performance;
-      exports$1.unstable_now = function() {
+      exports.unstable_now = function() {
         return localPerformance.now();
       };
     } else {
       var localDate = Date, initialTime = localDate.now();
-      exports$1.unstable_now = function() {
+      exports.unstable_now = function() {
         return localDate.now() - initialTime;
       };
     }
@@ -585,12 +585,12 @@ function requireScheduler_production() {
     }
     var isMessageLoopRunning = false, taskTimeoutID = -1, frameInterval = 5, startTime = -1;
     function shouldYieldToHost() {
-      return needsPaint ? true : exports$1.unstable_now() - startTime < frameInterval ? false : true;
+      return needsPaint ? true : exports.unstable_now() - startTime < frameInterval ? false : true;
     }
     function performWorkUntilDeadline() {
       needsPaint = false;
       if (isMessageLoopRunning) {
-        var currentTime = exports$1.unstable_now();
+        var currentTime = exports.unstable_now();
         startTime = currentTime;
         var hasMoreWork = true;
         try {
@@ -610,7 +610,7 @@ function requireScheduler_production() {
                     var continuationCallback = callback(
                       currentTask.expirationTime <= currentTime
                     );
-                    currentTime = exports$1.unstable_now();
+                    currentTime = exports.unstable_now();
                     if ("function" === typeof continuationCallback) {
                       currentTask.callback = continuationCallback;
                       advanceTimers(currentTime);
@@ -660,27 +660,27 @@ function requireScheduler_production() {
       };
     function requestHostTimeout(callback, ms) {
       taskTimeoutID = localSetTimeout(function() {
-        callback(exports$1.unstable_now());
+        callback(exports.unstable_now());
       }, ms);
     }
-    exports$1.unstable_IdlePriority = 5;
-    exports$1.unstable_ImmediatePriority = 1;
-    exports$1.unstable_LowPriority = 4;
-    exports$1.unstable_NormalPriority = 3;
-    exports$1.unstable_Profiling = null;
-    exports$1.unstable_UserBlockingPriority = 2;
-    exports$1.unstable_cancelCallback = function(task) {
+    exports.unstable_IdlePriority = 5;
+    exports.unstable_ImmediatePriority = 1;
+    exports.unstable_LowPriority = 4;
+    exports.unstable_NormalPriority = 3;
+    exports.unstable_Profiling = null;
+    exports.unstable_UserBlockingPriority = 2;
+    exports.unstable_cancelCallback = function(task) {
       task.callback = null;
     };
-    exports$1.unstable_forceFrameRate = function(fps) {
+    exports.unstable_forceFrameRate = function(fps) {
       0 > fps || 125 < fps ? console.error(
         "forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"
       ) : frameInterval = 0 < fps ? Math.floor(1e3 / fps) : 5;
     };
-    exports$1.unstable_getCurrentPriorityLevel = function() {
+    exports.unstable_getCurrentPriorityLevel = function() {
       return currentPriorityLevel;
     };
-    exports$1.unstable_next = function(eventHandler) {
+    exports.unstable_next = function(eventHandler) {
       switch (currentPriorityLevel) {
         case 1:
         case 2:
@@ -698,10 +698,10 @@ function requireScheduler_production() {
         currentPriorityLevel = previousPriorityLevel;
       }
     };
-    exports$1.unstable_requestPaint = function() {
+    exports.unstable_requestPaint = function() {
       needsPaint = true;
     };
-    exports$1.unstable_runWithPriority = function(priorityLevel, eventHandler) {
+    exports.unstable_runWithPriority = function(priorityLevel, eventHandler) {
       switch (priorityLevel) {
         case 1:
         case 2:
@@ -720,8 +720,8 @@ function requireScheduler_production() {
         currentPriorityLevel = previousPriorityLevel;
       }
     };
-    exports$1.unstable_scheduleCallback = function(priorityLevel, callback, options) {
-      var currentTime = exports$1.unstable_now();
+    exports.unstable_scheduleCallback = function(priorityLevel, callback, options) {
+      var currentTime = exports.unstable_now();
       "object" === typeof options && null !== options ? (options = options.delay, options = "number" === typeof options && 0 < options ? currentTime + options : currentTime) : options = currentTime;
       switch (priorityLevel) {
         case 1:
@@ -751,8 +751,8 @@ function requireScheduler_production() {
       options > currentTime ? (priorityLevel.sortIndex = options, push(timerQueue, priorityLevel), null === peek(taskQueue) && priorityLevel === peek(timerQueue) && (isHostTimeoutScheduled ? (localClearTimeout(taskTimeoutID), taskTimeoutID = -1) : isHostTimeoutScheduled = true, requestHostTimeout(handleTimeout, options - currentTime))) : (priorityLevel.sortIndex = timeout, push(taskQueue, priorityLevel), isHostCallbackScheduled || isPerformingWork || (isHostCallbackScheduled = true, isMessageLoopRunning || (isMessageLoopRunning = true, schedulePerformWorkUntilDeadline())));
       return priorityLevel;
     };
-    exports$1.unstable_shouldYield = shouldYieldToHost;
-    exports$1.unstable_wrapCallback = function(callback) {
+    exports.unstable_shouldYield = shouldYieldToHost;
+    exports.unstable_wrapCallback = function(callback) {
       var parentPriorityLevel = currentPriorityLevel;
       return function() {
         var previousPriorityLevel = currentPriorityLevel;
@@ -922,7 +922,7 @@ function requireReactDom_production() {
   reactDom_production.useFormStatus = function() {
     return ReactSharedInternals.H.useHostTransitionStatus();
   };
-  reactDom_production.version = "19.2.5";
+  reactDom_production.version = "19.2.7";
   return reactDom_production;
 }
 var hasRequiredReactDom;
@@ -12366,12 +12366,12 @@ function requireReactDomClient_production() {
     }
   };
   var isomorphicReactPackageVersion$jscomp$inline_1840 = React2.version;
-  if ("19.2.5" !== isomorphicReactPackageVersion$jscomp$inline_1840)
+  if ("19.2.7" !== isomorphicReactPackageVersion$jscomp$inline_1840)
     throw Error(
       formatProdErrorMessage(
         527,
         isomorphicReactPackageVersion$jscomp$inline_1840,
-        "19.2.5"
+        "19.2.7"
       )
     );
   ReactDOMSharedInternals.findDOMNode = function(componentOrElement) {
@@ -12389,10 +12389,10 @@ function requireReactDomClient_production() {
   };
   var internals$jscomp$inline_2347 = {
     bundleType: 0,
-    version: "19.2.5",
+    version: "19.2.7",
     rendererPackageName: "react-dom",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.5"
+    reconcilerVersion: "19.2.7"
   };
   if ("undefined" !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__) {
     var hook$jscomp$inline_2348 = __REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -12459,7 +12459,7 @@ function requireReactDomClient_production() {
     listenToAllSupportedEvents(container2);
     return new ReactDOMHydrationRoot(initialChildren);
   };
-  reactDomClient_production.version = "19.2.5";
+  reactDomClient_production.version = "19.2.7";
   return reactDomClient_production;
 }
 var hasRequiredClient;
@@ -14841,6 +14841,33 @@ function resolveFileReadPath(item) {
   const paths = item.action_envelope_json?.target_paths ?? [];
   if (paths.length > 0) return paths[0];
   return item.launch_target ?? null;
+}
+function buildApprovalSharePath(item) {
+  const requestId = item.request_id?.trim();
+  if (requestId) {
+    return `/requests/${requestId}`;
+  }
+  const stored = item.approval_url?.trim();
+  if (!stored) {
+    return null;
+  }
+  try {
+    const parsed = new URL(stored, "http://guard.local");
+    parsed.pathname = parsed.pathname.replace("/approvals/", "/requests/");
+    return `${parsed.pathname}${parsed.search}`;
+  } catch {
+    return stored.replace("/approvals/", "/requests/");
+  }
+}
+function resolveApprovalShareUrl(item) {
+  const path = buildApprovalSharePath(item);
+  if (path === null) {
+    return null;
+  }
+  if (typeof window === "undefined") {
+    return path;
+  }
+  return guardAwareHref(path);
 }
 function resolveTerminalLabel(item) {
   const actionType = item.action_envelope_json?.action_type;
@@ -21467,6 +21494,45 @@ function QueueCardRow(props) {
     }
   );
 }
+function QueueApprovalShareButton(props) {
+  const [shareState, setShareState] = reactExports.useState("idle");
+  const approvalUrl = resolveApprovalShareUrl(props.item);
+  const handleCopy = reactExports.useCallback(
+    async (event) => {
+      event.stopPropagation();
+      event.preventDefault();
+      if (approvalUrl === null) {
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(approvalUrl);
+        setShareState("copied");
+        window.setTimeout(() => setShareState("idle"), 1800);
+      } catch {
+        setShareState("failed");
+        window.setTimeout(() => setShareState("idle"), 2400);
+      }
+    },
+    [approvalUrl]
+  );
+  if (approvalUrl === null) {
+    return null;
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "button",
+    {
+      type: "button",
+      onClick: handleCopy,
+      className: "inline-flex shrink-0 items-center gap-1 rounded-md px-2 py-1 font-mono text-[10px] font-semibold uppercase tracking-[0.16em] text-brand-blue/80 transition-colors hover:bg-brand-blue/[0.06] hover:text-brand-blue",
+      "aria-label": "Copy approval link",
+      title: copyApprovalUrlLabel(shareState),
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboard, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "hidden sm:inline", children: copyApprovalUrlLabel(shareState) })
+      ]
+    }
+  );
+}
 function QueueCard(props) {
   const summary = buildQueueSummary(props.item);
   const fileReadPath = resolveFileReadPath(props.item);
@@ -21500,7 +21566,8 @@ function QueueCard(props) {
         props.duplicateCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "shrink-0 rounded-full bg-slate-100 px-2 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground", children: [
           "+",
           props.duplicateCount
-        ] })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(QueueApprovalShareButton, { item: props.item })
       ] })
     }
   );
@@ -22283,7 +22350,7 @@ function BlockedActionCard(props) {
   const mcpServer = isMcpTool ? envelope?.mcp_server ?? null : null;
   const mcpTool = isMcpTool ? envelope?.mcp_tool ?? null : null;
   const mcpInputSummary = isMcpTool && envelope !== null ? resolveMcpInputSummary(envelope.raw_payload_redacted) : null;
-  const approvalUrl = props.item.approval_url ? guardAwareHref(props.item.approval_url) : null;
+  const approvalUrl = resolveApprovalShareUrl(props.item);
   const toggleCommand = reactExports.useCallback(() => {
     setShowCommand((visible) => !visible);
   }, []);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -14860,14 +14860,31 @@ function buildApprovalSharePath(item) {
   }
 }
 function resolveApprovalShareUrl(item) {
-  const path = buildApprovalSharePath(item);
-  if (path === null) {
-    return null;
+  const requestId = item.request_id?.trim();
+  const stored = item.approval_url?.trim();
+  let absolute = null;
+  if (stored) {
+    absolute = stored.replace("/approvals/", "/requests/");
+    if (requestId) {
+      absolute = absolute.replace(/\/(?:approvals|requests)\/[^/?#]+/, `/requests/${requestId}`);
+    }
+  } else if (requestId && typeof window !== "undefined") {
+    absolute = `${window.location.origin}/requests/${requestId}`;
+  }
+  if (absolute === null) {
+    const path = buildApprovalSharePath(item);
+    if (path === null) {
+      return null;
+    }
+    if (typeof window === "undefined") {
+      return path;
+    }
+    absolute = `${window.location.origin}${path}`;
   }
   if (typeof window === "undefined") {
-    return path;
+    return absolute;
   }
-  return guardAwareHref(path);
+  return guardAwareHref(absolute);
 }
 function resolveTerminalLabel(item) {
   const actionType = item.action_envelope_json?.action_type;
@@ -21497,6 +21514,7 @@ function QueueCardRow(props) {
 function QueueApprovalShareButton(props) {
   const [shareState, setShareState] = reactExports.useState("idle");
   const approvalUrl = resolveApprovalShareUrl(props.item);
+  const timeoutRef = reactExports.useRef(null);
   const handleCopy = reactExports.useCallback(
     async (event) => {
       event.stopPropagation();
@@ -21504,17 +21522,27 @@ function QueueApprovalShareButton(props) {
       if (approvalUrl === null) {
         return;
       }
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
       try {
         await navigator.clipboard.writeText(approvalUrl);
         setShareState("copied");
-        window.setTimeout(() => setShareState("idle"), 1800);
+        timeoutRef.current = window.setTimeout(() => setShareState("idle"), 1800);
       } catch {
         setShareState("failed");
-        window.setTimeout(() => setShareState("idle"), 2400);
+        timeoutRef.current = window.setTimeout(() => setShareState("idle"), 2400);
       }
     },
     [approvalUrl]
   );
+  reactExports.useEffect(() => {
+    return () => {
+      if (timeoutRef.current !== null) {
+        window.clearTimeout(timeoutRef.current);
+      }
+    };
+  }, []);
   if (approvalUrl === null) {
     return null;
   }
@@ -21538,36 +21566,55 @@ function QueueCard(props) {
   const fileReadPath = resolveFileReadPath(props.item);
   const isBlocked = props.item.policy_action === "block";
   const statusDotClass = queueCardStatusDotClass(props.active, isBlocked);
+  const handleKeyDown = reactExports.useCallback(
+    (event) => {
+      if (event.key === "Enter" || event.key === " ") {
+        event.preventDefault();
+        props.onClick();
+      }
+    },
+    [props.onClick]
+  );
   return /* @__PURE__ */ jsxRuntimeExports.jsx(
-    "button",
+    "div",
     {
-      type: "button",
-      onClick: props.onClick,
-      "aria-pressed": props.active,
-      className: `group/item w-full cursor-pointer border-l-4 px-4 py-3.5 text-left transition-all duration-150 hover:bg-brand-blue/[0.035] ${props.active ? "border-brand-blue bg-brand-blue/[0.06]" : "border-transparent bg-white/70"}`,
+      className: `group/item w-full border-l-4 px-4 py-3.5 transition-all duration-150 hover:bg-brand-blue/[0.035] ${props.active ? "border-brand-blue bg-brand-blue/[0.06]" : "border-transparent bg-white/70"}`,
       children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start justify-between gap-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-start gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "span",
-            {
-              className: `mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full transition-colors ${statusDotClass}`
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-semibold text-brand-dark", children: actionDisplayTitle(props.item) }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 truncate text-xs text-muted-foreground", children: [
-              harnessDisplayName(props.item.harness),
-              " · ",
-              summary
-            ] }),
-            fileReadPath !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 truncate font-mono text-[11px] text-brand-dark/50", children: fileReadPath })
-          ] })
-        ] }),
-        props.duplicateCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "shrink-0 rounded-full bg-slate-100 px-2 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground", children: [
-          "+",
-          props.duplicateCount
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(QueueApprovalShareButton, { item: props.item })
+        /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "div",
+          {
+            role: "button",
+            tabIndex: 0,
+            onClick: props.onClick,
+            onKeyDown: handleKeyDown,
+            "aria-pressed": props.active,
+            className: "flex min-w-0 flex-1 cursor-pointer items-start gap-3 text-left",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "span",
+                {
+                  className: `mt-1.5 h-1.5 w-1.5 shrink-0 rounded-full transition-colors ${statusDotClass}`
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-semibold text-brand-dark", children: actionDisplayTitle(props.item) }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 truncate text-xs text-muted-foreground", children: [
+                  harnessDisplayName(props.item.harness),
+                  " · ",
+                  summary
+                ] }),
+                fileReadPath !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 truncate font-mono text-[11px] text-brand-dark/50", children: fileReadPath })
+              ] })
+            ]
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex shrink-0 items-start gap-2", children: [
+          props.duplicateCount > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "rounded-full bg-slate-100 px-2 py-0.5 font-mono text-[10px] font-semibold text-muted-foreground", children: [
+            "+",
+            props.duplicateCount
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(QueueApprovalShareButton, { item: props.item })
+        ] })
       ] })
     }
   );

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.3.0 | MIT License | https://tailwindcss.com */
 @layer properties {
   @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
     *, :before, :after, ::backdrop {
@@ -480,14 +480,6 @@
 
   .inset-y-0 {
     inset-block: calc(var(--spacing) * 0);
-  }
-
-  .start {
-    inset-inline-start: var(--spacing);
-  }
-
-  .end {
-    inset-inline-end: var(--spacing);
   }
 
   .-top-6 {
@@ -1255,6 +1247,10 @@
 
   .cursor-pointer {
     cursor: pointer;
+  }
+
+  .\[scrollbar-gutter\:stable\] {
+    scrollbar-gutter: stable;
   }
 
   .list-none {
@@ -3521,8 +3517,14 @@
     }
   }
 
-  .text-brand-blue {
+  .text-brand-blue, .text-brand-blue\/80 {
     color: var(--brand-blue);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .text-brand-blue\/80 {
+      color: color-mix(in oklab, var(--brand-blue) 80%, transparent);
+    }
   }
 
   .text-brand-dark, .text-brand-dark\/50 {
@@ -4021,10 +4023,6 @@
   .select-none {
     -webkit-user-select: none;
     user-select: none;
-  }
-
-  .\[scrollbar-gutter\:stable\] {
-    scrollbar-gutter: stable;
   }
 
   .ring-inset {

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -194,11 +194,12 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
         select request_id
         from approval_requests
         where queue_group_id = ?
+          and harness = ?
           and status = 'pending'
         order by last_seen_at desc, request_id desc
         limit 1
         """,
-        (queue_group_id,),
+        (queue_group_id, request.harness),
     ).fetchone()
     if existing is None:
         existing = connection.execute(
@@ -240,7 +241,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
         connection.execute(
             """
             update approval_requests
-            set artifact_name = ?, artifact_type = ?, artifact_hash = ?, publisher = ?, policy_action = ?,
+            set harness = ?, artifact_name = ?, artifact_type = ?, artifact_hash = ?, publisher = ?, policy_action = ?,
                 recommended_scope = ?, changed_fields_json = ?, source_scope = ?, config_path = ?, workspace = ?,
                 launch_target = ?, normalized_identity_key = ?, action_identity = ?, queue_group_id = ?,
                 dedupe_count = coalesce(dedupe_count, 1) + 1, last_seen_at = ?,
@@ -251,6 +252,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             where request_id = ?
             """,
             (
+                request.harness,
                 request.artifact_name,
                 request.artifact_type,
                 request.artifact_hash,
@@ -359,7 +361,8 @@ def _rewrite_review_command(command: str, request_id: str) -> str:
 
 
 def _rewrite_approval_url(url: str, request_id: str) -> str:
-    prefix, _, _ = url.rpartition("/")
+    normalized = url.replace("/approvals/", "/requests/")
+    prefix, _, _ = normalized.rpartition("/")
     if prefix:
         return f"{prefix}/{request_id}"
     return request_id

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -53,7 +53,7 @@ def _make_request(
         source_scope="project",
         config_path="/tmp/config.toml",
         review_command=f"hol-guard approvals approve {request_id}",
-        approval_url=approval_url or f"http://127.0.0.1:5474/approvals/{request_id}",
+        approval_url=approval_url or f"http://127.0.0.1:5474/requests/{request_id}",
     )
 
 
@@ -200,7 +200,7 @@ class TestApprovalsAutoOpenCommand:
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 0
-        assert opened_urls == ["http://127.0.0.1:5474/approvals/req-auto-open"]
+        assert opened_urls == ["http://127.0.0.1:5474/requests/req-auto-open"]
         assert output["auto_open"]["opened"] is True
         assert output["auto_open"]["request_id"] == "req-auto-open"
 
@@ -210,7 +210,7 @@ class TestApprovalsAutoOpenCommand:
         store.add_approval_request(
             _make_request(
                 request_id="req-stale-open",
-                approval_url="http://127.0.0.1:4000/approvals/req-stale-open",
+                approval_url="http://127.0.0.1:4000/requests/req-stale-open",
             ),
             "2026-01-01T00:00:00Z",
         )
@@ -230,7 +230,7 @@ class TestApprovalsAutoOpenCommand:
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 0
-        assert opened_urls == ["http://127.0.0.1:5474/approvals/req-stale-open"]
+        assert opened_urls == ["http://127.0.0.1:5474/requests/req-stale-open"]
         assert output["auto_open"]["opened"] is True
 
     def test_approvals_summary_honors_native_only_auto_open_opt_out(self, tmp_path: Path, monkeypatch, capsys) -> None:

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -9,7 +9,13 @@ import pytest
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.approvals import approval_center_hint, first_approval_url
+from codex_plugin_scanner.guard.approvals import (
+    approval_center_hint,
+    build_approval_request_url,
+    first_approval_url,
+    primary_approval_request,
+    primary_approval_url,
+)
 from codex_plugin_scanner.guard.cli import approval_commands as approval_commands_module
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
@@ -102,10 +108,48 @@ def test_first_approval_url_ignores_malformed_queue_items() -> None:
     queued = [
         "not-a-request",
         {"approval_url": "  "},
-        {"approval_url": "http://127.0.0.1:5474/approvals/req-ok"},
+        {"approval_url": "http://127.0.0.1:5474/requests/req-ok", "harness": "cursor"},
     ]
 
-    assert first_approval_url(queued) == "http://127.0.0.1:5474/approvals/req-ok"
+    assert (
+        first_approval_url(
+            queued,
+            harness="cursor",
+            approval_center_url="http://127.0.0.1:5474",
+        )
+        == "http://127.0.0.1:5474/requests/req-ok"
+    )
+
+
+def test_primary_approval_request_prefers_matching_harness() -> None:
+    queued = [
+        {
+            "request_id": "codex-req",
+            "harness": "codex",
+            "approval_url": "http://127.0.0.1:5474/requests/codex-req",
+        },
+        {
+            "request_id": "cursor-req",
+            "harness": "cursor",
+            "approval_url": "http://127.0.0.1:5474/requests/cursor-req",
+        },
+    ]
+
+    selected = primary_approval_request(queued, harness="cursor")
+
+    assert selected is not None
+    assert selected["request_id"] == "cursor-req"
+    assert (
+        primary_approval_url(queued, harness="cursor", approval_center_url="http://127.0.0.1:5474")
+        == "http://127.0.0.1:5474/requests/cursor-req"
+    )
+
+
+def test_build_approval_request_url_uses_requests_route() -> None:
+    assert (
+        build_approval_request_url("http://127.0.0.1:5474", "abc123")
+        == "http://127.0.0.1:5474/requests/abc123"
+    )
 
 
 class TestApprovalsOpenCommand:

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -82,7 +82,7 @@ def _request(request_id: str) -> GuardApprovalRequest:
         source_scope="project",
         config_path="/repo/.codex/config.toml",
         review_command=f"hol-guard approvals approve {request_id}",
-        approval_url=f"http://127.0.0.1:5474/approvals/{request_id}",
+        approval_url=f"http://127.0.0.1:5474/requests/{request_id}",
     )
 
 
@@ -1404,7 +1404,7 @@ def test_approval_gate_native_permission_failure_queues_guard_fallback(tmp_path:
     assert len(queued) == 1
     assert len(pending) == 1
     assert pending[0]["policy_action"] == "require-reapproval"
-    assert pending[0]["approval_url"].startswith("http://127.0.0.1:5474/approvals/")
+    assert pending[0]["approval_url"].startswith("http://127.0.0.1:5474/requests/")
     assert "approval_gate_required" in pending[0]["risk_signals"]
     assert store.list_policy_decisions("claude-code") == []
 

--- a/tests/test_guard_copilot_proxy.py
+++ b/tests/test_guard_copilot_proxy.py
@@ -167,5 +167,5 @@ def test_copilot_guard_proxy_queue_block_includes_request_url(tmp_path, monkeypa
 
     assert exit_code == 0
     assert error["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
-    assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
+    assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/requests/")
     assert approval_requests[0]["approval_url"] in error["message"]

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -1095,7 +1095,7 @@ def test_guard_prompt_artifact_workspace_scope_approval_targets_workspace(monkey
     )
 
     assert approval_request["workspace"] == str(workspace_dir)
-    assert approval_request["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
+    assert approval_request["approval_url"].startswith("http://127.0.0.1:4455/requests/")
     assert approval_request["review_command"].startswith("hol-guard approvals approve ")
     assert "http://127.0.0.1:4455" in output["review_hint"]
 
@@ -1175,7 +1175,7 @@ def test_opencode_prompt_hook_queues_prompt_approval(monkeypatch, tmp_path, caps
     assert rc == 1
     assert output["artifact_type"] == "prompt_request"
     assert prompt_request["artifact_type"] == "prompt_request"
-    assert prompt_request["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
+    assert prompt_request["approval_url"].startswith("http://127.0.0.1:4455/requests/")
 
 
 def test_guard_run_allows_debug_prompt_with_quoted_publish_error(monkeypatch, tmp_path, capsys):

--- a/tests/test_guard_opencode_proxy.py
+++ b/tests/test_guard_opencode_proxy.py
@@ -132,5 +132,5 @@ def test_runtime_guard_proxy_queue_block_includes_request_url(tmp_path, monkeypa
     approval_requests = error["data"]["approvalRequests"]
 
     assert error["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
-    assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
+    assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/requests/")
     assert approval_requests[0]["approval_url"] in error["message"]

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -391,7 +391,7 @@ def test_guard_hook_ask_package_live_wait_surfaces_approval_url(
     assert rc == 0
     assert captured.out == ""
     assert opened_urls
-    assert "/approvals/" in opened_urls[0]
+    assert "/requests/" in opened_urls[0]
     assert opened_urls[0] in captured.err
 
 

--- a/tests/test_guard_package_hook_phase14.py
+++ b/tests/test_guard_package_hook_phase14.py
@@ -399,7 +399,7 @@ def test_phase14_package_hook_block_copy_stays_consistent_across_harnesses(
     assert decision["harness_message"].startswith("HOL Guard blocked")
     assert "Reason:" in decision["harness_message"]
     assert "Fix: install `npm install minimist@1.2.9` or choose a team exception." in decision["harness_message"]
-    assert "Open HOL Guard to approve or keep this blocked: http://127.0.0.1:5474/approvals/" in decision[
+    assert "Open HOL Guard to approve or keep this blocked: http://127.0.0.1:5474/requests/" in decision[
         "harness_message"
     ]
     assert "guard/inbox" not in decision["harness_message"]

--- a/tests/test_guard_phase04_harness_ux.py
+++ b/tests/test_guard_phase04_harness_ux.py
@@ -151,7 +151,7 @@ def test_gr076_codex_prompt_secret_read_returns_branded_approval_context(tmp_pat
     assert payload["decision"] == "block"
     assert payload["continue"] is False
     assert "HOL Guard stopped this Codex prompt" in str(payload["reason"])
-    assert "/approvals/" in str(payload["reason"])
+    assert "/requests/" in str(payload["reason"])
     assert payload["stopReason"] == payload["reason"]
     assert payload["hookSpecificOutput"] == {
         "hookEventName": "UserPromptSubmit",
@@ -218,7 +218,7 @@ def test_gr076b_codex_prompt_secret_read_caps_browser_approval_wait(
     assert payload["continue"] is False
     assert observed_timeouts == [8]
     assert "Open HOL Guard" in str(payload["reason"])
-    assert "/approvals/" in str(payload["reason"])
+    assert "/requests/" in str(payload["reason"])
 
 
 def test_gr077_codex_shell_exfil_canary_gets_native_denial(tmp_path: Path) -> None:
@@ -367,7 +367,7 @@ def test_gr081c_codex_live_wait_opens_and_prints_approval_url(monkeypatch, capsy
             "approval_requests": [
                 {
                     "request_id": "req-1",
-                    "approval_url": "http://127.0.0.1:5475/approvals/req-1",
+                    "approval_url": "http://127.0.0.1:5475/requests/req-1",
                 }
             ]
         }
@@ -375,8 +375,8 @@ def test_gr081c_codex_live_wait_opens_and_prints_approval_url(monkeypatch, capsy
 
     captured = capsys.readouterr()
 
-    assert opened_urls == ["http://127.0.0.1:5475/approvals/req-1"]
-    assert "http://127.0.0.1:5475/approvals/req-1" in captured.err
+    assert opened_urls == ["http://127.0.0.1:5475/requests/req-1"]
+    assert "http://127.0.0.1:5475/requests/req-1" in captured.err
 
 
 def test_gr082_claude_pretooluse_brands_native_prompt(tmp_path: Path) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -620,8 +620,8 @@ clearer UX and an implementation plan with technical references.
         assert output["decision"] == "block"
         assert output["continue"] is False
         assert output["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
-        assert "http://127.0.0.1:4455/approvals/" in output["reason"]
-        assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/approvals/")
+        assert "http://127.0.0.1:4455/requests/" in output["reason"]
+        assert approval_requests[0]["approval_url"].startswith("http://127.0.0.1:4455/requests/")
         assert approval_requests[0]["approval_url"] in output["reason"]
         assert approval_requests[0]["launch_target"] == "Codex prompt for `.authrc`: read .authrc"
         assert approval_requests[0]["action_envelope_json"]["action_type"] == "prompt"
@@ -4344,7 +4344,7 @@ clearer UX and an implementation plan with technical references.
             "policy_action": "block",
             "permission_decision_reason": "This command sends local secret to network host.",
             "approval_center_url": "http://127.0.0.1:4455",
-            "approval_requests": [{"approval_url": "http://127.0.0.1:4455/approvals/request-1"}],
+            "approval_requests": [{"approval_url": "http://127.0.0.1:4455/requests/request-1"}],
             "changed_capabilities": ["command"],
             "provenance_summary": "project artifact defined at .codex/config.toml",
             "source_scope": "project",
@@ -4369,7 +4369,7 @@ clearer UX and an implementation plan with technical references.
         reason = output["hookSpecificOutput"]["permissionDecisionReason"]
         assert output["hookSpecificOutput"]["permissionDecision"] == "deny"
         assert "Open HOL Guard to approve or keep this blocked" in reason
-        assert "http://127.0.0.1:4455/approvals/request-1" in reason
+        assert "http://127.0.0.1:4455/requests/request-1" in reason
         assert "Approve it in HOL Guard, then retry." not in reason
 
     def test_guard_hook_fallback_artifact_id_uses_scope(self, tmp_path, capsys, monkeypatch):
@@ -7526,7 +7526,7 @@ def test_guard_hook_emits_copilot_permission_request_deny_for_risky_mcp_tool(
     assert output["interrupt"] is True
     assert "HOL Guard blocked" in output["message"]
     assert "danger_lab:dangerous_delete" in output["message"]
-    assert "http://127.0.0.1:4455/approvals/" in output["message"]
+    assert "http://127.0.0.1:4455/requests/" in output["message"]
     events = GuardStore(home_dir).list_guard_events_v1(uploaded=False)
     usage_events = [event for event in events if event["event_type"] == "harness.mcp.used"]
     assert len(usage_events) == 1
@@ -9412,7 +9412,7 @@ def test_runtime_artifact_native_reason_prefers_decision_v2_harness_message() ->
 def test_native_approval_center_context_uses_harness_specific_retry_copy() -> None:
     payload = {
         "approval_center_url": "http://127.0.0.1:4455",
-        "approval_requests": [{"approval_url": "http://127.0.0.1:4455/approvals/request-1"}],
+        "approval_requests": [{"approval_url": "http://127.0.0.1:4455/requests/request-1"}],
     }
 
     codex_context = guard_commands_module._native_approval_center_context(payload, harness="codex")
@@ -10146,7 +10146,7 @@ def test_guard_hook_localizes_package_review_copy_with_local_approval_url(
     )
 
     assert rc == 1
-    assert review_url.startswith("http://127.0.0.1:4455/approvals/")
+    assert review_url.startswith("http://127.0.0.1:4455/requests/")
     assert review_url in output["review_hint"]
     assert output["decision_v2_json"]["retry_instruction"] == retry_instruction
     assert review_url in output["decision_v2_json"]["harness_message"]
@@ -10229,7 +10229,7 @@ def test_guard_hook_localizes_package_review_copy_with_daemon_client_approval_ur
     )
 
     assert rc == 1
-    assert review_url == "http://127.0.0.1:4455/approvals/request-1"
+    assert review_url == "http://127.0.0.1:4455/requests/request-1"
     assert review_url in output["review_hint"]
     assert output["decision_v2_json"]["retry_instruction"] == retry_instruction
     assert review_url in output["decision_v2_json"]["harness_message"]
@@ -12438,7 +12438,7 @@ def test_guard_hook_codex_emits_native_deny_for_sensitive_bash_command(tmp_path,
     assert payload["hookSpecificOutput"]["permissionDecision"] == "deny"
     assert "HOL Guard" in reason
     assert "Open HOL Guard to approve or keep this blocked" in reason
-    assert "http://127.0.0.1:4455/approvals/" in reason
+    assert "http://127.0.0.1:4455/requests/" in reason
     assert "Approve it in HOL Guard, then retry." not in reason
 
 
@@ -12599,7 +12599,7 @@ def _install_fake_guard_surface_daemon(
                 source_scope=str(item.get("source_scope") or "project"),
                 config_path=str(item.get("config_path") or "~/.codex/config.toml"),
                 review_command=f"hol-guard approvals approve {request_id}",
-                approval_url=f"{approval_center_url}/approvals/{request_id}",
+                approval_url=f"{approval_center_url}/requests/{request_id}",
                 launch_target=str(item.get("launch_target") or "Codex request"),
                 artifact_type=str(item.get("artifact_type") or "artifact"),
             )
@@ -13036,7 +13036,7 @@ def test_guard_hook_codex_user_prompt_submit_secret_read_includes_approval_url(
     assert "HOL Guard paused your Codex prompt" in payload["systemMessage"]
     assert "Open HOL Guard" in payload["systemMessage"]
     assert "approve" in payload["systemMessage"].lower()
-    assert "http://127.0.0.1:4455/approvals/" in payload["reason"]
+    assert "http://127.0.0.1:4455/requests/" in payload["reason"]
     pending = GuardStore(home_dir).list_approval_requests(limit=10)
     assert len(pending) == 1
     assert pending[0]["artifact_type"] == "prompt_request"
@@ -14157,7 +14157,7 @@ def test_guard_hook_codex_user_prompt_submit_guard_bypass_hard_blocks_without_ap
     assert rc == 0
     assert payload["decision"] == "block"
     assert "HOL Guard" in payload["reason"]
-    assert "http://127.0.0.1:4455/approvals/" not in payload["reason"]
+    assert "http://127.0.0.1:4455/requests/" not in payload["reason"]
     assert GuardStore(home_dir).list_approval_requests(limit=10) == []
 
 
@@ -14388,7 +14388,7 @@ PY
     assert "HOL Guard" in reason
     assert "credential exfiltration" in reason
     assert "Open HOL Guard to approve or keep this blocked" in reason
-    assert "http://127.0.0.1:4455/approvals/" in reason
+    assert "http://127.0.0.1:4455/requests/" in reason
 
 
 def test_guard_hook_codex_post_tool_use_blocks_credential_looking_output(
@@ -14435,7 +14435,7 @@ def test_guard_hook_codex_post_tool_use_blocks_credential_looking_output(
     assert payload["continue"] is False
     assert "HOL Guard" in payload["stopReason"]
     assert "credential-looking output" in payload["stopReason"]
-    assert "http://127.0.0.1:4455/approvals/" in payload["stopReason"]
+    assert "http://127.0.0.1:4455/requests/" in payload["stopReason"]
 
 
 def test_guard_hook_codex_post_tool_use_browser_approval_resumes_result(
@@ -14514,7 +14514,7 @@ def test_codex_browser_approval_decision_updates_daemon_operation_status(tmp_pat
         source_scope="project",
         config_path="~/.codex/config.toml",
         review_command="hol-guard approvals approve request-1",
-        approval_url="http://127.0.0.1:4455/approvals/request-1",
+        approval_url="http://127.0.0.1:4455/requests/request-1",
         launch_target="bash ./guard-canary.sh",
     )
     store.add_approval_request(request, "2026-04-30T00:00:00+00:00")
@@ -14566,7 +14566,7 @@ def test_codex_browser_block_decision_updates_daemon_operation_status(tmp_path):
         source_scope="project",
         config_path="~/.codex/config.toml",
         review_command="hol-guard approvals approve request-1",
-        approval_url="http://127.0.0.1:4455/approvals/request-1",
+        approval_url="http://127.0.0.1:4455/requests/request-1",
         launch_target="bash ./guard-canary.sh",
     )
     store.add_approval_request(request, "2026-04-30T00:00:00+00:00")
@@ -14725,7 +14725,7 @@ def test_guard_hook_codex_user_prompt_submit_blocks_credential_looking_dotfile(
     assert payload["decision"] == "block"
     assert "HOL Guard" in payload["reason"]
     assert "credential-looking local file" in payload["reason"]
-    assert "http://127.0.0.1:4455/approvals/" in payload["reason"]
+    assert "http://127.0.0.1:4455/requests/" in payload["reason"]
 
 
 def test_guard_hook_codex_user_prompt_submit_allows_generic_dotfile_with_canary_text(


### PR DESCRIPTION
## Summary
- Scope hook and review URLs to the approval request for the active harness instead of the first queued item, and emit `primary_approval_url` on hook payloads for Cursor.
- Canonicalize local deep links to `/requests/{id}` and refresh harness metadata when deduping pending approvals.
- Add a copy-link control on inbox queue rows and normalize share URLs from `request_id`.

## Testing
- `uv run pytest tests/test_guard_approval_copy_commands.py tests/test_guard_approvals.py tests/test_cursor_hooks.py -q`
- `cd dashboard && npx tsx src/approval-center-layout.test.ts`
- `cd dashboard && npm run build`
