### PR TITLE
feat(guard): Phase 06 workspace audit daemon proofs

### DIFF
--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -45,6 +45,23 @@ export type AuditRemediationRequest = {
   label: string;
 };
 
+function isSupplyChainAuditEvidence(value: unknown): value is Record<string, unknown> & { operation: "audit" } {
+  return typeof value === "object" && value !== null && (value as Record<string, unknown>).operation === "audit";
+}
+
+function auditSeverityForDecision(decision: string, blockedCount: number): AuditSeverity {
+  if (decision === "block" || blockedCount > 0) {
+    return "high";
+  }
+  if (decision === "ask") {
+    return "medium";
+  }
+  if (decision === "warn") {
+    return "medium";
+  }
+  return "info";
+}
+
 export type AuditFilterState = {
   severityFilter: AuditSeverity | "all";
   harnessFilter: string;
@@ -111,6 +128,60 @@ export function deriveFrontendAuditResults(
       remediationAction: null,
       resolved: true,
       evidenceHref: `/evidence?${evidenceParams.toString()}`,
+    });
+  }
+
+  for (const receipt of receipts) {
+    if (receipt.harness !== "package-firewall") {
+      continue;
+    }
+    const evidence = receipt.scanner_evidence?.find(isSupplyChainAuditEvidence);
+    if (evidence === undefined) {
+      continue;
+    }
+    const decision =
+      typeof evidence.audit_decision === "string" ? evidence.audit_decision : "monitor";
+    const blockedCount =
+      typeof evidence.blocked_package_count === "number" ? evidence.blocked_package_count : 0;
+    const totalPackages =
+      typeof evidence.total_packages === "number" ? evidence.total_packages : blockedCount;
+    const manifestPaths = Array.isArray(evidence.manifest_paths)
+      ? evidence.manifest_paths.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    const lockfilePaths = Array.isArray(evidence.lockfile_paths)
+      ? evidence.lockfile_paths.filter((entry): entry is string => typeof entry === "string")
+      : [];
+    const inventorySummary = [
+      manifestPaths.length > 0 ? `${manifestPaths.length} manifest(s)` : null,
+      lockfilePaths.length > 0 ? `${lockfilePaths.length} lockfile(s)` : null,
+      `${totalPackages} package(s)`,
+    ]
+      .filter((entry): entry is string => entry !== null)
+      .join(", ");
+    results.push({
+      id: `workspace-audit-${receipt.receipt_id}`,
+      severity: auditSeverityForDecision(decision, blockedCount),
+      title:
+        decision === "block"
+          ? "Workspace audit found blocked packages"
+          : decision === "ask"
+            ? "Workspace audit needs review"
+            : "Workspace audit completed",
+      detail:
+        receipt.capabilities_summary ||
+        `Guard scanned ${inventorySummary} and returned a ${decision} decision.`,
+      harness: "package-firewall",
+      workspace: receipt.source_scope,
+      timestamp: receipt.timestamp,
+      remediation:
+        blockedCount > 0
+          ? "Review blocked packages in Evidence and update lockfiles before retrying installs."
+          : decision === "ask"
+            ? "Review flagged packages and repair lockfiles before continuing."
+            : "Re-run workspace audit after dependency changes.",
+      remediationAction: null,
+      resolved: decision === "monitor" && blockedCount === 0,
+      evidenceHref: `/evidence?harness=package-firewall&search=${encodeURIComponent(receipt.receipt_id)}`,
     });
   }
 

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -62,6 +62,26 @@ function auditSeverityForDecision(decision: string, blockedCount: number): Audit
   return "info";
 }
 
+function workspaceAuditTitle(decision: string): string {
+  if (decision === "block") {
+    return "Workspace audit found blocked packages";
+  }
+  if (decision === "ask") {
+    return "Workspace audit needs review";
+  }
+  return "Workspace audit completed";
+}
+
+function workspaceAuditRemediation(decision: string, blockedCount: number): string {
+  if (blockedCount > 0) {
+    return "Review blocked packages in Evidence and update lockfiles before retrying installs.";
+  }
+  if (decision === "ask") {
+    return "Review flagged packages and repair lockfiles before continuing.";
+  }
+  return "Re-run workspace audit after dependency changes.";
+}
+
 export type AuditFilterState = {
   severityFilter: AuditSeverity | "all";
   harnessFilter: string;
@@ -161,24 +181,14 @@ export function deriveFrontendAuditResults(
     results.push({
       id: `workspace-audit-${receipt.receipt_id}`,
       severity: auditSeverityForDecision(decision, blockedCount),
-      title:
-        decision === "block"
-          ? "Workspace audit found blocked packages"
-          : decision === "ask"
-            ? "Workspace audit needs review"
-            : "Workspace audit completed",
+      title: workspaceAuditTitle(decision),
       detail:
         receipt.capabilities_summary ||
         `Guard scanned ${inventorySummary} and returned a ${decision} decision.`,
       harness: "package-firewall",
       workspace: receipt.source_scope,
       timestamp: receipt.timestamp,
-      remediation:
-        blockedCount > 0
-          ? "Review blocked packages in Evidence and update lockfiles before retrying installs."
-          : decision === "ask"
-            ? "Review flagged packages and repair lockfiles before continuing."
-            : "Re-run workspace audit after dependency changes.",
+      remediation: workspaceAuditRemediation(decision, blockedCount),
       remediationAction: null,
       resolved: decision === "monitor" && blockedCount === 0,
       evidenceHref: `/evidence?harness=package-firewall&search=${encodeURIComponent(receipt.receipt_id)}`,

--- a/dashboard/src/scrg159-170.test.ts
+++ b/dashboard/src/scrg159-170.test.ts
@@ -253,6 +253,33 @@ const blockedItem = auditWithBlocked.find((r) => r.id === `blocked-${blockedRece
 assert(blockedItem !== undefined, "SCRG162-G: blocked receipt should appear in audit");
 assert(blockedItem!.severity === "medium", "SCRG162-H: blocked receipt should be medium");
 
+const workspaceAuditReceipt = {
+  ...makeReceipt("block", receiptNow),
+  harness: "package-firewall",
+  artifact_name: "Workspace supply-chain audit",
+  capabilities_summary: "Workspace audit completed with block decision across 3 packages.",
+  scanner_evidence: [
+    {
+      operation: "audit",
+      audit_decision: "block",
+      blocked_package_count: 1,
+      manifest_paths: ["package.json"],
+      lockfile_paths: ["package-lock.json"],
+      total_packages: 3,
+    },
+  ],
+};
+const auditWithWorkspaceScan = deriveFrontendAuditResults([workspaceAuditReceipt], baseSnapshot);
+const workspaceAuditItem = auditWithWorkspaceScan.find(
+  (result) => result.id === `workspace-audit-${workspaceAuditReceipt.receipt_id}`,
+);
+assert(workspaceAuditItem !== undefined, "SCRG162-I: workspace audit receipt should render in audit tab");
+assert(workspaceAuditItem!.severity === "high", "SCRG162-J: blocked workspace audit should be high severity");
+assert(
+  workspaceAuditItem!.detail.includes("Workspace audit completed"),
+  "SCRG162-K: workspace audit detail should summarize the receipt",
+);
+
 const policies = [makePolicy("claude"), makePolicy("claude"), makePolicy("cursor")];
 const grouped = groupPoliciesByHarness(policies);
 assert(grouped.get("claude")?.length === 2, "SCRG164-A: 2 claude policies");

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -24,7 +24,6 @@ from pathlib import Path
 from typing import Any, cast
 from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlunparse
 
-from ...path_support import resolve_path_within_allowed_roots
 from ...version import __version__
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
@@ -91,8 +90,10 @@ from ..desktop_notifications import (
 from ..insights_share import publish_insights_share
 from ..local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE, build_local_dashboard_session_token
 from ..local_supply_chain import (
+    audit_receipt_metadata,
     build_workspace_audit_payload,
     resolve_package_firewall_entitlement_with_refresh,
+    resolve_supply_chain_audit_workspace_dir,
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
 from ..package_firewall_entitlement import (
@@ -1950,6 +1951,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError as error:
             self._write_json({"error": str(error), "operation": operation}, status=400)
             return
+        receipt_overrides: dict[str, object] = {}
+        if operation == "audit":
+            receipt_overrides = audit_receipt_metadata(result)
         receipt = self._record_headless_receipt(
             harness="package-firewall",
             operation=operation,
@@ -1957,16 +1961,27 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             result=result,
             workspace_id=self._optional_string(payload.get("workspace_id"))
             or self.server.store.get_cloud_workspace_id(),  # type: ignore[attr-defined]
+            policy_decision=self._optional_string(receipt_overrides.get("policy_decision")),
+            capabilities_summary=self._optional_string(receipt_overrides.get("capabilities_summary")),
+            artifact_name=self._optional_string(receipt_overrides.get("artifact_name")),
+            scanner_evidence_extra=(
+                receipt_overrides.get("scanner_evidence")
+                if isinstance(receipt_overrides.get("scanner_evidence"), dict)
+                else None
+            ),
         )
-        self._write_json(
-            {
-                "entitlement": entitlement,
-                "operation": operation,
-                "receipt": receipt,
-                "result": result,
-                "status": "completed",
-            }
-        )
+        response_payload: dict[str, object] = {
+            "entitlement": entitlement,
+            "operation": operation,
+            "receipt": receipt,
+            "result": result,
+            "status": "completed",
+        }
+        if operation == "audit":
+            cloud_sync = _queue_headless_cloud_sync(store=self.server.store)  # type: ignore[attr-defined]
+            receipt["cloud_sync"] = cloud_sync
+            response_payload["cloud_sync"] = cloud_sync
+        self._write_json(response_payload)
 
     def _run_supply_chain_package_action(
         self,
@@ -2007,22 +2022,20 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         raise ValueError("unsupported_supply_chain_operation")
 
     @staticmethod
-    def _resolve_supply_chain_workspace_dir(value: object) -> Path | None:
-        if not isinstance(value, str):
-            return None
+    def _resolve_supply_chain_workspace_dir(payload: dict[str, object]) -> Path | None:
         allowed_roots = (
             Path.home().resolve(),
             Path.cwd().resolve(),
             Path(tempfile.gettempdir()).resolve(),
         )
-        return resolve_path_within_allowed_roots(
-            value,
-            allowed_roots,
-            require_exists=True,
+        return resolve_supply_chain_audit_workspace_dir(
+            workspace_dir_value=payload.get("workspace_dir"),
+            workspace_value=payload.get("workspace"),
+            allowed_roots=allowed_roots,
         )
 
     def _supply_chain_context(self, payload: dict[str, object]) -> HarnessContext:
-        workspace_dir = self._resolve_supply_chain_workspace_dir(payload.get("workspace_dir"))
+        workspace_dir = self._resolve_supply_chain_workspace_dir(payload)
         return HarnessContext(
             home_dir=Path.home().resolve(),
             workspace_dir=workspace_dir,
@@ -2259,6 +2272,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         result: dict[str, object],
         workspace_id: str | None,
         cloud_sync: dict[str, object] | None = None,
+        policy_decision: str | None = None,
+        capabilities_summary: str | None = None,
+        artifact_name: str | None = None,
+        scanner_evidence_extra: dict[str, object] | None = None,
     ) -> dict[str, object]:
         cursor_receipt_context = self._cursor_receipt_context(
             harness=harness,
@@ -2281,19 +2298,22 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         artifact_hash = stable_digest_hex(material.encode("utf-8"))
         changed_capabilities = [] if operation in {"status", "scan"} else [operation]
         artifact_id = f"headless:{harness}:{operation}"
-        artifact_name = f"Headless {operation}"
-        capabilities_summary = f"Guard local daemon completed headless {operation}."
+        resolved_artifact_name = artifact_name or f"Headless {operation}"
+        resolved_capabilities_summary = capabilities_summary or f"Guard local daemon completed headless {operation}."
         source_scope = "local-daemon"
+        resolved_policy_decision = policy_decision or "allow"
         scanner_evidence: dict[str, object] = {
             "operation": operation,
             "location_id": location_id,
             "workspace_id": workspace_id,
             "status": "completed",
         }
+        if scanner_evidence_extra is not None:
+            scanner_evidence.update(scanner_evidence_extra)
         if cursor_receipt_context is not None:
             artifact_id = str(cursor_receipt_context["action_scope"])
-            artifact_name = str(cursor_receipt_context["artifact_name"])
-            capabilities_summary = str(cursor_receipt_context["capabilities_summary"])
+            resolved_artifact_name = str(cursor_receipt_context["artifact_name"])
+            resolved_capabilities_summary = str(cursor_receipt_context["capabilities_summary"])
             source_scope = str(cursor_receipt_context["source_scope"])
             changed_capabilities = [str(cursor_receipt_context["changed_capability"])]
             scanner_evidence.update(cursor_receipt_context["scanner_evidence"])
@@ -2301,11 +2321,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             harness=harness,
             artifact_id=artifact_id,
             artifact_hash=artifact_hash,
-            policy_decision="allow",
-            capabilities_summary=capabilities_summary,
+            policy_decision=resolved_policy_decision,
+            capabilities_summary=resolved_capabilities_summary,
             changed_capabilities=changed_capabilities,
             provenance_summary="Guard Cloud local daemon API",
-            artifact_name=artifact_name,
+            artifact_name=resolved_artifact_name,
             source_scope=source_scope,
             scanner_evidence=(scanner_evidence,),
             approval_source="guard-cloud-headless",

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 import shlex
 import subprocess
 import threading
@@ -16,6 +17,8 @@ from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from uuid import uuid4
+
+from codex_plugin_scanner.path_support import resolve_path_within_allowed_roots, resolves_within_root
 
 from .adapters.base import HarnessContext
 from .config import GuardConfig, resolve_risk_action
@@ -145,6 +148,17 @@ _SEVERITY_RANK = {
 _PACKAGE_FIREWALL_REFRESH_MIN_INTERVAL_SECONDS = 300.0
 _PACKAGE_FIREWALL_REFRESH_STATE_FILE = "package-firewall-refresh.json"
 _PACKAGE_FIREWALL_REFRESH_LOCK = threading.Lock()
+_AUDIT_SENSITIVE_BASENAMES = frozenset(
+    {
+        ".env",
+        ".env.local",
+        ".env.development",
+        ".env.production",
+        ".env.test",
+        ".envrc",
+    }
+)
+_KNOWN_UNSUPPORTED_LOCKFILE_BASENAMES = frozenset({"bun.lockb"})
 
 
 def _package_firewall_refresh_state_path(guard_home: Path) -> Path:
@@ -327,6 +341,144 @@ def resolve_package_firewall_entitlement_with_refresh(store: GuardStore) -> dict
     return resolve_package_firewall_entitlement(store)
 
 
+def _is_audit_sensitive_basename(name: str) -> bool:
+    lowered = name.lower()
+    return lowered in _AUDIT_SENSITIVE_BASENAMES or lowered.startswith(".env.")
+
+
+def _read_workspace_audit_text(workspace_dir: Path, relative_path: str) -> str | None:
+    if _is_audit_sensitive_basename(Path(relative_path).name):
+        return None
+    disk_path = workspace_dir / relative_path
+    try:
+        return disk_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def _workspace_has_project_markers(workspace_dir: Path) -> bool:
+    try:
+        resolved = workspace_dir.resolve()
+    except OSError:
+        return False
+    return any((resolved / marker).exists() for marker in _MANIFEST_CANDIDATES)
+
+
+def resolve_supply_chain_audit_workspace_dir(
+    *,
+    workspace_dir_value: object,
+    workspace_value: object,
+    allowed_roots: tuple[Path, ...],
+) -> Path | None:
+    for candidate in (workspace_dir_value, workspace_value):
+        if isinstance(candidate, str):
+            resolved = resolve_path_within_allowed_roots(
+                candidate,
+                allowed_roots,
+                require_exists=True,
+            )
+            if resolved is not None:
+                return resolved
+    cursor_project = os.environ.get("CURSOR_PROJECT_DIR", "").strip()
+    if cursor_project:
+        resolved = resolve_path_within_allowed_roots(
+            cursor_project,
+            allowed_roots,
+            require_exists=True,
+        )
+        if resolved is not None and _workspace_has_project_markers(resolved):
+            return resolved
+    try:
+        cwd = Path.cwd().resolve()
+    except OSError:
+        return None
+    if not _workspace_has_project_markers(cwd):
+        return None
+    for root in allowed_roots:
+        if resolves_within_root(root, cwd, require_exists=True):
+            return cwd
+    return None
+
+
+def _audit_lockfile_warnings(
+    workspace_dir: Path,
+    lockfile_paths: tuple[str, ...],
+) -> tuple[dict[str, object], ...]:
+    warnings: list[dict[str, object]] = []
+    for lockfile_path in lockfile_paths:
+        lockfile_name = Path(lockfile_path).name
+        disk_path = workspace_dir / lockfile_path
+        if not disk_path.exists():
+            continue
+        if lockfile_name in _KNOWN_UNSUPPORTED_LOCKFILE_BASENAMES:
+            warnings.append(
+                {
+                    "code": "bun_lockfile_binary_fallback",
+                    "message": (
+                        "Guard detected bun.lockb but Bun stores it as a binary lockfile, so audit "
+                        "fell back to manifest-only monitoring."
+                    ),
+                    "path": lockfile_path,
+                }
+            )
+            continue
+        if lockfile_name not in _ECOSYSTEM_BY_LOCKFILE:
+            continue
+        lockfile_text = _read_workspace_audit_text(workspace_dir, lockfile_path)
+        if lockfile_text is None:
+            warnings.append(
+                {
+                    "code": "lockfile_unreadable",
+                    "message": f"Guard could not read {lockfile_name} for workspace audit.",
+                    "path": lockfile_path,
+                }
+            )
+            continue
+        dependency_map = parse_manifest_dependencies(path=lockfile_path, text=lockfile_text)
+        if not dependency_map:
+            warnings.append(
+                {
+                    "code": "lockfile_parse_warning",
+                    "message": f"Guard could not parse {lockfile_name} for workspace audit.",
+                    "path": lockfile_path,
+                }
+            )
+    return tuple(warnings)
+
+
+def audit_receipt_metadata(result: dict[str, object]) -> dict[str, object]:
+    evaluation = result.get("evaluation")
+    if not isinstance(evaluation, dict):
+        return {}
+    decision = str(evaluation.get("decision") or "monitor")
+    packages = evaluation.get("packages")
+    package_items = [item for item in packages if isinstance(item, dict)] if isinstance(packages, list) else []
+    blocked_packages = [item for item in package_items if str(item.get("decision") or "") == "block"]
+    policy_decision = "allow"
+    if decision == "block":
+        policy_decision = "block"
+    elif decision == "ask":
+        policy_decision = "ask"
+    inventory = result.get("inventory")
+    inventory_summary = inventory if isinstance(inventory, dict) else {}
+    return {
+        "policy_decision": policy_decision,
+        "capabilities_summary": (
+            f"Workspace audit completed with {decision} decision across "
+            f"{inventory_summary.get('total_packages', len(package_items))} packages."
+        ),
+        "artifact_name": "Workspace supply-chain audit",
+        "scanner_evidence": {
+            "operation": "audit",
+            "audit_decision": decision,
+            "blocked_package_count": len(blocked_packages),
+            "lockfile_paths": list(result.get("lockfile_paths") or ()),
+            "manifest_paths": list(result.get("manifest_paths") or ()),
+            "total_packages": inventory_summary.get("total_packages", len(package_items)),
+        },
+    }
+
+
 def build_workspace_scan_payload(
     *,
     store: GuardStore,
@@ -453,6 +605,9 @@ def build_workspace_audit_payload(
         "evaluation": evaluation,
         "supply_chain": posture,
     }
+    lockfile_warnings = _audit_lockfile_warnings(target_workspace_dir, lockfile_paths)
+    if lockfile_warnings:
+        payload["lockfile_warnings"] = list(lockfile_warnings)
     if diff_summary is not None:
         payload["diff"] = diff_summary
     if fallback_reason is not None:
@@ -950,10 +1105,8 @@ def _workspace_inventory_from_paths(
         ecosystem = _ECOSYSTEM_BY_MANIFEST.get(Path(manifest_path).name)
         if ecosystem is None:
             continue
-        disk_path = workspace_dir / manifest_path
-        try:
-            manifest_text = disk_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        manifest_text = _read_workspace_audit_text(workspace_dir, manifest_path)
+        if manifest_text is None:
             continue
         for package_name, version in parse_manifest_dependencies(path=manifest_path, text=manifest_text).items():
             namespace, name = _split_namespace_name(package_name)
@@ -972,10 +1125,8 @@ def _workspace_inventory_from_paths(
         ecosystem = _ECOSYSTEM_BY_LOCKFILE.get(Path(lockfile_path).name)
         if ecosystem is None:
             continue
-        disk_path = workspace_dir / lockfile_path
-        try:
-            lockfile_text = disk_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        lockfile_text = _read_workspace_audit_text(workspace_dir, lockfile_path)
+        if lockfile_text is None:
             continue
         for package_name, version in parse_manifest_dependencies(path=lockfile_path, text=lockfile_text).items():
             namespace, name = _split_namespace_name(package_name)
@@ -1365,17 +1516,18 @@ def _workspace_audit_lockfile_context(
     lockfile_path = workspace_dir / lockfile_paths[0]
     if not lockfile_path.exists():
         return None
-    try:
-        lockfile_text = lockfile_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    lockfile_text = _read_workspace_audit_text(workspace_dir, lockfile_paths[0])
+    if lockfile_text is None:
         return None
     manifest_hash = None
     if manifest_paths:
         manifest_path = workspace_dir / manifest_paths[0]
         try:
-            manifest_hash = stable_digest_hex(manifest_path.read_bytes())
+            manifest_bytes = manifest_path.read_bytes()
         except OSError:
-            manifest_hash = None
+            manifest_bytes = None
+        if manifest_bytes is not None and not _is_audit_sensitive_basename(manifest_path.name):
+            manifest_hash = stable_digest_hex(manifest_bytes)
     return {
         "dependencyCount": len(inventory),
         "fileName": lockfile_path.name,

--- a/tests/test_guard_phase06_workspace_audit.py
+++ b/tests/test_guard_phase06_workspace_audit.py
@@ -1,0 +1,529 @@
+"""Phase 06 workspace audit daemon and inventory proofs."""
+
+from __future__ import annotations
+
+import json
+import threading
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.config import load_guard_config
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon import server as daemon_server
+from codex_plugin_scanner.guard.local_supply_chain import (
+    build_workspace_audit_payload,
+    resolve_supply_chain_audit_workspace_dir,
+)
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_guard_headless_daemon_api import (
+    _dashboard_token_for,
+    _read_json_response,
+    _request,
+)
+from tests.test_guard_supply_chain_evaluator import (
+    WORKSPACE_ID,
+    _artifact_for_targets,
+    _bundle_response,
+    _force_cloud_fallback,
+    _package,
+)
+
+WORKSPACE_AUDIT_NOW = "2026-06-08T12:00:00.000Z"
+
+
+def _write_text(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _seed_premium_entitlement(store: GuardStore) -> None:
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "cloud-token",
+        WORKSPACE_AUDIT_NOW,
+        workspace_id=WORKSPACE_ID,
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "premium", "workspace_id": WORKSPACE_ID},
+        WORKSPACE_AUDIT_NOW,
+    )
+
+
+def _audit_payload_for_workspace(
+    tmp_path: Path,
+    *,
+    files: dict[str, str],
+    monkeypatch: pytest.MonkeyPatch | None = None,
+) -> dict[str, object]:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    for relative_path, text in files.items():
+        _write_text(workspace_dir / relative_path, text)
+    store = GuardStore(home_dir)
+    _seed_premium_entitlement(store)
+    if monkeypatch is not None:
+        monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+        store.cache_supply_chain_bundle(
+            WORKSPACE_ID,
+            _bundle_response(
+                packages=[
+                    _package(
+                        ecosystem="npm",
+                        name="minimist",
+                        version="1.2.8",
+                        default_action="block",
+                        recommended_fix_version="1.2.9",
+                    )
+                ]
+            ),
+            WORKSPACE_AUDIT_NOW,
+        )
+        _force_cloud_fallback(monkeypatch)
+    config = load_guard_config(store.guard_home)
+    payload, _exit_code = build_workspace_audit_payload(
+        command_name="audit",
+        config=config,
+        now=WORKSPACE_AUDIT_NOW,
+        sbom_paths=(),
+        store=store,
+        workspace_dir=workspace_dir,
+    )
+    return payload
+
+
+@pytest.mark.parametrize(
+    ("manifest_name", "manifest_text", "lockfile_name", "lockfile_text", "expected_package"),
+    [
+        (
+            "package.json",
+            '{"dependencies":{"minimist":"^1.2.0"}}',
+            "package-lock.json",
+            json.dumps(
+                {
+                    "packages": {
+                        "": {"dependencies": {"minimist": "^1.2.0"}},
+                        "node_modules/minimist": {"version": "1.2.8"},
+                    }
+                }
+            ),
+            "minimist",
+        ),
+        (
+            "package.json",
+            '{"dependencies":{"minimist":"^1.2.0"}}',
+            "pnpm-lock.yaml",
+            """
+lockfileVersion: '9.0'
+importers:
+  .:
+    dependencies:
+      minimist:
+        specifier: ^1.2.0
+        version: 1.2.8
+packages:
+  minimist@1.2.8:
+    resolution: {integrity: sha512-demo}
+""",
+            "minimist",
+        ),
+        (
+            "package.json",
+            '{"dependencies":{"minimist":"^1.2.0"}}',
+            "yarn.lock",
+            """
+__metadata:
+  version: 4
+  cacheKey: 8
+
+"minimist@^1.2.0":
+  version "1.2.8"
+""",
+            "minimist",
+        ),
+        (
+            "package.json",
+            '{"dependencies":{"minimist":"^1.2.0"}}',
+            "bun.lock",
+            """
+[[package]]
+name = "minimist"
+version = "1.2.8"
+resolved = "npm:minimist@1.2.8"
+dependencies = []
+""",
+            "minimist",
+        ),
+        (
+            "requirements.txt",
+            "requests==2.31.0\n",
+            None,
+            None,
+            "requests",
+        ),
+        (
+            "pyproject.toml",
+            '[project]\nname = "demo"\ndependencies = ["requests>=2.31.0"]\n',
+            None,
+            None,
+            "requests",
+        ),
+        (
+            "pyproject.toml",
+            '[tool.poetry.dependencies]\nrequests = "^2.31.0"\n',
+            "poetry.lock",
+            '[[package]]\nname = "requests"\nversion = "2.31.0"\n',
+            "requests",
+        ),
+        (
+            "pyproject.toml",
+            '[project]\nname = "demo"\ndependencies = ["requests>=2.31.0"]\n',
+            "uv.lock",
+            'version = 1\n[[package]]\nname = "requests"\nversion = "2.31.0"\n',
+            "requests",
+        ),
+        (
+            "Pipfile",
+            '[[source]]\nname = "pypi"\nurl = "https://pypi.org/simple"\n\n[packages]\nrequests = "*"\n',
+            "Pipfile.lock",
+            json.dumps(
+                {
+                    "_meta": {"hash": {"sha256": "demo"}},
+                    "default": {"requests": {"version": "==2.31.0"}},
+                }
+            ),
+            "requests",
+        ),
+        (
+            "go.mod",
+            "module example.com/demo\n\ngo 1.22\n\nrequire github.com/gin-gonic/gin v1.9.1\n",
+            "go.sum",
+            "github.com/gin-gonic/gin v1.9.1 h1:demo\n",
+            "github.com/gin-gonic/gin",
+        ),
+        (
+            "Cargo.toml",
+            '[package]\nname = "demo"\nversion = "0.1.0"\n\n[dependencies]\nserde = "1.0"\n',
+            "Cargo.lock",
+            'version = 3\n\n[[package]]\nname = "serde"\nversion = "1.0.210"\n',
+            "serde",
+        ),
+        (
+            "composer.json",
+            '{"require":{"laravel/framework":"^11.0"}}',
+            "composer.lock",
+            '{"packages":[{"name":"laravel/framework","version":"11.1.0"}]}',
+            "laravel/framework",
+        ),
+        (
+            "Gemfile",
+            'source "https://rubygems.org"\ngem "rspec"\n',
+            "Gemfile.lock",
+            "GEM\n  specs:\n    rspec (3.13.0)\n",
+            "rspec",
+        ),
+        (
+            "pom.xml",
+            "<project><dependencies><dependency><groupId>org.example</groupId><artifactId>demo</artifactId><version>1.2.3</version></dependency></dependencies></project>\n",
+            None,
+            None,
+            "org.example:demo",
+        ),
+        (
+            "build.gradle",
+            'dependencies { implementation("org.example:demo:1.2.3") }\n',
+            "gradle.lockfile",
+            "org.example:demo:1.2.3=compileClasspath\n",
+            "org.example:demo",
+        ),
+    ],
+)
+def test_workspace_audit_inventory_includes_supported_lockfiles(
+    tmp_path: Path,
+    manifest_name: str,
+    manifest_text: str,
+    lockfile_name: str | None,
+    lockfile_text: str | None,
+    expected_package: str,
+) -> None:
+    files = {manifest_name: manifest_text}
+    if lockfile_name is not None and lockfile_text is not None:
+        files[lockfile_name] = lockfile_text
+    payload = _audit_payload_for_workspace(tmp_path, files=files)
+    assert manifest_name in payload["manifest_paths"]
+    if lockfile_name is not None:
+        assert lockfile_name in payload["lockfile_paths"]
+    inventory = payload["inventory"]
+    assert isinstance(inventory, dict)
+    assert inventory["total_packages"] >= 1
+
+
+def test_workspace_audit_returns_evaluation_not_posture_only(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _audit_payload_for_workspace(
+        tmp_path,
+        files={
+            "package.json": '{"dependencies":{"minimist":"^1.2.0"}}',
+            "package-lock.json": json.dumps(
+                {
+                    "packages": {
+                        "": {"dependencies": {"minimist": "^1.2.0"}},
+                        "node_modules/minimist": {"version": "1.2.8"},
+                    }
+                }
+            ),
+        },
+        monkeypatch=monkeypatch,
+    )
+    evaluation = payload["evaluation"]
+    assert isinstance(evaluation, dict)
+    assert "decision" in evaluation
+    assert "packages" in evaluation
+    assert payload["inventory"]["total_packages"] >= 1
+
+
+def test_workspace_audit_inference_uses_current_directory_with_markers(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}')
+    monkeypatch.chdir(workspace_dir)
+    allowed_roots = (tmp_path.resolve(),)
+    resolved = resolve_supply_chain_audit_workspace_dir(
+        workspace_dir_value=None,
+        workspace_value=None,
+        allowed_roots=allowed_roots,
+    )
+    assert resolved == workspace_dir.resolve()
+
+
+def test_workspace_audit_inference_accepts_workspace_alias(
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}')
+    allowed_roots = (tmp_path.resolve(),)
+    resolved = resolve_supply_chain_audit_workspace_dir(
+        workspace_dir_value=None,
+        workspace_value=str(workspace_dir),
+        allowed_roots=allowed_roots,
+    )
+    assert resolved == workspace_dir.resolve()
+
+
+def test_workspace_audit_never_reads_env_files(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    read_paths: list[str] = []
+    original_read_text = Path.read_text
+
+    def tracked_read_text(self: Path, *args: object, **kwargs: object) -> str:
+        read_paths.append(str(self))
+        return original_read_text(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "read_text", tracked_read_text)
+    payload = _audit_payload_for_workspace(
+        tmp_path,
+        files={
+            "package.json": '{"dependencies":{"minimist":"^1.2.0"}}',
+            ".env": "SENTINEL_SHOULD_NOT_BE_READ=demo\n",
+        },
+    )
+    assert payload["manifest_paths"] == ["package.json"]
+    assert not any(path.endswith(".env") for path in read_paths)
+
+
+def test_workspace_audit_reports_bun_lockb_warning(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"dependencies":{"minimist":"^1.2.0"}}')
+    (workspace_dir / "bun.lockb").write_bytes(b"bunlock")
+    store = GuardStore(tmp_path / "guard-home")
+    config = load_guard_config(store.guard_home)
+    payload, _exit_code = build_workspace_audit_payload(
+        command_name="audit",
+        config=config,
+        now=WORKSPACE_AUDIT_NOW,
+        sbom_paths=(),
+        store=store,
+        workspace_dir=workspace_dir,
+    )
+    warnings = payload.get("lockfile_warnings")
+    assert isinstance(warnings, list)
+    assert any(item.get("code") == "bun_lockfile_binary_fallback" for item in warnings if isinstance(item, dict))
+
+
+def test_workspace_audit_inventory_marks_direct_and_transitive_packages(tmp_path: Path) -> None:
+    payload = _audit_payload_for_workspace(
+        tmp_path,
+        files={
+            "package.json": '{"dependencies":{"react":"^18.0.0"}}',
+            "package-lock.json": json.dumps(
+                {
+                    "packages": {
+                        "": {"dependencies": {"react": "^18.0.0"}},
+                        "node_modules/react": {"version": "18.0.0"},
+                        "node_modules/react/node_modules/minimist": {"version": "1.2.8"},
+                    }
+                }
+            ),
+        },
+    )
+    inventory = payload["inventory"]
+    assert isinstance(inventory, dict)
+    assert inventory["direct_package_count"] >= 1
+    assert inventory["transitive_package_count"] >= 1
+
+
+def test_workspace_audit_lockfile_evaluation_preserves_dependency_path_and_fix_version(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"dependencies":{"react":"^18.0.0"}}')
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "packages": {
+                    "": {"dependencies": {"react": "^18.0.0"}},
+                    "node_modules/react": {"version": "18.0.0"},
+                    "node_modules/react/node_modules/minimist": {"version": "1.2.8"},
+                }
+            }
+        ),
+    )
+    store = GuardStore(home_dir)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: WORKSPACE_ID)
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[
+                _package(
+                    ecosystem="npm",
+                    name="minimist",
+                    version="1.2.8",
+                    default_action="block",
+                    recommended_fix_version="1.2.9",
+                )
+            ]
+        ),
+        WORKSPACE_AUDIT_NOW,
+    )
+    _force_cloud_fallback(monkeypatch)
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("react@18.0.0", lockfile_paths=("package-lock.json",)),
+        store=store,
+        workspace_dir=workspace_dir,
+        now=WORKSPACE_AUDIT_NOW,
+    )
+    transitive = next(package for package in result.packages if package["name"] == "minimist")
+    assert transitive["direct"] is False
+    assert transitive["dependencyPath"] == "react/node_modules/minimist"
+    assert transitive["recommendedFixVersion"] == "1.2.9"
+
+
+def test_daemon_workspace_audit_persists_receipt_and_queues_cloud_sync(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}')
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "packages": {
+                    "": {"dependencies": {"minimist": "^1.2.0"}},
+                    "node_modules/minimist": {"version": "1.2.8"},
+                }
+            }
+        ),
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_premium_entitlement(store)
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=WORKSPACE_AUDIT_NOW,
+        request_id="connect-1",
+    )
+    sync_finished = threading.Event()
+
+    def fake_sync_local_guard_cloud_proof(current_store: GuardStore) -> dict[str, object]:
+        assert current_store is store
+        sync_finished.set()
+        return {"synced_at": WORKSPACE_AUDIT_NOW, "receipts_stored": 1}
+
+    monkeypatch.setattr(daemon_server, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof, raising=False)
+    monkeypatch.chdir(workspace_dir)
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/audit",
+                token=token,
+                payload={},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["operation"] == "audit"
+    assert payload["result"]["evaluation"]["decision"] in {"block", "ask", "monitor", "warn"}
+    assert payload["cloud_sync"] == {
+        "status": "queued",
+        "message": "Guard Cloud sync started.",
+    }
+    assert sync_finished.wait(timeout=2)
+    receipts = store.list_receipts(limit=5, harness="package-firewall")
+    assert receipts
+    assert receipts[0]["artifact_name"] == "Workspace supply-chain audit"
+    evidence = receipts[0]["scanner_evidence"]
+    assert isinstance(evidence, list)
+    assert evidence[0]["operation"] == "audit"
+
+
+def test_daemon_workspace_audit_requires_workspace_when_uninferable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    monkeypatch.chdir(empty_dir)
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_premium_entitlement(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/audit",
+                token=token,
+                payload={},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "workspace_dir_required"


### PR DESCRIPTION
## Summary
- Wire daemon `/v1/supply-chain/audit` to real workspace inventory/evaluation with cwd/workspace inference, `.env` read guard, and lockfile warnings (SCSR091–093, SCSR112).
- Persist enriched workspace-audit receipts and queue Guard Cloud sync after audit completes (SCSR113–114).
- Render workspace audit findings in the local dashboard audit tab (SCSR115).
- Add Phase 06 proof tests across supported lockfile/manifest fixtures (SCSR094–111).

## Testing
- `python3 -m pytest tests/test_guard_phase06_workspace_audit.py -q`
- `python3 -m pytest tests/test_guard_headless_daemon_api.py::test_supply_chain_audit_scans_workspace_manifests -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_phase06_workspace_audit.py`
