### PR TITLE
feat(about): v3 trust cockpit redesign with Trust Contract, Data Boundary, and tiered pathways

### DIFF
--- a/dashboard/src/about/about-analytics.ts
+++ b/dashboard/src/about/about-analytics.ts
@@ -1,14 +1,16 @@
 /**
  * About page analytics stub.
  * No remote tracking in the local dashboard.
- * All events are console-only in development.
+ * All events use stable IDs only — never raw URLs, paths, or sensitive data.
  */
+
+import type { AboutSectionId, AboutLinkId, AboutCtaId } from "./about-types";
 
 export type AboutEvent =
   | { type: "about_page_viewed" }
-  | { type: "about_section_viewed"; sectionId: string }
-  | { type: "about_external_link_clicked"; href: string }
-  | { type: "about_cta_clicked"; ctaId: string };
+  | { type: "about_section_viewed"; sectionId: AboutSectionId }
+  | { type: "about_external_link_clicked"; linkId: AboutLinkId }
+  | { type: "about_cta_clicked"; ctaId: AboutCtaId };
 
 export function trackAboutEvent(event: AboutEvent): void {
   if (import.meta.env.DEV) {

--- a/dashboard/src/about/about-content.test.ts
+++ b/dashboard/src/about/about-content.test.ts
@@ -1,7 +1,7 @@
 import {
   ABOUT_HERO_TITLE,
-  ABOUT_HERO_SUBTITLE,
   ABOUT_HERO_BODY,
+  ABOUT_HERO_KICKER,
   ABOUT_LOCAL_SECTION_TITLE,
   ABOUT_LOCAL_SECTION_BODY,
   ABOUT_MISSION_SECTION_TITLE,
@@ -16,10 +16,13 @@ import {
   ABOUT_AFFILIATE_CTA,
   ABOUT_AFFILIATE_CTA_HREF,
   ABOUT_AFFILIATE_DISCLOSURE,
-  ABOUT_TRUST_CARDS,
+  ABOUT_TRUST_CONTRACT_CLAIMS,
+  ABOUT_DATA_BOUNDARY_ROWS,
+  ABOUT_STANDARDS_NODES,
   ABOUT_PATH_CARDS,
   ABOUT_PARTNER_LEVELS,
   ABOUT_AFFILIATE_TERMS,
+  ALLOWED_LINKS,
 } from "./about-content";
 
 function assert(condition: boolean, message: string): void {
@@ -28,10 +31,57 @@ function assert(condition: boolean, message: string): void {
   }
 }
 
+function assertNoBannedPhrases(text: string, sourceLabel: string): void {
+  const banned = [
+    "score a recurring commission",
+    "tamper-evident",
+    "guaranteed",
+    "unbreakable",
+    "always secure",
+    "cloud required",
+  ];
+  for (const phrase of banned) {
+    assert(
+      !text.toLowerCase().includes(phrase),
+      `${sourceLabel} avoids banned phrase: ${phrase}`
+    );
+  }
+}
+
+function collectAllCopy(): string {
+  const parts = [
+    ABOUT_HERO_TITLE,
+    ABOUT_HERO_BODY,
+    ABOUT_HERO_KICKER,
+    ABOUT_LOCAL_SECTION_TITLE,
+    ABOUT_LOCAL_SECTION_BODY,
+    ABOUT_MISSION_SECTION_TITLE,
+    ABOUT_MISSION_SECTION_BODY,
+    ABOUT_OPEN_SOURCE_NOTE,
+    ABOUT_PARTNER_SECTION_TITLE,
+    ABOUT_PARTNER_SECTION_BODY,
+    ABOUT_PARTNER_CTA,
+    ABOUT_AFFILIATE_SECTION_TITLE,
+    ABOUT_AFFILIATE_SECTION_BODY,
+    ABOUT_AFFILIATE_CTA,
+    ABOUT_AFFILIATE_DISCLOSURE,
+    ...ABOUT_TRUST_CONTRACT_CLAIMS.flatMap((c) => [c.title, c.body]),
+    ...ABOUT_DATA_BOUNDARY_ROWS.flatMap((r) => [r.label, r.localDefault, r.optionalSync, r.neverFromAbout]),
+    ...ABOUT_STANDARDS_NODES.flatMap((n) => [n.label, n.body]),
+    ...ABOUT_PATH_CARDS.flatMap((c) => [c.title, c.description, c.ctaLabel]),
+    ...ABOUT_PARTNER_LEVELS.flatMap((l) => [l.name, l.description]),
+    ABOUT_AFFILIATE_TERMS.commissionRate,
+    ABOUT_AFFILIATE_TERMS.commissionDuration,
+    ABOUT_AFFILIATE_TERMS.cookieWindow,
+    ABOUT_AFFILIATE_TERMS.qualificationNote,
+  ];
+  return parts.join(" ");
+}
+
 // Hero content
 assert(ABOUT_HERO_TITLE.length > 0, "hero title is non-empty");
-assert(ABOUT_HERO_SUBTITLE.length > 0, "hero subtitle is non-empty");
 assert(ABOUT_HERO_BODY.length > 0, "hero body is non-empty");
+assert(ABOUT_HERO_KICKER.length > 0, "hero kicker is non-empty");
 assert(!ABOUT_HERO_BODY.includes("earn"), "hero body avoids earn language");
 
 // Local-first section
@@ -64,15 +114,42 @@ assert(ABOUT_AFFILIATE_CTA_HREF.startsWith("https://"), "affiliate CTA uses HTTP
 assert(!ABOUT_AFFILIATE_CTA_HREF.includes("guard-token"), "affiliate CTA has no guard-token");
 assert(ABOUT_AFFILIATE_DISCLOSURE.length > 0, "affiliate disclosure is non-empty");
 
-// Trust cards
-assert(ABOUT_TRUST_CARDS.length === 4, "trust cards has exactly 4 items");
-for (const card of ABOUT_TRUST_CARDS) {
-  assert(card.title.length > 0, "trust card title is non-empty");
-  assert(card.description.length > 0, "trust card description is non-empty");
+// Trust contract claims
+assert(ABOUT_TRUST_CONTRACT_CLAIMS.length === 4, "trust contract claims has exactly 4 items");
+for (const claim of ABOUT_TRUST_CONTRACT_CLAIMS) {
+  assert(claim.title.length > 0, "trust claim title is non-empty");
+  assert(claim.body.length > 0, "trust claim body is non-empty");
+  assert(claim.proofLabel.length > 0, "trust claim proofLabel is non-empty");
+}
+
+// Data boundary rows
+assert(ABOUT_DATA_BOUNDARY_ROWS.length === 4, "data boundary rows has exactly 4 items");
+for (const row of ABOUT_DATA_BOUNDARY_ROWS) {
+  assert(row.label.length > 0, "data boundary label is non-empty");
+  assert(row.localDefault.length > 0, "data boundary localDefault is non-empty");
+  assert(row.optionalSync.length > 0, "data boundary optionalSync is non-empty");
+  assert(row.neverFromAbout.length > 0, "data boundary neverFromAbout is non-empty");
+}
+
+// Standards nodes
+assert(ABOUT_STANDARDS_NODES.length === 6, "standards nodes has exactly 6 items");
+for (const node of ABOUT_STANDARDS_NODES) {
+  assert(node.label.length > 0, "standards node label is non-empty");
+  assert(node.body.length > 0, "standards node body is non-empty");
 }
 
 // Path cards
 assert(ABOUT_PATH_CARDS.length === 5, "path cards has exactly 5 items");
+const primaryPaths = ABOUT_PATH_CARDS.filter((c) => c.priority === "primary");
+const secondaryPaths = ABOUT_PATH_CARDS.filter((c) => c.priority === "secondary");
+const tertiaryPaths = ABOUT_PATH_CARDS.filter((c) => c.priority === "tertiary");
+assert(primaryPaths.length === 1, "has exactly 1 primary path");
+assert(primaryPaths[0].id === "protect_locally", "primary path is protect_locally");
+assert(secondaryPaths.length === 2, "has exactly 2 secondary paths");
+assert(tertiaryPaths.length === 2, "has exactly 2 tertiary paths");
+assert(tertiaryPaths.some((c) => c.id === "affiliate_starter_kit"), "affiliate is tertiary");
+assert(tertiaryPaths.some((c) => c.id === "standards_partner"), "partner is tertiary");
+
 for (const card of ABOUT_PATH_CARDS) {
   assert(card.title.length > 0, "path card title is non-empty");
   assert(card.description.length > 0, "path card description is non-empty");
@@ -93,5 +170,26 @@ assert(ABOUT_AFFILIATE_TERMS.commissionRate.length > 0, "commission rate is non-
 assert(ABOUT_AFFILIATE_TERMS.commissionDuration.length > 0, "commission duration is non-empty");
 assert(ABOUT_AFFILIATE_TERMS.cookieWindow.length > 0, "cookie window is non-empty");
 assert(ABOUT_AFFILIATE_TERMS.qualificationNote.length > 0, "qualification note is non-empty");
+
+// Allowed links
+assert(Object.keys(ALLOWED_LINKS).length >= 10, "has at least 10 allowed link definitions");
+for (const [id, cfg] of Object.entries(ALLOWED_LINKS)) {
+  assert(cfg.host.length > 0, `${id} has a host`);
+  assert(cfg.pathPrefix.length > 0, `${id} has a pathPrefix`);
+  assert(cfg.pathPrefix.startsWith("/"), `${id} pathPrefix starts with /`);
+}
+
+// Banned phrases across all copy
+assertNoBannedPhrases(collectAllCopy(), "all about copy");
+
+// Affiliate copy is honest - test checks for these exact words
+assert(
+  ABOUT_AFFILIATE_SECTION_BODY.toLowerCase().includes("approved affiliates"),
+  "affiliate body mentions approval requirement"
+);
+assert(
+  ABOUT_AFFILIATE_SECTION_BODY.toLowerCase().includes("qualified paid"),
+  "affiliate body mentions qualified paid referrals"
+);
 
 console.log("about-content.test.ts: all assertions passed");

--- a/dashboard/src/about/about-content.ts
+++ b/dashboard/src/about/about-content.ts
@@ -1,10 +1,17 @@
-import type { TrustCard, PathCard, PartnerLevel, AffiliateTerms } from "./about-types";
+import type {
+  TrustContractClaim,
+  DataBoundaryRow,
+  StandardsNode,
+  AboutPathCard,
+  PartnerLevel,
+  AffiliateTerms,
+  AboutLinkId,
+} from "./about-types";
 
-export const ABOUT_HERO_TITLE = "Open standards. Local protection.";
-export const ABOUT_HERO_SUBTITLE =
-  "A local safety layer for the agent internet.";
+export const ABOUT_HERO_KICKER = "Open standards. Local protection.";
+export const ABOUT_HERO_TITLE = "About HOL Guard";
 export const ABOUT_HERO_BODY =
-  "HOL Guard protects local AI harness activity before risky work executes. HOL is building open trust infrastructure for the agent ecosystem — registries, identity, receipts, privacy, payments, and communication that agents can rely on.";
+  "A local-first safety layer for AI harnesses, built by HOL as part of open trust infrastructure for the agent internet.";
 
 export const ABOUT_LOCAL_SECTION_TITLE = "What stays local";
 export const ABOUT_LOCAL_SECTION_BODY =
@@ -20,20 +27,213 @@ export const ABOUT_OPEN_SOURCE_NOTE =
 export const ABOUT_PARTNER_SECTION_TITLE = "Standards partner program";
 export const ABOUT_PARTNER_SECTION_BODY =
   "Join teams building on HOL open standards. Partners get early access to protocol drafts, co-marketing, and direct engineering support.";
-
-export const ABOUT_PARTNER_CTA = "Become a partner";
+export const ABOUT_PARTNER_CTA = "Explore partner programs";
 export const ABOUT_PARTNER_CTA_HREF = "https://hol.org/guard/partners";
 
 export const ABOUT_AFFILIATE_SECTION_TITLE = "Affiliate starter kit";
 export const ABOUT_AFFILIATE_SECTION_BODY =
-  "Share Guard with your community and score a recurring commission on qualified referrals.";
+  "Approved affiliates can share Guard with their community and receive recurring commission on qualified paid referrals.";
 export const ABOUT_AFFILIATE_CTA = "Learn about affiliates";
 export const ABOUT_AFFILIATE_CTA_HREF = "https://hol.org/guard/affiliates";
 
 export const ABOUT_AFFILIATE_DISCLOSURE =
   "Affiliate earnings are paid on qualified paid customers after approval. Terms apply.";
 
-export const ABOUT_TRUST_CARDS: TrustCard[] = [
+export const ABOUT_TRUST_CONTRACT_CLAIMS: TrustContractClaim[] = [
+  {
+    id: "local_decisions",
+    title: "Local decisions stay local",
+    body: "Approvals and saved policy decisions are stored on this machine unless you enable sync.",
+    proofLabel: "Local-first",
+    tone: "blue",
+  },
+  {
+    id: "exportable_receipts",
+    title: "Receipts are inspectable",
+    body: "Guard stores local receipts you can inspect, export, and compare over time.",
+    proofLabel: "Auditable",
+    tone: "green",
+  },
+  {
+    id: "optional_sync",
+    title: "Cloud sync is optional",
+    body: "Guard Cloud adds team policy and shared history, but local protection works without it.",
+    proofLabel: "Opt-in",
+    tone: "purple",
+  },
+  {
+    id: "open_standards",
+    title: "Built around open standards",
+    body: "HOL works on portable trust infrastructure for agent registries, identity, receipts, and coordination.",
+    proofLabel: "Portable",
+    tone: "slate",
+  },
+];
+
+export const ABOUT_DATA_BOUNDARY_ROWS: DataBoundaryRow[] = [
+  {
+    id: "approvals",
+    label: "Approvals and saved decisions",
+    localDefault: "Stored on this machine",
+    optionalSync: "Policy summaries when enabled",
+    neverFromAbout: "Raw prompts, local paths, secrets",
+  },
+  {
+    id: "receipts",
+    label: "Receipts",
+    localDefault: "Inspectable and exportable locally",
+    optionalSync: "Receipt history when enabled",
+    neverFromAbout: "Guard token or install ID",
+  },
+  {
+    id: "runtime_state",
+    label: "Runtime state",
+    localDefault: "Used to show local status",
+    optionalSync: "Aggregate fleet status when enabled",
+    neverFromAbout: "Workspace names or filesystem paths",
+  },
+  {
+    id: "external_links",
+    label: "About page links",
+    localDefault: "No remote calls on first render",
+    optionalSync: "None",
+    neverFromAbout: "Referral IDs or user identifiers",
+  },
+];
+
+export const ABOUT_STANDARDS_NODES: StandardsNode[] = [
+  {
+    id: "registries",
+    label: "Registries",
+    body: "Packages and agent capabilities should be discoverable and verifiable.",
+  },
+  {
+    id: "identity",
+    label: "Identity",
+    body: "Agents and tools need portable identity signals.",
+  },
+  {
+    id: "receipts",
+    label: "Receipts",
+    body: "Important actions should leave evidence users can audit.",
+  },
+  {
+    id: "privacy",
+    label: "Privacy",
+    body: "Local context should not leak just because a tool needs trust.",
+  },
+  {
+    id: "payments",
+    label: "Payments",
+    body: "Agent economies need trusted settlement rails.",
+  },
+  {
+    id: "communication",
+    label: "Communication",
+    body: "Agents need safe ways to coordinate across systems.",
+  },
+];
+
+export const ABOUT_PATH_CARDS: AboutPathCard[] = [
+  {
+    id: "protect_locally",
+    title: "Protect locally",
+    description:
+      "Install HOL Guard and start intercepting risky harness actions on this machine.",
+    ctaLabel: "Get started",
+    ctaHref: "https://hol.org/guard/install",
+    ctaId: "path_protect_locally",
+    priority: "primary",
+    tone: "blue",
+  },
+  {
+    id: "sync_team",
+    title: "Sync with your team",
+    description:
+      "Connect to Guard Cloud for shared policy bundles and cross-device fleet visibility.",
+    ctaLabel: "Guard Cloud",
+    ctaHref: "https://hol.org/guard",
+    ctaId: "path_sync_team",
+    priority: "secondary",
+    tone: "green",
+  },
+  {
+    id: "validate_ci",
+    title: "Validate packages in CI",
+    description:
+      "Add the plugin-scanner to your CI pipeline to catch risky dependencies before deploy.",
+    ctaLabel: "CI docs",
+    ctaHref: "https://hol.org/guard/docs/plugin-scanner/report-formats-and-ci",
+    ctaId: "path_validate_ci",
+    priority: "secondary",
+    tone: "purple",
+  },
+  {
+    id: "standards_partner",
+    title: "Standards partner program",
+    description:
+      "Contribute to open trust standards for agent identity, registries, and receipts.",
+    ctaLabel: "Explore partners",
+    ctaHref: "https://hol.org/guard/partners",
+    ctaId: "path_standards_partner",
+    priority: "tertiary",
+    tone: "slate",
+  },
+  {
+    id: "affiliate_starter_kit",
+    title: "Affiliate starter kit",
+    description:
+      "Approved affiliates can share Guard with their community and receive recurring commission on qualified paid referrals.",
+    ctaLabel: "Learn about affiliates",
+    ctaHref: "https://hol.org/guard/affiliates",
+    ctaId: "path_affiliate_starter_kit",
+    priority: "tertiary",
+    tone: "slate",
+    disclosureRequired: true,
+  },
+];
+
+export const ABOUT_PARTNER_LEVELS: PartnerLevel[] = [
+  {
+    name: "Integrator",
+    description: "Build Guard into your product or CI pipeline.",
+  },
+  {
+    name: "Standards contributor",
+    description: "Propose and review open trust protocol drafts.",
+  },
+  {
+    name: "Advocate",
+    description: "Publish guides, run workshops, and represent Guard in your community.",
+  },
+];
+
+export const ABOUT_AFFILIATE_TERMS: AffiliateTerms = {
+  commissionRate: "25%",
+  commissionDuration: "12 months",
+  cookieWindow: "120 days",
+  qualificationNote: "Qualified paid customers after approval",
+};
+
+export const ALLOWED_LINKS: Record<AboutLinkId, { host: string; pathPrefix: string }> = {
+  guard_docs: { host: "hol.org", pathPrefix: "/guard/docs" },
+  hol_home: { host: "hol.org", pathPrefix: "/" },
+  hol_guard: { host: "hol.org", pathPrefix: "/guard" },
+  hol_guard_install: { host: "hol.org", pathPrefix: "/guard/install" },
+  hol_guard_cloud: { host: "hol.org", pathPrefix: "/guard" },
+  plugin_scanner_ci_docs: { host: "hol.org", pathPrefix: "/guard/docs/plugin-scanner" },
+  standards_sdk_github: { host: "github.com", pathPrefix: "/hashgraph-online/standards-sdk" },
+  hol_partners: { host: "hol.org", pathPrefix: "/guard/partners" },
+  hol_affiliates: { host: "hol.org", pathPrefix: "/guard/affiliates" },
+  hol_guard_source: { host: "github.com", pathPrefix: "/hashgraph-online/hol-guard" },
+};
+
+// Legacy content preserved for backward compatibility during transition
+export const ABOUT_HERO_SUBTITLE = "A local safety layer for the agent internet.";
+export const ABOUT_HERO_BODY_LEGACY =
+  "HOL Guard protects local AI harness activity before risky work executes. HOL is building open trust infrastructure for the agent ecosystem — registries, identity, receipts, privacy, payments, and communication that agents can rely on.";
+
+export const ABOUT_TRUST_CARDS: import("./about-types").TrustCard[] = [
   {
     title: "Approvals stay here",
     description:
@@ -56,7 +256,7 @@ export const ABOUT_TRUST_CARDS: TrustCard[] = [
   },
 ];
 
-export const ABOUT_PATH_CARDS: PathCard[] = [
+export const ABOUT_PATH_CARDS_LEGACY: import("./about-types").PathCard[] = [
   {
     title: "Protect locally",
     description: "Install HOL Guard and start intercepting risky harness actions on this machine.",
@@ -88,25 +288,3 @@ export const ABOUT_PATH_CARDS: PathCard[] = [
     ctaHref: "https://hol.org/guard/affiliates",
   },
 ];
-
-export const ABOUT_PARTNER_LEVELS: PartnerLevel[] = [
-  {
-    name: "Integrator",
-    description: "Build Guard into your product or CI pipeline.",
-  },
-  {
-    name: "Standards contributor",
-    description: "Propose and review open trust protocol drafts.",
-  },
-  {
-    name: "Advocate",
-    description: "Publish guides, run workshops, and represent Guard in your community.",
-  },
-];
-
-export const ABOUT_AFFILIATE_TERMS: AffiliateTerms = {
-  commissionRate: "25%",
-  commissionDuration: "12 months",
-  cookieWindow: "120 days",
-  qualificationNote: "Qualified paid customers after approval",
-};

--- a/dashboard/src/about/about-design.test.ts
+++ b/dashboard/src/about/about-design.test.ts
@@ -1,0 +1,64 @@
+import {
+  ABOUT_PATH_CARDS,
+  ABOUT_TRUST_CONTRACT_CLAIMS,
+  ABOUT_DATA_BOUNDARY_ROWS,
+  ABOUT_STANDARDS_NODES,
+} from "./about-content";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+// Hierarchy: affiliate is tertiary, not primary or secondary
+const affiliateCard = ABOUT_PATH_CARDS.find((c) => c.id === "affiliate_starter_kit");
+assert(affiliateCard !== undefined, "affiliate card exists");
+assert(affiliateCard!.priority === "tertiary", "affiliate priority is tertiary");
+
+// Hero does not link to affiliate
+assert(
+  !ABOUT_PATH_CARDS.some((c) => c.priority === "primary" && c.id === "affiliate_starter_kit"),
+  "affiliate is not primary"
+);
+
+// Trust contract has 4 claims
+assert(ABOUT_TRUST_CONTRACT_CLAIMS.length === 4, "trust contract has 4 claims");
+
+// Data boundary has 4 rows
+assert(ABOUT_DATA_BOUNDARY_ROWS.length === 4, "data boundary has 4 rows");
+
+// Standards map has 6 nodes
+assert(ABOUT_STANDARDS_NODES.length === 6, "standards map has 6 nodes");
+
+// No local path or sensitive token patterns in content strings
+const allStrings = [
+  ...ABOUT_PATH_CARDS.flatMap((c) => [c.title, c.description, c.ctaLabel]),
+  ...ABOUT_TRUST_CONTRACT_CLAIMS.flatMap((c) => [c.title, c.body]),
+  ...ABOUT_DATA_BOUNDARY_ROWS.flatMap((r) => [r.label, r.localDefault, r.optionalSync, r.neverFromAbout]),
+  ...ABOUT_STANDARDS_NODES.flatMap((n) => [n.label, n.body]),
+].join(" ");
+
+const forbiddenPatterns = [
+  "/Users/",
+  "/home/",
+  "/var/folders/",
+  "guard-token",
+  "guardDaemon",
+  "workspace=",
+  "device=",
+  "install=",
+  "user=",
+  "127.0.0.1",
+  "localhost",
+  ".local",
+];
+
+for (const pattern of forbiddenPatterns) {
+  assert(
+    !allStrings.includes(pattern),
+    `content does not contain forbidden pattern: ${pattern}`
+  );
+}
+
+console.log("about-design.test.ts: all assertions passed");

--- a/dashboard/src/about/about-external-links.test.ts
+++ b/dashboard/src/about/about-external-links.test.ts
@@ -1,4 +1,5 @@
 import { assertSafeAboutExternalUrl, validateAboutExternalLinkOrThrow, AboutExternalLinkError } from "./about-external-links";
+import type { AboutLinkId } from "./about-types";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -6,32 +7,51 @@ function assert(condition: boolean, message: string): void {
   }
 }
 
-// Allowed hosts - HTTPS
+// Allowed links - correct linkId + href pairs
 assert(
-  assertSafeAboutExternalUrl("https://hol.org/partners").hostname === "hol.org",
-  "hol.org is allowed"
+  assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners").hostname === "hol.org",
+  "hol.org partners is allowed with correct linkId"
 );
 assert(
-  assertSafeAboutExternalUrl("https://www.hol.org/guard").hostname === "www.hol.org",
-  "www.hol.org is allowed"
+  assertSafeAboutExternalUrl("hol_affiliates", "https://hol.org/guard/affiliates").hostname === "hol.org",
+  "hol.org affiliates is allowed with correct linkId"
 );
 assert(
-  assertSafeAboutExternalUrl("https://github.com/hashgraph-online/standards-sdk").hostname === "github.com",
-  "github.com is allowed"
+  assertSafeAboutExternalUrl("hol_guard_source", "https://github.com/hashgraph-online/hol-guard").hostname === "github.com",
+  "github.com source is allowed with correct linkId"
 );
 assert(
-  assertSafeAboutExternalUrl("https://x.com/hashgraphonline").hostname === "x.com",
-  "x.com is allowed"
+  assertSafeAboutExternalUrl("standards_sdk_github", "https://github.com/hashgraph-online/standards-sdk").hostname === "github.com",
+  "github.com standards-sdk is allowed with correct linkId"
 );
 assert(
-  assertSafeAboutExternalUrl("https://t.me/hashgraphonline").hostname === "t.me",
-  "t.me is allowed"
+  assertSafeAboutExternalUrl("guard_docs", "https://hol.org/guard/docs").hostname === "hol.org",
+  "hol.org guard docs is allowed"
 );
 
-// Must use HTTPS
+// Path prefix mismatch
 let threw = false;
 try {
-  assertSafeAboutExternalUrl("http://hol.org/partners");
+  assertSafeAboutExternalUrl("hol_affiliates", "https://hol.org/guard/pricing");
+} catch (e) {
+  threw = true;
+  assert(e instanceof AboutExternalLinkError, "path mismatch throws AboutExternalLinkError");
+}
+assert(threw, "affiliates linkId with wrong path is rejected");
+
+// Wrong repo for source linkId
+threw = false;
+try {
+  assertSafeAboutExternalUrl("hol_guard_source", "https://github.com/other/repo");
+} catch (e) {
+  threw = true;
+}
+assert(threw, "github.com/other/repo is rejected for hol_guard_source");
+
+// Must use HTTPS
+threw = false;
+try {
+  assertSafeAboutExternalUrl("hol_partners", "http://hol.org/guard/partners");
 } catch (e) {
   threw = true;
   assert(e instanceof AboutExternalLinkError, "http throws AboutExternalLinkError");
@@ -41,7 +61,7 @@ assert(threw, "http is rejected");
 // Must not contain credentials
 threw = false;
 try {
-  assertSafeAboutExternalUrl("https://user:pass@hol.org/partners");
+  assertSafeAboutExternalUrl("hol_partners", "https://user:pass@hol.org/guard/partners");
 } catch (e) {
   threw = true;
 }
@@ -50,7 +70,7 @@ assert(threw, "credentials are rejected");
 // Must not point to localhost
 threw = false;
 try {
-  assertSafeAboutExternalUrl("https://localhost:3000");
+  assertSafeAboutExternalUrl("hol_partners", "https://localhost:3000/guard/partners");
 } catch (e) {
   threw = true;
 }
@@ -58,7 +78,7 @@ assert(threw, "localhost is rejected");
 
 threw = false;
 try {
-  assertSafeAboutExternalUrl("https://127.0.0.1:3000");
+  assertSafeAboutExternalUrl("hol_partners", "https://127.0.0.1:3000/guard/partners");
 } catch (e) {
   threw = true;
 }
@@ -67,7 +87,7 @@ assert(threw, "127.0.0.1 is rejected");
 // Must not have forbidden params
 threw = false;
 try {
-  assertSafeAboutExternalUrl("https://hol.org?guard-token=abc");
+  assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners?guard-token=abc");
 } catch (e) {
   threw = true;
 }
@@ -75,27 +95,70 @@ assert(threw, "guard-token param is rejected");
 
 threw = false;
 try {
-  assertSafeAboutExternalUrl("https://hol.org?workspace=test");
+  assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners?workspace=test");
 } catch (e) {
   threw = true;
 }
 assert(threw, "workspace param is rejected");
 
-// Unknown hosts are rejected
+// Referral param rejected
 threw = false;
 try {
-  assertSafeAboutExternalUrl("https://evil.com/phishing");
+  assertSafeAboutExternalUrl("hol_affiliates", "https://hol.org/guard/affiliates?ref=abc123");
 } catch (e) {
   threw = true;
 }
-assert(threw, "unknown host is rejected");
+assert(threw, "ref param is rejected");
+
+// Private IP ranges
+threw = false;
+try {
+  assertSafeAboutExternalUrl("hol_partners", "https://10.0.0.1/guard/partners");
+} catch (e) {
+  threw = true;
+}
+assert(threw, "10.x.x.x is rejected");
+
+threw = false;
+try {
+  assertSafeAboutExternalUrl("hol_partners", "https://192.168.1.1/guard/partners");
+} catch (e) {
+  threw = true;
+}
+assert(threw, "192.168.x.x is rejected");
+
+threw = false;
+try {
+  assertSafeAboutExternalUrl("hol_partners", "https://172.16.0.1/guard/partners");
+} catch (e) {
+  threw = true;
+}
+assert(threw, "172.16.x.x is rejected");
+
+threw = false;
+try {
+  assertSafeAboutExternalUrl("hol_partners", "https://172.31.255.255/guard/partners");
+} catch (e) {
+  threw = true;
+}
+assert(threw, "172.31.x.x is rejected");
+
+// 172.15 should be allowed (outside 172.16/12)
+let allowed = false;
+try {
+  assertSafeAboutExternalUrl("hol_partners", "https://172.15.0.1/guard/partners");
+  allowed = true;
+} catch {
+  allowed = false;
+}
+assert(!allowed, "172.15.x.x is outside RFC1918 and should be rejected by host mismatch, not private range");
 
 // Returns correct rel and target
-const result = assertSafeAboutExternalUrl("https://hol.org/partners");
+const result = assertSafeAboutExternalUrl("hol_partners", "https://hol.org/guard/partners");
 assert(result.rel === "noopener noreferrer", "rel is noopener noreferrer");
 assert(result.target === "_blank", "target is _blank");
 
 // validateAboutExternalLinkOrThrow works
-validateAboutExternalLinkOrThrow("https://hol.org/partners");
+validateAboutExternalLinkOrThrow("hol_partners", "https://hol.org/guard/partners");
 
 console.log("about-external-links.test.ts: all assertions passed");

--- a/dashboard/src/about/about-external-links.ts
+++ b/dashboard/src/about/about-external-links.ts
@@ -1,14 +1,11 @@
 /**
- * Allowed external hosts for the About page.
+ * Allowed external links for the About page.
  * All links must use HTTPS. No localhost, loopback, or unknown hosts.
+ * Links are validated by stable linkId + href, not just hostname.
  */
-const ALLOWED_HOSTS = new Set([
-  "hol.org",
-  "www.hol.org",
-  "github.com",
-  "x.com",
-  "t.me",
-]);
+
+import type { AboutLinkId } from "./about-types";
+import { ALLOWED_LINKS } from "./about-content";
 
 export class AboutExternalLinkError extends Error {
   constructor(message: string) {
@@ -17,21 +14,40 @@ export class AboutExternalLinkError extends Error {
   }
 }
 
-function isLocalhost(hostname: string): boolean {
-  return (
-    hostname === "localhost" ||
-    hostname === "127.0.0.1" ||
-    hostname === "[::1]" ||
-    hostname === "::1" ||
-    hostname.startsWith("192.168.") ||
-    hostname.startsWith("10.") ||
-    hostname.startsWith("172.") ||
-    hostname.endsWith(".local") ||
-    hostname.endsWith(".internal")
-  );
+function isPrivateHost(rawHostname: string): boolean {
+  // Strip IPv6 brackets before checking
+  const hostname = rawHostname.startsWith("[") && rawHostname.endsWith("]")
+    ? rawHostname.slice(1, -1)
+    : rawHostname;
+
+  if (hostname === "localhost" || hostname.startsWith("127.") || hostname === "::1" || hostname === "0.0.0.0") {
+    return true;
+  }
+
+  // RFC1918 private ranges
+  if (hostname.startsWith("10.")) return true;
+  if (hostname.startsWith("192.168.")) return true;
+
+  // 172.16.0.0/12
+  if (hostname.startsWith("172.")) {
+    const secondOctet = parseInt(hostname.split(".")[1] ?? "", 10);
+    if (secondOctet >= 16 && secondOctet <= 31) return true;
+  }
+
+  // Link-local
+  if (hostname === "169.254.0.0" || hostname.startsWith("169.254.")) return true;
+  if (hostname.endsWith(".local") || hostname.endsWith(".internal")) return true;
+
+  // IPv6 link-local
+  if (hostname.startsWith("fe80:")) return true;
+
+  return false;
 }
 
-export function assertSafeAboutExternalUrl(raw: string): {
+export function assertSafeAboutExternalUrl(
+  linkId: AboutLinkId,
+  raw: string
+): {
   url: string;
   hostname: string;
   rel: string;
@@ -61,15 +77,28 @@ export function assertSafeAboutExternalUrl(raw: string): {
     throw new AboutExternalLinkError(`URL must not contain credentials: ${raw}`);
   }
 
-  if (isLocalhost(parsed.hostname)) {
-    throw new AboutExternalLinkError(`URL must not point to localhost or loopback: ${raw}`);
+  if (isPrivateHost(parsed.hostname)) {
+    throw new AboutExternalLinkError(`URL must not point to localhost or private host: ${raw}`);
   }
 
-  if (!ALLOWED_HOSTS.has(parsed.hostname)) {
-    throw new AboutExternalLinkError(`Unknown host not in allowlist: ${parsed.hostname}`);
+  const allowed = ALLOWED_LINKS[linkId];
+  if (!allowed) {
+    throw new AboutExternalLinkError(`Unknown link ID: ${linkId}`);
   }
 
-  const forbiddenParams = ["guard-token", "guardDaemon", "workspace", "device", "install", "user"];
+  if (parsed.hostname !== allowed.host && !parsed.hostname.endsWith(`.${allowed.host}`)) {
+    throw new AboutExternalLinkError(
+      `Host mismatch for ${linkId}: expected ${allowed.host}, got ${parsed.hostname}`
+    );
+  }
+
+  if (!parsed.pathname.startsWith(allowed.pathPrefix)) {
+    throw new AboutExternalLinkError(
+      `Path prefix mismatch for ${linkId}: expected ${allowed.pathPrefix}, got ${parsed.pathname}`
+    );
+  }
+
+  const forbiddenParams = ["guard-token", "guardDaemon", "workspace", "device", "install", "user", "referral", "ref"];
   for (const param of forbiddenParams) {
     if (parsed.searchParams.has(param)) {
       throw new AboutExternalLinkError(`URL must not contain parameter ${param}: ${raw}`);
@@ -84,6 +113,6 @@ export function assertSafeAboutExternalUrl(raw: string): {
   };
 }
 
-export function validateAboutExternalLinkOrThrow(raw: string): void {
-  assertSafeAboutExternalUrl(raw);
+export function validateAboutExternalLinkOrThrow(linkId: AboutLinkId, raw: string): void {
+  assertSafeAboutExternalUrl(linkId, raw);
 }

--- a/dashboard/src/about/about-types.ts
+++ b/dashboard/src/about/about-types.ts
@@ -2,8 +2,92 @@
  * About page content version.
  * Bump when the content shape changes in a way that tests must validate.
  */
-export const ABOUT_CONTENT_VERSION = "1.0.0";
+export const ABOUT_CONTENT_VERSION = "2.0.0";
 
+export type AboutSectionId =
+  | "hero"
+  | "data_boundary"
+  | "open_standards"
+  | "pathways"
+  | "partner_program"
+  | "affiliate_program"
+  | "trust_footer";
+
+export type AboutLinkId =
+  | "guard_docs"
+  | "hol_home"
+  | "hol_guard"
+  | "hol_guard_install"
+  | "hol_guard_cloud"
+  | "plugin_scanner_ci_docs"
+  | "standards_sdk_github"
+  | "hol_partners"
+  | "hol_affiliates"
+  | "hol_guard_source";
+
+export type AboutCtaId =
+  | "hero_docs"
+  | "hero_source"
+  | "path_protect_locally"
+  | "path_sync_team"
+  | "path_validate_ci"
+  | "path_standards_partner"
+  | "path_affiliate_starter_kit"
+  | "partner_program"
+  | "affiliate_program";
+
+export type TrustContractClaim = {
+  id: "local_decisions" | "exportable_receipts" | "optional_sync" | "open_standards";
+  title: string;
+  body: string;
+  proofLabel: string;
+  tone: "blue" | "green" | "purple" | "slate";
+};
+
+export type DataBoundaryRow = {
+  id: "approvals" | "receipts" | "runtime_state" | "external_links";
+  label: string;
+  localDefault: string;
+  optionalSync: string;
+  neverFromAbout: string;
+};
+
+export type StandardsNode = {
+  id: "registries" | "identity" | "receipts" | "privacy" | "payments" | "communication";
+  label: string;
+  body: string;
+};
+
+export type AboutPathPriority = "primary" | "secondary" | "tertiary";
+
+export type AboutPathCard = {
+  id:
+    | "protect_locally"
+    | "sync_team"
+    | "validate_ci"
+    | "standards_partner"
+    | "affiliate_starter_kit";
+  title: string;
+  description: string;
+  ctaLabel: string;
+  ctaHref: string;
+  ctaId: AboutCtaId;
+  priority: AboutPathPriority;
+  tone: "blue" | "green" | "purple" | "slate";
+  disclosureRequired?: boolean;
+};
+
+export type AboutRuntimeSummary = {
+  guardVersion: string | null;
+  cloudState: "local_only" | "paired_waiting" | "paired_active" | "unknown";
+  cloudStateLabel: string;
+  syncConfigured: boolean;
+  pendingCount: number;
+  receiptCount: number;
+  protectedAppCount: number;
+};
+
+// Legacy types preserved for backward compatibility during transition
 export type AboutSection = {
   id: string;
   heading: string;

--- a/dashboard/src/about/about-workspace.tsx
+++ b/dashboard/src/about/about-workspace.tsx
@@ -1,393 +1,48 @@
-import { useRef, useEffect, useState, useCallback, type ReactNode } from "react";
-import {
-  HiMiniShieldCheck,
-  HiMiniLockClosed,
-  HiMiniDocumentText,
-  HiMiniCloud,
-  HiMiniArrowTopRightOnSquare,
-  HiMiniCheckBadge,
-} from "react-icons/hi2";
-import { Badge } from "../approval-center-primitives";
+import { useEffect } from "react";
+import { AboutHero } from "./components/about-hero";
+import { DataBoundaryPanel } from "./components/data-boundary-panel";
+import { OpenStandardsMap } from "./components/open-standards-map";
+import { PathwayGrid } from "./components/pathway-grid";
+import { EcosystemPrograms } from "./components/ecosystem-programs";
+import { AboutFooter } from "./components/about-footer";
+import { SectionShell } from "./components/section-shell";
 import { trackAboutEvent } from "./about-analytics";
-import { assertSafeAboutExternalUrl } from "./about-external-links";
-import {
-  ABOUT_HERO_TITLE,
-  ABOUT_HERO_SUBTITLE,
-  ABOUT_HERO_BODY,
-  ABOUT_LOCAL_SECTION_TITLE,
-  ABOUT_LOCAL_SECTION_BODY,
-  ABOUT_MISSION_SECTION_TITLE,
-  ABOUT_MISSION_SECTION_BODY,
-  ABOUT_OPEN_SOURCE_NOTE,
-  ABOUT_PARTNER_SECTION_TITLE,
-  ABOUT_PARTNER_SECTION_BODY,
-  ABOUT_PARTNER_CTA,
-  ABOUT_PARTNER_CTA_HREF,
-  ABOUT_AFFILIATE_SECTION_TITLE,
-  ABOUT_AFFILIATE_SECTION_BODY,
-  ABOUT_AFFILIATE_CTA,
-  ABOUT_AFFILIATE_CTA_HREF,
-  ABOUT_AFFILIATE_DISCLOSURE,
-  ABOUT_TRUST_CARDS,
-  ABOUT_PATH_CARDS,
-  ABOUT_PARTNER_LEVELS,
-  ABOUT_AFFILIATE_TERMS,
-} from "./about-content";
+import type { AboutRuntimeSummary } from "./about-types";
 
-function AboutSectionLabel({ children }: { children: ReactNode }) {
-  return (
-    <span className="text-sm font-bold tracking-widest uppercase text-brand-blue mb-3 block">
-      {children}
-    </span>
-  );
-}
-
-function useEditorialVisibility(threshold = 0.08) {
-  const ref = useRef<HTMLElement>(null);
-  const [state, setState] = useState<"idle" | "hidden" | "visible">("idle");
-
+export function AboutWorkspace({
+  runtimeSummary,
+}: {
+  runtimeSummary?: AboutRuntimeSummary | null;
+}) {
   useEffect(() => {
-    if (typeof IntersectionObserver === "undefined") {
-      setState("visible");
-      return;
-    }
-    setState("hidden");
-    const el = ref.current;
-    if (!el) return;
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (entry.isIntersecting) {
-          setState("visible");
-          observer.disconnect();
-        }
-      },
-      { threshold }
-    );
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, [threshold]);
+    trackAboutEvent({ type: "about_page_viewed" });
+  }, []);
 
-  return { ref, state };
-}
-
-function EditorialSection({
-  children,
-  className = "",
-  threshold = 0.08,
-}: {
-  children: ReactNode;
-  className?: string;
-  threshold?: number;
-}) {
-  const { ref, state } = useEditorialVisibility(threshold);
-
-  return (
-    <section
-      ref={ref}
-      className={[
-        className,
-        state === "idle"
-          ? ""
-          : "motion-safe:transition-[opacity,transform] transition-opacity duration-700 ease-[cubic-bezier(0.16,1,0.3,1)]",
-        state === "idle" || state === "visible"
-          ? "opacity-100 translate-y-0"
-          : "opacity-0 motion-safe:translate-y-6",
-      ].join(" ")}
-    >
-      {children}
-    </section>
-  );
-}
-
-function AboutExternalLink({
-  href,
-  children,
-  className,
-}: {
-  href: string;
-  children: ReactNode;
-  className?: string;
-}) {
-  let safe: { rel: string; target: string } | null = null;
-  let errorReason = "";
-  try {
-    safe = assertSafeAboutExternalUrl(href);
-  } catch (e) {
-    errorReason = e instanceof Error ? e.message : "Invalid URL";
-  }
-
-  const handleClick = useCallback(() => {
-    trackAboutEvent({ type: "about_external_link_clicked", href });
-  }, [href]);
-
-  if (!safe) {
-    return (
-      <span
-        className={[`text-slate-400 cursor-not-allowed`, className ?? ""].join(" ")}
-        title={errorReason}
-      >
-        {children}
-      </span>
-    );
-  }
-
-  return (
-    <a
-      href={href}
-      target={safe.target}
-      rel={safe.rel}
-      onClick={handleClick}
-      className={[
-        `inline-flex items-center gap-1 transition-colors hover:text-brand-blue`,
-        `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 focus-visible:ring-offset-2`,
-        className ?? "",
-      ].join(" ")}
-    >
-      {children}
-      <HiMiniArrowTopRightOnSquare className="h-3.5 w-3.5 opacity-60" aria-hidden="true" />
-    </a>
-  );
-}
-
-function TrustPillar({
-  title,
-  desc,
-  icon,
-}: {
-  title: string;
-  desc: string;
-  icon: ReactNode;
-}) {
-  return (
-    <div className="border-l-4 border-brand-blue/60 pl-6 py-2">
-      <div className="flex items-center gap-3 mb-2">
-        <div className="shrink-0 flex h-8 w-8 items-center justify-center rounded-lg bg-brand-blue/[0.06] text-brand-blue">
-          {icon}
-        </div>
-        <h3 className="text-base font-bold text-brand-dark">{title}</h3>
-      </div>
-      <p className="text-sm leading-relaxed text-slate-500">{desc}</p>
-    </div>
-  );
-}
-
-function PathStep({
-  index,
-  title,
-  desc,
-  ctaLabel,
-  ctaHref,
-}: {
-  index: number;
-  title: string;
-  desc: string;
-  ctaLabel: string;
-  ctaHref: string;
-}) {
-  return (
-    <div className="relative grid grid-cols-[48px_1fr] gap-4 sm:gap-6">
-      <div className="relative z-10 flex h-12 w-12 items-center justify-center rounded-full border-2 border-brand-blue bg-white">
-        <span className="font-mono text-sm font-black text-brand-blue">
-          {String(index + 1).padStart(2, "0")}
-        </span>
-      </div>
-      <div className="pt-1">
-        <h4 className="text-base font-bold text-brand-dark">{title}</h4>
-        <p className="mt-1.5 text-sm leading-relaxed text-slate-500">{desc}</p>
-        <div className="mt-3">
-          <AboutExternalLink
-            href={ctaHref}
-            className="text-sm font-semibold text-brand-blue hover:underline"
-          >
-            {ctaLabel}
-          </AboutExternalLink>
-        </div>
-      </div>
-    </div>
-  );
-}
-
-function PartnerLevelRow({
-  level,
-  index,
-}: {
-  level: { name: string; description: string };
-  index: number;
-}) {
-  return (
-    <div className="border-t border-slate-100 py-5">
-      <div className="flex items-baseline gap-3">
-        <span className="font-mono text-xs font-black text-brand-blue/70">
-          {String(index + 1).padStart(2, "0")}
-        </span>
-        <h3 className="text-base font-bold text-brand-dark">{level.name}</h3>
-      </div>
-      <p className="mt-1 ml-7 text-sm leading-relaxed text-slate-500">
-        {level.description}
-      </p>
-    </div>
-  );
-}
-
-export function AboutWorkspace() {
   return (
     <div className="space-y-20 pb-10">
-      {/* Hero */}
-      <EditorialSection>
-        <div className="max-w-3xl">
-          <h1 className="text-4xl sm:text-5xl font-black tracking-tight text-brand-dark leading-none mb-6">
-            {ABOUT_HERO_TITLE}
-          </h1>
-          <p className="text-xl sm:text-2xl font-medium text-brand-blue mb-6">
-            {ABOUT_HERO_SUBTITLE}
-          </p>
-          <p className="text-base leading-relaxed text-brand-dark/75 max-w-2xl">
-            {ABOUT_HERO_BODY}
-          </p>
-        </div>
-      </EditorialSection>
+      <SectionShell id="hero">
+        <AboutHero runtimeSummary={runtimeSummary ?? null} />
+      </SectionShell>
 
-      {/* Local-first promise */}
-      <EditorialSection>
-        <div className="mb-8">
-          <AboutSectionLabel>{ABOUT_LOCAL_SECTION_TITLE}</AboutSectionLabel>
-          <p className="text-base leading-relaxed text-slate-500 max-w-2xl">
-            {ABOUT_LOCAL_SECTION_BODY}
-          </p>
-        </div>
-        <div className="grid sm:grid-cols-2 gap-x-12 gap-y-8">
-          {ABOUT_TRUST_CARDS.map((card, i) => (
-            <TrustPillar
-              key={card.title}
-              title={card.title}
-              desc={card.description}
-              icon={
-                i === 0 ? (
-                  <HiMiniShieldCheck className="h-4 w-4" />
-                ) : i === 1 ? (
-                  <HiMiniDocumentText className="h-4 w-4" />
-                ) : i === 2 ? (
-                  <HiMiniLockClosed className="h-4 w-4" />
-                ) : (
-                  <HiMiniCloud className="h-4 w-4" />
-                )
-              }
-            />
-          ))}
-        </div>
-      </EditorialSection>
+      <SectionShell id="data-boundary">
+        <DataBoundaryPanel />
+      </SectionShell>
 
-      {/* Mission */}
-      <EditorialSection>
-        <div className="max-w-3xl">
-          <AboutSectionLabel>{ABOUT_MISSION_SECTION_TITLE}</AboutSectionLabel>
-          <p className="text-lg leading-relaxed text-brand-dark/75">
-            {ABOUT_MISSION_SECTION_BODY}
-          </p>
-          <p className="mt-4 text-sm text-slate-400">{ABOUT_OPEN_SOURCE_NOTE}</p>
-        </div>
-      </EditorialSection>
+      <SectionShell id="open-standards">
+        <OpenStandardsMap />
+      </SectionShell>
 
-      {/* Choose-your-path timeline */}
-      <EditorialSection threshold={0.15}>
-        <div className="mb-10">
-          <AboutSectionLabel>Choose your path</AboutSectionLabel>
-          <p className="text-base leading-relaxed text-slate-500 max-w-2xl">
-            There are many ways to participate in the Guard ecosystem.
-          </p>
-        </div>
-        <div className="relative">
-          <div className="absolute left-[23px] top-0 bottom-0 w-[2px] bg-slate-100" />
-          <div className="space-y-12">
-            {ABOUT_PATH_CARDS.map((card, i) => (
-              <PathStep
-                key={card.title}
-                index={i}
-                title={card.title}
-                desc={card.description}
-                ctaLabel={card.ctaLabel}
-                ctaHref={card.ctaHref}
-              />
-            ))}
-          </div>
-        </div>
-      </EditorialSection>
+      <SectionShell id="pathways">
+        <PathwayGrid />
+      </SectionShell>
 
-      {/* Partner program */}
-      <EditorialSection>
-        <div className="max-w-3xl">
-          <AboutSectionLabel>{ABOUT_PARTNER_SECTION_TITLE}</AboutSectionLabel>
-          <p className="text-base leading-relaxed text-brand-dark/75 mb-8">
-            {ABOUT_PARTNER_SECTION_BODY}
-          </p>
-          <div>
-            {ABOUT_PARTNER_LEVELS.map((level, i) => (
-              <PartnerLevelRow key={level.name} level={level} index={i} />
-            ))}
-          </div>
-          <div className="mt-6 pt-4 border-t border-slate-100">
-            <AboutExternalLink
-              href={ABOUT_PARTNER_CTA_HREF}
-              className="inline-flex items-center gap-1.5 rounded-lg bg-brand-blue px-4 py-2 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-blue/90"
-            >
-              {ABOUT_PARTNER_CTA}
-              <HiMiniArrowTopRightOnSquare className="h-4 w-4" aria-hidden="true" />
-            </AboutExternalLink>
-          </div>
-        </div>
-      </EditorialSection>
+      <SectionShell id="ecosystem">
+        <EcosystemPrograms />
+      </SectionShell>
 
-      {/* Affiliate starter kit */}
-      <EditorialSection>
-        <div className="max-w-3xl">
-          <AboutSectionLabel>{ABOUT_AFFILIATE_SECTION_TITLE}</AboutSectionLabel>
-          <p className="text-base leading-relaxed text-brand-dark/75 mb-8">
-            {ABOUT_AFFILIATE_SECTION_BODY}
-          </p>
-          <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4 mb-8">
-            {[
-              { label: "Commission", value: ABOUT_AFFILIATE_TERMS.commissionRate },
-              { label: "Duration", value: ABOUT_AFFILIATE_TERMS.commissionDuration },
-              { label: "Cookie window", value: ABOUT_AFFILIATE_TERMS.cookieWindow },
-              {
-                label: "Qualification",
-                value: ABOUT_AFFILIATE_TERMS.qualificationNote,
-              },
-            ].map((metric) => (
-              <div key={metric.label} className="border-t border-slate-100 pt-4">
-                <p className="text-xs text-slate-400 mb-1">{metric.label}</p>
-                <p className="text-lg font-bold text-brand-dark">{metric.value}</p>
-              </div>
-            ))}
-          </div>
-          <div className="flex flex-wrap items-center gap-3 pt-4 border-t border-slate-100">
-            <AboutExternalLink
-              href={ABOUT_AFFILIATE_CTA_HREF}
-              className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-4 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 hover:border-slate-300"
-            >
-              {ABOUT_AFFILIATE_CTA}
-              <HiMiniArrowTopRightOnSquare className="h-4 w-4" aria-hidden="true" />
-            </AboutExternalLink>
-            <p className="text-xs text-slate-400">{ABOUT_AFFILIATE_DISCLOSURE}</p>
-          </div>
-        </div>
-      </EditorialSection>
-
-      {/* Trust footer */}
-      <EditorialSection>
-        <footer className="border-t border-slate-100 pt-8">
-          <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
-            <div className="flex items-center gap-2">
-              <HiMiniCheckBadge className="h-5 w-5 text-brand-blue" aria-hidden="true" />
-              <span className="text-sm font-semibold text-brand-dark">HOL Guard</span>
-              <Badge tone="success">Local-first</Badge>
-            </div>
-            <p className="text-xs text-slate-400">
-              Built by Hashgraph Online. Open standards for the agent internet.
-            </p>
-          </div>
-        </footer>
-      </EditorialSection>
+      <SectionShell id="trust-footer">
+        <AboutFooter />
+      </SectionShell>
     </div>
   );
 }

--- a/dashboard/src/about/components/about-external-link.tsx
+++ b/dashboard/src/about/components/about-external-link.tsx
@@ -1,0 +1,57 @@
+import { useCallback, type ReactNode } from "react";
+import { HiMiniArrowTopRightOnSquare } from "react-icons/hi2";
+import { assertSafeAboutExternalUrl } from "../about-external-links";
+import { trackAboutEvent } from "../about-analytics";
+import type { AboutLinkId } from "../about-types";
+
+export function AboutExternalLink({
+  linkId,
+  href,
+  children,
+  className,
+}: {
+  linkId: AboutLinkId;
+  href: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  let safe: { rel: string; target: string } | null = null;
+  let errorReason = "";
+  try {
+    safe = assertSafeAboutExternalUrl(linkId, href);
+  } catch (e) {
+    errorReason = e instanceof Error ? e.message : "Invalid URL";
+  }
+
+  const handleClick = useCallback(() => {
+    trackAboutEvent({ type: "about_external_link_clicked", linkId });
+  }, [linkId]);
+
+  if (!safe) {
+    return (
+      <span
+        className={[`text-slate-400 cursor-not-allowed`, className ?? ""].join(" ")}
+        title={errorReason}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target={safe.target}
+      rel={safe.rel}
+      onClick={handleClick}
+      className={[
+        `inline-flex items-center gap-1 transition-colors hover:text-brand-blue`,
+        `focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 focus-visible:ring-offset-2`,
+        className ?? "",
+      ].join(" ")}
+    >
+      {children}
+      <HiMiniArrowTopRightOnSquare className="h-3.5 w-3.5 opacity-60" aria-hidden="true" />
+    </a>
+  );
+}

--- a/dashboard/src/about/components/about-footer.tsx
+++ b/dashboard/src/about/components/about-footer.tsx
@@ -1,0 +1,19 @@
+import { Badge } from "../../approval-center-primitives";
+import { HiMiniCheckBadge } from "react-icons/hi2";
+
+export function AboutFooter() {
+  return (
+    <footer className="border-t border-slate-100 pt-8">
+      <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-center gap-2">
+          <HiMiniCheckBadge className="h-5 w-5 text-brand-blue" aria-hidden="true" />
+          <span className="text-sm font-semibold text-brand-dark">HOL Guard</span>
+          <Badge tone="success">Local-first</Badge>
+        </div>
+        <p className="text-xs text-slate-400">
+          Built by Hashgraph Online. Open standards for the agent internet.
+        </p>
+      </div>
+    </footer>
+  );
+}

--- a/dashboard/src/about/components/about-hero.tsx
+++ b/dashboard/src/about/components/about-hero.tsx
@@ -1,0 +1,33 @@
+import { SectionLabel } from "../../approval-center-primitives";
+import { TrustContractPanel } from "./trust-contract-panel";
+import { TrackedExternalButton } from "./tracked-action-button";
+import type { AboutRuntimeSummary } from "../about-types";
+
+export function AboutHero({
+  runtimeSummary,
+}: {
+  runtimeSummary: AboutRuntimeSummary | null;
+}) {
+  return (
+    <section className="grid gap-8 lg:grid-cols-[minmax(0,1fr)_420px] lg:items-center">
+      <div className="max-w-3xl">
+        <SectionLabel>Open standards. Local protection.</SectionLabel>
+        <h1 className="mt-4 text-4xl font-black tracking-tight text-brand-dark sm:text-5xl lg:text-6xl">
+          About HOL Guard
+        </h1>
+        <p className="mt-5 max-w-2xl text-lg leading-8 text-brand-dark/75">
+          A local-first safety layer for AI harnesses, built by HOL as part of open trust infrastructure for the agent internet.
+        </p>
+        <div className="mt-6 flex flex-wrap gap-3">
+          <TrackedExternalButton linkId="guard_docs" href="https://hol.org/guard/docs" variant="primary">
+            Read Guard docs
+          </TrackedExternalButton>
+          <TrackedExternalButton linkId="hol_guard_source" href="https://github.com/hashgraph-online/hol-guard" variant="outline">
+            View source
+          </TrackedExternalButton>
+        </div>
+      </div>
+      <TrustContractPanel runtimeSummary={runtimeSummary} />
+    </section>
+  );
+}

--- a/dashboard/src/about/components/about-runtime-proof-strip.tsx
+++ b/dashboard/src/about/components/about-runtime-proof-strip.tsx
@@ -1,0 +1,46 @@
+import { Tag } from "../../approval-center-primitives";
+import type { AboutRuntimeSummary } from "../about-types";
+
+export function AboutRuntimeProofStrip({
+  summary,
+}: {
+  summary: AboutRuntimeSummary | null;
+}) {
+  if (!summary) return null;
+
+  const items = [
+    {
+      label: "Local protection",
+      value: summary.pendingCount > 0 ? `${summary.pendingCount} pending` : "Active",
+      tone: summary.pendingCount > 0 ? ("attention" as const) : ("green" as const),
+    },
+    {
+      label: "Guard version",
+      value: summary.guardVersion ?? "Unknown",
+      tone: "slate" as const,
+    },
+    {
+      label: "Sync",
+      value: summary.cloudStateLabel,
+      tone: summary.syncConfigured ? ("blue" as const) : ("slate" as const),
+    },
+    {
+      label: "Receipts",
+      value: String(summary.receiptCount),
+      tone: "green" as const,
+    },
+  ];
+
+  return (
+    <div className="flex flex-wrap gap-2 pt-3">
+      {items.map((item) => (
+        <div key={item.label} className="flex items-center gap-1.5">
+          <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">
+            {item.label}
+          </span>
+          <Tag tone={item.tone}>{item.value}</Tag>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/dashboard/src/about/components/data-boundary-panel.tsx
+++ b/dashboard/src/about/components/data-boundary-panel.tsx
@@ -1,0 +1,55 @@
+import { Surface, SectionLabel } from "../../approval-center-primitives";
+import { ABOUT_DATA_BOUNDARY_ROWS } from "../about-content";
+
+export function DataBoundaryPanel() {
+  return (
+    <div>
+      <SectionLabel>Where your data goes</SectionLabel>
+      <p className="mt-2 max-w-2xl text-base leading-relaxed text-brand-dark/75">
+        Guard keeps your decisions on this device. Sync is strictly opt-in.
+      </p>
+      <div className="mt-6 hidden md:block">
+        <div className="overflow-hidden rounded-xl border border-slate-100">
+          <div className="grid grid-cols-[1fr_180px_180px_180px] border-b border-slate-100 bg-slate-50/60 px-4 py-2.5">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">Data</span>
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">Local by default</span>
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">Syncs only when enabled</span>
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">Never send from About</span>
+          </div>
+          {ABOUT_DATA_BOUNDARY_ROWS.map((row) => (
+            <div
+              key={row.id}
+              className="grid grid-cols-[1fr_180px_180px_180px] border-b border-slate-100 px-4 py-3 last:border-b-0"
+            >
+              <span className="text-sm font-medium text-brand-dark">{row.label}</span>
+              <span className="text-sm text-brand-dark/70">{row.localDefault}</span>
+              <span className="text-sm text-brand-dark/70">{row.optionalSync}</span>
+              <span className="text-sm text-brand-dark/70">{row.neverFromAbout}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+      <div className="mt-6 space-y-3 md:hidden">
+        {ABOUT_DATA_BOUNDARY_ROWS.map((row) => (
+          <Surface key={row.id} className="!p-4">
+            <p className="text-sm font-semibold text-brand-dark mb-2">{row.label}</p>
+            <div className="space-y-1.5">
+              <div className="flex justify-between gap-2">
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">Local</span>
+                <span className="text-sm text-brand-dark/70 text-right">{row.localDefault}</span>
+              </div>
+              <div className="flex justify-between gap-2">
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">Sync</span>
+                <span className="text-sm text-brand-dark/70 text-right">{row.optionalSync}</span>
+              </div>
+              <div className="flex justify-between gap-2">
+                <span className="text-[11px] font-semibold uppercase tracking-wider text-slate-400">Never</span>
+                <span className="text-sm text-brand-dark/70 text-right">{row.neverFromAbout}</span>
+              </div>
+            </div>
+          </Surface>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/about/components/ecosystem-programs.tsx
+++ b/dashboard/src/about/components/ecosystem-programs.tsx
@@ -1,0 +1,89 @@
+import { Surface, SectionLabel, Badge } from "../../approval-center-primitives";
+import {
+  ABOUT_PARTNER_SECTION_TITLE,
+  ABOUT_PARTNER_SECTION_BODY,
+  ABOUT_PARTNER_CTA,
+  ABOUT_PARTNER_CTA_HREF,
+  ABOUT_PARTNER_LEVELS,
+  ABOUT_AFFILIATE_SECTION_TITLE,
+  ABOUT_AFFILIATE_SECTION_BODY,
+  ABOUT_AFFILIATE_CTA,
+  ABOUT_AFFILIATE_CTA_HREF,
+  ABOUT_AFFILIATE_DISCLOSURE,
+  ABOUT_AFFILIATE_TERMS,
+} from "../about-content";
+import { AboutExternalLink } from "./about-external-link";
+
+export function EcosystemPrograms() {
+  return (
+    <div className="grid gap-8 lg:grid-cols-2">
+      {/* Partner program */}
+      <div>
+        <SectionLabel>{ABOUT_PARTNER_SECTION_TITLE}</SectionLabel>
+        <p className="mt-2 text-base leading-relaxed text-brand-dark/75">
+          {ABOUT_PARTNER_SECTION_BODY}
+        </p>
+        <div className="mt-4 space-y-0">
+          {ABOUT_PARTNER_LEVELS.map((level, i) => (
+            <div key={level.name} className="border-t border-slate-100 py-4">
+              <div className="flex items-baseline gap-3">
+                <span className="font-mono text-xs font-black text-brand-blue/70">
+                  {String(i + 1).padStart(2, "0")}
+                </span>
+                <h3 className="text-sm font-bold text-brand-dark">{level.name}</h3>
+              </div>
+              <p className="mt-1 ml-7 text-sm leading-relaxed text-slate-500">
+                {level.description}
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 pt-4 border-t border-slate-100">
+          <AboutExternalLink
+            linkId="hol_partners"
+            href={ABOUT_PARTNER_CTA_HREF}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-brand-blue px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition-colors hover:bg-brand-blue/90"
+          >
+            {ABOUT_PARTNER_CTA}
+          </AboutExternalLink>
+        </div>
+      </div>
+
+      {/* Affiliate program */}
+      <div>
+        <SectionLabel>{ABOUT_AFFILIATE_SECTION_TITLE}</SectionLabel>
+        <p className="mt-2 text-base leading-relaxed text-brand-dark/75">
+          {ABOUT_AFFILIATE_SECTION_BODY}
+        </p>
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          {[
+            { label: "Commission", value: ABOUT_AFFILIATE_TERMS.commissionRate },
+            { label: "Duration", value: ABOUT_AFFILIATE_TERMS.commissionDuration },
+            { label: "Cookie window", value: ABOUT_AFFILIATE_TERMS.cookieWindow },
+            {
+              label: "Qualification",
+              value: ABOUT_AFFILIATE_TERMS.qualificationNote,
+            },
+          ].map((metric) => (
+            <div key={metric.label} className="border-t border-slate-100 pt-3">
+              <p className="text-[11px] font-semibold uppercase tracking-wider text-slate-400 mb-1">
+                {metric.label}
+              </p>
+              <p className="text-sm font-bold text-brand-dark">{metric.value}</p>
+            </div>
+          ))}
+        </div>
+        <div className="mt-4 flex flex-wrap items-center gap-3 pt-4 border-t border-slate-100">
+          <AboutExternalLink
+            linkId="hol_affiliates"
+            href={ABOUT_AFFILIATE_CTA_HREF}
+            className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-4 py-2.5 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 hover:border-slate-300"
+          >
+            {ABOUT_AFFILIATE_CTA}
+          </AboutExternalLink>
+          <p className="text-xs text-slate-400">{ABOUT_AFFILIATE_DISCLOSURE}</p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/about/components/open-standards-map.tsx
+++ b/dashboard/src/about/components/open-standards-map.tsx
@@ -1,0 +1,36 @@
+import { Surface, SectionLabel } from "../../approval-center-primitives";
+import { ABOUT_STANDARDS_NODES } from "../about-content";
+
+export function OpenStandardsMap() {
+  return (
+    <div>
+      <SectionLabel>Open standards map</SectionLabel>
+      <p className="mt-2 max-w-2xl text-base leading-relaxed text-brand-dark/75">
+        HOL builds directional infrastructure for the agent internet. These are the areas we are working on.
+      </p>
+      <div className="mt-6 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {ABOUT_STANDARDS_NODES.map((node, index) => (
+          <Surface
+            key={node.id}
+            className="relative overflow-hidden"
+            tone={index === 0 ? "accent" : "default"}
+          >
+            <div className="flex items-start gap-3">
+              <span className="mt-0.5 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md bg-brand-blue/10 text-brand-blue font-mono text-xs font-bold">
+                {String(index + 1).padStart(2, "0")}
+              </span>
+              <div>
+                <h3 className="text-sm font-semibold text-brand-dark">
+                  {node.label}
+                </h3>
+                <p className="mt-1 text-xs leading-relaxed text-brand-dark/60">
+                  {node.body}
+                </p>
+              </div>
+            </div>
+          </Surface>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/about/components/pathway-grid.tsx
+++ b/dashboard/src/about/components/pathway-grid.tsx
@@ -1,0 +1,88 @@
+import { Surface, SectionLabel, ActionButton, Badge } from "../../approval-center-primitives";
+import { ABOUT_PATH_CARDS } from "../about-content";
+import { AboutExternalLink } from "./about-external-link";
+import type { AboutPathCard, AboutLinkId } from "../about-types";
+
+const CARD_LINK_MAP: Record<AboutPathCard["id"], AboutLinkId> = {
+  protect_locally: "hol_guard_install",
+  sync_team: "hol_guard_cloud",
+  validate_ci: "plugin_scanner_ci_docs",
+  standards_partner: "hol_partners",
+  affiliate_starter_kit: "hol_affiliates",
+};
+
+function priorityLabel(priority: AboutPathCard["priority"]): string {
+  if (priority === "primary") return "Primary";
+  if (priority === "secondary") return "Secondary";
+  return "Ecosystem";
+}
+
+function PathCard({ card }: { card: AboutPathCard }) {
+  const isPrimary = card.priority === "primary";
+  const isTertiary = card.priority === "tertiary";
+
+  return (
+    <Surface
+      className={`flex flex-col h-full ${isPrimary ? "sm:col-span-2 lg:col-span-2" : ""}`}
+      tone={isPrimary ? "accent" : "default"}
+    >
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <Badge tone={isPrimary ? "info" : isTertiary ? "default" : "warning"}>
+          {priorityLabel(card.priority)}
+        </Badge>
+        {card.disclosureRequired && (
+          <span className="text-[10px] text-slate-400">Disclosure required</span>
+        )}
+      </div>
+      <h3 className="text-base font-bold text-brand-dark">{card.title}</h3>
+      <p className="mt-1.5 text-sm leading-relaxed text-brand-dark/70 flex-1">
+        {card.description}
+      </p>
+      <div className="mt-4">
+        <AboutExternalLink
+          linkId={CARD_LINK_MAP[card.id]}
+          href={card.ctaHref}
+          className="text-sm font-semibold text-brand-blue hover:underline"
+        >
+          {card.ctaLabel}
+        </AboutExternalLink>
+      </div>
+    </Surface>
+  );
+}
+
+export function PathwayGrid() {
+  const primary = ABOUT_PATH_CARDS.filter((c) => c.priority === "primary");
+  const secondary = ABOUT_PATH_CARDS.filter((c) => c.priority === "secondary");
+  const tertiary = ABOUT_PATH_CARDS.filter((c) => c.priority === "tertiary");
+
+  return (
+    <div>
+      <SectionLabel>Choose your path</SectionLabel>
+      <p className="mt-2 max-w-2xl text-base leading-relaxed text-brand-dark/75">
+        There are many ways to participate in the Guard ecosystem. Local protection comes first.
+      </p>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {primary.map((card) => (
+          <PathCard key={card.id} card={card} />
+        ))}
+      </div>
+
+      <div className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {secondary.map((card) => (
+          <PathCard key={card.id} card={card} />
+        ))}
+      </div>
+
+      <div className="mt-8">
+        <h3 className="text-sm font-bold text-brand-dark mb-3">Ecosystem programs</h3>
+        <div className="grid gap-4 sm:grid-cols-2">
+          {tertiary.map((card) => (
+            <PathCard key={card.id} card={card} />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/about/components/section-shell.tsx
+++ b/dashboard/src/about/components/section-shell.tsx
@@ -1,0 +1,61 @@
+import { useRef, useEffect, useState, type ReactNode } from "react";
+
+export function useEditorialVisibility(threshold = 0.08) {
+  const ref = useRef<HTMLElement>(null);
+  const [state, setState] = useState<"idle" | "hidden" | "visible">("idle");
+
+  useEffect(() => {
+    if (typeof IntersectionObserver === "undefined") {
+      setState("visible");
+      return;
+    }
+    setState("hidden");
+    const el = ref.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setState("visible");
+          observer.disconnect();
+        }
+      },
+      { threshold }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [threshold]);
+
+  return { ref, state };
+}
+
+export function SectionShell({
+  children,
+  className = "",
+  threshold = 0.08,
+  id,
+}: {
+  children: ReactNode;
+  className?: string;
+  threshold?: number;
+  id?: string;
+}) {
+  const { ref, state } = useEditorialVisibility(threshold);
+
+  return (
+    <section
+      id={id}
+      ref={ref}
+      className={[
+        className,
+        state === "idle"
+          ? ""
+          : "motion-safe:transition-[opacity,transform] transition-opacity duration-700 ease-[cubic-bezier(0.16,1,0.3,1)]",
+        state === "idle" || state === "visible"
+          ? "opacity-100 translate-y-0"
+          : "opacity-0 motion-safe:translate-y-6",
+      ].join(" ")}
+    >
+      {children}
+    </section>
+  );
+}

--- a/dashboard/src/about/components/tracked-action-button.tsx
+++ b/dashboard/src/about/components/tracked-action-button.tsx
@@ -1,0 +1,59 @@
+import { useCallback, type ReactNode } from "react";
+import { trackAboutEvent } from "../about-analytics";
+import { assertSafeAboutExternalUrl } from "../about-external-links";
+import type { AboutLinkId } from "../about-types";
+
+export function TrackedExternalButton({
+  linkId,
+  href,
+  children,
+  variant = "primary",
+}: {
+  linkId: AboutLinkId;
+  href: string;
+  children: ReactNode;
+  variant?: "primary" | "outline";
+}) {
+  let safe: { rel: string; target: string } | null = null;
+  let errorReason = "";
+  try {
+    safe = assertSafeAboutExternalUrl(linkId, href);
+  } catch (e) {
+    errorReason = e instanceof Error ? e.message : "Invalid URL";
+  }
+
+  const handleClick = useCallback(() => {
+    trackAboutEvent({ type: "about_external_link_clicked", linkId });
+  }, [linkId]);
+
+  const base =
+    "inline-flex items-center justify-center rounded-lg text-sm font-semibold transition-colors duration-150 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40 focus-visible:ring-offset-2";
+  const size = "min-h-11 h-auto px-4 py-2";
+  const tone =
+    variant === "outline"
+      ? "border border-slate-200 bg-white hover:bg-slate-50 text-slate-900"
+      : "bg-brand-blue text-white shadow-lg shadow-brand-blue/20 hover:bg-brand-blue/90";
+
+  if (!safe) {
+    return (
+      <span
+        className={`${base} ${size} ${tone} opacity-50 cursor-not-allowed`}
+        title={errorReason}
+      >
+        {children}
+      </span>
+    );
+  }
+
+  return (
+    <a
+      href={href}
+      target={safe.target}
+      rel={safe.rel}
+      onClick={handleClick}
+      className={`${base} ${size} ${tone} no-underline`}
+    >
+      {children}
+    </a>
+  );
+}

--- a/dashboard/src/about/components/trust-contract-panel.tsx
+++ b/dashboard/src/about/components/trust-contract-panel.tsx
@@ -1,0 +1,54 @@
+import { Surface, Badge } from "../../approval-center-primitives";
+import { ABOUT_TRUST_CONTRACT_CLAIMS } from "../about-content";
+import type { AboutRuntimeSummary } from "../about-types";
+import { AboutRuntimeProofStrip } from "./about-runtime-proof-strip";
+
+const toneClasses: Record<string, string> = {
+  blue: "border-brand-blue/30 bg-brand-blue/[0.04]",
+  green: "border-brand-green/30 bg-brand-green-bg/20",
+  purple: "border-brand-purple/20 bg-brand-purple/[0.03]",
+  slate: "border-slate-200 bg-slate-50/60",
+};
+
+const badgeTones: Record<string, "blue" | "green" | "purple" | "slate"> = {
+  blue: "blue",
+  green: "green",
+  purple: "purple",
+  slate: "slate",
+};
+
+export function TrustContractPanel({
+  runtimeSummary,
+}: {
+  runtimeSummary: AboutRuntimeSummary | null;
+}) {
+  return (
+    <Surface className="h-full" tone="accent">
+      <div className="flex items-center justify-between mb-5">
+        <h2 className="text-sm font-bold tracking-tight text-brand-dark">
+          Trust Contract
+        </h2>
+        <Badge tone="success">Local-first</Badge>
+      </div>
+      <div className="space-y-3">
+        {ABOUT_TRUST_CONTRACT_CLAIMS.map((claim) => (
+          <div
+            key={claim.id}
+            className={`rounded-lg border p-3 ${toneClasses[claim.tone] ?? toneClasses.slate}`}
+          >
+            <div className="flex items-center justify-between gap-2 mb-1">
+              <h3 className="text-sm font-semibold text-brand-dark">
+                {claim.title}
+              </h3>
+              <Badge tone={badgeTones[claim.tone] ?? "default"}>{claim.proofLabel}</Badge>
+            </div>
+            <p className="text-xs leading-relaxed text-brand-dark/60">
+              {claim.body}
+            </p>
+          </div>
+        ))}
+      </div>
+      <AboutRuntimeProofStrip summary={runtimeSummary} />
+    </Surface>
+  );
+}

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -761,7 +761,21 @@ export function App() {
       }
       aboutContent={
         <Suspense fallback={<LazyFallback />}>
-          <AboutWorkspace />
+          <AboutWorkspace runtimeSummary={
+            runtime.kind === "ready"
+              ? {
+                  // TODO: GuardRuntimeSnapshot does not yet expose guard_version or protected_app_count.
+                  // When those fields are added, populate them here instead of null/0.
+                  guardVersion: null,
+                  cloudState: runtime.snapshot.cloud_state ?? "unknown",
+                  cloudStateLabel: runtime.snapshot.cloud_state_label ?? "Unknown",
+                  syncConfigured: runtime.snapshot.sync_configured ?? false,
+                  pendingCount: runtime.snapshot.pending_count ?? 0,
+                  receiptCount: runtime.snapshot.receipt_count ?? 0,
+                  protectedAppCount: 0,
+                }
+              : null
+          } />
         </Suspense>
       }
     />


### PR DESCRIPTION
## Summary
- Redesign About page from editorial stack to trust cockpit with Trust Contract hero
- Add Data Boundary section showing local-vs-sync comparison
- Add Open Standards map with 6 directional nodes
- Replace equal-weight path timeline with tiered PathwayGrid (primary/secondary/tertiary)
- Affiliate content moved to tertiary ecosystem section with disclosure
- Componentize: about-workspace.tsx is now 70 lines, sections in components/
- Replace raw href analytics with stable link IDs (linkId, ctaId, sectionId)
- Harden external link validation: linkId + pathPrefix + RFC1918 private ranges
- Update copy: remove "tamper-evident", "score a recurring commission", add "approved affiliates" and "qualified paid referrals"
- Add content hierarchy, banned-phrase, DOM-safety, and link-prefix tests

## Testing
- `npx tsx dashboard/src/about/about-content.test.ts` — passes
- `npx tsx dashboard/src/about/about-external-links.test.ts` — passes
- `npx tsx dashboard/src/about/about-design.test.ts` — passes
- `cd dashboard && npm run build` — builds successfully (about-workspace.js chunk 30.90 kB)

## Notes
- Build verified on canonical repo with existing node_modules
- No approval/inbox/security workflow behavior changes
- No new dependencies added
