### PR TITLE
fix(dashboard): align evidence header tabs to top-right and improve responsive behavior

### DIFF
--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { HiMiniArrowDownTray, HiMiniDocumentText } from "react-icons/hi2";
+import { HiMiniArrowDownTray, HiMiniDocumentText, HiMiniXMark } from "react-icons/hi2";
 
-import { EmptyState, ActionButton, SectionLabel } from "./approval-center-primitives";
+import { EmptyState, ActionButton, SectionLabel, IconActionButton } from "./approval-center-primitives";
 import { isDisplayableHarness, normalizeHarnessFilter } from "./approval-center-utils";
 import type { GuardReceipt } from "./guard-types";
 import type { EvidenceFilterState, EvidenceView, EvidenceSortKey } from "./evidence/evidence-types";
@@ -204,24 +204,21 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
   const headerActions = useMemo(
     () => (
       <>
-        <button
-          type="button"
+        <IconActionButton
+          label="Export"
+          icon={<HiMiniDocumentText className="h-4 w-4" />}
+          variant="outline"
           onClick={handleOpenExport}
           aria-label="Export evidence"
-          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-brand-dark shadow-sm transition-colors hover:bg-slate-50"
-        >
-          <HiMiniDocumentText className="h-4 w-4 text-slate-400" aria-hidden="true" />
-          Export
-        </button>
+        />
         {onClearEvidence && receiptItems.length > 0 && (
-          <button
-            type="button"
+          <IconActionButton
+            label="Clear"
+            icon={<HiMiniXMark className="h-4 w-4" />}
+            variant="ghost"
             onClick={handleOpenClear}
             aria-label="Clear all evidence"
-            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm font-medium text-slate-500 shadow-sm transition-colors hover:bg-slate-50 hover:text-brand-attention"
-          >
-            Clear
-          </button>
+          />
         )}
       </>
     ),
@@ -229,7 +226,7 @@ function EvidenceWorkbench({ receiptItems, onClearEvidence }: EvidenceWorkbenchP
   );
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-6">
       <WorkspacePageHeader
         eyebrow="Evidence"
         title={evidenceTitleForView(filters.view)}

--- a/dashboard/src/workspace-page-header.tsx
+++ b/dashboard/src/workspace-page-header.tsx
@@ -20,16 +20,16 @@ export function WorkspacePageHeader<T extends string>({
   actions,
 }: WorkspacePageHeaderProps<T>) {
   return (
-    <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+    <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
       <div className="space-y-1">
         <p className="text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">{eyebrow}</p>
         <h1 className="text-2xl font-semibold tracking-tight text-brand-dark">{title}</h1>
       </div>
-      <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center sm:gap-4">
-        <div className="-mx-1 w-full overflow-x-auto px-1 sm:mx-0 sm:w-auto sm:overflow-visible [&>div]:!flex-nowrap">
+      <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-start sm:justify-end sm:gap-4">
+        <div className="-mx-1 w-full overflow-x-auto px-1 pb-1 sm:mx-0 sm:w-auto sm:pb-0 [&>div]:!flex-nowrap">
           <TabBar tabs={tabs} active={activeTab} onChange={onTabChange} />
         </div>
-        {actions ? <div className="flex shrink-0 flex-wrap items-center gap-2">{actions}</div> : null}
+        {actions ? <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">{actions}</div> : null}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- Fix evidence page tab alignment to consistently place tabs in the top-right on desktop, matching the supply chain hub pattern
- Remove `sm:overflow-visible` from the tab bar wrapper so tabs scroll horizontally on narrow viewports instead of breaking layout
- Switch evidence header action buttons (Export, Clear) to the shared `IconActionButton` primitive for consistency with supply chain and audit pages
- Align evidence page vertical spacing (`space-y-6`) with the supply chain hub

## Testing
- `npx vite build` in `dashboard/`
- Verified tab bar scrolls smoothly on narrow desktop widths (768px–1024px) without pushing actions to a second row

## Notes
- This is a source-only PR; built static assets will be generated and deployed in a follow-up deploy PR.
