### PR TITLE
fix(guard): stop oauth health polls from spamming macOS keychain

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -607,7 +607,12 @@ def build_runtime_snapshot(
     snapshot_now = now or _now()
     config = load_guard_config(store.guard_home)
     latest_connect_state = _build_latest_connect_state(store, snapshot_now)
-    cloud_context = _build_runtime_cloud_context(store, latest_connect_state=latest_connect_state)
+    oauth_storage_health = store.get_oauth_local_credential_health()
+    cloud_context = _build_runtime_cloud_context(
+        store,
+        latest_connect_state=latest_connect_state,
+        oauth_storage_health=oauth_storage_health,
+    )
     headline_state = _resolve_runtime_headline_state(
         pending_count=store.count_approval_requests(),
         runtime_state=store.get_runtime_state(),
@@ -617,7 +622,7 @@ def build_runtime_snapshot(
         "generated_at": snapshot_now,
         "approval_center_url": approval_center_url,
         "runtime_state": store.get_runtime_state(),
-        "oauth_storage_health": store.get_oauth_local_credential_health(),
+        "oauth_storage_health": oauth_storage_health,
         "device": _build_runtime_device_context(store),
         "latest_connect_state": latest_connect_state,
         "proof_status": _build_runtime_proof_status(latest_connect_state),
@@ -798,9 +803,12 @@ def _now() -> str:
 def _build_runtime_cloud_context(
     store: GuardStore,
     latest_connect_state: dict[str, object] | None,
+    *,
+    oauth_storage_health: dict[str, object] | None = None,
 ) -> dict[str, object]:
     cloud_profile = store.get_cloud_sync_profile()
-    oauth_storage_health = store.get_oauth_local_credential_health()
+    if oauth_storage_health is None:
+        oauth_storage_health = store.get_oauth_local_credential_health()
     oauth_repair_required = (
         bool(oauth_storage_health.get("configured")) and oauth_storage_health.get("state") == "degraded"
     )

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shlex
 import subprocess
+import threading
 import time
 import urllib.error
 import urllib.parse
@@ -141,6 +142,7 @@ _SEVERITY_RANK = {
 }
 _PACKAGE_FIREWALL_REFRESH_ATTEMPTS: dict[str, float] = {}
 _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS = 300.0
+_PACKAGE_FIREWALL_REFRESH_LOCK = threading.Lock()
 
 
 def build_local_supply_chain_posture(
@@ -272,10 +274,11 @@ def resolve_package_firewall_entitlement_with_refresh(store: GuardStore) -> dict
         return entitlement
     refresh_key = str(store.guard_home.expanduser().resolve())
     now = time.monotonic()
-    last_refresh_at = _PACKAGE_FIREWALL_REFRESH_ATTEMPTS.get(refresh_key)
-    if last_refresh_at is not None and (now - last_refresh_at) < _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS:
-        return entitlement
-    _PACKAGE_FIREWALL_REFRESH_ATTEMPTS[refresh_key] = now
+    with _PACKAGE_FIREWALL_REFRESH_LOCK:
+        last_refresh_at = _PACKAGE_FIREWALL_REFRESH_ATTEMPTS.get(refresh_key)
+        if last_refresh_at is not None and (now - last_refresh_at) < _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS:
+            return entitlement
+        _PACKAGE_FIREWALL_REFRESH_ATTEMPTS[refresh_key] = now
     for refresh in (sync_local_guard_cloud_proof, sync_supply_chain_bundle):
         try:
             refresh(store)

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import shlex
 import subprocess
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -138,6 +139,8 @@ _SEVERITY_RANK = {
     "high": 3,
     "critical": 4,
 }
+_PACKAGE_FIREWALL_REFRESH_ATTEMPTS: dict[str, float] = {}
+_PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS = 300.0
 
 
 def build_local_supply_chain_posture(
@@ -267,6 +270,12 @@ def resolve_package_firewall_entitlement_with_refresh(store: GuardStore) -> dict
         return entitlement
     if str(entitlement.get("reason") or "") not in {"guard_cloud_reconnect_required", "paid_guard_cloud_required"}:
         return entitlement
+    refresh_key = str(store.guard_home.expanduser().resolve())
+    now = time.monotonic()
+    last_refresh_at = _PACKAGE_FIREWALL_REFRESH_ATTEMPTS.get(refresh_key)
+    if last_refresh_at is not None and (now - last_refresh_at) < _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS:
+        return entitlement
+    _PACKAGE_FIREWALL_REFRESH_ATTEMPTS[refresh_key] = now
     for refresh in (sync_local_guard_cloud_proof, sync_supply_chain_bundle):
         try:
             refresh(store)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -764,7 +764,10 @@ def _should_warn_on_slow_store_transactions() -> bool:
 
 
 _SLOW_QUERY_THRESHOLD_MS: int = 200
+_OAUTH_HEALTH_CACHE_TTL_SECONDS = 60.0
 _store_logger = logging.getLogger(__name__)
+_OAUTH_SECRET_PAYLOAD_PROCESS_CACHE: dict[tuple[str, str, str], str] = {}
+_OAUTH_HEALTH_RESULT_PROCESS_CACHE: dict[tuple[str, str], tuple[float, dict[str, object]]] = {}
 
 
 class GuardStore:
@@ -3696,7 +3699,12 @@ class GuardStore:
         if metadata is None:
             health["state"] = "degraded"
             return health
-        secret_payload = self._load_oauth_secret_payload(payload, promote=False)
+        secret_hash = payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)
+        cached_health = self._get_cached_oauth_health_result(secret_hash)
+        if cached_health is not None:
+            health.update(cached_health)
+            return health
+        secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
         if secret_payload is None:
             health["state"] = "degraded"
             return health
@@ -3708,6 +3716,7 @@ class GuardStore:
             value = payload.get(key)
             if isinstance(value, str) and value:
                 health[key] = value
+        self._remember_oauth_health_result(secret_hash, health)
         return health
 
     def get_sync_credential_health(self) -> dict[str, object]:
@@ -3778,6 +3787,7 @@ class GuardStore:
         payload: dict[str, object],
         *,
         promote: bool = True,
+        allow_primary: bool = True,
     ) -> dict[str, object] | None:
         secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)
         secret_hash = payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)
@@ -3793,6 +3803,8 @@ class GuardStore:
         if fallback_secret_payload is not None:
             self._remember_oauth_secret_payload(secret_ref, secret_hash, fallback_secret_json)
             return fallback_secret_payload
+        if not allow_primary:
+            return None
         for candidate in self._get_secret_candidates(
             self._oauth_secret_store,
             secret_ref,
@@ -3826,19 +3838,68 @@ class GuardStore:
         secret_json = self._get_secret_from_store(fallback_store, secret_ref)
         return secret_json if isinstance(secret_json, str) and secret_json else None
 
+    def _oauth_process_cache_scope(self) -> str:
+        return str(self.guard_home.expanduser().resolve())
+
+    def _oauth_secret_process_cache_key(self, secret_ref: str, secret_hash: str) -> tuple[str, str, str]:
+        return (self._oauth_process_cache_scope(), secret_ref, secret_hash)
+
+    def _oauth_health_process_cache_key(self, secret_hash: str | None) -> tuple[str, str] | None:
+        if not isinstance(secret_hash, str) or not secret_hash:
+            return None
+        return (self._oauth_process_cache_scope(), secret_hash)
+
     def _get_cached_oauth_secret_payload(self, secret_ref: str, secret_hash: str) -> dict[str, object] | None:
         cached = self._cached_oauth_secret_payload
-        if cached is None or cached[0] != secret_ref or cached[1] != secret_hash:
+        if cached is not None and cached[0] == secret_ref and cached[1] == secret_hash:
+            parsed = self._parse_oauth_secret_payload(cached[2])
+            if parsed is not None:
+                return parsed
+        process_cached = _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.get(
+            self._oauth_secret_process_cache_key(secret_ref, secret_hash)
+        )
+        if process_cached is None:
             return None
-        return self._parse_oauth_secret_payload(cached[2])
+        parsed = self._parse_oauth_secret_payload(process_cached)
+        if parsed is None:
+            return None
+        self._cached_oauth_secret_payload = (secret_ref, secret_hash, process_cached)
+        return parsed
 
     def _remember_oauth_secret_payload(self, secret_ref: str, secret_hash: str, secret_json: str | None) -> None:
         if not isinstance(secret_json, str) or not secret_json:
             return
         self._cached_oauth_secret_payload = (secret_ref, secret_hash, secret_json)
+        _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE[self._oauth_secret_process_cache_key(secret_ref, secret_hash)] = secret_json
+
+    def _get_cached_oauth_health_result(self, secret_hash: object) -> dict[str, object] | None:
+        cache_key = self._oauth_health_process_cache_key(secret_hash if isinstance(secret_hash, str) else None)
+        if cache_key is None:
+            return None
+        cached = _OAUTH_HEALTH_RESULT_PROCESS_CACHE.get(cache_key)
+        if cached is None:
+            return None
+        cached_at, cached_health = cached
+        if (time.monotonic() - cached_at) >= _OAUTH_HEALTH_CACHE_TTL_SECONDS:
+            _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
+            return None
+        return dict(cached_health)
+
+    def _remember_oauth_health_result(self, secret_hash: object, health: dict[str, object]) -> None:
+        cache_key = self._oauth_health_process_cache_key(secret_hash if isinstance(secret_hash, str) else None)
+        if cache_key is None or health.get("state") != "healthy":
+            return
+        _OAUTH_HEALTH_RESULT_PROCESS_CACHE[cache_key] = (time.monotonic(), dict(health))
 
     def _clear_oauth_secret_payload_cache(self) -> None:
         self._cached_oauth_secret_payload = None
+        scope = self._oauth_process_cache_scope()
+        for cache_key in list(_OAUTH_SECRET_PAYLOAD_PROCESS_CACHE):
+            if cache_key[0] == scope:
+                _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.pop(cache_key, None)
+        for cache_key in list(_OAUTH_HEALTH_RESULT_PROCESS_CACHE):
+            if cache_key[0] == scope:
+                _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
 
     @staticmethod
     def _parse_oauth_secret_payload(secret_json: str) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -765,6 +765,7 @@ def _should_warn_on_slow_store_transactions() -> bool:
 
 _SLOW_QUERY_THRESHOLD_MS: int = 200
 _OAUTH_HEALTH_CACHE_TTL_SECONDS = 60.0
+_OAUTH_HEALTH_DEGRADED_CACHE_TTL_SECONDS = 15.0
 _store_logger = logging.getLogger(__name__)
 _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE: dict[tuple[str, str, str], str] = {}
 _OAUTH_HEALTH_RESULT_PROCESS_CACHE: dict[tuple[str, str], tuple[float, dict[str, object]]] = {}
@@ -3638,6 +3639,8 @@ class GuardStore:
         secret_material_changed = (
             existing_secret_ref != self._oauth_local_credentials_ref or existing_secret_hash != secret_hash
         )
+        if secret_material_changed:
+            self._clear_oauth_secret_payload_cache()
         # Metadata-only updates can skip the primary rewrite because the encrypted
         # fallback remains current and continues to backstop headless recovery.
         skip_primary_secret_rewrite = (
@@ -3707,9 +3710,11 @@ class GuardStore:
         secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
         if secret_payload is None:
             health["state"] = "degraded"
+            self._remember_oauth_health_result(secret_hash, health)
             return health
         if self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload) is None:
             health["state"] = "degraded"
+            self._remember_oauth_health_result(secret_hash, health)
             return health
         health["state"] = "healthy"
         for key in ("issuer", "client_id", "grant_id", "machine_id", "workspace_id"):
@@ -3870,7 +3875,12 @@ class GuardStore:
         if not isinstance(secret_json, str) or not secret_json:
             return
         self._cached_oauth_secret_payload = (secret_ref, secret_hash, secret_json)
-        _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE[self._oauth_secret_process_cache_key(secret_ref, secret_hash)] = secret_json
+        cache_key = self._oauth_secret_process_cache_key(secret_ref, secret_hash)
+        scope = cache_key[0]
+        for existing_key in list(_OAUTH_SECRET_PAYLOAD_PROCESS_CACHE):
+            if existing_key[0] == scope and existing_key[1] == secret_ref and existing_key != cache_key:
+                _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.pop(existing_key, None)
+        _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE[cache_key] = secret_json
 
     def _get_cached_oauth_health_result(self, secret_hash: object) -> dict[str, object] | None:
         cache_key = self._oauth_health_process_cache_key(secret_hash if isinstance(secret_hash, str) else None)
@@ -3880,14 +3890,23 @@ class GuardStore:
         if cached is None:
             return None
         cached_at, cached_health = cached
-        if (time.monotonic() - cached_at) >= _OAUTH_HEALTH_CACHE_TTL_SECONDS:
+        state = cached_health.get("state")
+        ttl = (
+            _OAUTH_HEALTH_CACHE_TTL_SECONDS
+            if state == "healthy"
+            else _OAUTH_HEALTH_DEGRADED_CACHE_TTL_SECONDS
+        )
+        if (time.monotonic() - cached_at) >= ttl:
             _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
             return None
         return dict(cached_health)
 
     def _remember_oauth_health_result(self, secret_hash: object, health: dict[str, object]) -> None:
         cache_key = self._oauth_health_process_cache_key(secret_hash if isinstance(secret_hash, str) else None)
-        if cache_key is None or health.get("state") != "healthy":
+        if cache_key is None:
+            return
+        state = health.get("state")
+        if state not in {"healthy", "degraded"}:
             return
         _OAUTH_HEALTH_RESULT_PROCESS_CACHE[cache_key] = (time.monotonic(), dict(health))
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3891,11 +3891,7 @@ class GuardStore:
             return None
         cached_at, cached_health = cached
         state = cached_health.get("state")
-        ttl = (
-            _OAUTH_HEALTH_CACHE_TTL_SECONDS
-            if state == "healthy"
-            else _OAUTH_HEALTH_DEGRADED_CACHE_TTL_SECONDS
-        )
+        ttl = _OAUTH_HEALTH_CACHE_TTL_SECONDS if state == "healthy" else _OAUTH_HEALTH_DEGRADED_CACHE_TTL_SECONDS
         if (time.monotonic() - cached_at) >= ttl:
             _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
             return None

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -394,6 +394,23 @@ def test_sync_guard_events_preserves_unavailable_summary_when_no_events_pending(
     assert stored == result
 
 
+def test_build_runtime_snapshot_calls_oauth_health_once(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    calls = 0
+    original = store.get_oauth_local_credential_health
+
+    def counted_health() -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        return original()
+
+    monkeypatch.setattr(store, "get_oauth_local_credential_health", counted_health)
+
+    build_runtime_snapshot(store=store, approval_center_url=None)
+
+    assert calls == 1
+
+
 def test_runtime_snapshot_treats_naive_sync_timestamps_as_utc(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.set_sync_credentials(

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -75,6 +75,15 @@ def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
 
 
+@pytest.fixture(autouse=True)
+def _clear_oauth_process_caches() -> None:
+    guard_store_module._OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.clear()
+    guard_store_module._OAUTH_HEALTH_RESULT_PROCESS_CACHE.clear()
+    yield
+    guard_store_module._OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.clear()
+    guard_store_module._OAUTH_HEALTH_RESULT_PROCESS_CACHE.clear()
+
+
 def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch, usable_macos_keychain=False)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
@@ -1477,3 +1486,74 @@ def test_device_identity_and_label_management_are_persistent(tmp_path):
     rotated = store.rotate_installation_id("2026-04-19T02:00:00+00:00")
     assert rotated["device_label"] == "VPS - Guard Runtime"
     assert rotated["installation_id"] != original["installation_id"]
+
+
+def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+
+    primary_reads = 0
+
+    def count_primary_reads(_secret_id: str, *, timeout_seconds: float) -> str | None:
+        nonlocal primary_reads
+        primary_reads += 1
+        return store._oauth_secret_store.primary.get_secret(_secret_id)
+
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
+
+    for _ in range(10):
+        health = store.get_oauth_local_credential_health()
+        assert health["state"] == "degraded"
+
+    assert primary_reads == 0
+
+
+def test_oauth_secret_payload_process_cache_is_shared_across_store_instances(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+
+    primary_reads = 0
+
+    def count_primary_reads(_secret_id: str, *, timeout_seconds: float) -> str | None:
+        nonlocal primary_reads
+        primary_reads += 1
+        return store._oauth_secret_store.primary.get_secret(_secret_id)
+
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
+
+    assert store.get_oauth_local_credentials() is not None
+    assert primary_reads == 1
+
+    second_store = GuardStore(guard_home)
+    assert second_store.get_oauth_local_credentials() is not None
+    assert primary_reads == 1


### PR DESCRIPTION
## Summary
- Stop OAuth health checks from reading the macOS keychain on every dashboard poll by validating encrypted fallback and process caches only
- Deduplicate OAuth health work inside runtime snapshots and throttle opportunistic package-firewall reconnect refresh attempts

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py -q -k oauth`
- `python3 -m pytest tests/test_guard_cloud_local_sync.py::test_build_runtime_snapshot_calls_oauth_health_once -q`
