### PR TITLE
fix(guard): harden dashboard sync and honor cached install blocks

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
+++ b/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
@@ -41,8 +41,7 @@ def sync_dashboard_assets() -> dict[str, object] | None:
             "source_checkout": str(source_checkout),
             "dashboard_dir_found": False,
             "notes": [
-                "Source checkout found but no built dashboard assets. "
-                "Run `npm run build` in the dashboard directory.",
+                "Source checkout found but no built dashboard assets. Run `npm run build` in the dashboard directory.",
             ],
         }
 

--- a/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
+++ b/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
@@ -169,15 +169,12 @@ def _origin_urls_from_git_config(config_text: str) -> list[str]:
     in_origin = False
     for line in config_text.splitlines():
         stripped = line.strip()
-        section_match = re.fullmatch(r'\[remote "(.+)"\]', stripped)
-        if section_match is not None:
-            in_origin = section_match.group(1) == "origin"
+        if stripped.startswith("[") and stripped.endswith("]"):
+            section_match = re.fullmatch(r'\[remote "(.+)"\]', stripped)
+            in_origin = section_match is not None and section_match.group(1) == "origin"
             continue
         if in_origin and stripped.startswith("url ="):
             urls.append(stripped.split("=", 1)[1].strip())
-            continue
-        if stripped.startswith("["):
-            in_origin = False
     return urls
 
 

--- a/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
+++ b/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
@@ -175,6 +175,9 @@ def _origin_urls_from_git_config(config_text: str) -> list[str]:
             continue
         if in_origin and stripped.startswith("url ="):
             urls.append(stripped.split("=", 1)[1].strip())
+            continue
+        if stripped.startswith("["):
+            in_origin = False
     return urls
 
 
@@ -211,7 +214,11 @@ def _git_head_exists(checkout: Path) -> bool:
     return result is not None and result.returncode == 0
 
 
-def _git_run(checkout: Path, *args: str) -> subprocess.CompletedProcess[str] | None:
+def _git_run(
+    checkout: Path,
+    *args: str,
+    text: bool = True,
+) -> subprocess.CompletedProcess[str] | subprocess.CompletedProcess[bytes] | None:
     try:
         return _RUN_PROCESS(
             [
@@ -224,7 +231,7 @@ def _git_run(checkout: Path, *args: str) -> subprocess.CompletedProcess[str] | N
             ],
             capture_output=True,
             check=False,
-            text=True,
+            text=text,
             timeout=_GIT_TIMEOUT_SECONDS,
         )
     except (OSError, subprocess.TimeoutExpired):
@@ -246,10 +253,13 @@ def _list_committed_static_files(checkout: Path, static_prefix: str) -> list[str
 
 
 def _read_committed_file(checkout: Path, relative_path: str) -> bytes | None:
-    result = _git_run(checkout, "show", f"HEAD:{relative_path}")
+    result = _git_run(checkout, "show", f"HEAD:{relative_path}", text=False)
     if result is None or result.returncode != 0:
         return None
-    return result.stdout.encode("utf-8")
+    stdout = result.stdout
+    if not isinstance(stdout, bytes):
+        return None
+    return stdout
 
 
 def _relative_static_path(relative_path: str, static_prefix: str) -> Path | None:

--- a/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
+++ b/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import importlib.util
 import re
-import shutil
 import subprocess
 from pathlib import Path
 from urllib.parse import urlparse
@@ -48,7 +47,6 @@ def sync_dashboard_assets() -> dict[str, object] | None:
         }
 
     static_prefix = source_static.relative_to(source_checkout).as_posix()
-    source_index = source_static / "index.html"
     installed_index = installed_static / "index.html"
     needs_copy = True
     try:

--- a/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
+++ b/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
@@ -1,21 +1,23 @@
+"""Dashboard asset sync helpers with trusted-source verification."""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import shutil
+import subprocess
 from pathlib import Path
+from urllib.parse import urlparse
 
 from ..redaction import redact_sensitive_text
 
+_TRUSTED_REPO_SLUG = "hashgraph-online/hol-guard"
+_GIT_HOOKS_DISABLED = ("/dev/null",)
+_GIT_TIMEOUT_SECONDS = 10.0
+
 
 def sync_dashboard_assets() -> dict[str, object] | None:
-    """Copy pre-built dashboard assets from a local source checkout to the installed package.
-
-    When HOL Guard is installed from PyPI/uv/pipx, the wheel may not include the latest
-    dashboard Vite build. This function detects a local source checkout and copies the
-    already-built assets into the installed package's static directory so the running
-    daemon serves fresh UI. No build step is performed; run ``npm run build`` in the
-    dashboard directory first if assets are stale.
-    """
-    import importlib.util
-    import shutil
-
-    # Find the installed package's static directory
+    """Copy committed dashboard assets from a verified hol-guard checkout."""
     spec = importlib.util.find_spec("codex_plugin_scanner.guard.daemon.server")
     if spec is None or spec.origin is None:
         return None
@@ -26,7 +28,6 @@ def sync_dashboard_assets() -> dict[str, object] | None:
     except OSError:
         return None
 
-    # Find a local source checkout by walking up from cwd looking for hol-guard/dashboard
     try:
         source_checkout = find_source_checkout()
     except OSError:
@@ -34,40 +35,27 @@ def sync_dashboard_assets() -> dict[str, object] | None:
     if source_checkout is None:
         return {"source_checkout_found": False, "installed_static": str(installed_static)}
 
-    try:
-        dashboard_dir = source_checkout / "dashboard"
-        source_static = dashboard_dir / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "static"
-        # Fallback: if the repo builds into src/codex_plugin_scanner/guard/daemon/static
-        if not source_static.is_dir():
-            source_static = source_checkout / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "static"
-        if not source_static.is_dir():
-            return {
-                "source_checkout_found": True,
-                "source_checkout": str(source_checkout),
-                "dashboard_dir_found": False,
-                "notes": [
-                    "Source checkout found but no built dashboard assets. "
-                    "Run `npm run build` in the dashboard directory.",
-                ],
-            }
-    except OSError as error:
+    source_static = _resolve_source_static(source_checkout)
+    if source_static is None:
         return {
             "source_checkout_found": True,
             "source_checkout": str(source_checkout),
-            "copied": False,
-            "error": redact_sensitive_text(str(error)),
-            "notes": ["Dashboard asset sync failed due to file system error."],
+            "dashboard_dir_found": False,
+            "notes": [
+                "Source checkout found but no built dashboard assets. "
+                "Run `npm run build` in the dashboard directory.",
+            ],
         }
 
-    # Compare source vs installed to decide if copy is needed
+    static_prefix = source_static.relative_to(source_checkout).as_posix()
     source_index = source_static / "index.html"
     installed_index = installed_static / "index.html"
     needs_copy = True
     try:
-        if installed_index.is_file() and source_index.is_file():
-            installed_mtime = installed_index.stat().st_mtime
-            source_mtime = source_index.stat().st_mtime
-            needs_copy = source_mtime > installed_mtime
+        if installed_index.is_file():
+            committed_index = _read_committed_file(source_checkout, f"{static_prefix}/index.html")
+            if committed_index is not None:
+                needs_copy = committed_index != installed_index.read_bytes()
     except OSError:
         needs_copy = True
 
@@ -79,17 +67,12 @@ def sync_dashboard_assets() -> dict[str, object] | None:
             "reason": "installed assets are already up to date",
         }
 
-    # Copy all files from source static to installed static
-    copied_count = 0
     try:
-        for src_file in source_static.rglob("*"):
-            if not src_file.is_file():
-                continue
-            relative = src_file.relative_to(source_static)
-            dest = installed_static / relative
-            dest.parent.mkdir(parents=True, exist_ok=True)
-            shutil.copy2(src_file, dest)
-            copied_count += 1
+        copied_count = _export_committed_static_files(
+            source_checkout=source_checkout,
+            static_prefix=static_prefix,
+            installed_static=installed_static,
+        )
     except OSError as error:
         return {
             "source_checkout_found": True,
@@ -98,6 +81,16 @@ def sync_dashboard_assets() -> dict[str, object] | None:
             "error": redact_sensitive_text(str(error)),
             "notes": ["Dashboard asset sync failed. The daemon may serve stale UI."],
         }
+    if copied_count == 0:
+        return {
+            "source_checkout_found": True,
+            "source_checkout": str(source_checkout),
+            "dashboard_dir_found": False,
+            "notes": [
+                "Trusted checkout found but no committed dashboard assets at HEAD. "
+                "Commit a dashboard build before syncing.",
+            ],
+        }
 
     return {
         "source_checkout_found": True,
@@ -105,18 +98,12 @@ def sync_dashboard_assets() -> dict[str, object] | None:
         "installed_static": str(installed_static),
         "copied": True,
         "copied_files": copied_count,
-        "notes": [f"Synced {copied_count} dashboard asset files to the installed package."],
+        "notes": [f"Synced {copied_count} committed dashboard asset files to the installed package."],
     }
 
 
 def find_source_checkout() -> Path | None:
-    """Return a local hol-guard source checkout if one is detected nearby.
-
-    Security: Only returns a directory after VCS verification proves it is the
-    real hashgraph-online/hol-guard repository. Trivial directory markers like
-    dashboard/package.json and src/codex_plugin_scanner are NOT sufficient on
-    their own because any untrusted project can create them.
-    """
+    """Return a verified local hol-guard checkout near the current working directory."""
     try:
         cwd = Path.cwd().resolve()
     except OSError:
@@ -126,7 +113,6 @@ def find_source_checkout() -> Path | None:
         checkout = verify_source_checkout(candidate)
         if checkout is not None:
             return checkout
-    # Check one level deeper for repo roots that may contain hol-guard as a sub-project
     for candidate in candidates:
         try:
             for sub in candidate.iterdir():
@@ -141,26 +127,14 @@ def find_source_checkout() -> Path | None:
     return None
 
 
-_TRUSTED_REPO_KEYWORDS = ("hashgraph-online/hol-guard",)
-
-
 def verify_source_checkout(path: Path) -> Path | None:
-    """Verify a candidate directory is the real hol-guard source checkout.
-
-    Returns *path* only when:
-    - It contains the expected source tree markers.
-    - It is a git repository whose remotes reference the trusted upstream.
-
-    Security: This function reads ``.git/config`` directly instead of executing
-    ``git`` in the candidate directory to avoid triggering repository-local Git
-    hooks or configuration that could lead to arbitrary code execution.
-    """
+    """Accept only the canonical hol-guard GitHub origin and source tree markers."""
     try:
         if not (path / "dashboard" / "package.json").is_file():
             return None
         if not (path / "src" / "codex_plugin_scanner").is_dir():
             return None
-        if not (path / ".git").is_dir():
+        if not (path / ".git").exists():
             return None
     except OSError:
         return None
@@ -173,7 +147,133 @@ def verify_source_checkout(path: Path) -> Path | None:
     except OSError:
         return None
 
-    if not any(kw in remote_text for kw in _TRUSTED_REPO_KEYWORDS):
+    origin_urls = _origin_urls_from_git_config(remote_text)
+    if not any(_is_trusted_hol_guard_origin(url) for url in origin_urls):
+        return None
+    if not _git_head_exists(path):
+        return None
+    return path
+
+
+def _resolve_source_static(checkout: Path) -> Path | None:
+    dashboard_dir = checkout / "dashboard"
+    source_static = dashboard_dir / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "static"
+    if source_static.is_dir():
+        return source_static
+    fallback = checkout / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "static"
+    if fallback.is_dir():
+        return fallback
+    return None
+
+
+def _origin_urls_from_git_config(config_text: str) -> list[str]:
+    urls: list[str] = []
+    in_origin = False
+    for line in config_text.splitlines():
+        stripped = line.strip()
+        section_match = re.fullmatch(r'\[remote "(.+)"\]', stripped)
+        if section_match is not None:
+            in_origin = section_match.group(1) == "origin"
+            continue
+        if in_origin and stripped.startswith("url ="):
+            urls.append(stripped.split("=", 1)[1].strip())
+    return urls
+
+
+def _normalize_github_repo_slug(url: str) -> str | None:
+    candidate = url.strip()
+    if candidate == "":
+        return None
+    if candidate.startswith("git@"):
+        host_and_path = candidate[4:]
+        if ":" not in host_and_path:
+            return None
+        host, repo_path = host_and_path.split(":", 1)
+        if host != "github.com":
+            return None
+        return repo_path.strip("/").removesuffix(".git")
+    parsed = urlparse(candidate)
+    if parsed.scheme not in {"http", "https", "ssh"}:
+        return None
+    host = parsed.hostname
+    if host is None:
+        return None
+    if host != "github.com":
+        return None
+    return parsed.path.strip("/").removesuffix(".git")
+
+
+def _is_trusted_hol_guard_origin(url: str) -> bool:
+    slug = _normalize_github_repo_slug(url)
+    return slug == _TRUSTED_REPO_SLUG
+
+
+def _git_head_exists(checkout: Path) -> bool:
+    result = _git_run(checkout, "rev-parse", "--verify", "HEAD")
+    return result is not None and result.returncode == 0
+
+
+def _git_run(checkout: Path, *args: str) -> subprocess.CompletedProcess[str] | None:
+    try:
+        return subprocess.run(
+            [
+                "git",
+                "-c",
+                f"core.hooksPath={_GIT_HOOKS_DISABLED[0]}",
+                "-C",
+                str(checkout),
+                *args,
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=_GIT_TIMEOUT_SECONDS,
+        )
+    except (OSError, subprocess.TimeoutExpired):
         return None
 
-    return path
+
+def _list_committed_static_files(checkout: Path, static_prefix: str) -> list[str]:
+    result = _git_run(checkout, "ls-tree", "-r", "--name-only", "HEAD", "--", static_prefix)
+    if result is None or result.returncode != 0:
+        return []
+    files: list[str] = []
+    for line in result.stdout.splitlines():
+        relative = line.strip()
+        if relative == "" or relative.endswith("/"):
+            continue
+        files.append(relative)
+    return files
+
+
+def _read_committed_file(checkout: Path, relative_path: str) -> bytes | None:
+    result = _git_run(checkout, "show", f"HEAD:{relative_path}")
+    if result is None or result.returncode != 0:
+        return None
+    return result.stdout.encode("utf-8")
+
+
+def _export_committed_static_files(
+    *,
+    source_checkout: Path,
+    static_prefix: str,
+    installed_static: Path,
+) -> int:
+    copied_count = 0
+    for relative_path in _list_committed_static_files(source_checkout, static_prefix):
+        payload = _read_committed_file(source_checkout, relative_path)
+        if payload is None:
+            continue
+        relative_to_static = Path(relative_path).relative_to(static_prefix)
+        dest = installed_static / relative_to_static
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(payload)
+        copied_count += 1
+    return copied_count
+
+
+__all__ = [
+    "find_source_checkout",
+    "sync_dashboard_assets",
+    "verify_source_checkout",
+]

--- a/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
+++ b/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
@@ -13,6 +13,7 @@ from ..redaction import redact_sensitive_text
 _TRUSTED_REPO_SLUG = "hashgraph-online/hol-guard"
 _GIT_HOOKS_DISABLED = ("/dev/null",)
 _GIT_TIMEOUT_SECONDS = 10.0
+_RUN_PROCESS = subprocess.run
 
 
 def sync_dashboard_assets() -> dict[str, object] | None:
@@ -70,7 +71,7 @@ def sync_dashboard_assets() -> dict[str, object] | None:
             static_prefix=static_prefix,
             installed_static=installed_static,
         )
-    except OSError as error:
+    except (OSError, ValueError) as error:
         return {
             "source_checkout_found": True,
             "source_checkout": str(source_checkout),
@@ -212,7 +213,7 @@ def _git_head_exists(checkout: Path) -> bool:
 
 def _git_run(checkout: Path, *args: str) -> subprocess.CompletedProcess[str] | None:
     try:
-        return subprocess.run(
+        return _RUN_PROCESS(
             [
                 "git",
                 "-c",
@@ -235,9 +236,10 @@ def _list_committed_static_files(checkout: Path, static_prefix: str) -> list[str
     if result is None or result.returncode != 0:
         return []
     files: list[str] = []
+    prefix = f"{static_prefix.rstrip('/')}/"
     for line in result.stdout.splitlines():
         relative = line.strip()
-        if relative == "" or relative.endswith("/"):
+        if relative == "" or relative.endswith("/") or not relative.startswith(prefix):
             continue
         files.append(relative)
     return files
@@ -248,6 +250,13 @@ def _read_committed_file(checkout: Path, relative_path: str) -> bytes | None:
     if result is None or result.returncode != 0:
         return None
     return result.stdout.encode("utf-8")
+
+
+def _relative_static_path(relative_path: str, static_prefix: str) -> Path | None:
+    normalized_prefix = static_prefix.rstrip("/")
+    if not relative_path.startswith(f"{normalized_prefix}/"):
+        return None
+    return Path(relative_path.removeprefix(f"{normalized_prefix}/"))
 
 
 def _export_committed_static_files(
@@ -261,7 +270,9 @@ def _export_committed_static_files(
         payload = _read_committed_file(source_checkout, relative_path)
         if payload is None:
             continue
-        relative_to_static = Path(relative_path).relative_to(static_prefix)
+        relative_to_static = _relative_static_path(relative_path, static_prefix)
+        if relative_to_static is None:
+            continue
         dest = installed_static / relative_to_static
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(payload)

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -24,7 +24,7 @@ from ..adapters.base import HarnessContext
 from ..adapters.codex import CodexHarnessAdapter, codex_native_hook_state
 from ..redaction import redact_sensitive_text
 from ..store import GuardStore
-from .dashboard_sync import sync_dashboard_assets
+from .dashboard_sync import sync_dashboard_assets as _sync_dashboard_assets
 from .install_commands import apply_managed_install
 
 _ALREADY_CURRENT_HINTS = (
@@ -159,7 +159,7 @@ def run_guard_update(
             payload["managed_install"] = repaired_installs[0]
     # Sync dashboard static assets after package update so the daemon serves fresh UI.
     if not dry_run and payload.get("status") in {"updated", "current"}:
-        dashboard_sync = sync_dashboard_assets()
+        dashboard_sync = _sync_dashboard_assets()
         if dashboard_sync:
             payload["dashboard_sync"] = dashboard_sync
             sync_notes = dashboard_sync.get("notes")

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -123,20 +123,28 @@ def build_protect_payload(
     if len(command) == 0:
         raise ValueError("Guard protect requires a command to wrap.")
     request = parse_protect_command(command)
+    advisories = store.list_cached_advisories(limit=None)
+    cached_verdict = evaluate_protect_request(request, advisories)
+    cached_gate = cached_verdict.blocking or cached_verdict.action == "review"
     package_payload = build_package_protect_payload(
         command=command,
         store=store,
         workspace_dir=workspace_dir,
-        dry_run=dry_run,
+        dry_run=dry_run or cached_gate,
         now=now,
         config=config,
         unsafe_raw_output=unsafe_raw_output,
         timeout_seconds=_protect_command_timeout_seconds(),
     )
     if package_payload is not None:
+        if cached_gate:
+            return _merge_cached_advisory_into_package_payload(
+                package_payload,
+                cached_verdict=cached_verdict,
+                requested_dry_run=dry_run,
+            )
         return package_payload
-    advisories = store.list_cached_advisories(limit=None)
-    verdict = evaluate_protect_request(request, advisories)
+    verdict = cached_verdict
     receipt = _build_install_receipt(request, verdict)
     payload: dict[str, object] = {
         "generated_at": now,
@@ -211,6 +219,66 @@ def build_protect_payload(
             now,
         )
     return (payload, int(execution.returncode))
+
+
+def _merge_cached_advisory_into_package_payload(
+    result: tuple[dict[str, object], int],
+    *,
+    cached_verdict: ProtectVerdict,
+    requested_dry_run: bool,
+) -> tuple[dict[str, object], int]:
+    """Apply locally cached advisory blocks/reviews to package protect results."""
+
+    payload, exit_code = result
+    verdict = payload.get("verdict")
+    if not isinstance(verdict, dict):
+        return result
+    package_action = verdict.get("action")
+    if not isinstance(package_action, str):
+        package_action = "allow"
+
+    merged_action = package_action
+    merged_reason = verdict.get("reason")
+    if not isinstance(merged_reason, str):
+        merged_reason = cached_verdict.reason
+    merged_advisories = list(verdict.get("matched_advisories") or [])
+    risk_signals = list(verdict.get("risk_signals") or [])
+
+    if cached_verdict.action == "block":
+        merged_action = "block"
+        merged_reason = cached_verdict.reason
+    elif cached_verdict.action == "review" and package_action in {"allow", "warn"}:
+        merged_action = "review"
+        merged_reason = cached_verdict.reason
+
+    if merged_action == package_action:
+        return result
+
+    for item in cached_verdict.matched_advisories:
+        if item not in merged_advisories:
+            merged_advisories.append(item)
+    for signal in cached_verdict.risk_signals:
+        if signal not in risk_signals:
+            risk_signals.append(signal)
+    blocking = merged_action in {"block", "review"}
+    updated_verdict = {
+        **verdict,
+        "action": merged_action,
+        "reason": merged_reason,
+        "risk_signals": risk_signals,
+        "matched_advisories": merged_advisories,
+        "blocking": blocking,
+    }
+    updated_payload: dict[str, object] = {
+        **payload,
+        "verdict": updated_verdict,
+        "matched_advisories": merged_advisories,
+        "executed": False,
+        "dry_run": requested_dry_run or blocking,
+    }
+    if blocking:
+        return (updated_payload, 2)
+    return (updated_payload, exit_code)
 
 
 def _protect_command_timeout_seconds() -> int:

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -288,6 +288,9 @@ def _merge_cached_advisory_into_package_payload(
         updated_receipt = {**receipt, "policy_decision": merged_action}
         updated_payload["receipt"] = updated_receipt
         if action_changed:
+            receipt_id = updated_receipt.get("receipt_id")
+            if isinstance(receipt_id, str) and receipt_id:
+                store.update_receipt_policy_decision(receipt_id, merged_action)
             request = payload.get("request")
             executor = request.get("executor") if isinstance(request, dict) else None
             install_kind = request.get("install_kind") if isinstance(request, dict) else None

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -125,7 +125,7 @@ def build_protect_payload(
     request = parse_protect_command(command)
     advisories = store.list_cached_advisories(limit=None)
     cached_verdict = evaluate_protect_request(request, advisories)
-    cached_gate = cached_verdict.blocking or cached_verdict.action == "review"
+    cached_gate = cached_verdict.blocking
     package_payload = build_package_protect_payload(
         command=command,
         store=store,
@@ -142,6 +142,8 @@ def build_protect_payload(
                 package_payload,
                 cached_verdict=cached_verdict,
                 requested_dry_run=dry_run,
+                store=store,
+                now=now,
             )
         return package_payload
     verdict = cached_verdict
@@ -226,6 +228,8 @@ def _merge_cached_advisory_into_package_payload(
     *,
     cached_verdict: ProtectVerdict,
     requested_dry_run: bool,
+    store: GuardStore,
+    now: str,
 ) -> tuple[dict[str, object], int]:
     """Apply locally cached advisory blocks/reviews to package protect results."""
 
@@ -251,15 +255,18 @@ def _merge_cached_advisory_into_package_payload(
         merged_action = "review"
         merged_reason = cached_verdict.reason
 
-    if merged_action == package_action:
-        return result
-
     for item in cached_verdict.matched_advisories:
         if item not in merged_advisories:
             merged_advisories.append(item)
     for signal in cached_verdict.risk_signals:
         if signal not in risk_signals:
             risk_signals.append(signal)
+
+    action_changed = merged_action != package_action
+    advisories_changed = merged_advisories != list(verdict.get("matched_advisories") or [])
+    if not action_changed and not advisories_changed:
+        return result
+
     blocking = merged_action in {"block", "review"}
     updated_verdict = {
         **verdict,
@@ -276,6 +283,27 @@ def _merge_cached_advisory_into_package_payload(
         "executed": False,
         "dry_run": requested_dry_run or blocking,
     }
+    receipt = payload.get("receipt")
+    if isinstance(receipt, dict):
+        updated_receipt = {**receipt, "policy_decision": merged_action}
+        updated_payload["receipt"] = updated_receipt
+        if action_changed:
+            request = payload.get("request")
+            executor = request.get("executor") if isinstance(request, dict) else None
+            install_kind = request.get("install_kind") if isinstance(request, dict) else None
+            store.add_event(
+                f"install_time_{merged_action}",
+                {
+                    "artifact_id": updated_receipt.get("artifact_id"),
+                    "artifact_name": updated_receipt.get("artifact_name"),
+                    "executor": executor,
+                    "install_kind": install_kind,
+                    "action": merged_action,
+                    "risk_signals": risk_signals,
+                    "cached_advisory_override": True,
+                },
+                now,
+            )
     if blocking:
         return (updated_payload, 2)
     return (updated_payload, exit_code)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2156,6 +2156,13 @@ class GuardStore:
                 ),
             )
 
+    def update_receipt_policy_decision(self, receipt_id: str, policy_decision: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "update runtime_receipts set policy_decision = ? where receipt_id = ?",
+                (policy_decision, receipt_id),
+            )
+
     @staticmethod
     def _receipt_base_query(where_clause: str = "") -> str:
         base = """

--- a/tests/test_dashboard_sync_security.py
+++ b/tests/test_dashboard_sync_security.py
@@ -1,0 +1,70 @@
+"""Security tests for dashboard asset sync source verification."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from codex_plugin_scanner.guard.cli.dashboard_sync import (
+    _is_trusted_hol_guard_origin,
+    _normalize_github_repo_slug,
+    verify_source_checkout,
+)
+
+
+def _init_fake_checkout(root: Path, *, remote_url: str) -> Path:
+    checkout = root / "hol-guard"
+    (checkout / "dashboard").mkdir(parents=True)
+    (checkout / "dashboard" / "package.json").write_text("{}", encoding="utf-8")
+    (checkout / "src" / "codex_plugin_scanner").mkdir(parents=True)
+    subprocess.run(["git", "init"], cwd=checkout, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", remote_url],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    static_dir = checkout / "src" / "codex_plugin_scanner" / "guard" / "daemon" / "static"
+    static_dir.mkdir(parents=True)
+    (static_dir / "index.html").write_text("<html>safe</html>", encoding="utf-8")
+    subprocess.run(["git", "add", "."], cwd=checkout, check=True, capture_output=True, text=True)
+    subprocess.run(
+        ["git", "-c", "user.email=guard@test", "-c", "user.name=Guard", "commit", "-m", "seed"],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return checkout
+
+
+def test_normalize_github_repo_slug_requires_exact_repo_path() -> None:
+    assert _normalize_github_repo_slug("https://github.com/hashgraph-online/hol-guard.git") == "hashgraph-online/hol-guard"
+    assert _normalize_github_repo_slug("git@github.com:hashgraph-online/hol-guard.git") == "hashgraph-online/hol-guard"
+    assert _normalize_github_repo_slug("https://evil.example/hashgraph-online/hol-guard.git") is None
+    assert _normalize_github_repo_slug("https://github.com/evil/hashgraph-online/hol-guard.git") == "evil/hashgraph-online/hol-guard"
+
+
+def test_is_trusted_hol_guard_origin_rejects_spoofed_hosts() -> None:
+    assert _is_trusted_hol_guard_origin("https://github.com/hashgraph-online/hol-guard.git") is True
+    assert _is_trusted_hol_guard_origin("https://evil.example/hashgraph-online/hol-guard.git") is False
+    assert _is_trusted_hol_guard_origin("https://github.com/evil/hashgraph-online/hol-guard.git") is False
+
+
+def test_verify_source_checkout_rejects_substring_spoof_remote(tmp_path: Path) -> None:
+    checkout = _init_fake_checkout(
+        tmp_path,
+        remote_url="https://evil.example/repos/hashgraph-online/hol-guard-backdoor.git",
+    )
+
+    assert verify_source_checkout(checkout) is None
+
+
+def test_verify_source_checkout_accepts_canonical_origin(tmp_path: Path) -> None:
+    checkout = _init_fake_checkout(
+        tmp_path,
+        remote_url="https://github.com/hashgraph-online/hol-guard.git",
+    )
+
+    assert verify_source_checkout(checkout) == checkout

--- a/tests/test_dashboard_sync_security.py
+++ b/tests/test_dashboard_sync_security.py
@@ -40,10 +40,14 @@ def _init_fake_checkout(root: Path, *, remote_url: str) -> Path:
 
 
 def test_normalize_github_repo_slug_requires_exact_repo_path() -> None:
-    assert _normalize_github_repo_slug("https://github.com/hashgraph-online/hol-guard.git") == "hashgraph-online/hol-guard"
-    assert _normalize_github_repo_slug("git@github.com:hashgraph-online/hol-guard.git") == "hashgraph-online/hol-guard"
-    assert _normalize_github_repo_slug("https://evil.example/hashgraph-online/hol-guard.git") is None
-    assert _normalize_github_repo_slug("https://github.com/evil/hashgraph-online/hol-guard.git") == "evil/hashgraph-online/hol-guard"
+    trusted_https = "https://github.com/hashgraph-online/hol-guard.git"
+    trusted_ssh = "git@github.com:hashgraph-online/hol-guard.git"
+    spoofed_host = "https://evil.example/hashgraph-online/hol-guard.git"
+    wrong_owner = "https://github.com/evil/hashgraph-online/hol-guard.git"
+    assert _normalize_github_repo_slug(trusted_https) == "hashgraph-online/hol-guard"
+    assert _normalize_github_repo_slug(trusted_ssh) == "hashgraph-online/hol-guard"
+    assert _normalize_github_repo_slug(spoofed_host) is None
+    assert _normalize_github_repo_slug(wrong_owner) == "evil/hashgraph-online/hol-guard"
 
 
 def test_is_trusted_hol_guard_origin_rejects_spoofed_hosts() -> None:

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -655,11 +655,12 @@ class TestGuardProtect:
         output = json.loads(capsys.readouterr().out)
 
         assert "supply_chain_evaluation" in output
-        assert not any(item.get("id") == "adv-block-tail" for item in output.get("matched_advisories", []))
+        assert any(item.get("id") == "adv-block-tail" for item in output.get("matched_advisories", []))
+        assert output["verdict"]["action"] == "block"
         assert output.get("dry_run") is True
-        assert rc in {0, 2}
+        assert rc == 2
 
-    def test_guard_protect_ignores_legacy_package_url_blocks_for_package_installs(self, tmp_path, capsys) -> None:
+    def test_guard_protect_honors_cached_package_url_blocks_for_package_installs(self, tmp_path, capsys) -> None:
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         workspace_dir.mkdir(parents=True)
@@ -697,11 +698,12 @@ class TestGuardProtect:
         output = json.loads(capsys.readouterr().out)
 
         assert "supply_chain_evaluation" in output
-        assert not any(item.get("id") == "adv-purl-block" for item in output.get("matched_advisories", []))
+        assert any(item.get("id") == "adv-purl-block" for item in output.get("matched_advisories", []))
+        assert output["verdict"]["action"] == "block"
         assert output.get("dry_run") is True
-        assert rc in {0, 2}
+        assert rc == 2
 
-    def test_guard_protect_ignores_legacy_scoped_package_url_blocks_for_package_installs(
+    def test_guard_protect_honors_cached_scoped_package_url_blocks_for_package_installs(
         self,
         tmp_path,
         capsys,
@@ -743,9 +745,54 @@ class TestGuardProtect:
         output = json.loads(capsys.readouterr().out)
 
         assert "supply_chain_evaluation" in output
-        assert not any(item.get("id") == "adv-purl-scoped-block" for item in output.get("matched_advisories", []))
+        assert any(item.get("id") == "adv-purl-scoped-block" for item in output.get("matched_advisories", []))
+        assert output["verdict"]["action"] == "block"
         assert output.get("dry_run") is True
-        assert rc in {0, 2}
+        assert rc == 2
+
+    def test_guard_protect_blocks_package_install_when_cached_advisory_overrides_bundle_allow(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        from codex_plugin_scanner.guard.protect import build_protect_payload
+
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir(parents=True)
+        store = GuardStore(home_dir)
+        _seed_bundle_cache_only(
+            home_dir=home_dir,
+            ecosystem="npm",
+            package_name="badpkg",
+            package_version="1.0.0",
+            action="allow",
+        )
+        store.cache_advisories(
+            [
+                {
+                    "id": "adv-cached-block",
+                    "ecosystem": "npm",
+                    "package": "badpkg",
+                    "severity": "high",
+                    "action": "block",
+                    "headline": "Locally cached malicious package block.",
+                }
+            ],
+            _now(),
+        )
+
+        payload, exit_code = build_protect_payload(
+            command=["npm", "install", "badpkg@1.0.0"],
+            store=store,
+            workspace_dir=workspace_dir,
+            dry_run=False,
+            now=_now(),
+        )
+
+        assert exit_code == 2
+        assert payload["executed"] is False
+        assert payload["verdict"]["action"] == "block"
+        assert any(item.get("id") == "adv-cached-block" for item in payload.get("matched_advisories", []))
 
     def test_guard_protect_matches_review_advisory_by_remote_endpoint_indicator(
         self,

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -792,7 +792,16 @@ class TestGuardProtect:
         assert exit_code == 2
         assert payload["executed"] is False
         assert payload["verdict"]["action"] == "block"
+        assert payload["receipt"]["policy_decision"] == "block"
         assert any(item.get("id") == "adv-cached-block" for item in payload.get("matched_advisories", []))
+        stored_receipt = store.list_receipts(limit=1)[0]
+        assert stored_receipt["policy_decision"] == "block"
+        events = store.list_events(limit=10)
+        assert any(
+            event.get("event_name") == "install_time_block"
+            and event.get("payload", {}).get("cached_advisory_override") is True
+            for event in events
+        )
 
     def test_guard_protect_matches_review_advisory_by_remote_endpoint_indicator(
         self,


### PR DESCRIPTION
## Summary
- Harden dashboard asset sync by requiring an exact `github.com/hashgraph-online/hol-guard` origin and exporting only committed static files at `HEAD`.
- Ensure package install protect honors locally cached block/review advisories before supply-chain evaluation can allow execution.
- Align receipt policy decisions and audit events when cached advisories override bundle allow verdicts.

## Testing
- `python3 -m pytest tests/test_dashboard_sync_security.py tests/test_guard_protect.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/dashboard_sync.py src/codex_plugin_scanner/guard/protect.py src/codex_plugin_scanner/guard/store.py`
- CI: ci 3.10–3.13, Semgrep, CodeQL, Gitleaks, cross-platform

## Notes
- Addresses Codex security findings for spoofable dashboard sync and cached advisory bypass on package installs.
