### PR TITLE
fix(cursor): complete native shell approval memory after PR #669

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -103,11 +103,11 @@ def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, obje
 def _validated_hol_guard_src_path(path_str: str) -> str | None:
     """Accept only directories that look like a hol-guard source tree."""
 
-    if not path_str.strip():
-        return None
     try:
+        if not isinstance(path_str, str) or not path_str.strip():
+            return None
         candidate = Path(path_str.strip()).expanduser().resolve()
-    except OSError:
+    except (OSError, RuntimeError, ValueError, TypeError):
         return None
     if not candidate.is_dir():
         return None
@@ -519,11 +519,11 @@ def _hook_process_env() -> dict[str, str]:
 
 
 def _validated_hol_guard_src_path(path_str: str) -> str | None:
-    if not path_str.strip():
-        return None
     try:
+        if not isinstance(path_str, str) or not path_str.strip():
+            return None
         candidate = Path(path_str.strip()).expanduser().resolve()
-    except OSError:
+    except (OSError, RuntimeError, ValueError, TypeError):
         return None
     if not candidate.is_dir():
         return None

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -100,6 +100,38 @@ def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, obje
     return normalized
 
 
+def _validated_hol_guard_src_path(path_str: str) -> str | None:
+    """Accept only directories that look like a hol-guard source tree."""
+
+    if not path_str.strip():
+        return None
+    try:
+        candidate = Path(path_str.strip()).expanduser().resolve()
+    except OSError:
+        return None
+    if not candidate.is_dir():
+        return None
+    if not (candidate / "codex_plugin_scanner").is_dir():
+        return None
+    return str(candidate)
+
+
+def cursor_hook_would_prompt_user(
+    *,
+    policy_action: str,
+    guard_payload: Mapping[str, object] | None = None,
+) -> bool:
+    """Return True when Guard maps this hook result to Cursor permission ask."""
+
+    if policy_action in {"require-reapproval", "review"}:
+        return True
+    return (
+        policy_action == "warn"
+        and guard_payload is not None
+        and _guard_payload_has_actionable_risk_for_policy(guard_payload)
+    )
+
+
 def cursor_hook_response_from_guard(
     *,
     policy_action: str,
@@ -442,6 +474,7 @@ _INHERIT_ENV_KEYS = (
     "CURSOR_TRACE_ID",
     "CURSOR_SESSION_ID",
     "CURSOR_TRANSCRIPT_PATH",
+    "HOL_GUARD_SRC",
 )
 
 _HOOK_SCRIPT_TEMPLATE = '''#!/usr/bin/env python3
@@ -468,7 +501,35 @@ def _hook_process_env() -> dict[str, str]:
         value = os.environ.get(key)
         if isinstance(value, str) and value:
             env[key] = value
+    dev_src = os.environ.get("HOL_GUARD_SRC")
+    validated = _validated_hol_guard_src_path(dev_src) if isinstance(dev_src, str) else None
+    if validated is not None:
+        env["PYTHONPATH"] = validated
+    else:
+        dev_src_file = Path(GUARD_HOME) / "cursor-dev-src"
+        if dev_src_file.is_file():
+            try:
+                configured_src = dev_src_file.read_text(encoding="utf-8").strip()
+            except OSError:
+                configured_src = ""
+            validated = _validated_hol_guard_src_path(configured_src)
+            if validated is not None:
+                env["PYTHONPATH"] = validated
     return env
+
+
+def _validated_hol_guard_src_path(path_str: str) -> str | None:
+    if not path_str.strip():
+        return None
+    try:
+        candidate = Path(path_str.strip()).expanduser().resolve()
+    except OSError:
+        return None
+    if not candidate.is_dir():
+        return None
+    if not (candidate / "codex_plugin_scanner").is_dir():
+        return None
+    return str(candidate)
 
 
 def _workspace_from_cursor_input(payload: dict[str, object]) -> str | None:
@@ -810,6 +871,8 @@ def _is_managed_hook_command(command: object) -> bool:
     if not isinstance(command, str):
         return False
     lowered = command.lower()
+    if "hol-guard-cursor-hook" in lowered:
+        return True
     if HOOK_SCRIPT_NAME.lower() in lowered:
         return True
     if "hol_guard_hook_argv" not in lowered.replace("-", "_"):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3285,6 +3285,28 @@ def run_guard_command(
             artifact_id = runtime_artifact.artifact_id
             artifact_name = runtime_artifact.name
             policy_harness = _canonical_harness_name(args.harness)
+            if (
+                policy_harness == "cursor"
+                and event_name == "PreToolUse"
+                and runtime_artifact.artifact_type == "tool_action_request"
+                and _cursor_native_shell_is_approved(store, payload)
+            ):
+                response_payload = {
+                    "recorded": True,
+                    "harness": policy_harness,
+                    "artifact_id": artifact_id,
+                    "artifact_name": artifact_name,
+                    "artifact_type": runtime_artifact.artifact_type,
+                    "policy_action": "allow",
+                }
+                _emit("hook", response_payload, getattr(args, "json", False))
+                _record_harness_usage_for_hook(
+                    store=store,
+                    action_envelope=action_envelope,
+                    payload=payload,
+                    policy_action="allow",
+                )
+                return 0
             stored_policy_action = _runtime_stored_policy_action(
                 store=store,
                 harness=policy_harness,
@@ -3501,6 +3523,25 @@ def run_guard_command(
             }
             if package_evaluation is not None:
                 response_payload["supply_chain_evaluation"] = package_evaluation.to_dict()
+            if (
+                _canonical_harness_name(args.harness) == "cursor"
+                and event_name == "PreToolUse"
+                and runtime_artifact.artifact_type == "tool_action_request"
+            ):
+                from ..adapters.cursor_hooks import cursor_hook_would_prompt_user
+
+                if cursor_hook_would_prompt_user(
+                    policy_action=policy_action,
+                    guard_payload=response_payload,
+                ):
+                    native_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
+                    _record_cursor_pending_shell_permission(
+                        store=store,
+                        payload=payload,
+                        reason=native_reason,
+                        artifact=runtime_artifact,
+                        artifact_hash=runtime_artifact_hash,
+                    )
             if policy_action in {"block", "sandbox-required", "require-reapproval"}:
                 native_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
                 additional_context = _claude_prompt_additional_context(
@@ -3516,18 +3557,6 @@ def run_guard_command(
                     and policy_action == "require-reapproval"
                 ):
                     _record_claude_permission_notice(
-                        store=store,
-                        payload=payload,
-                        reason=native_reason,
-                        artifact=runtime_artifact,
-                        artifact_hash=runtime_artifact_hash,
-                    )
-                if (
-                    _canonical_harness_name(args.harness) == "cursor"
-                    and event_name == "PreToolUse"
-                    and policy_action == "require-reapproval"
-                ):
-                    _record_cursor_pending_shell_permission(
                         store=store,
                         payload=payload,
                         reason=native_reason,
@@ -3685,13 +3714,19 @@ def run_guard_command(
                     if (
                         _canonical_harness_name(args.harness) == "cursor"
                         and event_name == "PreToolUse"
-                        and policy_action == "require-reapproval"
+                        and runtime_artifact.artifact_type == "tool_action_request"
                     ):
-                        _attach_cursor_pending_approval_request_ids(
-                            store=store,
-                            payload=payload,
-                            response_payload=response_payload,
-                        )
+                        from ..adapters.cursor_hooks import cursor_hook_would_prompt_user
+
+                        if cursor_hook_would_prompt_user(
+                            policy_action=policy_action,
+                            guard_payload=response_payload,
+                        ):
+                            _attach_cursor_pending_approval_request_ids(
+                                store=store,
+                                payload=payload,
+                                response_payload=response_payload,
+                            )
                     response_payload["approval_center_url"] = approval_center_url
                     response_payload["review_hint"] = approval_center_hint(
                         context=context,
@@ -4629,6 +4664,79 @@ def _append_cursor_pending_shell_key(
         return
 
 
+def _cursor_native_shell_allow_state_key(conversation_id: str, command: str) -> str:
+    return f"cursor_native_shell_allow:{conversation_id}:{_cursor_shell_command_fingerprint(command)}"
+
+
+_CURSOR_PENDING_SHELL_MAX_AGE_SECONDS = 30 * 60
+
+
+def _cursor_pending_shell_is_fresh(pending: Mapping[str, object], *, now: str) -> bool:
+    saved_at = _optional_string(pending.get("saved_at"))
+    if saved_at is None:
+        return False
+    try:
+        saved_time = datetime.fromisoformat(saved_at.replace("Z", "+00:00"))
+        current_time = datetime.fromisoformat(now.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    if saved_time.tzinfo is None:
+        saved_time = saved_time.replace(tzinfo=timezone.utc)
+    if current_time.tzinfo is None:
+        current_time = current_time.replace(tzinfo=timezone.utc)
+    age_seconds = (current_time - saved_time).total_seconds()
+    return 0 <= age_seconds <= _CURSOR_PENDING_SHELL_MAX_AGE_SECONDS
+
+
+def _cursor_after_shell_observed(payload: Mapping[str, object]) -> bool:
+    duration = payload.get("duration")
+    if isinstance(duration, (int, float)):
+        return duration >= 0
+    output = payload.get("output")
+    return isinstance(output, str)
+
+
+def _record_cursor_native_shell_allow_state(
+    *,
+    store: GuardStore,
+    conversation_id: str,
+    command: str,
+    artifact: GuardArtifact,
+    artifact_hash: str,
+    now: str,
+) -> bool:
+    allow_payload: dict[str, object] = {
+        "saved_at": now,
+        "action": "allow",
+        "artifact_id": artifact.artifact_id,
+        "artifact_hash": artifact_hash,
+        "artifact_name": artifact.name,
+        "command": command,
+        "native_source": "cursor-native",
+    }
+    try:
+        store.set_sync_payload(
+            _cursor_native_shell_allow_state_key(conversation_id, command),
+            allow_payload,
+            now,
+        )
+    except (OSError, sqlite3.Error):
+        return False
+    return True
+
+
+def _cursor_native_shell_is_approved(store: GuardStore, payload: Mapping[str, object]) -> bool:
+    conversation_id = _cursor_conversation_id(dict(payload))
+    command = _cursor_shell_command_from_payload(payload)
+    if conversation_id is None or command is None:
+        return False
+    try:
+        approved = store.get_sync_payload(_cursor_native_shell_allow_state_key(conversation_id, command))
+    except (OSError, sqlite3.Error):
+        return False
+    return isinstance(approved, dict) and approved.get("action") == "allow"
+
+
 def _record_cursor_pending_shell_permission(
     *,
     store: GuardStore,
@@ -4834,6 +4942,11 @@ def _persist_cursor_native_permission_after_shell(
     )
     if pending is None:
         return False
+    now = _now()
+    if not _cursor_after_shell_observed(prepared):
+        return False
+    if not _cursor_pending_shell_is_fresh(pending, now=now):
+        return False
     action_envelope = _hook_action_envelope(
         harness=harness,
         payload=prepared,
@@ -4851,7 +4964,6 @@ def _persist_cursor_native_permission_after_shell(
     if runtime_artifact is None:
         return False
     runtime_artifact_hash = artifact_hash(runtime_artifact)
-    now = _now()
     saved_policy = _persist_cursor_native_permission_policy(
         store=store,
         artifact_id=runtime_artifact.artifact_id,
@@ -4860,19 +4972,30 @@ def _persist_cursor_native_permission_after_shell(
         reason="Approved in Cursor native shell approval prompt.",
         now=now,
     )
+    session_saved = saved_policy
     if not saved_policy:
-        return False
-    try:
-        store.record_inventory_artifact(
+        session_saved = _record_cursor_native_shell_allow_state(
+            store=store,
+            conversation_id=conversation_id,
+            command=command,
             artifact=runtime_artifact,
             artifact_hash=runtime_artifact_hash,
-            policy_action="allow",
-            changed=False,
             now=now,
-            approved=True,
         )
-    except (OSError, sqlite3.Error):
+    if not session_saved:
         return False
+    if saved_policy:
+        try:
+            store.record_inventory_artifact(
+                artifact=runtime_artifact,
+                artifact_hash=runtime_artifact_hash,
+                policy_action="allow",
+                changed=False,
+                now=now,
+                approved=True,
+            )
+        except (OSError, sqlite3.Error):
+            return False
     _resolve_cursor_pending_approval_requests(
         store=store,
         pending=pending,
@@ -4890,7 +5013,7 @@ def _persist_cursor_native_permission_after_shell(
         artifact_name=runtime_artifact.name,
         source_scope=runtime_artifact.source_scope,
         user_override="cursor-native-approve",
-        approval_source="inline",
+        approval_source="inline" if saved_policy else "harness-native-session",
     )
     try:
         store.add_receipt(receipt)

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4690,7 +4690,7 @@ def _cursor_pending_shell_is_fresh(pending: Mapping[str, object], *, now: str) -
 
 def _cursor_after_shell_observed(payload: Mapping[str, object]) -> bool:
     duration = payload.get("duration")
-    if isinstance(duration, (int, float)):
+    if isinstance(duration, (int, float)) and not isinstance(duration, bool):
         return duration >= 0
     output = payload.get("output")
     return isinstance(output, str)
@@ -4734,7 +4734,14 @@ def _cursor_native_shell_is_approved(store: GuardStore, payload: Mapping[str, ob
         approved = store.get_sync_payload(_cursor_native_shell_allow_state_key(conversation_id, command))
     except (OSError, sqlite3.Error):
         return False
-    return isinstance(approved, dict) and approved.get("action") == "allow"
+    if not isinstance(approved, dict) or approved.get("action") != "allow":
+        return False
+    now = _now()
+    if not _cursor_pending_shell_is_fresh(approved, now=now):
+        with suppress(OSError, sqlite3.Error):
+            store.delete_sync_payload(_cursor_native_shell_allow_state_key(conversation_id, command))
+        return False
+    return True
 
 
 def _record_cursor_pending_shell_permission(

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -370,7 +370,10 @@ def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> No
     )
 
 
-def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path: Path) -> None:
+def test_cursor_native_shell_session_allow_survives_approval_gate_block(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
     from codex_plugin_scanner.guard.models import GuardArtifact
@@ -407,39 +410,86 @@ def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path
         del kwargs
         return False
 
-    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(guard_commands_module, "_persist_cursor_native_permission_policy", _blocked_policy)
-    try:
-        saved = guard_commands_module._persist_cursor_native_permission_after_shell(
-            store=store,
-            payload=prepare_cursor_hook_payload(
-                {
-                    "conversation_id": conversation_id,
-                    "hook_event_name": "afterShellExecution",
-                    "command": command,
-                    "cwd": str(workspace_dir),
-                    "duration": 12,
-                }
-            ),
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+                "duration": 12,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+    )
+    assert saved is True
+    assert guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "beforeShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+            }
+        ),
+    )
+
+
+def test_cursor_after_shell_rejects_boolean_duration(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.models import GuardArtifact
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-bool-duration"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    guard_commands_module._record_cursor_pending_shell_permission(
+        store=store,
+        payload={
+            "conversation_id": conversation_id,
+            "hook_event_name": "beforeShellExecution",
+            "command": command,
+            "cwd": str(workspace_dir),
+        },
+        reason="Requests a sensitive native tool action.",
+        artifact=GuardArtifact(
+            artifact_id="cursor:project:shell:rm",
+            name="Shell",
             harness="cursor",
-            home_dir=home_dir,
-            guard_home=home_dir,
-            workspace=workspace_dir,
-        )
-        assert saved is True
-        assert guard_commands_module._cursor_native_shell_is_approved(
-            store,
-            prepare_cursor_hook_payload(
-                {
-                    "conversation_id": conversation_id,
-                    "hook_event_name": "beforeShellExecution",
-                    "command": command,
-                    "cwd": str(workspace_dir),
-                }
-            ),
-        )
-    finally:
-        monkeypatch.undo()
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(workspace_dir / ".cursor" / "mcp.json"),
+            command=command,
+        ),
+        artifact_hash="hash-cursor-shell",
+    )
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+                "duration": True,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+    )
+    assert saved is False
 
 
 def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -199,6 +199,77 @@ def test_cursor_hook_response_from_guard_allows_shell() -> None:
     assert response["permission"] == "allow"
 
 
+def test_cursor_hook_would_prompt_user_for_warn_with_risk() -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_would_prompt_user
+
+    assert cursor_hook_would_prompt_user(
+        policy_action="warn",
+        guard_payload={"risk_signals": ["destructive shell command"]},
+    )
+    assert not cursor_hook_would_prompt_user(policy_action="allow", guard_payload={})
+    assert cursor_hook_would_prompt_user(policy_action="require-reapproval", guard_payload={})
+
+
+def test_validated_hol_guard_src_path_rejects_non_guard_trees(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import _validated_hol_guard_src_path
+
+    assert _validated_hol_guard_src_path(str(tmp_path)) is None
+    src_root = tmp_path / "src"
+    src_root.mkdir()
+    (src_root / "codex_plugin_scanner").mkdir()
+    assert _validated_hol_guard_src_path(str(src_root)) == str(src_root.resolve())
+
+
+def test_cursor_after_shell_requires_observer_fields(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.models import GuardArtifact
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-after-shell-guard"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    guard_commands_module._record_cursor_pending_shell_permission(
+        store=store,
+        payload={
+            "conversation_id": conversation_id,
+            "hook_event_name": "beforeShellExecution",
+            "command": command,
+            "cwd": str(workspace_dir),
+        },
+        reason="Requests a sensitive native tool action.",
+        artifact=GuardArtifact(
+            artifact_id="cursor:project:shell:rm",
+            name="Shell",
+            harness="cursor",
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(workspace_dir / ".cursor" / "mcp.json"),
+            command=command,
+        ),
+        artifact_hash="hash-cursor-shell",
+    )
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+    )
+    assert saved is False
+
+
 def test_cursor_hook_should_block() -> None:
     assert cursor_hook_should_block(policy_action="block") is True
     assert cursor_hook_should_block(policy_action="allow") is False
@@ -297,6 +368,78 @@ def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> No
         )
         is None
     )
+
+
+def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.models import GuardArtifact
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-session-allow"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    guard_commands_module._record_cursor_pending_shell_permission(
+        store=store,
+        payload={
+            "conversation_id": conversation_id,
+            "hook_event_name": "beforeShellExecution",
+            "command": command,
+            "cwd": str(workspace_dir),
+        },
+        reason="Requests a sensitive native tool action.",
+        artifact=GuardArtifact(
+            artifact_id="cursor:project:shell:rm",
+            name="Shell",
+            harness="cursor",
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(workspace_dir / ".cursor" / "mcp.json"),
+            command=command,
+        ),
+        artifact_hash="hash-cursor-shell",
+    )
+
+    def _blocked_policy(**kwargs: object) -> bool:
+        del kwargs
+        return False
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(guard_commands_module, "_persist_cursor_native_permission_policy", _blocked_policy)
+    try:
+        saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+            store=store,
+            payload=prepare_cursor_hook_payload(
+                {
+                    "conversation_id": conversation_id,
+                    "hook_event_name": "afterShellExecution",
+                    "command": command,
+                    "cwd": str(workspace_dir),
+                    "duration": 12,
+                }
+            ),
+            harness="cursor",
+            home_dir=home_dir,
+            guard_home=home_dir,
+            workspace=workspace_dir,
+        )
+        assert saved is True
+        assert guard_commands_module._cursor_native_shell_is_approved(
+            store,
+            prepare_cursor_hook_payload(
+                {
+                    "conversation_id": conversation_id,
+                    "hook_event_name": "beforeShellExecution",
+                    "command": command,
+                    "cwd": str(workspace_dir),
+                }
+            ),
+        )
+    finally:
+        monkeypatch.undo()
 
 
 def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Record Cursor pending shell approvals for warn-level prompts that still map to native `ask`
- Persist session-scoped allow memory when the approval gate blocks policy writes, and honor it on repeat shell requests
- Strip legacy `hol-guard-cursor-hook.sh` entries during install and validate optional dev source overrides
- Require Cursor `afterShellExecution` observer fields and fresh pending state before accepting native approvals

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_hooks.py -q`

## Notes
- Session allow is conversation+command scoped and only written after a matching pending shell approval and observed afterShell event
- Dev source overrides must resolve to a directory containing `codex_plugin_scanner`
