### PR TITLE
fix(cursor): block forged afterShell approval persistence

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -12,6 +12,7 @@ from hashlib import sha256
 from pathlib import Path
 
 from .base import HarnessContext
+from .cursor_native_approval import ensure_cursor_hook_attestation_secret
 
 HOOK_SCRIPT_NAME = "hol-guard-cursor-hook.py"
 _BLOCKING_MANAGED_HOOK_EVENTS = (
@@ -195,6 +196,7 @@ def install_cursor_hooks(context: HarnessContext) -> dict[str, object]:
     script_path.parent.mkdir(parents=True, exist_ok=True)
     script_path.write_text(script_source, encoding="utf-8")
     _make_executable(script_path)
+    ensure_cursor_hook_attestation_secret(context.guard_home)
 
     original_text = hooks_path.read_text(encoding="utf-8") if hooks_path.is_file() else None
     backup_path = _hooks_backup_path(hooks_path, context)
@@ -481,6 +483,8 @@ _HOOK_SCRIPT_TEMPLATE = '''#!/usr/bin/env python3
 """Managed by HOL Guard. Re-run `hol-guard install cursor` after moving Guard home."""
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
 import os
 import subprocess
@@ -733,6 +737,57 @@ def _emit_cursor_response(
     return response, exit_code
 
 
+def _cursor_generation_id(payload: Mapping[str, object]) -> str | None:
+    for key in ("generation_id", "generationId"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _cursor_conversation_id(payload: Mapping[str, object]) -> str | None:
+    for key in ("conversation_id", "conversationId", "session_id", "sessionId"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    session_id = os.environ.get("CURSOR_SESSION_ID")
+    if isinstance(session_id, str) and session_id.strip():
+        return session_id.strip()
+    return None
+
+
+def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:
+    command = payload.get("command")
+    if isinstance(command, str) and command.strip():
+        return command.strip()
+    tool_input = payload.get("tool_input")
+    if isinstance(tool_input, dict):
+        nested = tool_input.get("command")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+    return None
+
+
+def _load_cursor_hook_attestation_secret() -> bytes | None:
+    secret_path = Path(GUARD_HOME) / "secrets" / "cursor-hook-attestation.key"
+    try:
+        secret = secret_path.read_bytes()
+    except OSError:
+        return None
+    return secret or None
+
+
+def _compute_cursor_after_shell_proof(payload: Mapping[str, object]) -> str | None:
+    conversation_id = _cursor_conversation_id(payload)
+    command = _cursor_shell_command(payload)
+    generation_id = _cursor_generation_id(payload)
+    secret = _load_cursor_hook_attestation_secret()
+    if conversation_id is None or command is None or generation_id is None or secret is None:
+        return None
+    message = "\\0".join((conversation_id, command, generation_id, "afterShellExecution")).encode("utf-8")
+    return hmac.new(secret, message, hashlib.sha256).hexdigest()
+
+
 def main() -> int:
     raw = sys.stdin.read()
     if not raw.strip():
@@ -758,6 +813,12 @@ def main() -> int:
                 guard_argv[workspace_index + 1] = workspace
         else:
             guard_argv.extend(["--workspace", workspace])
+    guard_env = _hook_process_env()
+    guard_env["HOL_GUARD_MANAGED_CURSOR_HOOK"] = "1"
+    if hook_event_name.strip().lower() == "aftershellexecution":
+        proof = _compute_cursor_after_shell_proof(prepared)
+        if proof:
+            guard_env["HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"] = proof
     try:
         proc = subprocess.run(
             [*GUARD_CLI, *guard_argv],
@@ -765,7 +826,7 @@ def main() -> int:
             capture_output=True,
             text=True,
             cwd=GUARD_HOME,
-            env=_hook_process_env(),
+            env=guard_env,
             timeout=GUARD_HOOK_TIMEOUT_SECONDS,
         )
     except subprocess.TimeoutExpired:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -1,0 +1,158 @@
+"""Cursor native shell approval attestation for afterShell observer hooks."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import secrets
+from collections.abc import Mapping
+from pathlib import Path
+
+_CURSOR_HOOK_ATTESTATION_RELATIVE = Path("secrets") / "cursor-hook-attestation.key"
+_MANAGED_HOOK_ENV = "HOL_GUARD_MANAGED_CURSOR_HOOK"
+_AFTER_SHELL_PROOF_ENV = "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"
+
+
+def cursor_hook_attestation_secret_path(guard_home: Path) -> Path:
+    return guard_home / _CURSOR_HOOK_ATTESTATION_RELATIVE
+
+
+def ensure_cursor_hook_attestation_secret(guard_home: Path) -> bytes:
+    secret_path = cursor_hook_attestation_secret_path(guard_home)
+    secret_path.parent.mkdir(parents=True, exist_ok=True)
+    if secret_path.is_file():
+        try:
+            existing = secret_path.read_bytes()
+        except OSError:
+            existing = b""
+        if existing:
+            return existing
+    generated = secrets.token_bytes(32)
+    secret_path.write_bytes(generated)
+    with suppress_permission_error():
+        secret_path.chmod(0o600)
+    return generated
+
+
+def _optional_string(value: object) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
+def cursor_generation_id(payload: Mapping[str, object]) -> str | None:
+    for key in ("generation_id", "generationId"):
+        value = _optional_string(payload.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def compute_cursor_after_shell_proof(
+    *,
+    secret: bytes,
+    conversation_id: str,
+    command: str,
+    generation_id: str,
+) -> str:
+    message = "\0".join(
+        (
+            conversation_id.strip(),
+            command.strip(),
+            generation_id.strip(),
+            "afterShellExecution",
+        )
+    ).encode("utf-8")
+    digest = hmac.new(secret, message, hashlib.sha256).hexdigest()
+    return digest
+
+
+def verify_cursor_after_shell_proof(
+    *,
+    secret: bytes,
+    conversation_id: str,
+    command: str,
+    generation_id: str,
+    proof: str,
+) -> bool:
+    if not proof.strip():
+        return False
+    expected = compute_cursor_after_shell_proof(
+        secret=secret,
+        conversation_id=conversation_id,
+        command=command,
+        generation_id=generation_id,
+    )
+    return hmac.compare_digest(expected, proof.strip())
+
+
+def managed_cursor_hook_invocation(env: Mapping[str, str] | None = None) -> bool:
+    source = os.environ if env is None else env
+    return source.get(_MANAGED_HOOK_ENV) == "1"
+
+
+def after_shell_proof_from_env(env: Mapping[str, str] | None = None) -> str | None:
+    source = os.environ if env is None else env
+    return _optional_string(source.get(_AFTER_SHELL_PROOF_ENV))
+
+
+def cursor_after_shell_trusted(
+    *,
+    guard_home: Path,
+    pending: Mapping[str, object],
+    payload: Mapping[str, object],
+    conversation_id: str,
+    command: str,
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    from ..runtime.harness_attribution import cursor_runtime_detected
+
+    if not managed_cursor_hook_invocation(env):
+        return False
+    if not cursor_runtime_detected(env):
+        return False
+    pending_generation_id = _optional_string(pending.get("generation_id"))
+    payload_generation_id = cursor_generation_id(payload)
+    if pending_generation_id is None or payload_generation_id is None:
+        return False
+    if pending_generation_id != payload_generation_id:
+        return False
+    proof = after_shell_proof_from_env(env)
+    if proof is None:
+        return False
+    expected_proof = pending.get("after_shell_proof")
+    if not isinstance(expected_proof, str) or not expected_proof.strip():
+        return False
+    if not hmac.compare_digest(expected_proof.strip(), proof.strip()):
+        return False
+    try:
+        secret = ensure_cursor_hook_attestation_secret(guard_home)
+    except OSError:
+        return False
+    return verify_cursor_after_shell_proof(
+        secret=secret,
+        conversation_id=conversation_id,
+        command=command,
+        generation_id=payload_generation_id,
+        proof=proof,
+    )
+
+
+def suppress_permission_error() -> object:
+    from contextlib import suppress
+
+    return suppress(OSError)
+
+
+__all__ = [
+    "after_shell_proof_from_env",
+    "compute_cursor_after_shell_proof",
+    "cursor_after_shell_trusted",
+    "cursor_generation_id",
+    "cursor_hook_attestation_secret_path",
+    "ensure_cursor_hook_attestation_secret",
+    "managed_cursor_hook_invocation",
+    "verify_cursor_after_shell_proof",
+]

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -7,6 +7,7 @@ import hmac
 import os
 import secrets
 from collections.abc import Mapping
+from contextlib import suppress
 from pathlib import Path
 
 _CURSOR_HOOK_ATTESTATION_RELATIVE = Path("secrets") / "cursor-hook-attestation.key"
@@ -16,6 +17,24 @@ _AFTER_SHELL_PROOF_ENV = "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"
 
 def cursor_hook_attestation_secret_path(guard_home: Path) -> Path:
     return guard_home / _CURSOR_HOOK_ATTESTATION_RELATIVE
+
+
+def _write_attestation_secret(secret_path: Path, generated: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL
+    try:
+        fd = os.open(secret_path, flags, 0o600)
+    except OSError:
+        secret_path.write_bytes(generated)
+        with suppress(OSError):
+            secret_path.chmod(0o600)
+        return
+    try:
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(generated)
+    except OSError:
+        with suppress(OSError):
+            secret_path.unlink(missing_ok=True)
+        raise
 
 
 def ensure_cursor_hook_attestation_secret(guard_home: Path) -> bytes:
@@ -29,9 +48,7 @@ def ensure_cursor_hook_attestation_secret(guard_home: Path) -> bytes:
         if existing:
             return existing
     generated = secrets.token_bytes(32)
-    secret_path.write_bytes(generated)
-    with suppress_permission_error():
-        secret_path.chmod(0o600)
+    _write_attestation_secret(secret_path, generated)
     return generated
 
 
@@ -138,12 +155,6 @@ def cursor_after_shell_trusted(
         generation_id=payload_generation_id,
         proof=proof,
     )
-
-
-def suppress_permission_error() -> object:
-    from contextlib import suppress
-
-    return suppress(OSError)
 
 
 __all__ = [

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2864,13 +2864,14 @@ def run_guard_command(
                 home_dir=context.home_dir,
                 guard_home=context.guard_home,
                 workspace=runtime_workspace,
+                hook_env=os.environ,
             )
             _emit(
                 "hook",
                 {
                     "recorded": saved,
                     "harness": "cursor",
-                    "policy_action": "allow",
+                    "session_approved": saved,
                 },
                 getattr(args, "json", False),
             )
@@ -3537,6 +3538,7 @@ def run_guard_command(
                     native_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
                     _record_cursor_pending_shell_permission(
                         store=store,
+                        guard_home=context.guard_home,
                         payload=payload,
                         reason=native_reason,
                         artifact=runtime_artifact,
@@ -4747,16 +4749,34 @@ def _cursor_native_shell_is_approved(store: GuardStore, payload: Mapping[str, ob
 def _record_cursor_pending_shell_permission(
     *,
     store: GuardStore,
+    guard_home: Path,
     payload: dict[str, object],
     reason: str,
     artifact: GuardArtifact,
     artifact_hash: str,
 ) -> None:
+    from ..adapters.cursor_native_approval import (
+        compute_cursor_after_shell_proof,
+        cursor_generation_id,
+        ensure_cursor_hook_attestation_secret,
+    )
+
     conversation_id = _cursor_conversation_id(payload)
     command = _cursor_shell_command_from_payload(payload)
-    if conversation_id is None or command is None:
+    generation_id = cursor_generation_id(payload)
+    if conversation_id is None or command is None or generation_id is None:
         return
     saved_at = _now()
+    try:
+        secret = ensure_cursor_hook_attestation_secret(guard_home)
+        after_shell_proof = compute_cursor_after_shell_proof(
+            secret=secret,
+            conversation_id=conversation_id,
+            command=command,
+            generation_id=generation_id,
+        )
+    except OSError:
+        return
     notice_payload: dict[str, object] = {
         "saved_at": saved_at,
         "reason": reason,
@@ -4767,6 +4787,9 @@ def _record_cursor_pending_shell_permission(
         "config_path": artifact.config_path,
         "source_scope": artifact.source_scope,
         "command": command,
+        "conversation_id": conversation_id,
+        "generation_id": generation_id,
+        "after_shell_proof": after_shell_proof,
         "native_source": "cursor-native",
     }
     pending_key = _cursor_pending_shell_state_key(conversation_id, command)
@@ -4936,7 +4959,10 @@ def _persist_cursor_native_permission_after_shell(
     home_dir: Path,
     guard_home: Path,
     workspace: Path | None,
+    hook_env: Mapping[str, str] | None = None,
 ) -> bool:
+    from ..adapters.cursor_native_approval import cursor_after_shell_trusted
+
     prepared = payload
     conversation_id = _cursor_conversation_id(prepared)
     command = _cursor_shell_command_from_payload(prepared)
@@ -4953,6 +4979,15 @@ def _persist_cursor_native_permission_after_shell(
     if not _cursor_after_shell_observed(prepared):
         return False
     if not _cursor_pending_shell_is_fresh(pending, now=now):
+        return False
+    if not cursor_after_shell_trusted(
+        guard_home=guard_home,
+        pending=pending,
+        payload=prepared,
+        conversation_id=conversation_id,
+        command=command,
+        env=hook_env,
+    ):
         return False
     action_envelope = _hook_action_envelope(
         harness=harness,
@@ -4971,38 +5006,16 @@ def _persist_cursor_native_permission_after_shell(
     if runtime_artifact is None:
         return False
     runtime_artifact_hash = artifact_hash(runtime_artifact)
-    saved_policy = _persist_cursor_native_permission_policy(
+    session_saved = _record_cursor_native_shell_allow_state(
         store=store,
-        artifact_id=runtime_artifact.artifact_id,
+        conversation_id=conversation_id,
+        command=command,
+        artifact=runtime_artifact,
         artifact_hash=runtime_artifact_hash,
-        action="allow",
-        reason="Approved in Cursor native shell approval prompt.",
         now=now,
     )
-    session_saved = saved_policy
-    if not saved_policy:
-        session_saved = _record_cursor_native_shell_allow_state(
-            store=store,
-            conversation_id=conversation_id,
-            command=command,
-            artifact=runtime_artifact,
-            artifact_hash=runtime_artifact_hash,
-            now=now,
-        )
     if not session_saved:
         return False
-    if saved_policy:
-        try:
-            store.record_inventory_artifact(
-                artifact=runtime_artifact,
-                artifact_hash=runtime_artifact_hash,
-                policy_action="allow",
-                changed=False,
-                now=now,
-                approved=True,
-            )
-        except (OSError, sqlite3.Error):
-            return False
     _resolve_cursor_pending_approval_requests(
         store=store,
         pending=pending,
@@ -5015,12 +5028,12 @@ def _persist_cursor_native_permission_after_shell(
         artifact_hash=runtime_artifact_hash,
         policy_decision="allow",
         capabilities_summary=_runtime_capabilities_summary(runtime_artifact),
-        changed_capabilities=[runtime_artifact.artifact_type, "cursor-native-approved"],
-        provenance_summary=f"runtime shell command approved from {runtime_artifact.config_path}",
+        changed_capabilities=[runtime_artifact.artifact_type, "cursor-native-session-approved"],
+        provenance_summary=f"runtime shell command session-approved from {runtime_artifact.config_path}",
         artifact_name=runtime_artifact.name,
         source_scope=runtime_artifact.source_scope,
         user_override="cursor-native-approve",
-        approval_source="inline" if saved_policy else "harness-native-session",
+        approval_source="harness-native-session",
     )
     try:
         store.add_receipt(receipt)

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -18,6 +18,74 @@ from codex_plugin_scanner.guard.adapters.cursor_hooks import (
     prepare_cursor_hook_payload,
     uninstall_cursor_hooks,
 )
+from codex_plugin_scanner.guard.models import GuardArtifact
+
+
+def _cursor_shell_artifact(*, workspace_dir: Path, command: str) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id="cursor:project:shell:rm",
+        name="Shell",
+        harness="cursor",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace_dir / ".cursor" / "mcp.json"),
+        command=command,
+    )
+
+
+def _record_cursor_pending_for_test(
+    *,
+    store,
+    guard_home: Path,
+    guard_commands_module,
+    conversation_id: str,
+    command: str,
+    workspace_dir: Path,
+    generation_id: str = "gen-cursor-test",
+) -> None:
+    guard_commands_module._record_cursor_pending_shell_permission(
+        store=store,
+        guard_home=guard_home,
+        payload={
+            "conversation_id": conversation_id,
+            "generation_id": generation_id,
+            "hook_event_name": "beforeShellExecution",
+            "command": command,
+            "cwd": str(workspace_dir),
+        },
+        reason="Requests a sensitive native tool action.",
+        artifact=_cursor_shell_artifact(workspace_dir=workspace_dir, command=command),
+        artifact_hash="hash-cursor-shell",
+    )
+
+
+def _trusted_cursor_after_shell_env(
+    guard_home: Path,
+    *,
+    conversation_id: str,
+    command: str,
+    workspace_dir: Path,
+    generation_id: str = "gen-cursor-test",
+) -> dict[str, str]:
+    from codex_plugin_scanner.guard.adapters.cursor_native_approval import (
+        compute_cursor_after_shell_proof,
+        ensure_cursor_hook_attestation_secret,
+    )
+
+    secret = ensure_cursor_hook_attestation_secret(guard_home)
+    proof = compute_cursor_after_shell_proof(
+        secret=secret,
+        conversation_id=conversation_id,
+        command=command,
+        generation_id=generation_id,
+    )
+    return {
+        "HOL_GUARD_MANAGED_CURSOR_HOOK": "1",
+        "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF": proof,
+        "CURSOR_SESSION_ID": conversation_id,
+        "CURSOR_PROJECT_DIR": str(workspace_dir),
+        "CURSOR_VERSION": "test",
+    }
 
 
 def test_managed_hook_events_exclude_pretooluse() -> None:
@@ -223,7 +291,6 @@ def test_validated_hol_guard_src_path_rejects_non_guard_trees(tmp_path: Path) ->
 def test_cursor_after_shell_requires_observer_fields(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
-    from codex_plugin_scanner.guard.models import GuardArtifact
     from codex_plugin_scanner.guard.store import GuardStore
 
     home_dir = tmp_path / "home"
@@ -232,31 +299,22 @@ def test_cursor_after_shell_requires_observer_fields(tmp_path: Path) -> None:
     store = GuardStore(home_dir)
     conversation_id = "conv-cursor-after-shell-guard"
     command = "rm -rf ./hol-guard-cursor-native-test-marker"
-    guard_commands_module._record_cursor_pending_shell_permission(
+    generation_id = "gen-cursor-after-shell-guard"
+    _record_cursor_pending_for_test(
         store=store,
-        payload={
-            "conversation_id": conversation_id,
-            "hook_event_name": "beforeShellExecution",
-            "command": command,
-            "cwd": str(workspace_dir),
-        },
-        reason="Requests a sensitive native tool action.",
-        artifact=GuardArtifact(
-            artifact_id="cursor:project:shell:rm",
-            name="Shell",
-            harness="cursor",
-            artifact_type="tool_action_request",
-            source_scope="project",
-            config_path=str(workspace_dir / ".cursor" / "mcp.json"),
-            command=command,
-        ),
-        artifact_hash="hash-cursor-shell",
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=generation_id,
     )
     saved = guard_commands_module._persist_cursor_native_permission_after_shell(
         store=store,
         payload=prepare_cursor_hook_payload(
             {
                 "conversation_id": conversation_id,
+                "generation_id": generation_id,
                 "hook_event_name": "afterShellExecution",
                 "command": command,
                 "cwd": str(workspace_dir),
@@ -266,6 +324,13 @@ def test_cursor_after_shell_requires_observer_fields(tmp_path: Path) -> None:
         home_dir=home_dir,
         guard_home=home_dir,
         workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_shell_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=command,
+            workspace_dir=workspace_dir,
+            generation_id=generation_id,
+        ),
     )
     assert saved is False
 
@@ -283,6 +348,8 @@ def test_cursor_hook_script_source_infers_event_before_prepare(tmp_path: Path) -
     assert "inferred = _infer_cursor_hook_event_name(payload)" in source
     assert "hook_event_name = str(inferred.get(\"hook_event_name\")" in source
     assert "aftershellexecution" in source.lower()
+    assert "HOL_GUARD_MANAGED_CURSOR_HOOK" in source
+    assert "_compute_cursor_after_shell_proof" in source
 
 
 def test_install_cursor_hooks_registers_after_shell_observer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -304,12 +371,12 @@ def test_install_cursor_hooks_registers_after_shell_observer(tmp_path: Path, mon
     installed = json.loads(hooks_path.read_text(encoding="utf-8"))
     after_shell = installed["hooks"]["afterShellExecution"][-1]
     assert after_shell.get("failClosed") is not True
+    assert (guard_home / "secrets" / "cursor-hook-attestation.key").is_file()
 
 
-def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> None:
+def test_cursor_native_shell_session_allow_after_trusted_after_shell(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
-    from codex_plugin_scanner.guard.models import GuardArtifact
     from codex_plugin_scanner.guard.store import GuardStore
 
     home_dir = tmp_path / "home"
@@ -318,31 +385,22 @@ def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> No
     store = GuardStore(home_dir)
     conversation_id = "conv-cursor-native-shell"
     command = "rm -rf ./hol-guard-cursor-native-test-marker"
-    guard_commands_module._record_cursor_pending_shell_permission(
+    generation_id = "gen-cursor-native-shell"
+    _record_cursor_pending_for_test(
         store=store,
-        payload={
-            "conversation_id": conversation_id,
-            "hook_event_name": "beforeShellExecution",
-            "command": command,
-            "cwd": str(workspace_dir),
-        },
-        reason="Requests a sensitive native tool action.",
-        artifact=GuardArtifact(
-            artifact_id="cursor:project:shell:rm",
-            name="Shell",
-            harness="cursor",
-            artifact_type="tool_action_request",
-            source_scope="project",
-            config_path=str(workspace_dir / ".cursor" / "mcp.json"),
-            command=command,
-        ),
-        artifact_hash="hash-cursor-shell",
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=generation_id,
     )
     saved = guard_commands_module._persist_cursor_native_permission_after_shell(
         store=store,
         payload=prepare_cursor_hook_payload(
             {
                 "conversation_id": conversation_id,
+                "generation_id": generation_id,
                 "hook_event_name": "afterShellExecution",
                 "command": command,
                 "cwd": str(workspace_dir),
@@ -353,13 +411,29 @@ def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> No
         home_dir=home_dir,
         guard_home=home_dir,
         workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_shell_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=command,
+            workspace_dir=workspace_dir,
+            generation_id=generation_id,
+        ),
     )
     policies = store.list_policy_decisions("cursor")
 
     assert saved is True
-    assert len(policies) == 1
-    assert policies[0]["action"] == "allow"
-    assert policies[0]["source"] == "cursor-native-approval"
+    assert policies == []
+    assert guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "beforeShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+            }
+        ),
+    )
     assert (
         guard_commands_module._load_cursor_pending_shell_permission(
             store,
@@ -370,13 +444,63 @@ def test_cursor_native_shell_approval_persists_after_shell(tmp_path: Path) -> No
     )
 
 
-def test_cursor_native_shell_session_allow_survives_approval_gate_block(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_forged_after_shell_without_attestation_is_rejected(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
-    from codex_plugin_scanner.guard.models import GuardArtifact
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-forged-after-shell"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    generation_id = "gen-cursor-forged"
+    _record_cursor_pending_for_test(
+        store=store,
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=generation_id,
+    )
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "generation_id": generation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+                "duration": 15,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        hook_env={},
+    )
+    assert saved is False
+    assert not guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "beforeShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+            }
+        ),
+    )
+    assert len(store.list_policy_decisions("cursor")) == 0
+
+
+def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
     from codex_plugin_scanner.guard.store import GuardStore
 
     home_dir = tmp_path / "home"
@@ -385,37 +509,22 @@ def test_cursor_native_shell_session_allow_survives_approval_gate_block(
     store = GuardStore(home_dir)
     conversation_id = "conv-cursor-session-allow"
     command = "rm -rf ./hol-guard-cursor-native-test-marker"
-    guard_commands_module._record_cursor_pending_shell_permission(
+    generation_id = "gen-cursor-session-allow"
+    _record_cursor_pending_for_test(
         store=store,
-        payload={
-            "conversation_id": conversation_id,
-            "hook_event_name": "beforeShellExecution",
-            "command": command,
-            "cwd": str(workspace_dir),
-        },
-        reason="Requests a sensitive native tool action.",
-        artifact=GuardArtifact(
-            artifact_id="cursor:project:shell:rm",
-            name="Shell",
-            harness="cursor",
-            artifact_type="tool_action_request",
-            source_scope="project",
-            config_path=str(workspace_dir / ".cursor" / "mcp.json"),
-            command=command,
-        ),
-        artifact_hash="hash-cursor-shell",
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=generation_id,
     )
-
-    def _blocked_policy(**kwargs: object) -> bool:
-        del kwargs
-        return False
-
-    monkeypatch.setattr(guard_commands_module, "_persist_cursor_native_permission_policy", _blocked_policy)
     saved = guard_commands_module._persist_cursor_native_permission_after_shell(
         store=store,
         payload=prepare_cursor_hook_payload(
             {
                 "conversation_id": conversation_id,
+                "generation_id": generation_id,
                 "hook_event_name": "afterShellExecution",
                 "command": command,
                 "cwd": str(workspace_dir),
@@ -426,6 +535,13 @@ def test_cursor_native_shell_session_allow_survives_approval_gate_block(
         home_dir=home_dir,
         guard_home=home_dir,
         workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_shell_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=command,
+            workspace_dir=workspace_dir,
+            generation_id=generation_id,
+        ),
     )
     assert saved is True
     assert guard_commands_module._cursor_native_shell_is_approved(
@@ -444,7 +560,6 @@ def test_cursor_native_shell_session_allow_survives_approval_gate_block(
 def test_cursor_after_shell_rejects_boolean_duration(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
-    from codex_plugin_scanner.guard.models import GuardArtifact
     from codex_plugin_scanner.guard.store import GuardStore
 
     home_dir = tmp_path / "home"
@@ -453,31 +568,22 @@ def test_cursor_after_shell_rejects_boolean_duration(tmp_path: Path) -> None:
     store = GuardStore(home_dir)
     conversation_id = "conv-cursor-bool-duration"
     command = "rm -rf ./hol-guard-cursor-native-test-marker"
-    guard_commands_module._record_cursor_pending_shell_permission(
+    generation_id = "gen-cursor-bool-duration"
+    _record_cursor_pending_for_test(
         store=store,
-        payload={
-            "conversation_id": conversation_id,
-            "hook_event_name": "beforeShellExecution",
-            "command": command,
-            "cwd": str(workspace_dir),
-        },
-        reason="Requests a sensitive native tool action.",
-        artifact=GuardArtifact(
-            artifact_id="cursor:project:shell:rm",
-            name="Shell",
-            harness="cursor",
-            artifact_type="tool_action_request",
-            source_scope="project",
-            config_path=str(workspace_dir / ".cursor" / "mcp.json"),
-            command=command,
-        ),
-        artifact_hash="hash-cursor-shell",
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=generation_id,
     )
     saved = guard_commands_module._persist_cursor_native_permission_after_shell(
         store=store,
         payload=prepare_cursor_hook_payload(
             {
                 "conversation_id": conversation_id,
+                "generation_id": generation_id,
                 "hook_event_name": "afterShellExecution",
                 "command": command,
                 "cwd": str(workspace_dir),
@@ -488,6 +594,13 @@ def test_cursor_after_shell_rejects_boolean_duration(tmp_path: Path) -> None:
         home_dir=home_dir,
         guard_home=home_dir,
         workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_shell_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=command,
+            workspace_dir=workspace_dir,
+            generation_id=generation_id,
+        ),
     )
     assert saved is False
 


### PR DESCRIPTION
## Summary
- Close Codex Security finding: forged `afterShellExecution` payloads can no longer upsert artifact allow policies or session memory without managed-hook attestation.
- Bind pending shell approvals to Cursor `generation_id` and an HMAC proof generated at prompt time; only the managed hook bridge supplies the proof env var.
- Limit afterShell success to conversation-scoped session allow (30-minute TTL); persistent policy changes still require dashboard/approval-gate paths.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_hooks.py -q`

## Notes
- Run `hol-guard install cursor` after upgrade so hook scripts pick up attestation logic and the install-time secret is created.
