### PR TITLE
fix(update): sync dashboard static assets after package update

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -156,6 +156,15 @@ def run_guard_update(
         payload["managed_installs"] = repaired_installs
         if len(repaired_installs) == 1:
             payload["managed_install"] = repaired_installs[0]
+    # Sync dashboard static assets after package update so the daemon serves fresh UI.
+    if not dry_run and payload.get("status") in {"updated", "current"}:
+        dashboard_sync = _sync_dashboard_assets()
+        if dashboard_sync:
+            payload["dashboard_sync"] = dashboard_sync
+            sync_notes = dashboard_sync.get("notes")
+            if sync_notes:
+                existing = payload.get("notes") or []
+                payload["notes"] = [*existing, *sync_notes]
     return payload, 0
 
 
@@ -673,6 +682,142 @@ def build_guard_update_status_payload() -> dict[str, object]:
         "update_available": update_available,
         "blocked_reason": blocked_reason,
     }
+
+
+def _sync_dashboard_assets() -> dict[str, object] | None:
+    """Copy pre-built dashboard assets from a local source checkout to the installed package.
+
+    When HOL Guard is installed from PyPI/uv/pipx, the wheel may not include the latest
+    dashboard Vite build. This function detects a local source checkout and copies the
+    already-built assets into the installed package's static directory so the running
+    daemon serves fresh UI. No build step is performed; run ``npm run build`` in the
+    dashboard directory first if assets are stale.
+    """
+    import importlib.util
+
+    # Find the installed package's static directory
+    spec = importlib.util.find_spec("codex_plugin_scanner.guard.daemon.server")
+    if spec is None or spec.origin is None:
+        return None
+    installed_static = Path(spec.origin).with_name("static")
+    try:
+        if not installed_static.is_dir():
+            return None
+    except OSError:
+        return None
+
+    # Find a local source checkout by walking up from cwd looking for hol-guard/dashboard
+    try:
+        source_checkout = _find_source_checkout()
+    except OSError:
+        return {"source_checkout_found": False, "installed_static": str(installed_static)}
+    if source_checkout is None:
+        return {"source_checkout_found": False, "installed_static": str(installed_static)}
+
+    try:
+        dashboard_dir = source_checkout / "dashboard"
+        source_static = dashboard_dir / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "static"
+        # Fallback: if the repo builds into src/codex_plugin_scanner/guard/daemon/static
+        if not source_static.is_dir():
+            source_static = source_checkout / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "static"
+        if not source_static.is_dir():
+            return {
+                "source_checkout_found": True,
+                "source_checkout": str(source_checkout),
+                "dashboard_dir_found": False,
+                "notes": ["Source checkout found but no built dashboard assets. Run `npm run build` in the dashboard directory."],
+            }
+    except OSError as error:
+        return {
+            "source_checkout_found": True,
+            "source_checkout": str(source_checkout),
+            "copied": False,
+            "error": redact_sensitive_text(str(error)),
+            "notes": ["Dashboard asset sync failed due to file system error."],
+        }
+
+    # Compare source vs installed to decide if copy is needed
+    source_index = source_static / "index.html"
+    installed_index = installed_static / "index.html"
+    needs_copy = True
+    try:
+        if installed_index.is_file() and source_index.is_file():
+            installed_mtime = installed_index.stat().st_mtime
+            source_mtime = source_index.stat().st_mtime
+            needs_copy = source_mtime > installed_mtime
+    except OSError:
+        needs_copy = True
+
+    if not needs_copy:
+        return {
+            "source_checkout_found": True,
+            "source_checkout": str(source_checkout),
+            "copied": False,
+            "reason": "installed assets are already up to date",
+        }
+
+    # Copy all files from source static to installed static
+    copied_count = 0
+    try:
+        for src_file in source_static.rglob("*"):
+            if not src_file.is_file():
+                continue
+            relative = src_file.relative_to(source_static)
+            dest = installed_static / relative
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src_file, dest)
+            copied_count += 1
+    except OSError as error:
+        return {
+            "source_checkout_found": True,
+            "source_checkout": str(source_checkout),
+            "copied": False,
+            "error": redact_sensitive_text(str(error)),
+            "notes": ["Dashboard asset sync failed. The daemon may serve stale UI."],
+        }
+
+    return {
+        "source_checkout_found": True,
+        "source_checkout": str(source_checkout),
+        "installed_static": str(installed_static),
+        "copied": True,
+        "copied_files": copied_count,
+        "notes": [f"Synced {copied_count} dashboard asset files to the installed package."],
+    }
+
+
+def _find_source_checkout() -> Path | None:
+    """Return a local hol-guard source checkout if one is detected nearby."""
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return None
+    candidates = [cwd, *cwd.parents]
+    # Also check common locations near the install
+    for candidate in candidates:
+        try:
+            if (candidate / "dashboard" / "package.json").is_file() and (
+                candidate / "src" / "codex_plugin_scanner"
+            ).is_dir():
+                return candidate
+        except OSError:
+            continue
+    # Check one level deeper for repo roots that may contain hol-guard as a sub-project
+    for candidate in candidates:
+        try:
+            for sub in candidate.iterdir():
+                try:
+                    if (
+                        sub.is_dir()
+                        and (sub / "dashboard" / "package.json").is_file()
+                        and (sub / "src" / "codex_plugin_scanner").is_dir()
+                    ):
+                        return sub
+                except OSError:
+                    continue
+        except OSError:
+            continue
+    return None
 
 
 __all__ = ["build_guard_update_status_payload", "run_guard_update"]


### PR DESCRIPTION
## Summary
- After `hol-guard update` installs a new package version, the dashboard Vite build artifacts in the installed package's `daemon/static/` directory may be stale if the wheel was built before the dashboard source changes.
- Added `_sync_dashboard_assets()` to `update_commands.py` that runs after a successful update.
- Detects a local source checkout by walking up from cwd looking for `dashboard/package.json` + `src/codex_plugin_scanner`.
- Compares `index.html` mtime between source and installed static directories.
- Copies all built assets from source to installed package when source is newer.
- Fails gracefully: never blocks the update, logs `dashboard_sync` details in the update payload.

## Testing
- `python3 -c "from codex_plugin_scanner.guard.cli.update_commands import _sync_dashboard_assets; print(_sync_dashboard_assets())"` — detects checkout, compares mtimes, copies when needed
- `cd /tmp && python3 -c "..."` — returns `source_checkout_found: false` when no checkout nearby

## Notes
- For PyPI installs without a local checkout, no sync occurs (expected behavior — wheel should include fresh assets).
- For developers with a local repo, update now automatically keeps the served UI in sync.
