### PR TITLE
fix(guard): stop hot-path OAuth reads from spamming macOS keychain

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -872,7 +872,8 @@ def run_guard_disconnect_command(
     now: str | None = None,
     urlopen=urllib.request.urlopen,
 ) -> dict[str, object]:
-    credentials = store.get_oauth_local_credentials()
+    store.repair_oauth_local_credential_storage_from_primary()
+    credentials = store.get_oauth_local_credentials(allow_primary=True)
     if credentials is None:
         return {
             "status": "not_connected",
@@ -944,6 +945,7 @@ def run_guard_device_connect_command(
     machine_label: str | None = None,
     include_sync_auth_context: bool = False,
 ) -> dict[str, object]:
+    store.repair_oauth_local_credential_storage_from_primary()
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
     oauth_client = resolve_guard_oauth_client_config(allowed_origin)
@@ -1039,6 +1041,7 @@ def run_guard_browser_connect_command(
     wait_timeout_seconds: float = 180,
     include_sync_auth_context: bool = False,
 ) -> dict[str, object]:
+    store.repair_oauth_local_credential_storage_from_primary()
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
     oauth_client = resolve_guard_oauth_client_config(allowed_origin)

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -11,9 +11,11 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Sequence
+from contextlib import suppress
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from uuid import uuid4
 
 from .adapters.base import HarnessContext
 from .config import GuardConfig, resolve_risk_action
@@ -161,12 +163,17 @@ def _read_package_firewall_refresh_state(guard_home: Path) -> dict[str, object]:
 def _write_package_firewall_refresh_state(guard_home: Path, last_attempt: float) -> None:
     path = _package_firewall_refresh_state_path(guard_home)
     path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
-    tmp_path.write_text(
-        json.dumps({"last_refresh_attempt_monotonic": last_attempt}, sort_keys=True, separators=(",", ":")),
-        encoding="utf-8",
-    )
-    tmp_path.replace(path)
+    tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+    try:
+        tmp_path.write_text(
+            json.dumps({"last_refresh_attempt_at": last_attempt}, sort_keys=True, separators=(",", ":")),
+            encoding="utf-8",
+        )
+        tmp_path.replace(path)
+    finally:
+        if tmp_path.exists():
+            with suppress(OSError):
+                tmp_path.unlink()
 
 
 def build_local_supply_chain_posture(
@@ -296,10 +303,10 @@ def resolve_package_firewall_entitlement_with_refresh(store: GuardStore) -> dict
         return entitlement
     if str(entitlement.get("reason") or "") not in {"guard_cloud_reconnect_required", "paid_guard_cloud_required"}:
         return entitlement
-    now = time.monotonic()
+    now = time.time()
     with _PACKAGE_FIREWALL_REFRESH_LOCK:
         state = _read_package_firewall_refresh_state(store.guard_home)
-        last_refresh_at = state.get("last_refresh_attempt_monotonic")
+        last_refresh_at = state.get("last_refresh_attempt_at")
         if (
             isinstance(last_refresh_at, (int, float))
             and (now - float(last_refresh_at)) < _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -140,9 +140,33 @@ _SEVERITY_RANK = {
     "high": 3,
     "critical": 4,
 }
-_PACKAGE_FIREWALL_REFRESH_ATTEMPTS: dict[str, float] = {}
 _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS = 300.0
+_PACKAGE_FIREWALL_REFRESH_STATE_FILE = "package-firewall-refresh.json"
 _PACKAGE_FIREWALL_REFRESH_LOCK = threading.Lock()
+
+
+def _package_firewall_refresh_state_path(guard_home: Path) -> Path:
+    return guard_home / _PACKAGE_FIREWALL_REFRESH_STATE_FILE
+
+
+def _read_package_firewall_refresh_state(guard_home: Path) -> dict[str, object]:
+    path = _package_firewall_refresh_state_path(guard_home)
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_package_firewall_refresh_state(guard_home: Path, last_attempt: float) -> None:
+    path = _package_firewall_refresh_state_path(guard_home)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+    tmp_path.write_text(
+        json.dumps({"last_refresh_attempt_monotonic": last_attempt}, sort_keys=True, separators=(",", ":")),
+        encoding="utf-8",
+    )
+    tmp_path.replace(path)
 
 
 def build_local_supply_chain_posture(
@@ -272,13 +296,16 @@ def resolve_package_firewall_entitlement_with_refresh(store: GuardStore) -> dict
         return entitlement
     if str(entitlement.get("reason") or "") not in {"guard_cloud_reconnect_required", "paid_guard_cloud_required"}:
         return entitlement
-    refresh_key = str(store.guard_home.expanduser().resolve())
     now = time.monotonic()
     with _PACKAGE_FIREWALL_REFRESH_LOCK:
-        last_refresh_at = _PACKAGE_FIREWALL_REFRESH_ATTEMPTS.get(refresh_key)
-        if last_refresh_at is not None and (now - last_refresh_at) < _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS:
+        state = _read_package_firewall_refresh_state(store.guard_home)
+        last_refresh_at = state.get("last_refresh_attempt_monotonic")
+        if (
+            isinstance(last_refresh_at, (int, float))
+            and (now - float(last_refresh_at)) < _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS
+        ):
             return entitlement
-        _PACKAGE_FIREWALL_REFRESH_ATTEMPTS[refresh_key] = now
+        _write_package_firewall_refresh_state(store.guard_home, now)
     for refresh in (sync_local_guard_cloud_proof, sync_supply_chain_bundle):
         try:
             refresh(store)

--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -78,6 +78,26 @@ def _bundle_entitlement(payload: object) -> dict[str, object] | None:
     }
 
 
+def _oauth_entitlement_fields_from_sync_payload(payload: object) -> dict[str, object] | None:
+    if not isinstance(payload, dict):
+        return None
+    fields: dict[str, object] = {}
+    for key in (
+        "supply_chain_plan_id",
+        "supply_chain_firewall",
+        "supply_chain_entitlement_expires_at",
+        "workspace_id",
+    ):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            fields[key] = value.strip()
+        elif key == "supply_chain_firewall" and isinstance(value, bool):
+            fields[key] = value
+    if _optional_string(fields.get("supply_chain_plan_id")) is None:
+        return None
+    return fields
+
+
 def _oauth_entitlement(credentials: dict[str, object] | None, *, now: datetime) -> dict[str, object] | None:
     if not isinstance(credentials, dict):
         return None
@@ -124,9 +144,10 @@ def _connect_state_entitlement(store: GuardStore, *, now: datetime) -> dict[str,
     oauth_health = store.get_oauth_local_credential_health()
     if not isinstance(oauth_health, dict) or not bool(oauth_health.get("configured")):
         return None
-    oauth_credentials = store.get_oauth_local_credentials()
-    if isinstance(oauth_credentials, dict):
-        plan_id = _optional_string(oauth_credentials.get("supply_chain_plan_id"))
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    oauth_fields = _oauth_entitlement_fields_from_sync_payload(oauth_payload)
+    if isinstance(oauth_fields, dict):
+        plan_id = _optional_string(oauth_fields.get("supply_chain_plan_id"))
         if plan_id is not None and plan_id.lower() not in PACKAGE_FIREWALL_PAID_TIERS:
             return None
     latest_state = store.get_effective_guard_connect_state(now=now.isoformat())
@@ -141,8 +162,8 @@ def _connect_state_entitlement(store: GuardStore, *, now: datetime) -> dict[str,
     }:
         return None
     tier = "unknown"
-    if isinstance(oauth_credentials, dict):
-        tier = _optional_string(oauth_credentials.get("supply_chain_plan_id")) or tier
+    if isinstance(oauth_fields, dict):
+        tier = _optional_string(oauth_fields.get("supply_chain_plan_id")) or tier
     elif isinstance(oauth_health.get("workspace_id"), str):
         tier = "unknown"
     return {
@@ -194,7 +215,12 @@ def resolve_package_firewall_entitlement(
 ) -> dict[str, object]:
     resolved_now = now or datetime.now(timezone.utc)
     bundle = _bundle_entitlement(store.get_sync_payload("supply_chain_bundle_entitlement"))
-    oauth = _oauth_entitlement(store.get_oauth_local_credentials(), now=resolved_now)
+    oauth_health = store.get_oauth_local_credential_health()
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    oauth_fields = None
+    if isinstance(oauth_health, dict) and oauth_health.get("state") == "healthy":
+        oauth_fields = _oauth_entitlement_fields_from_sync_payload(oauth_payload)
+    oauth = _oauth_entitlement(oauth_fields, now=resolved_now)
     connect_state = _connect_state_entitlement(store, now=resolved_now)
     if bundle is not None and bool(bundle.get("allowed")):
         return bundle

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2438,7 +2438,7 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
 def _resolve_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
     with _guard_sync_auth_lock(store):
         oauth_health = store.get_oauth_local_credential_health()
-        oauth_credentials = store.get_oauth_local_credentials()
+        oauth_credentials = store.get_oauth_local_credentials(allow_primary=True)
         if oauth_credentials is not None:
             return _resolve_guard_sync_auth_context_from_oauth_credentials(store, oauth_credentials)
         if bool(oauth_health.get("configured")):

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -278,7 +278,7 @@ def evaluate_package_request_artifact(
     if (
         bundle_evaluation is not None
         and bundle_evaluation.refresh_required
-        and store.get_oauth_local_credentials() is None
+        and not bool(store.get_oauth_local_credential_health().get("configured"))
     ):
         fallback = _finalize_evaluation(
             bundle_evaluation,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -767,10 +767,10 @@ _SLOW_QUERY_THRESHOLD_MS: int = 200
 _OAUTH_HEALTH_CACHE_TTL_SECONDS = 60.0
 _OAUTH_HEALTH_DEGRADED_CACHE_TTL_SECONDS = 15.0
 _OAUTH_STORAGE_REPAIR_MIN_INTERVAL_SECONDS = 3600.0
+_OAUTH_KEYCHAIN_ACCESS_STATE_FILE = "oauth-keychain-access.json"
 _store_logger = logging.getLogger(__name__)
 _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE: dict[tuple[str, str, str], str] = {}
 _OAUTH_HEALTH_RESULT_PROCESS_CACHE: dict[tuple[str, str], tuple[float, dict[str, object]]] = {}
-_OAUTH_STORAGE_REPAIR_ATTEMPTS: dict[str, float] = {}
 
 
 class GuardStore:
@@ -3548,16 +3548,16 @@ class GuardStore:
     def get_cloud_sync_profile(self) -> dict[str, str] | None:
         oauth_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if isinstance(oauth_payload, dict):
-            oauth_credentials = self.get_oauth_local_credentials()
-            if oauth_credentials is None:
+            metadata = self._oauth_local_credentials_metadata(oauth_payload)
+            if metadata is None:
                 return None
-            issuer = oauth_credentials.get("issuer")
+            issuer = metadata.get("issuer")
             if isinstance(issuer, str) and issuer.strip():
                 profile = {
                     "auth_mode": "oauth",
                     "sync_url": _oauth_sync_url_from_issuer(issuer),
                 }
-                workspace_id = oauth_credentials.get("workspace_id")
+                workspace_id = metadata.get("workspace_id")
                 if isinstance(workspace_id, str) and workspace_id.strip():
                     profile["workspace_id"] = workspace_id.strip()
                 return profile
@@ -3657,14 +3657,14 @@ class GuardStore:
         self._assert_oauth_secret_persisted(self._oauth_local_credentials_ref, secret_json)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
 
-    def get_oauth_local_credentials(self) -> dict[str, object] | None:
+    def get_oauth_local_credentials(self, *, allow_primary: bool = False) -> dict[str, object] | None:
         payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if not isinstance(payload, dict):
             return None
         metadata = self._oauth_local_credentials_metadata(payload)
         if metadata is None:
             return None
-        secret_payload = self._load_oauth_secret_payload(payload)
+        secret_payload = self._load_oauth_secret_payload(payload, allow_primary=allow_primary)
         if secret_payload is None:
             return None
         return self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload)
@@ -3710,8 +3710,6 @@ class GuardStore:
             health.update(cached_health)
             return health
         secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
-        if secret_payload is None and self._maybe_repair_oauth_local_credential_storage(payload):
-            secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
         if secret_payload is None:
             health["state"] = "degraded"
             self._remember_oauth_health_result(secret_hash, health)
@@ -3798,19 +3796,45 @@ class GuardStore:
             SystemKeyringSecretStore,
         )
 
+    def _oauth_keychain_access_state_path(self) -> Path:
+        return self.guard_home / _OAUTH_KEYCHAIN_ACCESS_STATE_FILE
+
+    def _read_oauth_keychain_access_state(self) -> dict[str, object]:
+        path = self._oauth_keychain_access_state_path()
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def _write_oauth_keychain_access_state(self, payload: dict[str, object]) -> None:
+        path = self._oauth_keychain_access_state_path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(f"{path.suffix}.tmp")
+        tmp_path.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+        _set_private_mode(tmp_path, _GUARD_STORE_PRIVATE_FILE_MODE)
+        tmp_path.replace(path)
+        _set_private_mode(path, _GUARD_STORE_PRIVATE_FILE_MODE)
+
     def _should_attempt_oauth_storage_repair(self) -> bool:
         if not self._oauth_primary_repair_available():
             return False
-        scope = self._oauth_process_cache_scope()
-        last_attempt = _OAUTH_STORAGE_REPAIR_ATTEMPTS.get(scope)
-        if last_attempt is None:
+        state = self._read_oauth_keychain_access_state()
+        last_attempt = state.get("last_repair_attempt_monotonic")
+        if not isinstance(last_attempt, (int, float)):
             return True
-        return (time.monotonic() - last_attempt) >= _OAUTH_STORAGE_REPAIR_MIN_INTERVAL_SECONDS
+        return (time.monotonic() - float(last_attempt)) >= _OAUTH_STORAGE_REPAIR_MIN_INTERVAL_SECONDS
 
     def _mark_oauth_storage_repair_attempt(self) -> None:
-        _OAUTH_STORAGE_REPAIR_ATTEMPTS[self._oauth_process_cache_scope()] = time.monotonic()
+        state = self._read_oauth_keychain_access_state()
+        state["last_repair_attempt_monotonic"] = time.monotonic()
+        self._write_oauth_keychain_access_state(state)
 
-    def _maybe_repair_oauth_local_credential_storage(self, payload: dict[str, object]) -> bool:
+    def repair_oauth_local_credential_storage_from_primary(self) -> bool:
+        """Re-mirror OAuth secrets from the system keychain into encrypted fallback storage."""
+        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        if not isinstance(payload, dict):
+            return False
         if not self._should_attempt_oauth_storage_repair():
             return False
         self._mark_oauth_storage_repair_attempt()
@@ -3820,6 +3844,7 @@ class GuardStore:
         cache_key = self._oauth_health_process_cache_key(payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY))
         if cache_key is not None:
             _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
+        self._clear_oauth_secret_payload_cache()
         return True
 
     def _load_oauth_secret_payload(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3810,24 +3810,29 @@ class GuardStore:
     def _write_oauth_keychain_access_state(self, payload: dict[str, object]) -> None:
         path = self._oauth_keychain_access_state_path()
         path.parent.mkdir(parents=True, exist_ok=True)
-        tmp_path = path.with_suffix(f"{path.suffix}.tmp")
-        tmp_path.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")), encoding="utf-8")
-        _set_private_mode(tmp_path, _GUARD_STORE_PRIVATE_FILE_MODE)
-        tmp_path.replace(path)
-        _set_private_mode(path, _GUARD_STORE_PRIVATE_FILE_MODE)
+        tmp_path = path.with_name(f".{path.name}.{uuid4().hex}.tmp")
+        try:
+            tmp_path.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+            _set_private_mode(tmp_path, _GUARD_STORE_PRIVATE_FILE_MODE)
+            tmp_path.replace(path)
+            _set_private_mode(path, _GUARD_STORE_PRIVATE_FILE_MODE)
+        finally:
+            if tmp_path.exists():
+                with suppress(OSError):
+                    tmp_path.unlink()
 
     def _should_attempt_oauth_storage_repair(self) -> bool:
         if not self._oauth_primary_repair_available():
             return False
         state = self._read_oauth_keychain_access_state()
-        last_attempt = state.get("last_repair_attempt_monotonic")
+        last_attempt = state.get("last_repair_attempt_at")
         if not isinstance(last_attempt, (int, float)):
             return True
-        return (time.monotonic() - float(last_attempt)) >= _OAUTH_STORAGE_REPAIR_MIN_INTERVAL_SECONDS
+        return (time.time() - float(last_attempt)) >= _OAUTH_STORAGE_REPAIR_MIN_INTERVAL_SECONDS
 
     def _mark_oauth_storage_repair_attempt(self) -> None:
         state = self._read_oauth_keychain_access_state()
-        state["last_repair_attempt_monotonic"] = time.monotonic()
+        state["last_repair_attempt_at"] = time.time()
         self._write_oauth_keychain_access_state(state)
 
     def repair_oauth_local_credential_storage_from_primary(self) -> bool:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3548,6 +3548,9 @@ class GuardStore:
     def get_cloud_sync_profile(self) -> dict[str, str] | None:
         oauth_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if isinstance(oauth_payload, dict):
+            oauth_health = self.get_oauth_local_credential_health()
+            if not isinstance(oauth_health, dict) or oauth_health.get("state") != "healthy":
+                return None
             metadata = self._oauth_local_credentials_metadata(oauth_payload)
             if metadata is None:
                 return None

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -79,11 +79,9 @@ def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
 def _clear_oauth_process_caches() -> None:
     guard_store_module._OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.clear()
     guard_store_module._OAUTH_HEALTH_RESULT_PROCESS_CACHE.clear()
-    guard_store_module._OAUTH_STORAGE_REPAIR_ATTEMPTS.clear()
     yield
     guard_store_module._OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.clear()
     guard_store_module._OAUTH_HEALTH_RESULT_PROCESS_CACHE.clear()
-    guard_store_module._OAUTH_STORAGE_REPAIR_ATTEMPTS.clear()
 
 
 def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing(tmp_path, monkeypatch):
@@ -789,6 +787,7 @@ def test_oauth_local_credentials_use_encrypted_file_fallback_when_system_keyring
 
 
 def test_oauth_local_credential_health_reports_backend_and_metadata(tmp_path, monkeypatch):
+    monkeypatch.setattr(SystemKeyringSecretStore, "_is_available", classmethod(lambda cls: False))
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
 
@@ -1096,8 +1095,8 @@ def test_get_oauth_local_credentials_recovers_from_timed_primary_lookup_when_fal
 
     monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
 
-    credentials = store.get_oauth_local_credentials()
-    repeated_credentials = store.get_oauth_local_credentials()
+    credentials = store.get_oauth_local_credentials(allow_primary=True)
+    repeated_credentials = store.get_oauth_local_credentials(allow_primary=True)
 
     assert credentials is not None
     assert repeated_credentials is not None
@@ -1223,7 +1222,7 @@ def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_key
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
     store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
 
-    credentials = store.get_oauth_local_credentials()
+    credentials = store.get_oauth_local_credentials(allow_primary=True)
 
     assert credentials is not None
     assert store._oauth_secret_store.fallback.get_secret(store._oauth_local_credentials_ref) is not None
@@ -1231,7 +1230,7 @@ def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_key
     monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: None))
     headless_store = GuardStore(guard_home)
 
-    assert headless_store.get_oauth_local_credentials() is not None
+    assert headless_store.get_oauth_local_credentials(allow_primary=False) is not None
 
 
 def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_write_failure(tmp_path, monkeypatch):
@@ -1520,9 +1519,9 @@ def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_pat
 
     for _ in range(10):
         health = store.get_oauth_local_credential_health()
-        assert health["state"] == "healthy"
+        assert health["state"] == "degraded"
 
-    assert primary_reads == 1
+    assert primary_reads == 0
 
 
 def test_oauth_secret_payload_process_cache_is_shared_across_store_instances(tmp_path, monkeypatch):
@@ -1553,15 +1552,15 @@ def test_oauth_secret_payload_process_cache_is_shared_across_store_instances(tmp
 
     monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
 
-    assert store.get_oauth_local_credentials() is not None
+    assert store.get_oauth_local_credentials(allow_primary=True) is not None
     assert primary_reads == 1
 
     second_store = GuardStore(guard_home)
-    assert second_store.get_oauth_local_credentials() is not None
+    assert second_store.get_oauth_local_credentials(allow_primary=True) is not None
     assert primary_reads == 1
 
 
-def test_get_oauth_local_credential_health_repairs_stale_encrypted_fallback_from_primary(tmp_path, monkeypatch):
+def test_repair_oauth_local_credential_storage_from_primary_repairs_stale_encrypted_fallback(tmp_path, monkeypatch):
     fake_keyring = _install_fake_system_keyring(monkeypatch)
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
@@ -1597,6 +1596,8 @@ def test_get_oauth_local_credential_health_repairs_stale_encrypted_fallback_from
 
     monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
 
+    assert store.get_oauth_local_credential_health()["state"] == "degraded"
+    assert store.repair_oauth_local_credential_storage_from_primary() is True
     health = store.get_oauth_local_credential_health()
     repeated_health = store.get_oauth_local_credential_health()
 
@@ -1604,3 +1605,45 @@ def test_get_oauth_local_credential_health_repairs_stale_encrypted_fallback_from
     assert repeated_health["state"] == "healthy"
     assert primary_reads == 1
     assert store._oauth_secret_store.fallback.get_secret(secret_id) == rotated_secret
+
+    second_store = GuardStore(guard_home)
+    assert second_store.repair_oauth_local_credential_storage_from_primary() is False
+    assert primary_reads == 1
+
+
+def test_get_cloud_sync_profile_uses_oauth_metadata_without_primary_keychain_reads(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+
+    primary_reads = 0
+
+    def count_primary_reads(_secret_id: str, *, timeout_seconds: float) -> str | None:
+        nonlocal primary_reads
+        primary_reads += 1
+        return store._oauth_secret_store.primary.get_secret(_secret_id)
+
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
+
+    profile = store.get_cloud_sync_profile()
+
+    assert profile == {
+        "auth_mode": "oauth",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "workspace_id": "workspace-123",
+    }
+    assert primary_reads == 0

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -1628,7 +1628,7 @@ def test_get_cloud_sync_profile_uses_oauth_metadata_without_primary_keychain_rea
         now="2026-06-01T00:00:00+00:00",
     )
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
-    store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+    assert store.get_oauth_local_credential_health()["state"] == "healthy"
 
     primary_reads = 0
 


### PR DESCRIPTION
## Summary
- Default OAuth credential loads to encrypted fallback only (`allow_primary=False`) so daemon polls, hooks, and entitlement checks avoid `security find-generic-password` for `hol-guard.oauth`
- Remove health-path auto-repair that re-hit the keychain on every short-lived process; expose explicit `repair_oauth_local_credential_storage_from_primary()` on connect/disconnect only
- Read cloud profile and package-firewall entitlement fields from sync payload metadata when OAuth health is healthy, without loading secrets from keychain
- Persist OAuth repair and package-firewall refresh throttles on disk so process restarts cannot bypass hourly/5-minute limits

## Testing
- `python -m pytest tests/test_guard_store_migrations.py -q -k 'oauth or cloud_sync_profile or repair'`
- `python -m pytest tests/test_guard_connect_flow.py tests/test_guard_store_migrations.py -q -k 'oauth or cloud_sync or repair or package_firewall or paid_metadata'`
- `ruff check src/codex_plugin_scanner/guard/ tests/test_guard_store_migrations.py`
