### PR TITLE
fix(about): broken links, editorial redesign, mailto support

### DIFF
--- a/dashboard/src/about/about-content.test.ts
+++ b/dashboard/src/about/about-content.test.ts
@@ -50,7 +50,10 @@ assert(ABOUT_OPEN_SOURCE_NOTE.length > 0, "open source note is non-empty");
 assert(ABOUT_PARTNER_SECTION_TITLE.length > 0, "partner title is non-empty");
 assert(ABOUT_PARTNER_SECTION_BODY.length > 0, "partner body is non-empty");
 assert(ABOUT_PARTNER_CTA.length > 0, "partner CTA label is non-empty");
-assert(ABOUT_PARTNER_CTA_HREF.startsWith("https://"), "partner CTA uses HTTPS");
+assert(
+  ABOUT_PARTNER_CTA_HREF.startsWith("https://") || ABOUT_PARTNER_CTA_HREF.startsWith("mailto:"),
+  "partner CTA uses HTTPS or mailto"
+);
 assert(!ABOUT_PARTNER_CTA_HREF.includes("guard-token"), "partner CTA has no guard-token");
 
 // Affiliate section

--- a/dashboard/src/about/about-content.ts
+++ b/dashboard/src/about/about-content.ts
@@ -22,11 +22,11 @@ export const ABOUT_PARTNER_SECTION_BODY =
   "Join teams building on HOL open standards. Partners get early access to protocol drafts, co-marketing, and direct engineering support.";
 
 export const ABOUT_PARTNER_CTA = "Become a partner";
-export const ABOUT_PARTNER_CTA_HREF = "https://hol.org/partners";
+export const ABOUT_PARTNER_CTA_HREF = "mailto:partners@hol.org";
 
 export const ABOUT_AFFILIATE_SECTION_TITLE = "Affiliate starter kit";
 export const ABOUT_AFFILIATE_SECTION_BODY =
-  "Share Guard with your community and earn a recurring commission on qualified referrals.";
+  "Share Guard with your community and score a recurring commission on qualified referrals.";
 export const ABOUT_AFFILIATE_CTA = "Learn about affiliates";
 export const ABOUT_AFFILIATE_CTA_HREF = "https://hol.org/guard/affiliates";
 
@@ -67,7 +67,7 @@ export const ABOUT_PATH_CARDS: PathCard[] = [
     title: "Sync with your team",
     description: "Connect to Guard Cloud for shared policy bundles and cross-device fleet visibility.",
     ctaLabel: "Guard Cloud",
-    ctaHref: "https://hol.org/guard/cloud",
+    ctaHref: "https://github.com/hashgraph-online/hol-guard",
   },
   {
     title: "Validate packages in CI",

--- a/dashboard/src/about/about-external-links.ts
+++ b/dashboard/src/about/about-external-links.ts
@@ -44,6 +44,15 @@ export function assertSafeAboutExternalUrl(raw: string): {
     throw new AboutExternalLinkError(`Invalid URL: ${raw}`);
   }
 
+  if (parsed.protocol === "mailto:") {
+    return {
+      url: raw,
+      hostname: "",
+      rel: "",
+      target: "",
+    };
+  }
+
   if (parsed.protocol !== "https:") {
     throw new AboutExternalLinkError(`URL must use HTTPS: ${raw}`);
   }

--- a/dashboard/src/about/about-workspace.tsx
+++ b/dashboard/src/about/about-workspace.tsx
@@ -1,5 +1,4 @@
-import { useCallback } from "react";
-import type { ReactNode } from "react";
+import { useRef, useEffect, useState, useCallback, type ReactNode } from "react";
 import {
   HiMiniShieldCheck,
   HiMiniLockClosed,
@@ -7,8 +6,9 @@ import {
   HiMiniCloud,
   HiMiniArrowTopRightOnSquare,
   HiMiniInformationCircle,
+  HiMiniCheckBadge,
 } from "react-icons/hi2";
-import { SectionLabel, Badge, ActionButton } from "../approval-center-primitives";
+import { SectionLabel, Badge } from "../approval-center-primitives";
 import { trackAboutEvent } from "./about-analytics";
 import { assertSafeAboutExternalUrl } from "./about-external-links";
 import {
@@ -35,6 +35,63 @@ import {
   ABOUT_AFFILIATE_TERMS,
 } from "./about-content";
 
+function useEditorialVisibility(threshold = 0.08) {
+  const ref = useRef<HTMLElement>(null);
+  const [state, setState] = useState<"idle" | "hidden" | "visible">("idle");
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") {
+      setState("visible");
+      return;
+    }
+    setState("hidden");
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setState("visible");
+          observer.disconnect();
+        }
+      },
+      { threshold }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold]);
+
+  return { ref, state };
+}
+
+function EditorialSection({
+  children,
+  className = "",
+  threshold = 0.08,
+}: {
+  children: ReactNode;
+  className?: string;
+  threshold?: number;
+}) {
+  const { ref, state } = useEditorialVisibility(threshold);
+
+  return (
+    <section
+      ref={ref}
+      className={[
+        className,
+        state === "idle"
+          ? ""
+          : "motion-safe:transition-[opacity,transform] transition-opacity duration-700 ease-[cubic-bezier(0.16,1,0.3,1)]",
+        state === "idle" || state === "visible"
+          ? "opacity-100 translate-y-0"
+          : "opacity-0 motion-safe:translate-y-6",
+      ].join(" ")}
+    >
+      {children}
+    </section>
+  );
+}
+
 function AboutExternalLink({
   href,
   children,
@@ -58,7 +115,10 @@ function AboutExternalLink({
 
   if (!safe) {
     return (
-      <span className={`text-slate-400 cursor-not-allowed ${className ?? ""}`} title={errorReason}>
+      <span
+        className={[`text-slate-400 cursor-not-allowed`, className ?? ""].join(" ")}
+        title={errorReason}
+      >
         {children}
       </span>
     );
@@ -70,7 +130,11 @@ function AboutExternalLink({
       target={safe.target}
       rel={safe.rel}
       onClick={handleClick}
-      className={`inline-flex items-center gap-1 transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 focus-visible:ring-offset-2 ${className ?? ""}`}
+      className={[
+        `inline-flex items-center gap-1 transition-colors hover:text-brand-blue`,
+        `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 focus-visible:ring-offset-2`,
+        className ?? "",
+      ].join(" ")}
     >
       {children}
       <HiMiniArrowTopRightOnSquare className="h-3.5 w-3.5 opacity-60" aria-hidden="true" />
@@ -78,48 +142,91 @@ function AboutExternalLink({
   );
 }
 
-function TrustCard({ title, desc, icon }: { title: string; desc: string; icon: ReactNode }) {
+function TrustRow({
+  title,
+  desc,
+  icon,
+}: {
+  title: string;
+  desc: string;
+  icon: ReactNode;
+}) {
   return (
-    <div className="rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
-      <div className="mb-3 flex h-10 w-10 items-center justify-center rounded-xl bg-brand-blue/[0.06] text-brand-blue">
+    <div className="flex items-start gap-4 py-5 border-b border-slate-100 last:border-b-0">
+      <div className="shrink-0 flex h-9 w-9 items-center justify-center rounded-lg bg-brand-blue/[0.06] text-brand-blue">
         {icon}
       </div>
-      <h3 className="mb-1 text-sm font-semibold text-brand-dark">{title}</h3>
-      <p className="text-sm leading-relaxed text-slate-500">{desc}</p>
+      <div>
+        <h3 className="text-sm font-semibold text-brand-dark">{title}</h3>
+        <p className="mt-0.5 text-sm leading-relaxed text-slate-500">{desc}</p>
+      </div>
     </div>
   );
 }
 
-function PathCard({
+function PathStep({
+  index,
   title,
   desc,
   ctaLabel,
   ctaHref,
 }: {
+  index: number;
   title: string;
   desc: string;
   ctaLabel: string;
   ctaHref: string;
 }) {
   return (
-    <div className="flex flex-col rounded-2xl border border-slate-100 bg-white p-5 shadow-sm">
-      <h3 className="mb-1 text-sm font-semibold text-brand-dark">{title}</h3>
-      <p className="mb-4 flex-1 text-sm leading-relaxed text-slate-500">{desc}</p>
-      <AboutExternalLink
-        href={ctaHref}
-        className="text-sm font-semibold text-brand-blue hover:underline"
-      >
-        {ctaLabel}
-      </AboutExternalLink>
+    <div className="relative grid grid-cols-[40px_1fr] gap-4 sm:gap-5">
+      <div className="relative z-10 flex h-10 w-10 items-center justify-center rounded-full border-2 border-brand-blue bg-white">
+        <span className="font-mono text-sm font-black text-brand-blue">
+          {String(index + 1).padStart(2, "0")}
+        </span>
+      </div>
+      <div className="pt-0.5">
+        <h4 className="text-sm font-bold text-brand-dark">{title}</h4>
+        <p className="mt-1 text-sm leading-relaxed text-slate-500">{desc}</p>
+        <div className="mt-2">
+          <AboutExternalLink
+            href={ctaHref}
+            className="text-sm font-semibold text-brand-blue hover:underline"
+          >
+            {ctaLabel}
+          </AboutExternalLink>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PartnerLevelRow({
+  level,
+  index,
+}: {
+  level: { name: string; description: string };
+  index: number;
+}) {
+  return (
+    <div className="border-t border-slate-100 py-5">
+      <div className="flex items-baseline gap-3">
+        <span className="font-mono text-xs font-black text-brand-blue/70">
+          {String(index + 1).padStart(2, "0")}
+        </span>
+        <h3 className="text-sm font-bold text-brand-dark">{level.name}</h3>
+      </div>
+      <p className="mt-1 ml-7 text-sm leading-relaxed text-slate-500">
+        {level.description}
+      </p>
     </div>
   );
 }
 
 export function AboutWorkspace() {
   return (
-    <div className="space-y-10">
+    <div className="space-y-16 pb-10">
       {/* Hero */}
-      <section className="rounded-2xl border border-brand-blue/10 bg-gradient-to-br from-brand-blue/[0.04] to-brand-dark/[0.02] p-6 sm:p-8">
+      <EditorialSection className="rounded-2xl border border-brand-blue/10 bg-gradient-to-br from-brand-blue/[0.04] to-brand-dark/[0.02] p-6 sm:p-8">
         <div className="max-w-2xl">
           <h1 className="mb-2 text-2xl font-bold tracking-tight text-brand-dark sm:text-3xl">
             {ABOUT_HERO_TITLE}
@@ -131,144 +238,149 @@ export function AboutWorkspace() {
             {ABOUT_HERO_BODY}
           </p>
         </div>
-      </section>
+      </EditorialSection>
 
       {/* Local-first promise */}
-      <section className="space-y-4">
-        <div>
+      <EditorialSection>
+        <div className="mb-6">
           <SectionLabel>{ABOUT_LOCAL_SECTION_TITLE}</SectionLabel>
           <p className="mt-1 text-sm leading-relaxed text-slate-500">
             {ABOUT_LOCAL_SECTION_BODY}
           </p>
         </div>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-2xl border border-slate-100 bg-white px-5 py-1 shadow-sm">
           {ABOUT_TRUST_CARDS.map((card, i) => (
-            <TrustCard
-              key={i}
+            <TrustRow
+              key={card.title}
               title={card.title}
               desc={card.description}
               icon={
                 i === 0 ? (
-                  <HiMiniShieldCheck className="h-5 w-5" />
+                  <HiMiniShieldCheck className="h-4 w-4" />
                 ) : i === 1 ? (
-                  <HiMiniDocumentText className="h-5 w-5" />
+                  <HiMiniDocumentText className="h-4 w-4" />
                 ) : i === 2 ? (
-                  <HiMiniLockClosed className="h-5 w-5" />
+                  <HiMiniLockClosed className="h-4 w-4" />
                 ) : (
-                  <HiMiniCloud className="h-5 w-5" />
+                  <HiMiniCloud className="h-4 w-4" />
                 )
               }
             />
           ))}
         </div>
-      </section>
+      </EditorialSection>
 
       {/* Mission */}
-      <section className="rounded-2xl border border-slate-100 bg-white p-6 sm:p-8 shadow-sm">
-        <SectionLabel>{ABOUT_MISSION_SECTION_TITLE}</SectionLabel>
-        <p className="mt-2 text-sm leading-relaxed text-brand-dark/75">
-          {ABOUT_MISSION_SECTION_BODY}
-        </p>
-        <p className="mt-4 text-xs text-slate-400">{ABOUT_OPEN_SOURCE_NOTE}</p>
-      </section>
+      <EditorialSection>
+        <div className="rounded-2xl border border-slate-100 bg-white p-6 sm:p-8 shadow-sm">
+          <SectionLabel>{ABOUT_MISSION_SECTION_TITLE}</SectionLabel>
+          <p className="mt-2 text-sm leading-relaxed text-brand-dark/75">
+            {ABOUT_MISSION_SECTION_BODY}
+          </p>
+          <p className="mt-4 text-xs text-slate-400">{ABOUT_OPEN_SOURCE_NOTE}</p>
+        </div>
+      </EditorialSection>
 
-      {/* Choose-your-path grid */}
-      <section className="space-y-4">
-        <div>
+      {/* Choose-your-path timeline */}
+      <EditorialSection threshold={0.15}>
+        <div className="mb-8">
           <SectionLabel>Choose your path</SectionLabel>
           <p className="mt-1 text-sm leading-relaxed text-slate-500">
             There are many ways to participate in the Guard ecosystem.
           </p>
         </div>
-        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {ABOUT_PATH_CARDS.map((card, i) => (
-            <PathCard
-              key={i}
-              title={card.title}
-              desc={card.description}
-              ctaLabel={card.ctaLabel}
-              ctaHref={card.ctaHref}
-            />
-          ))}
+        <div className="relative">
+          <div className="absolute left-[19px] top-0 bottom-0 w-[2px] bg-slate-100 sm:left-[23px]" />
+          <div className="space-y-10">
+            {ABOUT_PATH_CARDS.map((card, i) => (
+              <PathStep
+                key={card.title}
+                index={i}
+                title={card.title}
+                desc={card.description}
+                ctaLabel={card.ctaLabel}
+                ctaHref={card.ctaHref}
+              />
+            ))}
+          </div>
         </div>
-      </section>
+      </EditorialSection>
 
       {/* Partner program */}
-      <section className="rounded-2xl border border-slate-100 bg-white p-6 sm:p-8 shadow-sm">
-        <SectionLabel>{ABOUT_PARTNER_SECTION_TITLE}</SectionLabel>
-        <p className="mt-2 mb-6 text-sm leading-relaxed text-brand-dark/75">
-          {ABOUT_PARTNER_SECTION_BODY}
-        </p>
-        <div className="grid gap-4 sm:grid-cols-3">
-          {ABOUT_PARTNER_LEVELS.map((level, i) => (
-            <div key={i} className="rounded-xl border border-slate-100 bg-slate-50/60 p-4">
-              <h3 className="mb-1 text-sm font-semibold text-brand-dark">{level.name}</h3>
-              <p className="text-xs leading-relaxed text-slate-500">{level.description}</p>
-            </div>
-          ))}
+      <EditorialSection>
+        <div className="rounded-2xl border border-slate-100 bg-white p-6 sm:p-8 shadow-sm">
+          <SectionLabel>{ABOUT_PARTNER_SECTION_TITLE}</SectionLabel>
+          <p className="mt-2 text-sm leading-relaxed text-brand-dark/75">
+            {ABOUT_PARTNER_SECTION_BODY}
+          </p>
+          <div className="mt-6">
+            {ABOUT_PARTNER_LEVELS.map((level, i) => (
+              <PartnerLevelRow key={level.name} level={level} index={i} />
+            ))}
+          </div>
+          <div className="mt-6 pt-4 border-t border-slate-100">
+            <AboutExternalLink
+              href={ABOUT_PARTNER_CTA_HREF}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-blue/90"
+            >
+              {ABOUT_PARTNER_CTA}
+              <HiMiniArrowTopRightOnSquare className="h-4 w-4" aria-hidden="true" />
+            </AboutExternalLink>
+          </div>
         </div>
-        <div className="mt-6">
-          <AboutExternalLink
-            href={ABOUT_PARTNER_CTA_HREF}
-            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-blue/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 focus-visible:ring-offset-2"
-          >
-            {ABOUT_PARTNER_CTA}
-            <HiMiniArrowTopRightOnSquare className="h-4 w-4" aria-hidden="true" />
-          </AboutExternalLink>
-        </div>
-      </section>
+      </EditorialSection>
 
       {/* Affiliate starter kit */}
-      <section className="rounded-2xl border border-slate-100 bg-white p-6 sm:p-8 shadow-sm">
-        <SectionLabel>{ABOUT_AFFILIATE_SECTION_TITLE}</SectionLabel>
-        <p className="mt-2 mb-4 text-sm leading-relaxed text-brand-dark/75">
-          {ABOUT_AFFILIATE_SECTION_BODY}
-        </p>
-        <div className="mb-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <div className="rounded-xl border border-slate-100 bg-slate-50/60 p-4">
-            <p className="text-xs text-slate-400">Commission</p>
-            <p className="text-lg font-bold text-brand-dark">{ABOUT_AFFILIATE_TERMS.commissionRate}</p>
+      <EditorialSection>
+        <div className="rounded-2xl border border-slate-100 bg-white p-6 sm:p-8 shadow-sm">
+          <SectionLabel>{ABOUT_AFFILIATE_SECTION_TITLE}</SectionLabel>
+          <p className="mt-2 mb-6 text-sm leading-relaxed text-brand-dark/75">
+            {ABOUT_AFFILIATE_SECTION_BODY}
+          </p>
+          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-6">
+            {[
+              { label: "Commission", value: ABOUT_AFFILIATE_TERMS.commissionRate },
+              { label: "Duration", value: ABOUT_AFFILIATE_TERMS.commissionDuration },
+              { label: "Cookie window", value: ABOUT_AFFILIATE_TERMS.cookieWindow },
+              {
+                label: "Qualification",
+                value: ABOUT_AFFILIATE_TERMS.qualificationNote,
+              },
+            ].map((metric) => (
+              <div key={metric.label} className="border-t border-slate-100 pt-4">
+                <p className="text-xs text-slate-400 mb-1">{metric.label}</p>
+                <p className="text-lg font-bold text-brand-dark">{metric.value}</p>
+              </div>
+            ))}
           </div>
-          <div className="rounded-xl border border-slate-100 bg-slate-50/60 p-4">
-            <p className="text-xs text-slate-400">Duration</p>
-            <p className="text-lg font-bold text-brand-dark">{ABOUT_AFFILIATE_TERMS.commissionDuration}</p>
-          </div>
-          <div className="rounded-xl border border-slate-100 bg-slate-50/60 p-4">
-            <p className="text-xs text-slate-400">Cookie window</p>
-            <p className="text-lg font-bold text-brand-dark">{ABOUT_AFFILIATE_TERMS.cookieWindow}</p>
-          </div>
-          <div className="rounded-xl border border-slate-100 bg-slate-50/60 p-4">
-            <p className="text-xs text-slate-400">Qualification</p>
-            <p className="text-sm font-semibold text-brand-dark">{ABOUT_AFFILIATE_TERMS.qualificationNote}</p>
+          <div className="flex flex-wrap items-center gap-3 pt-4 border-t border-slate-100">
+            <AboutExternalLink
+              href={ABOUT_AFFILIATE_CTA_HREF}
+              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 hover:border-slate-300"
+            >
+              {ABOUT_AFFILIATE_CTA}
+              <HiMiniArrowTopRightOnSquare className="h-4 w-4" aria-hidden="true" />
+            </AboutExternalLink>
+            <p className="text-xs text-slate-400">{ABOUT_AFFILIATE_DISCLOSURE}</p>
           </div>
         </div>
-        <div className="flex flex-wrap items-center gap-3">
-          <AboutExternalLink
-            href={ABOUT_AFFILIATE_CTA_HREF}
-            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 hover:border-slate-300 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 focus-visible:ring-offset-2"
-          >
-            {ABOUT_AFFILIATE_CTA}
-            <HiMiniArrowTopRightOnSquare className="h-4 w-4" aria-hidden="true" />
-          </AboutExternalLink>
-          <p className="text-xs text-slate-400">{ABOUT_AFFILIATE_DISCLOSURE}</p>
-        </div>
-      </section>
+      </EditorialSection>
 
       {/* Trust footer */}
-      <footer className="rounded-2xl border border-slate-100 bg-white p-6 sm:p-8 shadow-sm">
-        <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <div className="flex items-center gap-2">
-            <HiMiniInformationCircle className="h-5 w-5 text-brand-blue" aria-hidden="true" />
-            <span className="text-sm font-semibold text-brand-dark">
-              HOL Guard
-            </span>
-            <Badge tone="success">Local-first</Badge>
+      <EditorialSection>
+        <footer className="rounded-2xl border border-slate-100 bg-white p-6 sm:p-8 shadow-sm">
+          <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex items-center gap-2">
+              <HiMiniCheckBadge className="h-5 w-5 text-brand-blue" aria-hidden="true" />
+              <span className="text-sm font-semibold text-brand-dark">HOL Guard</span>
+              <Badge tone="success">Local-first</Badge>
+            </div>
+            <p className="text-xs text-slate-400">
+              Built by Hashgraph Online. Open standards for the agent internet.
+            </p>
           </div>
-          <p className="text-xs text-slate-400">
-            Built by Hashgraph Online. Open standards for the agent internet.
-          </p>
-        </div>
-      </footer>
+        </footer>
+      </EditorialSection>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Fix broken external links: hol.org/guard/cloud → GitHub repo, hol.org/partners → mailto:partners@hol.org
- Replace "earn" with "score" per AGENTS.md copy guidelines
- Redesign about-workspace.tsx with editorial layout: horizontal rows, numbered timeline, intersection observer animations
- Add mailto: protocol support to about-external-links.ts
- Update about-content.test.ts to allow mailto: URLs for partner CTA

## Testing
- `pnpm run build` — 125 modules, no errors
- `tsx src/about/about-content.test.ts` — all assertions passed
- `tsx src/about/about-external-links.test.ts` — all assertions passed
- `tsx src/app-routing.test.ts` — all assertions passed

## Notes
- Removes card-heavy grid layout in favor of editorial rows and timeline
- IntersectionObserver animations respect prefers-reduced-motion via CSS
