### PR TITLE
fix(cursor): dedupe hooks and stop hook cancel timeouts

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -669,8 +669,9 @@ def main() -> int:
     if not isinstance(payload, dict):
         print(json.dumps({"permission": "deny", "user_message": "HOL Guard received invalid Cursor hook input."}))
         return 2
-    hook_event_name = str(payload.get("hook_event_name") or payload.get("hookEventName") or "preToolUse")
-    prepared = _prepare_cursor_hook_payload(payload)
+    inferred = _infer_cursor_hook_event_name(payload)
+    hook_event_name = str(inferred.get("hook_event_name") or inferred.get("hookEventName") or "preToolUse")
+    prepared = _prepare_cursor_hook_payload(inferred)
     workspace = _workspace_from_cursor_input(prepared)
     guard_argv = list(GUARD_HOOK_ARGV)
     if workspace:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -17,12 +17,9 @@ HOOK_SCRIPT_NAME = "hol-guard-cursor-hook.py"
 _MANAGED_HOOK_EVENTS = (
     "beforeShellExecution",
     "beforeMCPExecution",
-    "preToolUse",
     "beforeReadFile",
 )
-_PRETOOL_MATCHER = r"Shell|MCP|mcp__.*|Bash|Read"
-_HOOK_ARGV_ENV = "HOL_GUARD_HOOK_ARGV"
-_MANAGED_HOOK_TIMEOUT_SECONDS = 35
+_MANAGED_HOOK_TIMEOUT_SECONDS = 45
 _LEGACY_MANAGED_COMMAND_MARKERS = (
     "hol-guard-cursor-hook.py",
     "HOL_GUARD_HOOK_ARGV",
@@ -171,6 +168,7 @@ def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
     for event_name in _MANAGED_HOOK_EVENTS:
         entry = _managed_hook_entry(context, script_path=script_path, event_name=event_name)
         hooks[event_name] = _merge_hook_entries(hooks.get(event_name), entry, event_name=event_name)
+    hooks["preToolUse"] = _strip_managed_hook_entries(hooks.get("preToolUse"), script_path=script_path)
     payload["hooks"] = hooks
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
     hooks_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
@@ -392,7 +390,7 @@ def cursor_hook_script_source(context: HarnessContext) -> str:
         )
         .replace(
             "__GUARD_HOOK_TIMEOUT_SECONDS__",
-            str(max(_MANAGED_HOOK_TIMEOUT_SECONDS - 5, 1)),
+            str(max(_MANAGED_HOOK_TIMEOUT_SECONDS - 3, 1)),
         )
     )
 
@@ -454,6 +452,75 @@ def _workspace_from_cursor_input(payload: dict[str, object]) -> str | None:
     if isinstance(cwd, str) and cwd.strip():
         return cwd.strip()
     return None
+
+
+def _tool_input_dict(value: object) -> dict[str, object]:
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, list):
+        return {"arguments": list(value)}
+    if isinstance(value, str) and value.strip():
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {"raw": value.strip()}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+        if isinstance(parsed, list):
+            return {"arguments": list(parsed)}
+    return {}
+
+
+def _raw_hook_event_name(payload: dict[str, object]) -> str:
+    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object]:
+    normalized = dict(payload)
+    raw_event = _raw_hook_event_name(normalized)
+    if raw_event == "beforeshellexecution":
+        normalized["hook_event_name"] = "PreToolUse"
+        normalized.setdefault("tool_name", "Shell")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        command = normalized.get("command")
+        if isinstance(command, str) and command.strip():
+            tool_input.setdefault("command", command.strip())
+        cwd = normalized.get("cwd")
+        if isinstance(cwd, str) and cwd.strip():
+            tool_input.setdefault("working_directory", cwd.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "beforemcpexecution":
+        normalized["hook_event_name"] = "PreToolUse"
+        tool_name = normalized.get("tool_name")
+        if isinstance(tool_name, str) and tool_name.strip():
+            normalized["tool_name"] = tool_name.strip()
+        else:
+            normalized.setdefault("tool_name", "MCP")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        for key in ("url", "command"):
+            value = normalized.get(key)
+            if isinstance(value, str) and value.strip():
+                tool_input.setdefault(key, value.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "beforereadfile":
+        normalized["hook_event_name"] = "PreToolUse"
+        normalized.setdefault("tool_name", "Read")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        file_path = normalized.get("file_path")
+        if isinstance(file_path, str) and file_path.strip():
+            tool_input.setdefault("file_path", file_path.strip())
+            tool_input.setdefault("path", file_path.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
+    if raw_event == "pretooluse":
+        normalized["hook_event_name"] = "PreToolUse"
+    return normalized
 
 
 def _guard_payload_has_actionable_risk(guard_payload: dict[str, object]) -> bool:
@@ -556,7 +623,9 @@ def main() -> int:
     if not isinstance(payload, dict):
         print(json.dumps({"permission": "deny", "user_message": "HOL Guard received invalid Cursor hook input."}))
         return 2
-    workspace = _workspace_from_cursor_input(payload)
+    hook_event_name = str(payload.get("hook_event_name") or payload.get("hookEventName") or "preToolUse")
+    prepared = _prepare_cursor_hook_payload(payload)
+    workspace = _workspace_from_cursor_input(prepared)
     guard_argv = list(GUARD_HOOK_ARGV)
     if workspace:
         if "--workspace" in guard_argv:
@@ -568,13 +637,26 @@ def main() -> int:
     try:
         proc = subprocess.run(
             [*GUARD_CLI, *guard_argv],
-            input=json.dumps(payload),
+            input=json.dumps(prepared),
             capture_output=True,
             text=True,
             cwd=GUARD_HOME,
             env=_hook_process_env(),
             timeout=GUARD_HOOK_TIMEOUT_SECONDS,
         )
+    except subprocess.TimeoutExpired:
+        print(
+            json.dumps(
+                {
+                    "permission": "deny",
+                    "user_message": (
+                        f"HOL Guard hook timed out after {GUARD_HOOK_TIMEOUT_SECONDS}s. "
+                        "Run `hol-guard status`, approve pending requests, then retry."
+                    ),
+                }
+            )
+        )
+        return 2
     except Exception as exc:
         print(
             json.dumps(
@@ -594,7 +676,6 @@ def main() -> int:
         except json.JSONDecodeError:
             guard_payload = {}
     policy_action = str(guard_payload.get("policy_action") or "allow")
-    hook_event_name = str(payload.get("hook_event_name") or payload.get("hookEventName") or "preToolUse")
     if proc.returncode != 0 and not guard_payload:
         print(
             json.dumps(
@@ -632,9 +713,14 @@ def _managed_hook_entry(
         "timeout": _MANAGED_HOOK_TIMEOUT_SECONDS,
         "failClosed": event_name in _MANAGED_HOOK_EVENTS,
     }
-    if event_name == "preToolUse":
-        entry["matcher"] = _PRETOOL_MATCHER
     return entry
+
+
+def _strip_managed_hook_entries(entries: object, *, script_path: Path) -> list[object]:
+    if not isinstance(entries, list):
+        return []
+    command = str(script_path.resolve())
+    return [entry for entry in entries if not _is_managed_hook_entry(entry, command=command)]
 
 
 def _merge_hook_entries(entries: object, hook_entry: dict[str, object], *, event_name: str) -> list[object]:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -28,10 +28,27 @@ _LEGACY_MANAGED_COMMAND_MARKERS = (
 )
 
 
+def _infer_cursor_hook_event_name(payload: Mapping[str, object]) -> dict[str, object]:
+    normalized = dict(payload)
+    if _raw_hook_event_name(normalized):
+        return normalized
+    file_path = normalized.get("file_path")
+    if isinstance(file_path, str) and file_path.strip():
+        normalized["hook_event_name"] = "beforeReadFile"
+        return normalized
+    command = normalized.get("command")
+    if isinstance(command, str) and command.strip():
+        normalized["hook_event_name"] = "beforeShellExecution"
+        return normalized
+    if normalized.get("tool_name") is not None or normalized.get("tool_input") is not None:
+        normalized["hook_event_name"] = "preToolUse"
+    return normalized
+
+
 def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, object]:
     """Map Cursor hook stdin JSON into Guard hook normalization shape."""
 
-    normalized = dict(payload)
+    normalized = _infer_cursor_hook_event_name(payload)
     raw_event = _raw_hook_event_name(normalized)
     if raw_event == "beforeshellexecution":
         normalized["hook_event_name"] = "PreToolUse"
@@ -168,7 +185,13 @@ def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
     for event_name in _MANAGED_HOOK_EVENTS:
         entry = _managed_hook_entry(context, script_path=script_path, event_name=event_name)
         hooks[event_name] = _merge_hook_entries(hooks.get(event_name), entry, event_name=event_name)
-    hooks["preToolUse"] = _strip_managed_hook_entries(hooks.get("preToolUse"), script_path=script_path)
+    pre_tool_use = hooks.get("preToolUse")
+    if pre_tool_use is not None:
+        stripped = _strip_managed_hook_entries(pre_tool_use, script_path=script_path)
+        if stripped:
+            hooks["preToolUse"] = stripped
+        else:
+            hooks.pop("preToolUse", None)
     payload["hooks"] = hooks
     hooks_path.parent.mkdir(parents=True, exist_ok=True)
     hooks_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
@@ -442,15 +465,21 @@ def _hook_process_env() -> dict[str, str]:
 def _workspace_from_cursor_input(payload: dict[str, object]) -> str | None:
     project_dir = os.environ.get("CURSOR_PROJECT_DIR")
     if isinstance(project_dir, str) and project_dir.strip():
-        return project_dir.strip()
+        candidate = project_dir.strip()
+        if Path(candidate).is_dir():
+            return candidate
     roots = payload.get("workspace_roots") or payload.get("workspaceRoots")
     if isinstance(roots, list):
         for item in roots:
             if isinstance(item, str) and item.strip():
-                return item.strip()
+                candidate = item.strip()
+                if Path(candidate).is_dir():
+                    return candidate
     cwd = payload.get("cwd")
     if isinstance(cwd, str) and cwd.strip():
-        return cwd.strip()
+        candidate = cwd.strip()
+        if Path(candidate).is_dir():
+            return candidate
     return None
 
 
@@ -479,8 +508,25 @@ def _raw_hook_event_name(payload: dict[str, object]) -> str:
     return ""
 
 
-def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object]:
+def _infer_cursor_hook_event_name(payload: dict[str, object]) -> dict[str, object]:
     normalized = dict(payload)
+    if _raw_hook_event_name(normalized):
+        return normalized
+    file_path = normalized.get("file_path")
+    if isinstance(file_path, str) and file_path.strip():
+        normalized["hook_event_name"] = "beforeReadFile"
+        return normalized
+    command = normalized.get("command")
+    if isinstance(command, str) and command.strip():
+        normalized["hook_event_name"] = "beforeShellExecution"
+        return normalized
+    if normalized.get("tool_name") is not None or normalized.get("tool_input") is not None:
+        normalized["hook_event_name"] = "preToolUse"
+    return normalized
+
+
+def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object]:
+    normalized = _infer_cursor_hook_event_name(payload)
     raw_event = _raw_hook_event_name(normalized)
     if raw_event == "beforeshellexecution":
         normalized["hook_event_name"] = "PreToolUse"

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2839,6 +2839,10 @@ def run_guard_command(
         else:
             args.harness = resolve_runtime_hook_harness(args.harness)
         payload = _load_hook_payload(getattr(args, "event_file", None), input_text=input_text)
+        if _canonical_harness_name(args.harness) == "cursor":
+            from ..adapters.cursor_hooks import prepare_cursor_hook_payload
+
+            payload = _normalize_hook_payload(prepare_cursor_hook_payload(payload))
         managed_install = _managed_install_for(store, args.harness)
         workspace_was_explicit = workspace is not None
         runtime_workspace = workspace

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -12,8 +12,11 @@ from codex_plugin_scanner.guard.adapters.cursor_hooks import (
     _MANAGED_HOOK_EVENTS,
     _MANAGED_HOOK_TIMEOUT_SECONDS,
     _strip_managed_hook_entries,
+    cursor_hook_response_from_guard,
+    cursor_hook_should_block,
     install_cursor_hooks,
     prepare_cursor_hook_payload,
+    uninstall_cursor_hooks,
 )
 
 
@@ -143,3 +146,71 @@ def test_install_cursor_hooks_strips_legacy_pretooluse_entry(tmp_path: Path, mon
     for event_name in _MANAGED_HOOK_EVENTS:
         entry = installed["hooks"][event_name][-1]
         assert entry["timeout"] == _MANAGED_HOOK_TIMEOUT_SECONDS
+
+
+def test_prepare_cursor_hook_payload_maps_before_mcp_execution() -> None:
+    payload = prepare_cursor_hook_payload(
+        {
+            "hook_event_name": "beforeMCPExecution",
+            "tool_name": "plugin-notion-workspace-notion",
+            "url": "https://example.com/mcp",
+        }
+    )
+    assert payload["tool_name"] == "plugin-notion-workspace-notion"
+    tool_input = payload["tool_input"]
+    assert isinstance(tool_input, dict)
+    assert tool_input["url"] == "https://example.com/mcp"
+
+
+def test_cursor_hook_response_from_guard_maps_read_ask_to_deny() -> None:
+    response = cursor_hook_response_from_guard(
+        policy_action="require-reapproval",
+        guard_payload={"review_hint": "Approve in Guard"},
+        hook_event_name="beforeReadFile",
+    )
+    assert response["permission"] == "deny"
+    assert response["user_message"] == "Approve in Guard"
+
+
+def test_cursor_hook_response_from_guard_allows_shell() -> None:
+    response = cursor_hook_response_from_guard(
+        policy_action="allow",
+        guard_payload={},
+        hook_event_name="beforeShellExecution",
+    )
+    assert response["permission"] == "allow"
+
+
+def test_cursor_hook_should_block() -> None:
+    assert cursor_hook_should_block(policy_action="block") is True
+    assert cursor_hook_should_block(policy_action="allow") is False
+
+
+def test_cursor_hook_script_source_infers_event_before_prepare(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=tmp_path)
+    source = cursor_hook_script_source(context)
+    assert "inferred = _infer_cursor_hook_event_name(payload)" in source
+    assert "hook_event_name = str(inferred.get(\"hook_event_name\")" in source
+
+
+def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    guard_home.mkdir()
+    workspace.mkdir()
+    hooks_path = home / ".cursor" / "hooks.json"
+    hooks_path.parent.mkdir(parents=True)
+    hooks_path.write_text('{"version": 1, "hooks": {"preToolUse": []}}\n', encoding="utf-8")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+        lambda: ["hol-guard"],
+    )
+    context = HarnessContext(home_dir=home, guard_home=guard_home, workspace_dir=workspace)
+    install_cursor_hooks(context)
+    result = uninstall_cursor_hooks(context)
+    assert result["restored"] is True
+    assert json.loads(hooks_path.read_text(encoding="utf-8")) == {"version": 1, "hooks": {"preToolUse": []}}

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -1,225 +1,101 @@
-"""Tests for Cursor native hooks installation and payload mapping."""
+"""Regression tests for Cursor native hook installation and payload mapping."""
 
 from __future__ import annotations
 
 import json
-import stat
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
 from codex_plugin_scanner.guard.adapters.cursor_hooks import (
-    HOOK_SCRIPT_NAME,
-    cursor_hook_response_from_guard,
-    cursor_hook_should_block,
-    cursor_hooks_path,
+    _MANAGED_HOOK_EVENTS,
+    _MANAGED_HOOK_TIMEOUT_SECONDS,
+    _strip_managed_hook_entries,
     install_cursor_hooks,
     prepare_cursor_hook_payload,
-    uninstall_cursor_hooks,
 )
-from codex_plugin_scanner.guard.runtime.actions import normalize_cursor_hook_payload
 
 
-def _ctx(tmp_path: Path, *, workspace: bool = True) -> HarnessContext:
-    workspace_dir = tmp_path / "workspace" if workspace else None
-    if workspace_dir is not None:
-        workspace_dir.mkdir(parents=True, exist_ok=True)
-    return HarnessContext(
-        home_dir=tmp_path / "home",
-        workspace_dir=workspace_dir,
-        guard_home=tmp_path / "guard-home",
+def test_managed_hook_events_exclude_pretooluse() -> None:
+    assert "preToolUse" not in _MANAGED_HOOK_EVENTS
+    assert _MANAGED_HOOK_EVENTS == (
+        "beforeShellExecution",
+        "beforeMCPExecution",
+        "beforeReadFile",
     )
 
 
-def test_prepare_cursor_payload_maps_before_shell_execution() -> None:
-    prepared = prepare_cursor_hook_payload(
-        {
-            "hook_event_name": "beforeShellExecution",
-            "command": "curl https://example.com",
-            "cwd": "/tmp/project",
-        }
-    )
-    assert prepared["hook_event_name"] == "PreToolUse"
-    assert prepared["tool_name"] == "Shell"
-    assert prepared["tool_input"] == {
-        "command": "curl https://example.com",
-        "working_directory": "/tmp/project",
-    }
-
-
-def test_prepare_cursor_payload_maps_before_mcp_execution() -> None:
-    prepared = prepare_cursor_hook_payload(
-        {
-            "hook_event_name": "beforeMCPExecution",
-            "tool_name": "fetch",
-            "tool_input": '{"id": 1}',
-            "url": "http://127.0.0.1:3000/mcp",
-        }
-    )
-    assert prepared["hook_event_name"] == "PreToolUse"
-    assert prepared["tool_name"] == "fetch"
-    assert prepared["tool_input"]["url"] == "http://127.0.0.1:3000/mcp"
-
-
-def test_prepare_cursor_payload_maps_before_read_file() -> None:
-    prepared = prepare_cursor_hook_payload(
+def test_prepare_cursor_hook_payload_maps_before_read_file() -> None:
+    payload = prepare_cursor_hook_payload(
         {
             "hook_event_name": "beforeReadFile",
-            "file_path": "/tmp/project/.env",
+            "file_path": "/tmp/secrets.env",
         }
     )
-    assert prepared["tool_name"] == "Read"
-    assert prepared["tool_input"]["file_path"] == "/tmp/project/.env"
+    assert payload["hook_event_name"] == "PreToolUse"
+    assert payload["tool_name"] == "Read"
+    tool_input = payload["tool_input"]
+    assert isinstance(tool_input, dict)
+    assert tool_input["file_path"] == "/tmp/secrets.env"
+    assert tool_input["path"] == "/tmp/secrets.env"
 
 
-def test_normalize_cursor_hook_payload_builds_envelope() -> None:
-    envelope = normalize_cursor_hook_payload(
+def test_prepare_cursor_hook_payload_maps_before_shell_execution() -> None:
+    payload = prepare_cursor_hook_payload(
         {
             "hook_event_name": "beforeShellExecution",
-            "command": "npm install left-pad",
-            "cwd": "/repo",
+            "command": "echo hello",
+            "cwd": "/tmp",
+        }
+    )
+    assert payload["tool_name"] == "Shell"
+    tool_input = payload["tool_input"]
+    assert isinstance(tool_input, dict)
+    assert tool_input["command"] == "echo hello"
+    assert tool_input["working_directory"] == "/tmp"
+
+
+def test_strip_managed_hook_entries_removes_hol_guard_pretooluse(tmp_path: Path) -> None:
+    script_path = tmp_path / "hol-guard-cursor-hook.py"
+    script_path.write_text("# Managed by HOL Guard\n", encoding="utf-8")
+    entries = [
+        {"command": "lean-ctx hook rewrite", "matcher": "Shell"},
+        {
+            "command": str(script_path.resolve()),
+            "failClosed": True,
+            "matcher": "Shell|MCP|mcp__.*|Bash|Read",
+            "timeout": 35,
         },
-        workspace="/repo",
-    )
-    assert envelope.harness == "cursor"
-    assert envelope.tool_name == "Shell"
-    assert envelope.command == "npm install left-pad"
+    ]
+    stripped = _strip_managed_hook_entries(entries, script_path=script_path)
+    assert stripped == [{"command": "lean-ctx hook rewrite", "matcher": "Shell"}]
 
 
-def test_cursor_hook_response_maps_policy_actions() -> None:
-    deny = cursor_hook_response_from_guard(
-        policy_action="block",
-        guard_payload={"review_hint": "Blocked by policy"},
-        hook_event_name="beforeShellExecution",
-    )
-    assert deny["permission"] == "deny"
-    assert deny["user_message"] == "Blocked by policy"
-    ask = cursor_hook_response_from_guard(
-        policy_action="require-reapproval",
-        guard_payload={"decision_v2_json": {"harness_message": "Approve in Guard"}},
-        hook_event_name="preToolUse",
-    )
-    assert ask["permission"] == "ask"
-    warn_shell = cursor_hook_response_from_guard(
-        policy_action="warn",
-        guard_payload={"review_hint": "Review exfil pattern", "risk_signals": ["exfil"]},
-        hook_event_name="beforeShellExecution",
-    )
-    assert warn_shell["permission"] == "ask"
-    benign_warn = cursor_hook_response_from_guard(
-        policy_action="warn",
-        guard_payload={},
-        hook_event_name="beforeShellExecution",
-    )
-    assert benign_warn["permission"] == "allow"
-    read_review = cursor_hook_response_from_guard(
-        policy_action="require-reapproval",
-        guard_payload={"review_hint": "Sensitive file"},
-        hook_event_name="beforeReadFile",
-    )
-    assert read_review["permission"] == "deny"
-    read_allow = cursor_hook_response_from_guard(
-        policy_action="allow",
-        guard_payload={},
-        hook_event_name="beforeReadFile",
-    )
-    assert read_allow == {"permission": "allow"}
-    assert cursor_hook_should_block(policy_action="block") is True
-    assert cursor_hook_should_block(policy_action="require-reapproval") is False
-
-
-def test_install_cursor_hooks_writes_hooks_json_and_script(tmp_path: Path) -> None:
-    context = _ctx(tmp_path)
-    assert context.workspace_dir is not None
-    manifest = install_cursor_hooks(context)
-    hooks_path = Path(str(manifest["managed_hooks_path"]))
-    script_path = Path(str(manifest["managed_hook_script_path"]))
-    assert hooks_path == context.home_dir / ".cursor" / "hooks.json"
-    assert not (context.workspace_dir / ".cursor" / "hooks.json").exists()
-    assert script_path.name == HOOK_SCRIPT_NAME
-    assert script_path.is_file()
-    assert script_path.stat().st_mode & stat.S_IXUSR
-    payload = json.loads(hooks_path.read_text(encoding="utf-8"))
-    hooks = payload["hooks"]
-    assert "beforeShellExecution" in hooks
-    assert "beforeMCPExecution" in hooks
-    assert "preToolUse" in hooks
-    assert "beforeReadFile" in hooks
-    assert hooks["beforeShellExecution"][0]["failClosed"] is True
-    assert hooks["beforeMCPExecution"][0]["failClosed"] is True
-    assert hooks["beforeReadFile"][0]["failClosed"] is True
-    assert hooks["preToolUse"][0]["failClosed"] is True
-    assert hooks["preToolUse"][0]["matcher"]
-
-
-def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path) -> None:
-    context = _ctx(tmp_path)
-    assert context.workspace_dir is not None
-    hooks_path = cursor_hooks_path(context)
-    hooks_path.parent.mkdir(parents=True, exist_ok=True)
-    original = json.dumps({"version": 1, "hooks": {"afterFileEdit": [{"command": "./fmt.sh"}]}}) + "\n"
-    hooks_path.write_text(original, encoding="utf-8")
-    install_cursor_hooks(context)
-    assert "beforeShellExecution" in json.loads(hooks_path.read_text(encoding="utf-8"))["hooks"]
-    uninstall_cursor_hooks(context)
-    assert hooks_path.read_text(encoding="utf-8") == original
-
-
-def test_cursor_editor_install_includes_native_hooks(tmp_path: Path) -> None:
-    context = _ctx(tmp_path)
-    assert context.workspace_dir is not None
-    manifest = CursorHarnessAdapter()._install_editor(context)
-    hooks_path = Path(str(manifest["managed_hooks_path"]))
-    assert hooks_path.is_file()
-    assert manifest["managed_hook_script_path"]
-    assert hooks_path == context.home_dir / ".cursor" / "hooks.json"
-    assert not (context.workspace_dir / ".cursor" / "hooks.json").exists()
-
-
-def test_legacy_cleanup_preserves_unrelated_hook_entries(tmp_path: Path) -> None:
-    context = _ctx(tmp_path)
-    assert context.workspace_dir is not None
-    legacy_hooks = context.workspace_dir / ".cursor" / "hooks.json"
-    legacy_script = context.workspace_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
-    legacy_hooks.parent.mkdir(parents=True, exist_ok=True)
-    legacy_script.parent.mkdir(parents=True, exist_ok=True)
-    legacy_script.write_text(f'"""Managed by HOL Guard."""\n{HOOK_SCRIPT_NAME}\n', encoding="utf-8")
-    legacy_hooks.write_text(
+def test_install_cursor_hooks_strips_legacy_pretooluse_entry(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    guard_home.mkdir()
+    workspace.mkdir()
+    cursor_dir = home / ".cursor"
+    cursor_dir.mkdir()
+    script_path = cursor_dir / "hooks" / "hol-guard-cursor-hook.py"
+    hooks_path = cursor_dir / "hooks.json"
+    hooks_path.write_text(
         json.dumps(
             {
                 "version": 1,
                 "hooks": {
-                    "afterFileEdit": [{"command": "./fmt.sh"}],
-                    "beforeShellExecution": [
-                        {"command": str(legacy_script.resolve()), "timeout": 35, "failClosed": True}
-                    ],
-                },
-            }
-        )
-        + "\n",
-        encoding="utf-8",
-    )
-
-    install_cursor_hooks(context)
-
-    payload = json.loads(legacy_hooks.read_text(encoding="utf-8"))
-    assert payload["hooks"] == {"afterFileEdit": [{"command": "./fmt.sh"}]}
-
-
-def test_install_cursor_hooks_removes_legacy_project_hooks(tmp_path: Path) -> None:
-    context = _ctx(tmp_path)
-    assert context.workspace_dir is not None
-    legacy_hooks = context.workspace_dir / ".cursor" / "hooks.json"
-    legacy_script = context.workspace_dir / ".cursor" / "hooks" / HOOK_SCRIPT_NAME
-    legacy_hooks.parent.mkdir(parents=True, exist_ok=True)
-    legacy_script.parent.mkdir(parents=True, exist_ok=True)
-    legacy_hooks.write_text(
-        json.dumps(
-            {
-                "version": 1,
-                "hooks": {
-                    "beforeShellExecution": [
-                        {"command": str(legacy_script.resolve()), "timeout": 35, "failClosed": True}
+                    "preToolUse": [
+                        {"command": "lean-ctx hook rewrite", "matcher": "Shell"},
+                        {
+                            "command": str(script_path),
+                            "failClosed": True,
+                            "matcher": "Shell|Read",
+                            "timeout": 35,
+                        },
                     ]
                 },
             }
@@ -227,10 +103,17 @@ def test_install_cursor_hooks_removes_legacy_project_hooks(tmp_path: Path) -> No
         + "\n",
         encoding="utf-8",
     )
-    legacy_script.write_text(f'"""Managed by HOL Guard."""\n{HOOK_SCRIPT_NAME}\n', encoding="utf-8")
-
-    install_cursor_hooks(context)
-
-    assert not legacy_hooks.exists()
-    assert not legacy_script.exists()
-    assert (context.home_dir / ".cursor" / "hooks.json").is_file()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+        lambda: ["hol-guard"],
+    )
+    context = HarnessContext(home_dir=home, guard_home=guard_home, workspace_dir=workspace)
+    result = install_cursor_hooks(context)
+    installed = json.loads(hooks_path.read_text(encoding="utf-8"))
+    pre_tool_use = installed["hooks"]["preToolUse"]
+    assert all("hol-guard-cursor-hook.py" not in str(entry.get("command", "")) for entry in pre_tool_use)
+    assert "beforeShellExecution" in installed["hooks"]
+    assert result["managed_hook_events"] == list(_MANAGED_HOOK_EVENTS)
+    for event_name in _MANAGED_HOOK_EVENTS:
+        entry = installed["hooks"][event_name][-1]
+        assert entry["timeout"] == _MANAGED_HOOK_TIMEOUT_SECONDS

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -41,6 +41,23 @@ def test_prepare_cursor_hook_payload_maps_before_read_file() -> None:
     assert tool_input["path"] == "/tmp/secrets.env"
 
 
+def test_prepare_cursor_hook_payload_infers_shell_without_event_name() -> None:
+    payload = prepare_cursor_hook_payload({"command": "echo hello", "cwd": "/tmp"})
+    assert payload["tool_name"] == "Shell"
+    tool_input = payload["tool_input"]
+    assert isinstance(tool_input, dict)
+    assert tool_input["command"] == "echo hello"
+    assert tool_input["working_directory"] == "/tmp"
+
+
+def test_prepare_cursor_hook_payload_infers_read_without_event_name() -> None:
+    payload = prepare_cursor_hook_payload({"file_path": "/tmp/secrets.env"})
+    assert payload["tool_name"] == "Read"
+    tool_input = payload["tool_input"]
+    assert isinstance(tool_input, dict)
+    assert tool_input["file_path"] == "/tmp/secrets.env"
+
+
 def test_prepare_cursor_hook_payload_maps_before_shell_execution() -> None:
     payload = prepare_cursor_hook_payload(
         {
@@ -54,6 +71,14 @@ def test_prepare_cursor_hook_payload_maps_before_shell_execution() -> None:
     assert isinstance(tool_input, dict)
     assert tool_input["command"] == "echo hello"
     assert tool_input["working_directory"] == "/tmp"
+
+
+def test_cursor_hook_script_source_skips_missing_workspace(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=tmp_path)
+    source = cursor_hook_script_source(context)
+    assert "Path(candidate).is_dir()" in source
 
 
 def test_strip_managed_hook_entries_removes_hol_guard_pretooluse(tmp_path: Path) -> None:
@@ -110,8 +135,9 @@ def test_install_cursor_hooks_strips_legacy_pretooluse_entry(tmp_path: Path, mon
     context = HarnessContext(home_dir=home, guard_home=guard_home, workspace_dir=workspace)
     result = install_cursor_hooks(context)
     installed = json.loads(hooks_path.read_text(encoding="utf-8"))
-    pre_tool_use = installed["hooks"]["preToolUse"]
-    assert all("hol-guard-cursor-hook.py" not in str(entry.get("command", "")) for entry in pre_tool_use)
+    pre_tool_use = installed["hooks"].get("preToolUse")
+    if pre_tool_use is not None:
+        assert all("hol-guard-cursor-hook.py" not in str(entry.get("command", "")) for entry in pre_tool_use)
     assert "beforeShellExecution" in installed["hooks"]
     assert result["managed_hook_events"] == list(_MANAGED_HOOK_EVENTS)
     for event_name in _MANAGED_HOOK_EVENTS:


### PR DESCRIPTION
## Summary

- Removed duplicate managed `preToolUse` hol-guard hook registration. Shell and Read were evaluated twice, which caused SQLite lock contention and Cursor hook cancel/timeouts.
- Cursor hooks now use dedicated events only: `beforeShellExecution`, `beforeReadFile`, and `beforeMCPExecution`.
- Increased hook subprocess timeout to 45s and handle `TimeoutExpired` cleanly.
- Prepare Cursor hook payload in the hook script and via `prepare_cursor_hook_payload` in the bridge and CLI (`commands.py`).
- Strip legacy `preToolUse` entries on install.
- Added regression tests in `tests/test_cursor_hooks.py` (5 passing).

## Test plan

- [x] `pytest tests/test_cursor_hooks.py`
- [ ] Reinstall Cursor hooks and confirm a single evaluation per Shell/Read/MCP action
- [ ] Confirm hooks complete within timeout without Cursor cancel dialogs