### PR TITLE
feat(guard): Phase 07 entitlement and daemon security proofs

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3531,9 +3531,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return False
         location_id = self._claim_string(claims, "location_id", "locationId")
         payload_location_id = (
-            self._optional_string(payload.get("location_id"))
-            or self._optional_string(payload.get("locationId"))
-            or ""
+            self._optional_string(payload.get("location_id")) or self._optional_string(payload.get("locationId")) or ""
         )
         if location_id and payload_location_id != location_id:
             return False

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -96,10 +96,12 @@ from ..local_supply_chain import (
     resolve_supply_chain_audit_workspace_dir,
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
+from ..package_firewall_action_rate_limit import PackageFirewallActionRateLimiter
 from ..package_firewall_entitlement import (
     package_firewall_action_states,
     package_firewall_available_actions,
     package_firewall_block_details,
+    package_firewall_operation_allowed,
 )
 from ..receipts.manager import build_receipt
 from ..runtime.runner import (
@@ -200,6 +202,9 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     active_stream_clients_lock: threading.Lock
     package_firewall_connect_state: dict[str, object] | None
     package_firewall_connect_state_lock: threading.Lock
+    package_firewall_action_rate_limiter: PackageFirewallActionRateLimiter
+    package_firewall_session_nonces: dict[str, float]
+    package_firewall_session_nonces_lock: threading.Lock
 
 
 _STATIC_DIR = Path(__file__).with_name("static")
@@ -1914,10 +1919,16 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json(response, status=status)
             return
         operation = "remove" if action == "uninstall" else action
+        if not self._enforce_package_firewall_rate_limit(operation, payload):
+            return
         entitlement = self._supply_chain_entitlement()
         context = self._supply_chain_context(payload)
         current_status = package_shim_status(context)
-        if operation not in {"repair", "remove"} and not bool(entitlement["allowed"]):
+        if not package_firewall_operation_allowed(
+            entitlement,
+            operation,
+            has_installed_managers=bool(current_status.get("installed_managers")),
+        ):
             status, error_code, message = package_firewall_block_details(entitlement)
             self._write_json(
                 {
@@ -1938,7 +1949,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": manager_error, "operation": operation}, status=400)
             return
         try:
-            if operation in {"install", "repair", "remove", "test"}:
+            if operation in {"install", "repair", "remove", "test", "sync"}:
                 require_high_risk(
                     self.server.store.guard_home,  # type: ignore[attr-defined]
                     purpose="supply_chain_firewall",
@@ -3443,6 +3454,54 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             path_parts,
         )
 
+    def _claim_string(self, claims: dict[str, object], *keys: str) -> str | None:
+        for key in keys:
+            value = self._optional_string(claims.get(key))
+            if value is not None:
+                return value
+        return None
+
+    def _enforce_package_firewall_rate_limit(
+        self,
+        operation: str,
+        payload: dict[str, object],
+    ) -> bool:
+        workspace_id = (
+            self._optional_string(payload.get("workspace_id"))
+            or self._optional_string(payload.get("workspaceId"))
+            or self.server.store.get_cloud_workspace_id()  # type: ignore[attr-defined]
+            or "local"
+        )
+        rate_key = f"{workspace_id}:{operation}"
+        allowed, retry_after = self.server.package_firewall_action_rate_limiter.allow(rate_key)  # type: ignore[attr-defined]
+        if allowed:
+            return True
+        self._write_json(
+            {
+                "error": "rate_limited",
+                "message": "Package firewall actions are temporarily rate limited.",
+                "operation": operation,
+                "retry_after_seconds": retry_after,
+            },
+            status=429,
+        )
+        return False
+
+    def _consume_dashboard_session_nonce(self, nonce: str) -> bool:
+        now = time.monotonic()
+        ttl_seconds = 600.0
+        with self.server.package_firewall_session_nonces_lock:  # type: ignore[attr-defined]
+            stale_before = now - ttl_seconds
+            stale_keys = [
+                key for key, seen_at in self.server.package_firewall_session_nonces.items() if seen_at <= stale_before
+            ]
+            for key in stale_keys:
+                del self.server.package_firewall_session_nonces[key]
+            if nonce in self.server.package_firewall_session_nonces:
+                return False
+            self.server.package_firewall_session_nonces[nonce] = now
+            return True
+
     def _supply_chain_dashboard_claims_authorize(
         self,
         claims: dict[str, object],
@@ -3457,12 +3516,37 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         )
         if supply_chain_action != action_path and supply_chain_action not in allowed_actions:
             return False
+        claim_nonce = self._claim_string(claims, "nonce")
+        if claim_nonce is not None and not self._consume_dashboard_session_nonce(claim_nonce):
+            return False
         if payload is None:
             return supply_chain_action in {"package_shims_status", "supply_chain_bundle"}
-        workspace_id = self._optional_string(claims.get("workspace_id")) or ""
-        payload_workspace_id = self._optional_string(payload.get("workspace_id")) or ""
+        workspace_id = self._claim_string(claims, "workspace_id", "workspaceId") or ""
+        payload_workspace_id = (
+            self._optional_string(payload.get("workspace_id"))
+            or self._optional_string(payload.get("workspaceId"))
+            or ""
+        )
         if workspace_id and payload_workspace_id != workspace_id:
             return False
+        location_id = self._claim_string(claims, "location_id", "locationId")
+        payload_location_id = (
+            self._optional_string(payload.get("location_id"))
+            or self._optional_string(payload.get("locationId"))
+            or ""
+        )
+        if location_id and payload_location_id != location_id:
+            return False
+        daemon_origin = self._claim_string(claims, "daemon_origin", "daemonOrigin")
+        if daemon_origin is not None:
+            request_origin = self._normalize_origin(self.headers.get("Origin"))
+            payload_origin = (
+                self._optional_string(payload.get("daemon_origin"))
+                or self._optional_string(payload.get("daemonOrigin"))
+                or request_origin
+            )
+            if payload_origin != daemon_origin:
+                return False
         managers_claim = claims.get("managers")
         if not isinstance(managers_claim, list):
             return True
@@ -4133,6 +4217,9 @@ class GuardDaemonServer:
         self._server.active_stream_clients_lock = threading.Lock()
         self._server.package_firewall_connect_state = None
         self._server.package_firewall_connect_state_lock = threading.Lock()
+        self._server.package_firewall_action_rate_limiter = PackageFirewallActionRateLimiter()
+        self._server.package_firewall_session_nonces = {}
+        self._server.package_firewall_session_nonces_lock = threading.Lock()
         self.port = int(self._server.server_address[1])
         self._bundle_refresh_backoff_seconds = bundle_refresh_backoff_seconds
         self._bundle_refresh_interval_seconds = bundle_refresh_interval_seconds

--- a/src/codex_plugin_scanner/guard/package_firewall_action_rate_limit.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_action_rate_limit.py
@@ -1,0 +1,31 @@
+"""In-memory rate limiting for local package-firewall daemon actions."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+class PackageFirewallActionRateLimiter:
+    def __init__(self, *, limit: int = 30, window_seconds: float = 60.0) -> None:
+        self._limit = max(1, limit)
+        self._window_seconds = max(1.0, window_seconds)
+        self._lock = threading.Lock()
+        self._events: dict[str, list[float]] = {}
+
+    def allow(self, key: str, *, now: float | None = None) -> tuple[bool, int]:
+        current = now if now is not None else time.monotonic()
+        cutoff = current - self._window_seconds
+        with self._lock:
+            bucket = [timestamp for timestamp in self._events.get(key, []) if timestamp > cutoff]
+            if len(bucket) >= self._limit:
+                self._events[key] = bucket
+                retry_after = max(1, int(self._window_seconds - (current - bucket[0])))
+                return False, retry_after
+            bucket.append(current)
+            self._events[key] = bucket
+            return True, 0
+
+    def reset(self) -> None:
+        with self._lock:
+            self._events.clear()

--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -290,7 +290,7 @@ def package_firewall_operation_allowed(
     if normalized_operation in {"status", "connect", "open-shell"}:
         return True
     reason = str(entitlement.get("reason") or "").strip().lower()
-    if reason in {"guard_cloud_connect_required", "guard_cloud_reconnect_required"}:
+    if reason == "guard_cloud_reconnect_required":
         return False
     if bool(entitlement.get("allowed")):
         return True

--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -280,6 +280,25 @@ def package_firewall_available_actions(
     return actions
 
 
+def package_firewall_operation_allowed(
+    entitlement: dict[str, object],
+    operation: str,
+    *,
+    has_installed_managers: bool,
+) -> bool:
+    normalized_operation = operation.strip().lower()
+    if normalized_operation in {"status", "connect", "open-shell"}:
+        return True
+    reason = str(entitlement.get("reason") or "").strip().lower()
+    if reason in {"guard_cloud_connect_required", "guard_cloud_reconnect_required"}:
+        return False
+    if bool(entitlement.get("allowed")):
+        return True
+    if normalized_operation in {"repair", "remove"}:
+        return has_installed_managers
+    return False
+
+
 def package_firewall_block_details(entitlement: dict[str, object]) -> tuple[int, str, str]:
     if entitlement.get("reason") == "guard_cloud_connect_required":
         return (

--- a/tests/test_guard_phase07_entitlement_daemon_security.py
+++ b/tests/test_guard_phase07_entitlement_daemon_security.py
@@ -1,0 +1,314 @@
+"""Phase 07 entitlement and local daemon security proofs (SCSR116-SCSR130)."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
+from codex_plugin_scanner.guard.package_firewall_action_rate_limit import PackageFirewallActionRateLimiter
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_guard_headless_daemon_api import (
+    _dashboard_token_for,
+    _dashboard_token_with_claims,
+    _read_json_response,
+    _request,
+)
+
+
+def _seed_free_entitlement(store: GuardStore) -> None:
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "free", "workspace_id": "workspace-1"},
+        "2026-06-09T12:00:00.000Z",
+    )
+
+
+def _seed_free_connect_state(store: GuardStore) -> None:
+    store.set_sync_payload(
+        "oauth_local_credentials",
+        {
+            "supply_chain_plan_id": "free",
+            "supply_chain_firewall": False,
+        },
+        "2026-06-09T12:00:00.000Z",
+    )
+
+def _seed_premium_entitlement(store: GuardStore) -> None:
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "premium", "workspace_id": "workspace-1"},
+        "2026-06-09T12:00:00.000Z",
+    )
+
+
+def test_phase07_non_status_package_shim_operations_require_paid_entitlement(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_free_entitlement(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        install_status, install_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/install",
+                token=token,
+                payload={"managers": ["npm"], "workspace_id": "workspace-1"},
+            ),
+        )
+        status_status, status_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims",
+                method="GET",
+                token=token,
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert install_status in {402, 403}
+    assert install_payload["entitlement"]["allowed"] is False
+    assert install_payload["error"] in {"paid_guard_cloud_required", "guard_cloud_connect_required"}
+    assert status_status == 200
+    assert status_payload["operation"] == "status"
+
+
+def test_phase07_revoked_entitlement_blocks_repair_and_remove(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem="private-key",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value"},
+        dpop_public_jwk_thumbprint="thumbprint-1",
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-09T12:00:00.000Z",
+    )
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-09T12:00:00.000Z",
+        request_id="connect-1",
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-06-09T12:00:10.000Z",
+        reason="Guard authorization expired. Run `hol-guard connect` again.",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.local_supply_chain.sync_local_guard_cloud_proof",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("cloud auth still expired")),
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.local_supply_chain.sync_supply_chain_bundle",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("bundle refresh blocked")),
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        repair_status, repair_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/repair",
+                token=token,
+                payload={"managers": ["npm"], "workspace_id": "workspace-1"},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert repair_status == 403
+    assert repair_payload["error"] == "guard_cloud_reconnect_required"
+
+
+def test_phase07_dashboard_session_binds_operation_workspace_location_and_origin(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_premium_entitlement(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        auth_token = load_guard_daemon_auth_token(store.guard_home)
+        assert auth_token is not None
+        token = _dashboard_token_with_claims(
+            auth_token,
+            {
+                "action_path": "package_shims_test",
+                "allowed_action_paths": ["package_shims_test"],
+                "daemon_origin": "https://hol.org",
+                "location_id": "location-1",
+                "managers": ["npm"],
+                "nonce": "test-nonce-1",
+                "workspace_id": "workspace-1",
+            },
+        )
+        allowed_status, _allowed_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/test",
+                dashboard_session_token=token,
+                origin="https://hol.org",
+                payload={
+                    "daemon_origin": "https://hol.org",
+                    "location_id": "location-1",
+                    "managers": ["npm"],
+                    "workspace_id": "workspace-1",
+                },
+            ),
+        )
+        wrong_origin_status, _wrong_origin_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/test",
+                dashboard_session_token=token,
+                origin="https://evil.example",
+                payload={
+                    "daemon_origin": "https://evil.example",
+                    "location_id": "location-1",
+                    "managers": ["npm"],
+                    "workspace_id": "workspace-1",
+                },
+            ),
+        )
+        replay_status, replay_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/test",
+                dashboard_session_token=token,
+                origin="https://hol.org",
+                payload={
+                    "daemon_origin": "https://hol.org",
+                    "location_id": "location-1",
+                    "managers": ["npm"],
+                    "workspace_id": "workspace-1",
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert allowed_status == 200
+    assert wrong_origin_status == 403
+    assert replay_status == 401
+    assert replay_payload["error"] == "unauthorized"
+
+
+def test_phase07_install_and_sync_require_approval_gate(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_premium_entitlement(store)
+    update_approval_gate_settings(
+        store.guard_home,
+        {
+            "enabled": True,
+            "new_password": "phase07-password",
+            "confirm_password": "phase07-password",
+        },
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        install_status, install_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/install",
+                token=token,
+                payload={"managers": ["npm"], "workspace_id": "workspace-1"},
+            ),
+        )
+        sync_status, sync_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/sync",
+                token=token,
+                payload={"workspace_id": "workspace-1"},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert install_status == 403
+    assert install_payload["error"] == "approval_gate_required"
+    assert sync_status == 403
+    assert sync_payload["error"] == "approval_gate_required"
+
+
+def test_phase07_auth_audit_events_do_not_leak_dashboard_tokens(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        leaked_token = "gld1.leaked-payload.leaked-signature"
+        request = _request(
+            daemon.port,
+            "/v1/supply-chain/package-shims/install",
+            authorization_token=leaked_token,
+            dashboard_session_token=leaked_token,
+            payload={"managers": ["npm"], "workspace_id": "workspace-1"},
+        )
+        with pytest.raises(urllib.error.HTTPError):
+            urllib.request.urlopen(request, timeout=5)
+    finally:
+        daemon.stop()
+
+    events = store.list_events(limit=5, event_name="daemon.auth.unauthorized")
+    serialized = json.dumps(events)
+    assert "leaked-payload" not in serialized
+    assert "leaked-signature" not in serialized
+    assert events[0]["payload"]["has_dashboard_session"] is True
+
+
+def test_phase07_package_firewall_rate_limiter_blocks_burst_actions() -> None:
+    limiter = PackageFirewallActionRateLimiter(limit=2, window_seconds=60.0)
+    assert limiter.allow("workspace-1:install", now=100.0) == (True, 0)
+    assert limiter.allow("workspace-1:install", now=101.0) == (True, 0)
+    allowed, retry_after = limiter.allow("workspace-1:install", now=102.0)
+    assert allowed is False
+    assert retry_after >= 1
+
+
+def test_phase07_daemon_rate_limits_package_firewall_actions(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_premium_entitlement(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon._server.package_firewall_action_rate_limiter = PackageFirewallActionRateLimiter(limit=1, window_seconds=60.0)  # type: ignore[attr-defined]
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        first_status, _first_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/test",
+                token=token,
+                payload={"managers": ["npm"], "workspace_id": "workspace-1"},
+            ),
+        )
+        second_status, second_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/test",
+                token=token,
+                payload={"managers": ["npm"], "workspace_id": "workspace-1"},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert first_status == 200
+    assert second_status == 429
+    assert second_payload["error"] == "rate_limited"


### PR DESCRIPTION
## Summary
- Harden package-firewall daemon entitlement checks for paid, free, and revoked/reconnect states (SCSR116-118)
- Bind scoped dashboard session claims to workspace, location, daemon origin, managers, and nonce replay (SCSR120-125)
- Require approval gates for sync mutations and add per-workspace action rate limiting (SCSR126-127, SCSR130)
- Add Phase 07 regression suite covering auth log redaction and daemon security proofs (SCSR128)

## Testing
- `python3 -m pytest tests/test_guard_phase07_entitlement_daemon_security.py -q --cache-clear`
- `python3 -m ruff check src/codex_plugin_scanner/guard/package_firewall_action_rate_limit.py src/codex_plugin_scanner/guard/package_firewall_entitlement.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_phase07_entitlement_daemon_security.py`
