### PR TITLE
fix(dashboard): polish insights share UX and modal layering

### DIFF
--- a/dashboard/src/evidence/evidence-activity-heatmap.tsx
+++ b/dashboard/src/evidence/evidence-activity-heatmap.tsx
@@ -66,7 +66,9 @@ function monthLabels(weeks: Array<Array<HeatmapCell | null>>): string[] {
 }
 
 function isGuardModalOpen(): boolean {
-  return typeof document !== "undefined" && document.documentElement.dataset.guardModalOpen === "true";
+  if (typeof document === "undefined") return false;
+  const count = Number(document.documentElement.dataset.guardModalOpen ?? 0);
+  return Number.isFinite(count) && count > 0;
 }
 
 function flatCellsFromWeeks(weeks: Array<Array<HeatmapCell | null>>): HeatmapCell[] {
@@ -154,18 +156,17 @@ export function EvidenceActivityHeatmap({
   }, [displayKey, updateTooltipForKey]);
 
   useEffect(() => {
-    if (!tooltip) return;
+    if (typeof document === "undefined") return;
     const dismissWhenModalOpens = () => {
       if (isGuardModalOpen()) {
         setTooltip(null);
         setHoveredKey(null);
       }
     };
-    dismissWhenModalOpens();
     const observer = new MutationObserver(dismissWhenModalOpens);
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-guard-modal-open"] });
     return () => observer.disconnect();
-  }, [tooltip]);
+  }, []);
 
   const moveActive = useCallback(
     (delta: number) => {

--- a/dashboard/src/evidence/evidence-activity-heatmap.tsx
+++ b/dashboard/src/evidence/evidence-activity-heatmap.tsx
@@ -65,6 +65,10 @@ function monthLabels(weeks: Array<Array<HeatmapCell | null>>): string[] {
   return labels;
 }
 
+function isGuardModalOpen(): boolean {
+  return typeof document !== "undefined" && document.documentElement.dataset.guardModalOpen === "true";
+}
+
 function flatCellsFromWeeks(weeks: Array<Array<HeatmapCell | null>>): HeatmapCell[] {
   const result: HeatmapCell[] = [];
   for (const week of weeks) {
@@ -112,7 +116,7 @@ export function EvidenceActivityHeatmap({
   }, []);
 
   const updateTooltipForKey = useCallback((dateKey: string | null) => {
-    if (!dateKey) {
+    if (!dateKey || isGuardModalOpen()) {
       setTooltip(null);
       return;
     }
@@ -148,6 +152,20 @@ export function EvidenceActivityHeatmap({
       window.removeEventListener("resize", onScrollOrResize);
     };
   }, [displayKey, updateTooltipForKey]);
+
+  useEffect(() => {
+    if (!tooltip) return;
+    const dismissWhenModalOpens = () => {
+      if (isGuardModalOpen()) {
+        setTooltip(null);
+        setHoveredKey(null);
+      }
+    };
+    dismissWhenModalOpens();
+    const observer = new MutationObserver(dismissWhenModalOpens);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-guard-modal-open"] });
+    return () => observer.disconnect();
+  }, [tooltip]);
 
   const moveActive = useCallback(
     (delta: number) => {
@@ -191,10 +209,10 @@ export function EvidenceActivityHeatmap({
   }
 
   const tooltipNode =
-    tooltip && typeof document !== "undefined"
+    tooltip && !isGuardModalOpen() && typeof document !== "undefined"
       ? createPortal(
           <div
-            className="pointer-events-none fixed z-[120] -translate-x-1/2 rounded-lg bg-brand-dark px-3 py-2 text-xs text-white shadow-lg"
+            className="pointer-events-none fixed z-40 -translate-x-1/2 rounded-lg bg-brand-dark px-3 py-2 text-xs text-white shadow-lg"
             style={{
               left: tooltip.left,
               top: tooltip.top,

--- a/dashboard/src/evidence/evidence-insights-home-preview.test.ts
+++ b/dashboard/src/evidence/evidence-insights-home-preview.test.ts
@@ -29,6 +29,7 @@ assert(modalLayerSource.includes("useFocusTrap"), "modal layer: traps focus insi
 assert(modalLayerSource.includes("Escape"), "modal layer: supports escape to close");
 assert(modalLayerSource.includes("z-[200]"), "modal layer: stacks above heatmap tooltips");
 assert(modalLayerSource.includes("guardModalOpen"), "modal layer: signals open state for tooltip suppression");
+assert(modalLayerSource.includes("previousCount"), "modal layer: reference counts nested modals");
 assert(heatmapSource.includes("isGuardModalOpen"), "heatmap: suppresses tooltips while modal is open");
 assert(shareModalSource.includes("GuardModalLayer"), "share modal: uses viewport modal layer");
 assert(shareSheetSource.includes("GuardModalLayer"), "share sheet: uses viewport modal layer");

--- a/dashboard/src/evidence/evidence-insights-home-preview.test.ts
+++ b/dashboard/src/evidence/evidence-insights-home-preview.test.ts
@@ -10,18 +10,26 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 
 const homePreviewSource = readFileSync(join(__dirname, "evidence-insights-home-preview.tsx"), "utf8");
 const homeDashboardSource = readFileSync(join(__dirname, "../home-dashboard.tsx"), "utf8");
+const shareButtonSource = readFileSync(join(__dirname, "evidence-insights-share-button.tsx"), "utf8");
 const shareModalSource = readFileSync(join(__dirname, "evidence-insights-share-modal.tsx"), "utf8");
 const shareSheetSource = readFileSync(join(__dirname, "evidence-insights-share-sheet.tsx"), "utf8");
 const modalLayerSource = readFileSync(join(__dirname, "../guard-modal-layer.tsx"), "utf8");
+const heatmapSource = readFileSync(join(__dirname, "evidence-activity-heatmap.tsx"), "utf8");
 
 assert(homePreviewSource.includes("HomeOverviewStatsRow"), "home stats card: overview row component exists");
 assert(homePreviewSource.includes("overviewStats"), "home stats card: accepts overview stats");
 assert(homePreviewSource.includes("Queue, apps, and insights"), "home stats card: unified subtitle copy");
 assert(!homeDashboardSource.includes("ProofStrip"), "home dashboard: removed standalone proof strip");
 assert(homeDashboardSource.includes("EvidenceInsightsHomePreview"), "home dashboard: uses unified stats card");
+assert(homePreviewSource.includes("EvidenceInsightsShareButton"), "home stats card: primary share button");
+assert(shareButtonSource.includes("Share publicly"), "share button: clear sharing label");
+assert(!shareButtonSource.includes('variant="outline"'), "share button: uses primary styling");
 assert(modalLayerSource.includes("createPortal"), "modal layer: portals to document body");
 assert(modalLayerSource.includes("useFocusTrap"), "modal layer: traps focus inside dialog");
 assert(modalLayerSource.includes("Escape"), "modal layer: supports escape to close");
+assert(modalLayerSource.includes("z-[200]"), "modal layer: stacks above heatmap tooltips");
+assert(modalLayerSource.includes("guardModalOpen"), "modal layer: signals open state for tooltip suppression");
+assert(heatmapSource.includes("isGuardModalOpen"), "heatmap: suppresses tooltips while modal is open");
 assert(shareModalSource.includes("GuardModalLayer"), "share modal: uses viewport modal layer");
 assert(shareSheetSource.includes("GuardModalLayer"), "share sheet: uses viewport modal layer");
 assert(!shareModalSource.includes('className="fixed inset-0 z-50'), "share modal: no inline fixed overlay");

--- a/dashboard/src/evidence/evidence-insights-home-preview.tsx
+++ b/dashboard/src/evidence/evidence-insights-home-preview.tsx
@@ -1,6 +1,7 @@
 import type { GuardReceiptAnalytics, GuardRuntimeSnapshot } from "../guard-types";
 import { ActionButton, SectionLabel } from "../approval-center-primitives";
 import { EvidenceInsightsHeadlineBento } from "./evidence-insights-headline-bento";
+import { EvidenceInsightsShareButton } from "./evidence-insights-share-button";
 
 export type HomeOverviewStatTone = "blue" | "green" | "purple" | "slate";
 
@@ -72,9 +73,7 @@ export function EvidenceInsightsHomePreview({
           <p className="mt-1 text-sm text-slate-500">Queue, apps, and insights from this machine.</p>
         </div>
         {cloudConnected && onShare && insightsAvailable ? (
-          <ActionButton variant="outline" onClick={onShare} className="shrink-0">
-            Share stats
-          </ActionButton>
+          <EvidenceInsightsShareButton onClick={onShare} className="shrink-0" />
         ) : null}
       </div>
 

--- a/dashboard/src/evidence/evidence-insights-share-button.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-button.tsx
@@ -1,0 +1,18 @@
+import { FiShare2 } from "react-icons/fi";
+import { ActionButton } from "../approval-center-primitives";
+
+interface EvidenceInsightsShareButtonProps {
+  onClick: () => void;
+  className?: string;
+}
+
+export function EvidenceInsightsShareButton({ onClick, className }: EvidenceInsightsShareButtonProps) {
+  return (
+    <ActionButton onClick={onClick} className={className} aria-label="Share your Guard stats publicly">
+      <span className="inline-flex items-center gap-2">
+        <FiShare2 className="h-4 w-4" aria-hidden="true" />
+        Share publicly
+      </span>
+    </ActionButton>
+  );
+}

--- a/dashboard/src/evidence/evidence-insights-share-errors.ts
+++ b/dashboard/src/evidence/evidence-insights-share-errors.ts
@@ -1,0 +1,22 @@
+export function insightsSharePublishErrorMessage(raw: string): string {
+  const message = raw.trim();
+  const lower = message.toLowerCase();
+
+  if (lower.includes("not enabled")) {
+    return "Guard insights sharing is not live on Guard Cloud yet. If you just updated, wait a few minutes and try again.";
+  }
+
+  if (
+    lower.includes("guard:insights.share") ||
+    lower.includes("insufficient scope") ||
+    lower.includes("missing scope")
+  ) {
+    return "Reconnect Guard Cloud to grant insights sharing permission, then try again.";
+  }
+
+  if (lower.includes("unauthorized") || lower.includes("401")) {
+    return "Guard Cloud session expired. Reconnect from Settings, then try again.";
+  }
+
+  return message || "Unable to publish share link.";
+}

--- a/dashboard/src/evidence/evidence-insights-share-errors.ts
+++ b/dashboard/src/evidence/evidence-insights-share-errors.ts
@@ -2,7 +2,7 @@ export function insightsSharePublishErrorMessage(raw: string): string {
   const message = raw.trim();
   const lower = message.toLowerCase();
 
-  if (lower.includes("not enabled")) {
+  if (lower.includes("insights") && lower.includes("not enabled")) {
     return "Guard insights sharing is not live on Guard Cloud yet. If you just updated, wait a few minutes and try again.";
   }
 

--- a/dashboard/src/evidence/evidence-insights-share-modal.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-modal.tsx
@@ -5,6 +5,7 @@ import { GuardModalLayer } from "../guard-modal-layer";
 import { publishInsightsShare, type GuardInsightsShareResult } from "../guard-api";
 import { EvidenceInsightsHeadlineBento } from "./evidence-insights-headline-bento";
 import { EvidenceInsightsShareSheet } from "./evidence-insights-share-sheet";
+import { insightsSharePublishErrorMessage } from "./evidence-insights-share-errors";
 
 interface EvidenceInsightsShareModalProps {
   analytics: GuardReceiptAnalytics;
@@ -38,7 +39,8 @@ export function EvidenceInsightsShareModal({
       });
       setShareResult(result);
     } catch (publishError) {
-      setError(publishError instanceof Error ? publishError.message : "Unable to publish share link.");
+      const rawMessage = publishError instanceof Error ? publishError.message : "Unable to publish share link.";
+      setError(insightsSharePublishErrorMessage(rawMessage));
     } finally {
       setPublishing(false);
     }
@@ -62,9 +64,9 @@ export function EvidenceInsightsShareModal({
         <div className="border-b border-slate-100 px-5 py-4">
           <div className="flex items-start justify-between gap-3">
             <div>
-              <h2 className="text-lg font-semibold text-brand-dark">Share your Guard stats</h2>
+              <h2 className="text-lg font-semibold text-brand-dark">Share publicly</h2>
               <p className="mt-1 text-sm text-slate-500">
-                Publish a redacted snapshot to HOL Guard Cloud for social sharing.
+                Publish a redacted stats card to HOL Guard Cloud with a link and preview image.
               </p>
             </div>
             <button type="button" onClick={onClose} className="text-sm font-medium text-slate-500 hover:text-brand-dark">
@@ -127,7 +129,11 @@ export function EvidenceInsightsShareModal({
                 Include top recurring action labels (redacted)
               </label>
 
-              {error ? <p className="text-sm text-amber-700">{error}</p> : null}
+              {error ? (
+                <p className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900" role="alert">
+                  {error}
+                </p>
+              ) : null}
             </div>
 
             <div className="flex items-center justify-end gap-2 border-t border-slate-100 px-5 py-4">
@@ -135,7 +141,7 @@ export function EvidenceInsightsShareModal({
                 Cancel
               </ActionButton>
               <ActionButton onClick={handlePublish} disabled={publishing}>
-                {publishing ? "Publishing…" : "Publish share link"}
+                {publishing ? "Publishing…" : "Publish public link"}
               </ActionButton>
             </div>
           </>

--- a/dashboard/src/evidence/evidence-insights-surface.tsx
+++ b/dashboard/src/evidence/evidence-insights-surface.tsx
@@ -7,11 +7,12 @@ import type {
   GuardRuntimeSnapshot,
 } from "../guard-types";
 import { harnessDisplayName } from "../approval-center-utils";
-import { ActionButton, SectionLabel } from "../approval-center-primitives";
+import { SectionLabel } from "../approval-center-primitives";
 import { EvidenceActivityHeatmap } from "./evidence-activity-heatmap";
 import { EvidenceDataProvenanceStrip } from "./evidence-data-provenance-strip";
 import { EvidenceInsightsHeadlineBento } from "./evidence-insights-headline-bento";
 import { EvidenceInsightsShareModal } from "./evidence-insights-share-modal";
+import { EvidenceInsightsShareButton } from "./evidence-insights-share-button";
 import { EvidenceShareBar } from "./evidence-share-bar";
 
 interface EvidenceInsightsSurfaceProps {
@@ -175,6 +176,7 @@ export function EvidenceInsightsSurface({
     () => analytics.top_artifacts.reduce((sum, item) => sum + item.total, 0),
     [analytics.top_artifacts],
   );
+  const cloudConnected = runtime?.cloud_state === "paired_active";
 
   if (analytics.total === 0) {
     return (
@@ -200,9 +202,9 @@ export function EvidenceInsightsSurface({
             <SectionLabel>Your Guard stats</SectionLabel>
             <p className="mt-1 text-sm text-slate-500">All-time local store</p>
           </div>
-          <ActionButton variant="outline" onClick={() => setShareOpen(true)}>
-            Share stats
-          </ActionButton>
+          {cloudConnected ? (
+            <EvidenceInsightsShareButton onClick={() => setShareOpen(true)} />
+          ) : null}
         </div>
         <EvidenceInsightsHeadlineBento analytics={analytics} variant="full" />
 

--- a/dashboard/src/guard-modal-layer.tsx
+++ b/dashboard/src/guard-modal-layer.tsx
@@ -28,10 +28,16 @@ export function GuardModalLayer({
     if (!mounted) return;
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
-    document.documentElement.dataset.guardModalOpen = "true";
+    const previousCount = Number(document.documentElement.dataset.guardModalOpen ?? 0);
+    document.documentElement.dataset.guardModalOpen = String(previousCount + 1);
     return () => {
       document.body.style.overflow = previousOverflow;
-      delete document.documentElement.dataset.guardModalOpen;
+      const nextCount = Number(document.documentElement.dataset.guardModalOpen ?? 1) - 1;
+      if (nextCount <= 0) {
+        delete document.documentElement.dataset.guardModalOpen;
+      } else {
+        document.documentElement.dataset.guardModalOpen = String(nextCount);
+      }
     };
   }, [mounted]);
 

--- a/dashboard/src/guard-modal-layer.tsx
+++ b/dashboard/src/guard-modal-layer.tsx
@@ -28,8 +28,10 @@ export function GuardModalLayer({
     if (!mounted) return;
     const previousOverflow = document.body.style.overflow;
     document.body.style.overflow = "hidden";
+    document.documentElement.dataset.guardModalOpen = "true";
     return () => {
       document.body.style.overflow = previousOverflow;
+      delete document.documentElement.dataset.guardModalOpen;
     };
   }, [mounted]);
 
@@ -57,7 +59,7 @@ export function GuardModalLayer({
 
   return createPortal(
     <div
-      className="fixed inset-0 z-[100] flex items-end justify-center bg-slate-950/40 p-4 sm:items-center"
+      className="fixed inset-0 z-[200] flex items-end justify-center bg-slate-950/45 p-4 backdrop-blur-[2px] sm:items-center"
       onClick={handleBackdropClick}
       role="dialog"
       aria-modal="true"


### PR DESCRIPTION
## Summary
- Add primary "Share publicly" button with share icon on home and insights surfaces
- Raise share modal layer above heatmap tooltips and suppress tooltips while modal is open
- Improve publish error messaging for disabled sharing, missing scope, and expired sessions

## Testing
- `node dashboard/src/evidence/evidence-insights-home-preview.test.ts`
- `node dashboard/src/evidence/evidence-insights-layout.test.ts`
- `cd dashboard && npm run build`

## Notes
- Portal flag enablement PR should merge and deploy before publish works end to end in production
