### PR TITLE
fix(guard): avoid keyring promotion on oauth reads

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -776,6 +776,7 @@ class GuardStore:
         _set_private_mode(self.guard_home, _GUARD_STORE_PRIVATE_DIR_MODE)
         self._secret_store = _build_secret_store(self.guard_home)
         self._oauth_secret_store = _build_oauth_secret_store(self.guard_home)
+        self._cached_oauth_secret_payload: tuple[str, str, str] | None = None
         self._sync_token_ref = self._build_scoped_secret_ref(_SYNC_TOKEN_REF)
         self._oauth_local_credentials_ref = self._build_scoped_secret_ref(_OAUTH_LOCAL_CREDENTIALS_REF)
         self._guard_event_queue_limit = max(1, guard_event_queue_limit)
@@ -851,10 +852,13 @@ class GuardStore:
         expected_hash_value: str | None,
         *,
         prefer_fallback_first: bool = False,
+        fallback_token_hint: str | None = None,
     ) -> list[str]:
         if isinstance(secret_store, FallbackSecretStore):
             if prefer_fallback_first and isinstance(secret_store.fallback, EncryptedFileSecretStore):
-                fallback_token = self._get_secret_from_store(secret_store.fallback, secret_id)
+                fallback_token = fallback_token_hint
+                if fallback_token is None:
+                    fallback_token = self._get_secret_from_store(secret_store.fallback, secret_id)
                 if fallback_token is not None and (
                     expected_hash_value is None or _secret_matches_hash(fallback_token, expected_hash_value)
                 ):
@@ -3474,6 +3478,7 @@ class GuardStore:
         return self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload)
 
     def clear_oauth_local_credentials(self) -> None:
+        self._clear_oauth_secret_payload_cache()
         payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if isinstance(payload, dict):
             secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)
@@ -3584,82 +3589,88 @@ class GuardStore:
             return None
         if not isinstance(secret_hash, str) or not secret_hash:
             return None
-        fallback_secret_payload = self._load_validated_oauth_fallback_secret_payload(secret_ref, secret_hash)
+        cached_secret_payload = self._get_cached_oauth_secret_payload(secret_ref, secret_hash)
+        if cached_secret_payload is not None:
+            return cached_secret_payload
+        fallback_secret_json = self._load_oauth_fallback_secret_json(secret_ref)
+        fallback_secret_payload = self._load_validated_oauth_fallback_secret_payload(fallback_secret_json, secret_hash)
         if fallback_secret_payload is not None:
+            self._remember_oauth_secret_payload(secret_ref, secret_hash, fallback_secret_json)
             return fallback_secret_payload
         for candidate in self._get_secret_candidates(
             self._oauth_secret_store,
             secret_ref,
             secret_hash,
             prefer_fallback_first=True,
+            fallback_token_hint=fallback_secret_json,
         ):
             if not _secret_matches_hash(candidate, secret_hash):
                 continue
-            try:
-                secret_payload = json.loads(candidate)
-            except json.JSONDecodeError:
-                continue
-            if not isinstance(secret_payload, dict):
+            secret_payload = self._parse_oauth_secret_payload(candidate)
+            if secret_payload is None:
                 continue
             if promote:
                 self._mirror_oauth_secret_to_fallback(secret_ref, candidate)
+            self._remember_oauth_secret_payload(secret_ref, secret_hash, candidate)
             return secret_payload
         return None
 
-    def _load_validated_oauth_fallback_secret_payload(
-        self,
-        secret_ref: str,
-        secret_hash: str,
-    ) -> dict[str, object] | None:
+    def _resolve_oauth_fallback_store(self) -> EncryptedFileSecretStore | None:
         secret_store = self._oauth_secret_store
-        fallback_store: EncryptedFileSecretStore | None
         if isinstance(secret_store, FallbackSecretStore):
-            fallback_store = (
-                secret_store.fallback
-                if isinstance(secret_store.fallback, EncryptedFileSecretStore)
-                else None
-            )
-        elif isinstance(secret_store, EncryptedFileSecretStore):
-            fallback_store = secret_store
-        else:
-            fallback_store = None
+            return secret_store.fallback if isinstance(secret_store.fallback, EncryptedFileSecretStore) else None
+        if isinstance(secret_store, EncryptedFileSecretStore):
+            return secret_store
+        return None
+
+    def _load_oauth_fallback_secret_json(self, secret_ref: str) -> str | None:
+        fallback_store = self._resolve_oauth_fallback_store()
         if fallback_store is None:
             return None
         secret_json = self._get_secret_from_store(fallback_store, secret_ref)
+        return secret_json if isinstance(secret_json, str) and secret_json else None
+
+    def _get_cached_oauth_secret_payload(self, secret_ref: str, secret_hash: str) -> dict[str, object] | None:
+        cached = self._cached_oauth_secret_payload
+        if cached is None or cached[0] != secret_ref or cached[1] != secret_hash:
+            return None
+        return self._parse_oauth_secret_payload(cached[2])
+
+    def _remember_oauth_secret_payload(self, secret_ref: str, secret_hash: str, secret_json: str | None) -> None:
         if not isinstance(secret_json, str) or not secret_json:
-            return None
-        if not _secret_matches_hash(secret_json, secret_hash):
-            return None
+            return
+        self._cached_oauth_secret_payload = (secret_ref, secret_hash, secret_json)
+
+    def _clear_oauth_secret_payload_cache(self) -> None:
+        self._cached_oauth_secret_payload = None
+
+    @staticmethod
+    def _parse_oauth_secret_payload(secret_json: str) -> dict[str, object] | None:
         try:
             secret_payload = json.loads(secret_json)
         except json.JSONDecodeError:
             return None
         return secret_payload if isinstance(secret_payload, dict) else None
+
+    def _load_validated_oauth_fallback_secret_payload(
+        self,
+        secret_json: str | None,
+        secret_hash: str,
+    ) -> dict[str, object] | None:
+        if not isinstance(secret_json, str) or not secret_json:
+            return None
+        if not _secret_matches_hash(secret_json, secret_hash):
+            return None
+        return self._parse_oauth_secret_payload(secret_json)
 
     def _load_oauth_fallback_secret_payload(self, payload: dict[str, object]) -> dict[str, object] | None:
         secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)
         if not isinstance(secret_ref, str) or not secret_ref:
             return None
-        secret_store = self._oauth_secret_store
-        fallback_store: EncryptedFileSecretStore | None
-        if isinstance(secret_store, FallbackSecretStore):
-            fallback_store = (
-                secret_store.fallback if isinstance(secret_store.fallback, EncryptedFileSecretStore) else None
-            )
-        elif isinstance(secret_store, EncryptedFileSecretStore):
-            fallback_store = secret_store
-        else:
-            fallback_store = None
-        if fallback_store is None:
+        secret_json = self._load_oauth_fallback_secret_json(secret_ref)
+        if secret_json is None:
             return None
-        secret_json = self._get_secret_from_store(fallback_store, secret_ref)
-        if not isinstance(secret_json, str) or not secret_json:
-            return None
-        try:
-            secret_payload = json.loads(secret_json)
-        except json.JSONDecodeError:
-            return None
-        return secret_payload if isinstance(secret_payload, dict) else None
+        return self._parse_oauth_secret_payload(secret_json)
 
     @staticmethod
     def _build_oauth_local_credentials_result(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3584,6 +3584,9 @@ class GuardStore:
             return None
         if not isinstance(secret_hash, str) or not secret_hash:
             return None
+        fallback_secret_payload = self._load_validated_oauth_fallback_secret_payload(secret_ref, secret_hash)
+        if fallback_secret_payload is not None:
+            return fallback_secret_payload
         for candidate in self._get_secret_candidates(
             self._oauth_secret_store,
             secret_ref,
@@ -3599,10 +3602,39 @@ class GuardStore:
             if not isinstance(secret_payload, dict):
                 continue
             if promote:
-                self._promote_secret_to_primary(self._oauth_secret_store, secret_ref, candidate)
                 self._mirror_oauth_secret_to_fallback(secret_ref, candidate)
             return secret_payload
         return None
+
+    def _load_validated_oauth_fallback_secret_payload(
+        self,
+        secret_ref: str,
+        secret_hash: str,
+    ) -> dict[str, object] | None:
+        secret_store = self._oauth_secret_store
+        fallback_store: EncryptedFileSecretStore | None
+        if isinstance(secret_store, FallbackSecretStore):
+            fallback_store = (
+                secret_store.fallback
+                if isinstance(secret_store.fallback, EncryptedFileSecretStore)
+                else None
+            )
+        elif isinstance(secret_store, EncryptedFileSecretStore):
+            fallback_store = secret_store
+        else:
+            fallback_store = None
+        if fallback_store is None:
+            return None
+        secret_json = self._get_secret_from_store(fallback_store, secret_ref)
+        if not isinstance(secret_json, str) or not secret_json:
+            return None
+        if not _secret_matches_hash(secret_json, secret_hash):
+            return None
+        try:
+            secret_payload = json.loads(secret_json)
+        except json.JSONDecodeError:
+            return None
+        return secret_payload if isinstance(secret_payload, dict) else None
 
     def _load_oauth_fallback_secret_payload(self, payload: dict[str, object]) -> dict[str, object] | None:
         secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -30,6 +30,7 @@ class _FakeSystemKeyringModule:
     def __init__(self) -> None:
         self._secrets: dict[tuple[str, str], str] = {}
         self.fail_on_set = False
+        self.get_password_calls = 0
 
     @staticmethod
     def get_keyring():
@@ -44,6 +45,7 @@ class _FakeSystemKeyringModule:
         self._secrets[(service_name, secret_id)] = value
 
     def get_password(self, service_name: str, secret_id: str) -> str | None:
+        self.get_password_calls += 1
         return self._secrets.get((service_name, secret_id))
 
     def delete_password(self, service_name: str, secret_id: str) -> None:
@@ -876,7 +878,7 @@ def test_oauth_local_credentials_mirror_secret_into_encrypted_fallback_store(tmp
 
 
 def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before_keyring(tmp_path, monkeypatch):
-    _install_fake_system_keyring(monkeypatch)
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
@@ -894,15 +896,16 @@ def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before
         now="2026-06-01T00:00:00+00:00",
     )
 
-    def fail_primary_lookup(secret_id: str) -> str | None:
-        raise AssertionError(f"primary keyring lookup should not run for {secret_id}")
-
-    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret", fail_primary_lookup)
-
     credentials = store.get_oauth_local_credentials()
 
     assert credentials is not None
     assert credentials["refresh_token"] == "refresh-secret-value"
+    assert store.get_cloud_sync_profile() == {
+        "auth_mode": "oauth",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "workspace_id": "workspace-123",
+    }
+    assert fake_keyring.get_password_calls == 0
 
 
 def test_get_oauth_local_credentials_fails_closed_when_fallback_hash_is_stale(tmp_path, monkeypatch):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -882,6 +882,7 @@ def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    assert isinstance(store._oauth_secret_store.fallback, EncryptedFileSecretStore)
 
     store.set_oauth_local_credentials(
         issuer="https://hol.org",
@@ -896,15 +897,28 @@ def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before
         now="2026-06-01T00:00:00+00:00",
     )
 
+    fallback_reads = 0
+    original_fallback_get_secret = store._oauth_secret_store.fallback.get_secret
+
+    def count_fallback_reads(secret_id: str) -> str | None:
+        nonlocal fallback_reads
+        fallback_reads += 1
+        return original_fallback_get_secret(secret_id)
+
+    monkeypatch.setattr(store._oauth_secret_store.fallback, "get_secret", count_fallback_reads)
+
     credentials = store.get_oauth_local_credentials()
+    repeated_credentials = store.get_oauth_local_credentials()
 
     assert credentials is not None
+    assert repeated_credentials is not None
     assert credentials["refresh_token"] == "refresh-secret-value"
     assert store.get_cloud_sync_profile() == {
         "auth_mode": "oauth",
         "sync_url": "https://hol.org/api/guard/receipts/sync",
         "workspace_id": "workspace-123",
     }
+    assert fallback_reads == 1
     assert fake_keyring.get_password_calls == 0
 
 
@@ -989,10 +1003,22 @@ def test_get_oauth_local_credentials_recovers_from_timed_primary_lookup_when_fal
         lambda _secret_id, *, timeout_seconds: primary_secret,
     )
 
+    primary_reads = 0
+
+    def count_primary_reads(_secret_id: str, *, timeout_seconds: float) -> str | None:
+        nonlocal primary_reads
+        primary_reads += 1
+        return primary_secret
+
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
+
     credentials = store.get_oauth_local_credentials()
+    repeated_credentials = store.get_oauth_local_credentials()
 
     assert credentials is not None
+    assert repeated_credentials is not None
     assert credentials["refresh_token"] == "refresh-secret-value-rotated"
+    assert primary_reads == 1
     assert store.get_oauth_local_credential_health()["state"] == "healthy"
 
 


### PR DESCRIPTION
## Summary
- prefer the validated encrypted OAuth fallback before touching the system keyring
- stop promoting steady-state OAuth reads back into the keyring and prove the fallback-first path in regression coverage

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_store_migrations.py`
- `python3 -m pytest tests/test_guard_store_migrations.py -k "prefers_validated_encrypted_fallback_before_keyring or backfills_encrypted_fallback_for_legacy_keyring_only_state or recovers_from_timed_primary_lookup_when_fallback_hash_is_stale or oauth_local_credential_health_reports_system_keyring_backend"`

## Notes
- Process-level daemon verification compared `origin/main` and this branch under the real `guard daemon --serve` flow with the system-keyring path forced on; `origin/main` timed out after keyring read and write attempts, while this branch completed repeated `/v1/runtime` requests without keyring calls.
