### PR TITLE
fix(security): harden dashboard update runner spawn

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
@@ -74,11 +74,12 @@ def build_dashboard_update_runner_command(
 
 
 def build_dashboard_update_runner_popen_kwargs(guard_home: Path) -> dict[str, object]:
+    resolved_home = guard_home.expanduser().resolve()
     return {
         "stdin": subprocess.DEVNULL,
         "stdout": subprocess.DEVNULL,
         "stderr": subprocess.DEVNULL,
-        "cwd": str(guard_home),
+        "cwd": str(resolved_home),
         "env": _runner_env(),
     }
 

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
@@ -44,6 +44,45 @@ def dashboard_update_in_progress(guard_home: Path) -> bool:
     return True
 
 
+def dashboard_update_runner_script() -> Path:
+    """Return the installed runner script path (never resolve via cwd or -m imports)."""
+    return Path(__file__).resolve().with_name("dashboard_update_runner.py")
+
+
+def build_dashboard_update_runner_command(
+    guard_home: Path,
+    *,
+    daemon_pid: int,
+    daemon_port: int,
+) -> list[str]:
+    runner_script = dashboard_update_runner_script()
+    command = [sys.executable]
+    if sys.version_info >= (3, 11):
+        command.append("-P")
+    command.extend(
+        [
+            str(runner_script),
+            "--guard-home",
+            str(guard_home),
+            "--daemon-pid",
+            str(daemon_pid),
+            "--daemon-port",
+            str(daemon_port),
+        ]
+    )
+    return command
+
+
+def build_dashboard_update_runner_popen_kwargs(guard_home: Path) -> dict[str, object]:
+    return {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "cwd": str(guard_home),
+        "env": _runner_env(),
+    }
+
+
 def schedule_guard_dashboard_update(
     guard_home: Path,
     daemon_pid: int,
@@ -58,23 +97,12 @@ def schedule_guard_dashboard_update(
         }
     lock_path = dashboard_update_lock_path(guard_home)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
-    command = [
-        sys.executable,
-        "-m",
-        "codex_plugin_scanner.guard.daemon.dashboard_update_runner",
-        "--guard-home",
-        str(guard_home),
-        "--daemon-pid",
-        str(daemon_pid),
-        "--daemon-port",
-        str(daemon_port),
-    ]
-    kwargs: dict[str, object] = {
-        "stdin": subprocess.DEVNULL,
-        "stdout": subprocess.DEVNULL,
-        "stderr": subprocess.DEVNULL,
-        "env": _runner_env(),
-    }
+    command = build_dashboard_update_runner_command(
+        guard_home,
+        daemon_pid=daemon_pid,
+        daemon_port=daemon_port,
+    )
+    kwargs = build_dashboard_update_runner_popen_kwargs(guard_home)
     if os.name == "nt":
         kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
     else:
@@ -104,14 +132,9 @@ def clear_dashboard_update_lock(guard_home: Path) -> None:
 def _runner_env() -> dict[str, str]:
     env = dict(os.environ)
     source_root = str(Path(__file__).resolve().parents[3])
-    pythonpath_entries: list[str] = []
-    for raw_value in (source_root, env.get("PYTHONPATH", "")):
-        for entry in raw_value.split(os.pathsep):
-            normalized = entry.strip()
-            if normalized and normalized not in pythonpath_entries:
-                pythonpath_entries.append(normalized)
-    if pythonpath_entries:
-        env["PYTHONPATH"] = os.pathsep.join(pythonpath_entries)
+    env["PYTHONPATH"] = source_root
+    if sys.version_info >= (3, 11):
+        env["PYTHONSAFEPATH"] = "1"
     return env
 
 

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
@@ -55,6 +55,7 @@ def build_dashboard_update_runner_command(
     daemon_pid: int,
     daemon_port: int,
 ) -> list[str]:
+    resolved_home = guard_home.expanduser().resolve()
     runner_script = dashboard_update_runner_script()
     command = [sys.executable]
     if sys.version_info >= (3, 11):
@@ -63,7 +64,7 @@ def build_dashboard_update_runner_command(
         [
             str(runner_script),
             "--guard-home",
-            str(guard_home),
+            str(resolved_home),
             "--daemon-pid",
             str(daemon_pid),
             "--daemon-port",

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -275,3 +275,5 @@ def test_runner_env_ignores_inherited_pythonpath(tmp_path: Path, monkeypatch: py
     pythonpath = str(env.get("PYTHONPATH", ""))
     assert str(evil_root) not in pythonpath.split(os.pathsep)
     assert str(dashboard_update_runner_script().resolve().parents[3]) in pythonpath
+    if sys.version_info >= (3, 11):
+        assert env.get("PYTHONSAFEPATH") == "1"

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import os
+import sys
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -12,7 +14,12 @@ import pytest
 
 from codex_plugin_scanner.guard.cli.update_commands import build_guard_update_status_payload
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
-from codex_plugin_scanner.guard.daemon.dashboard_update import schedule_guard_dashboard_update
+from codex_plugin_scanner.guard.daemon.dashboard_update import (
+    build_dashboard_update_runner_command,
+    build_dashboard_update_runner_popen_kwargs,
+    dashboard_update_runner_script,
+    schedule_guard_dashboard_update,
+)
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -225,10 +232,46 @@ def test_schedule_guard_dashboard_update_spawns_runner(
     assert result["scheduled"] is True
     command = captured["command"]
     assert isinstance(command, list)
-    assert "codex_plugin_scanner.guard.daemon.dashboard_update_runner" in command
+    assert "-m" not in command
+    runner_script = dashboard_update_runner_script()
+    assert str(runner_script) in command
+    if sys.version_info >= (3, 11):
+        assert command[1] == "-P"
+        assert command[2] == str(runner_script)
+    else:
+        assert command[1] == str(runner_script)
     assert "--guard-home" in command
-    assert str(guard_home) in command
+    assert str(guard_home.resolve()) in command
     assert "--daemon-pid" in command
     assert "4242" in command
     assert "--daemon-port" in command
     assert "8787" in command
+    kwargs = captured["kwargs"]
+    assert isinstance(kwargs, dict)
+    assert kwargs.get("cwd") == str(guard_home.resolve())
+
+
+def test_runner_command_avoids_module_shadowing_from_cwd(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    command = build_dashboard_update_runner_command(
+        guard_home.resolve(),
+        daemon_pid=99,
+        daemon_port=1234,
+    )
+    assert "-m" not in command
+    assert "codex_plugin_scanner.guard.daemon.dashboard_update_runner" not in command
+    runner_script = dashboard_update_runner_script()
+    assert str(runner_script) in command
+    assert runner_script.is_file()
+
+
+def test_runner_env_ignores_inherited_pythonpath(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    evil_root = tmp_path / "evil-repo" / "src"
+    evil_root.mkdir(parents=True)
+    monkeypatch.setenv("PYTHONPATH", str(evil_root))
+    env = build_dashboard_update_runner_popen_kwargs(tmp_path / "guard-home")["env"]
+    assert isinstance(env, dict)
+    pythonpath = str(env.get("PYTHONPATH", ""))
+    assert str(evil_root) not in pythonpath.split(os.pathsep)
+    assert str(dashboard_update_runner_script().resolve().parents[3]) in pythonpath


### PR DESCRIPTION
## Summary
- Launch the dashboard update runner via its installed script path instead of `python -m`, preventing cwd module shadowing from a repository under review.
- Run the detached updater with `cwd` set to `guard_home`, `-P` on Python 3.11+, and a trusted-only `PYTHONPATH`.
- Add regression tests covering command shape, cwd, and inherited `PYTHONPATH` hardening.

## Testing
- `python3 -m pytest tests/test_dashboard_update.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/daemon/dashboard_update.py tests/test_dashboard_update.py`
