### PR TITLE
feat(cursor): persist native shell approvals via afterShell hook

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -47,35 +47,30 @@ def _infer_cursor_hook_event_name(payload: Mapping[str, object]) -> dict[str, ob
     return normalized
 
 
+def _cursor_shell_hook_payload(normalized: dict[str, object], *, hook_event_name: str) -> dict[str, object]:
+    payload = dict(normalized)
+    payload["hook_event_name"] = hook_event_name
+    payload.setdefault("tool_name", "Shell")
+    tool_input = _tool_input_dict(payload.get("tool_input"))
+    command = payload.get("command")
+    if isinstance(command, str) and command.strip():
+        tool_input.setdefault("command", command.strip())
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        tool_input.setdefault("working_directory", cwd.strip())
+    payload["tool_input"] = tool_input
+    return payload
+
+
 def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, object]:
     """Map Cursor hook stdin JSON into Guard hook normalization shape."""
 
     normalized = _infer_cursor_hook_event_name(payload)
     raw_event = _raw_hook_event_name(normalized)
     if raw_event == "aftershellexecution":
-        normalized["hook_event_name"] = "afterShellExecution"
-        normalized.setdefault("tool_name", "Shell")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
-        command = normalized.get("command")
-        if isinstance(command, str) and command.strip():
-            tool_input.setdefault("command", command.strip())
-        cwd = normalized.get("cwd")
-        if isinstance(cwd, str) and cwd.strip():
-            tool_input.setdefault("working_directory", cwd.strip())
-        normalized["tool_input"] = tool_input
-        return normalized
+        return _cursor_shell_hook_payload(normalized, hook_event_name="afterShellExecution")
     if raw_event == "beforeshellexecution":
-        normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Shell")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
-        command = normalized.get("command")
-        if isinstance(command, str) and command.strip():
-            tool_input.setdefault("command", command.strip())
-        cwd = normalized.get("cwd")
-        if isinstance(cwd, str) and cwd.strip():
-            tool_input.setdefault("working_directory", cwd.strip())
-        normalized["tool_input"] = tool_input
-        return normalized
+        return _cursor_shell_hook_payload(normalized, hook_event_name="PreToolUse")
     if raw_event == "beforemcpexecution":
         normalized["hook_event_name"] = "PreToolUse"
         tool_name = normalized.get("tool_name")
@@ -539,33 +534,28 @@ def _infer_cursor_hook_event_name(payload: dict[str, object]) -> dict[str, objec
     return normalized
 
 
+def _cursor_shell_hook_payload(normalized: dict[str, object], hook_event_name: str) -> dict[str, object]:
+    payload = dict(normalized)
+    payload["hook_event_name"] = hook_event_name
+    payload.setdefault("tool_name", "Shell")
+    tool_input = _tool_input_dict(payload.get("tool_input"))
+    command = payload.get("command")
+    if isinstance(command, str) and command.strip():
+        tool_input.setdefault("command", command.strip())
+    cwd = payload.get("cwd")
+    if isinstance(cwd, str) and cwd.strip():
+        tool_input.setdefault("working_directory", cwd.strip())
+    payload["tool_input"] = tool_input
+    return payload
+
+
 def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     normalized = _infer_cursor_hook_event_name(payload)
     raw_event = _raw_hook_event_name(normalized)
     if raw_event == "aftershellexecution":
-        normalized["hook_event_name"] = "afterShellExecution"
-        normalized.setdefault("tool_name", "Shell")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
-        command = normalized.get("command")
-        if isinstance(command, str) and command.strip():
-            tool_input.setdefault("command", command.strip())
-        cwd = normalized.get("cwd")
-        if isinstance(cwd, str) and cwd.strip():
-            tool_input.setdefault("working_directory", cwd.strip())
-        normalized["tool_input"] = tool_input
-        return normalized
+        return _cursor_shell_hook_payload(normalized, "afterShellExecution")
     if raw_event == "beforeshellexecution":
-        normalized["hook_event_name"] = "PreToolUse"
-        normalized.setdefault("tool_name", "Shell")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
-        command = normalized.get("command")
-        if isinstance(command, str) and command.strip():
-            tool_input.setdefault("command", command.strip())
-        cwd = normalized.get("cwd")
-        if isinstance(cwd, str) and cwd.strip():
-            tool_input.setdefault("working_directory", cwd.strip())
-        normalized["tool_input"] = tool_input
-        return normalized
+        return _cursor_shell_hook_payload(normalized, "PreToolUse")
     if raw_event == "beforemcpexecution":
         normalized["hook_event_name"] = "PreToolUse"
         tool_name = normalized.get("tool_name")

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -14,11 +14,13 @@ from pathlib import Path
 from .base import HarnessContext
 
 HOOK_SCRIPT_NAME = "hol-guard-cursor-hook.py"
-_MANAGED_HOOK_EVENTS = (
+_BLOCKING_MANAGED_HOOK_EVENTS = (
     "beforeShellExecution",
     "beforeMCPExecution",
     "beforeReadFile",
 )
+_OBSERVER_MANAGED_HOOK_EVENTS = ("afterShellExecution",)
+_MANAGED_HOOK_EVENTS = _BLOCKING_MANAGED_HOOK_EVENTS + _OBSERVER_MANAGED_HOOK_EVENTS
 _MANAGED_HOOK_TIMEOUT_SECONDS = 45
 _LEGACY_MANAGED_COMMAND_MARKERS = (
     "hol-guard-cursor-hook.py",
@@ -50,6 +52,18 @@ def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, obje
 
     normalized = _infer_cursor_hook_event_name(payload)
     raw_event = _raw_hook_event_name(normalized)
+    if raw_event == "aftershellexecution":
+        normalized["hook_event_name"] = "afterShellExecution"
+        normalized.setdefault("tool_name", "Shell")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        command = normalized.get("command")
+        if isinstance(command, str) and command.strip():
+            tool_input.setdefault("command", command.strip())
+        cwd = normalized.get("cwd")
+        if isinstance(cwd, str) and cwd.strip():
+            tool_input.setdefault("working_directory", cwd.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
     if raw_event == "beforeshellexecution":
         normalized["hook_event_name"] = "PreToolUse"
         normalized.setdefault("tool_name", "Shell")
@@ -528,6 +542,18 @@ def _infer_cursor_hook_event_name(payload: dict[str, object]) -> dict[str, objec
 def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     normalized = _infer_cursor_hook_event_name(payload)
     raw_event = _raw_hook_event_name(normalized)
+    if raw_event == "aftershellexecution":
+        normalized["hook_event_name"] = "afterShellExecution"
+        normalized.setdefault("tool_name", "Shell")
+        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        command = normalized.get("command")
+        if isinstance(command, str) and command.strip():
+            tool_input.setdefault("command", command.strip())
+        cwd = normalized.get("cwd")
+        if isinstance(cwd, str) and cwd.strip():
+            tool_input.setdefault("working_directory", cwd.strip())
+        normalized["tool_input"] = tool_input
+        return normalized
     if raw_event == "beforeshellexecution":
         normalized["hook_event_name"] = "PreToolUse"
         normalized.setdefault("tool_name", "Shell")
@@ -723,6 +749,9 @@ def main() -> int:
         except json.JSONDecodeError:
             guard_payload = {}
     policy_action = str(guard_payload.get("policy_action") or "allow")
+    if hook_event_name.strip().lower() == "aftershellexecution":
+        print("{}")
+        return 0
     if proc.returncode != 0 and not guard_payload:
         print(
             json.dumps(
@@ -758,7 +787,7 @@ def _managed_hook_entry(
     entry: dict[str, object] = {
         "command": str(script_path.resolve()),
         "timeout": _MANAGED_HOOK_TIMEOUT_SECONDS,
-        "failClosed": event_name in _MANAGED_HOOK_EVENTS,
+        "failClosed": event_name in _BLOCKING_MANAGED_HOOK_EVENTS,
     }
     return entry
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4605,14 +4605,26 @@ def _append_cursor_pending_shell_key(
 ) -> None:
     index_key = _cursor_pending_shell_index_key(conversation_id)
     try:
-        index_payload = store.get_sync_payload(index_key)
-    except (OSError, sqlite3.Error):
-        index_payload = None
-    pending_keys = [str(item) for item in index_payload] if isinstance(index_payload, list) else []
-    if pending_key not in pending_keys:
-        pending_keys.append(pending_key)
-    try:
-        store.set_sync_payload(index_key, pending_keys, now)
+        with store._connect() as connection:
+            connection.execute("begin immediate")
+            row = connection.execute(
+                "select payload_json from sync_state where state_key = ?",
+                (index_key,),
+            ).fetchone()
+            pending_keys = _sync_payload_list_from_row(row)
+            if pending_key in pending_keys:
+                return
+            pending_keys.append(pending_key)
+            connection.execute(
+                """
+                insert into sync_state (state_key, payload_json, updated_at)
+                values (?, ?, ?)
+                on conflict(state_key) do update set
+                  payload_json = excluded.payload_json,
+                  updated_at = excluded.updated_at
+                """,
+                (index_key, json.dumps(pending_keys), now),
+            )
     except (OSError, sqlite3.Error):
         return
 
@@ -4810,9 +4822,7 @@ def _persist_cursor_native_permission_after_shell(
     guard_home: Path,
     workspace: Path | None,
 ) -> bool:
-    from ..adapters.cursor_hooks import prepare_cursor_hook_payload
-
-    prepared = _normalize_hook_payload(prepare_cursor_hook_payload(payload))
+    prepared = payload
     conversation_id = _cursor_conversation_id(prepared)
     command = _cursor_shell_command_from_payload(prepared)
     if conversation_id is None or command is None:
@@ -4882,7 +4892,10 @@ def _persist_cursor_native_permission_after_shell(
         user_override="cursor-native-approve",
         approval_source="inline",
     )
-    store.add_receipt(receipt)
+    try:
+        store.add_receipt(receipt)
+    except (OSError, sqlite3.Error):
+        return False
     pending_key = _cursor_pending_shell_state_key(conversation_id, command)
     _remove_cursor_pending_shell_permission(
         store,

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2851,6 +2851,30 @@ def run_guard_command(
                 current_workspace = Path.cwd().resolve()
                 if current_workspace.is_dir():
                     runtime_workspace = current_workspace
+        if (
+            _canonical_harness_name(args.harness) == "cursor"
+            and _hook_event_name(payload) == "afterShellExecution"
+        ):
+            if runtime_workspace is None:
+                runtime_workspace = _workspace_from_cursor_project_dir()
+            saved = _persist_cursor_native_permission_after_shell(
+                store=store,
+                payload=payload,
+                harness=args.harness,
+                home_dir=context.home_dir,
+                guard_home=context.guard_home,
+                workspace=runtime_workspace,
+            )
+            _emit(
+                "hook",
+                {
+                    "recorded": saved,
+                    "harness": "cursor",
+                    "policy_action": "allow",
+                },
+                getattr(args, "json", False),
+            )
+            return 0
         if args.harness == "copilot":
             runtime_workspace = _resolve_copilot_workspace_root(runtime_workspace)
         action_envelope = _hook_action_envelope(
@@ -3498,6 +3522,18 @@ def run_guard_command(
                         artifact=runtime_artifact,
                         artifact_hash=runtime_artifact_hash,
                     )
+                if (
+                    _canonical_harness_name(args.harness) == "cursor"
+                    and event_name == "PreToolUse"
+                    and policy_action == "require-reapproval"
+                ):
+                    _record_cursor_pending_shell_permission(
+                        store=store,
+                        payload=payload,
+                        reason=native_reason,
+                        artifact=runtime_artifact,
+                        artifact_hash=runtime_artifact_hash,
+                    )
                 if _should_emit_copilot_hook_response(args):
                     _record_harness_usage_for_hook(
                         store=store,
@@ -3646,6 +3682,16 @@ def run_guard_command(
                         harness=_optional_string(args.harness) or args.harness,
                         approval_center_url=approval_center_url,
                     )
+                    if (
+                        _canonical_harness_name(args.harness) == "cursor"
+                        and event_name == "PreToolUse"
+                        and policy_action == "require-reapproval"
+                    ):
+                        _attach_cursor_pending_approval_request_ids(
+                            store=store,
+                            payload=payload,
+                            response_payload=response_payload,
+                        )
                     response_payload["approval_center_url"] = approval_center_url
                     response_payload["review_hint"] = approval_center_hint(
                         context=context,
@@ -4521,6 +4567,329 @@ def _remove_claude_pending_permission(
                 connection.execute("delete from sync_state where state_key = ?", (index_key,))
     except (OSError, sqlite3.Error):
         return
+
+
+def _cursor_conversation_id(payload: dict[str, object]) -> str | None:
+    for key in ("conversation_id", "conversationId", "session_id", "sessionId"):
+        value = _optional_string(payload.get(key))
+        if value is not None:
+            return value
+    return _optional_string(os.environ.get("CURSOR_SESSION_ID"))
+
+
+def _cursor_shell_command_from_payload(payload: Mapping[str, object]) -> str | None:
+    command = _optional_string(payload.get("command"))
+    if command is not None:
+        return command
+    return _hook_command_text(payload)
+
+
+def _cursor_shell_command_fingerprint(command: str) -> str:
+    return hashlib.sha256(command.strip().encode("utf-8")).hexdigest()[:24]
+
+
+def _cursor_pending_shell_index_key(conversation_id: str) -> str:
+    return f"cursor_pending_shells:{conversation_id}"
+
+
+def _cursor_pending_shell_state_key(conversation_id: str, command: str) -> str:
+    return f"cursor_pending_shell:{conversation_id}:{_cursor_shell_command_fingerprint(command)}"
+
+
+def _append_cursor_pending_shell_key(
+    store: GuardStore,
+    *,
+    conversation_id: str,
+    pending_key: str,
+    now: str,
+) -> None:
+    index_key = _cursor_pending_shell_index_key(conversation_id)
+    try:
+        index_payload = store.get_sync_payload(index_key)
+    except (OSError, sqlite3.Error):
+        index_payload = None
+    pending_keys = [str(item) for item in index_payload] if isinstance(index_payload, list) else []
+    if pending_key not in pending_keys:
+        pending_keys.append(pending_key)
+    try:
+        store.set_sync_payload(index_key, pending_keys, now)
+    except (OSError, sqlite3.Error):
+        return
+
+
+def _record_cursor_pending_shell_permission(
+    *,
+    store: GuardStore,
+    payload: dict[str, object],
+    reason: str,
+    artifact: GuardArtifact,
+    artifact_hash: str,
+) -> None:
+    conversation_id = _cursor_conversation_id(payload)
+    command = _cursor_shell_command_from_payload(payload)
+    if conversation_id is None or command is None:
+        return
+    saved_at = _now()
+    notice_payload: dict[str, object] = {
+        "saved_at": saved_at,
+        "reason": reason,
+        "artifact_id": artifact.artifact_id,
+        "artifact_hash": artifact_hash,
+        "artifact_name": artifact.name,
+        "artifact_type": artifact.artifact_type,
+        "config_path": artifact.config_path,
+        "source_scope": artifact.source_scope,
+        "command": command,
+        "native_source": "cursor-native",
+    }
+    pending_key = _cursor_pending_shell_state_key(conversation_id, command)
+    try:
+        store.set_sync_payload(pending_key, notice_payload, saved_at)
+        _append_cursor_pending_shell_key(
+            store,
+            conversation_id=conversation_id,
+            pending_key=pending_key,
+            now=saved_at,
+        )
+    except (OSError, sqlite3.Error):
+        return
+
+
+def _attach_cursor_pending_approval_request_ids(
+    *,
+    store: GuardStore,
+    payload: dict[str, object],
+    response_payload: dict[str, object],
+) -> None:
+    conversation_id = _cursor_conversation_id(payload)
+    command = _cursor_shell_command_from_payload(payload)
+    if conversation_id is None or command is None:
+        return
+    pending_key = _cursor_pending_shell_state_key(conversation_id, command)
+    try:
+        pending = store.get_sync_payload(pending_key)
+    except (OSError, sqlite3.Error):
+        return
+    if not isinstance(pending, dict):
+        return
+    request_ids: list[str] = []
+    approval_requests = response_payload.get("approval_requests")
+    if isinstance(approval_requests, list):
+        for item in approval_requests:
+            if isinstance(item, dict):
+                request_id = _optional_string(item.get("request_id"))
+                if request_id is not None:
+                    request_ids.append(request_id)
+    for request_id in _string_list(response_payload.get("approval_request_ids")):
+        if request_id not in request_ids:
+            request_ids.append(request_id)
+    if not request_ids:
+        return
+    updated = dict(pending)
+    updated["approval_request_ids"] = request_ids
+    try:
+        store.set_sync_payload(pending_key, updated, _now())
+    except (OSError, sqlite3.Error):
+        return
+
+
+def _load_cursor_pending_shell_permission(
+    store: GuardStore,
+    *,
+    conversation_id: str,
+    command: str,
+) -> dict[str, object] | None:
+    pending_key = _cursor_pending_shell_state_key(conversation_id, command)
+    try:
+        pending = store.get_sync_payload(pending_key)
+    except (OSError, sqlite3.Error):
+        return None
+    return pending if isinstance(pending, dict) else None
+
+
+def _remove_cursor_pending_shell_permission(
+    store: GuardStore,
+    *,
+    conversation_id: str,
+    pending_key: str,
+) -> None:
+    try:
+        index_key = _cursor_pending_shell_index_key(conversation_id)
+        with store._connect() as connection:
+            connection.execute("begin immediate")
+            connection.execute("delete from sync_state where state_key = ?", (pending_key,))
+            row = connection.execute(
+                "select payload_json from sync_state where state_key = ?",
+                (index_key,),
+            ).fetchone()
+            remaining = [key for key in _sync_payload_list_from_row(row) if key != pending_key]
+            if remaining:
+                connection.execute(
+                    """
+                    insert into sync_state (state_key, payload_json, updated_at)
+                    values (?, ?, ?)
+                    on conflict(state_key) do update set
+                      payload_json = excluded.payload_json,
+                      updated_at = excluded.updated_at
+                    """,
+                    (index_key, json.dumps(remaining), _now()),
+                )
+            else:
+                connection.execute("delete from sync_state where state_key = ?", (index_key,))
+    except (OSError, sqlite3.Error):
+        return
+
+
+def _persist_cursor_native_permission_policy(
+    *,
+    store: GuardStore,
+    artifact_id: str,
+    artifact_hash: str,
+    action: str,
+    reason: str,
+    now: str,
+    source: str = "cursor-native-approval",
+) -> bool:
+    try:
+        store.upsert_policy(
+            PolicyDecision(
+                harness="cursor",
+                scope="artifact",
+                action="allow" if action == "allow" else "block",
+                artifact_id=artifact_id,
+                artifact_hash=artifact_hash,
+                reason=reason,
+                source=source,
+            ),
+            now,
+        )
+        store.add_event(
+            "cursor/native_permission_saved",
+            {
+                "artifact_id": artifact_id,
+                "artifact_hash": artifact_hash,
+                "action": action,
+                "reason": reason,
+            },
+            now,
+        )
+    except (ApprovalGateError, OSError, sqlite3.Error):
+        return False
+    return True
+
+
+def _resolve_cursor_pending_approval_requests(
+    *,
+    store: GuardStore,
+    pending: Mapping[str, object],
+    reason: str,
+    now: str,
+) -> None:
+    request_ids = pending.get("approval_request_ids")
+    if not isinstance(request_ids, list):
+        return
+    for request_id in request_ids:
+        if not isinstance(request_id, str) or not request_id.strip():
+            continue
+        with suppress(ApprovalGateError, OSError, sqlite3.Error):
+            store.resolve_approval_request(
+                request_id.strip(),
+                resolution_action="allow",
+                resolution_scope="artifact",
+                reason=reason,
+                resolved_at=now,
+            )
+
+
+def _persist_cursor_native_permission_after_shell(
+    *,
+    store: GuardStore,
+    payload: dict[str, object],
+    harness: str,
+    home_dir: Path,
+    guard_home: Path,
+    workspace: Path | None,
+) -> bool:
+    from ..adapters.cursor_hooks import prepare_cursor_hook_payload
+
+    prepared = _normalize_hook_payload(prepare_cursor_hook_payload(payload))
+    conversation_id = _cursor_conversation_id(prepared)
+    command = _cursor_shell_command_from_payload(prepared)
+    if conversation_id is None or command is None:
+        return False
+    pending = _load_cursor_pending_shell_permission(
+        store,
+        conversation_id=conversation_id,
+        command=command,
+    )
+    if pending is None:
+        return False
+    action_envelope = _hook_action_envelope(
+        harness=harness,
+        payload=prepared,
+        home_dir=home_dir,
+        workspace=workspace,
+    )
+    runtime_artifact = _hook_runtime_artifact(
+        harness=harness,
+        payload=prepared,
+        action_envelope=action_envelope,
+        home_dir=home_dir,
+        guard_home=guard_home,
+        workspace=workspace,
+    )
+    if runtime_artifact is None:
+        return False
+    runtime_artifact_hash = artifact_hash(runtime_artifact)
+    now = _now()
+    saved_policy = _persist_cursor_native_permission_policy(
+        store=store,
+        artifact_id=runtime_artifact.artifact_id,
+        artifact_hash=runtime_artifact_hash,
+        action="allow",
+        reason="Approved in Cursor native shell approval prompt.",
+        now=now,
+    )
+    if not saved_policy:
+        return False
+    try:
+        store.record_inventory_artifact(
+            artifact=runtime_artifact,
+            artifact_hash=runtime_artifact_hash,
+            policy_action="allow",
+            changed=False,
+            now=now,
+            approved=True,
+        )
+    except (OSError, sqlite3.Error):
+        return False
+    _resolve_cursor_pending_approval_requests(
+        store=store,
+        pending=pending,
+        reason="Approved in Cursor native shell approval prompt.",
+        now=now,
+    )
+    receipt = build_receipt(
+        harness="cursor",
+        artifact_id=runtime_artifact.artifact_id,
+        artifact_hash=runtime_artifact_hash,
+        policy_decision="allow",
+        capabilities_summary=_runtime_capabilities_summary(runtime_artifact),
+        changed_capabilities=[runtime_artifact.artifact_type, "cursor-native-approved"],
+        provenance_summary=f"runtime shell command approved from {runtime_artifact.config_path}",
+        artifact_name=runtime_artifact.name,
+        source_scope=runtime_artifact.source_scope,
+        user_override="cursor-native-approve",
+        approval_source="inline",
+    )
+    store.add_receipt(receipt)
+    pending_key = _cursor_pending_shell_state_key(conversation_id, command)
+    _remove_cursor_pending_shell_permission(
+        store,
+        conversation_id=conversation_id,
+        pending_key=pending_key,
+    )
+    return True
 
 
 def _persist_claude_native_permission_policy(

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -236,6 +236,7 @@ def test_install_cursor_hooks_registers_after_shell_observer(tmp_path: Path, mon
 
 
 def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
     from codex_plugin_scanner.guard.models import GuardArtifact
     from codex_plugin_scanner.guard.store import GuardStore
@@ -268,13 +269,15 @@ def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> No
     )
     saved = guard_commands_module._persist_cursor_native_permission_after_shell(
         store=store,
-        payload={
-            "conversation_id": conversation_id,
-            "hook_event_name": "afterShellExecution",
-            "command": command,
-            "cwd": str(workspace_dir),
-            "duration": 15,
-        },
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+                "duration": 15,
+            }
+        ),
         harness="cursor",
         home_dir=home_dir,
         guard_home=home_dir,

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -26,6 +26,7 @@ def test_managed_hook_events_exclude_pretooluse() -> None:
         "beforeShellExecution",
         "beforeMCPExecution",
         "beforeReadFile",
+        "afterShellExecution",
     )
 
 
@@ -69,6 +70,23 @@ def test_prepare_cursor_hook_payload_maps_before_shell_execution() -> None:
             "cwd": "/tmp",
         }
     )
+    assert payload["tool_name"] == "Shell"
+    tool_input = payload["tool_input"]
+    assert isinstance(tool_input, dict)
+    assert tool_input["command"] == "echo hello"
+    assert tool_input["working_directory"] == "/tmp"
+
+
+def test_prepare_cursor_hook_payload_maps_after_shell_execution() -> None:
+    payload = prepare_cursor_hook_payload(
+        {
+            "hook_event_name": "afterShellExecution",
+            "command": "echo hello",
+            "cwd": "/tmp",
+            "duration": 12,
+        }
+    )
+    assert payload["hook_event_name"] == "afterShellExecution"
     assert payload["tool_name"] == "Shell"
     tool_input = payload["tool_input"]
     assert isinstance(tool_input, dict)
@@ -193,6 +211,89 @@ def test_cursor_hook_script_source_infers_event_before_prepare(tmp_path: Path) -
     source = cursor_hook_script_source(context)
     assert "inferred = _infer_cursor_hook_event_name(payload)" in source
     assert "hook_event_name = str(inferred.get(\"hook_event_name\")" in source
+    assert "aftershellexecution" in source.lower()
+
+
+def test_install_cursor_hooks_registers_after_shell_observer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    guard_home.mkdir()
+    workspace.mkdir()
+    hooks_path = home / ".cursor" / "hooks.json"
+    hooks_path.parent.mkdir(parents=True)
+    hooks_path.write_text('{"version": 1, "hooks": {}}\n', encoding="utf-8")
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+        lambda: ["hol-guard"],
+    )
+    context = HarnessContext(home_dir=home, guard_home=guard_home, workspace_dir=workspace)
+    install_cursor_hooks(context)
+    installed = json.loads(hooks_path.read_text(encoding="utf-8"))
+    after_shell = installed["hooks"]["afterShellExecution"][-1]
+    assert after_shell.get("failClosed") is not True
+
+
+def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.models import GuardArtifact
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-native-shell"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    guard_commands_module._record_cursor_pending_shell_permission(
+        store=store,
+        payload={
+            "conversation_id": conversation_id,
+            "hook_event_name": "beforeShellExecution",
+            "command": command,
+            "cwd": str(workspace_dir),
+        },
+        reason="Requests a sensitive native tool action.",
+        artifact=GuardArtifact(
+            artifact_id="cursor:project:shell:rm",
+            name="Shell",
+            harness="cursor",
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(workspace_dir / ".cursor" / "mcp.json"),
+            command=command,
+        ),
+        artifact_hash="hash-cursor-shell",
+    )
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload={
+            "conversation_id": conversation_id,
+            "hook_event_name": "afterShellExecution",
+            "command": command,
+            "cwd": str(workspace_dir),
+            "duration": 15,
+        },
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+    )
+    policies = store.list_policy_decisions("cursor")
+
+    assert saved is True
+    assert len(policies) == 1
+    assert policies[0]["action"] == "allow"
+    assert policies[0]["source"] == "cursor-native-approval"
+    assert (
+        guard_commands_module._load_cursor_pending_shell_permission(
+            store,
+            conversation_id=conversation_id,
+            command=command,
+        )
+        is None
+    )
 
 
 def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Add managed `afterShellExecution` Cursor hook to persist allow policy when the user approves a sensitive shell command in Cursor's native prompt
- Record pending Cursor shell approvals on `require-reapproval`, link queued dashboard request IDs, and resolve them after native approval
- Bridge script returns `{}` for observer hooks so shell execution is never blocked post-run

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_hooks.py -q`

