### PR TITLE
fix(guard): skip redundant oauth metadata keychain writes

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3463,6 +3463,7 @@ class GuardStore:
         skip_primary_secret_rewrite = (
             not secret_material_changed
             and isinstance(self._oauth_secret_store, FallbackSecretStore)
+            and isinstance(self._oauth_secret_store.primary, SystemKeyringSecretStore)
             and isinstance(self._oauth_secret_store.fallback, EncryptedFileSecretStore)
         )
         if not skip_primary_secret_rewrite:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3448,7 +3448,25 @@ class GuardStore:
             payload["runtime_id"] = runtime_id
         if runtime_label:
             payload["runtime_label"] = runtime_label
-        self._oauth_secret_store.set_secret(self._oauth_local_credentials_ref, secret_json)
+        existing_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        existing_secret_ref = (
+            existing_payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY) if isinstance(existing_payload, dict) else None
+        )
+        existing_secret_hash = (
+            existing_payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY) if isinstance(existing_payload, dict) else None
+        )
+        secret_material_changed = (
+            existing_secret_ref != self._oauth_local_credentials_ref or existing_secret_hash != secret_hash
+        )
+        # Metadata-only updates can skip the primary rewrite because the encrypted
+        # fallback remains current and continues to backstop headless recovery.
+        skip_primary_secret_rewrite = (
+            not secret_material_changed
+            and isinstance(self._oauth_secret_store, FallbackSecretStore)
+            and isinstance(self._oauth_secret_store.fallback, EncryptedFileSecretStore)
+        )
+        if not skip_primary_secret_rewrite:
+            self._oauth_secret_store.set_secret(self._oauth_local_credentials_ref, secret_json)
         self._mirror_oauth_secret_to_fallback(self._oauth_local_credentials_ref, secret_json)
         self._assert_oauth_secret_persisted(self._oauth_local_credentials_ref, secret_json)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -31,6 +31,7 @@ class _FakeSystemKeyringModule:
         self._secrets: dict[tuple[str, str], str] = {}
         self.fail_on_set = False
         self.get_password_calls = 0
+        self.set_password_calls = 0
 
     @staticmethod
     def get_keyring():
@@ -42,6 +43,7 @@ class _FakeSystemKeyringModule:
     def set_password(self, service_name: str, secret_id: str, value: str) -> None:
         if self.fail_on_set:
             raise RuntimeError("system keyring unavailable")
+        self.set_password_calls += 1
         self._secrets[(service_name, secret_id)] = value
 
     def get_password(self, service_name: str, secret_id: str) -> str | None:
@@ -875,6 +877,77 @@ def test_oauth_local_credentials_mirror_secret_into_encrypted_fallback_store(tmp
     assert credentials is not None
     assert credentials["refresh_token"] == "refresh-secret-value"
     assert headless_store.get_oauth_local_credential_health()["state"] == "healthy"
+
+
+def test_set_oauth_local_credentials_skips_keyring_rewrite_when_secret_material_is_unchanged(tmp_path, monkeypatch):
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+
+    refresh_token = "refresh-token-1"
+    rotated_refresh_token = "refresh-token-2"
+    key_material = "key-material-1"
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=refresh_token,
+        dpop_private_key_pem=key_material,
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        supply_chain_plan_id="starter",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    assert fake_keyring.set_password_calls == 1
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=refresh_token,
+        dpop_private_key_pem=key_material,
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        supply_chain_firewall=True,
+        supply_chain_plan_id="team",
+        now="2026-06-01T00:05:00+00:00",
+    )
+
+    assert fake_keyring.set_password_calls == 1
+    credentials = store.get_oauth_local_credentials()
+
+    assert credentials is not None
+    assert credentials["refresh_token"] == refresh_token
+    assert credentials["dpop_private_key_pem"] == key_material
+    assert credentials["supply_chain_firewall"] is True
+    assert credentials["supply_chain_plan_id"] == "team"
+
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=rotated_refresh_token,
+        dpop_private_key_pem=key_material,
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        supply_chain_firewall=True,
+        supply_chain_plan_id="team",
+        now="2026-06-01T00:10:00+00:00",
+    )
+
+    assert fake_keyring.set_password_calls == 2
+    rotated_credentials = store.get_oauth_local_credentials()
+
+    assert rotated_credentials is not None
+    assert rotated_credentials["refresh_token"] == rotated_refresh_token
 
 
 def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before_keyring(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- skip system-keyring rewrites when Guard refreshes OAuth metadata without changing the stored secret material
- keep the encrypted fallback mirror and metadata current while preserving keyring writes for real secret rotations

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_store_migrations.py`
- `python3 -m pytest tests/test_guard_store_migrations.py -k "skips_keyring_rewrite_when_secret_material_is_unchanged or prefers_validated_encrypted_fallback_before_keyring or recovers_from_timed_primary_lookup_when_fallback_hash_is_stale or backfills_encrypted_fallback_for_legacy_keyring_only_state or oauth_local_credential_health_reports_system_keyring_backend"`

## Notes
- End-to-end daemon verification exercised the real `guard daemon --serve` flow under forced system-keyring instrumentation for both steady-state `/v1/runtime` reads and a first-sync metadata update. The merged `origin/main` baseline still issued a keyring `set_password` during the metadata-only sync path; this branch completed both daemon scenarios with zero keyring calls.
- Supersedes #653 with clean commit history so secret scanning evaluates only the final tree.
