### PR TITLE
feat(guard): prove package-shim intercept invokes canonical evaluator

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -119,7 +119,7 @@ from ..shims import (
     activate_package_shims,
     package_shim_status,
     package_shim_supported_managers,
-    test_package_shim_intercepts,
+    probe_package_shim_intercepts,
     uninstall_package_shims,
 )
 from ..stable_digest import stable_digest_hex
@@ -1980,7 +1980,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if operation == "remove":
             return uninstall_package_shims(context, managers=managers)
         if operation == "test":
-            return test_package_shim_intercepts(
+            return probe_package_shim_intercepts(
                 context,
                 managers=managers,
                 workspace_dir=context.workspace_dir,

--- a/src/codex_plugin_scanner/guard/shim_probe.py
+++ b/src/codex_plugin_scanner/guard/shim_probe.py
@@ -52,9 +52,7 @@ def protect_evaluator_evidence(payload: dict[str, Any]) -> dict[str, object]:
     verdict_dict = verdict if isinstance(verdict, dict) else {}
     evidence_ids = supply_chain_dict.get("evidence_ids")
     normalized_evidence_ids = (
-        [str(item) for item in evidence_ids if item is not None]
-        if isinstance(evidence_ids, list)
-        else []
+        [str(item) for item in evidence_ids if item is not None] if isinstance(evidence_ids, list) else []
     )
     return {
         "evaluator_invoked": "supply_chain_evaluation" in payload or "verdict" in payload,

--- a/src/codex_plugin_scanner/guard/shim_probe.py
+++ b/src/codex_plugin_scanner/guard/shim_probe.py
@@ -1,0 +1,64 @@
+"""Shared helpers for package-shim intercept probes."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+_PACKAGE_SHIM_PROBE_ARGS: dict[str, tuple[str, ...]] = {
+    "npm": ("install", "--dry-run", "lodash@4.17.21"),
+    "pnpm": ("add", "--dry-run", "lodash@4.17.21"),
+    "yarn": ("add", "--dry-run", "lodash@4.17.21"),
+    "bun": ("add", "--dry-run", "lodash@4.17.21"),
+    "pip": ("install", "--dry-run", "requests==2.32.3"),
+    "pip3": ("install", "--dry-run", "requests==2.32.3"),
+    "uv": ("add", "--dry-run", "requests==2.32.3"),
+    "poetry": ("add", "--dry-run", "requests@2.32.3"),
+    "pipenv": ("install", "--dry-run", "requests==2.32.3"),
+    "pipx": ("install", "--dry-run", "requests==2.32.3"),
+    "cargo": ("add", "serde@1.0.203"),
+    "go": ("install", "-n", "github.com/pkg/errors@v0.9.1"),
+    "composer": ("require", "--dry-run", "monolog/monolog:3.6.0"),
+    "bundle": ("add", "rails", "--version", "7.1.3"),
+}
+
+
+def package_shim_probe_args(manager: str) -> tuple[str, ...]:
+    """Return install-shaped probe args that route through package protect."""
+
+    return _PACKAGE_SHIM_PROBE_ARGS.get(manager, ("--version",))
+
+
+def parse_protect_json_stdout(stdout: str) -> dict[str, Any]:
+    """Parse the first JSON object emitted by `hol-guard protect --json`."""
+
+    text = stdout.lstrip()
+    if not text:
+        return {}
+    decoder = json.JSONDecoder()
+    try:
+        payload, _index = decoder.raw_decode(text)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def protect_evaluator_evidence(payload: dict[str, Any]) -> dict[str, object]:
+    """Extract evaluator invocation evidence from a protect payload."""
+
+    supply_chain = payload.get("supply_chain_evaluation")
+    supply_chain_dict = supply_chain if isinstance(supply_chain, dict) else {}
+    verdict = payload.get("verdict")
+    verdict_dict = verdict if isinstance(verdict, dict) else {}
+    evidence_ids = supply_chain_dict.get("evidence_ids")
+    normalized_evidence_ids = (
+        [str(item) for item in evidence_ids if item is not None]
+        if isinstance(evidence_ids, list)
+        else []
+    )
+    return {
+        "evaluator_invoked": "supply_chain_evaluation" in payload or "verdict" in payload,
+        "protect_decision": verdict_dict.get("action"),
+        "evidence_ids": normalized_evidence_ids,
+        "dry_run": payload.get("dry_run"),
+    }

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -903,7 +903,7 @@ __all__ = [
     "package_shim_cloud_coverage",
     "package_shim_status",
     "package_shim_supported_managers",
-    "remove_guard_shim",
     "probe_package_shim_intercepts",
+    "remove_guard_shim",
     "uninstall_package_shims",
 ]

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -12,6 +12,11 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .launcher import merge_guard_launcher_env
+from .shim_probe import (
+    package_shim_probe_args,
+    parse_protect_json_stdout,
+    protect_evaluator_evidence,
+)
 
 if TYPE_CHECKING:
     from .adapters.base import HarnessContext
@@ -765,55 +770,6 @@ def _path_export_hint(shim_dir: Path) -> str:
     return f'export PATH="{shim_dir}:$PATH"'
 
 
-def _package_shim_probe_args(manager: str) -> tuple[str, ...]:
-    probes: dict[str, tuple[str, ...]] = {
-        "npm": ("install", "lodash@4.17.21"),
-        "pnpm": ("add", "lodash@4.17.21"),
-        "yarn": ("add", "lodash@4.17.21"),
-        "bun": ("add", "lodash@4.17.21"),
-        "pip": ("install", "requests==2.32.3"),
-        "pip3": ("install", "requests==2.32.3"),
-        "uv": ("add", "requests==2.32.3"),
-        "poetry": ("add", "requests@2.32.3"),
-        "pipenv": ("install", "requests==2.32.3"),
-        "pipx": ("install", "requests==2.32.3"),
-        "cargo": ("add", "serde@1.0.203"),
-        "go": ("install", "github.com/pkg/errors@v0.9.1"),
-        "composer": ("require", "monolog/monolog:3.6.0"),
-        "bundle": ("add", "rails", "--version", "7.1.3"),
-    }
-    return probes.get(manager, ("--version",))
-
-
-def _parse_protect_probe_output(stdout: str) -> dict[str, object]:
-    text = stdout.strip()
-    if not text:
-        return {}
-    try:
-        payload = json.loads(text)
-    except json.JSONDecodeError:
-        return {}
-    return payload if isinstance(payload, dict) else {}
-
-
-def _protect_evaluator_evidence(payload: dict[str, object]) -> dict[str, object]:
-    supply_chain = payload.get("supply_chain_evaluation")
-    supply_chain_dict = supply_chain if isinstance(supply_chain, dict) else {}
-    verdict = payload.get("verdict")
-    verdict_dict = verdict if isinstance(verdict, dict) else {}
-    evidence_ids = supply_chain_dict.get("evidence_ids")
-    normalized_evidence_ids = (
-        [str(item) for item in evidence_ids if isinstance(item, str)]
-        if isinstance(evidence_ids, list)
-        else []
-    )
-    return {
-        "evaluator_invoked": "supply_chain_evaluation" in payload or "verdict" in payload,
-        "protect_decision": verdict_dict.get("action"),
-        "evidence_ids": normalized_evidence_ids,
-    }
-
-
 def _path_export_hints(shim_dir: Path) -> dict[str, str]:
     posix_hint = f'export PATH="{shim_dir}:$PATH"'
     return {
@@ -892,7 +848,7 @@ def probe_package_shim_intercepts(
                 },
             )
             continue
-        probe_args = _package_shim_probe_args(manager)
+        probe_args = package_shim_probe_args(manager)
         try:
             # codeql[py/path-injection] target_workspace is home_dir or a validated daemon workspace_dir.
             result = subprocess.run(
@@ -913,8 +869,8 @@ def probe_package_shim_intercepts(
                 },
             )
             continue
-        protect_payload = _parse_protect_probe_output(result.stdout)
-        evaluator_evidence = _protect_evaluator_evidence(protect_payload)
+        protect_payload = parse_protect_json_stdout(result.stdout)
+        evaluator_evidence = protect_evaluator_evidence(protect_payload)
         manager_results.append(
             {
                 "evaluator_invoked": evaluator_evidence["evaluator_invoked"],

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -765,6 +765,55 @@ def _path_export_hint(shim_dir: Path) -> str:
     return f'export PATH="{shim_dir}:$PATH"'
 
 
+def _package_shim_probe_args(manager: str) -> tuple[str, ...]:
+    probes: dict[str, tuple[str, ...]] = {
+        "npm": ("install", "lodash@4.17.21"),
+        "pnpm": ("add", "lodash@4.17.21"),
+        "yarn": ("add", "lodash@4.17.21"),
+        "bun": ("add", "lodash@4.17.21"),
+        "pip": ("install", "requests==2.32.3"),
+        "pip3": ("install", "requests==2.32.3"),
+        "uv": ("add", "requests==2.32.3"),
+        "poetry": ("add", "requests@2.32.3"),
+        "pipenv": ("install", "requests==2.32.3"),
+        "pipx": ("install", "requests==2.32.3"),
+        "cargo": ("add", "serde@1.0.203"),
+        "go": ("install", "github.com/pkg/errors@v0.9.1"),
+        "composer": ("require", "monolog/monolog:3.6.0"),
+        "bundle": ("add", "rails", "--version", "7.1.3"),
+    }
+    return probes.get(manager, ("--version",))
+
+
+def _parse_protect_probe_output(stdout: str) -> dict[str, object]:
+    text = stdout.strip()
+    if not text:
+        return {}
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _protect_evaluator_evidence(payload: dict[str, object]) -> dict[str, object]:
+    supply_chain = payload.get("supply_chain_evaluation")
+    supply_chain_dict = supply_chain if isinstance(supply_chain, dict) else {}
+    verdict = payload.get("verdict")
+    verdict_dict = verdict if isinstance(verdict, dict) else {}
+    evidence_ids = supply_chain_dict.get("evidence_ids")
+    normalized_evidence_ids = (
+        [str(item) for item in evidence_ids if isinstance(item, str)]
+        if isinstance(evidence_ids, list)
+        else []
+    )
+    return {
+        "evaluator_invoked": "supply_chain_evaluation" in payload or "verdict" in payload,
+        "protect_decision": verdict_dict.get("action"),
+        "evidence_ids": normalized_evidence_ids,
+    }
+
+
 def _path_export_hints(shim_dir: Path) -> dict[str, str]:
     posix_hint = f'export PATH="{shim_dir}:$PATH"'
     return {
@@ -775,7 +824,7 @@ def _path_export_hints(shim_dir: Path) -> dict[str, str]:
     }
 
 
-def test_package_shim_intercepts(
+def probe_package_shim_intercepts(
     context: HarnessContext,
     *,
     managers: tuple[str, ...] | None = None,
@@ -789,14 +838,32 @@ def test_package_shim_intercepts(
     tested_managers = list(managers or tuple(sorted(installed)))
     path_repair_required = [manager for manager in tested_managers if manager in installed and manager not in protected]
     manager_results: list[dict[str, object]] = []
+    manager_details = status.get("manager_details", [])
+    detail_by_manager = {
+        str(item.get("manager")): item
+        for item in manager_details
+        if isinstance(item, dict) and isinstance(item.get("manager"), str)
+    }
     target_workspace = workspace_dir or context.workspace_dir or context.home_dir
     shim_dir = context.guard_home / "package-shims" / "bin"
     for manager in tested_managers:
         if manager not in installed:
             continue
+        manager_detail = detail_by_manager.get(manager)
+        if manager_detail is not None and manager_detail.get("integrity") == "tampered":
+            manager_results.append(
+                {
+                    "evaluator_invoked": False,
+                    "intercept_ran": False,
+                    "manager": manager,
+                    "skipped_reason": "shim_tampered",
+                },
+            )
+            continue
         if manager not in protected:
             manager_results.append(
                 {
+                    "evaluator_invoked": False,
                     "intercept_ran": False,
                     "manager": manager,
                     "skipped_reason": "path_inactive",
@@ -807,6 +874,7 @@ def test_package_shim_intercepts(
         if command is None:
             manager_results.append(
                 {
+                    "evaluator_invoked": False,
                     "intercept_ran": False,
                     "manager": manager,
                     "skipped_reason": "unsupported_manager",
@@ -817,16 +885,18 @@ def test_package_shim_intercepts(
         if not shim_path.exists():
             manager_results.append(
                 {
+                    "evaluator_invoked": False,
                     "intercept_ran": False,
                     "manager": manager,
                     "skipped_reason": "shim_missing",
                 },
             )
             continue
+        probe_args = _package_shim_probe_args(manager)
         try:
             # codeql[py/path-injection] target_workspace is home_dir or a validated daemon workspace_dir.
             result = subprocess.run(
-                [str(shim_path), "--version"],
+                [str(shim_path), *probe_args],
                 capture_output=True,
                 check=False,
                 cwd=target_workspace,
@@ -836,20 +906,27 @@ def test_package_shim_intercepts(
         except (subprocess.TimeoutExpired, OSError):
             manager_results.append(
                 {
+                    "evaluator_invoked": False,
                     "intercept_ran": False,
                     "manager": manager,
                     "skipped_reason": "probe_failed",
                 },
             )
             continue
+        protect_payload = _parse_protect_probe_output(result.stdout)
+        evaluator_evidence = _protect_evaluator_evidence(protect_payload)
         manager_results.append(
             {
-                "intercept_ran": True,
+                "evaluator_invoked": evaluator_evidence["evaluator_invoked"],
+                "evidence_ids": evaluator_evidence["evidence_ids"],
+                "intercept_ran": bool(evaluator_evidence["evaluator_invoked"]),
                 "manager": manager,
+                "protect_decision": evaluator_evidence["protect_decision"],
+                "probe_args": list(probe_args),
                 "shim_exit_code": result.returncode,
             },
         )
-    intercept_proved = any(bool(result.get("intercept_ran")) for result in manager_results)
+    intercept_proved = any(bool(result.get("evaluator_invoked")) for result in manager_results)
     return {
         "blocked_execution": bool(tested_managers) and all(manager in protected for manager in tested_managers),
         "intercept_proved": intercept_proved,
@@ -871,6 +948,6 @@ __all__ = [
     "package_shim_status",
     "package_shim_supported_managers",
     "remove_guard_shim",
-    "test_package_shim_intercepts",
+    "probe_package_shim_intercepts",
     "uninstall_package_shims",
 ]

--- a/tests/shim_execution_helpers.py
+++ b/tests/shim_execution_helpers.py
@@ -1,0 +1,108 @@
+"""Shared helpers for package-shim intercept and execution proofs."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+
+def write_fake_manager_script(
+    *,
+    fake_bin: Path,
+    manager: str,
+    marker_path: Path,
+    exit_code: int,
+    stdout_text: str | None = None,
+    stderr_text: str | None = None,
+) -> Path:
+    """Write a fake package manager that records argv/cwd when invoked."""
+
+    script_path = fake_bin / manager
+    script_path.write_text(
+        "\n".join(
+            [
+                "#!/usr/bin/env python3",
+                "from __future__ import annotations",
+                "import json",
+                "import os",
+                "import sys",
+                f"marker_path = {str(marker_path)!r}",
+                "payload = {",
+                "    'argv': sys.argv,",
+                "    'cwd': os.getcwd(),",
+                "    'path': os.environ.get('PATH', ''),",
+                "    'shim_var': os.environ.get('SHIM_TEST_VAR'),",
+                "}",
+                "with open(marker_path, 'w', encoding='utf-8') as handle:",
+                "    json.dump(payload, handle)",
+                f"if {stdout_text!r} is not None:",
+                f"    print({stdout_text!r})",
+                f"if {stderr_text!r} is not None:",
+                f"    print({stderr_text!r}, file=sys.stderr)",
+                f"raise SystemExit({exit_code})",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    script_path.chmod(script_path.stat().st_mode | 0o755)
+    return script_path
+
+
+def parse_protect_json_output(stdout: str) -> dict[str, Any]:
+    """Parse JSON emitted by `hol-guard protect --json`."""
+
+    text = stdout.strip()
+    if not text:
+        return {}
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def protect_evaluator_evidence(payload: dict[str, Any]) -> dict[str, object]:
+    """Extract evaluator invocation evidence from a protect payload."""
+
+    supply_chain = payload.get("supply_chain_evaluation")
+    supply_chain_dict = supply_chain if isinstance(supply_chain, dict) else {}
+    verdict = payload.get("verdict")
+    verdict_dict = verdict if isinstance(verdict, dict) else {}
+    evidence_ids = supply_chain_dict.get("evidence_ids")
+    normalized_evidence_ids = (
+        [str(item) for item in evidence_ids if isinstance(item, str)]
+        if isinstance(evidence_ids, list)
+        else []
+    )
+    return {
+        "evaluator_invoked": "supply_chain_evaluation" in payload or "verdict" in payload,
+        "protect_decision": verdict_dict.get("action"),
+        "evidence_ids": normalized_evidence_ids,
+        "dry_run": payload.get("dry_run"),
+    }
+
+
+_MANAGER_PROBE_ARGS: dict[str, tuple[str, ...]] = {
+    "npm": ("install", "lodash@4.17.21"),
+    "pnpm": ("add", "lodash@4.17.21"),
+    "yarn": ("add", "lodash@4.17.21"),
+    "bun": ("add", "lodash@4.17.21"),
+    "pip": ("install", "requests==2.32.3"),
+    "pip3": ("install", "requests==2.32.3"),
+    "uv": ("add", "requests==2.32.3"),
+    "poetry": ("add", "requests@2.32.3"),
+    "pipenv": ("install", "requests==2.32.3"),
+    "pipx": ("install", "requests==2.32.3"),
+    "cargo": ("add", "serde@1.0.203"),
+    "go": ("install", "github.com/pkg/errors@v0.9.1"),
+    "composer": ("require", "monolog/monolog:3.6.0"),
+    "bundle": ("add", "rails", "--version", "7.1.3"),
+}
+
+
+def manager_probe_args(manager: str) -> tuple[str, ...]:
+    """Return install-shaped probe args that route through package protect."""
+
+    return _MANAGER_PROBE_ARGS.get(manager, ("--version",))

--- a/tests/shim_execution_helpers.py
+++ b/tests/shim_execution_helpers.py
@@ -4,7 +4,19 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any
+
+from codex_plugin_scanner.guard.shim_probe import (
+    package_shim_probe_args,
+    parse_protect_json_stdout,
+    protect_evaluator_evidence,
+)
+
+__all__ = [
+    "manager_probe_args",
+    "parse_protect_json_output",
+    "protect_evaluator_evidence",
+    "write_fake_manager_script",
+]
 
 
 def write_fake_manager_script(
@@ -50,59 +62,13 @@ def write_fake_manager_script(
     return script_path
 
 
-def parse_protect_json_output(stdout: str) -> dict[str, Any]:
-    """Parse JSON emitted by `hol-guard protect --json`."""
+def parse_protect_json_output(stdout: str):
+    """Backward-compatible alias for protect stdout parsing."""
 
-    text = stdout.strip()
-    if not text:
-        return {}
-    try:
-        payload = json.loads(text)
-    except json.JSONDecodeError:
-        return {}
-    return payload if isinstance(payload, dict) else {}
-
-
-def protect_evaluator_evidence(payload: dict[str, Any]) -> dict[str, object]:
-    """Extract evaluator invocation evidence from a protect payload."""
-
-    supply_chain = payload.get("supply_chain_evaluation")
-    supply_chain_dict = supply_chain if isinstance(supply_chain, dict) else {}
-    verdict = payload.get("verdict")
-    verdict_dict = verdict if isinstance(verdict, dict) else {}
-    evidence_ids = supply_chain_dict.get("evidence_ids")
-    normalized_evidence_ids = (
-        [str(item) for item in evidence_ids if isinstance(item, str)]
-        if isinstance(evidence_ids, list)
-        else []
-    )
-    return {
-        "evaluator_invoked": "supply_chain_evaluation" in payload or "verdict" in payload,
-        "protect_decision": verdict_dict.get("action"),
-        "evidence_ids": normalized_evidence_ids,
-        "dry_run": payload.get("dry_run"),
-    }
-
-
-_MANAGER_PROBE_ARGS: dict[str, tuple[str, ...]] = {
-    "npm": ("install", "lodash@4.17.21"),
-    "pnpm": ("add", "lodash@4.17.21"),
-    "yarn": ("add", "lodash@4.17.21"),
-    "bun": ("add", "lodash@4.17.21"),
-    "pip": ("install", "requests==2.32.3"),
-    "pip3": ("install", "requests==2.32.3"),
-    "uv": ("add", "requests==2.32.3"),
-    "poetry": ("add", "requests@2.32.3"),
-    "pipenv": ("install", "requests==2.32.3"),
-    "pipx": ("install", "requests==2.32.3"),
-    "cargo": ("add", "serde@1.0.203"),
-    "go": ("install", "github.com/pkg/errors@v0.9.1"),
-    "composer": ("require", "monolog/monolog:3.6.0"),
-    "bundle": ("add", "rails", "--version", "7.1.3"),
-}
+    return parse_protect_json_stdout(stdout)
 
 
 def manager_probe_args(manager: str) -> tuple[str, ...]:
-    """Return install-shaped probe args that route through package protect."""
+    """Backward-compatible alias for install-shaped probe args."""
 
-    return _MANAGER_PROBE_ARGS.get(manager, ("--version",))
+    return package_shim_probe_args(manager)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -720,6 +720,7 @@ def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(
     assert test_payload["result"]["intercept_proved"] is False
     assert test_payload["result"]["manager_results"] == [
         {
+            "evaluator_invoked": False,
             "intercept_ran": False,
             "manager": "npm",
             "skipped_reason": "path_inactive",

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -22,6 +22,7 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.protect import build_protect_payload
 from codex_plugin_scanner.guard.shims import install_package_shims, package_shim_status
 from codex_plugin_scanner.guard.store import GuardStore
+from tests.shim_execution_helpers import write_fake_manager_script
 from tests.test_guard_protect import _seed_bundle_cache_only, _SyncAndEvaluateHandler
 from tests.test_guard_supply_chain_evaluator import _cloud_response, _EvaluateHandler
 
@@ -287,7 +288,7 @@ def test_package_manager_shim_uses_trusted_guard_import_path(tmp_path: Path, cap
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
     marker_path = tmp_path / "npm-ran.json"
-    _write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
     shim_path = _install_single_manager_shim(
         home_dir=home_dir,
         workspace_dir=workspace_dir,
@@ -351,7 +352,7 @@ def test_package_manager_shim_runs_allowed_command_once_when_shim_dir_is_on_path
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir()
     marker_path = tmp_path / "npm-allowed.json"
-    _write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
     server, thread, sync_url = _start_cloud_eval_server(decision="allow", package_name="minimist")
     try:
         _seed_bundle(
@@ -388,46 +389,6 @@ def test_package_manager_shim_runs_allowed_command_once_when_shim_dir_is_on_path
     assert result.returncode == 0
     assert marker_payload["argv"][1:] == ["install", "minimist@1.2.9"]
     assert marker_payload["cwd"] == str(workspace_dir)
-
-
-def _write_fake_manager_script(
-    *,
-    fake_bin: Path,
-    manager: str,
-    marker_path: Path,
-    exit_code: int,
-    stdout_text: str | None = None,
-    stderr_text: str | None = None,
-) -> None:
-    script_path = fake_bin / manager
-    script_path.write_text(
-        "\n".join(
-            [
-                "#!/usr/bin/env python3",
-                "from __future__ import annotations",
-                "import json",
-                "import os",
-                "import sys",
-                f"marker_path = {str(marker_path)!r}",
-                "payload = {",
-                "    'argv': sys.argv,",
-                "    'cwd': os.getcwd(),",
-                "    'path': os.environ.get('PATH', ''),",
-                "    'shim_var': os.environ.get('SHIM_TEST_VAR'),",
-                "}",
-                "with open(marker_path, 'w', encoding='utf-8') as handle:",
-                "    json.dump(payload, handle)",
-                f"if {stdout_text!r} is not None:",
-                f"    print({stdout_text!r})",
-                f"if {stderr_text!r} is not None:",
-                f"    print({stderr_text!r}, file=sys.stderr)",
-                f"raise SystemExit({exit_code})",
-                "",
-            ]
-        ),
-        encoding="utf-8",
-    )
-    script_path.chmod(script_path.stat().st_mode | 0o755)
 
 
 _BLOCKING_SHIM_CASES = (
@@ -756,7 +717,7 @@ def test_guard_package_shims_block_before_manager_execution(
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir(parents=True, exist_ok=True)
     marker_path = tmp_path / f"{manager}-marker.json"
-    _write_fake_manager_script(fake_bin=fake_bin, manager=manager, marker_path=marker_path, exit_code=0)
+    write_fake_manager_script(fake_bin=fake_bin, manager=manager, marker_path=marker_path, exit_code=0)
     server, thread, sync_url = _start_cloud_eval_server(
         decision="allow",
         package_name=package_name,
@@ -802,7 +763,7 @@ def test_guard_package_shim_preserves_argv_cwd_env_exitcode_and_stdio(tmp_path: 
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir(parents=True, exist_ok=True)
     marker_path = tmp_path / "npm-allow-marker.json"
-    _write_fake_manager_script(
+    write_fake_manager_script(
         fake_bin=fake_bin,
         manager="npm",
         marker_path=marker_path,
@@ -896,7 +857,7 @@ def test_guard_package_shims_block_npm_ci_before_manager_execution_from_lockfile
     fake_bin = tmp_path / "fake-bin"
     fake_bin.mkdir(parents=True, exist_ok=True)
     marker_path = tmp_path / "npm-ci-marker.json"
-    _write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
     server, thread, sync_url = _start_cloud_eval_server(decision="block", package_name="minimist")
     try:
         _seed_bundle(

--- a/tests/test_guard_shim_intercept_proofs.py
+++ b/tests/test_guard_shim_intercept_proofs.py
@@ -13,7 +13,12 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.shims import install_package_shims, probe_package_shim_intercepts
 from codex_plugin_scanner.guard.store import GuardStore
-from tests.shim_execution_helpers import write_fake_manager_script
+from tests.shim_execution_helpers import (
+    manager_probe_args,
+    parse_protect_json_output,
+    protect_evaluator_evidence,
+    write_fake_manager_script,
+)
 from tests.test_guard_headless_daemon_api import _dashboard_token_for, _read_json_response, _request
 
 
@@ -27,6 +32,24 @@ def _harness_context(tmp_path: Path, *, workspace_dir: Path | None = None) -> Ha
         workspace_dir=workspace_dir,
         guard_home=guard_home,
     )
+
+
+def test_parse_protect_json_output_ignores_trailing_manager_stdout() -> None:
+    payload = {
+        "dry_run": True,
+        "supply_chain_evaluation": {"evidence_ids": [42, "ev-1"]},
+        "verdict": {"action": "allow"},
+    }
+    stdout = json.dumps(payload) + "\nnpm notice dry-run complete\n"
+    parsed = parse_protect_json_output(stdout)
+    evidence = protect_evaluator_evidence(parsed)
+    assert evidence["evaluator_invoked"] is True
+    assert evidence["protect_decision"] == "allow"
+    assert evidence["evidence_ids"] == ["42", "ev-1"]
+
+
+def test_manager_probe_args_include_dry_run_for_npm() -> None:
+    assert manager_probe_args("npm") == ("install", "--dry-run", "lodash@4.17.21")
 
 
 def test_shim_execution_helper_records_fake_manager_invocation(tmp_path: Path) -> None:

--- a/tests/test_guard_shim_intercept_proofs.py
+++ b/tests/test_guard_shim_intercept_proofs.py
@@ -1,0 +1,148 @@
+"""Phase 04 intercept proofs for package-manager shims and daemon test action."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.shims import install_package_shims, probe_package_shim_intercepts
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.shim_execution_helpers import write_fake_manager_script
+from tests.test_guard_headless_daemon_api import _dashboard_token_for, _read_json_response, _request
+
+
+def _harness_context(tmp_path: Path, *, workspace_dir: Path | None = None) -> HarnessContext:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=guard_home,
+    )
+
+
+def test_shim_execution_helper_records_fake_manager_invocation(tmp_path: Path) -> None:
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    marker_path = tmp_path / "npm-marker.json"
+    write_fake_manager_script(
+        fake_bin=fake_bin,
+        manager="npm",
+        marker_path=marker_path,
+        exit_code=0,
+    )
+    result = subprocess.run(
+        [str(fake_bin / "npm"), "install", "lodash"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    payload = json.loads(marker_path.read_text(encoding="utf-8"))
+    assert payload["argv"][1:] == ["install", "lodash"]
+
+
+def test_package_shim_intercept_probe_records_evaluator_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    context = _harness_context(tmp_path, workspace_dir=workspace_dir)
+    install_package_shims(context, managers=("npm",))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    write_fake_manager_script(
+        fake_bin=fake_bin,
+        manager="npm",
+        marker_path=tmp_path / "npm-never-runs.json",
+        exit_code=0,
+    )
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shim_dir), str(fake_bin)]))
+
+    result = probe_package_shim_intercepts(context, managers=("npm",), workspace_dir=workspace_dir)
+
+    assert result["intercept_proved"] is True
+    manager_result = result["manager_results"][0]
+    assert manager_result["manager"] == "npm"
+    assert manager_result["evaluator_invoked"] is True
+    assert manager_result["intercept_ran"] is True
+    assert manager_result.get("protect_decision") in {"allow", "review", "block", "monitor"}
+
+
+def test_package_shim_intercept_skips_tampered_shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    context = _harness_context(tmp_path, workspace_dir=workspace_dir)
+    install_package_shims(context, managers=("npm",))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    (shim_dir / "npm").write_text("#!/bin/sh\necho tampered", encoding="utf-8")
+    monkeypatch.setenv("PATH", str(shim_dir))
+
+    result = probe_package_shim_intercepts(context, managers=("npm",), workspace_dir=workspace_dir)
+
+    assert result["intercept_proved"] is False
+    assert result["manager_results"] == [
+        {
+            "evaluator_invoked": False,
+            "intercept_ran": False,
+            "manager": "npm",
+            "skipped_reason": "shim_tampered",
+        },
+    ]
+
+
+def test_daemon_package_shim_test_reports_path_inactive_without_evaluator(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "cloud-token",
+        "2026-05-27T16:00:00.000Z",
+        workspace_id="workspace-1",
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "premium", "workspace_id": "workspace-1"},
+        "2026-05-27T16:00:00.000Z",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        install_status, _install_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/install",
+                token=token,
+                payload={"managers": ["npm"]},
+            ),
+        )
+        test_status, test_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/test",
+                token=token,
+                payload={"managers": ["npm"]},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert install_status == 200
+    assert test_status == 200
+    assert test_payload["result"]["intercept_proved"] is False
+    assert test_payload["result"]["manager_results"][0]["skipped_reason"] == "path_inactive"
+    assert test_payload["result"]["manager_results"][0]["evaluator_invoked"] is False


### PR DESCRIPTION
## Summary
- Add shared shim execution helpers for intercept proofs
- Run install-shaped probe commands in package-shim test action and record evaluator evidence
- Skip tampered shims during intercept test and rename probe entrypoint to avoid pytest collection

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_shim_intercept_proofs.py tests/test_guard_package_shims.py tests/test_guard_headless_daemon_api.py::test_supply_chain_package_firewall_paid_install_and_test_roundtrip -q`
