### PR TITLE
fix(cursor): shell approval binding when generation_id missing

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -769,8 +769,13 @@ def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:
 
 
 def _cursor_shell_binding_path(conversation_id: str, command: str) -> Path:
+    cleaned = conversation_id.strip()
+    if not cleaned or "/" in cleaned or "\\\\" in cleaned or cleaned in {".", ".."}:
+        segment = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:32] if cleaned else "missing-conversation"
+    else:
+        segment = cleaned
     fingerprint = hashlib.sha256(command.strip().encode("utf-8")).hexdigest()[:24]
-    return Path(GUARD_HOME) / "cursor-shell-bindings" / conversation_id / fingerprint
+    return Path(GUARD_HOME) / "cursor-shell-bindings" / segment / fingerprint
 
 
 def _read_cursor_shell_binding_file(conversation_id: str, command: str) -> str | None:
@@ -802,14 +807,19 @@ def _load_cursor_hook_attestation_secret() -> bytes | None:
     return secret or None
 
 
-def _compute_cursor_after_shell_proof(payload: Mapping[str, object]) -> str | None:
+def _compute_cursor_after_shell_proof(
+    payload: Mapping[str, object],
+    approval_binding: str | None = None,
+) -> str | None:
     conversation_id = _cursor_conversation_id(payload)
     command = _cursor_shell_command(payload)
-    approval_binding = _resolve_approval_binding(payload)
+    resolved_binding = approval_binding or _resolve_approval_binding(payload)
     secret = _load_cursor_hook_attestation_secret()
-    if conversation_id is None or command is None or approval_binding is None or secret is None:
+    if conversation_id is None or command is None or resolved_binding is None or secret is None:
         return None
-    message = "\\0".join((conversation_id, command, approval_binding, "afterShellExecution")).encode("utf-8")
+    message = chr(0).join(
+        (conversation_id, command, resolved_binding, "afterShellExecution")
+    ).encode("utf-8")
     return hmac.new(secret, message, hashlib.sha256).hexdigest()
 
 
@@ -842,7 +852,7 @@ def main() -> int:
     guard_env["HOL_GUARD_MANAGED_CURSOR_HOOK"] = "1"
     if hook_event_name.strip().lower() == "aftershellexecution":
         approval_binding = _resolve_approval_binding(prepared)
-        proof = _compute_cursor_after_shell_proof(prepared)
+        proof = _compute_cursor_after_shell_proof(prepared, approval_binding)
         if approval_binding:
             guard_env["HOL_GUARD_CURSOR_APPROVAL_BINDING"] = approval_binding
         if proof:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -768,6 +768,31 @@ def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:
     return None
 
 
+def _cursor_shell_binding_path(conversation_id: str, command: str) -> Path:
+    fingerprint = hashlib.sha256(command.strip().encode("utf-8")).hexdigest()[:24]
+    return Path(GUARD_HOME) / "cursor-shell-bindings" / conversation_id / fingerprint
+
+
+def _read_cursor_shell_binding_file(conversation_id: str, command: str) -> str | None:
+    binding_path = _cursor_shell_binding_path(conversation_id, command)
+    try:
+        binding = binding_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return binding or None
+
+
+def _resolve_approval_binding(payload: Mapping[str, object]) -> str | None:
+    binding = _cursor_generation_id(payload)
+    if binding is not None:
+        return binding
+    conversation_id = _cursor_conversation_id(payload)
+    command = _cursor_shell_command(payload)
+    if conversation_id is None or command is None:
+        return None
+    return _read_cursor_shell_binding_file(conversation_id, command)
+
+
 def _load_cursor_hook_attestation_secret() -> bytes | None:
     secret_path = Path(GUARD_HOME) / "secrets" / "cursor-hook-attestation.key"
     try:
@@ -780,11 +805,11 @@ def _load_cursor_hook_attestation_secret() -> bytes | None:
 def _compute_cursor_after_shell_proof(payload: Mapping[str, object]) -> str | None:
     conversation_id = _cursor_conversation_id(payload)
     command = _cursor_shell_command(payload)
-    generation_id = _cursor_generation_id(payload)
+    approval_binding = _resolve_approval_binding(payload)
     secret = _load_cursor_hook_attestation_secret()
-    if conversation_id is None or command is None or generation_id is None or secret is None:
+    if conversation_id is None or command is None or approval_binding is None or secret is None:
         return None
-    message = "\\0".join((conversation_id, command, generation_id, "afterShellExecution")).encode("utf-8")
+    message = "\\0".join((conversation_id, command, approval_binding, "afterShellExecution")).encode("utf-8")
     return hmac.new(secret, message, hashlib.sha256).hexdigest()
 
 
@@ -816,7 +841,10 @@ def main() -> int:
     guard_env = _hook_process_env()
     guard_env["HOL_GUARD_MANAGED_CURSOR_HOOK"] = "1"
     if hook_event_name.strip().lower() == "aftershellexecution":
+        approval_binding = _resolve_approval_binding(prepared)
         proof = _compute_cursor_after_shell_proof(prepared)
+        if approval_binding:
+            guard_env["HOL_GUARD_CURSOR_APPROVAL_BINDING"] = approval_binding
         if proof:
             guard_env["HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"] = proof
     try:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -11,12 +11,62 @@ from contextlib import suppress
 from pathlib import Path
 
 _CURSOR_HOOK_ATTESTATION_RELATIVE = Path("secrets") / "cursor-hook-attestation.key"
+_CURSOR_SHELL_BINDINGS_DIR = Path("cursor-shell-bindings")
 _MANAGED_HOOK_ENV = "HOL_GUARD_MANAGED_CURSOR_HOOK"
 _AFTER_SHELL_PROOF_ENV = "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"
+_APPROVAL_BINDING_ENV = "HOL_GUARD_CURSOR_APPROVAL_BINDING"
 
 
 def cursor_hook_attestation_secret_path(guard_home: Path) -> Path:
     return guard_home / _CURSOR_HOOK_ATTESTATION_RELATIVE
+
+
+def cursor_shell_binding_path(guard_home: Path, conversation_id: str, command: str) -> Path:
+    fingerprint = hashlib.sha256(command.strip().encode("utf-8")).hexdigest()[:24]
+    return guard_home / _CURSOR_SHELL_BINDINGS_DIR / conversation_id / fingerprint
+
+
+def write_cursor_shell_binding_file(
+    guard_home: Path,
+    *,
+    conversation_id: str,
+    command: str,
+    approval_binding: str,
+) -> None:
+    binding_path = cursor_shell_binding_path(guard_home, conversation_id, command)
+    binding_path.parent.mkdir(parents=True, exist_ok=True)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    try:
+        fd = os.open(binding_path, flags, 0o600)
+    except OSError:
+        binding_path.write_text(approval_binding, encoding="utf-8")
+        with suppress(OSError):
+            binding_path.chmod(0o600)
+        return
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(approval_binding)
+    except OSError:
+        with suppress(OSError):
+            binding_path.unlink(missing_ok=True)
+        raise
+
+
+def read_cursor_shell_binding_file(guard_home: Path, *, conversation_id: str, command: str) -> str | None:
+    binding_path = cursor_shell_binding_path(guard_home, conversation_id, command)
+    try:
+        binding = binding_path.read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return binding or None
+
+
+def remove_cursor_shell_binding_file(guard_home: Path, *, conversation_id: str, command: str) -> None:
+    binding_path = cursor_shell_binding_path(guard_home, conversation_id, command)
+    with suppress(OSError):
+        binding_path.unlink()
+    with suppress(OSError):
+        binding_path.parent.rmdir()
 
 
 def _write_attestation_secret(secret_path: Path, generated: bytes) -> None:
@@ -67,18 +117,37 @@ def cursor_generation_id(payload: Mapping[str, object]) -> str | None:
     return None
 
 
+def resolve_cursor_approval_binding(
+    payload: Mapping[str, object],
+    *,
+    env: Mapping[str, str] | None = None,
+) -> str | None:
+    binding = cursor_generation_id(payload)
+    if binding is not None:
+        return binding
+    source = os.environ if env is None else env
+    return _optional_string(source.get(_APPROVAL_BINDING_ENV))
+
+
+def ensure_cursor_approval_binding(payload: Mapping[str, object]) -> str:
+    binding = cursor_generation_id(payload)
+    if binding is not None:
+        return binding
+    return f"hol-guard:{secrets.token_urlsafe(24)}"
+
+
 def compute_cursor_after_shell_proof(
     *,
     secret: bytes,
     conversation_id: str,
     command: str,
-    generation_id: str,
+    approval_binding: str,
 ) -> str:
     message = "\0".join(
         (
             conversation_id.strip(),
             command.strip(),
-            generation_id.strip(),
+            approval_binding.strip(),
             "afterShellExecution",
         )
     ).encode("utf-8")
@@ -91,7 +160,7 @@ def verify_cursor_after_shell_proof(
     secret: bytes,
     conversation_id: str,
     command: str,
-    generation_id: str,
+    approval_binding: str,
     proof: str,
 ) -> bool:
     if not proof.strip():
@@ -100,7 +169,7 @@ def verify_cursor_after_shell_proof(
         secret=secret,
         conversation_id=conversation_id,
         command=command,
-        generation_id=generation_id,
+        approval_binding=approval_binding,
     )
     return hmac.compare_digest(expected, proof.strip())
 
@@ -130,11 +199,13 @@ def cursor_after_shell_trusted(
         return False
     if not cursor_runtime_detected(env):
         return False
-    pending_generation_id = _optional_string(pending.get("generation_id"))
-    payload_generation_id = cursor_generation_id(payload)
-    if pending_generation_id is None or payload_generation_id is None:
+    pending_binding = _optional_string(pending.get("approval_binding")) or _optional_string(
+        pending.get("generation_id")
+    )
+    payload_binding = resolve_cursor_approval_binding(payload, env=env)
+    if pending_binding is None or payload_binding is None:
         return False
-    if pending_generation_id != payload_generation_id:
+    if pending_binding != payload_binding:
         return False
     proof = after_shell_proof_from_env(env)
     if proof is None:
@@ -152,7 +223,7 @@ def cursor_after_shell_trusted(
         secret=secret,
         conversation_id=conversation_id,
         command=command,
-        generation_id=payload_generation_id,
+        approval_binding=payload_binding,
         proof=proof,
     )
 
@@ -163,7 +234,13 @@ __all__ = [
     "cursor_after_shell_trusted",
     "cursor_generation_id",
     "cursor_hook_attestation_secret_path",
+    "cursor_shell_binding_path",
+    "ensure_cursor_approval_binding",
     "ensure_cursor_hook_attestation_secret",
     "managed_cursor_hook_invocation",
+    "read_cursor_shell_binding_file",
+    "remove_cursor_shell_binding_file",
+    "resolve_cursor_approval_binding",
     "verify_cursor_after_shell_proof",
+    "write_cursor_shell_binding_file",
 ]

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -15,6 +15,36 @@ _CURSOR_SHELL_BINDINGS_DIR = Path("cursor-shell-bindings")
 _MANAGED_HOOK_ENV = "HOL_GUARD_MANAGED_CURSOR_HOOK"
 _AFTER_SHELL_PROOF_ENV = "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"
 _APPROVAL_BINDING_ENV = "HOL_GUARD_CURSOR_APPROVAL_BINDING"
+_AFTER_SHELL_PROOF_EVENT = "afterShellExecution"
+
+
+def _cursor_shell_binding_segment(conversation_id: str) -> str:
+    cleaned = conversation_id.strip()
+    if not cleaned:
+        return "missing-conversation"
+    if "/" in cleaned or "\\" in cleaned or cleaned in {".", ".."}:
+        return hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:32]
+    return cleaned
+
+
+def cursor_after_shell_proof_message(
+    *,
+    conversation_id: str,
+    command: str,
+    approval_binding: str,
+) -> bytes:
+    return (
+        chr(0)
+        .join(
+            (
+                conversation_id.strip(),
+                command.strip(),
+                approval_binding.strip(),
+                _AFTER_SHELL_PROOF_EVENT,
+            )
+        )
+        .encode("utf-8")
+    )
 
 
 def cursor_hook_attestation_secret_path(guard_home: Path) -> Path:
@@ -23,7 +53,7 @@ def cursor_hook_attestation_secret_path(guard_home: Path) -> Path:
 
 def cursor_shell_binding_path(guard_home: Path, conversation_id: str, command: str) -> Path:
     fingerprint = hashlib.sha256(command.strip().encode("utf-8")).hexdigest()[:24]
-    return guard_home / _CURSOR_SHELL_BINDINGS_DIR / conversation_id / fingerprint
+    return guard_home / _CURSOR_SHELL_BINDINGS_DIR / _cursor_shell_binding_segment(conversation_id) / fingerprint
 
 
 def write_cursor_shell_binding_file(
@@ -143,14 +173,11 @@ def compute_cursor_after_shell_proof(
     command: str,
     approval_binding: str,
 ) -> str:
-    message = "\0".join(
-        (
-            conversation_id.strip(),
-            command.strip(),
-            approval_binding.strip(),
-            "afterShellExecution",
-        )
-    ).encode("utf-8")
+    message = cursor_after_shell_proof_message(
+        conversation_id=conversation_id,
+        command=command,
+        approval_binding=approval_binding,
+    )
     digest = hmac.new(secret, message, hashlib.sha256).hexdigest()
     return digest
 
@@ -231,6 +258,7 @@ def cursor_after_shell_trusted(
 __all__ = [
     "after_shell_proof_from_env",
     "compute_cursor_after_shell_proof",
+    "cursor_after_shell_proof_message",
     "cursor_after_shell_trusted",
     "cursor_generation_id",
     "cursor_hook_attestation_secret_path",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4757,15 +4757,17 @@ def _record_cursor_pending_shell_permission(
 ) -> None:
     from ..adapters.cursor_native_approval import (
         compute_cursor_after_shell_proof,
-        cursor_generation_id,
+        ensure_cursor_approval_binding,
         ensure_cursor_hook_attestation_secret,
+        remove_cursor_shell_binding_file,
+        write_cursor_shell_binding_file,
     )
 
     conversation_id = _cursor_conversation_id(payload)
     command = _cursor_shell_command_from_payload(payload)
-    generation_id = cursor_generation_id(payload)
-    if conversation_id is None or command is None or generation_id is None:
+    if conversation_id is None or command is None:
         return
+    approval_binding = ensure_cursor_approval_binding(payload)
     saved_at = _now()
     try:
         secret = ensure_cursor_hook_attestation_secret(guard_home)
@@ -4773,7 +4775,13 @@ def _record_cursor_pending_shell_permission(
             secret=secret,
             conversation_id=conversation_id,
             command=command,
-            generation_id=generation_id,
+            approval_binding=approval_binding,
+        )
+        write_cursor_shell_binding_file(
+            guard_home,
+            conversation_id=conversation_id,
+            command=command,
+            approval_binding=approval_binding,
         )
     except OSError:
         return
@@ -4788,7 +4796,8 @@ def _record_cursor_pending_shell_permission(
         "source_scope": artifact.source_scope,
         "command": command,
         "conversation_id": conversation_id,
-        "generation_id": generation_id,
+        "approval_binding": approval_binding,
+        "generation_id": approval_binding,
         "after_shell_proof": after_shell_proof,
         "native_source": "cursor-native",
     }
@@ -5044,6 +5053,13 @@ def _persist_cursor_native_permission_after_shell(
         store,
         conversation_id=conversation_id,
         pending_key=pending_key,
+    )
+    from ..adapters.cursor_native_approval import remove_cursor_shell_binding_file
+
+    remove_cursor_shell_binding_file(
+        guard_home,
+        conversation_id=conversation_id,
+        command=command,
     )
     return True
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4759,7 +4759,6 @@ def _record_cursor_pending_shell_permission(
         compute_cursor_after_shell_proof,
         ensure_cursor_approval_binding,
         ensure_cursor_hook_attestation_secret,
-        remove_cursor_shell_binding_file,
         write_cursor_shell_binding_file,
     )
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -4759,6 +4759,7 @@ def _record_cursor_pending_shell_permission(
         compute_cursor_after_shell_proof,
         ensure_cursor_approval_binding,
         ensure_cursor_hook_attestation_secret,
+        remove_cursor_shell_binding_file,
         write_cursor_shell_binding_file,
     )
 
@@ -4772,12 +4773,6 @@ def _record_cursor_pending_shell_permission(
         secret = ensure_cursor_hook_attestation_secret(guard_home)
         after_shell_proof = compute_cursor_after_shell_proof(
             secret=secret,
-            conversation_id=conversation_id,
-            command=command,
-            approval_binding=approval_binding,
-        )
-        write_cursor_shell_binding_file(
-            guard_home,
             conversation_id=conversation_id,
             command=command,
             approval_binding=approval_binding,
@@ -4809,7 +4804,18 @@ def _record_cursor_pending_shell_permission(
             pending_key=pending_key,
             now=saved_at,
         )
+        write_cursor_shell_binding_file(
+            guard_home,
+            conversation_id=conversation_id,
+            command=command,
+            approval_binding=approval_binding,
+        )
     except (OSError, sqlite3.Error):
+        remove_cursor_shell_binding_file(
+            guard_home,
+            conversation_id=conversation_id,
+            command=command,
+        )
         return
 
 

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -566,6 +566,19 @@ def test_cursor_session_allow_without_generation_id_uses_binding_file(tmp_path: 
     )
 
 
+def test_cursor_after_shell_proof_message_uses_null_separator() -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_native_approval import cursor_after_shell_proof_message
+
+    message = cursor_after_shell_proof_message(
+        conversation_id="conv-test",
+        command="echo hello",
+        approval_binding="hol-guard:test-binding",
+    )
+    assert message == (
+        b"conv-test\x00echo hello\x00hol-guard:test-binding\x00afterShellExecution"
+    )
+
+
 def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -41,18 +41,20 @@ def _record_cursor_pending_for_test(
     conversation_id: str,
     command: str,
     workspace_dir: Path,
-    generation_id: str = "gen-cursor-test",
+    generation_id: str | None = "gen-cursor-test",
 ) -> None:
+    payload: dict[str, object] = {
+        "conversation_id": conversation_id,
+        "hook_event_name": "beforeShellExecution",
+        "command": command,
+        "cwd": str(workspace_dir),
+    }
+    if generation_id is not None:
+        payload["generation_id"] = generation_id
     guard_commands_module._record_cursor_pending_shell_permission(
         store=store,
         guard_home=guard_home,
-        payload={
-            "conversation_id": conversation_id,
-            "generation_id": generation_id,
-            "hook_event_name": "beforeShellExecution",
-            "command": command,
-            "cwd": str(workspace_dir),
-        },
+        payload=payload,
         reason="Requests a sensitive native tool action.",
         artifact=_cursor_shell_artifact(workspace_dir=workspace_dir, command=command),
         artifact_hash="hash-cursor-shell",
@@ -65,7 +67,7 @@ def _trusted_cursor_after_shell_env(
     conversation_id: str,
     command: str,
     workspace_dir: Path,
-    generation_id: str = "gen-cursor-test",
+    approval_binding: str = "gen-cursor-test",
 ) -> dict[str, str]:
     from codex_plugin_scanner.guard.adapters.cursor_native_approval import (
         compute_cursor_after_shell_proof,
@@ -77,11 +79,12 @@ def _trusted_cursor_after_shell_env(
         secret=secret,
         conversation_id=conversation_id,
         command=command,
-        generation_id=generation_id,
+        approval_binding=approval_binding,
     )
     return {
         "HOL_GUARD_MANAGED_CURSOR_HOOK": "1",
         "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF": proof,
+        "HOL_GUARD_CURSOR_APPROVAL_BINDING": approval_binding,
         "CURSOR_SESSION_ID": conversation_id,
         "CURSOR_PROJECT_DIR": str(workspace_dir),
         "CURSOR_VERSION": "test",
@@ -329,7 +332,7 @@ def test_cursor_after_shell_requires_observer_fields(tmp_path: Path) -> None:
             conversation_id=conversation_id,
             command=command,
             workspace_dir=workspace_dir,
-            generation_id=generation_id,
+            approval_binding=generation_id,
         ),
     )
     assert saved is False
@@ -416,7 +419,7 @@ def test_cursor_native_shell_session_allow_after_trusted_after_shell(tmp_path: P
             conversation_id=conversation_id,
             command=command,
             workspace_dir=workspace_dir,
-            generation_id=generation_id,
+            approval_binding=generation_id,
         ),
     )
     policies = store.list_policy_decisions("cursor")
@@ -498,6 +501,71 @@ def test_forged_after_shell_without_attestation_is_rejected(tmp_path: Path) -> N
     assert len(store.list_policy_decisions("cursor")) == 0
 
 
+def test_cursor_session_allow_without_generation_id_uses_binding_file(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.adapters.cursor_native_approval import read_cursor_shell_binding_file
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-no-generation-id"
+    command = "rm -rf ./hol-guard-cursor-native-test-marker"
+    _record_cursor_pending_for_test(
+        store=store,
+        guard_home=home_dir,
+        guard_commands_module=guard_commands_module,
+        conversation_id=conversation_id,
+        command=command,
+        workspace_dir=workspace_dir,
+        generation_id=None,
+    )
+    approval_binding = read_cursor_shell_binding_file(
+        home_dir,
+        conversation_id=conversation_id,
+        command=command,
+    )
+    assert approval_binding is not None
+    assert approval_binding.startswith("hol-guard:")
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "afterShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+                "duration": 8,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_shell_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=command,
+            workspace_dir=workspace_dir,
+            approval_binding=approval_binding,
+        ),
+    )
+    assert saved is True
+    assert guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "hook_event_name": "beforeShellExecution",
+                "command": command,
+                "cwd": str(workspace_dir),
+            }
+        ),
+    )
+
+
 def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
@@ -540,7 +608,7 @@ def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path
             conversation_id=conversation_id,
             command=command,
             workspace_dir=workspace_dir,
-            generation_id=generation_id,
+            approval_binding=generation_id,
         ),
     )
     assert saved is True
@@ -599,7 +667,7 @@ def test_cursor_after_shell_rejects_boolean_duration(tmp_path: Path) -> None:
             conversation_id=conversation_id,
             command=command,
             workspace_dir=workspace_dir,
-            generation_id=generation_id,
+            approval_binding=generation_id,
         ),
     )
     assert saved is False


### PR DESCRIPTION
## Summary
- Fix Cursor shell approval memory when `generation_id` is absent from shell hook payloads.
- Write a hol-guard binding token and binding file at prompt time; hook bridge reads it on afterShell for attestation.
- Keeps PR #681 security checks: managed-hook proof, no artifact policy upsert from forged afterShell.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_hooks.py -q`

## Notes
- After merge: `hol-guard update`, `hol-guard install cursor`, then reload Cursor.
