### PR TITLE
fix(dashboard): add Custom fine-tuning switch on preset lock

### DIFF
--- a/dashboard/src/settings-workspace.test.ts
+++ b/dashboard/src/settings-workspace.test.ts
@@ -80,3 +80,4 @@ assert(
 assert(isFineTuningEditable("custom") === true, "fine-tuning: custom level is editable");
 assert(isFineTuningEditable("strict") === false, "fine-tuning: strict level is locked until custom");
 assert(isFineTuningEditable("balanced") === false, "fine-tuning: balanced level is locked until custom");
+assert(isFineTuningEditable("relaxed") === false, "fine-tuning: relaxed level is locked until custom");

--- a/dashboard/src/settings-workspace.test.ts
+++ b/dashboard/src/settings-workspace.test.ts
@@ -5,6 +5,8 @@ import {
   buildTotpQrImageOptions,
   formatTotpManualKey,
   resolveSecurityLevelDescription,
+  resolveFineTuningSectionDescription,
+  isFineTuningEditable,
 } from "./settings-workspace";
 import { repairApprovalCenter, setupDesktopNotifications } from "./guard-api";
 
@@ -60,3 +62,21 @@ assert(
   formatTotpEnrollmentExpiry("not-a-date") === "Enrollment expiration unknown.",
   "T743: invalid TOTP expiry should not render Invalid Date"
 );
+
+const strictFineTuningDescription = resolveFineTuningSectionDescription("strict");
+assert(
+  strictFineTuningDescription.includes("Strict"),
+  "fine-tuning: strict description should name the preset"
+);
+assert(
+  !strictFineTuningDescription.includes("Protection"),
+  "fine-tuning: strict description should not send users to another tab"
+);
+assert(
+  strictFineTuningDescription.includes("Custom"),
+  "fine-tuning: strict description should mention Custom mode"
+);
+
+assert(isFineTuningEditable("custom") === true, "fine-tuning: custom level is editable");
+assert(isFineTuningEditable("strict") === false, "fine-tuning: strict level is locked until custom");
+assert(isFineTuningEditable("balanced") === false, "fine-tuning: balanced level is locked until custom");

--- a/dashboard/src/settings-workspace.tsx
+++ b/dashboard/src/settings-workspace.tsx
@@ -75,7 +75,7 @@ export function resolveFineTuningSectionDescription(
   if (securityLevel === "custom") {
     return "You are overriding the preset for this machine.";
   }
-  return `These rules follow ${securityLevelLabel(securityLevel)}. Use Custom fine-tuning to edit each action type here.`;
+  return `These rules follow the ${securityLevelLabel(securityLevel)} preset. Use Custom fine-tuning to edit each action type here.`;
 }
 
 export function isFineTuningEditable(securityLevel: GuardSettings["security_level"]): boolean {
@@ -1679,10 +1679,6 @@ function FineTuningPresetBanner(props: {
   securityLevel: GuardSettings["security_level"];
   onSwitchToCustom: () => void;
 }) {
-  const handleSwitch = useCallback(() => {
-    props.onSwitchToCustom();
-  }, [props.onSwitchToCustom]);
-
   if (isFineTuningEditable(props.securityLevel)) return null;
 
   return (
@@ -1693,14 +1689,14 @@ function FineTuningPresetBanner(props: {
     >
       <div className="min-w-0">
         <p className="text-sm font-medium text-brand-dark">
-          Using {securityLevelLabel(props.securityLevel)} preset
+          Using the {securityLevelLabel(props.securityLevel)} preset
         </p>
         <p className="mt-1 text-sm text-slate-500">
           Individual rules match this preset. Switch to Custom to change how Guard handles each risky action type on this machine.
         </p>
       </div>
       <div className="mt-3 w-full shrink-0 sm:mt-0 sm:w-auto">
-        <ActionButton onClick={handleSwitch}>Use Custom fine-tuning</ActionButton>
+        <ActionButton onClick={props.onSwitchToCustom}>Use Custom fine-tuning</ActionButton>
       </div>
     </div>
   );

--- a/dashboard/src/settings-workspace.tsx
+++ b/dashboard/src/settings-workspace.tsx
@@ -69,6 +69,19 @@ export function resolveSecurityLevelCardDescription(level: "relaxed" | "balanced
   return "Use the exact choices below for this machine and connected apps.";
 }
 
+export function resolveFineTuningSectionDescription(
+  securityLevel: GuardSettings["security_level"],
+): string {
+  if (securityLevel === "custom") {
+    return "You are overriding the preset for this machine.";
+  }
+  return `These rules follow ${securityLevelLabel(securityLevel)}. Use Custom fine-tuning to edit each action type here.`;
+}
+
+export function isFineTuningEditable(securityLevel: GuardSettings["security_level"]): boolean {
+  return securityLevel === "custom";
+}
+
 export function buildClearPolicyPayload(all: boolean): { harness?: string; all?: boolean } {
   return { all };
 }
@@ -475,6 +488,10 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
     });
     setSaveError(null);
   }, []);
+
+  const handleSwitchToCustomFineTuning = useCallback(() => {
+    handleSecurityLevelChange("custom");
+  }, [handleSecurityLevelChange]);
 
   const handleRiskActionChange = useCallback(
     (riskKey: string) => (event: ChangeEvent<HTMLSelectElement>) => {
@@ -1074,13 +1091,21 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
       {hasSearch && riskSearchMatches.length > 0 && (
         <div className="rounded-xl border border-slate-100 p-4">
           <SectionLabel>Matching fine-tuning rules</SectionLabel>
+          {!isFineTuningEditable(draft.security_level) ? (
+            <div className="mt-3">
+              <FineTuningPresetBanner
+                securityLevel={draft.security_level}
+                onSwitchToCustom={handleSwitchToCustomFineTuning}
+              />
+            </div>
+          ) : null}
           <div className="mt-3 divide-y divide-slate-100 border-t border-slate-100">
             {visibleRiskControls.map((risk) => (
               <RiskControlRow
                 key={risk.key}
                 risk={risk}
                 value={draft.risk_actions[risk.key] ?? "require-reapproval"}
-                disabled={draft.security_level !== "custom"}
+                disabled={!isFineTuningEditable(draft.security_level)}
                 onChange={handleRiskActionChange(risk.key)}
                 showConsequence
               />
@@ -1261,23 +1286,25 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
 
         {activeTab === "risk" && (
           <div className="flex min-h-0 flex-1 flex-col space-y-6">
+            {!isFineTuningEditable(draft.security_level) ? (
+              <FineTuningPresetBanner
+                securityLevel={draft.security_level}
+                onSwitchToCustom={handleSwitchToCustomFineTuning}
+              />
+            ) : null}
             <SettingsFormSection
               title="Risky action types"
-              description={
-                draft.security_level !== "custom"
-                  ? `Follows ${securityLevelLabel(draft.security_level)}. Choose Custom on Protection to edit each type.`
-                  : "You are overriding the preset for this machine."
-              }
+              description={resolveFineTuningSectionDescription(draft.security_level)}
             >
-              <div className={`space-y-1 ${draft.security_level !== "custom" ? "opacity-60" : ""}`}>
+              <div className={`space-y-1 ${!isFineTuningEditable(draft.security_level) ? "opacity-60" : ""}`}>
                 {riskControls.map((risk) => (
                   <RiskControlRow
                     key={risk.key}
                     risk={risk}
                     value={draft.risk_actions[risk.key] ?? "require-reapproval"}
-                    disabled={draft.security_level !== "custom"}
+                    disabled={!isFineTuningEditable(draft.security_level)}
                     onChange={handleRiskActionChange(risk.key)}
-                    showConsequence={draft.security_level === "custom"}
+                    showConsequence={isFineTuningEditable(draft.security_level)}
                   />
                 ))}
                 <div className="grid gap-2 border-t border-slate-100 py-3 md:grid-cols-[minmax(0,1fr)_200px] md:items-center">
@@ -1296,7 +1323,7 @@ export function SettingsWorkspace({ onApprovalGateChange }: SettingsWorkspacePro
                     }
                     options={actionOptions}
                     onChange={handleCodexSecretReadChange}
-                    disabled={draft.security_level !== "custom"}
+                    disabled={!isFineTuningEditable(draft.security_level)}
                   />
                 </div>
               </div>
@@ -1645,6 +1672,37 @@ function SettingToggle(props: {
       <span className="text-sm text-brand-dark">{props.label}</span>
       <input id={props.id} name={props.id} type="checkbox" checked={props.checked} onChange={props.onChange} className="h-4 w-4 accent-brand-blue" />
     </label>
+  );
+}
+
+function FineTuningPresetBanner(props: {
+  securityLevel: GuardSettings["security_level"];
+  onSwitchToCustom: () => void;
+}) {
+  const handleSwitch = useCallback(() => {
+    props.onSwitchToCustom();
+  }, [props.onSwitchToCustom]);
+
+  if (isFineTuningEditable(props.securityLevel)) return null;
+
+  return (
+    <div
+      className="rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-4 py-4 sm:flex sm:items-center sm:justify-between sm:gap-4"
+      role="region"
+      aria-label="Fine-tuning preset controls"
+    >
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-brand-dark">
+          Using {securityLevelLabel(props.securityLevel)} preset
+        </p>
+        <p className="mt-1 text-sm text-slate-500">
+          Individual rules match this preset. Switch to Custom to change how Guard handles each risky action type on this machine.
+        </p>
+      </div>
+      <div className="mt-3 w-full shrink-0 sm:mt-0 sm:w-auto">
+        <ActionButton onClick={handleSwitch}>Use Custom fine-tuning</ActionButton>
+      </div>
+    </div>
   );
 }
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
@@ -1488,7 +1488,7 @@ function resolveFineTuningSectionDescription(securityLevel) {
   if (securityLevel === "custom") {
     return "You are overriding the preset for this machine.";
   }
-  return `These rules follow ${securityLevelLabel(securityLevel)}. Use Custom fine-tuning to edit each action type here.`;
+  return `These rules follow the ${securityLevelLabel(securityLevel)} preset. Use Custom fine-tuning to edit each action type here.`;
 }
 function isFineTuningEditable(securityLevel) {
   return securityLevel === "custom";
@@ -2871,9 +2871,6 @@ function SettingToggle(props) {
   ] });
 }
 function FineTuningPresetBanner(props) {
-  const handleSwitch = reactExports.useCallback(() => {
-    props.onSwitchToCustom();
-  }, [props.onSwitchToCustom]);
   if (isFineTuningEditable(props.securityLevel)) return null;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "div",
@@ -2884,13 +2881,13 @@ function FineTuningPresetBanner(props) {
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm font-medium text-brand-dark", children: [
-            "Using ",
+            "Using the ",
             securityLevelLabel(props.securityLevel),
             " preset"
           ] }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Individual rules match this preset. Switch to Custom to change how Guard handles each risky action type on this machine." })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 w-full shrink-0 sm:mt-0 sm:w-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleSwitch, children: "Use Custom fine-tuning" }) })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 w-full shrink-0 sm:mt-0 sm:w-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: props.onSwitchToCustom, children: "Use Custom fine-tuning" }) })
       ]
     }
   );

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/settings-workspace.js
@@ -1484,6 +1484,15 @@ function resolveSecurityLevelCardDescription(level) {
   if (level === "strict") return "Ask more often, including new network destinations.";
   return "Use the exact choices below for this machine and connected apps.";
 }
+function resolveFineTuningSectionDescription(securityLevel) {
+  if (securityLevel === "custom") {
+    return "You are overriding the preset for this machine.";
+  }
+  return `These rules follow ${securityLevelLabel(securityLevel)}. Use Custom fine-tuning to edit each action type here.`;
+}
+function isFineTuningEditable(securityLevel) {
+  return securityLevel === "custom";
+}
 function buildClearPolicyPayload(all) {
   return { all };
 }
@@ -1842,6 +1851,9 @@ function SettingsWorkspace({ onApprovalGateChange }) {
     });
     setSaveError(null);
   }, []);
+  const handleSwitchToCustomFineTuning = reactExports.useCallback(() => {
+    handleSecurityLevelChange("custom");
+  }, [handleSecurityLevelChange]);
   const handleRiskActionChange = reactExports.useCallback(
     (riskKey) => (event) => {
       setDraft((value) => {
@@ -2394,12 +2406,19 @@ function SettingsWorkspace({ onApprovalGateChange }) {
     hasSearch && searchMatches.length === 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "No settings match your search." }),
     hasSearch && riskSearchMatches.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 p-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Matching fine-tuning rules" }),
+      !isFineTuningEditable(draft.security_level) ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        FineTuningPresetBanner,
+        {
+          securityLevel: draft.security_level,
+          onSwitchToCustom: handleSwitchToCustomFineTuning
+        }
+      ) }) : null,
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 divide-y divide-slate-100 border-t border-slate-100", children: visibleRiskControls.map((risk) => /* @__PURE__ */ jsxRuntimeExports.jsx(
         RiskControlRow,
         {
           risk,
           value: draft.risk_actions[risk.key] ?? "require-reapproval",
-          disabled: draft.security_level !== "custom",
+          disabled: !isFineTuningEditable(draft.security_level),
           onChange: handleRiskActionChange(risk.key),
           showConsequence: true
         },
@@ -2560,42 +2579,51 @@ function SettingsWorkspace({ onApprovalGateChange }) {
             ),
             /* @__PURE__ */ jsxRuntimeExports.jsx(SettingsActionMessage, { message: actionMessage, kind: actionMessageKind })
           ] }),
-          activeTab === "risk" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex min-h-0 flex-1 flex-col space-y-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-            SettingsFormSection,
-            {
-              title: "Risky action types",
-              description: draft.security_level !== "custom" ? `Follows ${securityLevelLabel(draft.security_level)}. Choose Custom on Protection to edit each type.` : "You are overriding the preset for this machine.",
-              children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `space-y-1 ${draft.security_level !== "custom" ? "opacity-60" : ""}`, children: [
-                riskControls.map((risk) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-                  RiskControlRow,
-                  {
-                    risk,
-                    value: draft.risk_actions[risk.key] ?? "require-reapproval",
-                    disabled: draft.security_level !== "custom",
-                    onChange: handleRiskActionChange(risk.key),
-                    showConsequence: draft.security_level === "custom"
-                  },
-                  risk.key
-                )),
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-2 border-t border-slate-100 py-3 md:grid-cols-[minmax(0,1fr)_200px] md:items-center", children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Codex reading secret files" }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Only for trusted projects where Codex may read .env or .npmrc without an extra prompt." })
-                  ] }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx(
-                    SettingSelect,
+          activeTab === "risk" && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-h-0 flex-1 flex-col space-y-6", children: [
+            !isFineTuningEditable(draft.security_level) ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+              FineTuningPresetBanner,
+              {
+                securityLevel: draft.security_level,
+                onSwitchToCustom: handleSwitchToCustomFineTuning
+              }
+            ) : null,
+            /* @__PURE__ */ jsxRuntimeExports.jsx(
+              SettingsFormSection,
+              {
+                title: "Risky action types",
+                description: resolveFineTuningSectionDescription(draft.security_level),
+                children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `space-y-1 ${!isFineTuningEditable(draft.security_level) ? "opacity-60" : ""}`, children: [
+                  riskControls.map((risk) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+                    RiskControlRow,
                     {
-                      label: "Codex should",
-                      value: draft.harness_risk_actions.codex?.local_secret_read ?? draft.risk_actions.local_secret_read ?? "require-reapproval",
-                      options: actionOptions,
-                      onChange: handleCodexSecretReadChange,
-                      disabled: draft.security_level !== "custom"
-                    }
-                  )
+                      risk,
+                      value: draft.risk_actions[risk.key] ?? "require-reapproval",
+                      disabled: !isFineTuningEditable(draft.security_level),
+                      onChange: handleRiskActionChange(risk.key),
+                      showConsequence: isFineTuningEditable(draft.security_level)
+                    },
+                    risk.key
+                  )),
+                  /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-2 border-t border-slate-100 py-3 md:grid-cols-[minmax(0,1fr)_200px] md:items-center", children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Codex reading secret files" }),
+                      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Only for trusted projects where Codex may read .env or .npmrc without an extra prompt." })
+                    ] }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx(
+                      SettingSelect,
+                      {
+                        label: "Codex should",
+                        value: draft.harness_risk_actions.codex?.local_secret_read ?? draft.risk_actions.local_secret_read ?? "require-reapproval",
+                        options: actionOptions,
+                        onChange: handleCodexSecretReadChange,
+                        disabled: !isFineTuningEditable(draft.security_level)
+                      }
+                    )
+                  ] })
                 ] })
-              ] })
-            }
-          ) }),
+              }
+            )
+          ] }),
           activeTab === "defaults" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex min-h-0 flex-1 flex-col space-y-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
             SettingsFormSection,
             {
@@ -2841,6 +2869,31 @@ function SettingToggle(props) {
     /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-brand-dark", children: props.label }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("input", { id: props.id, name: props.id, type: "checkbox", checked: props.checked, onChange: props.onChange, className: "h-4 w-4 accent-brand-blue" })
   ] });
+}
+function FineTuningPresetBanner(props) {
+  const handleSwitch = reactExports.useCallback(() => {
+    props.onSwitchToCustom();
+  }, [props.onSwitchToCustom]);
+  if (isFineTuningEditable(props.securityLevel)) return null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      className: "rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-4 py-4 sm:flex sm:items-center sm:justify-between sm:gap-4",
+      role: "region",
+      "aria-label": "Fine-tuning preset controls",
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm font-medium text-brand-dark", children: [
+            "Using ",
+            securityLevelLabel(props.securityLevel),
+            " preset"
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Individual rules match this preset. Switch to Custom to change how Guard handles each risky action type on this machine." })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 w-full shrink-0 sm:mt-0 sm:w-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { onClick: handleSwitch, children: "Use Custom fine-tuning" }) })
+      ]
+    }
+  );
 }
 function SecurityLevelCard({ level, isSelected, onSelect }) {
   const LevelIcon = level.icon;
@@ -3177,6 +3230,8 @@ export {
   formatTotpEnrollmentExpiry,
   formatTotpManualKey,
   hasUnsavedChanges,
+  isFineTuningEditable,
+  resolveFineTuningSectionDescription,
   resolveSecurityLevelCardDescription,
   resolveSecurityLevelDescription
 };

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -494,7 +494,7 @@ function requireReact_production() {
   react_production.useTransition = function() {
     return ReactSharedInternals.H.useTransition();
   };
-  react_production.version = "19.2.5";
+  react_production.version = "19.2.7";
   return react_production;
 }
 var hasRequiredReact;
@@ -922,7 +922,7 @@ function requireReactDom_production() {
   reactDom_production.useFormStatus = function() {
     return ReactSharedInternals.H.useHostTransitionStatus();
   };
-  reactDom_production.version = "19.2.5";
+  reactDom_production.version = "19.2.7";
   return reactDom_production;
 }
 var hasRequiredReactDom;
@@ -12366,12 +12366,12 @@ function requireReactDomClient_production() {
     }
   };
   var isomorphicReactPackageVersion$jscomp$inline_1840 = React2.version;
-  if ("19.2.5" !== isomorphicReactPackageVersion$jscomp$inline_1840)
+  if ("19.2.7" !== isomorphicReactPackageVersion$jscomp$inline_1840)
     throw Error(
       formatProdErrorMessage(
         527,
         isomorphicReactPackageVersion$jscomp$inline_1840,
-        "19.2.5"
+        "19.2.7"
       )
     );
   ReactDOMSharedInternals.findDOMNode = function(componentOrElement) {
@@ -12389,10 +12389,10 @@ function requireReactDomClient_production() {
   };
   var internals$jscomp$inline_2347 = {
     bundleType: 0,
-    version: "19.2.5",
+    version: "19.2.7",
     rendererPackageName: "react-dom",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.5"
+    reconcilerVersion: "19.2.7"
   };
   if ("undefined" !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__) {
     var hook$jscomp$inline_2348 = __REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -12459,7 +12459,7 @@ function requireReactDomClient_production() {
     listenToAllSupportedEvents(container2);
     return new ReactDOMHydrationRoot(initialChildren);
   };
-  reactDomClient_production.version = "19.2.5";
+  reactDomClient_production.version = "19.2.7";
   return reactDomClient_production;
 }
 var hasRequiredClient;


### PR DESCRIPTION
## Summary
- Add inline "Use Custom fine-tuning" banner on the Fine-tuning tab when a preset (Strict, Balanced, Relaxed) is active
- Replace dead-end copy that sent users to Protection with no control to switch modes
- Keep preset values visible until the user opts into Custom, then enable per-action editing

## Testing
- `cd dashboard && tsx src/settings-workspace.test.ts`
- `cd dashboard && npm run build`
