### PR TITLE
fix(guard): reconnect dashboard update after daemon port migration

### DIFF
--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -45,6 +45,7 @@ import type {
   GuardSettingsExport,
   GuardSettings,
   GuardUpdateScheduleResult,
+  GuardUpdateReconnectOptions,
   GuardUpdateStatus,
   GuardUpdateVersionCheck,
   DecisionScope,
@@ -65,6 +66,10 @@ import {
 const GUARD_TOKEN_PARAM = "guard-token";
 const GUARD_DAEMON_PARAM = "guardDaemon";
 const GUARD_SURFACE_PROTOCOL_VERSIONS = ["1.1", "1.0"] as const;
+const DEFAULT_GUARD_DAEMON_PORT = 4781;
+const GUARD_DAEMON_PORT_RANGE = 1000;
+const GUARD_DAEMON_DISCOVERY_PROBE_COUNT = 25;
+const GUARD_DAEMON_PROBE_TIMEOUT_MS = 800;
 let guardTokenOverride: string | null = null;
 let guardTokenLocationKey: string | null = null;
 
@@ -179,6 +184,181 @@ function readGuardToken(): string | null {
 function saveGuardToken(guardToken: string): void {
   guardTokenOverride = guardToken;
   window.sessionStorage.setItem(GUARD_TOKEN_PARAM, guardToken);
+}
+
+function saveGuardDaemonOrigin(daemonOrigin: string): void {
+  window.sessionStorage.setItem(GUARD_DAEMON_PARAM, daemonOrigin);
+}
+
+function preferredGuardDaemonPort(): number {
+  const fromOrigin = readGuardDaemonOrigin();
+  if (fromOrigin) {
+    try {
+      const port = Number(new URL(fromOrigin).port);
+      if (Number.isInteger(port) && port > 0) {
+        return port;
+      }
+    } catch {
+      // fall through
+    }
+  }
+  const port = Number(window.location.port);
+  if (Number.isInteger(port) && port > 0) {
+    return port;
+  }
+  return DEFAULT_GUARD_DAEMON_PORT;
+}
+
+export function buildGuardDaemonCandidatePorts(preferredPort: number): number[] {
+  const offset = preferredPort - DEFAULT_GUARD_DAEMON_PORT;
+  const ports: number[] = [];
+  for (let step = 0; step < GUARD_DAEMON_DISCOVERY_PROBE_COUNT; step += 1) {
+    const candidateOffset =
+      ((offset + step) % GUARD_DAEMON_PORT_RANGE + GUARD_DAEMON_PORT_RANGE) % GUARD_DAEMON_PORT_RANGE;
+    ports.push(DEFAULT_GUARD_DAEMON_PORT + candidateOffset);
+  }
+  return ports;
+}
+
+async function probeGuardDaemonHealth(origin: string): Promise<boolean> {
+  const controller = new AbortController();
+  const timeoutId = window.setTimeout(() => controller.abort(), GUARD_DAEMON_PROBE_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${origin}/healthz`, { signal: controller.signal });
+    if (!response.ok) {
+      return false;
+    }
+    const payload = (await response.json()) as Record<string, unknown>;
+    return payload.ok === true && payload.compatibility_version === 2;
+  } catch {
+    return false;
+  } finally {
+    window.clearTimeout(timeoutId);
+  }
+}
+
+export async function discoverGuardDaemonOrigin(preferredPort = preferredGuardDaemonPort()): Promise<string | null> {
+  for (const port of buildGuardDaemonCandidatePorts(preferredPort)) {
+    const origin = `http://127.0.0.1:${port}`;
+    if (await probeGuardDaemonHealth(origin)) {
+      return origin;
+    }
+  }
+  return null;
+}
+
+function updateReconnectSucceeded(
+  status: GuardUpdateStatus,
+  options: GuardUpdateReconnectOptions,
+): boolean {
+  if (!options.expectedPreviousVersion) {
+    return true;
+  }
+  if (status.update_available !== true) {
+    return true;
+  }
+  if (
+    options.expectedLatestVersion &&
+    status.current_version === options.expectedLatestVersion
+  ) {
+    return true;
+  }
+  return status.current_version !== options.expectedPreviousVersion;
+}
+
+async function initializeGuardDashboardSessionAtOrigin(
+  origin: string,
+  guardToken: string | null,
+): Promise<string | null> {
+  try {
+    const response = await fetch(`${origin}/v1/initialize`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        ...(guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {}),
+      },
+      body: JSON.stringify({
+        client_name: "guard-dashboard-web",
+        surface: "dashboard",
+        supported_protocol_versions: [...GUARD_SURFACE_PROTOCOL_VERSIONS],
+      }),
+    });
+    if (!response.ok) {
+      return null;
+    }
+    return parseDashboardSessionToken(await response.json());
+  } catch {
+    return null;
+  }
+}
+
+export async function fetchGuardUpdateStatusAtOrigin(
+  origin: string,
+  guardToken: string | null,
+): Promise<GuardUpdateStatus> {
+  const response = await fetch(`${origin}/v1/update/status`, {
+    headers: guardToken ? { "X-Guard-Dashboard-Session": guardToken } : {},
+  });
+  if (!response.ok) {
+    throw new Error(`Update status failed with ${response.status}`);
+  }
+  return normalizeGuardUpdateStatus(await response.json());
+}
+
+function redirectToGuardDaemonOrigin(
+  origin: string,
+  guardToken: string | null,
+): void {
+  const url = new URL(origin);
+  url.pathname = window.location.pathname;
+  url.search = window.location.search;
+  const fragmentPairs: string[] = [];
+  if (guardToken) {
+    fragmentPairs.push(`${GUARD_TOKEN_PARAM}=${encodeURIComponent(guardToken)}`);
+  }
+  fragmentPairs.push(`${GUARD_DAEMON_PARAM}=${encodeURIComponent(origin)}`);
+  url.hash = fragmentPairs.join("&");
+  window.location.replace(url.toString());
+}
+
+export async function reconnectGuardDaemonAfterUpdate(
+  options?: GuardUpdateReconnectOptions,
+): Promise<string | null> {
+  const guardToken = readGuardToken();
+  const reconnectOptions = options ?? {};
+  const awaitingVersionChange = Boolean(reconnectOptions.expectedPreviousVersion);
+
+  for (const port of buildGuardDaemonCandidatePorts(preferredGuardDaemonPort())) {
+    const origin = `http://127.0.0.1:${port}`;
+    if (!(await probeGuardDaemonHealth(origin))) {
+      continue;
+    }
+
+    let status: GuardUpdateStatus;
+    try {
+      status = await fetchGuardUpdateStatusAtOrigin(origin, guardToken);
+    } catch {
+      continue;
+    }
+
+    if (awaitingVersionChange && !updateReconnectSucceeded(status, reconnectOptions)) {
+      continue;
+    }
+
+    saveGuardDaemonOrigin(origin);
+    const refreshedToken = await initializeGuardDashboardSessionAtOrigin(origin, guardToken);
+    if (refreshedToken) {
+      saveGuardToken(refreshedToken);
+    }
+
+    if (origin !== window.location.origin) {
+      redirectToGuardDaemonOrigin(origin, refreshedToken ?? guardToken);
+    }
+
+    return origin;
+  }
+
+  return null;
 }
 
 function readGuardDaemonOrigin(): string | null {
@@ -1482,6 +1662,8 @@ export function normalizeGuardUpdateStatus(raw: unknown): GuardUpdateStatus {
     auto_updatable: booleanValue(value.auto_updatable),
     update_available: booleanValue(value.update_available),
     blocked_reason: stringValue(value.blocked_reason),
+    update_in_progress:
+      typeof value.update_in_progress === "boolean" ? value.update_in_progress : undefined,
   };
 }
 

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -69,6 +69,7 @@ const GUARD_SURFACE_PROTOCOL_VERSIONS = ["1.1", "1.0"] as const;
 const DEFAULT_GUARD_DAEMON_PORT = 4781;
 const GUARD_DAEMON_PORT_RANGE = 1000;
 const GUARD_DAEMON_DISCOVERY_PROBE_COUNT = 25;
+const GUARD_DAEMON_DISCOVERY_PROBE_BATCH_SIZE = 5;
 const GUARD_DAEMON_PROBE_TIMEOUT_MS = 800;
 let guardTokenOverride: string | null = null;
 let guardTokenLocationKey: string | null = null;
@@ -210,12 +211,19 @@ function preferredGuardDaemonPort(): number {
 }
 
 export function buildGuardDaemonCandidatePorts(preferredPort: number): number[] {
-  const offset = preferredPort - DEFAULT_GUARD_DAEMON_PORT;
   const ports: number[] = [];
+  const inStandardRange =
+    preferredPort >= DEFAULT_GUARD_DAEMON_PORT &&
+    preferredPort < DEFAULT_GUARD_DAEMON_PORT + GUARD_DAEMON_PORT_RANGE;
   for (let step = 0; step < GUARD_DAEMON_DISCOVERY_PROBE_COUNT; step += 1) {
-    const candidateOffset =
-      ((offset + step) % GUARD_DAEMON_PORT_RANGE + GUARD_DAEMON_PORT_RANGE) % GUARD_DAEMON_PORT_RANGE;
-    ports.push(DEFAULT_GUARD_DAEMON_PORT + candidateOffset);
+    if (inStandardRange) {
+      const offset = preferredPort - DEFAULT_GUARD_DAEMON_PORT;
+      const candidateOffset =
+        ((offset + step) % GUARD_DAEMON_PORT_RANGE + GUARD_DAEMON_PORT_RANGE) % GUARD_DAEMON_PORT_RANGE;
+      ports.push(DEFAULT_GUARD_DAEMON_PORT + candidateOffset);
+    } else {
+      ports.push(preferredPort + step);
+    }
   }
   return ports;
 }
@@ -237,14 +245,30 @@ async function probeGuardDaemonHealth(origin: string): Promise<boolean> {
   }
 }
 
-export async function discoverGuardDaemonOrigin(preferredPort = preferredGuardDaemonPort()): Promise<string | null> {
-  for (const port of buildGuardDaemonCandidatePorts(preferredPort)) {
-    const origin = `http://127.0.0.1:${port}`;
-    if (await probeGuardDaemonHealth(origin)) {
-      return origin;
+async function probeGuardDaemonCandidatePortsInBatches(
+  ports: number[],
+  probe: (port: number, origin: string) => Promise<boolean>,
+): Promise<string | null> {
+  for (let index = 0; index < ports.length; index += GUARD_DAEMON_DISCOVERY_PROBE_BATCH_SIZE) {
+    const batch = ports.slice(index, index + GUARD_DAEMON_DISCOVERY_PROBE_BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (port) => {
+        const origin = `http://127.0.0.1:${port}`;
+        const ok = await probe(port, origin);
+        return { port, origin, ok };
+      }),
+    );
+    const active = results.find((result) => result.ok);
+    if (active) {
+      return active.origin;
     }
   }
   return null;
+}
+
+export async function discoverGuardDaemonOrigin(preferredPort = preferredGuardDaemonPort()): Promise<string | null> {
+  const ports = buildGuardDaemonCandidatePorts(preferredPort);
+  return probeGuardDaemonCandidatePortsInBatches(ports, async (_port, origin) => probeGuardDaemonHealth(origin));
 }
 
 function updateReconnectSucceeded(
@@ -327,24 +351,34 @@ export async function reconnectGuardDaemonAfterUpdate(
   const guardToken = readGuardToken();
   const reconnectOptions = options ?? {};
   const awaitingVersionChange = Boolean(reconnectOptions.expectedPreviousVersion);
+  const ports = buildGuardDaemonCandidatePorts(preferredGuardDaemonPort());
 
-  for (const port of buildGuardDaemonCandidatePorts(preferredGuardDaemonPort())) {
-    const origin = `http://127.0.0.1:${port}`;
-    if (!(await probeGuardDaemonHealth(origin))) {
+  for (let index = 0; index < ports.length; index += GUARD_DAEMON_DISCOVERY_PROBE_BATCH_SIZE) {
+    const batch = ports.slice(index, index + GUARD_DAEMON_DISCOVERY_PROBE_BATCH_SIZE);
+    const results = await Promise.all(
+      batch.map(async (port) => {
+        const origin = `http://127.0.0.1:${port}`;
+        if (!(await probeGuardDaemonHealth(origin))) {
+          return null;
+        }
+        try {
+          const status = await fetchGuardUpdateStatusAtOrigin(origin, guardToken);
+          if (awaitingVersionChange && !updateReconnectSucceeded(status, reconnectOptions)) {
+            return null;
+          }
+          return { origin, status };
+        } catch {
+          return null;
+        }
+      }),
+    );
+
+    const active = results.find((result) => result !== null);
+    if (!active) {
       continue;
     }
 
-    let status: GuardUpdateStatus;
-    try {
-      status = await fetchGuardUpdateStatusAtOrigin(origin, guardToken);
-    } catch {
-      continue;
-    }
-
-    if (awaitingVersionChange && !updateReconnectSucceeded(status, reconnectOptions)) {
-      continue;
-    }
-
+    const { origin } = active;
     saveGuardDaemonOrigin(origin);
     const refreshedToken = await initializeGuardDashboardSessionAtOrigin(origin, guardToken);
     if (refreshedToken) {

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -165,7 +165,7 @@ function guardParam(name: string): string | null {
   return guardParams().get(name);
 }
 
-function readGuardToken(): string | null {
+export function readGuardToken(): string | null {
   const locationKey = `${window.location.origin}${window.location.pathname}${window.location.search}${window.location.hash}`;
   if (guardTokenLocationKey !== locationKey) {
     guardTokenOverride = null;
@@ -236,7 +236,10 @@ async function probeGuardDaemonHealth(origin: string): Promise<boolean> {
     if (!response.ok) {
       return false;
     }
-    const payload = (await response.json()) as Record<string, unknown>;
+    const payload: unknown = await response.json();
+    if (!isRecord(payload)) {
+      return false;
+    }
     return payload.ok === true && payload.compatibility_version === 2;
   } catch {
     return false;
@@ -329,7 +332,7 @@ export async function fetchGuardUpdateStatusAtOrigin(
   return normalizeGuardUpdateStatus(await response.json());
 }
 
-function redirectToGuardDaemonOrigin(
+export function redirectToGuardDaemonOrigin(
   origin: string,
   guardToken: string | null,
 ): void {
@@ -383,10 +386,6 @@ export async function reconnectGuardDaemonAfterUpdate(
     const refreshedToken = await initializeGuardDashboardSessionAtOrigin(origin, guardToken);
     if (refreshedToken) {
       saveGuardToken(refreshedToken);
-    }
-
-    if (origin !== window.location.origin) {
-      redirectToGuardDaemonOrigin(origin, refreshedToken ?? guardToken);
     }
 
     return origin;

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -617,6 +617,12 @@ export type GuardUpdateStatus = {
   auto_updatable: boolean;
   update_available: boolean;
   blocked_reason: string | null;
+  update_in_progress?: boolean;
+};
+
+export type GuardUpdateReconnectOptions = {
+  expectedPreviousVersion?: string | null;
+  expectedLatestVersion?: string | null;
 };
 
 export type GuardUpdateScheduleResult = {

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -1,12 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { HiMiniArrowPath } from "react-icons/hi2";
 
-import { fetchGuardUpdateStatus, repairApprovalCenter, scheduleGuardUpdate } from "./guard-api";
+import {
+  fetchGuardUpdateStatus,
+  reconnectGuardDaemonAfterUpdate,
+  scheduleGuardUpdate,
+} from "./guard-api";
 import type { GuardUpdatePhase, GuardUpdateStatus } from "./guard-types";
 
 const UPDATE_STATUS_POLL_MS = 60_000;
 const RECONNECT_POLL_MS = 1_500;
-const RECONNECT_TIMEOUT_MS = 120_000;
+const RECONNECT_TIMEOUT_MS = 180_000;
 
 export type GuardUpdatePanelProps = {
   guardVersion?: string | null;
@@ -138,32 +142,58 @@ export function useGuardUpdate(options?: { onReconnected?: () => void }) {
     };
   }, [refreshUpdateStatus]);
 
-  const waitForReconnect = useCallback(async () => {
-    reconnectStartedAt.current = Date.now();
-    while (Date.now() - (reconnectStartedAt.current ?? Date.now()) < RECONNECT_TIMEOUT_MS) {
-      try {
-        await repairApprovalCenter();
-        await fetchGuardUpdateStatus();
-        setUpdatePhase("idle");
-        options?.onReconnected?.();
-        return;
-      } catch {
-        await new Promise<void>((resolve) => window.setTimeout(resolve, RECONNECT_POLL_MS));
+  const waitForReconnect = useCallback(
+    async (expectedPreviousVersion: string, expectedLatestVersion: string | null) => {
+      reconnectStartedAt.current = Date.now();
+      while (Date.now() - (reconnectStartedAt.current ?? Date.now()) < RECONNECT_TIMEOUT_MS) {
+        try {
+          const origin = await reconnectGuardDaemonAfterUpdate({
+            expectedPreviousVersion,
+            expectedLatestVersion,
+          });
+          if (!origin) {
+            throw new Error("Guard daemon not found");
+          }
+          if (origin !== window.location.origin) {
+            return;
+          }
+          const status = await fetchGuardUpdateStatus();
+          setUpdateStatus(status);
+          setUpdatePhase("idle");
+          options?.onReconnected?.();
+          return;
+        } catch {
+          await new Promise<void>((resolve) => window.setTimeout(resolve, RECONNECT_POLL_MS));
+        }
       }
-    }
-    setUpdatePhase("error");
-    throw new Error("Guard did not reconnect after the update.");
-  }, [options]);
+      setUpdatePhase("error");
+      throw new Error("Guard did not reconnect after the update.");
+    },
+    [options],
+  );
 
   const onUpdateGuard = useCallback(async () => {
     if (!updateStatus?.update_available || !updateStatus.auto_updatable) {
       return;
     }
+    const expectedPreviousVersion = updateStatus.current_version;
+    const expectedLatestVersion = updateStatus.latest_version;
     setUpdatePhase("updating");
     try {
-      await scheduleGuardUpdate();
+      const scheduleResult = await scheduleGuardUpdate();
+      if (scheduleResult.scheduled === false && scheduleResult.error === "update_in_progress") {
+        setUpdatePhase("reconnecting");
+        await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
+        if (window.location.origin === (window.sessionStorage.getItem("guardDaemon") ?? window.location.origin)) {
+          window.location.reload();
+        }
+        return;
+      }
+      if (scheduleResult.scheduled !== true) {
+        throw new Error(scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled.");
+      }
       setUpdatePhase("reconnecting");
-      await waitForReconnect();
+      await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
       window.location.reload();
     } catch {
       setUpdatePhase("error");

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -143,7 +143,7 @@ export function useGuardUpdate(options?: { onReconnected?: () => void }) {
   }, [refreshUpdateStatus]);
 
   const waitForReconnect = useCallback(
-    async (expectedPreviousVersion: string, expectedLatestVersion: string | null) => {
+    async (expectedPreviousVersion: string, expectedLatestVersion: string | null): Promise<boolean> => {
       reconnectStartedAt.current = Date.now();
       while (Date.now() - (reconnectStartedAt.current ?? Date.now()) < RECONNECT_TIMEOUT_MS) {
         try {
@@ -155,13 +155,13 @@ export function useGuardUpdate(options?: { onReconnected?: () => void }) {
             throw new Error("Guard daemon not found");
           }
           if (origin !== window.location.origin) {
-            return;
+            return true;
           }
           const status = await fetchGuardUpdateStatus();
           setUpdateStatus(status);
           setUpdatePhase("idle");
           options?.onReconnected?.();
-          return;
+          return false;
         } catch {
           await new Promise<void>((resolve) => window.setTimeout(resolve, RECONNECT_POLL_MS));
         }
@@ -183,8 +183,8 @@ export function useGuardUpdate(options?: { onReconnected?: () => void }) {
       const scheduleResult = await scheduleGuardUpdate();
       if (scheduleResult.scheduled === false && scheduleResult.error === "update_in_progress") {
         setUpdatePhase("reconnecting");
-        await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
-        if (window.location.origin === (window.sessionStorage.getItem("guardDaemon") ?? window.location.origin)) {
+        const redirected = await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
+        if (!redirected) {
           window.location.reload();
         }
         return;
@@ -193,8 +193,10 @@ export function useGuardUpdate(options?: { onReconnected?: () => void }) {
         throw new Error(scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled.");
       }
       setUpdatePhase("reconnecting");
-      await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
-      window.location.reload();
+      const redirected = await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
+      if (!redirected) {
+        window.location.reload();
+      }
     } catch {
       setUpdatePhase("error");
     }

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -4,6 +4,8 @@ import { HiMiniArrowPath } from "react-icons/hi2";
 import {
   fetchGuardUpdateStatus,
   reconnectGuardDaemonAfterUpdate,
+  readGuardToken,
+  redirectToGuardDaemonOrigin,
   scheduleGuardUpdate,
 } from "./guard-api";
 import type { GuardUpdatePhase, GuardUpdateStatus } from "./guard-types";
@@ -155,6 +157,7 @@ export function useGuardUpdate(options?: { onReconnected?: () => void }) {
             throw new Error("Guard daemon not found");
           }
           if (origin !== window.location.origin) {
+            redirectToGuardDaemonOrigin(origin, readGuardToken());
             return true;
           }
           const status = await fetchGuardUpdateStatus();

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -1,4 +1,4 @@
-import { normalizeGuardUpdateStatus } from "./guard-api";
+import { buildGuardDaemonCandidatePorts, normalizeGuardUpdateStatus } from "./guard-api";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -20,6 +20,7 @@ const normalized = normalizeGuardUpdateStatus({
   auto_updatable: true,
   update_available: true,
   blocked_reason: null,
+  update_in_progress: true,
 });
 
 assert(normalized.current_version === "1.2.3", "current version should normalize");
@@ -27,6 +28,7 @@ assert(normalized.latest_version === "1.2.4", "latest version should normalize")
 assert(normalized.installer === "pipx", "installer should normalize");
 assert(normalized.update_available === true, "update_available should normalize");
 assert(normalized.version_check.update_available === true, "version_check should normalize");
+assert(normalized.update_in_progress === true, "update_in_progress should normalize");
 
 const blocked = normalizeGuardUpdateStatus({
   auto_updatable: false,
@@ -37,5 +39,9 @@ const blocked = normalizeGuardUpdateStatus({
 assert(blocked.auto_updatable === false, "auto_updatable false should normalize");
 assert(blocked.blocked_reason === "Local install only", "blocked_reason should normalize");
 assert(blocked.current_version === "unknown", "missing current_version should default to unknown");
+
+const candidatePorts = buildGuardDaemonCandidatePorts(5474);
+assert(candidatePorts.length === 25, "candidate port scan should probe 25 ports");
+assert(candidatePorts[0] === 5474, "candidate ports should start from the preferred port");
 
 console.log("guard-update.test.ts: all tests passed");

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
@@ -9,12 +9,21 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from ..cli.update_commands import build_guard_update_status_payload
+
 _DASHBOARD_UPDATE_LOCK = "dashboard-update.lock"
 _DASHBOARD_UPDATE_STALE_SECONDS = 15 * 60
 
 
 def dashboard_update_lock_path(guard_home: Path) -> Path:
     return guard_home / _DASHBOARD_UPDATE_LOCK
+
+
+def read_dashboard_update_lock(guard_home: Path) -> dict[str, object] | None:
+    lock_path = dashboard_update_lock_path(guard_home)
+    if not lock_path.is_file():
+        return None
+    return _read_update_lock(lock_path)
 
 
 def dashboard_update_in_progress(guard_home: Path) -> bool:
@@ -42,6 +51,23 @@ def dashboard_update_in_progress(guard_home: Path) -> bool:
         lock_path.unlink(missing_ok=True)
         return False
     return True
+
+
+def merge_dashboard_update_progress(
+    guard_home: Path,
+    status_payload: dict[str, object],
+) -> dict[str, object]:
+    payload = dict(status_payload)
+    lock_payload = read_dashboard_update_lock(guard_home)
+    if lock_payload is None:
+        payload["update_in_progress"] = False
+        return payload
+    payload["update_in_progress"] = True
+    for key in ("previous_version", "target_version", "daemon_port", "started_at"):
+        value = lock_payload.get(key)
+        if value is not None:
+            payload[key] = value
+    return payload
 
 
 def dashboard_update_runner_script() -> Path:
@@ -76,10 +102,13 @@ def build_dashboard_update_runner_command(
 
 def build_dashboard_update_runner_popen_kwargs(guard_home: Path) -> dict[str, object]:
     resolved_home = guard_home.expanduser().resolve()
+    resolved_home.mkdir(parents=True, exist_ok=True)
+    log_path = resolved_home / "dashboard-update.log"
+    log_handle = log_path.open("a", encoding="utf-8")
     return {
         "stdin": subprocess.DEVNULL,
         "stdout": subprocess.DEVNULL,
-        "stderr": subprocess.DEVNULL,
+        "stderr": log_handle,
         "cwd": str(resolved_home),
         "env": _runner_env(),
     }
@@ -97,6 +126,7 @@ def schedule_guard_dashboard_update(
             "error": "update_in_progress",
             "message": "Guard is already updating on this machine.",
         }
+    status_payload = build_guard_update_status_payload()
     lock_path = dashboard_update_lock_path(guard_home)
     lock_path.parent.mkdir(parents=True, exist_ok=True)
     command = build_dashboard_update_runner_command(
@@ -117,6 +147,8 @@ def schedule_guard_dashboard_update(
             "daemon_pid": daemon_pid,
             "daemon_port": daemon_port,
             "runner_pid": process.pid,
+            "previous_version": status_payload.get("current_version"),
+            "target_version": status_payload.get("latest_version"),
             "started_at": datetime.now(timezone.utc).isoformat(),
         },
     )
@@ -124,6 +156,8 @@ def schedule_guard_dashboard_update(
         "scheduled": True,
         "message": "Guard will update, restart briefly, and reload this dashboard.",
         "runner_pid": process.pid,
+        "previous_version": status_payload.get("current_version"),
+        "target_version": status_payload.get("latest_version"),
     }
 
 

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
@@ -58,6 +58,9 @@ def merge_dashboard_update_progress(
     status_payload: dict[str, object],
 ) -> dict[str, object]:
     payload = dict(status_payload)
+    if not dashboard_update_in_progress(guard_home):
+        payload["update_in_progress"] = False
+        return payload
     lock_payload = read_dashboard_update_lock(guard_home)
     if lock_payload is None:
         payload["update_in_progress"] = False

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
@@ -142,7 +142,10 @@ def schedule_guard_dashboard_update(
         kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS
     else:
         kwargs["start_new_session"] = True
+    stderr_target = kwargs.get("stderr")
     process = subprocess.Popen(command, **kwargs)
+    if stderr_target is not None and hasattr(stderr_target, "close"):
+        stderr_target.close()
     _write_update_lock(
         lock_path,
         {

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
@@ -34,6 +34,7 @@ def main(argv: list[str] | None = None) -> int:
         if exit_code != 0:
             message = update_payload.get("message") or update_payload.get("error") or "Guard update failed."
             print(str(message), file=sys.stderr)
+            ensure_guard_daemon_after_update(guard_home)
             return 1
 
         retire_all_guard_daemons_for_home(guard_home)

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
@@ -7,24 +7,36 @@ import sys
 import time
 from pathlib import Path
 
-from ..cli.update_commands import run_guard_update
-from .dashboard_update import clear_dashboard_update_lock
-from .manager import _retire_guard_daemon_pid, clear_guard_daemon_state, ensure_guard_daemon
+from codex_plugin_scanner.guard.cli.update_commands import run_guard_update
+from codex_plugin_scanner.guard.daemon.dashboard_update import clear_dashboard_update_lock
+from codex_plugin_scanner.guard.daemon.manager import (
+    clear_guard_daemon_state,
+    ensure_guard_daemon_after_update,
+    repair_approval_center_locator,
+    retire_all_guard_daemons_for_home,
+)
+
+_DASHBOARD_UPDATE_DAEMON_SETTLE_SECONDS = 1.5
 
 
 def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     guard_home = Path(args.guard_home).expanduser().resolve()
     try:
-        time.sleep(1.5)
+        time.sleep(_DASHBOARD_UPDATE_DAEMON_SETTLE_SECONDS)
+        retire_all_guard_daemons_for_home(guard_home)
+        clear_guard_daemon_state(guard_home)
+        repair_approval_center_locator(guard_home)
+
         update_payload, exit_code = run_guard_update(dry_run=False)
         if exit_code != 0:
             message = update_payload.get("message") or update_payload.get("error") or "Guard update failed."
             print(str(message), file=sys.stderr)
             return 1
-        _retire_guard_daemon_pid(args.daemon_pid, expected_guard_home=guard_home)
+
+        retire_all_guard_daemons_for_home(guard_home)
         clear_guard_daemon_state(guard_home)
-        ensure_guard_daemon(guard_home)
+        ensure_guard_daemon_after_update(guard_home)
         return 0
     finally:
         clear_dashboard_update_lock(guard_home)

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from codex_plugin_scanner.guard.cli.update_commands import run_guard_update
 from codex_plugin_scanner.guard.daemon.dashboard_update import clear_dashboard_update_lock
 from codex_plugin_scanner.guard.daemon.manager import (
+    _retire_guard_daemon_pid,
     clear_guard_daemon_state,
     ensure_guard_daemon_after_update,
     repair_approval_center_locator,
@@ -25,6 +26,7 @@ def main(argv: list[str] | None = None) -> int:
     try:
         time.sleep(_DASHBOARD_UPDATE_DAEMON_SETTLE_SECONDS)
         retire_all_guard_daemons_for_home(guard_home)
+        _retire_guard_daemon_pid(args.daemon_pid, expected_guard_home=guard_home)
         clear_guard_daemon_state(guard_home)
         repair_approval_center_locator(guard_home)
 
@@ -35,6 +37,7 @@ def main(argv: list[str] | None = None) -> int:
             return 1
 
         retire_all_guard_daemons_for_home(guard_home)
+        _retire_guard_daemon_pid(args.daemon_pid, expected_guard_home=guard_home)
         clear_guard_daemon_state(guard_home)
         ensure_guard_daemon_after_update(guard_home)
         return 0

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -29,6 +29,7 @@ GUARD_DAEMON_PORT_RANGE = 1000
 REQUIRED_DAEMON_TABLES = frozenset({"guard_connect_states"})
 GUARD_DAEMON_COMPATIBILITY_VERSION = 2
 GUARD_DAEMON_START_TIMEOUT_SECONDS = 5.0
+GUARD_DAEMON_POST_UPDATE_START_TIMEOUT_SECONDS = 30.0
 GUARD_DAEMON_POLL_INTERVAL_SECONDS = 0.1
 _EPHEMERAL_GUARD_DAEMON_REAP_INTERVAL_SECONDS = 30.0
 _EPHEMERAL_GUARD_DAEMON_STALE_SECONDS = 30.0
@@ -68,7 +69,12 @@ def _daemon_launcher_env() -> dict[str, str]:
     return env
 
 
-def ensure_guard_daemon(guard_home: Path) -> str:
+def ensure_guard_daemon(guard_home: Path, *, start_timeout: float | None = None) -> str:
+    timeout = (
+        GUARD_DAEMON_START_TIMEOUT_SECONDS
+        if start_timeout is None
+        else start_timeout
+    )
     _reap_stale_ephemeral_guard_daemons(exclude_guard_home=guard_home)
     state_path = _state_path(guard_home)
     existing_url = load_guard_daemon_url(guard_home)
@@ -88,7 +94,7 @@ def ensure_guard_daemon(guard_home: Path) -> str:
         if isinstance(stale_state, dict) and not _guard_daemon_state_matches_current_runtime(stale_state):
             _retire_guard_daemon_process({**stale_state, "guard_home": str(guard_home)})
         if _guard_daemon_start_in_progress(guard_home):
-            inflight_url = _wait_for_guard_daemon_url(guard_home, timeout=GUARD_DAEMON_START_TIMEOUT_SECONDS)
+            inflight_url = _wait_for_guard_daemon_url(guard_home, timeout=timeout)
             if inflight_url is not None:
                 _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(inflight_url))
                 return inflight_url
@@ -119,13 +125,36 @@ def ensure_guard_daemon(guard_home: Path) -> str:
             process = subprocess.Popen(command, **kwargs)
             url = _wait_for_guard_daemon_url(
                 guard_home,
-                timeout=GUARD_DAEMON_START_TIMEOUT_SECONDS,
+                timeout=timeout,
                 process=process,
             )
             if url is not None:
                 _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(url))
                 return url
     raise RuntimeError(f"Guard approval center did not start. Expected state file at {state_path}.")
+
+
+def ensure_guard_daemon_after_update(guard_home: Path) -> str:
+    """Restart the local daemon after a package update with a longer startup window."""
+    return ensure_guard_daemon(
+        guard_home,
+        start_timeout=GUARD_DAEMON_POST_UPDATE_START_TIMEOUT_SECONDS,
+    )
+
+
+def retire_all_guard_daemons_for_home(
+    guard_home: Path,
+    *,
+    keep_port: int | None = None,
+) -> list[int]:
+    """Stop Guard daemon processes for one guard home, optionally keeping one port alive."""
+    retired: list[int] = []
+    for pid, port in _running_guard_daemon_processes_for_guard_home(guard_home):
+        if keep_port is not None and port == keep_port:
+            continue
+        if _retire_guard_daemon_pid(pid, expected_guard_home=guard_home):
+            retired.append(pid)
+    return retired
 
 
 def guard_daemon_url_for_home(guard_home: Path) -> str:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -70,11 +70,7 @@ def _daemon_launcher_env() -> dict[str, str]:
 
 
 def ensure_guard_daemon(guard_home: Path, *, start_timeout: float | None = None) -> str:
-    timeout = (
-        GUARD_DAEMON_START_TIMEOUT_SECONDS
-        if start_timeout is None
-        else start_timeout
-    )
+    timeout = GUARD_DAEMON_START_TIMEOUT_SECONDS if start_timeout is None else start_timeout
     _reap_stale_ephemeral_guard_daemons(exclude_guard_home=guard_home)
     state_path = _state_path(guard_home)
     existing_url = load_guard_daemon_url(guard_home)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -915,7 +915,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/update/status":
             self._write_json(
                 merge_dashboard_update_progress(
-                    self.server.store.guard_home,  # type: ignore[attr-defined]
+                    store.guard_home,
                     build_guard_update_status_payload(),
                 )
             )

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -129,7 +129,7 @@ from ..store_evidence import (
     export_evidence_json,
     list_evidence,
 )
-from .dashboard_update import schedule_guard_dashboard_update
+from .dashboard_update import merge_dashboard_update_progress, schedule_guard_dashboard_update
 from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
     clear_guard_daemon_state,
@@ -913,7 +913,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json(_settings_response_payload(store.guard_home, editable_guard_settings(config)))
             return
         if parsed.path == "/v1/update/status":
-            self._write_json(build_guard_update_status_payload())
+            self._write_json(
+                merge_dashboard_update_progress(
+                    self.server.store.guard_home,  # type: ignore[attr-defined]
+                    build_guard_update_status_payload(),
+                )
+            )
             return
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "sessions"] and path_parts[3] == "resume":
             self._handle_session_resume(path_parts[2])

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -293,6 +293,10 @@ def test_merge_dashboard_update_progress_includes_lock_metadata(
         FakeProcess,
     )
     monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update._pid_is_running",
+        lambda pid: pid == 5151,
+    )
+    monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.dashboard_update.build_guard_update_status_payload",
         lambda: {
             "current_version": "2.0.508",
@@ -342,6 +346,10 @@ def test_dashboard_update_runner_retires_all_daemons_before_upgrade(
         lambda _home, **kwargs: calls.append("retire") or [],
     )
     monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update_runner._retire_guard_daemon_pid",
+        lambda pid, **kwargs: calls.append(f"retire_pid:{pid}"),
+    )
+    monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.dashboard_update_runner.clear_guard_daemon_state",
         lambda _home: calls.append("clear_state"),
     )
@@ -378,9 +386,11 @@ def test_dashboard_update_runner_retires_all_daemons_before_upgrade(
     assert exit_code == 0
     assert calls == [
         "retire",
+        "retire_pid:5150",
         "clear_state",
         "repair_locator",
         "retire",
+        "retire_pid:5150",
         "clear_state",
         "ensure",
         "clear_lock",

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -18,6 +18,7 @@ from codex_plugin_scanner.guard.daemon.dashboard_update import (
     build_dashboard_update_runner_command,
     build_dashboard_update_runner_popen_kwargs,
     dashboard_update_runner_script,
+    merge_dashboard_update_progress,
     schedule_guard_dashboard_update,
 )
 from codex_plugin_scanner.guard.store import GuardStore
@@ -277,3 +278,110 @@ def test_runner_env_ignores_inherited_pythonpath(tmp_path: Path, monkeypatch: py
     assert str(dashboard_update_runner_script().resolve().parents[3]) in pythonpath
     if sys.version_info >= (3, 11):
         assert env.get("PYTHONSAFEPATH") == "1"
+
+
+def test_merge_dashboard_update_progress_includes_lock_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class FakeProcess:
+        def __init__(self, command: list[str], **kwargs: object) -> None:
+            self.pid = 5151
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update.subprocess.Popen",
+        FakeProcess,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update.build_guard_update_status_payload",
+        lambda: {
+            "current_version": "2.0.508",
+            "latest_version": "2.0.509",
+            "installer": "pipx",
+            "version_check": {
+                "source": "pypi",
+                "status": "stale",
+                "current_version": "2.0.508",
+                "latest_version": "2.0.509",
+                "update_available": True,
+            },
+            "auto_updatable": True,
+            "update_available": True,
+            "blocked_reason": None,
+        },
+    )
+
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    schedule_guard_dashboard_update(guard_home, daemon_pid=5150, daemon_port=5474)
+    payload = merge_dashboard_update_progress(
+        guard_home,
+        {"current_version": "2.0.508", "update_available": True},
+    )
+
+    assert payload["update_in_progress"] is True
+    assert payload["previous_version"] == "2.0.508"
+    assert payload["target_version"] == "2.0.509"
+    assert payload["daemon_port"] == 5474
+
+
+def test_dashboard_update_runner_retires_all_daemons_before_upgrade(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    calls: list[str] = []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update_runner.time.sleep",
+        lambda _seconds: None,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update_runner.retire_all_guard_daemons_for_home",
+        lambda _home, **kwargs: calls.append("retire") or [],
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update_runner.clear_guard_daemon_state",
+        lambda _home: calls.append("clear_state"),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update_runner.repair_approval_center_locator",
+        lambda _home: calls.append("repair_locator") or {"repaired": True, "cleared": []},
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update_runner.run_guard_update",
+        lambda **kwargs: ({"status": "updated"}, 0),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update_runner.ensure_guard_daemon_after_update",
+        lambda _home: calls.append("ensure") or "http://127.0.0.1:5474",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.dashboard_update_runner.clear_dashboard_update_lock",
+        lambda _home: calls.append("clear_lock"),
+    )
+
+    from codex_plugin_scanner.guard.daemon.dashboard_update_runner import main
+
+    exit_code = main(
+        [
+            "--guard-home",
+            str(guard_home),
+            "--daemon-pid",
+            "5150",
+            "--daemon-port",
+            "5474",
+        ]
+    )
+
+    assert exit_code == 0
+    assert calls == [
+        "retire",
+        "clear_state",
+        "repair_locator",
+        "retire",
+        "clear_state",
+        "ensure",
+        "clear_lock",
+    ]


### PR DESCRIPTION
## Summary
- Retire all old Guard daemons before and after a dashboard-driven upgrade so stale processes cannot keep serving the previous port
- Extend the daemon restart timeout so the update runner can wait for the new daemon to come back after migration
- Add version-aware port discovery in the dashboard reconnect path so the UI follows the daemon after port changes
- Expose `update_in_progress` on the status API so the dashboard can reflect an active upgrade

## Test plan
- `pytest tests/test_dashboard_update.py -q` (9 passed)
- `cd dashboard && npx --yes tsx src/guard-update.test.ts` (blocked by HOL Guard package execute policy in this environment; not run)
- `cd dashboard && npm run build` (blocked by HOL Guard before npm install; not run)
