### PR TITLE
fix(cursor): strip agent prefix for cursor-agent launches

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_cli.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_cli.py
@@ -22,9 +22,12 @@ class CursorCliLaunchEntry:
     launch_mode: str = "cursor-agent"
 
     def launch_argv(self, passthrough_args: list[str]) -> list[str]:
-        if self.prefix_args and passthrough_args and passthrough_args[0] == self.prefix_args[0]:
-            return [self.executable, *passthrough_args]
-        return [self.executable, *self.prefix_args, *passthrough_args]
+        args = list(passthrough_args)
+        if not self.prefix_args and args and args[0] == CURSOR_AGENT_SUBCOMMAND:
+            args = args[1:]
+        if self.prefix_args and args and args[0] == self.prefix_args[0]:
+            return [self.executable, *args]
+        return [self.executable, *self.prefix_args, *args]
 
 
 @lru_cache(maxsize=8)

--- a/tests/test_cursor_cli.py
+++ b/tests/test_cursor_cli.py
@@ -9,6 +9,7 @@ import pytest
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
 from codex_plugin_scanner.guard.adapters.cursor_cli import (
+    CursorCliLaunchEntry,
     cursor_cli_command_available,
     cursor_cli_detected,
     resolve_cursor_cli_entry,
@@ -56,8 +57,6 @@ def _write_fake_cursor_with_agent_subcommand(bin_dir: Path) -> Path:
 
 
 def test_launch_argv_strips_agent_prefix_for_cursor_agent_binary() -> None:
-    from codex_plugin_scanner.guard.adapters.cursor_cli import CursorCliLaunchEntry
-
     entry = CursorCliLaunchEntry(executable="/bin/cursor-agent", launch_mode="cursor-agent")
     assert entry.launch_argv(["agent", "--print", "hello"]) == ["/bin/cursor-agent", "--print", "hello"]
 

--- a/tests/test_cursor_cli.py
+++ b/tests/test_cursor_cli.py
@@ -55,6 +55,13 @@ def _write_fake_cursor_with_agent_subcommand(bin_dir: Path) -> Path:
     return script
 
 
+def test_launch_argv_strips_agent_prefix_for_cursor_agent_binary() -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_cli import CursorCliLaunchEntry
+
+    entry = CursorCliLaunchEntry(executable="/bin/cursor-agent", launch_mode="cursor-agent")
+    assert entry.launch_argv(["agent", "--print", "hello"]) == ["/bin/cursor-agent", "--print", "hello"]
+
+
 def test_resolve_cursor_cli_entry_prefers_cursor_agent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     bin_dir = tmp_path / "bin"
     _write_fake_cursor_agent(bin_dir)


### PR DESCRIPTION
## Summary
- Strip a leading `agent` passthrough arg when launching the standalone `cursor-agent` binary.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_cli.py -q`
