### PR TITLE
fix(guard): add insights.share scope, overviewStats, miniHeatmap, and reauth CTA to share

### DIFF
--- a/dashboard/src/evidence/evidence-activity-heatmap-mini.tsx
+++ b/dashboard/src/evidence/evidence-activity-heatmap-mini.tsx
@@ -1,0 +1,47 @@
+import type { GuardInsightsShareHeatmapCell } from "../guard-types";
+
+export function getHeatmapLevel(total: number, peak: number): 0 | 1 | 2 | 3 | 4 {
+  if (total <= 0 || peak <= 0) return 0;
+  const ratio = total / peak;
+  if (ratio >= 0.85) return 4;
+  if (ratio >= 0.6) return 3;
+  if (ratio >= 0.35) return 2;
+  return 1;
+}
+
+interface EvidenceActivityHeatmapMiniProps {
+  cells: GuardInsightsShareHeatmapCell[];
+}
+
+export function EvidenceActivityHeatmapMini({ cells }: EvidenceActivityHeatmapMiniProps) {
+  const filled = cells.length < 5
+    ? [
+        ...Array.from({ length: 5 - cells.length }, () => null as GuardInsightsShareHeatmapCell | null),
+        ...cells,
+      ]
+    : cells.slice(-5);
+
+  return (
+    <div className="flex items-center gap-1.5">
+      {filled.map((cell, index) => {
+        if (!cell) {
+          return (
+            <div
+              key={`empty-${index}`}
+              className="h-4 w-4 rounded-[3px] evidence-heatmap-0"
+              aria-hidden="true"
+            />
+          );
+        }
+        return (
+          <div
+            key={cell.date}
+            className={`h-4 w-4 rounded-[3px] evidence-heatmap-${cell.level}`}
+            aria-label={`${cell.date}: level ${cell.level}`}
+            title={`${cell.date}: level ${cell.level}`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/dashboard/src/evidence/evidence-insights-home-preview.tsx
+++ b/dashboard/src/evidence/evidence-insights-home-preview.tsx
@@ -3,7 +3,7 @@ import { SectionLabel } from "../approval-center-primitives";
 import { GuardStatMetric, type GuardStatMetricTone } from "./guard-stat-metric";
 import { HomeInsightsMetrics } from "./evidence-insights-headline-bento";
 import { EvidenceInsightsShareButton } from "./evidence-insights-share-button";
-import { EvidenceActivityHeatmapMini } from "./evidence-activity-heatmap";
+import { EvidenceActivityHeatmapMini, getHeatmapLevel } from "./evidence-activity-heatmap-mini";
 
 export type HomeOverviewStatTone = GuardStatMetricTone;
 
@@ -61,6 +61,11 @@ export function EvidenceInsightsHomePreview({
   const showInsightsSection = analyticsLoading || insightsAvailable;
   const showInsightsFooter = Boolean(onOpenInsights) && (analyticsLoading || insightsAvailable);
 
+  const miniHeatmapDays = analytics?.daily_activity?.slice(-5).map((day) => ({
+    date: day.date_key,
+    level: getHeatmapLevel(day.total, analytics?.peak_day_total || 1),
+  })) ?? [];
+
   return (
     <section className="overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm">
       <div className="flex flex-wrap items-start justify-between gap-3 border-b border-slate-100 px-5 py-4">
@@ -95,9 +100,9 @@ export function EvidenceInsightsHomePreview({
           <>
             <HomeInsightsMetrics analytics={analytics} />
             <div className="border-t border-slate-100 px-5 py-4">
-              <SectionLabel>Recent Activity</SectionLabel>
+              <SectionLabel>Last 5 days</SectionLabel>
               <div className="mt-3">
-                <EvidenceActivityHeatmapMini days={analytics.daily_activity} dayCount={5} />
+                <EvidenceActivityHeatmapMini cells={miniHeatmapDays} />
               </div>
             </div>
           </>

--- a/dashboard/src/evidence/evidence-insights-share-errors.ts
+++ b/dashboard/src/evidence/evidence-insights-share-errors.ts
@@ -20,3 +20,15 @@ export function insightsSharePublishErrorMessage(raw: string): string {
 
   return message || "Unable to publish share link.";
 }
+
+export function isInsightsShareScopeError(raw: string): boolean {
+  const lower = raw.toLowerCase();
+  return (
+    lower.includes("guard:insights.share") ||
+    lower.includes("insufficient_scope") ||
+    lower.includes("insufficient scope") ||
+    lower.includes("missing_scope") ||
+    lower.includes("missing scope") ||
+    lower.includes("unauthorized")
+  );
+}

--- a/dashboard/src/evidence/evidence-insights-share-modal.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-modal.tsx
@@ -3,9 +3,11 @@ import type { GuardReceiptAnalytics, GuardRuntimeSnapshot } from "../guard-types
 import { ActionButton } from "../approval-center-primitives";
 import { GuardModalLayer } from "../guard-modal-layer";
 import { publishInsightsShare, type GuardInsightsShareResult } from "../guard-api";
-import { EvidenceInsightsHeadlineBento } from "./evidence-insights-headline-bento";
 import { EvidenceInsightsShareSheet } from "./evidence-insights-share-sheet";
-import { insightsSharePublishErrorMessage } from "./evidence-insights-share-errors";
+import { GuardStatMetric } from "./guard-stat-metric";
+import { HomeInsightsMetrics } from "./evidence-insights-headline-bento";
+import { EvidenceActivityHeatmapMini, getHeatmapLevel } from "./evidence-activity-heatmap-mini";
+import { insightsSharePublishErrorMessage, isInsightsShareScopeError } from "./evidence-insights-share-errors";
 
 interface EvidenceInsightsShareModalProps {
   analytics: GuardReceiptAnalytics;
@@ -23,14 +25,20 @@ export function EvidenceInsightsShareModal({
   const [displayName, setDisplayName] = useState("");
   const [publishing, setPublishing] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [rawError, setRawError] = useState<string | null>(null);
   const [shareResult, setShareResult] = useState<GuardInsightsShareResult | null>(null);
 
   const cloudConnected = runtime?.cloud_state === "paired_active";
   const connectUrl = runtime?.connect_url ?? "https://hol.org/guard/connect";
 
+  const handleReauth = useCallback(() => {
+    window.open(connectUrl, "_blank", "noopener,noreferrer");
+  }, [connectUrl]);
+
   const handlePublish = useCallback(async () => {
     setPublishing(true);
     setError(null);
+    setRawError(null);
     try {
       const result = await publishInsightsShare({
         includeTopArtifacts,
@@ -40,11 +48,15 @@ export function EvidenceInsightsShareModal({
       setShareResult(result);
     } catch (publishError) {
       const rawMessage = publishError instanceof Error ? publishError.message : "Unable to publish share link.";
+      setRawError(rawMessage);
       setError(insightsSharePublishErrorMessage(rawMessage));
     } finally {
       setPublishing(false);
     }
   }, [displayName, includeTopArtifacts, showDisplayName]);
+
+  const isScopeError = Boolean(rawError) && isInsightsShareScopeError(rawError ?? "");
+  const errorIsReauth = isScopeError || (rawError?.toLowerCase().includes("unauthorized") ?? false);
 
   if (shareResult) {
     return (
@@ -91,9 +103,41 @@ export function EvidenceInsightsShareModal({
         ) : (
           <>
             <div className="space-y-4 px-5 py-5">
-              <div className="overflow-hidden rounded-2xl border border-slate-200">
-                <EvidenceInsightsHeadlineBento analytics={analytics} variant="compact" />
+              <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white">
+                <div className="grid grid-cols-3 gap-px bg-slate-100">
+                  <GuardStatMetric
+                    label="Pending"
+                    value={String(runtime?.pending_count ?? 0)}
+                    compact
+                  />
+                  <GuardStatMetric
+                    label="Apps"
+                    value={String(runtime?.managed_installs?.length ?? 0)}
+                    compact
+                  />
+                  <GuardStatMetric
+                    label="Recorded"
+                    value={String(runtime?.receipt_count ?? 0)}
+                    compact
+                  />
+                </div>
+                <HomeInsightsMetrics analytics={analytics} />
+                <div className="px-4 py-3">
+                  <p className="text-[10px] font-semibold uppercase tracking-[0.15em] text-slate-500">Last 5 days</p>
+                  <div className="mt-2">
+                    <EvidenceActivityHeatmapMini
+                      cells={
+                        analytics.daily_activity.slice(-5).map((day) => ({
+                          date: day.date_key,
+                          level: getHeatmapLevel(day.total, analytics.peak_day_total || 1),
+                        }))
+                      }
+                    />
+                  </div>
+                </div>
               </div>
+
+              <hr className="border-slate-100" />
 
               <label className="flex items-center gap-3 text-sm text-brand-dark">
                 <input
@@ -130,9 +174,14 @@ export function EvidenceInsightsShareModal({
               </label>
 
               {error ? (
-                <p className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900" role="alert">
-                  {error}
-                </p>
+                <div className={`rounded-xl border px-3 py-2 text-sm ${errorIsReauth ? 'border-amber-200 bg-amber-50 text-amber-900' : 'border-rose-200 bg-rose-50 text-rose-900'}`} role="alert">
+                  <p>{error}</p>
+                  {errorIsReauth ? (
+                    <ActionButton variant="outline" onClick={handleReauth} className="mt-2 w-full">
+                      Reconnect Guard Cloud
+                    </ActionButton>
+                  ) : null}
+                </div>
               ) : null}
             </div>
 

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -448,6 +448,17 @@ export type GuardInsightsShareResult = {
   expiresAt: string;
 };
 
+export type GuardInsightsShareHeatmapCell = {
+  date: string;
+  level: 0 | 1 | 2 | 3 | 4;
+};
+
+export type GuardInsightsShareOverviewStats = {
+  pending: number;
+  apps: number;
+  recorded: number;
+};
+
 export type GuardArtifactDiff = {
   artifact_id: string;
   harness: string;

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -36,6 +36,7 @@ DEFAULT_GUARD_DEVICE_SCOPES = (
     "guard:runtime.sync",
     "guard:receipt.write",
     "guard:runtime.session.write",
+    "guard:insights.share",
     "guard:offline_access",
 )
 CI_SAFE_GUARD_DEVICE_SCOPES = (

--- a/src/codex_plugin_scanner/guard/insights_share.py
+++ b/src/codex_plugin_scanner/guard/insights_share.py
@@ -50,6 +50,7 @@ def build_insights_share_payload(
     include_top_artifacts: bool = False,
     show_display_name: bool = False,
     display_name: str | None = None,
+    overview_stats: dict[str, int] | None = None,
 ) -> dict[str, object]:
     total = int(analytics.get("total") or 0)
     blocked = int(analytics.get("blocked") or 0)
@@ -87,6 +88,20 @@ def build_insights_share_payload(
             }
         )
 
+    # Build mini heatmap for last 5 days
+    mini_heatmap_cells: list[dict[str, object]] = []
+    for row in daily_rows[-5:]:
+        date_key = str(row.get("date_key") or "")
+        if not date_key:
+            continue
+        day_total = int(row.get("total") or 0)
+        mini_heatmap_cells.append(
+            {
+                "date": date_key,
+                "level": _heatmap_level(day_total, peak=heatmap_peak),
+            }
+        )
+
     payload: dict[str, object] = {
         "version": 1,
         "generatedAt": datetime.now(tz=timezone.utc).isoformat().replace("+00:00", "Z"),
@@ -104,6 +119,16 @@ def build_insights_share_payload(
         "heatmap": {"days": len(heatmap_cells) or 90, "cells": heatmap_cells},
         "showDisplayName": bool(show_display_name and display_name),
     }
+
+    payload["overviewStats"] = {
+        "pending": int(overview_stats.get("pending") or 0) if overview_stats else 0,
+        "apps": int(overview_stats.get("apps") or 0) if overview_stats else 0,
+        "recorded": int(overview_stats.get("recorded") or 0) if overview_stats else 0,
+    }
+
+    if mini_heatmap_cells:
+        payload["miniHeatmap"] = {"days": len(mini_heatmap_cells), "cells": mini_heatmap_cells}
+
     if show_display_name and display_name:
         payload["displayName"] = display_name.strip()[:120]
 
@@ -156,11 +181,17 @@ def publish_insights_share(
     )
 
     analytics = store.receipt_analytics(activity_days=90, trend_days=7, top_limit=8)
+    overview_stats = {
+        "pending": store.count_approval_requests(),
+        "apps": len(store.list_managed_installs()),
+        "recorded": store.count_receipts(),
+    }
     payload = build_insights_share_payload(
         analytics,
         include_top_artifacts=include_top_artifacts,
         show_display_name=show_display_name,
         display_name=display_name,
+        overview_stats=overview_stats,
     )
     resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
     request_url = normalized_insights_share_url(str(resolved_auth_context["sync_url"]))

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -151,7 +151,7 @@ def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path
             access_token="access-token-1",
             refresh_token="refresh-token-1",
             expires_in=300,
-            scope="guard:runtime.sync guard:offline_access",
+            scope="guard:runtime.sync guard:receipt.write guard:runtime.session.write guard:insights.share guard:offline_access",
             token_type="Bearer",
             grant_id="grant-1",
             machine_id="machine-1",

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -179,7 +179,7 @@ def test_device_authorization_request_uses_oauth_scopes_without_token_material()
 
     assert parsed["client_id"] == ["guard-local-daemon"]
     assert parsed["scope"] == [
-        "guard:runtime.sync guard:receipt.write guard:runtime.session.write guard:offline_access"
+        "guard:runtime.sync guard:receipt.write guard:runtime.session.write guard:insights.share guard:offline_access"
     ]
     assert parsed["requested_machine_id"] == ["machine-123"]
     assert parsed["requested_machine_label"] == ["Michaels MacBook"]

--- a/tests/test_insights_share.py
+++ b/tests/test_insights_share.py
@@ -23,6 +23,9 @@ def test_build_insights_share_payload_defaults():
     assert payload["headline"]["topHarness"] == "Cursor"
     assert payload["headline"]["stopRatePct"] == 10
     assert "topArtifacts" not in payload
+    assert payload["overviewStats"] == {"pending": 0, "apps": 0, "recorded": 0}
+    assert payload["miniHeatmap"]["days"] == len(payload["miniHeatmap"]["cells"])
+    assert len(payload["miniHeatmap"]["cells"]) == 2
 
 
 def test_build_insights_share_payload_with_top_artifacts():
@@ -40,10 +43,14 @@ def test_build_insights_share_payload_with_top_artifacts():
         include_top_artifacts=True,
         show_display_name=True,
         display_name="Alex",
+        overview_stats={"pending": 2, "apps": 3, "recorded": 50},
     )
     assert payload["topArtifacts"] == [{"label": "bash", "count": 3}]
     assert payload["displayName"] == "Alex"
     assert payload["showDisplayName"] is True
+    assert payload["overviewStats"] == {"pending": 2, "apps": 3, "recorded": 50}
+    assert payload["miniHeatmap"]["days"] == len(payload["miniHeatmap"]["cells"])
+    assert len(payload["miniHeatmap"]["cells"]) == 1
 
 
 def test_normalized_insights_share_url_from_receipts_sync():


### PR DESCRIPTION
## Summary
- Add `guard:insights.share` to `DEFAULT_GUARD_DEVICE_SCOPES` so daemon can publish insights shares without incremental reauth.
- Extend `build_insights_share_payload` with `overviewStats` (pending/apps/recorded) and `miniHeatmap` (last 5 days) matching home card.
- Update dashboard share modal: overview stats + mini heatmap preview, re-auth CTA for scope errors.

## Testing
- `python -m pytest tests/test_guard_connect_flow.py tests/test_insights_share.py -q`
- `cd dashboard && pnpm run typecheck`
