### PR TITLE
feat(dashboard): sortable policy table with evidence links and consistent action buttons

### DIFF
--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -394,6 +394,34 @@ export const ActionButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Ac
 );
 ActionButton.displayName = "ActionButton";
 
+type IconActionButtonProps = {
+  label: string;
+  icon: ReactNode;
+  variant?: "primary" | "outline" | "danger" | "ghost";
+  onClick: () => void;
+  disabled?: boolean;
+  spinning?: boolean;
+  "aria-label"?: string;
+};
+
+export function IconActionButton({ label, icon, variant = "outline", onClick, disabled, spinning, "aria-label": ariaLabel }: IconActionButtonProps) {
+  const base = "inline-flex items-center justify-center gap-1.5 rounded-lg text-sm font-semibold transition-[color,background-color,border-color,opacity] duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 min-h-9 h-9 px-2.5 sm:px-3";
+  const tone =
+    variant === "primary"
+      ? "bg-brand-blue text-white shadow-sm hover:bg-brand-blue/90"
+      : variant === "danger"
+        ? "bg-brand-purple text-white shadow-sm hover:bg-brand-purple/90"
+        : variant === "ghost"
+          ? "text-slate-600 hover:bg-slate-100"
+          : "border border-slate-200 bg-white text-slate-700 hover:bg-slate-50 hover:border-slate-300";
+  return (
+    <button type="button" onClick={onClick} disabled={disabled} aria-label={ariaLabel ?? label} className={`${base} ${tone}`}>
+      <span className={`h-4 w-4 ${spinning ? "animate-spin" : ""}`} aria-hidden="true">{icon}</span>
+      <span className="hidden sm:inline">{spinning ? "Running..." : label}</span>
+    </button>
+  );
+}
+
 export function ListControls(props: {
   searchLabel: string;
   searchValue: string;

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useMemo } from "react";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, ReactNode } from "react";
 import {
   HiMiniExclamationTriangle,
   HiMiniCheckCircle,
@@ -11,11 +11,14 @@ import {
   HiMiniArrowUp,
   HiMiniChevronRight,
   HiMiniWrenchScrewdriver,
+  HiMiniShieldCheck,
+  HiMiniDocumentText,
+  HiMiniArrowPath,
 } from "react-icons/hi2";
-import { SectionLabel, Badge, Tag, ActionButton, EmptyState } from "./approval-center-primitives";
+import { SectionLabel, Badge, Tag, ActionButton, IconActionButton, EmptyState } from "./approval-center-primitives";
 import { ApprovalProofModal } from "./approval-proof-modal";
 import { formatRelativeTime, harnessDisplayName } from "./approval-center-utils";
-import { GuardHarnessActionError, runAuditRemediation } from "./guard-api";
+import { GuardHarnessActionError, runAuditRemediation, guardAwareHref } from "./guard-api";
 import type { AuditRemediationAction } from "./guard-api";
 import type { GuardApprovalGatePublicConfig, GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
 import { useResolvedApprovalGate } from "./use-resolved-approval-gate";
@@ -33,6 +36,7 @@ export type AuditResult = {
   remediation: string | null;
   remediationAction: AuditRemediationRequest | null;
   resolved: boolean;
+  evidenceHref: string | null;
 };
 
 export type AuditRemediationRequest = {
@@ -78,15 +82,23 @@ export function deriveFrontendAuditResults(
           : {
               action: "package_shim_path",
               manager: mgr,
-              label: `Install Guard for ${mgr}`,
+              label: "Install Guard",
             },
         resolved: false,
+        evidenceHref: restartRequired
+          ? null
+          : `/evidence?harness=global&search=${encodeURIComponent(mgr)}`,
       });
     }
   }
 
   const blockedReceipts = receipts.filter((r) => r.policy_decision === "block");
   for (const r of blockedReceipts.slice(0, 20)) {
+    const evidenceParams = new URLSearchParams();
+    evidenceParams.set("harness", r.harness || "global");
+    if (r.artifact_name) {
+      evidenceParams.set("search", r.artifact_name);
+    }
     results.push({
       id: `blocked-${r.receipt_id}`,
       severity: "medium",
@@ -98,6 +110,7 @@ export function deriveFrontendAuditResults(
       remediation: "Review the action in evidence and adjust policy if it was a false positive.",
       remediationAction: null,
       resolved: true,
+      evidenceHref: `/evidence?${evidenceParams.toString()}`,
     });
   }
 
@@ -113,6 +126,7 @@ export function deriveFrontendAuditResults(
       remediation: "Start Guard with hol-guard bootstrap or check system logs.",
       remediationAction: null,
       resolved: false,
+      evidenceHref: null,
     });
   }
 
@@ -224,21 +238,48 @@ function AuditRowActions(props: {
 
   if (result.remediationAction !== null) {
     return (
-      <div className="w-full sm:w-auto">
-        <ActionButton onClick={handleRunRemediation} disabled={running}>
-          <HiMiniWrenchScrewdriver className="mr-1.5 h-4 w-4" aria-hidden="true" />
-          {running ? "Running..." : result.remediationAction.label}
-        </ActionButton>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {result.evidenceHref && (
+          <a
+            href={guardAwareHref(result.evidenceHref)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 hover:text-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/30 transition-colors"
+            aria-label={`View evidence for ${result.title}`}
+            title="View evidence"
+          >
+            <HiMiniDocumentText className="h-4 w-4" aria-hidden="true" />
+          </a>
+        )}
+        <IconActionButton
+          variant="primary"
+          label={result.remediationAction.label}
+          icon={running ? <HiMiniArrowPath className="h-4 w-4" /> : <HiMiniShieldCheck className="h-4 w-4" />}
+          onClick={handleRunRemediation}
+          disabled={running}
+          spinning={running}
+        />
       </div>
     );
   }
 
   if (onMarkResolved) {
     return (
-      <div className="w-full sm:w-auto">
-        <ActionButton variant="outline" onClick={handleMarkResolved}>
-          Resolve
-        </ActionButton>
+      <div className="flex flex-wrap items-center gap-1.5">
+        {result.evidenceHref && (
+          <a
+            href={guardAwareHref(result.evidenceHref)}
+            className="inline-flex h-9 w-9 items-center justify-center rounded-lg p-1.5 text-slate-400 hover:bg-slate-100 hover:text-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/30 transition-colors"
+            aria-label={`View evidence for ${result.title}`}
+            title="View evidence"
+          >
+            <HiMiniDocumentText className="h-4 w-4" aria-hidden="true" />
+          </a>
+        )}
+        <IconActionButton
+          variant="outline"
+          label="Resolve"
+          icon={<HiMiniCheckCircle className="h-4 w-4" />}
+          onClick={handleMarkResolved}
+        />
       </div>
     );
   }

--- a/dashboard/src/policy-workspace.tsx
+++ b/dashboard/src/policy-workspace.tsx
@@ -9,9 +9,13 @@ import {
   HiMiniMagnifyingGlass,
   HiMiniPlus,
   HiMiniChevronRight,
+  HiMiniBarsArrowUp,
+  HiMiniBarsArrowDown,
+  HiMiniDocumentText,
 } from "react-icons/hi2";
 import { SectionLabel, Badge, Tag, ActionButton, EmptyState } from "./approval-center-primitives";
 import { harnessDisplayName, formatRelativeTime } from "./approval-center-utils";
+import { guardAwareHref } from "./guard-api";
 import type { GuardPolicyDecision, GuardRuntimeSnapshot } from "./guard-types";
 
 export type PolicyPageView = "rules" | "exceptions" | "strict";
@@ -21,6 +25,10 @@ export type PolicyFilterState = {
   harnessFilter: string;
   scopeFilter: string;
 };
+
+type PolicySortKey = "app" | "scope" | "action" | "target" | "updated";
+type PolicySortDirection = "asc" | "desc";
+type PolicySortState = { key: PolicySortKey; direction: PolicySortDirection } | null;
 
 export function groupPoliciesByHarness(
   policies: GuardPolicyDecision[],
@@ -90,6 +98,46 @@ export function resolveCloudPolicyBundleCopy(snapshot: GuardRuntimeSnapshot): {
   };
 }
 
+function policyTargetLabel(policy: GuardPolicyDecision): string {
+  return policy.artifact_id ?? policy.publisher ?? policy.workspace ?? "Global";
+}
+
+function policyEvidenceHref(policy: GuardPolicyDecision): string {
+  const params = new URLSearchParams();
+  params.set("harness", policy.harness || "global");
+  const target = policyTargetLabel(policy);
+  if (target && target !== "Global") {
+    params.set("search", target);
+  }
+  return `/evidence?${params.toString()}`;
+}
+
+function sortPolicies(
+  policies: GuardPolicyDecision[],
+  sort: PolicySortState,
+): GuardPolicyDecision[] {
+  if (sort === null) return policies;
+  const sorted = [...policies];
+  const dir = sort.direction === "asc" ? 1 : -1;
+  sorted.sort((a, b) => {
+    switch (sort.key) {
+      case "app":
+        return a.harness.localeCompare(b.harness) * dir;
+      case "scope":
+        return a.scope.localeCompare(b.scope) * dir;
+      case "action":
+        return a.action.localeCompare(b.action) * dir;
+      case "target":
+        return policyTargetLabel(a).localeCompare(policyTargetLabel(b)) * dir;
+      case "updated":
+        return (new Date(a.updated_at || 0).getTime() - new Date(b.updated_at || 0).getTime()) * dir;
+      default:
+        return 0;
+    }
+  });
+  return sorted;
+}
+
 type PolicyRowProps = {
   policy: GuardPolicyDecision;
   onClear?: (policy: GuardPolicyDecision) => void;
@@ -119,26 +167,77 @@ function PolicyRow({ policy, onClear }: PolicyRowProps) {
         <Badge tone={actionTone}>{policy.action}</Badge>
       </td>
       <td className="px-4 py-2.5 text-xs text-slate-500 max-w-[200px]">
-        <span className="truncate block" title={policy.artifact_id ?? undefined}>
-          {policy.artifact_id ?? policy.publisher ?? policy.workspace ?? "Global"}
+        <span className="truncate block" title={policyTargetLabel(policy)}>
+          {policyTargetLabel(policy)}
         </span>
       </td>
       <td className="px-4 py-2.5 text-xs text-slate-400 whitespace-nowrap">
         {policy.updated_at ? formatRelativeTime(policy.updated_at) : null}
       </td>
       <td className="px-4 py-2.5">
-        {onClear && (
-          <button
-            type="button"
-            onClick={handleClear}
-            aria-label={`Clear policy for ${harnessDisplayName(policy.harness)}`}
-            className="inline-flex items-center justify-center rounded p-1 text-slate-400 hover:bg-red-50 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-300/50 transition-colors"
+        <div className="flex items-center gap-0.5">
+          <a
+            href={guardAwareHref(policyEvidenceHref(policy))}
+            className="inline-flex h-8 w-8 items-center justify-center rounded p-1.5 text-slate-400 hover:bg-slate-100 hover:text-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/30 transition-colors"
+            aria-label={`View evidence for ${harnessDisplayName(policy.harness)}`}
+            title="View evidence"
           >
-            <HiMiniTrash className="h-3.5 w-3.5" aria-hidden="true" />
-          </button>
-        )}
+            <HiMiniDocumentText className="h-4 w-4" aria-hidden="true" />
+          </a>
+          {onClear && (
+            <button
+              type="button"
+              onClick={handleClear}
+              aria-label={`Clear policy for ${harnessDisplayName(policy.harness)}`}
+              className="inline-flex h-8 w-8 items-center justify-center rounded p-1.5 text-slate-400 hover:bg-red-50 hover:text-red-500 focus:outline-none focus:ring-2 focus:ring-red-300/50 transition-colors"
+              title="Clear policy"
+            >
+              <HiMiniTrash className="h-4 w-4" aria-hidden="true" />
+            </button>
+          )}
+        </div>
       </td>
     </tr>
+  );
+}
+
+type SortHeaderProps = {
+  label: string;
+  sortKey: PolicySortKey;
+  activeSort: PolicySortState;
+  onSort: (key: PolicySortKey) => void;
+  className?: string;
+};
+
+function SortHeader({ label, sortKey, activeSort, onSort, className }: SortHeaderProps) {
+  const isActive = activeSort?.key === sortKey;
+  const ariaSort = isActive ? (activeSort.direction === "asc" ? "ascending" : "descending") : "none";
+  return (
+    <th
+      scope="col"
+      aria-sort={ariaSort}
+      className={`px-4 py-2.5 text-left ${className ?? ""}`}
+    >
+      <button
+        type="button"
+        onClick={() => onSort(sortKey)}
+        className="group inline-flex items-center gap-1 text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400 transition-colors hover:text-brand-dark focus:outline-none focus:ring-2 focus:ring-brand-blue/30 rounded px-1 -ml-1"
+        aria-label={`Sort by ${label}, ${isActive ? (activeSort.direction === "asc" ? "descending" : "ascending") : "ascending"}`}
+      >
+        {label}
+        <span className="inline-flex h-3.5 w-3.5 items-center justify-center" aria-hidden="true">
+          {isActive ? (
+            activeSort.direction === "asc" ? (
+              <HiMiniBarsArrowUp className="h-3 w-3 text-brand-blue" />
+            ) : (
+              <HiMiniBarsArrowDown className="h-3 w-3 text-brand-blue" />
+            )
+          ) : (
+            <HiMiniBarsArrowUp className="h-3 w-3 text-slate-300 opacity-0 group-hover:opacity-100 transition-opacity" />
+          )}
+        </span>
+      </button>
+    </th>
   );
 }
 
@@ -161,6 +260,7 @@ export function PolicyWorkspace({
     harnessFilter: "",
     scopeFilter: "",
   });
+  const [sort, setSort] = useState<PolicySortState>({ key: "updated", direction: "desc" });
 
   const handleSearchChange = useCallback((e: ChangeEvent<HTMLInputElement>) => {
     setFilter((f) => ({ ...f, searchQuery: e.target.value }));
@@ -168,6 +268,18 @@ export function PolicyWorkspace({
 
   const handleViewChange = useCallback((v: PolicyPageView) => {
     setActiveView(v);
+  }, []);
+
+  const handleSort = useCallback((key: PolicySortKey) => {
+    setSort((current) => {
+      if (current?.key === key) {
+        if (current.direction === "asc") {
+          return { key, direction: "desc" };
+        }
+        return { key, direction: "asc" };
+      }
+      return { key, direction: "asc" };
+    });
   }, []);
 
   const securityLevel = snapshot.security_level;
@@ -181,22 +293,21 @@ export function PolicyWorkspace({
         p.harness.toLowerCase().includes(q) ||
         (p.artifact_id ?? "").toLowerCase().includes(q) ||
         (p.workspace ?? "").toLowerCase().includes(q) ||
-        (p.publisher ?? "").toLowerCase().includes(q)
+        (p.publisher ?? "").toLowerCase().includes(q) ||
+        p.scope.toLowerCase().includes(q) ||
+        p.action.toLowerCase().includes(q)
       );
     });
   }, [policies, filter.searchQuery]);
 
-  const allowPolicies = useMemo(
-    () => filteredPolicies.filter((p) => p.action === "allow"),
-    [filteredPolicies],
+  const sortedPolicies = useMemo(
+    () => sortPolicies(filteredPolicies, sort),
+    [filteredPolicies, sort],
   );
-  const blockPolicies = useMemo(
-    () => filteredPolicies.filter((p) => p.action === "block"),
-    [filteredPolicies],
-  );
+
   const exceptionPolicies = useMemo(
-    () => filteredPolicies.filter((p) => p.action !== "allow" && p.action !== "block"),
-    [filteredPolicies],
+    () => sortedPolicies.filter((p) => p.action !== "allow" && p.action !== "block"),
+    [sortedPolicies],
   );
 
   const policyByHarness = useMemo(() => groupPoliciesByHarness(policies), [policies]);
@@ -274,15 +385,16 @@ export function PolicyWorkspace({
             value={filter.searchQuery}
             onChange={handleSearchChange}
             aria-label="Search policies"
-            className="bg-transparent text-sm text-brand-dark placeholder:text-slate-400 focus:outline-none w-36"
+            className="bg-transparent text-sm text-brand-dark placeholder:text-slate-400 focus:outline-none w-36 sm:w-48"
           />
         </div>
       </div>
 
       {activeView === "rules" && (
         <PolicyTable
-          allowPolicies={allowPolicies}
-          blockPolicies={blockPolicies}
+          policies={sortedPolicies.filter((p) => p.action === "allow" || p.action === "block")}
+          sort={sort}
+          onSort={handleSort}
           onClearPolicy={onClearPolicy}
         />
       )}
@@ -297,13 +409,14 @@ export function PolicyWorkspace({
 }
 
 type PolicyTableProps = {
-  allowPolicies: GuardPolicyDecision[];
-  blockPolicies: GuardPolicyDecision[];
+  policies: GuardPolicyDecision[];
+  sort: PolicySortState;
+  onSort: (key: PolicySortKey) => void;
   onClearPolicy?: (policy: GuardPolicyDecision) => void;
 };
 
-function PolicyTable({ allowPolicies, blockPolicies, onClearPolicy }: PolicyTableProps) {
-  const allPolicies = [...allowPolicies, ...blockPolicies];
+function PolicyTable({ policies, sort, onSort, onClearPolicy }: PolicyTableProps) {
+  const allPolicies = policies;
 
   if (allPolicies.length === 0) {
     return (
@@ -318,24 +431,14 @@ function PolicyTable({ allowPolicies, blockPolicies, onClearPolicy }: PolicyTabl
   return (
     <div className="rounded-2xl border border-slate-100 bg-white shadow-sm overflow-hidden">
       <div className="overflow-x-auto">
-        <table className="w-full min-w-[600px] text-sm" aria-label="Policy rules">
+        <table className="w-full min-w-[640px] text-sm" aria-label="Policy rules">
           <thead>
             <tr className="border-b border-slate-100 bg-slate-50">
-              <th scope="col" className="px-4 py-2.5 text-left text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
-                App
-              </th>
-              <th scope="col" className="px-4 py-2.5 text-left text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
-                Scope
-              </th>
-              <th scope="col" className="px-4 py-2.5 text-left text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
-                Action
-              </th>
-              <th scope="col" className="px-4 py-2.5 text-left text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
-                Target
-              </th>
-              <th scope="col" className="px-4 py-2.5 text-left text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400">
-                Updated
-              </th>
+              <SortHeader label="App" sortKey="app" activeSort={sort} onSort={onSort} />
+              <SortHeader label="Scope" sortKey="scope" activeSort={sort} onSort={onSort} />
+              <SortHeader label="Action" sortKey="action" activeSort={sort} onSort={onSort} />
+              <SortHeader label="Target" sortKey="target" activeSort={sort} onSort={onSort} />
+              <SortHeader label="Updated" sortKey="updated" activeSort={sort} onSort={onSort} />
               <th scope="col" className="px-4 py-2.5">
                 <span className="sr-only">Actions</span>
               </th>
@@ -344,7 +447,7 @@ function PolicyTable({ allowPolicies, blockPolicies, onClearPolicy }: PolicyTabl
           <tbody>
             {allPolicies.map((p) => (
               <PolicyRow
-                key={`${p.harness}-${p.scope}-${p.artifact_id ?? p.publisher ?? p.workspace ?? "global"}`}
+                key={`${p.harness}-${p.scope}-${policyTargetLabel(p)}-${p.updated_at ?? ""}`}
                 policy={p}
                 onClear={onClearPolicy}
               />
@@ -396,16 +499,27 @@ function ExceptionsView({
                   <span className="truncate block">{p.reason ?? "No reason recorded"}</span>
                 </td>
                 <td className="px-4 py-2.5">
-                  {onClearPolicy && (
-                    <button
-                      type="button"
-                      onClick={() => onClearPolicy(p)}
-                      aria-label={`Remove exception for ${harnessDisplayName(p.harness)}`}
-                      className="inline-flex items-center justify-center rounded p-1 text-slate-400 hover:bg-red-50 hover:text-red-500 transition-colors"
+                  <div className="flex items-center gap-0.5">
+                    <a
+                      href={guardAwareHref(policyEvidenceHref(p))}
+                      className="inline-flex h-8 w-8 items-center justify-center rounded p-1.5 text-slate-400 hover:bg-slate-100 hover:text-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/30 transition-colors"
+                      aria-label={`View evidence for ${harnessDisplayName(p.harness)}`}
+                      title="View evidence"
                     >
-                      <HiMiniTrash className="h-3.5 w-3.5" aria-hidden="true" />
-                    </button>
-                  )}
+                      <HiMiniDocumentText className="h-4 w-4" aria-hidden="true" />
+                    </a>
+                    {onClearPolicy && (
+                      <button
+                        type="button"
+                        onClick={() => onClearPolicy(p)}
+                        aria-label={`Remove exception for ${harnessDisplayName(p.harness)}`}
+                        className="inline-flex h-8 w-8 items-center justify-center rounded p-1.5 text-slate-400 hover:bg-red-50 hover:text-red-500 transition-colors"
+                        title="Remove exception"
+                      >
+                        <HiMiniTrash className="h-4 w-4" aria-hidden="true" />
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo } from "react";
-import type { ChangeEvent } from "react";
+import type { ChangeEvent, ReactNode } from "react";
 import {
   HiMiniArrowPath,
   HiMiniBugAnt,
@@ -10,9 +10,10 @@ import {
   HiMiniTrash,
   HiMiniCheckCircle,
   HiMiniMagnifyingGlass,
+  HiMiniXCircle,
 } from "react-icons/hi2";
 import { ApprovalProofModal } from "./approval-proof-modal";
-import { SectionLabel, Tag, ActionButton, EmptyState } from "./approval-center-primitives";
+import { SectionLabel, Tag, ActionButton, IconActionButton, EmptyState } from "./approval-center-primitives";
 import type {
   GuardApprovalGatePublicConfig,
   PackageFirewallStatusResponse,
@@ -163,42 +164,58 @@ function ManagerRow({
           <div className="shrink-0">
             {isConfirmingRemove ? (
               <div className="flex items-center gap-1.5">
-                <ActionButton variant="ghost" onClick={onRemoveCancel} disabled={anyPending}>
-                  Cancel
-                </ActionButton>
-                <ActionButton
+                <IconActionButton
+                  variant="ghost"
+                  label="Cancel"
+                  icon={<HiMiniXCircle className="h-4 w-4" />}
+                  onClick={onRemoveCancel}
+                  disabled={anyPending}
+                />
+                <IconActionButton
                   variant="danger"
+                  label="Confirm"
+                  icon={<HiMiniTrash className="h-4 w-4" />}
                   onClick={handleRemoveConfirm}
                   disabled={anyPending}
-                >
-                  Confirm
-                </ActionButton>
+                />
               </div>
             ) : (
               <div className="flex flex-wrap items-center gap-1.5">
                 {showInstall && (
-                  <ActionButton variant="primary" onClick={handleInstall} disabled={anyPending}>
-                    <HiMiniShieldCheck className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
-                    Protect
-                  </ActionButton>
+                  <IconActionButton
+                    variant="primary"
+                    label="Protect"
+                    icon={<HiMiniShieldCheck className="h-4 w-4" />}
+                    onClick={handleInstall}
+                    disabled={anyPending}
+                  />
                 )}
                 {showRepair && (
-                  <ActionButton variant="primary" onClick={handleRepair} disabled={anyPending}>
-                    <HiMiniWrenchScrewdriver className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
-                    Fix PATH
-                  </ActionButton>
+                  <IconActionButton
+                    variant="primary"
+                    label="Fix PATH"
+                    icon={<HiMiniWrenchScrewdriver className="h-4 w-4" />}
+                    onClick={handleRepair}
+                    disabled={anyPending}
+                  />
                 )}
                 {showTest && (
-                  <ActionButton variant="outline" onClick={handleTest} disabled={anyPending}>
-                    <HiMiniBeaker className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
-                    Test
-                  </ActionButton>
+                  <IconActionButton
+                    variant="outline"
+                    label="Test"
+                    icon={<HiMiniBeaker className="h-4 w-4" />}
+                    onClick={handleTest}
+                    disabled={anyPending}
+                  />
                 )}
                 {showRemove && (
-                  <ActionButton variant="danger" onClick={handleRemoveRequest} disabled={anyPending}>
-                    <HiMiniTrash className="mr-1 h-3.5 w-3.5" aria-hidden="true" />
-                    Remove
-                  </ActionButton>
+                  <IconActionButton
+                    variant="danger"
+                    label="Remove"
+                    icon={<HiMiniTrash className="h-4 w-4" />}
+                    onClick={handleRemoveRequest}
+                    disabled={anyPending}
+                  />
                 )}
               </div>
             )}


### PR DESCRIPTION
## Summary
- Make the Policy table sortable by App, Scope, Action, Target, and Updated with clickable column headers
- Add a "View evidence" action on every policy row that links to `/evidence?harness=...&search=...`
- Add the same evidence link to Exception rules
- Unify the previously separate allow/block policy tables into one sortable table
- Introduce a compact `IconActionButton` for Supply Chain manager rows with consistent sizing, focus rings, and icon + label on desktop / icon-only on mobile
- Apply the same compact action-button pattern to Audit remediation buttons
- Add evidence links from Audit blocked receipts and unprotected-manager findings to matching evidence filters
- Reduce Audit remediation button label from "Install Guard for X" to "Install Guard" to avoid overflow and match Supply Chain vocabulary

## Testing
- `npx vite build` in `dashboard/`
- Verified the Policy sort state cycles asc → desc per column and defaults to Updated desc
- Verified evidence links include the correct harness and optional target search

## Notes
- Built assets are intentionally excluded from this PR; they will be generated and deployed in a follow-up deploy PR if needed.
