### PR TITLE
fix(cursor): support cursor agent CLI entry point end to end

### DIFF
--- a/docs/guard/cursor-local-cloud-contract.md
+++ b/docs/guard/cursor-local-cloud-contract.md
@@ -7,9 +7,20 @@ Cursor support is split by surface so the dashboard does not imply protection th
 | Surface | What Guard installs | What is intercepted |
 | ------- | ------------------- | ----------------- |
 | **Editor (IDE)** | MCP proxies in `.cursor/mcp.json` and native hooks in `.cursor/hooks.json` | Agent `beforeShellExecution`, `beforeMCPExecution`, `preToolUse` (Shell/MCP/Read), and `beforeReadFile` |
-| **CLI** | `guard-cursor-agent` shim on `PATH` | Launches routed through `hol-guard run cursor` before `cursor-agent` starts |
+| **CLI** | `guard-cursor-agent` and `guard-cursor` shims on `PATH` | Launches routed through `hol-guard run cursor` before the real Cursor CLI agent starts |
 
-Run `hol-guard install cursor --surface all` to enable both editor hooks and the CLI shim.
+Run `hol-guard apps connect cursor --surface all` (or `hol-guard install cursor` for both surfaces) to enable editor hooks and CLI shims.
+
+### Cursor CLI entry points
+
+Guard supports both modern Cursor CLI installs:
+
+| User command | Guard shim | Resolved launch |
+| ------------ | ---------- | --------------- |
+| `cursor-agent ...` | `guard-cursor-agent ...` | `cursor-agent ...` when available |
+| `cursor agent ...` | `guard-cursor agent ...` | `cursor agent ...` when the app CLI exposes the `agent` subcommand |
+
+CLI install prepends `$HOL_GUARD_HOME/bin` to your shell profile when needed. Restart the shell or open a new terminal, then use the Guard shims instead of the raw Cursor binaries for preflight protection.
 
 ## Native Cursor hooks
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -32,7 +32,7 @@ Current Guard support in this repo:
 - `cursor`
   - detects global and project `mcp.json`
   - installs native Cursor hooks in `.cursor/hooks.json` for `beforeShellExecution`, `beforeMCPExecution`, `preToolUse`, and `beforeReadFile`
-  - supports wrapper-mode management state and the `guard-cursor-agent` CLI shim
+  - supports wrapper-mode management state and `guard-cursor-agent` / `guard-cursor` CLI shims
   - wrapper prompt screening is covered for benign debug prompts and risky secret-read prompts
   - leaves native Cursor tool approval in place for `ask` decisions and focuses Guard on artifact trust plus runtime interception
   - managed MCP package-manager tool calls are routed through the supply-chain decision engine before Cursor receives the tool result

--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -9,8 +9,13 @@ from pathlib import Path
 
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
-from ..shims import install_guard_shim, remove_guard_shim
-from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload, _run_command_probe
+from ..shims import ensure_guard_shim_path_in_shell_profile, install_guard_shim, remove_guard_shim
+from .base import HarnessAdapter, HarnessContext, _json_payload, _run_command_probe
+from .cursor_cli import (
+    CURSOR_CLI_SHIM_COMMANDS,
+    cursor_cli_command_available,
+    resolve_cursor_cli_entry,
+)
 from .cursor_hooks import install_cursor_hooks, uninstall_cursor_hooks
 from .mcp_servers import (
     ManagedMcpServer,
@@ -109,14 +114,27 @@ class CursorHarnessAdapter(HarnessAdapter):
                         },
                     )
                 )
+        cli_available = cursor_cli_command_available(context)
         return HarnessDetection(
             harness=self.harness,
-            installed=bool(found_paths) or _command_available(self.executable),
-            command_available=_command_available(self.executable),
+            installed=bool(found_paths) or cli_available,
+            command_available=cli_available,
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
             warnings=(),
         )
+
+    def resolved_executable(self, context: HarnessContext) -> str | None:
+        entry = resolve_cursor_cli_entry(context)
+        if entry is None:
+            return None
+        return entry.executable
+
+    def launch_command(self, context: HarnessContext, passthrough_args: list[str]) -> list[str]:
+        entry = resolve_cursor_cli_entry(context)
+        if entry is None:
+            return [self.executable, *passthrough_args]
+        return entry.launch_argv(passthrough_args)
 
     def install(self, context: HarnessContext, *, surface: str = "editor") -> dict[str, object]:
         if surface == "cli":
@@ -277,17 +295,41 @@ class CursorHarnessAdapter(HarnessAdapter):
         }
 
     def _install_cli(self, context: HarnessContext) -> dict[str, object]:
-        shim_manifest = install_guard_shim(
+        agent_shim = install_guard_shim(
             self.harness,
             context,
             launcher_name="cursor-agent",
-            display_name="Cursor CLI",
+            display_name="Cursor CLI (cursor-agent)",
         )
+        cursor_shim = install_guard_shim(
+            self.harness,
+            context,
+            launcher_name="cursor",
+            display_name="Cursor CLI (cursor agent)",
+        )
+        profile = ensure_guard_shim_path_in_shell_profile(context)
+        notes = [
+            *agent_shim.get("notes", ()),
+            "Use guard-cursor-agent for the standalone cursor-agent binary.",
+            "Use guard-cursor agent ... when launching through the Cursor app CLI.",
+            f"Guard launcher shims live in {context.guard_home / 'bin'}.",
+        ]
+        if profile.get("changed"):
+            notes.append("Prepended the Guard launcher shim directory to your shell profile.")
+        elif profile.get("restart_shell_required"):
+            notes.append("Restart your shell or open a new terminal so guard-cursor shims are on PATH.")
         return {
             "harness": self.harness,
             "active": True,
             "surface": "cli",
-            **shim_manifest,
+            "shim_path": agent_shim["shim_path"],
+            "shim_dir": agent_shim["shim_dir"],
+            "shim_command": agent_shim["shim_command"],
+            "shim_paths": [agent_shim["shim_path"], cursor_shim["shim_path"]],
+            "shim_commands": list(CURSOR_CLI_SHIM_COMMANDS),
+            "windows_shim_path": agent_shim.get("windows_shim_path"),
+            "shell_profile": profile,
+            "notes": notes,
         }
 
     def _uninstall_cli(self, context: HarnessContext) -> dict[str, object]:
@@ -295,6 +337,7 @@ class CursorHarnessAdapter(HarnessAdapter):
             self.harness,
             context,
             launcher_name="cursor-agent",
+            legacy_launcher_names=self.legacy_launcher_names,
             display_name="Cursor CLI",
         )
         return {
@@ -305,9 +348,10 @@ class CursorHarnessAdapter(HarnessAdapter):
         }
 
     def runtime_probe(self, context: HarnessContext) -> dict[str, object] | None:
-        if not _command_available(self.executable):
+        entry = resolve_cursor_cli_entry(context)
+        if entry is None:
             return None
-        payload = _run_command_probe([self.executable, "mcp", "list"])
+        payload = _run_command_probe(entry.launch_argv(["mcp", "list"]))
         stdout = payload.get("stdout")
         reported_artifacts = None
         if isinstance(stdout, str):

--- a/src/codex_plugin_scanner/guard/adapters/cursor_cli.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_cli.py
@@ -1,0 +1,74 @@
+"""Cursor CLI entry-point resolution for Guard launch shims."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from .base import HarnessContext, _resolve_command, _run_command_probe
+
+CURSOR_AGENT_EXECUTABLE = "cursor-agent"
+CURSOR_EXECUTABLE = "cursor"
+CURSOR_AGENT_SUBCOMMAND = "agent"
+CURSOR_CLI_SHIM_COMMANDS = ("guard-cursor-agent", "guard-cursor")
+
+
+@dataclass(frozen=True, slots=True)
+class CursorCliLaunchEntry:
+    """Resolved local Cursor CLI agent launcher."""
+
+    executable: str
+    prefix_args: tuple[str, ...] = ()
+    launch_mode: str = "cursor-agent"
+
+    def launch_argv(self, passthrough_args: list[str]) -> list[str]:
+        if self.prefix_args and passthrough_args and passthrough_args[0] == self.prefix_args[0]:
+            return [self.executable, *passthrough_args]
+        return [self.executable, *self.prefix_args, *passthrough_args]
+
+
+def cursor_agent_subcommand_available(cursor_path: str) -> bool:
+    probe = _run_command_probe([cursor_path, CURSOR_AGENT_SUBCOMMAND, "--help"], timeout_seconds=5)
+    return probe.get("ok") is True or probe.get("return_code") == 0
+
+
+def resolve_cursor_cli_entry(context: HarnessContext) -> CursorCliLaunchEntry | None:
+    del context
+    agent_path = _resolve_command(CURSOR_AGENT_EXECUTABLE)
+    if agent_path is not None:
+        return CursorCliLaunchEntry(executable=agent_path, launch_mode="cursor-agent")
+    cursor_path = _resolve_command(CURSOR_EXECUTABLE)
+    if cursor_path is not None and cursor_agent_subcommand_available(cursor_path):
+        return CursorCliLaunchEntry(
+            executable=cursor_path,
+            prefix_args=(CURSOR_AGENT_SUBCOMMAND,),
+            launch_mode="cursor-agent-subcommand",
+        )
+    return None
+
+
+def cursor_cli_command_available(context: HarnessContext) -> bool:
+    return resolve_cursor_cli_entry(context) is not None
+
+
+def cursor_cli_shim_installed(context: HarnessContext) -> bool:
+    shim_dir = context.guard_home / "bin"
+    return any((shim_dir / command).exists() for command in CURSOR_CLI_SHIM_COMMANDS)
+
+
+def cursor_cli_detected(context: HarnessContext) -> bool:
+    if cursor_cli_command_available(context):
+        return True
+    return cursor_cli_shim_installed(context)
+
+
+__all__ = [
+    "CURSOR_AGENT_EXECUTABLE",
+    "CURSOR_AGENT_SUBCOMMAND",
+    "CURSOR_CLI_SHIM_COMMANDS",
+    "CURSOR_EXECUTABLE",
+    "CursorCliLaunchEntry",
+    "cursor_agent_subcommand_available",
+    "cursor_cli_command_available",
+    "cursor_cli_detected",
+    "cursor_cli_shim_installed",
+    "resolve_cursor_cli_entry",
+]

--- a/src/codex_plugin_scanner/guard/adapters/cursor_cli.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_cli.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from functools import lru_cache
+
 from .base import HarnessContext, _resolve_command, _run_command_probe
 
 CURSOR_AGENT_EXECUTABLE = "cursor-agent"
@@ -25,6 +27,7 @@ class CursorCliLaunchEntry:
         return [self.executable, *self.prefix_args, *passthrough_args]
 
 
+@lru_cache(maxsize=8)
 def cursor_agent_subcommand_available(cursor_path: str) -> bool:
     probe = _run_command_probe([cursor_path, CURSOR_AGENT_SUBCOMMAND, "--help"], timeout_seconds=5)
     return probe.get("ok") is True or probe.get("return_code") == 0

--- a/src/codex_plugin_scanner/guard/cli/cursor_actions.py
+++ b/src/codex_plugin_scanner/guard/cli/cursor_actions.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
-from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
+from ..adapters.cursor_cli import cursor_cli_detected, cursor_cli_shim_installed
 from ..adapters.mcp_servers import is_guard_proxy_command
 from ..store import GuardStore
 
@@ -135,7 +135,7 @@ def _cursor_status(detected: bool, *, protected: bool) -> str:
 
 def _cursor_redacted_path(context: HarnessContext, surface: str) -> str:
     if surface == "cli":
-        return "PATH:cursor-agent"
+        return "PATH:guard-cursor-agent|guard-cursor"
     workspace_path = context.workspace_dir / ".cursor" / "mcp.json" if context.workspace_dir is not None else None
     if workspace_path is not None and workspace_path.exists():
         return "$WORKSPACE/.cursor/mcp.json"
@@ -151,9 +151,7 @@ def _cursor_editor_config_paths(context: HarnessContext) -> tuple[Path, ...]:
 
 
 def _cursor_cli_detected(context: HarnessContext) -> bool:
-    if get_adapter("cursor").resolved_executable(context) is not None:
-        return True
-    return (context.guard_home / "bin" / "guard-cursor-agent").exists()
+    return cursor_cli_detected(context)
 
 
 def _cursor_editor_protected(context: HarnessContext) -> bool:
@@ -178,4 +176,4 @@ def _cursor_editor_protected(context: HarnessContext) -> bool:
 
 
 def _cursor_cli_protected(context: HarnessContext) -> bool:
-    return (context.guard_home / "bin" / "guard-cursor-agent").exists()
+    return cursor_cli_shim_installed(context)

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -87,7 +87,17 @@ def _managed_install_payload(managed_install: dict[str, object]) -> dict[str, ob
         payload["primary_integration"] = "native_hooks" if protection_contract.native_approval else "browser_fallback"
     manifest = payload.get("manifest")
     if isinstance(manifest, dict):
-        for key in ("config_path", "managed_config_path", "shim_path", "shim_command", "mode", "surface", "surfaces"):
+        for key in (
+            "config_path",
+            "managed_config_path",
+            "shim_path",
+            "shim_paths",
+            "shim_command",
+            "shim_commands",
+            "mode",
+            "surface",
+            "surfaces",
+        ):
             value = manifest.get(key)
             if value is not None:
                 payload[key] = value

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -560,6 +560,30 @@ def repair_package_shims(
     }
 
 
+def ensure_guard_shim_path_in_shell_profile(context: HarnessContext) -> dict[str, object]:
+    """Prepend the harness launcher shim dir in the user's normal shell profile."""
+
+    shim_dir = context.guard_home / "bin"
+    profile_path, export_line = _guard_shim_profile_target(context.home_dir, shim_dir)
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = profile_path.read_text(encoding="utf-8") if profile_path.exists() else ""
+    if _profile_already_references_path(existing, shim_dir):
+        return {
+            "changed": False,
+            "profile_path": str(profile_path),
+            "shim_dir": str(shim_dir),
+            "restart_shell_required": True,
+        }
+    prefix = "" if existing == "" or existing.endswith("\n") else "\n"
+    profile_path.write_text(f"{existing}{prefix}{export_line}\n", encoding="utf-8")
+    return {
+        "changed": True,
+        "profile_path": str(profile_path),
+        "shim_dir": str(shim_dir),
+        "restart_shell_required": True,
+    }
+
+
 def ensure_package_shim_path_in_shell_profile(context: HarnessContext) -> dict[str, object]:
     """Prepend the package shim dir in the user's normal shell profile."""
 
@@ -582,6 +606,25 @@ def ensure_package_shim_path_in_shell_profile(context: HarnessContext) -> dict[s
         "shim_dir": str(shim_dir),
         "restart_shell_required": True,
     }
+
+
+def _guard_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, str]:
+    shell = Path(os.environ.get("SHELL", "")).name
+    marker = "# HOL Guard harness launchers"
+    if shell == "fish":
+        return (
+            home_dir / ".config" / "fish" / "config.fish",
+            f"{marker}\nfish_add_path --prepend {shim_dir}",
+        )
+    if shell == "bash":
+        return (
+            home_dir / ".bashrc",
+            f'{marker}\nexport PATH="{shim_dir}:$PATH"',
+        )
+    return (
+        home_dir / ".zshrc",
+        f'{marker}\nexport PATH="{shim_dir}:$PATH"',
+    )
 
 
 def _package_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, str]:
@@ -725,6 +768,7 @@ def _path_export_hints(shim_dir: Path) -> dict[str, str]:
 
 __all__ = [
     "activate_package_shims",
+    "ensure_guard_shim_path_in_shell_profile",
     "ensure_package_shim_path_in_shell_profile",
     "install_guard_shim",
     "install_package_shims",

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -564,6 +564,14 @@ def ensure_guard_shim_path_in_shell_profile(context: HarnessContext) -> dict[str
     """Prepend the harness launcher shim dir in the user's normal shell profile."""
 
     shim_dir = context.guard_home / "bin"
+    if os.name == "nt":
+        return {
+            "changed": False,
+            "profile_path": None,
+            "shim_dir": str(shim_dir),
+            "restart_shell_required": False,
+            "manual_path_required": True,
+        }
     profile_path, export_line = _guard_shim_profile_target(context.home_dir, shim_dir)
     profile_path.parent.mkdir(parents=True, exist_ok=True)
     existing = profile_path.read_text(encoding="utf-8") if profile_path.exists() else ""

--- a/tests/test_cursor_cli.py
+++ b/tests/test_cursor_cli.py
@@ -1,0 +1,187 @@
+"""Tests for Cursor CLI entry-point resolution and launch shims."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
+from codex_plugin_scanner.guard.adapters.cursor_cli import (
+    cursor_cli_command_available,
+    cursor_cli_detected,
+    resolve_cursor_cli_entry,
+)
+from codex_plugin_scanner.guard.cli.install_commands import apply_managed_install
+from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    guard_home = tmp_path / "guard-home"
+    home.mkdir()
+    workspace.mkdir()
+    guard_home.mkdir()
+    return HarnessContext(home_dir=home, workspace_dir=workspace, guard_home=guard_home)
+
+
+def _write_fake_cursor_agent(bin_dir: Path) -> Path:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / "cursor-agent"
+    script.write_text(
+        '#!/bin/sh\nif [ "$1" = "mcp" ] && [ "$2" = "list" ]; then exit 0; fi\nexit 0\n',
+        encoding="utf-8",
+    )
+    script.chmod(script.stat().st_mode | 0o755)
+    return script
+
+
+def _write_fake_cursor_with_agent_subcommand(bin_dir: Path) -> Path:
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    script = bin_dir / "cursor"
+    script.write_text(
+        "#!/bin/sh\n"
+        'if [ "$1" = "agent" ]; then\n'
+        "  shift\n"
+        '  if [ "$1" = "--help" ] || [ "$1" = "mcp" ]; then exit 0; fi\n'
+        "fi\n"
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    script.chmod(script.stat().st_mode | 0o755)
+    return script
+
+
+def test_resolve_cursor_cli_entry_prefers_cursor_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bin_dir = tmp_path / "bin"
+    _write_fake_cursor_agent(bin_dir)
+    _write_fake_cursor_with_agent_subcommand(bin_dir)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    context = _context(tmp_path)
+
+    entry = resolve_cursor_cli_entry(context)
+
+    assert entry is not None
+    assert Path(entry.executable).name == "cursor-agent"
+    assert entry.prefix_args == ()
+    assert entry.launch_argv(["--print", "hello"]) == [
+        str(bin_dir / "cursor-agent"),
+        "--print",
+        "hello",
+    ]
+
+
+def test_resolve_cursor_cli_entry_uses_cursor_agent_subcommand(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    bin_dir = tmp_path / "bin"
+    _write_fake_cursor_with_agent_subcommand(bin_dir)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    context = _context(tmp_path)
+
+    entry = resolve_cursor_cli_entry(context)
+
+    assert entry is not None
+    assert Path(entry.executable).name == "cursor"
+    assert entry.launch_argv(["--print", "hello"]) == [
+        str(bin_dir / "cursor"),
+        "agent",
+        "--print",
+        "hello",
+    ]
+    assert entry.launch_argv(["agent", "--print", "hello"]) == [
+        str(bin_dir / "cursor"),
+        "agent",
+        "--print",
+        "hello",
+    ]
+
+
+def test_cursor_cli_install_creates_dual_shims_and_shell_profile(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    _write_fake_cursor_with_agent_subcommand(bin_dir)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+
+    install_payload = apply_managed_install(
+        "install",
+        "cursor",
+        False,
+        context,
+        store,
+        str(context.workspace_dir),
+        "2026-05-29T12:00:00Z",
+        surface="cli",
+    )
+    managed_install = install_payload["managed_install"]
+
+    assert managed_install["shim_command"] == "guard-cursor-agent"
+    assert managed_install["shim_commands"] == ["guard-cursor-agent", "guard-cursor"]
+    assert Path(managed_install["shim_paths"][0]).exists()
+    assert Path(managed_install["shim_paths"][1]).exists()
+    profile_path = context.home_dir / ".zshrc"
+    assert profile_path.exists()
+    assert "HOL Guard harness launchers" in profile_path.read_text(encoding="utf-8")
+    assert str(context.guard_home / "bin") in profile_path.read_text(encoding="utf-8")
+
+
+def test_guard_run_launches_cursor_agent_subcommand(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    cursor_path = _write_fake_cursor_with_agent_subcommand(bin_dir)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    context = _context(tmp_path)
+    captured: dict[str, object] = {}
+
+    class _CompletedProcess:
+        returncode = 0
+        stdout = ""
+        stderr = ""
+
+    def _fake_run(command, cwd=None, check=False, env=None, **kwargs):
+        del check, kwargs, cwd, env
+        captured["command"] = list(command)
+        return _CompletedProcess()
+
+    monkeypatch.setattr(guard_runner_module.subprocess, "run", _fake_run)
+
+    from codex_plugin_scanner.guard.config import load_guard_config
+    from codex_plugin_scanner.guard.runtime.runner import guard_run
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    store = GuardStore(context.guard_home)
+    config = load_guard_config(context.guard_home, workspace=context.workspace_dir)
+    evaluation = guard_run(
+        "cursor",
+        context,
+        store,
+        config,
+        dry_run=False,
+        passthrough_args=["agent", "--print", "hello"],
+        default_action="allow",
+    )
+
+    assert evaluation["launched"] is True
+    assert captured["command"] == [str(cursor_path), "agent", "--print", "hello"]
+
+
+def test_cursor_cli_detected_without_shims_when_cursor_agent_subcommand_exists(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    bin_dir = tmp_path / "bin"
+    _write_fake_cursor_with_agent_subcommand(bin_dir)
+    monkeypatch.setenv("PATH", str(bin_dir))
+    context = _context(tmp_path)
+
+    assert cursor_cli_command_available(context) is True
+    assert cursor_cli_detected(context) is True
+    assert CursorHarnessAdapter().detect(context).command_available is True

--- a/tests/test_cursor_local_actions.py
+++ b/tests/test_cursor_local_actions.py
@@ -217,7 +217,9 @@ def test_cursor_cli_install_uses_cursor_agent_shim_without_editor_config(
     managed_install = install_payload["managed_install"]
     assert managed_install["surface"] == "cli"
     assert managed_install["shim_command"] == "guard-cursor-agent"
+    assert managed_install["shim_commands"] == ["guard-cursor-agent", "guard-cursor"]
     assert Path(managed_install["shim_path"]).exists()
+    assert Path(managed_install["shim_paths"][1]).exists()
     assert install_payload["cursor_action"]["surface"] == "cli"
     assert not (context.workspace_dir / ".cursor" / "mcp.json").exists()
 
@@ -234,6 +236,7 @@ def test_cursor_cli_install_uses_cursor_agent_shim_without_editor_config(
 
     assert remove_payload["managed_install"]["surface"] == "cli"
     assert not Path(managed_install["shim_path"]).exists()
+    assert not Path(managed_install["shim_paths"][1]).exists()
 
 
 def test_cursor_local_action_receipts_include_surface_scope_and_sync_summary(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -8882,7 +8882,7 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        monkeypatch.setattr(cursor_adapter_module, "_command_available", lambda command: True)
+        monkeypatch.setattr(cursor_adapter_module, "cursor_cli_command_available", lambda _context: True)
         monkeypatch.setattr(
             cursor_adapter_module,
             "_run_command_probe",

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -25,6 +25,7 @@ except ModuleNotFoundError:
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import claude_code as claude_adapter_module
 from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
+from codex_plugin_scanner.guard.adapters.cursor_cli import CursorCliLaunchEntry
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER, ClaudeCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
@@ -8883,6 +8884,14 @@ url = http://127.0.0.1:8787/guard-canary
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         monkeypatch.setattr(cursor_adapter_module, "cursor_cli_command_available", lambda _context: True)
+        monkeypatch.setattr(
+            cursor_adapter_module,
+            "resolve_cursor_cli_entry",
+            lambda _context: CursorCliLaunchEntry(
+                executable="cursor-agent",
+                launch_mode="cursor-agent",
+            ),
+        )
         monkeypatch.setattr(
             cursor_adapter_module,
             "_run_command_probe",

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -181,7 +181,10 @@ def test_doctor_reports_partial_setup_for_found_unprotected_harness(
     config_path = context.home_dir / ".cursor" / "mcp.json"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps({"mcpServers": {"local": {"command": "node"}}}), encoding="utf-8")
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor.cursor_cli_command_available",
+        lambda _context: False,
+    )
 
     from codex_plugin_scanner.guard.adapters import get_adapter
 
@@ -201,7 +204,10 @@ def test_doctor_does_not_mark_harness_command_presence_as_guard_active(
     config_path = context.home_dir / ".cursor" / "mcp.json"
     config_path.parent.mkdir(parents=True, exist_ok=True)
     config_path.write_text(json.dumps({"mcpServers": {"local": {"command": "node"}}}), encoding="utf-8")
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: True)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor.cursor_cli_command_available",
+        lambda _context: True,
+    )
 
     from codex_plugin_scanner.guard.adapters import get_adapter
 
@@ -259,7 +265,10 @@ def test_doctor_treats_guard_launcher_shim_as_active_install(
 ) -> None:
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: True)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor.cursor_cli_command_available",
+        lambda _context: True,
+    )
 
     install_payload = apply_managed_install(
         "install",
@@ -296,7 +305,10 @@ def test_doctor_marks_guard_launcher_shim_without_harness_command_broken(
         str(context.workspace_dir),
         "2026-05-13T00:00:00Z",
     )
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor.cursor_cli_command_available",
+        lambda _context: False,
+    )
 
     from codex_plugin_scanner.guard.adapters import get_adapter
 
@@ -314,7 +326,10 @@ def test_doctor_ignores_non_utf8_guard_launcher_shim(
     shim_path = context.guard_home / "bin" / "guard-cursor"
     shim_path.parent.mkdir(parents=True, exist_ok=True)
     shim_path.write_bytes(b"\xff\xfe\x00")
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: False)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor.cursor_cli_command_available",
+        lambda _context: False,
+    )
 
     from codex_plugin_scanner.guard.adapters import get_adapter
 
@@ -358,7 +373,10 @@ def test_doctor_treats_guard_command_artifact_as_managed(
         json.dumps({"mcpServers": {"wrapped": {"command": "guard-cursor", "args": ["--flag"]}}}),
         encoding="utf-8",
     )
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: True)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor.cursor_cli_command_available",
+        lambda _context: True,
+    )
 
     from codex_plugin_scanner.guard.adapters import get_adapter
 
@@ -383,7 +401,10 @@ def test_doctor_keeps_active_setup_status_for_runtime_probe_timeout(
         str(context.workspace_dir),
         "2026-05-13T00:00:00Z",
     )
-    monkeypatch.setattr("codex_plugin_scanner.guard.adapters.cursor._command_available", lambda command: True)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor.cursor_cli_command_available",
+        lambda _context: True,
+    )
 
     from codex_plugin_scanner.guard.adapters import get_adapter
     from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter


### PR DESCRIPTION
## Summary
- Add Cursor CLI resolution for both `cursor-agent` and `cursor agent` entry points.
- Install `guard-cursor-agent` and `guard-cursor` launch shims during CLI surface connect/install.
- Prepend the Guard launcher bin directory to the shell profile when CLI shims are installed.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_cli.py tests/test_cursor_local_actions.py tests/test_cursor_adapter.py tests/test_cursor_completion_gates.py -q`
- `PYTHONPATH=src python3 -m ruff format --check src/`

## Notes
- After merge, run `hol-guard apps connect cursor --surface cli` (or `--surface all`) and use `guard-cursor agent ...` or `guard-cursor-agent ...` instead of the raw Cursor binaries.
