### PR TITLE
fix(cursor): route hook script through hol-guard guard hook

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -420,9 +420,13 @@ def _resolve_guard_cli_command() -> list[str]:
     return [sys.executable, "-m", "codex_plugin_scanner.cli"]
 
 
-def _uses_top_level_hook_command(_guard_cli: list[str]) -> bool:
-    # Installed hol-guard exposes hooks at `hol-guard guard hook`, not `hol-guard hook`.
-    return False
+def _uses_top_level_hook_command(guard_cli: list[str]) -> bool:
+    if not guard_cli:
+        return False
+    # hol-guard/plugin-guard entrypoints expose `hook` at the top level (combined-mode
+    # hol-guard rewrites `hook` to `guard hook` internally). Only module invocations
+    # need an explicit `guard` prefix.
+    return Path(guard_cli[0]).name in {"hol-guard", "plugin-guard"}
 
 
 def _embedded_guard_hook_argv(context: HarnessContext) -> list[str]:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -421,7 +421,9 @@ def _resolve_guard_cli_command() -> list[str]:
 
 
 def _uses_top_level_hook_command(guard_cli: list[str]) -> bool:
-    return bool(guard_cli) and Path(guard_cli[0]).name == "hol-guard"
+    del guard_cli
+    # Installed hol-guard exposes hooks at `hol-guard guard hook`, not `hol-guard hook`.
+    return False
 
 
 def _embedded_guard_hook_argv(context: HarnessContext) -> list[str]:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -420,8 +420,7 @@ def _resolve_guard_cli_command() -> list[str]:
     return [sys.executable, "-m", "codex_plugin_scanner.cli"]
 
 
-def _uses_top_level_hook_command(guard_cli: list[str]) -> bool:
-    del guard_cli
+def _uses_top_level_hook_command(_guard_cli: list[str]) -> bool:
     # Installed hol-guard exposes hooks at `hol-guard guard hook`, not `hol-guard hook`.
     return False
 

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -173,18 +174,26 @@ def test_cursor_hook_script_source_skips_missing_workspace(tmp_path: Path) -> No
     assert "Path(candidate).is_dir()" in source
 
 
-def test_cursor_hook_script_source_uses_guard_subcommand_for_hol_guard_cli(
+def test_cursor_hook_script_source_routes_hook_argv_by_cli_entrypoint(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
 
+    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=tmp_path)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
         lambda: ["hol-guard"],
     )
-    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=tmp_path)
-    source = cursor_hook_script_source(context)
-    assert 'GUARD_HOOK_ARGV = ["guard", "hook"' in source
+    hol_guard_source = cursor_hook_script_source(context)
+    assert 'GUARD_HOOK_ARGV = ["hook"' in hol_guard_source
+    assert 'GUARD_HOOK_ARGV = ["guard", "hook"' not in hol_guard_source
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+        lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+    )
+    module_source = cursor_hook_script_source(context)
+    assert 'GUARD_HOOK_ARGV = ["guard", "hook"' in module_source
 
 
 def test_strip_managed_hook_entries_removes_hol_guard_pretooluse(tmp_path: Path) -> None:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -173,6 +173,20 @@ def test_cursor_hook_script_source_skips_missing_workspace(tmp_path: Path) -> No
     assert "Path(candidate).is_dir()" in source
 
 
+def test_cursor_hook_script_source_uses_guard_subcommand_for_hol_guard_cli(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+        lambda: ["hol-guard"],
+    )
+    context = HarnessContext(home_dir=tmp_path / "home", guard_home=tmp_path / "guard", workspace_dir=tmp_path)
+    source = cursor_hook_script_source(context)
+    assert 'GUARD_HOOK_ARGV = ["guard", "hook"' in source
+
+
 def test_strip_managed_hook_entries_removes_hol_guard_pretooluse(tmp_path: Path) -> None:
     script_path = tmp_path / "hol-guard-cursor-hook.py"
     script_path.write_text("# Managed by HOL Guard\n", encoding="utf-8")


### PR DESCRIPTION
## Summary
- Keep `hook` at the top level for `hol-guard` and `plugin-guard` hook scripts; only `python -m codex_plugin_scanner.cli` invocations use the `guard hook` prefix.
- Add regression coverage for both CLI entrypoint routing paths.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_hooks.py::test_cursor_hook_script_source_routes_hook_argv_by_cli_entrypoint -q`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_install_workspace.py::test_install_cursor_hook_script_allows_benign_shell_command -q`
- `PYTHONPATH=src python3 -m pytest "tests/test_cursor_headless_fixtures.py::TestCursorHeadlessHookExecution::test_cursor_hook_fixture_permission[benign-echo.json]" -q`
