### PR TITLE
fix(approvals): bind primary link to blocked request id

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -62,27 +62,50 @@ def _normalize_harness_slug(harness: str | None) -> str | None:
     return normalized or None
 
 
+def _queued_request_dicts(queued: Sequence[object]) -> list[dict[str, object]]:
+    items: list[dict[str, object]] = []
+    for item in queued:
+        if isinstance(item, Mapping):
+            items.append(dict(item))
+    return items
+
+
 def primary_approval_request(
     queued: Sequence[object],
     *,
     harness: str | None = None,
+    request_id: str | None = None,
+    artifact_id: str | None = None,
 ) -> dict[str, object] | None:
-    """Return the approval request dict that best matches the current harness action."""
+    """Return the approval request created for this blocked action."""
+
+    items = _queued_request_dicts(queued)
+    if not items:
+        return None
+
+    bound_request_id = _string_or_none(request_id)
+    if bound_request_id is not None:
+        for item in items:
+            if _string_or_none(item.get("request_id")) == bound_request_id:
+                return item
+
+    bound_artifact_id = _string_or_none(artifact_id)
+    if bound_artifact_id is not None:
+        for item in reversed(items):
+            if _string_or_none(item.get("artifact_id")) == bound_artifact_id:
+                return item
+
+    if len(items) == 1:
+        return items[0]
 
     normalized_harness = _normalize_harness_slug(harness)
-    matched: dict[str, object] | None = None
-    fallback: dict[str, object] | None = None
-    for item in reversed(tuple(queued)):
-        if not isinstance(item, Mapping):
-            continue
-        request = dict(item)
-        if fallback is None:
-            fallback = request
-        item_harness = _normalize_harness_slug(str(request.get("harness") or ""))
-        if normalized_harness is not None and item_harness == normalized_harness:
-            matched = request
-            break
-    return matched or fallback
+    if normalized_harness is not None:
+        for item in reversed(items):
+            item_harness = _normalize_harness_slug(str(item.get("harness") or ""))
+            if item_harness == normalized_harness:
+                return item
+
+    return None
 
 
 def primary_approval_url(
@@ -90,8 +113,15 @@ def primary_approval_url(
     *,
     harness: str | None = None,
     approval_center_url: str | None = None,
+    request_id: str | None = None,
+    artifact_id: str | None = None,
 ) -> str | None:
-    request = primary_approval_request(queued, harness=harness)
+    request = primary_approval_request(
+        queued,
+        harness=harness,
+        request_id=request_id,
+        artifact_id=artifact_id,
+    )
     if request is None:
         return None
     approval_url = request.get("approval_url")
@@ -391,6 +421,8 @@ def approval_center_hint(
     approval_center_url: str,
     queued: list[dict[str, object]],
     managed_install: dict[str, object] | None = None,
+    request_id: str | None = None,
+    artifact_id: str | None = None,
 ) -> str:
     del context
     flow = approval_prompt_flow(harness, managed_install=managed_install)
@@ -401,6 +433,8 @@ def approval_center_hint(
             queued,
             harness=harness,
             approval_center_url=approval_center_url,
+            request_id=request_id,
+            artifact_id=artifact_id,
         )
         or approval_center_url
     )
@@ -418,12 +452,78 @@ def first_approval_url(
     *,
     harness: str | None = None,
     approval_center_url: str | None = None,
+    request_id: str | None = None,
+    artifact_id: str | None = None,
 ) -> str | None:
     return primary_approval_url(
         queued,
         harness=harness,
         approval_center_url=approval_center_url,
+        request_id=request_id,
+        artifact_id=artifact_id,
     )
+
+
+def attach_primary_approval_link(
+    payload: dict[str, object],
+    *,
+    harness: str | None = None,
+    approval_center_url: str | None = None,
+    request_id: str | None = None,
+    artifact_id: str | None = None,
+) -> None:
+    """Bind primary approval fields to the request created by this block."""
+
+    queued = payload.get("approval_requests")
+    if not isinstance(queued, list):
+        return
+
+    bound_request_id = _string_or_none(request_id)
+    if bound_request_id is None:
+        bound_request_id = _string_or_none(payload.get("primary_approval_request_id"))
+    if bound_request_id is None:
+        operation_ids = payload.get("approval_request_ids")
+        if isinstance(operation_ids, list):
+            for item in operation_ids:
+                candidate = _string_or_none(item)
+                if candidate is not None:
+                    bound_request_id = candidate
+                    break
+        if bound_request_id is None:
+            operation = payload.get("operation")
+            if isinstance(operation, Mapping):
+                nested_ids = operation.get("approval_request_ids")
+                if isinstance(nested_ids, list):
+                    for item in nested_ids:
+                        candidate = _string_or_none(item)
+                        if candidate is not None:
+                            bound_request_id = candidate
+                            break
+
+    bound_artifact_id = _string_or_none(artifact_id)
+    if bound_artifact_id is None:
+        bound_artifact_id = _string_or_none(payload.get("artifact_id"))
+
+    primary = primary_approval_request(
+        queued,
+        harness=harness,
+        request_id=bound_request_id,
+        artifact_id=bound_artifact_id,
+    )
+    if primary is None:
+        return
+    resolved_request_id = _string_or_none(primary.get("request_id"))
+    if resolved_request_id is not None:
+        payload["primary_approval_request_id"] = resolved_request_id
+    review_url = primary_approval_url(
+        queued,
+        harness=harness,
+        approval_center_url=approval_center_url,
+        request_id=resolved_request_id,
+        artifact_id=bound_artifact_id,
+    )
+    if review_url is not None:
+        payload["primary_approval_url"] = review_url
 
 
 def build_runtime_snapshot(

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -88,6 +88,7 @@ def primary_approval_request(
         for item in items:
             if _string_or_none(item.get("request_id")) == bound_request_id:
                 return item
+        return None
 
     bound_artifact_id = _string_or_none(artifact_id)
     if bound_artifact_id is not None:
@@ -464,6 +465,46 @@ def first_approval_url(
     )
 
 
+def _primary_request_id_candidates(
+    payload: Mapping[str, object],
+    *,
+    request_id: str | None = None,
+) -> list[str]:
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add(value: object) -> None:
+        normalized = _string_or_none(value)
+        if normalized is not None and normalized not in seen:
+            seen.add(normalized)
+            candidates.append(normalized)
+
+    add(request_id)
+    add(payload.get("primary_approval_request_id"))
+    operation_ids = payload.get("approval_request_ids")
+    if isinstance(operation_ids, list):
+        for item in operation_ids:
+            add(item)
+    operation = payload.get("operation")
+    if isinstance(operation, Mapping):
+        nested_ids = operation.get("approval_request_ids")
+        if isinstance(nested_ids, list):
+            for item in nested_ids:
+                add(item)
+    return candidates
+
+
+def _queued_request_ids(queued: Sequence[object]) -> set[str]:
+    request_ids: set[str] = set()
+    for item in queued:
+        if not isinstance(item, Mapping):
+            continue
+        normalized = _string_or_none(item.get("request_id"))
+        if normalized is not None:
+            request_ids.add(normalized)
+    return request_ids
+
+
 def attach_primary_approval_link(
     payload: dict[str, object],
     *,
@@ -478,38 +519,34 @@ def attach_primary_approval_link(
     if not isinstance(queued, list):
         return
 
-    bound_request_id = _string_or_none(request_id)
-    if bound_request_id is None:
-        bound_request_id = _string_or_none(payload.get("primary_approval_request_id"))
-    if bound_request_id is None:
-        operation_ids = payload.get("approval_request_ids")
-        if isinstance(operation_ids, list):
-            for item in operation_ids:
-                candidate = _string_or_none(item)
-                if candidate is not None:
-                    bound_request_id = candidate
-                    break
-        if bound_request_id is None:
-            operation = payload.get("operation")
-            if isinstance(operation, Mapping):
-                nested_ids = operation.get("approval_request_ids")
-                if isinstance(nested_ids, list):
-                    for item in nested_ids:
-                        candidate = _string_or_none(item)
-                        if candidate is not None:
-                            bound_request_id = candidate
-                            break
-
     bound_artifact_id = _string_or_none(artifact_id)
     if bound_artifact_id is None:
         bound_artifact_id = _string_or_none(payload.get("artifact_id"))
 
-    primary = primary_approval_request(
-        queued,
-        harness=harness,
-        request_id=bound_request_id,
-        artifact_id=bound_artifact_id,
+    queued_ids = _queued_request_ids(queued)
+    bound_request_id = next(
+        (
+            candidate
+            for candidate in _primary_request_id_candidates(payload, request_id=request_id)
+            if candidate in queued_ids
+        ),
+        None,
     )
+
+    primary = None
+    if bound_artifact_id is not None:
+        primary = primary_approval_request(
+            queued,
+            harness=harness,
+            artifact_id=bound_artifact_id,
+        )
+    if primary is None:
+        primary = primary_approval_request(
+            queued,
+            harness=harness,
+            request_id=bound_request_id,
+            artifact_id=bound_artifact_id,
+        )
     if primary is None:
         return
     resolved_request_id = _string_or_none(primary.get("request_id"))

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3077,16 +3077,12 @@ def run_guard_command(
                     ),
                     open_key=artifact_id,
                 )
-                operation = (
-                    blocked_operation["operation"]
-                    if isinstance(blocked_operation.get("operation"), dict)
-                    else {}
-                )
-                queued = (
-                    blocked_operation["approval_requests"]
-                    if isinstance(blocked_operation.get("approval_requests"), list)
-                    else []
-                )
+                operation = blocked_operation.get("operation")
+                if not isinstance(operation, dict):
+                    operation = {}
+                queued = blocked_operation.get("approval_requests")
+                if not isinstance(queued, list):
+                    queued = []
                 operation_id = _optional_string(operation.get("operation_id"))
                 if operation_id is not None:
                     response_payload["operation_id"] = operation_id
@@ -3627,16 +3623,12 @@ def run_guard_command(
                             ),
                             open_key=artifact_id,
                         )
-                        operation = (
-                            blocked_operation["operation"]
-                            if isinstance(blocked_operation.get("operation"), dict)
-                            else {}
-                        )
-                        queued = (
-                            blocked_operation["approval_requests"]
-                            if isinstance(blocked_operation.get("approval_requests"), list)
-                            else []
-                        )
+                        operation = blocked_operation.get("operation")
+                        if not isinstance(operation, dict):
+                            operation = {}
+                        queued = blocked_operation.get("approval_requests")
+                        if not isinstance(queued, list):
+                            queued = []
                         operation_id = _optional_string(operation.get("operation_id"))
                         if operation_id is not None:
                             response_payload["operation_id"] = operation_id

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -49,9 +49,8 @@ from ..approvals import (
     approval_center_hint,
     approval_delivery_payload,
     approval_prompt_flow,
+    attach_primary_approval_link,
     first_approval_url,
-    primary_approval_request,
-    primary_approval_url,
     queue_blocked_approvals,
     wait_for_approval_requests,
 )
@@ -3078,11 +3077,23 @@ def run_guard_command(
                     ),
                     open_key=artifact_id,
                 )
+                operation = (
+                    blocked_operation["operation"]
+                    if isinstance(blocked_operation.get("operation"), dict)
+                    else {}
+                )
                 queued = (
                     blocked_operation["approval_requests"]
                     if isinstance(blocked_operation.get("approval_requests"), list)
                     else []
                 )
+                operation_id = _optional_string(operation.get("operation_id"))
+                if operation_id is not None:
+                    response_payload["operation_id"] = operation_id
+                response_payload["operation"] = operation
+                approval_request_ids = operation.get("approval_request_ids")
+                if isinstance(approval_request_ids, list):
+                    response_payload["approval_request_ids"] = approval_request_ids
             response_payload["approval_requests"] = queued
             _attach_primary_approval_link(
                 response_payload,
@@ -3096,6 +3107,8 @@ def run_guard_command(
                 approval_center_url=approval_center_url,
                 queued=queued,
                 managed_install=managed_install,
+                request_id=_optional_string(response_payload.get("primary_approval_request_id")),
+                artifact_id=_optional_string(response_payload.get("artifact_id")),
             )
             _localize_pending_approval_copy(response_payload, harness=args.harness)
             _record_harness_usage_for_hook(
@@ -3624,7 +3637,13 @@ def run_guard_command(
                             if isinstance(blocked_operation.get("approval_requests"), list)
                             else []
                         )
-                        response_payload["operation_id"] = str(operation["operation_id"])
+                        operation_id = _optional_string(operation.get("operation_id"))
+                        if operation_id is not None:
+                            response_payload["operation_id"] = operation_id
+                        response_payload["operation"] = operation
+                        approval_request_ids = operation.get("approval_request_ids")
+                        if isinstance(approval_request_ids, list):
+                            response_payload["approval_request_ids"] = approval_request_ids
                     response_payload["approval_requests"] = queued
                     _attach_primary_approval_link(
                         response_payload,
@@ -3638,6 +3657,8 @@ def run_guard_command(
                         approval_center_url=approval_center_url,
                         queued=queued,
                         managed_install=managed_install,
+                        request_id=_optional_string(response_payload.get("primary_approval_request_id")),
+                        artifact_id=_optional_string(response_payload.get("artifact_id")),
                     )
                     response_payload["approval_delivery"] = _approval_delivery_payload(
                         args.harness,
@@ -4175,34 +4196,34 @@ def _attach_primary_approval_link(
     harness: str,
     approval_center_url: str | None,
 ) -> None:
-    queued = response_payload.get("approval_requests")
-    if not isinstance(queued, list):
-        return
-    primary = primary_approval_request(queued, harness=harness)
-    if primary is None:
-        return
-    request_id = primary.get("request_id")
-    if isinstance(request_id, str) and request_id.strip():
-        response_payload["primary_approval_request_id"] = request_id.strip()
-    review_url = primary_approval_url(
-        queued,
+    attach_primary_approval_link(
+        response_payload,
         harness=harness,
         approval_center_url=approval_center_url,
     )
-    if review_url is not None:
-        response_payload["primary_approval_url"] = review_url
+
+
+def _primary_approval_lookup_kwargs(response_payload: dict[str, object], *, harness: str) -> dict[str, object]:
+    return {
+        "harness": harness,
+        "approval_center_url": _optional_string(response_payload.get("approval_center_url")),
+        "request_id": _optional_string(response_payload.get("primary_approval_request_id")),
+        "artifact_id": _optional_string(response_payload.get("artifact_id")),
+    }
 
 
 def _open_codex_live_approval(response_payload: Mapping[str, object]) -> None:
     queued = response_payload.get("approval_requests")
+    lookup: dict[str, object] = {
+        "harness": _optional_string(response_payload.get("harness")),
+        "approval_center_url": _optional_string(response_payload.get("approval_center_url")),
+        "request_id": _optional_string(response_payload.get("primary_approval_request_id")),
+        "artifact_id": _optional_string(response_payload.get("artifact_id")),
+    }
     review_url = (
         _optional_string(response_payload.get("primary_approval_url"))
         or (
-            first_approval_url(
-                queued,
-                harness=_optional_string(response_payload.get("harness")),
-                approval_center_url=_optional_string(response_payload.get("approval_center_url")),
-            )
+            first_approval_url(queued, **lookup)
             if isinstance(queued, list)
             else None
         )
@@ -5165,8 +5186,7 @@ def _native_approval_center_context(response_payload: dict[str, object], *, harn
         or (
             first_approval_url(
                 queued,
-                harness=harness,
-                approval_center_url=approval_center_url.strip(),
+                **_primary_approval_lookup_kwargs(response_payload, harness=harness),
             )
             if isinstance(queued, list)
             else None
@@ -5195,8 +5215,7 @@ def _localize_pending_approval_copy(response_payload: dict[str, object], *, harn
         or (
             first_approval_url(
                 queued,
-                harness=harness,
-                approval_center_url=_optional_string(response_payload.get("approval_center_url")),
+                **_primary_approval_lookup_kwargs(response_payload, harness=harness),
             )
             if isinstance(queued, list)
             else None

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -11,6 +11,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import (
     approval_center_hint,
+    attach_primary_approval_link,
     build_approval_request_url,
     first_approval_url,
     primary_approval_request,
@@ -145,11 +146,114 @@ def test_primary_approval_request_prefers_matching_harness() -> None:
     )
 
 
-def test_build_approval_request_url_uses_requests_route() -> None:
-    assert (
-        build_approval_request_url("http://127.0.0.1:5474", "abc123")
-        == "http://127.0.0.1:5474/requests/abc123"
+def test_primary_approval_request_prefers_request_id() -> None:
+    queued = [
+        {
+            "request_id": "older-req",
+            "harness": "cursor",
+            "artifact_id": "cursor:project:shell-a",
+        },
+        {
+            "request_id": "newer-req",
+            "harness": "cursor",
+            "artifact_id": "cursor:project:shell-b",
+        },
+    ]
+
+    selected = primary_approval_request(queued, harness="cursor", request_id="older-req")
+
+    assert selected is not None
+    assert selected["request_id"] == "older-req"
+
+
+def test_primary_approval_request_prefers_artifact_id_over_harness_latest() -> None:
+    queued = [
+        {
+            "request_id": "req-a",
+            "harness": "cursor",
+            "artifact_id": "cursor:project:shell-a",
+            "approval_url": "http://127.0.0.1:5474/requests/req-a",
+        },
+        {
+            "request_id": "req-b",
+            "harness": "cursor",
+            "artifact_id": "cursor:project:shell-b",
+            "approval_url": "http://127.0.0.1:5474/requests/req-b",
+        },
+    ]
+
+    selected = primary_approval_request(
+        queued,
+        harness="cursor",
+        artifact_id="cursor:project:shell-a",
     )
+
+    assert selected is not None
+    assert selected["request_id"] == "req-a"
+
+
+def test_primary_approval_request_single_item_without_harness() -> None:
+    queued = [
+        {
+            "request_id": "solo-req",
+            "harness": "cursor",
+            "approval_url": "http://127.0.0.1:5474/requests/solo-req",
+        }
+    ]
+
+    selected = primary_approval_request(queued)
+
+    assert selected is not None
+    assert selected["request_id"] == "solo-req"
+
+
+def test_primary_approval_request_returns_none_without_binding() -> None:
+    queued = [
+        {
+            "request_id": "codex-req",
+            "harness": "codex",
+        },
+        {
+            "request_id": "cursor-req",
+            "harness": "cursor",
+        },
+    ]
+
+    assert primary_approval_request(queued) is None
+
+
+def test_attach_primary_approval_link_uses_operation_request_id() -> None:
+    payload: dict[str, object] = {
+        "artifact_id": "cursor:project:shell-b",
+        "approval_request_ids": ["bound-req"],
+        "approval_requests": [
+            {
+                "request_id": "other-req",
+                "harness": "cursor",
+                "artifact_id": "cursor:project:shell-a",
+                "approval_url": "http://127.0.0.1:5474/requests/other-req",
+            },
+            {
+                "request_id": "bound-req",
+                "harness": "cursor",
+                "artifact_id": "cursor:project:shell-b",
+                "approval_url": "http://127.0.0.1:5474/requests/bound-req",
+            },
+        ],
+    }
+
+    attach_primary_approval_link(
+        payload,
+        harness="cursor",
+        approval_center_url="http://127.0.0.1:5474",
+    )
+
+    assert payload["primary_approval_request_id"] == "bound-req"
+    assert payload["primary_approval_url"] == "http://127.0.0.1:5474/requests/bound-req"
+
+
+def test_build_approval_request_url_uses_requests_route() -> None:
+    assert build_approval_request_url("http://127.0.0.1:5474", "abc123") == "http://127.0.0.1:5474/requests/abc123"
 
 
 class TestApprovalsOpenCommand:

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -222,6 +222,48 @@ def test_primary_approval_request_returns_none_without_binding() -> None:
     assert primary_approval_request(queued) is None
 
 
+def test_primary_approval_request_returns_none_when_request_id_missing_from_queue() -> None:
+    queued = [
+        {
+            "request_id": "local-req",
+            "harness": "cursor",
+            "artifact_id": "cursor:project:shell-a",
+        }
+    ]
+
+    assert primary_approval_request(queued, request_id="missing-req") is None
+
+
+def test_attach_primary_approval_link_prefers_artifact_over_operation_ids() -> None:
+    payload: dict[str, object] = {
+        "artifact_id": "cursor:project:shell-b",
+        "approval_request_ids": ["first-op-req"],
+        "approval_requests": [
+            {
+                "request_id": "first-op-req",
+                "harness": "cursor",
+                "artifact_id": "cursor:project:shell-a",
+                "approval_url": "http://127.0.0.1:5474/requests/first-op-req",
+            },
+            {
+                "request_id": "bound-req",
+                "harness": "cursor",
+                "artifact_id": "cursor:project:shell-b",
+                "approval_url": "http://127.0.0.1:5474/requests/bound-req",
+            },
+        ],
+    }
+
+    attach_primary_approval_link(
+        payload,
+        harness="cursor",
+        approval_center_url="http://127.0.0.1:5474",
+    )
+
+    assert payload["primary_approval_request_id"] == "bound-req"
+    assert payload["primary_approval_url"] == "http://127.0.0.1:5474/requests/bound-req"
+
+
 def test_attach_primary_approval_link_uses_operation_request_id() -> None:
     payload: dict[str, object] = {
         "artifact_id": "cursor:project:shell-b",


### PR DESCRIPTION
## Summary
- Bind primary approval URLs to the request created by the current block
- Prefer request_id, artifact_id, and operation approval_request_ids over harness heuristics
- Remove cross-harness fallback when the blocked queue cannot be resolved exactly

## Testing
- `uv run pytest tests/test_guard_approval_copy_commands.py tests/test_cursor_hooks.py -q`
- `uv run pytest tests/test_guard_approvals.py tests/test_guard_runtime.py -q`
