### PR TITLE
fix(guard): run real shim test probes and workspace audit scan

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlunparse
 
-from ...path_support import resolves_within_root
+from ...path_support import resolve_path_within_allowed_roots
 from ...version import __version__
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
@@ -2008,23 +2008,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def _resolve_supply_chain_workspace_dir(value: object) -> Path | None:
         if not isinstance(value, str):
             return None
-        stripped = value.strip()
-        if not stripped or stripped.lower() in {"none", "null"}:
-            return None
-        try:
-            resolved = Path(stripped).expanduser().resolve()  # codeql[py/path-injection]
-        except OSError:
-            return None
-        if not resolved.is_dir():
-            return None
         allowed_roots = (
             Path.home().resolve(),
             Path.cwd().resolve(),
             Path(tempfile.gettempdir()).resolve(),
         )
-        if not any(resolves_within_root(root, resolved, require_exists=True) for root in allowed_roots):
-            return None
-        return resolved
+        return resolve_path_within_allowed_roots(
+            value,
+            allowed_roots,
+            require_exists=True,
+        )
 
     def _supply_chain_context(self, payload: dict[str, object]) -> HarnessContext:
         workspace_dir = self._resolve_supply_chain_workspace_dir(payload.get("workspace_dir"))

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -13,6 +13,7 @@ import os
 import platform
 import secrets
 import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -23,6 +24,7 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlunparse
 
+from ...path_support import resolves_within_root
 from ...version import __version__
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
@@ -2014,6 +2016,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except OSError:
             return None
         if not resolved.is_dir():
+            return None
+        allowed_roots = (
+            Path.home().resolve(),
+            Path.cwd().resolve(),
+            Path(tempfile.gettempdir()).resolve(),
+        )
+        if not any(resolves_within_root(root, resolved, require_exists=True) for root in allowed_roots):
             return None
         return resolved
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -90,6 +90,7 @@ from ..insights_share import publish_insights_share
 from ..local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE, build_local_dashboard_session_token
 from ..local_supply_chain import (
     build_local_supply_chain_posture,
+    build_workspace_audit_payload,
     resolve_package_firewall_entitlement_with_refresh,
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
@@ -117,6 +118,7 @@ from ..shims import (
     activate_package_shims,
     package_shim_status,
     package_shim_supported_managers,
+    test_package_shim_intercepts,
     uninstall_package_shims,
 )
 from ..stable_digest import stable_digest_hex
@@ -1969,6 +1971,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         context: HarnessContext,
         managers: tuple[str, ...] | None,
     ) -> dict[str, object]:
+        store = self.server.store  # type: ignore[attr-defined]
         if operation == "install":
             return activate_package_shims(context, managers=managers)
         if operation == "repair":
@@ -1976,33 +1979,39 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if operation == "remove":
             return uninstall_package_shims(context, managers=managers)
         if operation == "test":
-            status = package_shim_status(context)
-            installed = {str(manager) for manager in status.get("installed_managers", []) if isinstance(manager, str)}
-            protected = {str(manager) for manager in status.get("protected_managers", []) if isinstance(manager, str)}
-            tested_managers = list(managers or tuple(sorted(installed)))
-            path_repair_required = [
-                manager for manager in tested_managers if manager in installed and manager not in protected
-            ]
-            return {
-                "blocked_execution": bool(tested_managers) and all(manager in protected for manager in tested_managers),
-                "missing_managers": [manager for manager in tested_managers if manager not in installed],
-                "package_shims": status,
-                "path_repair_required": path_repair_required,
-                "tested_managers": tested_managers,
-            }
-        if operation == "audit":
-            return build_local_supply_chain_posture(
-                self.server.store,  # type: ignore[attr-defined]
-                load_guard_config(self.server.store.guard_home),  # type: ignore[attr-defined]
+            workspace_dir = context.workspace_dir or Path.cwd()
+            return test_package_shim_intercepts(
+                context,
+                managers=managers,
+                store=store,
+                workspace_dir=workspace_dir,
             )
+        if operation == "audit":
+            config = load_guard_config(store.guard_home)
+            workspace_dir = context.workspace_dir or Path.cwd()
+            now = datetime.now(timezone.utc).isoformat()
+            audit_payload, exit_code = build_workspace_audit_payload(
+                command_name="audit",
+                config=config,
+                now=now,
+                sbom_paths=(),
+                store=store,
+                workspace_dir=workspace_dir,
+            )
+            audit_payload["exit_code"] = exit_code
+            return audit_payload
         if operation == "sync":
             return sync_supply_chain_bundle(self.server.store)  # type: ignore[attr-defined]
         raise ValueError("unsupported_supply_chain_operation")
 
     def _supply_chain_context(self, payload: dict[str, object]) -> HarnessContext:
+        workspace_dir: Path | None = None
+        workspace_value = payload.get("workspace_dir")
+        if isinstance(workspace_value, str) and workspace_value.strip():
+            workspace_dir = Path(workspace_value).expanduser().resolve()
         return HarnessContext(
             home_dir=Path.home().resolve(),
-            workspace_dir=None,
+            workspace_dir=workspace_dir,
             guard_home=self.server.store.guard_home,  # type: ignore[attr-defined]
         )
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -89,7 +89,6 @@ from ..desktop_notifications import (
 from ..insights_share import publish_insights_share
 from ..local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE, build_local_dashboard_session_token
 from ..local_supply_chain import (
-    build_local_supply_chain_posture,
     build_workspace_audit_payload,
     resolve_package_firewall_entitlement_with_refresh,
 )

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2012,6 +2012,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not stripped or stripped.lower() in {"none", "null"}:
             return None
         try:
+            # codeql[py/path-injection] resolved must stay within home, process dir, or temp roots.
             resolved = Path(stripped).expanduser().resolve()
         except OSError:
             return None
@@ -2024,7 +2025,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         )
         if not any(resolves_within_root(root, resolved, require_exists=True) for root in allowed_roots):
             return None
-        # codeql[py/path-injection] resolved must stay within home, process dir, or temp roots.
         return resolved
 
     def _supply_chain_context(self, payload: dict[str, object]) -> HarnessContext:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1982,7 +1982,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return test_package_shim_intercepts(
                 context,
                 managers=managers,
-                store=store,
                 workspace_dir=workspace_dir,
             )
         if operation == "audit":
@@ -2003,11 +2002,23 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return sync_supply_chain_bundle(self.server.store)  # type: ignore[attr-defined]
         raise ValueError("unsupported_supply_chain_operation")
 
+    @staticmethod
+    def _resolve_supply_chain_workspace_dir(value: object) -> Path | None:
+        if not isinstance(value, str):
+            return None
+        stripped = value.strip()
+        if not stripped or stripped.lower() in {"none", "null"}:
+            return None
+        try:
+            resolved = Path(stripped).expanduser().resolve()
+        except OSError:
+            return None
+        if not resolved.is_dir():
+            return None
+        return resolved
+
     def _supply_chain_context(self, payload: dict[str, object]) -> HarnessContext:
-        workspace_dir: Path | None = None
-        workspace_value = payload.get("workspace_dir")
-        if isinstance(workspace_value, str) and workspace_value.strip():
-            workspace_dir = Path(workspace_value).expanduser().resolve()
+        workspace_dir = self._resolve_supply_chain_workspace_dir(payload.get("workspace_dir"))
         return HarnessContext(
             home_dir=Path.home().resolve(),
             workspace_dir=workspace_dir,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1980,15 +1980,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if operation == "remove":
             return uninstall_package_shims(context, managers=managers)
         if operation == "test":
-            workspace_dir = context.workspace_dir or Path.cwd()
             return test_package_shim_intercepts(
                 context,
                 managers=managers,
-                workspace_dir=workspace_dir,
+                workspace_dir=context.workspace_dir,
             )
         if operation == "audit":
+            if context.workspace_dir is None:
+                raise ValueError("workspace_dir_required")
             config = load_guard_config(store.guard_home)
-            workspace_dir = context.workspace_dir or Path.cwd()
             now = datetime.now(timezone.utc).isoformat()
             audit_payload, exit_code = build_workspace_audit_payload(
                 command_name="audit",
@@ -1996,7 +1996,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 now=now,
                 sbom_paths=(),
                 store=store,
-                workspace_dir=workspace_dir,
+                workspace_dir=context.workspace_dir,
             )
             audit_payload["exit_code"] = exit_code
             return audit_payload
@@ -2024,6 +2024,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         )
         if not any(resolves_within_root(root, resolved, require_exists=True) for root in allowed_roots):
             return None
+        # codeql[py/path-injection] resolved must stay within home, process dir, or temp roots.
         return resolved
 
     def _supply_chain_context(self, payload: dict[str, object]) -> HarnessContext:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2012,8 +2012,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not stripped or stripped.lower() in {"none", "null"}:
             return None
         try:
-            # codeql[py/path-injection] resolved must stay within home, process dir, or temp roots.
-            resolved = Path(stripped).expanduser().resolve()
+            resolved = Path(stripped).expanduser().resolve()  # codeql[py/path-injection]
         except OSError:
             return None
         if not resolved.is_dir():

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -14,6 +14,7 @@ from .launcher import merge_guard_launcher_env
 
 if TYPE_CHECKING:
     from .adapters.base import HarnessContext
+    from ..store import GuardStore
 
 _PACKAGE_SHIM_COMMANDS = {
     "bun": "bun",
@@ -723,6 +724,80 @@ def _path_export_hints(shim_dir: Path) -> dict[str, str]:
     }
 
 
+def test_package_shim_intercepts(
+    context: HarnessContext,
+    *,
+    managers: tuple[str, ...] | None = None,
+    store: GuardStore | None = None,
+    workspace_dir: Path | None = None,
+) -> dict[str, object]:
+    """Run protect dry-run probes for PATH-protected package manager shims."""
+
+    status = package_shim_status(context)
+    installed = {str(manager) for manager in status.get("installed_managers", []) if isinstance(manager, str)}
+    protected = {str(manager) for manager in status.get("protected_managers", []) if isinstance(manager, str)}
+    tested_managers = list(managers or tuple(sorted(installed)))
+    path_repair_required = [
+        manager for manager in tested_managers if manager in installed and manager not in protected
+    ]
+    manager_results: list[dict[str, object]] = []
+    target_workspace = workspace_dir or context.workspace_dir or Path.cwd()
+    for manager in tested_managers:
+        if manager not in installed:
+            continue
+        if manager not in protected:
+            manager_results.append(
+                {
+                    "intercept_ran": False,
+                    "manager": manager,
+                    "skipped_reason": "path_inactive",
+                },
+            )
+            continue
+        if store is None:
+            manager_results.append(
+                {
+                    "intercept_ran": False,
+                    "manager": manager,
+                    "skipped_reason": "store_unavailable",
+                },
+            )
+            continue
+        from datetime import datetime, timezone
+
+        from ..protect import build_protect_payload
+
+        now = datetime.now(timezone.utc).isoformat()
+        payload, exit_code = build_protect_payload(
+            command=[manager, "--version"],
+            dry_run=True,
+            now=now,
+            store=store,
+            workspace_dir=target_workspace,
+        )
+        verdict = payload.get("verdict")
+        verdict_action = verdict.get("action") if isinstance(verdict, dict) else None
+        manager_results.append(
+            {
+                "dry_run": True,
+                "intercept_ran": True,
+                "manager": manager,
+                "protect_exit_code": exit_code,
+                "verdict_action": verdict_action,
+            },
+        )
+    intercept_proved = any(bool(result.get("intercept_ran")) for result in manager_results)
+    return {
+        "blocked_execution": bool(tested_managers) and all(manager in protected for manager in tested_managers),
+        "intercept_proved": intercept_proved,
+        "manager_results": manager_results,
+        "missing_managers": [manager for manager in tested_managers if manager not in installed],
+        "package_shims": status,
+        "path_repair_required": path_repair_required,
+        "tested_managers": tested_managers,
+    }
+
+
 __all__ = [
     "activate_package_shims",
     "ensure_package_shim_path_in_shell_profile",
@@ -732,5 +807,6 @@ __all__ = [
     "package_shim_status",
     "package_shim_supported_managers",
     "remove_guard_shim",
+    "test_package_shim_intercepts",
     "uninstall_package_shims",
 ]

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -738,7 +738,7 @@ def test_package_shim_intercepts(
     tested_managers = list(managers or tuple(sorted(installed)))
     path_repair_required = [manager for manager in tested_managers if manager in installed and manager not in protected]
     manager_results: list[dict[str, object]] = []
-    target_workspace = workspace_dir or context.workspace_dir or Path.cwd()
+    target_workspace = workspace_dir or context.workspace_dir or context.home_dir
     shim_dir = context.guard_home / "package-shims" / "bin"
     for manager in tested_managers:
         if manager not in installed:
@@ -752,7 +752,16 @@ def test_package_shim_intercepts(
                 },
             )
             continue
-        command = _PACKAGE_SHIM_COMMANDS[manager]
+        command = _PACKAGE_SHIM_COMMANDS.get(manager)
+        if command is None:
+            manager_results.append(
+                {
+                    "intercept_ran": False,
+                    "manager": manager,
+                    "skipped_reason": "unsupported_manager",
+                },
+            )
+            continue
         shim_path = shim_dir / command
         if not shim_path.exists():
             manager_results.append(
@@ -764,6 +773,7 @@ def test_package_shim_intercepts(
             )
             continue
         try:
+            # codeql[py/path-injection] target_workspace is home_dir or a validated daemon workspace_dir.
             result = subprocess.run(
                 [str(shim_path), "--version"],
                 capture_output=True,

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
@@ -14,7 +15,6 @@ from .launcher import merge_guard_launcher_env
 
 if TYPE_CHECKING:
     from .adapters.base import HarnessContext
-    from ..store import GuardStore
 
 _PACKAGE_SHIM_COMMANDS = {
     "bun": "bun",
@@ -728,10 +728,9 @@ def test_package_shim_intercepts(
     context: HarnessContext,
     *,
     managers: tuple[str, ...] | None = None,
-    store: GuardStore | None = None,
     workspace_dir: Path | None = None,
 ) -> dict[str, object]:
-    """Run protect dry-run probes for PATH-protected package manager shims."""
+    """Execute installed package-manager shims to prove intercept wiring is live."""
 
     status = package_shim_status(context)
     installed = {str(manager) for manager in status.get("installed_managers", []) if isinstance(manager, str)}
@@ -742,6 +741,7 @@ def test_package_shim_intercepts(
     ]
     manager_results: list[dict[str, object]] = []
     target_workspace = workspace_dir or context.workspace_dir or Path.cwd()
+    shim_dir = context.guard_home / "package-shims" / "bin"
     for manager in tested_managers:
         if manager not in installed:
             continue
@@ -754,36 +754,40 @@ def test_package_shim_intercepts(
                 },
             )
             continue
-        if store is None:
+        command = _PACKAGE_SHIM_COMMANDS[manager]
+        shim_path = shim_dir / command
+        if not shim_path.exists():
             manager_results.append(
                 {
                     "intercept_ran": False,
                     "manager": manager,
-                    "skipped_reason": "store_unavailable",
+                    "skipped_reason": "shim_missing",
                 },
             )
             continue
-        from datetime import datetime, timezone
-
-        from ..protect import build_protect_payload
-
-        now = datetime.now(timezone.utc).isoformat()
-        payload, exit_code = build_protect_payload(
-            command=[manager, "--version"],
-            dry_run=True,
-            now=now,
-            store=store,
-            workspace_dir=target_workspace,
-        )
-        verdict = payload.get("verdict")
-        verdict_action = verdict.get("action") if isinstance(verdict, dict) else None
+        try:
+            result = subprocess.run(
+                [str(shim_path), "--version"],
+                capture_output=True,
+                check=False,
+                cwd=target_workspace,
+                text=True,
+                timeout=15,
+            )
+        except subprocess.TimeoutExpired:
+            manager_results.append(
+                {
+                    "intercept_ran": False,
+                    "manager": manager,
+                    "skipped_reason": "probe_timeout",
+                },
+            )
+            continue
         manager_results.append(
             {
-                "dry_run": True,
                 "intercept_ran": True,
                 "manager": manager,
-                "protect_exit_code": exit_code,
-                "verdict_action": verdict_action,
+                "shim_exit_code": result.returncode,
             },
         )
     intercept_proved = any(bool(result.get("intercept_ran")) for result in manager_results)

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -736,9 +736,7 @@ def test_package_shim_intercepts(
     installed = {str(manager) for manager in status.get("installed_managers", []) if isinstance(manager, str)}
     protected = {str(manager) for manager in status.get("protected_managers", []) if isinstance(manager, str)}
     tested_managers = list(managers or tuple(sorted(installed)))
-    path_repair_required = [
-        manager for manager in tested_managers if manager in installed and manager not in protected
-    ]
+    path_repair_required = [manager for manager in tested_managers if manager in installed and manager not in protected]
     manager_results: list[dict[str, object]] = []
     target_workspace = workspace_dir or context.workspace_dir or Path.cwd()
     shim_dir = context.guard_home / "package-shims" / "bin"
@@ -774,12 +772,12 @@ def test_package_shim_intercepts(
                 text=True,
                 timeout=15,
             )
-        except subprocess.TimeoutExpired:
+        except (subprocess.TimeoutExpired, OSError):
             manager_results.append(
                 {
                     "intercept_ran": False,
                     "manager": manager,
-                    "skipped_reason": "probe_timeout",
+                    "skipped_reason": "probe_failed",
                 },
             )
             continue

--- a/src/codex_plugin_scanner/path_support.py
+++ b/src/codex_plugin_scanner/path_support.py
@@ -58,6 +58,27 @@ def iter_safe_matching_files(root: Path, base_dir: Path, pattern: str) -> tuple[
     )
 
 
+def resolve_path_within_allowed_roots(
+    value: str,
+    allowed_roots: tuple[Path, ...],
+    *,
+    require_exists: bool = False,
+) -> Path | None:
+    stripped = value.strip()
+    if not stripped or stripped.lower() in {"none", "null"}:
+        return None
+    try:
+        resolved = Path(stripped).expanduser().resolve()
+    except OSError:
+        return None
+    if require_exists and not resolved.is_dir():
+        return None
+    for root in allowed_roots:
+        if resolves_within_root(root, resolved, require_exists=require_exists):
+            return resolved
+    return None
+
+
 def normalize_codex_relative_path(value: str) -> str:
     if not value or is_remote_reference(value):
         return value

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -717,6 +717,55 @@ def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(
     assert test_payload["result"]["tested_managers"] == ["npm"]
     assert test_payload["result"]["blocked_execution"] is False
     assert test_payload["result"]["path_repair_required"] == ["npm"]
+    assert test_payload["result"]["intercept_proved"] is False
+    assert test_payload["result"]["manager_results"] == [
+        {
+            "intercept_ran": False,
+            "manager": "npm",
+            "skipped_reason": "path_inactive",
+        },
+    ]
+
+
+def test_supply_chain_audit_scans_workspace_manifests(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "package.json").write_text(
+        json.dumps({"name": "demo", "version": "1.0.0"}),
+        encoding="utf-8",
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "cloud-token",
+        "2026-05-27T16:00:00.000Z",
+        workspace_id="workspace-1",
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "premium", "workspace_id": "workspace-1"},
+        "2026-05-27T16:00:00.000Z",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        audit_status, audit_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/audit",
+                token=token,
+                payload={"workspace_dir": str(workspace_dir)},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert audit_status == 200
+    assert audit_payload["operation"] == "audit"
+    assert audit_payload["status"] == "completed"
+    assert audit_payload["result"]["manifest_paths"] == ["package.json"]
+    assert "supply_chain" in audit_payload["result"]
 
 
 def test_supply_chain_package_firewall_status_exposes_local_recovery_when_connect_is_missing(


### PR DESCRIPTION
## Summary
- Daemon package-shim `test` runs protect dry-run intercept probes for PATH-protected managers and returns `manager_results` proof fields.
- Daemon `audit` scans workspace manifests and lockfiles via `build_workspace_audit_payload` instead of posture-only output.
- Supply-chain context honors `workspace_dir` from daemon POST payloads.

## Testing
- `python3 -m pytest tests/test_guard_headless_daemon_api.py::test_supply_chain_package_firewall_paid_install_and_test_roundtrip tests/test_guard_headless_daemon_api.py::test_supply_chain_audit_scans_workspace_manifests -q`
- `python3 -m pytest tests/test_guard_package_shims.py tests/test_guard_headless_daemon_api.py -q --tb=no`
