### PR TITLE
fix(daemon): register /about route in _is_dashboard_route

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3977,6 +3977,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/policy",
             "/feed-health",
             "/settings",
+            "/about",
             "/requests",
             "/approvals",
         }:


### PR DESCRIPTION
## Summary
- Register `/about` route in daemon's `_is_dashboard_route()` so the SPA correctly serves index.html for `/about` requests.

## Testing
- `cd dashboard && npx vite build` — builds successfully (125 modules, ~about-workspace.js 17.76 kB)
- Verified `/about` is now present in the `_is_dashboard_route` route set alongside existing routes like `/settings`, `/policy`, `/audit`, etc.

## Notes
- Static assets from PR #667 already contain the built `about-workspace.js` chunk; this PR only fixes the missing route registration in the Python daemon.
