### PR TITLE
fix(guard): auto-repair stale oauth fallback from keychain once

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -766,9 +766,11 @@ def _should_warn_on_slow_store_transactions() -> bool:
 _SLOW_QUERY_THRESHOLD_MS: int = 200
 _OAUTH_HEALTH_CACHE_TTL_SECONDS = 60.0
 _OAUTH_HEALTH_DEGRADED_CACHE_TTL_SECONDS = 15.0
+_OAUTH_STORAGE_REPAIR_MIN_INTERVAL_SECONDS = 3600.0
 _store_logger = logging.getLogger(__name__)
 _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE: dict[tuple[str, str, str], str] = {}
 _OAUTH_HEALTH_RESULT_PROCESS_CACHE: dict[tuple[str, str], tuple[float, dict[str, object]]] = {}
+_OAUTH_STORAGE_REPAIR_ATTEMPTS: dict[str, float] = {}
 
 
 class GuardStore:
@@ -3708,6 +3710,8 @@ class GuardStore:
             health.update(cached_health)
             return health
         secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
+        if secret_payload is None and self._maybe_repair_oauth_local_credential_storage(payload):
+            secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
         if secret_payload is None:
             health["state"] = "degraded"
             self._remember_oauth_health_result(secret_hash, health)
@@ -3786,6 +3790,37 @@ class GuardStore:
         if isinstance(supply_chain_firewall, bool):
             result["supply_chain_firewall"] = supply_chain_firewall
         return result
+
+    def _oauth_primary_repair_available(self) -> bool:
+        secret_store = self._oauth_secret_store
+        return isinstance(secret_store, FallbackSecretStore) and isinstance(
+            secret_store.primary,
+            SystemKeyringSecretStore,
+        )
+
+    def _should_attempt_oauth_storage_repair(self) -> bool:
+        if not self._oauth_primary_repair_available():
+            return False
+        scope = self._oauth_process_cache_scope()
+        last_attempt = _OAUTH_STORAGE_REPAIR_ATTEMPTS.get(scope)
+        if last_attempt is None:
+            return True
+        return (time.monotonic() - last_attempt) >= _OAUTH_STORAGE_REPAIR_MIN_INTERVAL_SECONDS
+
+    def _mark_oauth_storage_repair_attempt(self) -> None:
+        _OAUTH_STORAGE_REPAIR_ATTEMPTS[self._oauth_process_cache_scope()] = time.monotonic()
+
+    def _maybe_repair_oauth_local_credential_storage(self, payload: dict[str, object]) -> bool:
+        if not self._should_attempt_oauth_storage_repair():
+            return False
+        self._mark_oauth_storage_repair_attempt()
+        repaired_payload = self._load_oauth_secret_payload(payload, promote=True, allow_primary=True)
+        if repaired_payload is None:
+            return False
+        cache_key = self._oauth_health_process_cache_key(payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY))
+        if cache_key is not None:
+            _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
+        return True
 
     def _load_oauth_secret_payload(
         self,

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -79,9 +79,11 @@ def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
 def _clear_oauth_process_caches() -> None:
     guard_store_module._OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.clear()
     guard_store_module._OAUTH_HEALTH_RESULT_PROCESS_CACHE.clear()
+    guard_store_module._OAUTH_STORAGE_REPAIR_ATTEMPTS.clear()
     yield
     guard_store_module._OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.clear()
     guard_store_module._OAUTH_HEALTH_RESULT_PROCESS_CACHE.clear()
+    guard_store_module._OAUTH_STORAGE_REPAIR_ATTEMPTS.clear()
 
 
 def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing(tmp_path, monkeypatch):
@@ -1518,9 +1520,9 @@ def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_pat
 
     for _ in range(10):
         health = store.get_oauth_local_credential_health()
-        assert health["state"] == "degraded"
+        assert health["state"] == "healthy"
 
-    assert primary_reads == 0
+    assert primary_reads == 1
 
 
 def test_oauth_secret_payload_process_cache_is_shared_across_store_instances(tmp_path, monkeypatch):
@@ -1557,3 +1559,48 @@ def test_oauth_secret_payload_process_cache_is_shared_across_store_instances(tmp
     second_store = GuardStore(guard_home)
     assert second_store.get_oauth_local_credentials() is not None
     assert primary_reads == 1
+
+
+def test_get_oauth_local_credential_health_repairs_stale_encrypted_fallback_from_primary(tmp_path, monkeypatch):
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    secret_id = str(oauth_payload["credentials_ref"])
+    rotated_secret_payload = json.loads(fake_keyring.get_password("hol-guard.oauth", secret_id) or "{}")
+    rotated_secret_payload["refresh_token"] = "refresh-secret-value-rotated"
+    rotated_secret = json.dumps(rotated_secret_payload)
+    fake_keyring.set_password("hol-guard.oauth", secret_id, rotated_secret)
+    oauth_payload["credentials_sha256"] = guard_store_module._secret_fingerprint(rotated_secret)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-01T00:01:00+00:00")
+
+    primary_reads = 0
+    original = store._oauth_secret_store.primary.get_secret_with_timeout
+
+    def count_primary_reads(_secret_id: str, *, timeout_seconds: float) -> str | None:
+        nonlocal primary_reads
+        primary_reads += 1
+        return original(_secret_id, timeout_seconds=timeout_seconds)
+
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
+
+    health = store.get_oauth_local_credential_health()
+    repeated_health = store.get_oauth_local_credential_health()
+
+    assert health["state"] == "healthy"
+    assert repeated_health["state"] == "healthy"
+    assert primary_reads == 1
+    assert store._oauth_secret_store.fallback.get_secret(secret_id) == rotated_secret


### PR DESCRIPTION
## Summary
- Auto-repair stale encrypted OAuth fallback storage from the system keychain when health checks detect drift
- Throttle repair to once per guard home per hour so normal polling stays keychain-quiet

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py::test_get_oauth_local_credential_health_repairs_stale_encrypted_fallback_from_primary -q`
- `python3 -m pytest tests/test_guard_store_migrations.py -q -k oauth`
