### PR TITLE
feat(guard): package manager detection and Phase 05 lifecycle proofs

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -179,8 +179,10 @@ def _build_snapshot_payload(context: HarnessContext) -> dict[str, object]:
     status = package_shim_status(context)
     return {
         "package_manager_coverage": {
-            "shims_installed": status.get("active_managers", []),
+            "detected_managers": status.get("detected_managers", []),
             "path_active": status.get("active_managers", []),
+            "shims_installed": status.get("active_managers", []),
+            "undetected_managers": status.get("undetected_managers", []),
             "unsupported_managers": [],
         }
     }

--- a/src/codex_plugin_scanner/guard/shim_probe.py
+++ b/src/codex_plugin_scanner/guard/shim_probe.py
@@ -13,7 +13,6 @@ _PACKAGE_SHIM_PROBE_ARGS: dict[str, tuple[str, ...]] = {
     "bun": ("add", "--dry-run", "lodash@4.17.21"),
     "pip": ("install", "--dry-run", "requests==2.32.3"),
     "pip3": ("install", "--dry-run", "requests==2.32.3"),
-    "pip3": ("install", "--dry-run", "requests==2.32.3"),
     "uv": ("add", "--dry-run", "requests==2.32.3"),
     "poetry": ("add", "--dry-run", "requests@2.32.3"),
     "pipenv": ("install", "--dry-run", "requests==2.32.3"),

--- a/src/codex_plugin_scanner/guard/shim_probe.py
+++ b/src/codex_plugin_scanner/guard/shim_probe.py
@@ -7,10 +7,12 @@ from typing import Any
 
 _PACKAGE_SHIM_PROBE_ARGS: dict[str, tuple[str, ...]] = {
     "npm": ("install", "--dry-run", "lodash@4.17.21"),
+    "npx": ("-y", "lodash@4.17.21"),
     "pnpm": ("add", "--dry-run", "lodash@4.17.21"),
     "yarn": ("add", "--dry-run", "lodash@4.17.21"),
     "bun": ("add", "--dry-run", "lodash@4.17.21"),
     "pip": ("install", "--dry-run", "requests==2.32.3"),
+    "pip3": ("install", "--dry-run", "requests==2.32.3"),
     "pip3": ("install", "--dry-run", "requests==2.32.3"),
     "uv": ("add", "--dry-run", "requests==2.32.3"),
     "poetry": ("add", "--dry-run", "requests@2.32.3"),

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -770,9 +770,7 @@ def _filtered_manager_path(context: HarnessContext) -> str:
     shim_dir = context.guard_home / "package-shims" / "bin"
     shim_dir_abs = os.path.abspath(os.path.expanduser(str(shim_dir)))
     path_entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
-    filtered_entries = [
-        entry for entry in path_entries if os.path.abspath(os.path.expanduser(entry)) != shim_dir_abs
-    ]
+    filtered_entries = [entry for entry in path_entries if os.path.abspath(os.path.expanduser(entry)) != shim_dir_abs]
     return os.pathsep.join(filtered_entries)
 
 

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import shutil
 import subprocess
 import sys
 from datetime import datetime, timezone
@@ -30,7 +31,9 @@ _PACKAGE_SHIM_COMMANDS = {
     "gradle": "gradle",
     "mvn": "mvn",
     "npm": "npm",
+    "npx": "npx",
     "pip": "pip",
+    "pip3": "pip3",
     "pipenv": "pipenv",
     "pipx": "pipx",
     "pnpm": "pnpm",
@@ -309,6 +312,8 @@ def install_package_shims(
     )
     tracked_managers = tuple(dict.fromkeys([*existing_managers, *normalized_managers]))
     existing_hashes: dict[str, str] = existing_manifest.get("content_hashes", {})
+    existing_last_tests = existing_manifest.get("last_test_at", {})
+    last_test_at = dict(existing_last_tests) if isinstance(existing_last_tests, dict) else {}
     installed: list[str] = []
     content_hashes: dict[str, str] = dict(existing_hashes)
     for manager in normalized_managers:
@@ -324,9 +329,10 @@ def install_package_shims(
     manifest_payload = {
         "content_hashes": content_hashes,
         "installed_managers": list(tracked_managers),
+        "last_test_at": last_test_at,
         "shim_dir": str(shim_dir),
     }
-    _package_shim_manifest_path(context).write_text(json.dumps(manifest_payload, sort_keys=True), encoding="utf-8")
+    _write_package_shim_manifest(context, manifest_payload)
     program_name = _command_program_name()
     shell_hints = _path_export_hints(shim_dir)
     path_repair_required = [
@@ -379,6 +385,10 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         for manager in manifest.get("installed_managers", [])
         if isinstance(manager, str) and manager in _PACKAGE_SHIM_COMMANDS
     ]
+    last_test_at = manifest.get("last_test_at", {})
+    normalized_last_tests = last_test_at if isinstance(last_test_at, dict) else {}
+    detected_managers, undetected_managers = _detect_system_package_managers(context)
+    detected_set = set(detected_managers)
     shim_dir = context.guard_home / "package-shims" / "bin"
     stored_hashes: dict[str, str] = manifest.get("content_hashes", {})
     active_managers: list[str] = []
@@ -409,6 +419,7 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         manager_details.append(
             {
                 "integrity": integrity,
+                "last_test_at": normalized_last_tests.get(manager),
                 "manager": manager,
                 "path_active": bool(path_status.get("shim_precedes_real")),
                 "path_index": path_status.get("shim_path_index"),
@@ -417,6 +428,7 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
                 "real_binary_path": path_status.get("real_binary_path"),
                 "real_binary_path_index": path_status.get("real_binary_path_index"),
                 "shim_path": str(shim_path),
+                "system_binary_detected": manager in detected_set,
             }
         )
         if exists and bool(path_status.get("shim_precedes_real")):
@@ -436,7 +448,9 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
     )
     return {
         "active_managers": active_managers,
+        "detected_managers": detected_managers,
         "installed_managers": installed_managers,
+        "last_test_at": normalized_last_tests,
         "protected_managers": protected_managers,
         "path_active": bool(installed_managers) and len(protected_managers) == len(installed_managers),
         "path_contains_shim_dir": path_contains_shim_dir,
@@ -450,6 +464,8 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         "shell_profile_path": profile_status["shell_profile_path"],
         "shell_hints": _path_export_hints(shim_dir),
         "shim_dir": str(shim_dir),
+        "supported_managers": list(package_shim_supported_managers()),
+        "undetected_managers": undetected_managers,
     }
 
 
@@ -499,16 +515,20 @@ def uninstall_package_shims(
             for manager, hash_value in (manifest_hashes.items() if isinstance(manifest_hashes, dict) else ())
             if manager in remaining and isinstance(hash_value, str)
         }
-        manifest_path.write_text(
-            json.dumps(
-                {
-                    "content_hashes": content_hashes,
-                    "installed_managers": remaining,
-                    "shim_dir": str(shim_dir),
-                },
-                sort_keys=True,
-            ),
-            encoding="utf-8",
+        manifest_last_tests = manifest.get("last_test_at", {})
+        last_test_at = {
+            manager: timestamp
+            for manager, timestamp in (manifest_last_tests.items() if isinstance(manifest_last_tests, dict) else ())
+            if manager in remaining and isinstance(timestamp, str)
+        }
+        _write_package_shim_manifest(
+            context,
+            {
+                "content_hashes": content_hashes,
+                "installed_managers": remaining,
+                "last_test_at": last_test_at,
+                "shim_dir": str(shim_dir),
+            },
         )
     elif manifest_path.exists():
         manifest_path.unlink()
@@ -746,6 +766,30 @@ def _package_shim_manifest_path(context: HarnessContext) -> Path:
     return context.guard_home / "package-shims" / _PACKAGE_SHIM_MANIFEST
 
 
+def _filtered_manager_path(context: HarnessContext) -> str:
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    shim_dir_resolved = shim_dir.expanduser().resolve()
+    path_entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
+    filtered_entries = [entry for entry in path_entries if Path(entry).expanduser().resolve() != shim_dir_resolved]
+    return os.pathsep.join(filtered_entries)
+
+
+def _detect_system_package_managers(context: HarnessContext) -> tuple[list[str], list[str]]:
+    """Return supported managers with and without a real binary on PATH."""
+
+    filtered_path = _filtered_manager_path(context)
+    detected: list[str] = []
+    undetected: list[str] = []
+    for manager in package_shim_supported_managers():
+        command = _PACKAGE_SHIM_COMMANDS[manager]
+        resolved = shutil.which(command, path=filtered_path or None)
+        if resolved is not None:
+            detected.append(manager)
+        else:
+            undetected.append(manager)
+    return detected, undetected
+
+
 def _load_package_shim_manifest(context: HarnessContext) -> dict[str, object]:
     manifest_path = _package_shim_manifest_path(context)
     if not manifest_path.exists():
@@ -755,6 +799,28 @@ def _load_package_shim_manifest(context: HarnessContext) -> dict[str, object]:
     except (json.JSONDecodeError, OSError):
         return {}
     return payload if isinstance(payload, dict) else {}
+
+
+def _write_package_shim_manifest(context: HarnessContext, payload: dict[str, object]) -> None:
+    _package_shim_manifest_path(context).write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def _record_package_shim_test_results(
+    context: HarnessContext,
+    manager_results: list[dict[str, object]],
+    *,
+    tested_at: str | None = None,
+) -> None:
+    manifest = _load_package_shim_manifest(context)
+    last_test_at = manifest.get("last_test_at")
+    normalized_last_tests = dict(last_test_at) if isinstance(last_test_at, dict) else {}
+    timestamp = tested_at or datetime.now(timezone.utc).isoformat()
+    for result in manager_results:
+        manager = result.get("manager")
+        if isinstance(manager, str):
+            normalized_last_tests[manager] = timestamp
+    manifest["last_test_at"] = normalized_last_tests
+    _write_package_shim_manifest(context, manifest)
 
 
 def _command_program_name() -> str:
@@ -883,6 +949,8 @@ def probe_package_shim_intercepts(
             },
         )
     intercept_proved = any(bool(result.get("evaluator_invoked")) for result in manager_results)
+    if manager_results:
+        _record_package_shim_test_results(context, manager_results)
     return {
         "blocked_execution": bool(tested_managers) and all(manager in protected for manager in tested_managers),
         "intercept_proved": intercept_proved,

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -768,9 +768,11 @@ def _package_shim_manifest_path(context: HarnessContext) -> Path:
 
 def _filtered_manager_path(context: HarnessContext) -> str:
     shim_dir = context.guard_home / "package-shims" / "bin"
-    shim_dir_resolved = shim_dir.expanduser().resolve()
+    shim_dir_abs = os.path.abspath(os.path.expanduser(str(shim_dir)))
     path_entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
-    filtered_entries = [entry for entry in path_entries if Path(entry).expanduser().resolve() != shim_dir_resolved]
+    filtered_entries = [
+        entry for entry in path_entries if os.path.abspath(os.path.expanduser(entry)) != shim_dir_abs
+    ]
     return os.pathsep.join(filtered_entries)
 
 
@@ -778,11 +780,13 @@ def _detect_system_package_managers(context: HarnessContext) -> tuple[list[str],
     """Return supported managers with and without a real binary on PATH."""
 
     filtered_path = _filtered_manager_path(context)
+    if filtered_path == "":
+        return [], list(package_shim_supported_managers())
     detected: list[str] = []
     undetected: list[str] = []
     for manager in package_shim_supported_managers():
         command = _PACKAGE_SHIM_COMMANDS[manager]
-        resolved = shutil.which(command, path=filtered_path or None)
+        resolved = shutil.which(command, path=filtered_path)
         if resolved is not None:
             detected.append(manager)
         else:

--- a/tests/test_guard_phase05_manager_coverage.py
+++ b/tests/test_guard_phase05_manager_coverage.py
@@ -1,0 +1,129 @@
+"""Phase 05 package-manager shim lifecycle and detection proofs."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon.server import _build_snapshot_payload
+from codex_plugin_scanner.guard.shims import (
+    install_package_shims,
+    package_shim_status,
+    package_shim_supported_managers,
+    probe_package_shim_intercepts,
+    uninstall_package_shims,
+)
+from tests.shim_execution_helpers import write_fake_manager_script
+
+PHASE05_MANAGERS = package_shim_supported_managers()
+
+
+def _harness_context(tmp_path: Path) -> MagicMock:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    context = MagicMock()
+    context.home_dir = home_dir
+    context.workspace_dir = workspace_dir
+    context.guard_home = guard_home
+    return context
+
+
+@pytest.mark.parametrize("manager", PHASE05_MANAGERS)
+def test_package_shim_lifecycle_install_status_remove(manager: str, tmp_path: Path) -> None:
+    context = _harness_context(tmp_path)
+    install_payload = install_package_shims(context, managers=(manager,))
+    assert manager in install_payload["installed_managers"]
+
+    status = package_shim_status(context)
+    assert manager in status["installed_managers"]
+    assert manager in status["active_managers"]
+    detail = next(item for item in status["manager_details"] if item["manager"] == manager)
+    assert detail["integrity"] == "ok"
+    assert detail["shim_path"]
+
+    remove_payload = uninstall_package_shims(context, managers=(manager,))
+    assert manager in remove_payload["removed_managers"]
+    assert manager not in package_shim_status(context)["installed_managers"]
+
+
+@pytest.mark.parametrize("manager", ["npm", "pip", "npx", "pnpm", "uv"])
+def test_package_shim_probe_records_last_test_timestamp(
+    manager: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _harness_context(tmp_path)
+    install_package_shims(context, managers=(manager,))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    command = manager
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    write_fake_manager_script(
+        fake_bin=fake_bin,
+        manager=command,
+        marker_path=tmp_path / f"{manager}-probe-marker.json",
+        exit_code=0,
+    )
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shim_dir), str(fake_bin)]))
+
+    result = probe_package_shim_intercepts(context, managers=(manager,), workspace_dir=context.workspace_dir)
+    status = package_shim_status(context)
+    detail = next(item for item in status["manager_details"] if item["manager"] == manager)
+
+    assert result["intercept_proved"] is True
+    assert isinstance(detail["last_test_at"], str)
+    assert detail["last_test_at"] == status["last_test_at"][manager]
+
+
+def test_package_shim_status_marks_undetected_managers_honestly(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _harness_context(tmp_path)
+    install_package_shims(context, managers=("npm", "pip"))
+
+    def fake_which(command: str, path: str | None = None) -> str | None:
+        if command in {"npm", "pip"}:
+            return f"/usr/local/bin/{command}"
+        return None
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.shims.shutil.which", fake_which)
+
+    status = package_shim_status(context)
+
+    assert status["detected_managers"] == ["npm", "pip"]
+    assert "cargo" in status["undetected_managers"]
+    npm_detail = next(item for item in status["manager_details"] if item["manager"] == "npm")
+    pip_detail = next(item for item in status["manager_details"] if item["manager"] == "pip")
+    assert npm_detail["system_binary_detected"] is True
+    assert pip_detail["system_binary_detected"] is True
+
+
+def test_daemon_snapshot_includes_detected_manager_subset(tmp_path: Path) -> None:
+    context = _harness_context(tmp_path)
+    install_package_shims(context, managers=("npm",))
+    snapshot = _build_snapshot_payload(context)
+
+    coverage = snapshot["package_manager_coverage"]
+    assert "detected_managers" in coverage
+    assert "undetected_managers" in coverage
+    assert isinstance(coverage["detected_managers"], list)
+    assert isinstance(coverage["undetected_managers"], list)
+
+
+def test_npx_shim_installs_alongside_npm(tmp_path: Path) -> None:
+    context = _harness_context(tmp_path)
+    install_package_shims(context, managers=("npm", "npx"))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    assert (shim_dir / "npm").exists()
+    assert (shim_dir / "npx").exists()
+    manifest = json.loads((context.guard_home / "package-shims" / "manifest.json").read_text(encoding="utf-8"))
+    assert "npx" in manifest["installed_managers"]


### PR DESCRIPTION
## Summary
- Add `npx` and `pip3` package shims and expose `detected_managers` / `undetected_managers` in shim status
- Persist per-manager `last_test_at` timestamps when intercept probes run
- Add Phase 05 parametrized lifecycle, probe, detection, and daemon snapshot coverage tests

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_phase05_manager_coverage.py tests/test_guard_shim_truth.py -q`
