### PR TITLE
fix(dashboard): polish insights seven-day trend chart

### DIFF
--- a/dashboard/src/evidence/evidence-trend-chart.test.ts
+++ b/dashboard/src/evidence/evidence-trend-chart.test.ts
@@ -1,21 +1,19 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import type { GuardReceiptAnalyticsBucket } from "../guard-types";
+import { bucketTotal, computeTrendBarHeight } from "./evidence-trend-chart";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const chartSource = readFileSync(join(__dirname, "evidence-trend-chart.tsx"), "utf8");
-const stylesSource = readFileSync(join(__dirname, "../styles.css"), "utf8");
+const bucket: GuardReceiptAnalyticsBucket = {
+  date_key: "2026-06-08",
+  label: "Jun 8",
+  allowed: 2800,
+  blocked: 12,
+  reviewed: 310,
+};
 
-assert(chartSource.includes('role="group"'), "trend chart: uses accessible group role");
-assert(!chartSource.includes('role="img"'), "trend chart: avoids presentational img role");
-assert(chartSource.includes("formatEvidenceCount"), "trend chart: formats large totals");
-assert(chartSource.includes("flexGrow"), "trend chart: proportional segment sizing");
-assert(chartSource.includes("min-h-[3px]"), "trend chart: minimum visible segment height");
-assert(chartSource.includes("evidence-trend-chart-well"), "trend chart: column well background");
-assert(chartSource.includes("createPortal"), "trend chart: portals tooltip above modals");
-assert(chartSource.includes("prefers-reduced-motion"), "trend chart: respects reduced motion");
-assert(stylesSource.includes(".evidence-trend-chart-bar-motion"), "styles: bar entrance animation");
-assert(stylesSource.includes(".evidence-trend-chart-bar-active"), "styles: active bar elevation");
+assert.equal(bucketTotal(bucket), 3122);
+assert.equal(bucketTotal({ ...bucket, allowed: 0, blocked: 0, reviewed: 0 }), 0);
+assert.equal(computeTrendBarHeight(0, 100), 0);
+assert.equal(computeTrendBarHeight(50, 100, 100), 50);
+assert.equal(computeTrendBarHeight(5, 100, 100), 10);
 
 console.log("evidence-trend-chart.test.ts: all tests passed");

--- a/dashboard/src/evidence/evidence-trend-chart.test.ts
+++ b/dashboard/src/evidence/evidence-trend-chart.test.ts
@@ -1,0 +1,21 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const chartSource = readFileSync(join(__dirname, "evidence-trend-chart.tsx"), "utf8");
+const stylesSource = readFileSync(join(__dirname, "../styles.css"), "utf8");
+
+assert(chartSource.includes('role="group"'), "trend chart: uses accessible group role");
+assert(!chartSource.includes('role="img"'), "trend chart: avoids presentational img role");
+assert(chartSource.includes("formatEvidenceCount"), "trend chart: formats large totals");
+assert(chartSource.includes("flexGrow"), "trend chart: proportional segment sizing");
+assert(chartSource.includes("min-h-[3px]"), "trend chart: minimum visible segment height");
+assert(chartSource.includes("evidence-trend-chart-well"), "trend chart: column well background");
+assert(chartSource.includes("createPortal"), "trend chart: portals tooltip above modals");
+assert(chartSource.includes("prefers-reduced-motion"), "trend chart: respects reduced motion");
+assert(stylesSource.includes(".evidence-trend-chart-bar-motion"), "styles: bar entrance animation");
+assert(stylesSource.includes(".evidence-trend-chart-bar-active"), "styles: active bar elevation");
+
+console.log("evidence-trend-chart.test.ts: all tests passed");

--- a/dashboard/src/evidence/evidence-trend-chart.tsx
+++ b/dashboard/src/evidence/evidence-trend-chart.tsx
@@ -1,8 +1,29 @@
-import { useState } from "react";
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { createPortal } from "react-dom";
 import type { GuardReceiptAnalyticsBucket } from "../guard-types";
+import { formatEvidenceCount } from "./evidence-format";
+
+const CHART_HEIGHT_PX = 112;
+const TOOLTIP_ID = "evidence-trend-chart-tooltip";
 
 function bucketTotal(bucket: GuardReceiptAnalyticsBucket): number {
   return bucket.allowed + bucket.blocked + bucket.reviewed;
+}
+
+function isGuardModalOpen(): boolean {
+  if (typeof document === "undefined") return false;
+  const count = Number(document.documentElement.dataset.guardModalOpen ?? 0);
+  return Number.isFinite(count) && count > 0;
+}
+
+interface TooltipState {
+  label: string;
+  allowed: number;
+  blocked: number;
+  reviewed: number;
+  top: number;
+  left: number;
+  placement: "above" | "below";
 }
 
 interface EvidenceTrendChartProps {
@@ -10,91 +31,224 @@ interface EvidenceTrendChartProps {
 }
 
 export function EvidenceTrendChart({ buckets }: EvidenceTrendChartProps) {
+  const cellRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   const [hoveredKey, setHoveredKey] = useState<string | null>(null);
-  const maxTotal = Math.max(...buckets.map((bucket) => bucketTotal(bucket)), 1);
-  const chartHeight = 100;
-  const hasAnyData = buckets.some((bucket) => bucketTotal(bucket) > 0);
+  const [tooltip, setTooltip] = useState<TooltipState | null>(null);
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  const maxTotal = useMemo(() => Math.max(...buckets.map((bucket) => bucketTotal(bucket)), 1), [buckets]);
+  const hasAnyData = useMemo(() => buckets.some((bucket) => bucketTotal(bucket) > 0), [buckets]);
+
+  useEffect(() => {
+    setReduceMotion(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+  }, []);
+
+  const updateTooltipForKey = useCallback(
+    (dateKey: string | null) => {
+      if (!dateKey || isGuardModalOpen()) {
+        setTooltip(null);
+        return;
+      }
+      const bucket = buckets.find((entry) => entry.date_key === dateKey);
+      const element = cellRefs.current.get(dateKey);
+      if (!bucket || !element || bucketTotal(bucket) <= 0) {
+        setTooltip(null);
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      const aboveTop = rect.top - 8;
+      const belowTop = rect.bottom + 8;
+      const placement = aboveTop > 80 ? "above" : "below";
+      setTooltip({
+        label: bucket.label,
+        allowed: bucket.allowed,
+        blocked: bucket.blocked,
+        reviewed: bucket.reviewed,
+        left: rect.left + rect.width / 2,
+        top: placement === "above" ? aboveTop : belowTop,
+        placement,
+      });
+    },
+    [buckets],
+  );
+
+  useLayoutEffect(() => {
+    updateTooltipForKey(hoveredKey);
+  }, [hoveredKey, updateTooltipForKey, buckets]);
+
+  useEffect(() => {
+    if (!hoveredKey) return;
+    const onScrollOrResize = () => updateTooltipForKey(hoveredKey);
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, [hoveredKey, updateTooltipForKey]);
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const dismissWhenModalOpens = () => {
+      if (isGuardModalOpen()) {
+        setTooltip(null);
+        setHoveredKey(null);
+      }
+    };
+    const observer = new MutationObserver(dismissWhenModalOpens);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-guard-modal-open"] });
+    return () => observer.disconnect();
+  }, []);
 
   if (!hasAnyData) {
     return <p className="px-5 py-6 text-sm text-slate-400">No activity in this period.</p>;
   }
 
+  const tooltipNode =
+    tooltip && !isGuardModalOpen() && typeof document !== "undefined"
+      ? createPortal(
+          <div
+            id={TOOLTIP_ID}
+            className="pointer-events-none fixed z-40 -translate-x-1/2 rounded-lg bg-brand-dark px-3 py-2 text-xs text-white shadow-lg"
+            style={{
+              left: tooltip.left,
+              top: tooltip.top,
+              transform: `translate(-50%, ${tooltip.placement === "above" ? "-100%" : "0"})`,
+            }}
+            role="tooltip"
+          >
+            <div className="font-semibold">{tooltip.label}</div>
+            <div className="mt-1 flex flex-wrap gap-x-3 gap-y-0.5">
+              {tooltip.allowed > 0 && (
+                <span className="text-emerald-300">{formatEvidenceCount(tooltip.allowed)} allowed</span>
+              )}
+              {tooltip.blocked > 0 && (
+                <span className="text-amber-300">{formatEvidenceCount(tooltip.blocked)} stopped</span>
+              )}
+              {tooltip.reviewed > 0 && (
+                <span className="text-sky-300">{formatEvidenceCount(tooltip.reviewed)} reviewed</span>
+              )}
+            </div>
+          </div>,
+          document.body,
+        )
+      : null;
+
   return (
-    <div className="px-5 py-5">
+    <div className="px-5 pb-5 pt-4">
+      {tooltipNode}
       <div
-        className="flex items-end gap-2"
-        style={{ minHeight: chartHeight }}
-        role="img"
+        className="relative flex items-end gap-1.5 sm:gap-2"
+        style={{ minHeight: CHART_HEIGHT_PX + 44 }}
+        role="group"
         aria-label="Seven day activity chart"
       >
-        {buckets.map((bucket) => {
+        <div
+          className="pointer-events-none absolute inset-x-0 bottom-[26px] flex flex-col justify-between"
+          style={{ height: CHART_HEIGHT_PX }}
+          aria-hidden="true"
+        >
+          {[0, 1, 2].map((line) => (
+            <div
+              key={line}
+              className="h-px w-full bg-slate-200/70"
+              style={{ opacity: line === 0 ? 0.35 : 0.55 }}
+            />
+          ))}
+        </div>
+
+        {buckets.map((bucket, index) => {
           const total = bucketTotal(bucket);
-          const barHeight = total > 0 ? Math.max(Math.round((total / maxTotal) * chartHeight), 6) : 0;
-          const blockedHeight = total > 0 ? Math.round((bucket.blocked / total) * barHeight) : 0;
-          const allowedHeight = total > 0 ? Math.round((bucket.allowed / total) * barHeight) : 0;
-          const reviewedHeight = Math.max(barHeight - blockedHeight - allowedHeight, 0);
-          const isHovered = hoveredKey === bucket.date_key;
+          const barHeight =
+            total > 0 ? Math.max(Math.round((total / maxTotal) * CHART_HEIGHT_PX), 10) : 0;
+          const isActive = hoveredKey === bucket.date_key;
+          const showTooltip = isActive && tooltip !== null;
 
           return (
-            <div
-              key={bucket.date_key}
-              className="relative flex min-w-0 flex-1 flex-col items-center justify-end"
-              onMouseEnter={() => setHoveredKey(bucket.date_key)}
-              onMouseLeave={() => setHoveredKey(null)}
-            >
-              {total > 0 && (
-                <span className="mb-1 text-[10px] font-semibold tabular-nums text-brand-dark">{total}</span>
-              )}
-              <div className="flex w-full flex-col justify-end" style={{ height: chartHeight }}>
+            <div key={bucket.date_key} className="relative z-[1] flex min-w-0 flex-1 flex-col items-center justify-end">
+              <span
+                className={`mb-2 text-[11px] font-semibold tabular-nums tracking-tight transition-colors ${
+                  isActive ? "text-brand-blue" : "text-brand-dark"
+                }`}
+                aria-hidden={total <= 0}
+              >
+                {total > 0 ? formatEvidenceCount(total) : ""}
+              </span>
+
+              <div className="relative w-full max-w-[3.25rem]" style={{ height: CHART_HEIGHT_PX }}>
+                <div className="evidence-trend-chart-well absolute inset-0 rounded-lg" aria-hidden="true" />
+
                 {total > 0 ? (
-                  <div
-                    className={`flex w-full flex-col-reverse overflow-hidden rounded-md transition-opacity ${
-                      isHovered ? "opacity-100 ring-1 ring-inset ring-slate-200" : "opacity-95"
-                    }`}
-                    style={{ height: barHeight }}
+                  <button
+                    type="button"
+                    ref={(node) => {
+                      if (node) cellRefs.current.set(bucket.date_key, node);
+                      else cellRefs.current.delete(bucket.date_key);
+                    }}
+                    aria-label={`${bucket.label}: ${formatEvidenceCount(total)} actions`}
+                    aria-describedby={showTooltip ? TOOLTIP_ID : undefined}
+                    className={`evidence-trend-chart-bar absolute inset-x-0 bottom-0 flex w-full flex-col-reverse overflow-hidden rounded-t-lg shadow-[inset_0_1px_0_rgba(255,255,255,0.35)] outline-none ${
+                      isActive ? "evidence-trend-chart-bar-active" : ""
+                    } ${reduceMotion ? "" : "evidence-trend-chart-bar-motion"}`}
+                    style={{
+                      height: barHeight,
+                      animationDelay: reduceMotion ? undefined : `${index * 45}ms`,
+                    }}
+                    onMouseEnter={() => setHoveredKey(bucket.date_key)}
+                    onMouseLeave={() => setHoveredKey(null)}
+                    onFocus={() => setHoveredKey(bucket.date_key)}
+                    onBlur={() => setHoveredKey(null)}
                   >
                     {bucket.blocked > 0 && (
-                      <div className="w-full evidence-chart-stopped" style={{ height: blockedHeight }} />
+                      <div
+                        className="evidence-chart-stopped min-h-[3px] w-full shrink-0"
+                        style={{ flexGrow: bucket.blocked }}
+                      />
                     )}
                     {bucket.allowed > 0 && (
-                      <div className="w-full evidence-chart-allowed" style={{ height: allowedHeight }} />
+                      <div
+                        className="evidence-chart-allowed min-h-[3px] w-full shrink-0"
+                        style={{ flexGrow: bucket.allowed }}
+                      />
                     )}
                     {bucket.reviewed > 0 && (
-                      <div className="w-full evidence-chart-reviewed" style={{ height: reviewedHeight }} />
+                      <div
+                        className="evidence-chart-reviewed min-h-[3px] w-full shrink-0"
+                        style={{ flexGrow: bucket.reviewed }}
+                      />
                     )}
-                  </div>
+                  </button>
                 ) : (
-                  <div className="mx-auto h-1.5 w-1.5 rounded-full bg-slate-200" aria-hidden="true" />
+                  <div
+                    className="absolute inset-x-2 bottom-0 h-1.5 rounded-full bg-slate-200/90"
+                    aria-hidden="true"
+                  />
                 )}
               </div>
-              <span className="mt-2 w-full truncate text-center text-[10px] font-medium text-slate-500">
+
+              <span
+                className={`mt-2.5 w-full truncate text-center text-[10px] font-medium leading-none transition-colors ${
+                  isActive ? "text-brand-dark" : "text-slate-500"
+                }`}
+              >
                 {bucket.label}
               </span>
-              {isHovered && total > 0 && (
-                <div className="absolute bottom-full z-10 mb-2 rounded-lg bg-brand-dark px-3 py-2 text-xs text-white shadow-lg">
-                  <div className="font-semibold">{bucket.label}</div>
-                  <div className="mt-1 flex gap-3">
-                    {bucket.allowed > 0 && <span className="text-emerald-300">{bucket.allowed} allowed</span>}
-                    {bucket.blocked > 0 && <span className="text-amber-300">{bucket.blocked} stopped</span>}
-                    {bucket.reviewed > 0 && <span className="text-blue-300">{bucket.reviewed} reviewed</span>}
-                  </div>
-                </div>
-              )}
             </div>
           );
         })}
       </div>
-      <div className="mt-3 flex flex-wrap items-center gap-3 text-[11px] text-slate-500">
+
+      <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-slate-100 pt-3 text-[11px] text-slate-500">
         <span className="inline-flex items-center gap-1.5">
-          <span className="inline-block h-2.5 w-2.5 rounded-sm evidence-chart-allowed" />
+          <span className="inline-block h-2 w-2 rounded-full evidence-chart-allowed" />
           Allowed
         </span>
         <span className="inline-flex items-center gap-1.5">
-          <span className="inline-block h-2.5 w-2.5 rounded-sm evidence-chart-stopped" />
+          <span className="inline-block h-2 w-2 rounded-full evidence-chart-stopped" />
           Stopped
         </span>
         <span className="inline-flex items-center gap-1.5">
-          <span className="inline-block h-2.5 w-2.5 rounded-sm evidence-chart-reviewed" />
+          <span className="inline-block h-2 w-2 rounded-full evidence-chart-reviewed" />
           Reviewed
         </span>
       </div>

--- a/dashboard/src/evidence/evidence-trend-chart.tsx
+++ b/dashboard/src/evidence/evidence-trend-chart.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import type { GuardReceiptAnalyticsBucket } from "../guard-types";
 import { formatEvidenceCount } from "./evidence-format";
@@ -6,8 +6,15 @@ import { formatEvidenceCount } from "./evidence-format";
 const CHART_HEIGHT_PX = 112;
 const TOOLTIP_ID = "evidence-trend-chart-tooltip";
 
-function bucketTotal(bucket: GuardReceiptAnalyticsBucket): number {
+export function bucketTotal(bucket: GuardReceiptAnalyticsBucket): number {
   return bucket.allowed + bucket.blocked + bucket.reviewed;
+}
+
+export function computeTrendBarHeight(total: number, maxTotal: number, chartHeight = CHART_HEIGHT_PX): number {
+  if (total <= 0 || maxTotal <= 0) {
+    return 0;
+  }
+  return Math.max(Math.round((total / maxTotal) * chartHeight), 10);
 }
 
 function isGuardModalOpen(): boolean {
@@ -40,7 +47,11 @@ export function EvidenceTrendChart({ buckets }: EvidenceTrendChartProps) {
   const hasAnyData = useMemo(() => buckets.some((bucket) => bucketTotal(bucket) > 0), [buckets]);
 
   useEffect(() => {
-    setReduceMotion(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const syncPreference = () => setReduceMotion(media.matches);
+    syncPreference();
+    media.addEventListener("change", syncPreference);
+    return () => media.removeEventListener("change", syncPreference);
   }, []);
 
   const updateTooltipForKey = useCallback(
@@ -72,7 +83,7 @@ export function EvidenceTrendChart({ buckets }: EvidenceTrendChartProps) {
     [buckets],
   );
 
-  useLayoutEffect(() => {
+  useEffect(() => {
     updateTooltipForKey(hoveredKey);
   }, [hoveredKey, updateTooltipForKey, buckets]);
 
@@ -109,7 +120,7 @@ export function EvidenceTrendChart({ buckets }: EvidenceTrendChartProps) {
       ? createPortal(
           <div
             id={TOOLTIP_ID}
-            className="pointer-events-none fixed z-40 -translate-x-1/2 rounded-lg bg-brand-dark px-3 py-2 text-xs text-white shadow-lg"
+            className="pointer-events-none fixed z-40 rounded-lg bg-brand-dark px-3 py-2 text-xs text-white shadow-lg"
             style={{
               left: tooltip.left,
               top: tooltip.top,
@@ -159,8 +170,7 @@ export function EvidenceTrendChart({ buckets }: EvidenceTrendChartProps) {
 
         {buckets.map((bucket, index) => {
           const total = bucketTotal(bucket);
-          const barHeight =
-            total > 0 ? Math.max(Math.round((total / maxTotal) * CHART_HEIGHT_PX), 10) : 0;
+          const barHeight = computeTrendBarHeight(total, maxTotal);
           const isActive = hoveredKey === bucket.date_key;
           const showTooltip = isActive && tooltip !== null;
 
@@ -170,7 +180,7 @@ export function EvidenceTrendChart({ buckets }: EvidenceTrendChartProps) {
                 className={`mb-2 text-[11px] font-semibold tabular-nums tracking-tight transition-colors ${
                   isActive ? "text-brand-blue" : "text-brand-dark"
                 }`}
-                aria-hidden={total <= 0}
+                aria-hidden="true"
               >
                 {total > 0 ? formatEvidenceCount(total) : ""}
               </span>

--- a/dashboard/src/styles.css
+++ b/dashboard/src/styles.css
@@ -290,7 +290,8 @@ a:focus-visible {
 
   .evidence-metric-enter,
   .evidence-share-bar-fill-animate,
-  .evidence-heatmap-motion {
+  .evidence-heatmap-motion,
+  .evidence-trend-chart-bar-motion {
     animation: none !important;
     transition: none !important;
   }
@@ -335,6 +336,50 @@ a:focus-visible {
 
 .evidence-chart-reviewed {
   background-color: var(--evidence-reviewed);
+}
+
+.evidence-trend-chart-well {
+  background-color: color-mix(in srgb, var(--surface-2) 88%, white);
+  box-shadow: inset 0 1px 0 color-mix(in srgb, white 70%, transparent);
+}
+
+.evidence-trend-chart-bar {
+  transition:
+    transform 180ms var(--ease-out-quart),
+    box-shadow 180ms var(--ease-out-quart);
+}
+
+.evidence-trend-chart-bar:focus-visible {
+  outline: 2px solid color-mix(in srgb, var(--brand-blue) 55%, white);
+  outline-offset: 2px;
+}
+
+.evidence-trend-chart-bar-active {
+  transform: translateY(-2px);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.4),
+    0 6px 16px color-mix(in srgb, var(--brand-blue) 12%, transparent);
+}
+
+@keyframes evidence-trend-bar-rise {
+  from {
+    transform: scaleY(0);
+    opacity: 0.65;
+  }
+  to {
+    transform: scaleY(1);
+    opacity: 1;
+  }
+}
+
+.evidence-trend-chart-bar-motion {
+  transform-origin: bottom center;
+  animation: evidence-trend-bar-rise 520ms var(--ease-out-expo) both;
+}
+
+.evidence-trend-chart-bar-motion.evidence-trend-chart-bar-active {
+  animation: none;
+  transform: translateY(-2px);
 }
 
 .evidence-share-bar-fill {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17960,7 +17960,7 @@ function formatDayLabel(dateKey) {
   });
 }
 function selectRecentDailyActivity(days, dayCount) {
-  if (dayCount <= 0) {
+  if (!days || dayCount <= 0) {
     return [];
   }
   return days.slice(-dayCount);
@@ -17974,7 +17974,7 @@ function intensityClass(total, peak) {
   return "evidence-heatmap-1";
 }
 function formatWeekdayShort(dateKey) {
-  return (/* @__PURE__ */ new Date(`${dateKey}T12:00:00`)).toLocaleDateString(void 0, { weekday: "short" });
+  return (/* @__PURE__ */ new Date(`${dateKey}T12:00:00`)).toLocaleDateString("en-US", { weekday: "short" });
 }
 function buildWeekColumns(days) {
   if (days.length === 0) return [];
@@ -18018,7 +18018,7 @@ function monthLabels(weeks) {
   }
   return labels;
 }
-function isGuardModalOpen() {
+function isGuardModalOpen$1() {
   if (typeof document === "undefined") return false;
   const count = Number(document.documentElement.dataset.guardModalOpen ?? 0);
   return Number.isFinite(count) && count > 0;
@@ -18048,7 +18048,7 @@ function EvidenceActivityHeatmapMini({
   }, []);
   const updateTooltipForKey = reactExports.useCallback(
     (dateKey) => {
-      if (!dateKey || isGuardModalOpen()) {
+      if (!dateKey || isGuardModalOpen$1()) {
         setTooltip(null);
         return;
       }
@@ -18076,6 +18076,7 @@ function EvidenceActivityHeatmapMini({
     updateTooltipForKey(hoveredKey);
   }, [hoveredKey, updateTooltipForKey, visibleDays]);
   reactExports.useEffect(() => {
+    if (!hoveredKey) return;
     const onScrollOrResize = () => updateTooltipForKey(hoveredKey);
     window.addEventListener("scroll", onScrollOrResize, true);
     window.addEventListener("resize", onScrollOrResize);
@@ -18087,7 +18088,7 @@ function EvidenceActivityHeatmapMini({
   reactExports.useEffect(() => {
     if (typeof document === "undefined") return;
     const dismissWhenModalOpens = () => {
-      if (isGuardModalOpen()) {
+      if (isGuardModalOpen$1()) {
         setTooltip(null);
         setHoveredKey(null);
       }
@@ -18096,10 +18097,11 @@ function EvidenceActivityHeatmapMini({
     observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-guard-modal-open"] });
     return () => observer.disconnect();
   }, []);
+  const miniHeatmapTooltipId = "mini-heatmap-tooltip";
   if (visibleDays.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "py-2 text-sm text-slate-400", children: "No activity in this period." });
   }
-  const tooltipNode = tooltip && !isGuardModalOpen() && typeof document !== "undefined" ? reactDomExports.createPortal(
+  const tooltipNode = tooltip && !isGuardModalOpen$1() && typeof document !== "undefined" ? reactDomExports.createPortal(
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "div",
       {
@@ -18110,6 +18112,7 @@ function EvidenceActivityHeatmapMini({
           transform: `translate(-50%, ${tooltip.placement === "above" ? "-100%" : "0"})`
         },
         role: "tooltip",
+        id: miniHeatmapTooltipId,
         children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "font-semibold", children: formatDayLabel(tooltip.dateKey) }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-0.5 text-slate-200", children: tooltip.total > 0 ? `${formatEvidenceCount(tooltip.total)} action${tooltip.total === 1 ? "" : "s"}` : "No activity" })
@@ -18125,10 +18128,11 @@ function EvidenceActivityHeatmapMini({
       {
         className: "grid gap-2",
         style: { gridTemplateColumns: `repeat(${visibleDays.length}, minmax(0, 1fr))` },
-        role: "img",
+        role: "group",
         "aria-label": `Last ${visibleDays.length} days of Guard activity`,
         children: visibleDays.map((day) => {
           const isHovered = hoveredKey === day.date_key;
+          const showTooltip = isHovered && tooltip !== null;
           return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 flex-col items-center gap-1.5", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               "button",
@@ -18139,6 +18143,7 @@ function EvidenceActivityHeatmapMini({
                   else cellRefs.current.delete(day.date_key);
                 },
                 "aria-label": `${formatDayLabel(day.date_key)}: ${day.total} actions`,
+                "aria-describedby": showTooltip ? miniHeatmapTooltipId : void 0,
                 className: `h-5 w-full max-w-5 rounded-[3px] transition-[transform,opacity] duration-150 ${intensityClass(day.total, peak)} ${day.total > 0 ? "cursor-pointer hover:opacity-90" : "cursor-default opacity-90"} ${isHovered ? "evidence-heatmap-active" : ""} ${reduceMotion ? "" : "evidence-heatmap-motion"}`,
                 onMouseEnter: () => setHoveredKey(day.date_key),
                 onMouseLeave: () => setHoveredKey(null),
@@ -18189,7 +18194,7 @@ function EvidenceActivityHeatmap({
     setReduceMotion(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
   }, []);
   const updateTooltipForKey = reactExports.useCallback((dateKey) => {
-    if (!dateKey || isGuardModalOpen()) {
+    if (!dateKey || isGuardModalOpen$1()) {
       setTooltip(null);
       return;
     }
@@ -18226,7 +18231,7 @@ function EvidenceActivityHeatmap({
   reactExports.useEffect(() => {
     if (typeof document === "undefined") return;
     const dismissWhenModalOpens = () => {
-      if (isGuardModalOpen()) {
+      if (isGuardModalOpen$1()) {
         setTooltip(null);
         setHoveredKey(null);
       }
@@ -18272,7 +18277,7 @@ function EvidenceActivityHeatmap({
   if (days.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "py-8 text-center text-sm text-slate-400", children: "No activity in this period." });
   }
-  const tooltipNode = tooltip && !isGuardModalOpen() && typeof document !== "undefined" ? reactDomExports.createPortal(
+  const tooltipNode = tooltip && !isGuardModalOpen$1() && typeof document !== "undefined" ? reactDomExports.createPortal(
     /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "div",
       {
@@ -18919,88 +18924,231 @@ function EvidenceShareBar({ label, count, shareOfTotal, onClick, animate = true 
     ) })
   ] }) });
 }
+const CHART_HEIGHT_PX = 112;
+const TOOLTIP_ID = "evidence-trend-chart-tooltip";
 function bucketTotal(bucket) {
   return bucket.allowed + bucket.blocked + bucket.reviewed;
 }
+function isGuardModalOpen() {
+  if (typeof document === "undefined") return false;
+  const count = Number(document.documentElement.dataset.guardModalOpen ?? 0);
+  return Number.isFinite(count) && count > 0;
+}
 function EvidenceTrendChart({ buckets }) {
+  const cellRefs = reactExports.useRef(/* @__PURE__ */ new Map());
   const [hoveredKey, setHoveredKey] = reactExports.useState(null);
-  const maxTotal = Math.max(...buckets.map((bucket) => bucketTotal(bucket)), 1);
-  const chartHeight = 100;
-  const hasAnyData = buckets.some((bucket) => bucketTotal(bucket) > 0);
+  const [tooltip, setTooltip] = reactExports.useState(null);
+  const [reduceMotion, setReduceMotion] = reactExports.useState(false);
+  const maxTotal = reactExports.useMemo(() => Math.max(...buckets.map((bucket) => bucketTotal(bucket)), 1), [buckets]);
+  const hasAnyData = reactExports.useMemo(() => buckets.some((bucket) => bucketTotal(bucket) > 0), [buckets]);
+  reactExports.useEffect(() => {
+    setReduceMotion(window.matchMedia("(prefers-reduced-motion: reduce)").matches);
+  }, []);
+  const updateTooltipForKey = reactExports.useCallback(
+    (dateKey) => {
+      if (!dateKey || isGuardModalOpen()) {
+        setTooltip(null);
+        return;
+      }
+      const bucket = buckets.find((entry) => entry.date_key === dateKey);
+      const element = cellRefs.current.get(dateKey);
+      if (!bucket || !element || bucketTotal(bucket) <= 0) {
+        setTooltip(null);
+        return;
+      }
+      const rect = element.getBoundingClientRect();
+      const aboveTop = rect.top - 8;
+      const belowTop = rect.bottom + 8;
+      const placement = aboveTop > 80 ? "above" : "below";
+      setTooltip({
+        label: bucket.label,
+        allowed: bucket.allowed,
+        blocked: bucket.blocked,
+        reviewed: bucket.reviewed,
+        left: rect.left + rect.width / 2,
+        top: placement === "above" ? aboveTop : belowTop,
+        placement
+      });
+    },
+    [buckets]
+  );
+  reactExports.useLayoutEffect(() => {
+    updateTooltipForKey(hoveredKey);
+  }, [hoveredKey, updateTooltipForKey, buckets]);
+  reactExports.useEffect(() => {
+    if (!hoveredKey) return;
+    const onScrollOrResize = () => updateTooltipForKey(hoveredKey);
+    window.addEventListener("scroll", onScrollOrResize, true);
+    window.addEventListener("resize", onScrollOrResize);
+    return () => {
+      window.removeEventListener("scroll", onScrollOrResize, true);
+      window.removeEventListener("resize", onScrollOrResize);
+    };
+  }, [hoveredKey, updateTooltipForKey]);
+  reactExports.useEffect(() => {
+    if (typeof document === "undefined") return;
+    const dismissWhenModalOpens = () => {
+      if (isGuardModalOpen()) {
+        setTooltip(null);
+        setHoveredKey(null);
+      }
+    };
+    const observer = new MutationObserver(dismissWhenModalOpens);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ["data-guard-modal-open"] });
+    return () => observer.disconnect();
+  }, []);
   if (!hasAnyData) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "px-5 py-6 text-sm text-slate-400", children: "No activity in this period." });
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "px-5 py-5", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
+  const tooltipNode = tooltip && !isGuardModalOpen() && typeof document !== "undefined" ? reactDomExports.createPortal(
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "div",
       {
-        className: "flex items-end gap-2",
-        style: { minHeight: chartHeight },
-        role: "img",
-        "aria-label": "Seven day activity chart",
-        children: buckets.map((bucket) => {
-          const total = bucketTotal(bucket);
-          const barHeight = total > 0 ? Math.max(Math.round(total / maxTotal * chartHeight), 6) : 0;
-          const blockedHeight = total > 0 ? Math.round(bucket.blocked / total * barHeight) : 0;
-          const allowedHeight = total > 0 ? Math.round(bucket.allowed / total * barHeight) : 0;
-          const reviewedHeight = Math.max(barHeight - blockedHeight - allowedHeight, 0);
-          const isHovered = hoveredKey === bucket.date_key;
-          return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-            "div",
-            {
-              className: "relative flex min-w-0 flex-1 flex-col items-center justify-end",
-              onMouseEnter: () => setHoveredKey(bucket.date_key),
-              onMouseLeave: () => setHoveredKey(null),
-              children: [
-                total > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mb-1 text-[10px] font-semibold tabular-nums text-brand-dark", children: total }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex w-full flex-col justify-end", style: { height: chartHeight }, children: total > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
-                  "div",
-                  {
-                    className: `flex w-full flex-col-reverse overflow-hidden rounded-md transition-opacity ${isHovered ? "opacity-100 ring-1 ring-inset ring-slate-200" : "opacity-95"}`,
-                    style: { height: barHeight },
-                    children: [
-                      bucket.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full evidence-chart-stopped", style: { height: blockedHeight } }),
-                      bucket.allowed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full evidence-chart-allowed", style: { height: allowedHeight } }),
-                      bucket.reviewed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full evidence-chart-reviewed", style: { height: reviewedHeight } })
-                    ]
-                  }
-                ) : /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mx-auto h-1.5 w-1.5 rounded-full bg-slate-200", "aria-hidden": "true" }) }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-2 w-full truncate text-center text-[10px] font-medium text-slate-500", children: bucket.label }),
-                isHovered && total > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "absolute bottom-full z-10 mb-2 rounded-lg bg-brand-dark px-3 py-2 text-xs text-white shadow-lg", children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "font-semibold", children: bucket.label }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1 flex gap-3", children: [
-                    bucket.allowed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-emerald-300", children: [
-                      bucket.allowed,
-                      " allowed"
-                    ] }),
-                    bucket.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-amber-300", children: [
-                      bucket.blocked,
-                      " stopped"
-                    ] }),
-                    bucket.reviewed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-blue-300", children: [
-                      bucket.reviewed,
-                      " reviewed"
-                    ] })
-                  ] })
-                ] })
-              ]
-            },
-            bucket.date_key
-          );
-        })
+        id: TOOLTIP_ID,
+        className: "pointer-events-none fixed z-40 -translate-x-1/2 rounded-lg bg-brand-dark px-3 py-2 text-xs text-white shadow-lg",
+        style: {
+          left: tooltip.left,
+          top: tooltip.top,
+          transform: `translate(-50%, ${tooltip.placement === "above" ? "-100%" : "0"})`
+        },
+        role: "tooltip",
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "font-semibold", children: tooltip.label }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1 flex flex-wrap gap-x-3 gap-y-0.5", children: [
+            tooltip.allowed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-emerald-300", children: [
+              formatEvidenceCount(tooltip.allowed),
+              " allowed"
+            ] }),
+            tooltip.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-amber-300", children: [
+              formatEvidenceCount(tooltip.blocked),
+              " stopped"
+            ] }),
+            tooltip.reviewed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "text-sky-300", children: [
+              formatEvidenceCount(tooltip.reviewed),
+              " reviewed"
+            ] })
+          ] })
+        ]
       }
     ),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex flex-wrap items-center gap-3 text-[11px] text-slate-500", children: [
+    document.body
+  ) : null;
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "px-5 pb-5 pt-4", children: [
+    tooltipNode,
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "div",
+      {
+        className: "relative flex items-end gap-1.5 sm:gap-2",
+        style: { minHeight: CHART_HEIGHT_PX + 44 },
+        role: "group",
+        "aria-label": "Seven day activity chart",
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "div",
+            {
+              className: "pointer-events-none absolute inset-x-0 bottom-[26px] flex flex-col justify-between",
+              style: { height: CHART_HEIGHT_PX },
+              "aria-hidden": "true",
+              children: [0, 1, 2].map((line) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "div",
+                {
+                  className: "h-px w-full bg-slate-200/70",
+                  style: { opacity: line === 0 ? 0.35 : 0.55 }
+                },
+                line
+              ))
+            }
+          ),
+          buckets.map((bucket, index) => {
+            const total = bucketTotal(bucket);
+            const barHeight = total > 0 ? Math.max(Math.round(total / maxTotal * CHART_HEIGHT_PX), 10) : 0;
+            const isActive = hoveredKey === bucket.date_key;
+            const showTooltip = isActive && tooltip !== null;
+            return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative z-[1] flex min-w-0 flex-1 flex-col items-center justify-end", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "span",
+                {
+                  className: `mb-2 text-[11px] font-semibold tabular-nums tracking-tight transition-colors ${isActive ? "text-brand-blue" : "text-brand-dark"}`,
+                  "aria-hidden": total <= 0,
+                  children: total > 0 ? formatEvidenceCount(total) : ""
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative w-full max-w-[3.25rem]", style: { height: CHART_HEIGHT_PX }, children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "evidence-trend-chart-well absolute inset-0 rounded-lg", "aria-hidden": "true" }),
+                total > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                  "button",
+                  {
+                    type: "button",
+                    ref: (node) => {
+                      if (node) cellRefs.current.set(bucket.date_key, node);
+                      else cellRefs.current.delete(bucket.date_key);
+                    },
+                    "aria-label": `${bucket.label}: ${formatEvidenceCount(total)} actions`,
+                    "aria-describedby": showTooltip ? TOOLTIP_ID : void 0,
+                    className: `evidence-trend-chart-bar absolute inset-x-0 bottom-0 flex w-full flex-col-reverse overflow-hidden rounded-t-lg shadow-[inset_0_1px_0_rgba(255,255,255,0.35)] outline-none ${isActive ? "evidence-trend-chart-bar-active" : ""} ${reduceMotion ? "" : "evidence-trend-chart-bar-motion"}`,
+                    style: {
+                      height: barHeight,
+                      animationDelay: reduceMotion ? void 0 : `${index * 45}ms`
+                    },
+                    onMouseEnter: () => setHoveredKey(bucket.date_key),
+                    onMouseLeave: () => setHoveredKey(null),
+                    onFocus: () => setHoveredKey(bucket.date_key),
+                    onBlur: () => setHoveredKey(null),
+                    children: [
+                      bucket.blocked > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+                        "div",
+                        {
+                          className: "evidence-chart-stopped min-h-[3px] w-full shrink-0",
+                          style: { flexGrow: bucket.blocked }
+                        }
+                      ),
+                      bucket.allowed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+                        "div",
+                        {
+                          className: "evidence-chart-allowed min-h-[3px] w-full shrink-0",
+                          style: { flexGrow: bucket.allowed }
+                        }
+                      ),
+                      bucket.reviewed > 0 && /* @__PURE__ */ jsxRuntimeExports.jsx(
+                        "div",
+                        {
+                          className: "evidence-chart-reviewed min-h-[3px] w-full shrink-0",
+                          style: { flexGrow: bucket.reviewed }
+                        }
+                      )
+                    ]
+                  }
+                ) : /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "div",
+                  {
+                    className: "absolute inset-x-2 bottom-0 h-1.5 rounded-full bg-slate-200/90",
+                    "aria-hidden": "true"
+                  }
+                )
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "span",
+                {
+                  className: `mt-2.5 w-full truncate text-center text-[10px] font-medium leading-none transition-colors ${isActive ? "text-brand-dark" : "text-slate-500"}`,
+                  children: bucket.label
+                }
+              )
+            ] }, bucket.date_key);
+          })
+        ]
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap items-center gap-x-4 gap-y-2 border-t border-slate-100 pt-3 text-[11px] text-slate-500", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-1.5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2.5 w-2.5 rounded-sm evidence-chart-allowed" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2 w-2 rounded-full evidence-chart-allowed" }),
         "Allowed"
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-1.5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2.5 w-2.5 rounded-sm evidence-chart-stopped" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2 w-2 rounded-full evidence-chart-stopped" }),
         "Stopped"
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-1.5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2.5 w-2.5 rounded-sm evidence-chart-reviewed" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-block h-2 w-2 rounded-full evidence-chart-reviewed" }),
         "Reviewed"
       ] })
     ] })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -105,6 +105,7 @@
     --color-emerald-500: oklch(69.6% .17 162.48);
     --color-emerald-600: oklch(59.6% .145 163.225);
     --color-emerald-700: oklch(50.8% .118 165.612);
+    --color-sky-300: oklch(82.8% .111 230.318);
     --color-blue-50: oklch(97% .014 254.604);
     --color-blue-100: oklch(93.2% .032 255.585);
     --color-blue-200: oklch(88.2% .059 254.128);
@@ -486,6 +487,14 @@
     inset: calc(var(--spacing) * 0);
   }
 
+  .inset-x-0 {
+    inset-inline: calc(var(--spacing) * 0);
+  }
+
+  .inset-x-2 {
+    inset-inline: calc(var(--spacing) * 2);
+  }
+
   .inset-y-0 {
     inset-block: calc(var(--spacing) * 0);
   }
@@ -570,8 +579,8 @@
     bottom: calc(var(--spacing) * 6);
   }
 
-  .bottom-full {
-    bottom: 100%;
+  .bottom-\[26px\] {
+    bottom: 26px;
   }
 
   .-left-1\.5 {
@@ -616,6 +625,10 @@
 
   .z-50 {
     z-index: 50;
+  }
+
+  .z-\[1\] {
+    z-index: 1;
   }
 
   .z-\[200\] {
@@ -710,6 +723,10 @@
 
   .mt-2 {
     margin-top: calc(var(--spacing) * 2);
+  }
+
+  .mt-2\.5 {
+    margin-top: calc(var(--spacing) * 2.5);
   }
 
   .mt-3 {
@@ -995,6 +1012,10 @@
     height: 100%;
   }
 
+  .h-px {
+    height: 1px;
+  }
+
   .max-h-4 {
     max-height: calc(var(--spacing) * 4);
   }
@@ -1033,6 +1054,10 @@
 
   .min-h-16 {
     min-height: calc(var(--spacing) * 16);
+  }
+
+  .min-h-\[3px\] {
+    min-height: 3px;
   }
 
   .min-h-\[72px\] {
@@ -1213,6 +1238,10 @@
 
   .max-w-7xl {
     max-width: var(--container-7xl);
+  }
+
+  .max-w-\[3\.25rem\] {
+    max-width: 3.25rem;
   }
 
   .max-w-\[200px\] {
@@ -1562,6 +1591,10 @@
     margin-block-end: calc(calc(var(--spacing) * 20) * calc(1 - var(--tw-space-y-reverse)));
   }
 
+  .gap-x-3 {
+    column-gap: calc(var(--spacing) * 3);
+  }
+
   .gap-x-4 {
     column-gap: calc(var(--spacing) * 4);
   }
@@ -1574,8 +1607,16 @@
     column-gap: calc(var(--spacing) * 12);
   }
 
+  .gap-y-0\.5 {
+    row-gap: calc(var(--spacing) * .5);
+  }
+
   .gap-y-1 {
     row-gap: calc(var(--spacing) * 1);
+  }
+
+  .gap-y-2 {
+    row-gap: calc(var(--spacing) * 2);
   }
 
   .gap-y-4 {
@@ -1694,6 +1735,11 @@
   .rounded-t-2xl {
     border-top-left-radius: var(--radius-2xl);
     border-top-right-radius: var(--radius-2xl);
+  }
+
+  .rounded-t-lg {
+    border-top-left-radius: var(--radius-lg);
+    border-top-right-radius: var(--radius-lg);
   }
 
   .rounded-t-sm {
@@ -2796,6 +2842,26 @@
     background-color: var(--color-slate-200);
   }
 
+  .bg-slate-200\/70 {
+    background-color: #e2e8f0b3;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-slate-200\/70 {
+      background-color: color-mix(in oklab, var(--color-slate-200) 70%, transparent);
+    }
+  }
+
+  .bg-slate-200\/90 {
+    background-color: #e2e8f0e6;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-slate-200\/90 {
+      background-color: color-mix(in oklab, var(--color-slate-200) 90%, transparent);
+    }
+  }
+
   .bg-slate-300 {
     background-color: var(--color-slate-300);
   }
@@ -3443,6 +3509,10 @@
     padding-bottom: calc(var(--spacing) * 4);
   }
 
+  .pb-5 {
+    padding-bottom: calc(var(--spacing) * 5);
+  }
+
   .pb-10 {
     padding-bottom: calc(var(--spacing) * 10);
   }
@@ -3727,10 +3797,6 @@
     color: var(--color-blue-200);
   }
 
-  .text-blue-300 {
-    color: var(--color-blue-300);
-  }
-
   .text-blue-700 {
     color: var(--color-blue-700);
   }
@@ -3909,6 +3975,10 @@
     color: var(--color-red-500);
   }
 
+  .text-sky-300 {
+    color: var(--color-sky-300);
+  }
+
   .text-slate-200 {
     color: var(--color-slate-200);
   }
@@ -4064,10 +4134,6 @@
     opacity: .9;
   }
 
-  .opacity-95 {
-    opacity: .95;
-  }
-
   .opacity-100 {
     opacity: 1;
   }
@@ -4099,6 +4165,11 @@
 
   .shadow-\[0_20px_60px_rgba\(63\,65\,116\,0\.08\)\] {
     --tw-shadow: 0 20px 60px var(--tw-shadow-color, #3f417414);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .shadow-\[inset_0_1px_0_rgba\(255\,255\,255\,0\.35\)\] {
+    --tw-shadow: inset 0 1px 0 var(--tw-shadow-color, #ffffff59);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 
@@ -4338,10 +4409,6 @@
 
   .\[scrollbar-gutter\:stable\] {
     scrollbar-gutter: stable;
-  }
-
-  .ring-inset {
-    --tw-ring-inset: inset;
   }
 
   .group-open\:rotate-90:is(:where(.group):is([open], :popover-open, :open) *) {
@@ -5110,6 +5177,10 @@
       justify-content: flex-end;
     }
 
+    .sm\:gap-2 {
+      gap: calc(var(--spacing) * 2);
+    }
+
     .sm\:gap-3 {
       gap: calc(var(--spacing) * 3);
     }
@@ -5706,7 +5777,7 @@ input:focus-visible, button:focus-visible, a:focus-visible {
     transition-duration: .01ms !important;
   }
 
-  .evidence-metric-enter, .evidence-share-bar-fill-animate, .evidence-heatmap-motion {
+  .evidence-metric-enter, .evidence-share-bar-fill-animate, .evidence-heatmap-motion, .evidence-trend-chart-bar-motion {
     transition: none !important;
     animation: none !important;
   }
@@ -5760,6 +5831,71 @@ input:focus-visible, button:focus-visible, a:focus-visible {
 
 .evidence-chart-reviewed {
   background-color: var(--evidence-reviewed);
+}
+
+.evidence-trend-chart-well {
+  background-color: var(--surface-2);
+}
+
+@supports (color: color-mix(in lab, red, red)) {
+  .evidence-trend-chart-well {
+    background-color: color-mix(in srgb, var(--surface-2) 88%, white);
+  }
+}
+
+.evidence-trend-chart-well {
+  box-shadow: inset 0 1px #ffffffb3;
+}
+
+.evidence-trend-chart-bar {
+  transition: transform .18s var(--ease-out-quart), box-shadow .18s var(--ease-out-quart);
+}
+
+.evidence-trend-chart-bar:focus-visible {
+  outline: 2px solid var(--brand-blue);
+}
+
+@supports (color: color-mix(in lab, red, red)) {
+  .evidence-trend-chart-bar:focus-visible {
+    outline: 2px solid color-mix(in srgb, var(--brand-blue) 55%, white);
+  }
+}
+
+.evidence-trend-chart-bar:focus-visible {
+  outline-offset: 2px;
+}
+
+.evidence-trend-chart-bar-active {
+  box-shadow: inset 0 1px 0 #fff6, 0 6px 16px var(--brand-blue);
+  transform: translateY(-2px);
+}
+
+@supports (color: color-mix(in lab, red, red)) {
+  .evidence-trend-chart-bar-active {
+    box-shadow: inset 0 1px 0 #fff6, 0 6px 16px color-mix(in srgb, var(--brand-blue) 12%, transparent);
+  }
+}
+
+@keyframes evidence-trend-bar-rise {
+  from {
+    opacity: .65;
+    transform: scaleY(0);
+  }
+
+  to {
+    opacity: 1;
+    transform: scaleY(1);
+  }
+}
+
+.evidence-trend-chart-bar-motion {
+  transform-origin: bottom;
+  animation: evidence-trend-bar-rise .52s var(--ease-out-expo) both;
+}
+
+.evidence-trend-chart-bar-motion.evidence-trend-chart-bar-active {
+  animation: none;
+  transform: translateY(-2px);
 }
 
 .evidence-share-bar-fill {


### PR DESCRIPTION
## Summary
- Redesign the Insights "Last 7 Days" stacked bar chart with column wells, proportional flex segments, formatted totals, and calmer hover/focus states.
- Portal tooltips, keyboard-accessible bar buttons, and reduced-motion-safe entrance animation.
- Minimum segment height so stopped actions remain visible on busy days.

## Testing
- `cd dashboard && node node_modules/tsx/dist/cli.mjs --test src/evidence/evidence-trend-chart.test.ts`
- `cd dashboard && node node_modules/vite/bin/vite.js build`
