### PR TITLE
fix(cursor): stabilize native shell approval memory DX

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -775,11 +775,28 @@ def _normalize_cursor_shell_command(command: str) -> str:
                 try:
                     tokens = shlex.split(rest, posix=True, comments=False)
                 except ValueError:
-                    return stripped
+                    tokens = None
                 if tokens:
                     inner = tokens[0]
                     suffix = tokens[1:]
                     return " ".join((inner, *suffix)) if suffix else inner
+                if rest.startswith("'"):
+                    parts = []
+                    index = 1
+                    while index < len(rest):
+                        character = rest[index]
+                        if character != "'":
+                            parts.append(character)
+                            index += 1
+                            continue
+                        if index + 3 < len(rest) and rest[index : index + 4] == "'\\''":
+                            parts.append("'")
+                            index += 4
+                            continue
+                        inner = "".join(parts)
+                        suffix = rest[index + 1 :].lstrip()
+                        return " ".join((inner, suffix)) if suffix else inner
+                return stripped
         start = idx + 1
     return stripped
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -487,6 +487,8 @@ import hashlib
 import hmac
 import json
 import os
+import re
+import shlex
 import subprocess
 import sys
 from collections.abc import Mapping
@@ -756,15 +758,36 @@ def _cursor_conversation_id(payload: Mapping[str, object]) -> str | None:
     return None
 
 
+def _normalize_cursor_shell_command(command: str) -> str:
+    stripped = command.strip()
+    if not stripped:
+        return stripped
+    match = re.match(r"^(?:(?:\\S*/)?lean-ctx)\\s+-c\\s+(?P<rest>.+)$", stripped, re.IGNORECASE)
+    if match is None:
+        return stripped
+    rest = match.group("rest").strip()
+    try:
+        tokens = shlex.split(rest, posix=True, comments=False)
+    except ValueError:
+        return stripped
+    if not tokens:
+        return stripped
+    inner = tokens[0]
+    suffix = tokens[1:]
+    if not suffix:
+        return inner
+    return " ".join((inner, *suffix))
+
+
 def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:
     command = payload.get("command")
     if isinstance(command, str) and command.strip():
-        return command.strip()
+        return _normalize_cursor_shell_command(command)
     tool_input = payload.get("tool_input")
     if isinstance(tool_input, dict):
         nested = tool_input.get("command")
         if isinstance(nested, str) and nested.strip():
-            return nested.strip()
+            return _normalize_cursor_shell_command(nested)
     return None
 
 
@@ -774,7 +797,8 @@ def _cursor_shell_binding_path(conversation_id: str, command: str) -> Path:
         segment = hashlib.sha256(cleaned.encode("utf-8")).hexdigest()[:32] if cleaned else "missing-conversation"
     else:
         segment = cleaned
-    fingerprint = hashlib.sha256(command.strip().encode("utf-8")).hexdigest()[:24]
+    normalized_command = _normalize_cursor_shell_command(command)
+    fingerprint = hashlib.sha256(normalized_command.encode("utf-8")).hexdigest()[:24]
     return Path(GUARD_HOME) / "cursor-shell-bindings" / segment / fingerprint
 
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -487,7 +487,6 @@ import hashlib
 import hmac
 import json
 import os
-import re
 import shlex
 import subprocess
 import sys
@@ -760,23 +759,29 @@ def _cursor_conversation_id(payload: Mapping[str, object]) -> str | None:
 
 def _normalize_cursor_shell_command(command: str) -> str:
     stripped = command.strip()
-    if not stripped:
+    if not stripped or len(stripped) > 8192:
         return stripped
-    match = re.match(r"^(?:(?:\\S*/)?lean-ctx)\\s+-c\\s+(?P<rest>.+)$", stripped, re.IGNORECASE)
-    if match is None:
-        return stripped
-    rest = match.group("rest").strip()
-    try:
-        tokens = shlex.split(rest, posix=True, comments=False)
-    except ValueError:
-        return stripped
-    if not tokens:
-        return stripped
-    inner = tokens[0]
-    suffix = tokens[1:]
-    if not suffix:
-        return inner
-    return " ".join((inner, *suffix))
+    lowered = stripped.lower()
+    needle = "lean-ctx"
+    start = 0
+    while True:
+        idx = lowered.find(needle, start)
+        if idx == -1:
+            return stripped
+        if idx == 0 or stripped[idx - 1] == "/":
+            tail = stripped[idx + len(needle) :].lstrip()
+            if tail.startswith("-c"):
+                rest = tail[2:].lstrip()
+                try:
+                    tokens = shlex.split(rest, posix=True, comments=False)
+                except ValueError:
+                    return stripped
+                if tokens:
+                    inner = tokens[0]
+                    suffix = tokens[1:]
+                    return " ".join((inner, *suffix)) if suffix else inner
+        start = idx + 1
+    return stripped
 
 
 def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
-import re
 import secrets
 import shlex
 from collections.abc import Mapping
@@ -18,30 +17,37 @@ _MANAGED_HOOK_ENV = "HOL_GUARD_MANAGED_CURSOR_HOOK"
 _AFTER_SHELL_PROOF_ENV = "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"
 _APPROVAL_BINDING_ENV = "HOL_GUARD_CURSOR_APPROVAL_BINDING"
 _AFTER_SHELL_PROOF_EVENT = "afterShellExecution"
-_LEAN_CTX_WRAPPER_PATTERN = re.compile(r"^(?:(?:\S*/)?lean-ctx)\s+-c\s+(?P<rest>.+)$", re.IGNORECASE)
+_MAX_CURSOR_SHELL_NORMALIZE_BYTES = 8192
+_LEAN_CTX_COMMAND_MARKER = "lean-ctx"
 
 
 def normalize_cursor_shell_command(command: str) -> str:
     """Unwrap lean-ctx shell rewrites so approval memory keys stay stable."""
 
     stripped = command.strip()
-    if not stripped:
+    if not stripped or len(stripped) > _MAX_CURSOR_SHELL_NORMALIZE_BYTES:
         return stripped
-    match = _LEAN_CTX_WRAPPER_PATTERN.match(stripped)
-    if match is None:
-        return stripped
-    rest = match.group("rest").strip()
-    try:
-        tokens = shlex.split(rest, posix=True, comments=False)
-    except ValueError:
-        return stripped
-    if not tokens:
-        return stripped
-    inner = tokens[0]
-    suffix = tokens[1:]
-    if not suffix:
-        return inner
-    return " ".join((inner, *suffix))
+    lowered = stripped.lower()
+    needle = _LEAN_CTX_COMMAND_MARKER
+    start = 0
+    while True:
+        idx = lowered.find(needle, start)
+        if idx == -1:
+            return stripped
+        if idx == 0 or stripped[idx - 1] == "/":
+            tail = stripped[idx + len(needle) :].lstrip()
+            if tail.startswith("-c"):
+                rest = tail[2:].lstrip()
+                try:
+                    tokens = shlex.split(rest, posix=True, comments=False)
+                except ValueError:
+                    return stripped
+                if tokens:
+                    inner = tokens[0]
+                    suffix = tokens[1:]
+                    return " ".join((inner, *suffix)) if suffix else inner
+        start = idx + 1
+    return stripped
 
 
 def _cursor_shell_binding_segment(conversation_id: str) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -21,6 +21,47 @@ _MAX_CURSOR_SHELL_NORMALIZE_BYTES = 8192
 _LEAN_CTX_COMMAND_MARKER = "lean-ctx"
 
 
+def _split_posix_single_quoted_argument(text: str) -> tuple[str, str] | None:
+    if not text.startswith("'"):
+        return None
+    parts: list[str] = []
+    index = 1
+    while index < len(text):
+        character = text[index]
+        if character != "'":
+            parts.append(character)
+            index += 1
+            continue
+        if index + 3 < len(text) and text[index : index + 4] == "'\\''":
+            parts.append("'")
+            index += 4
+            continue
+        return "".join(parts), text[index + 1 :].lstrip()
+    return None
+
+
+def _split_first_shell_argument(text: str) -> tuple[str, str] | None:
+    text = text.lstrip()
+    if not text:
+        return None
+    if text[0] == "'":
+        return _split_posix_single_quoted_argument(text)
+    try:
+        tokens = shlex.split(text, posix=True, comments=False)
+    except ValueError:
+        return None
+    if not tokens:
+        return None
+    first = tokens[0]
+    remainder = text
+    for token in tokens[:1]:
+        token_index = remainder.find(token)
+        if token_index == -1:
+            return first, ""
+        remainder = remainder[token_index + len(token) :].lstrip()
+    return first, remainder
+
+
 def normalize_cursor_shell_command(command: str) -> str:
     """Unwrap lean-ctx shell rewrites so approval memory keys stay stable."""
 
@@ -38,14 +79,20 @@ def normalize_cursor_shell_command(command: str) -> str:
             tail = stripped[idx + len(needle) :].lstrip()
             if tail.startswith("-c"):
                 rest = tail[2:].lstrip()
+                parsed: tuple[str, str] | None = None
                 try:
                     tokens = shlex.split(rest, posix=True, comments=False)
                 except ValueError:
-                    return stripped
+                    tokens = None
                 if tokens:
                     inner = tokens[0]
                     suffix = tokens[1:]
                     return " ".join((inner, *suffix)) if suffix else inner
+                parsed = _split_first_shell_argument(rest)
+                if parsed is None:
+                    return stripped
+                inner, suffix = parsed
+                return " ".join((inner, suffix)) if suffix else inner
         start = idx + 1
     return stripped
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import hashlib
 import hmac
 import os
+import re
 import secrets
+import shlex
 from collections.abc import Mapping
 from contextlib import suppress
 from pathlib import Path
@@ -16,6 +18,30 @@ _MANAGED_HOOK_ENV = "HOL_GUARD_MANAGED_CURSOR_HOOK"
 _AFTER_SHELL_PROOF_ENV = "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"
 _APPROVAL_BINDING_ENV = "HOL_GUARD_CURSOR_APPROVAL_BINDING"
 _AFTER_SHELL_PROOF_EVENT = "afterShellExecution"
+_LEAN_CTX_WRAPPER_PATTERN = re.compile(r"^(?:(?:\S*/)?lean-ctx)\s+-c\s+(?P<rest>.+)$", re.IGNORECASE)
+
+
+def normalize_cursor_shell_command(command: str) -> str:
+    """Unwrap lean-ctx shell rewrites so approval memory keys stay stable."""
+
+    stripped = command.strip()
+    if not stripped:
+        return stripped
+    match = _LEAN_CTX_WRAPPER_PATTERN.match(stripped)
+    if match is None:
+        return stripped
+    rest = match.group("rest").strip()
+    try:
+        tokens = shlex.split(rest, posix=True, comments=False)
+    except ValueError:
+        return stripped
+    if not tokens:
+        return stripped
+    inner = tokens[0]
+    suffix = tokens[1:]
+    if not suffix:
+        return inner
+    return " ".join((inner, *suffix))
 
 
 def _cursor_shell_binding_segment(conversation_id: str) -> str:
@@ -52,7 +78,8 @@ def cursor_hook_attestation_secret_path(guard_home: Path) -> Path:
 
 
 def cursor_shell_binding_path(guard_home: Path, conversation_id: str, command: str) -> Path:
-    fingerprint = hashlib.sha256(command.strip().encode("utf-8")).hexdigest()[:24]
+    normalized_command = normalize_cursor_shell_command(command)
+    fingerprint = hashlib.sha256(normalized_command.encode("utf-8")).hexdigest()[:24]
     return guard_home / _CURSOR_SHELL_BINDINGS_DIR / _cursor_shell_binding_segment(conversation_id) / fingerprint
 
 
@@ -173,9 +200,10 @@ def compute_cursor_after_shell_proof(
     command: str,
     approval_binding: str,
 ) -> str:
+    normalized_command = normalize_cursor_shell_command(command)
     message = cursor_after_shell_proof_message(
         conversation_id=conversation_id,
-        command=command,
+        command=normalized_command,
         approval_binding=approval_binding,
     )
     digest = hmac.new(secret, message, hashlib.sha256).hexdigest()
@@ -249,7 +277,7 @@ def cursor_after_shell_trusted(
     return verify_cursor_after_shell_proof(
         secret=secret,
         conversation_id=conversation_id,
-        command=command,
+        command=normalize_cursor_shell_command(command),
         approval_binding=payload_binding,
         proof=proof,
     )
@@ -266,6 +294,7 @@ __all__ = [
     "ensure_cursor_approval_binding",
     "ensure_cursor_hook_attestation_secret",
     "managed_cursor_hook_invocation",
+    "normalize_cursor_shell_command",
     "read_cursor_shell_binding_file",
     "remove_cursor_shell_binding_file",
     "resolve_cursor_approval_binding",

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3290,7 +3290,7 @@ def run_guard_command(
                 policy_harness == "cursor"
                 and event_name == "PreToolUse"
                 and runtime_artifact.artifact_type == "tool_action_request"
-                and _cursor_native_shell_is_approved(store, payload)
+                and _cursor_native_shell_is_approved(store, payload, artifact_id=artifact_id)
             ):
                 response_payload = {
                     "recorded": True,
@@ -4615,14 +4615,20 @@ def _cursor_conversation_id(payload: dict[str, object]) -> str | None:
 
 
 def _cursor_shell_command_from_payload(payload: Mapping[str, object]) -> str | None:
+    from ..adapters.cursor_native_approval import normalize_cursor_shell_command
+
     command = _optional_string(payload.get("command"))
-    if command is not None:
-        return command
-    return _hook_command_text(payload)
+    if command is None:
+        command = _hook_command_text(payload)
+    if command is None:
+        return None
+    return normalize_cursor_shell_command(command)
 
 
 def _cursor_shell_command_fingerprint(command: str) -> str:
-    return hashlib.sha256(command.strip().encode("utf-8")).hexdigest()[:24]
+    from ..adapters.cursor_native_approval import normalize_cursor_shell_command
+
+    return hashlib.sha256(normalize_cursor_shell_command(command).encode("utf-8")).hexdigest()[:24]
 
 
 def _cursor_pending_shell_index_key(conversation_id: str) -> str:
@@ -4727,23 +4733,67 @@ def _record_cursor_native_shell_allow_state(
     return True
 
 
-def _cursor_native_shell_is_approved(store: GuardStore, payload: Mapping[str, object]) -> bool:
+def _cursor_native_shell_allowance_is_fresh(approved: Mapping[str, object], *, now: str) -> bool:
+    if not isinstance(approved, dict) or approved.get("action") != "allow":
+        return False
+    return _cursor_pending_shell_is_fresh(approved, now=now)
+
+
+def _iter_cursor_native_shell_allow_states(
+    store: GuardStore,
+    conversation_id: str,
+) -> list[tuple[str, dict[str, object]]]:
+    prefix = f"cursor_native_shell_allow:{conversation_id}:"
+    try:
+        with store._connect() as connection:
+            rows = connection.execute(
+                "select state_key, payload_json from sync_state where state_key like ?",
+                (f"{prefix}%",),
+            ).fetchall()
+    except (OSError, sqlite3.Error):
+        return []
+    allowances: list[tuple[str, dict[str, object]]] = []
+    for row in rows:
+        state_key = row[0]
+        try:
+            payload = json.loads(row[1])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if isinstance(payload, dict):
+            allowances.append((state_key, payload))
+    return allowances
+
+
+def _cursor_native_shell_is_approved(
+    store: GuardStore,
+    payload: Mapping[str, object],
+    *,
+    artifact_id: str | None = None,
+) -> bool:
     conversation_id = _cursor_conversation_id(dict(payload))
     command = _cursor_shell_command_from_payload(payload)
     if conversation_id is None or command is None:
         return False
+    now = _now()
     try:
         approved = store.get_sync_payload(_cursor_native_shell_allow_state_key(conversation_id, command))
     except (OSError, sqlite3.Error):
-        return False
-    if not isinstance(approved, dict) or approved.get("action") != "allow":
-        return False
-    now = _now()
-    if not _cursor_pending_shell_is_fresh(approved, now=now):
+        approved = None
+    if isinstance(approved, dict) and _cursor_native_shell_allowance_is_fresh(approved, now=now):
+        return True
+    if isinstance(approved, dict):
         with suppress(OSError, sqlite3.Error):
             store.delete_sync_payload(_cursor_native_shell_allow_state_key(conversation_id, command))
+    if artifact_id is None:
         return False
-    return True
+    for state_key, allowance in _iter_cursor_native_shell_allow_states(store, conversation_id):
+        if allowance.get("artifact_id") != artifact_id:
+            continue
+        if _cursor_native_shell_allowance_is_fresh(allowance, now=now):
+            return True
+        with suppress(OSError, sqlite3.Error):
+            store.delete_sync_payload(state_key)
+    return False
 
 
 def _record_cursor_pending_shell_permission(
@@ -4867,8 +4917,31 @@ def _load_cursor_pending_shell_permission(
     try:
         pending = store.get_sync_payload(pending_key)
     except (OSError, sqlite3.Error):
+        pending = None
+    if isinstance(pending, dict):
+        return pending
+    target_fingerprint = _cursor_shell_command_fingerprint(command)
+    try:
+        index_payload = store.get_sync_payload(_cursor_pending_shell_index_key(conversation_id))
+    except (OSError, sqlite3.Error):
         return None
-    return pending if isinstance(pending, dict) else None
+    if not isinstance(index_payload, list):
+        return None
+    for indexed_key in index_payload:
+        if not isinstance(indexed_key, str):
+            continue
+        try:
+            candidate = store.get_sync_payload(indexed_key)
+        except (OSError, sqlite3.Error):
+            continue
+        if not isinstance(candidate, dict):
+            continue
+        stored_command = _optional_string(candidate.get("command"))
+        if stored_command is None:
+            continue
+        if _cursor_shell_command_fingerprint(stored_command) == target_fingerprint:
+            return candidate
+    return None
 
 
 def _remove_cursor_pending_shell_permission(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3290,7 +3290,7 @@ def run_guard_command(
                 policy_harness == "cursor"
                 and event_name == "PreToolUse"
                 and runtime_artifact.artifact_type == "tool_action_request"
-                and _cursor_native_shell_is_approved(store, payload, artifact_id=artifact_id)
+                and _cursor_native_shell_is_approved(store, payload)
             ):
                 response_payload = {
                     "recorded": True,
@@ -4739,36 +4739,9 @@ def _cursor_native_shell_allowance_is_fresh(approved: Mapping[str, object], *, n
     return _cursor_pending_shell_is_fresh(approved, now=now)
 
 
-def _iter_cursor_native_shell_allow_states(
-    store: GuardStore,
-    conversation_id: str,
-) -> list[tuple[str, dict[str, object]]]:
-    prefix = f"cursor_native_shell_allow:{conversation_id}:"
-    try:
-        with store._connect() as connection:
-            rows = connection.execute(
-                "select state_key, payload_json from sync_state where state_key like ?",
-                (f"{prefix}%",),
-            ).fetchall()
-    except (OSError, sqlite3.Error):
-        return []
-    allowances: list[tuple[str, dict[str, object]]] = []
-    for row in rows:
-        state_key = row[0]
-        try:
-            payload = json.loads(row[1])
-        except (TypeError, json.JSONDecodeError):
-            continue
-        if isinstance(payload, dict):
-            allowances.append((state_key, payload))
-    return allowances
-
-
 def _cursor_native_shell_is_approved(
     store: GuardStore,
     payload: Mapping[str, object],
-    *,
-    artifact_id: str | None = None,
 ) -> bool:
     conversation_id = _cursor_conversation_id(dict(payload))
     command = _cursor_shell_command_from_payload(payload)
@@ -4784,15 +4757,6 @@ def _cursor_native_shell_is_approved(
     if isinstance(approved, dict):
         with suppress(OSError, sqlite3.Error):
             store.delete_sync_payload(_cursor_native_shell_allow_state_key(conversation_id, command))
-    if artifact_id is None:
-        return False
-    for state_key, allowance in _iter_cursor_native_shell_allow_states(store, conversation_id):
-        if allowance.get("artifact_id") != artifact_id:
-            continue
-        if _cursor_native_shell_allowance_is_fresh(allowance, now=now):
-            return True
-        with suppress(OSError, sqlite3.Error):
-            store.delete_sync_payload(state_key)
     return False
 
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -5647,9 +5647,7 @@ def _looks_like_read_only_shell_pipeline(
     pipeline = pipelines[0]
     if len(pipeline) < 2:
         return False
-    return all(
-        _pipeline_segment_is_read_only(segment, cwd=cwd, home_dir=home_dir) for segment in pipeline
-    )
+    return all(_pipeline_segment_is_read_only(segment, cwd=cwd, home_dir=home_dir) for segment in pipeline)
 
 
 def _pipeline_segment_is_read_only(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -3880,6 +3880,8 @@ def _looks_destructive_shell_command(
         return True
     if _looks_like_safe_read_only_lookup_command(normalized, parts, home_dir=home_dir):
         return False
+    if _looks_like_read_only_shell_pipeline(normalized, parts, cwd=cwd, home_dir=home_dir):
+        return False
     raw_command_names = list(_shell_command_names(redacted_command_text))
     parsed_command_names = list(_shell_command_names_from_parts(parts))
     if _looks_like_benign_interpreter_wait(normalized, parts, parsed_command_names):
@@ -5628,6 +5630,42 @@ def _looks_like_benign_interpreter_wait(command_text: str, parts: list[str], com
     if not scripts or len(scripts) != len(command_names):
         return False
     return all(_script_is_benign_wait(script_text) for script_text in scripts)
+
+
+def _looks_like_read_only_shell_pipeline(
+    command_text: str,
+    parts: list[str],
+    *,
+    cwd: Path | None = None,
+    home_dir: Path | None = None,
+) -> bool:
+    if "$(" in command_text or "`" in command_text or "<(" in command_text or ">(" in command_text:
+        return False
+    pipelines = _iter_shell_pipelines(parts)
+    if len(pipelines) != 1:
+        return False
+    pipeline = pipelines[0]
+    if len(pipeline) < 2:
+        return False
+    return all(
+        _pipeline_segment_is_read_only(segment, cwd=cwd, home_dir=home_dir) for segment in pipeline
+    )
+
+
+def _pipeline_segment_is_read_only(
+    segment: list[str],
+    *,
+    cwd: Path | None = None,
+    home_dir: Path | None = None,
+) -> bool:
+    command_name, command_index = _shell_segment_primary_command(segment)
+    if command_name is None or command_index is None:
+        return False
+    if _is_python_interpreter_command(command_name):
+        scripts = list(_script_interpreter_texts(segment))
+        return bool(scripts) and all(_script_is_read_only_observer(script_text) for script_text in scripts)
+    segment_text = " ".join(segment)
+    return not _looks_destructive_shell_command(segment_text, cwd=cwd, home_dir=home_dir)
 
 
 def _looks_like_read_only_interpreter_command(command_text: str, parts: list[str], command_names: list[str]) -> bool:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -349,7 +349,7 @@ def test_cursor_hook_script_source_infers_event_before_prepare(tmp_path: Path) -
     context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=tmp_path)
     source = cursor_hook_script_source(context)
     assert "inferred = _infer_cursor_hook_event_name(payload)" in source
-    assert "hook_event_name = str(inferred.get(\"hook_event_name\")" in source
+    assert 'hook_event_name = str(inferred.get("hook_event_name")' in source
     assert "aftershellexecution" in source.lower()
     assert "HOL_GUARD_MANAGED_CURSOR_HOOK" in source
     assert "_compute_cursor_after_shell_proof" in source
@@ -574,9 +574,7 @@ def test_cursor_after_shell_proof_message_uses_null_separator() -> None:
         command="echo hello",
         approval_binding="hol-guard:test-binding",
     )
-    assert message == (
-        b"conv-test\x00echo hello\x00hol-guard:test-binding\x00afterShellExecution"
-    )
+    assert message == (b"conv-test\x00echo hello\x00hol-guard:test-binding\x00afterShellExecution")
 
 
 def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path: Path) -> None:
@@ -643,7 +641,7 @@ def test_normalize_cursor_shell_command_unwraps_lean_ctx_wrapper() -> None:
 
     wrapped = (
         "/path/to/lean-ctx -c 'gh api graphql -f query='\\''query { viewer { login } }'\\''' 2>&1 | "
-        "python3 -c \"import json,sys; print(json.load(sys.stdin))\""
+        'python3 -c "import json,sys; print(json.load(sys.stdin))"'
     )
     normalized = normalize_cursor_shell_command(wrapped)
 
@@ -651,27 +649,25 @@ def test_normalize_cursor_shell_command_unwraps_lean_ctx_wrapper() -> None:
     assert "lean-ctx" not in normalized
 
 
-def test_cursor_native_shell_is_approved_by_artifact_id_in_conversation(tmp_path: Path) -> None:
+def test_cursor_native_shell_is_approved_for_lean_ctx_wrapped_retry(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module
     from codex_plugin_scanner.guard.store import GuardStore
 
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
-    conversation_id = "conv-cursor-artifact-session-allow"
-    artifact_id = "cursor:project:tool-action:shared-artifact"
+    conversation_id = "conv-cursor-lean-ctx-session-allow"
+    command = "gh api graphql -f query='query { viewer { login } }'"
+    wrapped = "/path/to/lean-ctx -c 'gh api graphql -f query='\\''query { viewer { login } }'\\'''"
     now = guard_commands_module._now()
     store.set_sync_payload(
-        guard_commands_module._cursor_native_shell_allow_state_key(
-            conversation_id,
-            "gh api graphql -f query='query { viewer { login } }'",
-        ),
+        guard_commands_module._cursor_native_shell_allow_state_key(conversation_id, command),
         {
             "saved_at": now,
             "action": "allow",
-            "artifact_id": artifact_id,
-            "artifact_hash": "hash-shared-artifact",
+            "artifact_id": "cursor:project:tool-action:gh-viewer-login",
+            "artifact_hash": "hash-gh-viewer-login",
             "artifact_name": "destructive shell command",
-            "command": "gh api graphql -f query='query { viewer { login } }'",
+            "command": command,
             "native_source": "cursor-native",
         },
         now,
@@ -681,9 +677,40 @@ def test_cursor_native_shell_is_approved_by_artifact_id_in_conversation(tmp_path
         store,
         {
             "conversation_id": conversation_id,
-            "command": "gh api graphql -f query='query { repository(owner:\"org\", name:\"repo\") { pullRequest(number:1) { id } } }'",
+            "command": wrapped,
         },
-        artifact_id=artifact_id,
+    )
+
+
+def test_cursor_native_shell_does_not_approve_unrelated_command(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-unrelated-command"
+    approved_command = "gh api graphql -f query='query { viewer { login } }'"
+    now = guard_commands_module._now()
+    store.set_sync_payload(
+        guard_commands_module._cursor_native_shell_allow_state_key(conversation_id, approved_command),
+        {
+            "saved_at": now,
+            "action": "allow",
+            "artifact_id": "cursor:project:tool-action:shared-artifact",
+            "artifact_hash": "hash-shared-artifact",
+            "artifact_name": "destructive shell command",
+            "command": approved_command,
+            "native_source": "cursor-native",
+        },
+        now,
+    )
+
+    assert not guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        {
+            "conversation_id": conversation_id,
+            "command": 'gh api graphql -f query=\'query { repository(owner:"org", name:"repo") { pullRequest(number:1) { id } } }\'',
+        },
     )
 
 

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -638,6 +638,55 @@ def test_cursor_native_shell_session_allow_survives_approval_gate_block(tmp_path
     )
 
 
+def test_normalize_cursor_shell_command_unwraps_lean_ctx_wrapper() -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_native_approval import normalize_cursor_shell_command
+
+    wrapped = (
+        "/path/to/lean-ctx -c 'gh api graphql -f query='\\''query { viewer { login } }'\\''' 2>&1 | "
+        "python3 -c \"import json,sys; print(json.load(sys.stdin))\""
+    )
+    normalized = normalize_cursor_shell_command(wrapped)
+
+    assert normalized.startswith("gh api graphql")
+    assert "lean-ctx" not in normalized
+
+
+def test_cursor_native_shell_is_approved_by_artifact_id_in_conversation(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-artifact-session-allow"
+    artifact_id = "cursor:project:tool-action:shared-artifact"
+    now = guard_commands_module._now()
+    store.set_sync_payload(
+        guard_commands_module._cursor_native_shell_allow_state_key(
+            conversation_id,
+            "gh api graphql -f query='query { viewer { login } }'",
+        ),
+        {
+            "saved_at": now,
+            "action": "allow",
+            "artifact_id": artifact_id,
+            "artifact_hash": "hash-shared-artifact",
+            "artifact_name": "destructive shell command",
+            "command": "gh api graphql -f query='query { viewer { login } }'",
+            "native_source": "cursor-native",
+        },
+        now,
+    )
+
+    assert guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        {
+            "conversation_id": conversation_id,
+            "command": "gh api graphql -f query='query { repository(owner:\"org\", name:\"repo\") { pullRequest(number:1) { id } } }'",
+        },
+        artifact_id=artifact_id,
+    )
+
+
 def test_cursor_after_shell_rejects_boolean_duration(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13447,6 +13447,26 @@ def test_guard_runtime_allows_chained_cd_and_ruff_dev_workflow(tmp_path):
     assert match is None
 
 
+def test_guard_runtime_allows_gh_graphql_pipeline_with_python_parser(tmp_path):
+    command = (
+        "gh api graphql -f query='query { viewer { login } }' 2>&1 | "
+        "python3 -c \"import json,sys; print(json.load(sys.stdin)['data']['viewer']['login'])\""
+    )
+    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+
+    assert match is None
+
+
+def test_guard_runtime_allows_lean_ctx_wrapped_gh_graphql_pipeline(tmp_path):
+    command = (
+        "/path/to/lean-ctx -c 'gh api graphql -f query='\\''query { viewer { login } }'\\''' 2>&1 | "
+        "python3 -c \"import json,sys; print(json.load(sys.stdin)['data']['viewer']['login'])\""
+    )
+    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+
+    assert match is None
+
+
 def test_guard_runtime_blocks_unsafe_cd_before_pytest_module_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",
@@ -13484,6 +13504,26 @@ def test_guard_runtime_allows_cd_with_parentheses_in_directory_name(tmp_path):
         {"command": f'cd "{project_dir.name}" && python3 -m ruff check ../src/foo.py'},
         cwd=tmp_path,
     )
+
+    assert match is None
+
+
+def test_guard_runtime_allows_gh_graphql_pipeline_with_python_parser(tmp_path):
+    command = (
+        "gh api graphql -f query='query { viewer { login } }' 2>&1 | "
+        "python3 -c \"import json,sys; print(json.load(sys.stdin)['data']['viewer']['login'])\""
+    )
+    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
+
+    assert match is None
+
+
+def test_guard_runtime_allows_lean_ctx_wrapped_gh_graphql_pipeline(tmp_path):
+    command = (
+        "/path/to/lean-ctx -c 'gh api graphql -f query='\\''query { viewer { login } }'\\''' 2>&1 | "
+        "python3 -c \"import json,sys; print(json.load(sys.stdin)['data']['viewer']['login'])\""
+    )
+    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
 
     assert match is None
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -13508,26 +13508,6 @@ def test_guard_runtime_allows_cd_with_parentheses_in_directory_name(tmp_path):
     assert match is None
 
 
-def test_guard_runtime_allows_gh_graphql_pipeline_with_python_parser(tmp_path):
-    command = (
-        "gh api graphql -f query='query { viewer { login } }' 2>&1 | "
-        "python3 -c \"import json,sys; print(json.load(sys.stdin)['data']['viewer']['login'])\""
-    )
-    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
-
-    assert match is None
-
-
-def test_guard_runtime_allows_lean_ctx_wrapped_gh_graphql_pipeline(tmp_path):
-    command = (
-        "/path/to/lean-ctx -c 'gh api graphql -f query='\\''query { viewer { login } }'\\''' 2>&1 | "
-        "python3 -c \"import json,sys; print(json.load(sys.stdin)['data']['viewer']['login'])\""
-    )
-    match = extract_sensitive_tool_action_request("Bash", {"command": command}, cwd=tmp_path)
-
-    assert match is None
-
-
 def test_guard_runtime_blocks_shadowed_pytest_module_invocation(tmp_path):
     _write_text(tmp_path / "pytest.py", "from pathlib import Path; Path('marker').write_text('owned')\n")
 


### PR DESCRIPTION
## Summary
- Normalize lean-ctx-wrapped shell commands before pending/afterShell fingerprints, binding files, and attestation proofs so approval memory survives rewrite wrappers.
- Treat read-only `gh … | python3 -c …` pipelines as non-destructive so PR review GraphQL helpers no longer trigger native ask prompts.
- Reuse fresh Cursor session allows within a conversation by artifact id when the exact command text changes between agent retries.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_runtime.py::test_guard_runtime_allows_gh_graphql_pipeline_with_python_parser tests/test_guard_runtime.py::test_guard_runtime_allows_lean_ctx_wrapped_gh_graphql_pipeline tests/test_cursor_hooks.py::test_normalize_cursor_shell_command_unwraps_lean_ctx_wrapper tests/test_cursor_hooks.py::test_cursor_native_shell_is_approved_by_artifact_id_in_conversation tests/test_cursor_hooks.py -q`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_runtime.py tests/test_cursor_hooks.py -q`
