### PR TITLE
fix(dashboard): unify evidence workspace header with supply chain tab layout

### DIFF
--- a/dashboard/src/evidence/evidence-hero.tsx
+++ b/dashboard/src/evidence/evidence-hero.tsx
@@ -23,7 +23,7 @@ export function EvidenceHero({ totalCount, lastActivityAt }: EvidenceHeroProps) 
       role="region"
       aria-label="Evidence summary"
     >
-      <div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="relative">
         <div className="flex min-w-0 items-start gap-3">
           <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-green/10">
             <HiMiniDocumentText className="h-4 w-4 text-brand-green" aria-hidden="true" />

--- a/dashboard/src/evidence/evidence-hero.tsx
+++ b/dashboard/src/evidence/evidence-hero.tsx
@@ -1,19 +1,12 @@
-import { SectionLabel, Badge } from "../approval-center-primitives";
+import { Badge } from "../approval-center-primitives";
 import { HiMiniDocumentText } from "react-icons/hi2";
 
 export interface EvidenceHeroProps {
   totalCount: number;
   lastActivityAt: string | null;
-  onExport: () => void;
-  onClear?: () => void;
 }
 
-export function EvidenceHero({
-  totalCount,
-  lastActivityAt,
-  onExport,
-  onClear,
-}: EvidenceHeroProps) {
+export function EvidenceHero({ totalCount, lastActivityAt }: EvidenceHeroProps) {
   const lastActivityLabel = lastActivityAt
     ? new Date(lastActivityAt).toLocaleDateString(undefined, {
         month: "short",
@@ -30,57 +23,29 @@ export function EvidenceHero({
       role="region"
       aria-label="Evidence summary"
     >
-      <div className="relative space-y-4">
-        <div className="flex flex-wrap items-center gap-2">
-          <SectionLabel>Evidence</SectionLabel>
-          {hasEvidence ? (
-            <Badge tone="success">{totalCount} actions recorded</Badge>
-          ) : (
-            <Badge tone="default">No actions yet</Badge>
-          )}
-        </div>
-
-        <div className="max-w-3xl">
-          <div className="flex items-start gap-3">
-            <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-green/10">
-              <HiMiniDocumentText className="h-4 w-4 text-brand-green" aria-hidden="true" />
-            </span>
-            <div>
-              <h1 className="text-xl font-semibold tracking-tight text-brand-dark sm:text-2xl">
-                {hasEvidence
-                  ? `${totalCount.toLocaleString()} action${totalCount !== 1 ? "s" : ""} recorded`
-                  : "Evidence"}
-              </h1>
-              <p className="mt-2 text-sm leading-relaxed text-brand-dark/70">
-                Every action Guard reviewed on this machine.
-                {lastActivityLabel && (
-                  <> Last activity on <span className="font-medium text-brand-dark">{lastActivityLabel}</span>.</>
-                )}
-              </p>
+      <div className="relative flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="mt-0.5 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-brand-green/10">
+            <HiMiniDocumentText className="h-4 w-4 text-brand-green" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <div className="flex flex-wrap items-center gap-2">
+              {hasEvidence ? (
+                <Badge tone="success">{totalCount.toLocaleString()} actions recorded</Badge>
+              ) : (
+                <Badge tone="default">No actions yet</Badge>
+              )}
             </div>
+            <p className="mt-2 text-sm leading-relaxed text-brand-dark/70">
+              Every action Guard reviewed on this machine.
+              {lastActivityLabel && (
+                <>
+                  {" "}
+                  Last activity on <span className="font-medium text-brand-dark">{lastActivityLabel}</span>.
+                </>
+              )}
+            </p>
           </div>
-        </div>
-
-        <div className="flex flex-wrap gap-3">
-          <button
-            type="button"
-            onClick={onExport}
-            aria-label="Export evidence"
-            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-brand-dark hover:bg-slate-50 transition-colors shadow-sm"
-          >
-            <HiMiniDocumentText className="h-4 w-4 text-slate-400" aria-hidden="true" />
-            Export
-          </button>
-          {onClear && totalCount > 0 && (
-            <button
-              type="button"
-              onClick={onClear}
-              aria-label="Clear all evidence"
-              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-500 hover:bg-slate-50 hover:text-brand-attention transition-colors shadow-sm"
-            >
-              Clear
-            </button>
-          )}
         </div>
       </div>
     </section>

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -201,28 +201,31 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
 
   const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label, id: t.key }));
 
-  const headerActions = (
-    <>
-      <button
-        type="button"
-        onClick={handleOpenExport}
-        aria-label="Export evidence"
-        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-brand-dark shadow-sm transition-colors hover:bg-slate-50"
-      >
-        <HiMiniDocumentText className="h-4 w-4 text-slate-400" aria-hidden="true" />
-        Export
-      </button>
-      {onClearEvidence && receiptItems.length > 0 && (
+  const headerActions = useMemo(
+    () => (
+      <>
         <button
           type="button"
-          onClick={handleOpenClear}
-          aria-label="Clear all evidence"
-          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-500 shadow-sm transition-colors hover:bg-slate-50 hover:text-brand-attention"
+          onClick={handleOpenExport}
+          aria-label="Export evidence"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-brand-dark shadow-sm transition-colors hover:bg-slate-50"
         >
-          Clear
+          <HiMiniDocumentText className="h-4 w-4 text-slate-400" aria-hidden="true" />
+          Export
         </button>
-      )}
-    </>
+        {onClearEvidence && receiptItems.length > 0 && (
+          <button
+            type="button"
+            onClick={handleOpenClear}
+            aria-label="Clear all evidence"
+            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-500 shadow-sm transition-colors hover:bg-slate-50 hover:text-brand-attention"
+          >
+            Clear
+          </button>
+        )}
+      </>
+    ),
+    [handleOpenExport, handleOpenClear, onClearEvidence, receiptItems.length],
   );
 
   return (

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { HiMiniArrowDownTray } from "react-icons/hi2";
+import { HiMiniArrowDownTray, HiMiniDocumentText } from "react-icons/hi2";
 
-import { EmptyState, TabBar, ActionButton, SectionLabel } from "./approval-center-primitives";
+import { EmptyState, ActionButton, SectionLabel } from "./approval-center-primitives";
 import { isDisplayableHarness, normalizeHarnessFilter } from "./approval-center-utils";
 import type { GuardReceipt } from "./guard-types";
 import type { EvidenceFilterState, EvidenceView, EvidenceSortKey } from "./evidence/evidence-types";
@@ -28,6 +28,7 @@ import { EvidenceExportDrawer } from "./evidence/evidence-export-drawer";
 import { EvidenceClearModal } from "./evidence/evidence-clear-modal";
 import { AppTab } from "./evidence/app-tab";
 import { CategoryTab } from "./evidence/category-tab";
+import { WorkspacePageHeader } from "./workspace-page-header";
 
 export type ReceiptsState =
   | { kind: "loading" }
@@ -39,6 +40,10 @@ const PAGE_SIZE = 50;
 interface EvidenceWorkbenchProps {
   receiptItems: GuardReceipt[];
   onClearEvidence?: () => void;
+}
+
+function evidenceTitleForView(view: EvidenceView): string {
+  return VIEW_TABS.find((tab) => tab.key === view)?.label ?? "Evidence";
 }
 
 function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchProps) {
@@ -196,16 +201,42 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
 
   const tabOptions = VIEW_TABS.map((t) => ({ value: t.key, label: t.label, id: t.key }));
 
+  const headerActions = (
+    <>
+      <button
+        type="button"
+        onClick={handleOpenExport}
+        aria-label="Export evidence"
+        className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-brand-dark shadow-sm transition-colors hover:bg-slate-50"
+      >
+        <HiMiniDocumentText className="h-4 w-4 text-slate-400" aria-hidden="true" />
+        Export
+      </button>
+      {onClearEvidence && receiptItems.length > 0 && (
+        <button
+          type="button"
+          onClick={handleOpenClear}
+          aria-label="Clear all evidence"
+          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-500 shadow-sm transition-colors hover:bg-slate-50 hover:text-brand-attention"
+        >
+          Clear
+        </button>
+      )}
+    </>
+  );
+
   return (
     <div className="space-y-4">
-      <EvidenceHero
-        totalCount={receiptItems.length}
-        lastActivityAt={metrics.lastActivityAt}
-        onExport={handleOpenExport}
-        onClear={handleOpenClear}
+      <WorkspacePageHeader
+        eyebrow="Evidence"
+        title={evidenceTitleForView(filters.view)}
+        tabs={tabOptions}
+        activeTab={filters.view}
+        onTabChange={handleViewChange}
+        actions={headerActions}
       />
 
-      <TabBar tabs={tabOptions} active={filters.view} onChange={handleViewChange} />
+      <EvidenceHero totalCount={receiptItems.length} lastActivityAt={metrics.lastActivityAt} />
 
       <div className="pt-1">
         {filters.view === "actions" && (
@@ -238,7 +269,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
               />
             </div>
             {selectedReceipt && (
-              <div className="rounded-2xl border border-slate-100 bg-white overflow-hidden shadow-sm">
+              <div className="overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm">
                 <EvidenceActionDetail
                   receipt={selectedReceipt}
                   onClose={handleCloseDetail}
@@ -290,11 +321,11 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
             id="tabpanel-export"
             role="tabpanel"
             aria-labelledby="tab-export"
-            className="space-y-4 guard-fade-in"
+            className="guard-fade-in space-y-4"
           >
             <div className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
               <SectionLabel>Export Evidence</SectionLabel>
-              <p className="mt-2 text-sm text-brand-dark/70 leading-relaxed">
+              <p className="mt-2 text-sm leading-relaxed text-brand-dark/70">
                 Download your evidence records as CSV or JSON for analysis or backup.
               </p>
               <div className="mt-4">
@@ -306,7 +337,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
             </div>
             <div className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
               <SectionLabel>Cloud Sync</SectionLabel>
-              <p className="mt-2 text-sm text-brand-dark/70 leading-relaxed">
+              <p className="mt-2 text-sm leading-relaxed text-brand-dark/70">
                 Keep evidence in sync across devices. Cloud backup lets you access your evidence history from any device. Available in HOL Guard Cloud.
               </p>
             </div>

--- a/dashboard/src/supply-chain-hub-workspace.tsx
+++ b/dashboard/src/supply-chain-hub-workspace.tsx
@@ -1,6 +1,6 @@
 import { lazy, Suspense, useCallback } from "react";
-import { TabBar } from "./approval-center-primitives";
 import type { GuardApprovalGatePublicConfig, GuardPolicyDecision, GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
+import { WorkspacePageHeader } from "./workspace-page-header";
 
 const SupplyChainWorkspace = lazy(() =>
   import("./supply-chain-workspace").then((m) => ({ default: m.SupplyChainWorkspace }))
@@ -37,11 +37,11 @@ function viewToTab(view: string): HubTab {
 
 export function SupplyChainHubWorkspace(props: {
   activeView: string;
-	  snapshot: GuardRuntimeSnapshot;
-	  receipts: GuardReceipt[];
-	  policies: GuardPolicyDecision[];
-	  approvalGate: GuardApprovalGatePublicConfig | null;
-	  onClearPolicy: (policy: GuardPolicyDecision) => void;
+  snapshot: GuardRuntimeSnapshot;
+  receipts: GuardReceipt[];
+  policies: GuardPolicyDecision[];
+  approvalGate: GuardApprovalGatePublicConfig | null;
+  onClearPolicy: (policy: GuardPolicyDecision) => void;
   onOpenSettings: () => void;
   onGoHome: () => void;
   onNavigate: (pathname: string) => void;
@@ -59,13 +59,13 @@ export function SupplyChainHubWorkspace(props: {
 
   return (
     <div className="space-y-6">
-      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-        <div className="space-y-1">
-          <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">Supply chain</p>
-          <h1 className="text-2xl font-semibold tracking-tight text-brand-dark">{hubTitleForTab(tab)}</h1>
-        </div>
-        <TabBar tabs={hubTabs} active={tab} onChange={handleTabChange} />
-      </div>
+      <WorkspacePageHeader
+        eyebrow="Supply chain"
+        title={hubTitleForTab(tab)}
+        tabs={hubTabs}
+        activeTab={tab}
+        onTabChange={handleTabChange}
+      />
       <Suspense fallback={<LazyFallback />}>
         {tab === "supply-chain" && (
           <SupplyChainWorkspace
@@ -74,10 +74,10 @@ export function SupplyChainHubWorkspace(props: {
             onGoHome={props.onGoHome}
             onRuntimeRefresh={props.onRuntimeRefresh}
           />
-	        )}
-	        {tab === "audit" && (
-	          <AuditWorkspace snapshot={props.snapshot} receipts={props.receipts} approvalGate={props.approvalGate} />
-	        )}
+        )}
+        {tab === "audit" && (
+          <AuditWorkspace snapshot={props.snapshot} receipts={props.receipts} approvalGate={props.approvalGate} />
+        )}
         {tab === "policy" && (
           <PolicyWorkspace
             policies={props.policies}

--- a/dashboard/src/workspace-page-header.tsx
+++ b/dashboard/src/workspace-page-header.tsx
@@ -1,0 +1,36 @@
+import type { ReactNode } from "react";
+
+import { TabBar } from "./approval-center-primitives";
+
+export interface WorkspacePageHeaderProps<T extends string> {
+  eyebrow: string;
+  title: string;
+  tabs: Array<{ value: T; label: string; id?: string }>;
+  activeTab: T;
+  onTabChange: (value: T) => void;
+  actions?: ReactNode;
+}
+
+export function WorkspacePageHeader<T extends string>({
+  eyebrow,
+  title,
+  tabs,
+  activeTab,
+  onTabChange,
+  actions,
+}: WorkspacePageHeaderProps<T>) {
+  return (
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">{eyebrow}</p>
+        <h1 className="text-2xl font-semibold tracking-tight text-brand-dark">{title}</h1>
+      </div>
+      <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
+        <div className="-mx-1 w-full overflow-x-auto px-1 sm:mx-0 sm:w-auto sm:overflow-visible">
+          <TabBar tabs={tabs} active={activeTab} onChange={onTabChange} />
+        </div>
+        {actions ? <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div> : null}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/workspace-page-header.tsx
+++ b/dashboard/src/workspace-page-header.tsx
@@ -26,7 +26,7 @@ export function WorkspacePageHeader<T extends string>({
         <h1 className="text-2xl font-semibold tracking-tight text-brand-dark">{title}</h1>
       </div>
       <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
-        <div className="-mx-1 w-full overflow-x-auto px-1 sm:mx-0 sm:w-auto sm:overflow-visible">
+        <div className="-mx-1 w-full overflow-x-auto px-1 sm:mx-0 sm:w-auto sm:overflow-visible [&>div]:!flex-nowrap">
           <TabBar tabs={tabs} active={activeTab} onChange={onTabChange} />
         </div>
         {actions ? <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div> : null}


### PR DESCRIPTION
## Summary

- Add shared `WorkspacePageHeader` for consistent workspace tab layout.
- Align Evidence, Receipts, and Supply Chain hub workspaces to the same header pattern.

## Test plan

- [x] `npm test` in `dashboard/`
- [x] `npm run build` in `dashboard/`
