### PR TITLE
fix(hol-guard): reject git tree path traversal in dashboard sync

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
+++ b/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
@@ -235,6 +235,12 @@ def _git_run(
         return None
 
 
+def _is_safe_committed_tree_path(path: str) -> bool:
+    if path == "" or path.startswith(("/", "\\")) or "\\" in path or "\0" in path:
+        return False
+    return all(part not in {"", ".", ".."} for part in path.split("/"))
+
+
 def _list_committed_static_files(checkout: Path, static_prefix: str) -> list[str]:
     result = _git_run(checkout, "ls-tree", "-r", "--name-only", "HEAD", "--", static_prefix)
     if result is None or result.returncode != 0:
@@ -243,13 +249,20 @@ def _list_committed_static_files(checkout: Path, static_prefix: str) -> list[str
     prefix = f"{static_prefix.rstrip('/')}/"
     for line in result.stdout.splitlines():
         relative = line.strip()
-        if relative == "" or relative.endswith("/") or not relative.startswith(prefix):
+        if (
+            relative == ""
+            or relative.endswith("/")
+            or not relative.startswith(prefix)
+            or not _is_safe_committed_tree_path(relative)
+        ):
             continue
         files.append(relative)
     return files
 
 
 def _read_committed_file(checkout: Path, relative_path: str) -> bytes | None:
+    if not _is_safe_committed_tree_path(relative_path):
+        return None
     result = _git_run(checkout, "show", f"HEAD:{relative_path}", text=False)
     if result is None or result.returncode != 0:
         return None
@@ -263,7 +276,20 @@ def _relative_static_path(relative_path: str, static_prefix: str) -> Path | None
     normalized_prefix = static_prefix.rstrip("/")
     if not relative_path.startswith(f"{normalized_prefix}/"):
         return None
-    return Path(relative_path.removeprefix(f"{normalized_prefix}/"))
+    suffix = relative_path.removeprefix(f"{normalized_prefix}/")
+    if not _is_safe_committed_tree_path(suffix):
+        return None
+    return Path(suffix)
+
+
+def _resolve_static_export_path(installed_static: Path, relative_to_static: Path) -> Path | None:
+    base = installed_static.resolve()
+    destination = (base / relative_to_static).resolve()
+    try:
+        destination.relative_to(base)
+    except ValueError:
+        return None
+    return destination
 
 
 def _export_committed_static_files(
@@ -280,7 +306,9 @@ def _export_committed_static_files(
         relative_to_static = _relative_static_path(relative_path, static_prefix)
         if relative_to_static is None:
             continue
-        dest = installed_static / relative_to_static
+        dest = _resolve_static_export_path(installed_static, relative_to_static)
+        if dest is None:
+            continue
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(payload)
         copied_count += 1

--- a/tests/test_dashboard_sync_security.py
+++ b/tests/test_dashboard_sync_security.py
@@ -6,8 +6,11 @@ import subprocess
 from pathlib import Path
 
 from codex_plugin_scanner.guard.cli.dashboard_sync import (
+    _export_committed_static_files,
+    _is_safe_committed_tree_path,
     _is_trusted_hol_guard_origin,
     _normalize_github_repo_slug,
+    _relative_static_path,
     verify_source_checkout,
 )
 
@@ -72,3 +75,182 @@ def test_verify_source_checkout_accepts_canonical_origin(tmp_path: Path) -> None
     )
 
     assert verify_source_checkout(checkout) == checkout
+
+
+def test_is_safe_committed_tree_path_rejects_traversal_segments() -> None:
+    static_prefix = "src/codex_plugin_scanner/guard/daemon/static"
+    traversal_path = f"{static_prefix}/../../evil.py"
+
+    assert _is_safe_committed_tree_path(traversal_path) is False
+    assert _relative_static_path(traversal_path, static_prefix) is None
+
+
+def _hash_blob(checkout: Path, payload: bytes) -> str:
+    return (
+        subprocess.run(
+            ["git", "hash-object", "-w", "--stdin"],
+            cwd=checkout,
+            input=payload,
+            capture_output=True,
+            check=True,
+            text=False,
+        )
+        .stdout.decode("utf-8")
+        .strip()
+    )
+
+
+def _mktree(checkout: Path, entries: list[tuple[str, str, str, str]]) -> str:
+    lines = [f"{mode} {kind} {obj_hash}\t{name}" for mode, kind, obj_hash, name in entries]
+    result = subprocess.run(
+        ["git", "mktree"],
+        cwd=checkout,
+        input="\n".join(lines).encode("utf-8") + b"\n",
+        capture_output=True,
+        check=True,
+        text=False,
+    )
+    return result.stdout.decode("utf-8").strip()
+
+
+def _parse_ls_tree_line(line: str) -> tuple[str, str, str, str]:
+    mode, obj_type, obj_hash, name = line.split(maxsplit=3)
+    return mode, obj_type, obj_hash, name.removeprefix('"').removesuffix('"')
+
+
+def _replace_tree_at_path(
+    checkout: Path,
+    tree_hash: str,
+    parts: list[str],
+    replacement_hash: str,
+) -> str:
+    if not parts:
+        return replacement_hash
+
+    part = parts[0]
+    child_entries: list[tuple[str, str, str, str]] = []
+    child_hash = ""
+    for line in subprocess.run(
+        ["git", "ls-tree", tree_hash],
+        cwd=checkout,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.splitlines():
+        mode, obj_type, obj_hash, name = _parse_ls_tree_line(line)
+        if name == part:
+            child_hash = obj_hash
+        child_entries.append((mode, obj_type, obj_hash, name))
+
+    if child_hash == "":
+        raise RuntimeError(f"missing tree segment: {part}")
+
+    updated_child = (
+        replacement_hash
+        if len(parts) == 1
+        else _replace_tree_at_path(checkout, child_hash, parts[1:], replacement_hash)
+    )
+    return _mktree(
+        checkout,
+        [
+            (mode, obj_type, updated_child if name == part else obj_hash, name)
+            for mode, obj_type, obj_hash, name in child_entries
+        ],
+    )
+
+
+def _commit_tree_with_traversal_entry(
+    checkout: Path,
+    *,
+    static_prefix: str,
+    blob_text: str,
+) -> None:
+    safe_index_path = f"{static_prefix}/index.html"
+    safe_index_bytes = subprocess.run(
+        ["git", "show", f"HEAD:{safe_index_path}"],
+        cwd=checkout,
+        capture_output=True,
+        check=True,
+        text=False,
+    ).stdout
+    safe_blob_hash = _hash_blob(checkout, safe_index_bytes)
+    evil_blob_hash = _hash_blob(checkout, blob_text.encode("utf-8"))
+    parent_tree = _mktree(checkout, [("100644", "blob", evil_blob_hash, "evil.py")])
+    static_tree = _mktree(
+        checkout,
+        [
+            ("100644", "blob", safe_blob_hash, "index.html"),
+            ("040000", "tree", parent_tree, ".."),
+        ],
+    )
+    head_tree = subprocess.run(
+        ["git", "rev-parse", "HEAD^{tree}"],
+        cwd=checkout,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.strip()
+    root_tree = _replace_tree_at_path(
+        checkout,
+        head_tree,
+        static_prefix.split("/"),
+        static_tree,
+    )
+    parent_hash = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=checkout,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.strip()
+    commit_hash = subprocess.run(
+        ["git", "commit-tree", root_tree, "-p", parent_hash, "-m", "add traversal entry"],
+        cwd=checkout,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.strip()
+    branch = subprocess.run(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+        cwd=checkout,
+        capture_output=True,
+        check=True,
+        text=True,
+    ).stdout.strip()
+    subprocess.run(
+        ["git", "update-ref", f"refs/heads/{branch}", commit_hash],
+        cwd=checkout,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_export_committed_static_files_rejects_git_tree_traversal(
+    tmp_path: Path,
+) -> None:
+    checkout = _init_fake_checkout(
+        tmp_path,
+        remote_url="https://github.com/hashgraph-online/hol-guard.git",
+    )
+    static_prefix = "src/codex_plugin_scanner/guard/daemon/static"
+    _commit_tree_with_traversal_entry(
+        checkout,
+        static_prefix=static_prefix,
+        blob_text="malicious",
+    )
+
+    installed_static = tmp_path / "installed-static"
+    installed_static.mkdir(parents=True)
+    (installed_static / "index.html").write_text("<html>safe</html>", encoding="utf-8")
+
+    copied_count = _export_committed_static_files(
+        source_checkout=checkout,
+        static_prefix=static_prefix,
+        installed_static=installed_static,
+    )
+
+    assert copied_count == 1
+    assert (installed_static / "index.html").is_file()
+    assert not (tmp_path / "evil.py").exists()
+    assert not (installed_static.parent / "evil.py").exists()

--- a/tests/test_dashboard_sync_security.py
+++ b/tests/test_dashboard_sync_security.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import subprocess
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.cli.dashboard_sync import (
     _export_committed_static_files,
     _is_safe_committed_tree_path,
@@ -77,11 +79,26 @@ def test_verify_source_checkout_accepts_canonical_origin(tmp_path: Path) -> None
     assert verify_source_checkout(checkout) == checkout
 
 
-def test_is_safe_committed_tree_path_rejects_traversal_segments() -> None:
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "src/static/../../evil.py",
+        "src/static/./hidden.js",
+        "/etc/passwd",
+        "src\\static\\evil.py",
+        "src/static/\x00evil.py",
+        "",
+        "src/static//double-slash",
+    ],
+)
+def test_is_safe_committed_tree_path_rejects_unsafe_paths(bad_path: str) -> None:
+    assert _is_safe_committed_tree_path(bad_path) is False
+
+
+def test_relative_static_path_rejects_traversal_suffix() -> None:
     static_prefix = "src/codex_plugin_scanner/guard/daemon/static"
     traversal_path = f"{static_prefix}/../../evil.py"
 
-    assert _is_safe_committed_tree_path(traversal_path) is False
     assert _relative_static_path(traversal_path, static_prefix) is None
 
 
@@ -253,4 +270,4 @@ def test_export_committed_static_files_rejects_git_tree_traversal(
     assert copied_count == 1
     assert (installed_static / "index.html").is_file()
     assert not (tmp_path / "evil.py").exists()
-    assert not (installed_static.parent / "evil.py").exists()
+    assert not (installed_static / "evil.py").exists()

--- a/tests/test_dashboard_sync_security.py
+++ b/tests/test_dashboard_sync_security.py
@@ -11,6 +11,7 @@ from codex_plugin_scanner.guard.cli.dashboard_sync import (
     _export_committed_static_files,
     _is_safe_committed_tree_path,
     _is_trusted_hol_guard_origin,
+    _list_committed_static_files,
     _normalize_github_repo_slug,
     _relative_static_path,
     verify_source_checkout,
@@ -102,159 +103,50 @@ def test_relative_static_path_rejects_traversal_suffix() -> None:
     assert _relative_static_path(traversal_path, static_prefix) is None
 
 
-def _hash_blob(checkout: Path, payload: bytes) -> str:
-    return (
-        subprocess.run(
-            ["git", "hash-object", "-w", "--stdin"],
-            cwd=checkout,
-            input=payload,
-            capture_output=True,
-            check=True,
-            text=False,
-        )
-        .stdout.decode("utf-8")
-        .strip()
-    )
+class _FakeGitLsTreeResult:
+    returncode = 0
+
+    def __init__(self, stdout: str) -> None:
+        self.stdout = stdout
 
 
-def _mktree(checkout: Path, entries: list[tuple[str, str, str, str]]) -> str:
-    lines = [f"{mode} {kind} {obj_hash}\t{name}" for mode, kind, obj_hash, name in entries]
-    result = subprocess.run(
-        ["git", "mktree"],
-        cwd=checkout,
-        input="\n".join(lines).encode("utf-8") + b"\n",
-        capture_output=True,
-        check=True,
-        text=False,
-    )
-    return result.stdout.decode("utf-8").strip()
-
-
-def _parse_ls_tree_line(line: str) -> tuple[str, str, str, str]:
-    mode, obj_type, obj_hash, name = line.split(maxsplit=3)
-    return mode, obj_type, obj_hash, name.removeprefix('"').removesuffix('"')
-
-
-def _replace_tree_at_path(
-    checkout: Path,
-    tree_hash: str,
-    parts: list[str],
-    replacement_hash: str,
-) -> str:
-    if not parts:
-        return replacement_hash
-
-    part = parts[0]
-    child_entries: list[tuple[str, str, str, str]] = []
-    child_hash = ""
-    for line in subprocess.run(
-        ["git", "ls-tree", tree_hash],
-        cwd=checkout,
-        capture_output=True,
-        check=True,
-        text=True,
-    ).stdout.splitlines():
-        mode, obj_type, obj_hash, name = _parse_ls_tree_line(line)
-        if name == part:
-            child_hash = obj_hash
-        child_entries.append((mode, obj_type, obj_hash, name))
-
-    if child_hash == "":
-        raise RuntimeError(f"missing tree segment: {part}")
-
-    updated_child = (
-        replacement_hash
-        if len(parts) == 1
-        else _replace_tree_at_path(checkout, child_hash, parts[1:], replacement_hash)
-    )
-    return _mktree(
-        checkout,
-        [
-            (mode, obj_type, updated_child if name == part else obj_hash, name)
-            for mode, obj_type, obj_hash, name in child_entries
-        ],
-    )
-
-
-def _commit_tree_with_traversal_entry(
-    checkout: Path,
-    *,
-    static_prefix: str,
-    blob_text: str,
-) -> None:
-    safe_index_path = f"{static_prefix}/index.html"
-    safe_index_bytes = subprocess.run(
-        ["git", "show", f"HEAD:{safe_index_path}"],
-        cwd=checkout,
-        capture_output=True,
-        check=True,
-        text=False,
-    ).stdout
-    safe_blob_hash = _hash_blob(checkout, safe_index_bytes)
-    evil_blob_hash = _hash_blob(checkout, blob_text.encode("utf-8"))
-    parent_tree = _mktree(checkout, [("100644", "blob", evil_blob_hash, "evil.py")])
-    static_tree = _mktree(
-        checkout,
-        [
-            ("100644", "blob", safe_blob_hash, "index.html"),
-            ("040000", "tree", parent_tree, ".."),
-        ],
-    )
-    head_tree = subprocess.run(
-        ["git", "rev-parse", "HEAD^{tree}"],
-        cwd=checkout,
-        capture_output=True,
-        check=True,
-        text=True,
-    ).stdout.strip()
-    root_tree = _replace_tree_at_path(
-        checkout,
-        head_tree,
-        static_prefix.split("/"),
-        static_tree,
-    )
-    parent_hash = subprocess.run(
-        ["git", "rev-parse", "HEAD"],
-        cwd=checkout,
-        capture_output=True,
-        check=True,
-        text=True,
-    ).stdout.strip()
-    commit_hash = subprocess.run(
-        ["git", "commit-tree", root_tree, "-p", parent_hash, "-m", "add traversal entry"],
-        cwd=checkout,
-        capture_output=True,
-        check=True,
-        text=True,
-    ).stdout.strip()
-    branch = subprocess.run(
-        ["git", "rev-parse", "--abbrev-ref", "HEAD"],
-        cwd=checkout,
-        capture_output=True,
-        check=True,
-        text=True,
-    ).stdout.strip()
-    subprocess.run(
-        ["git", "update-ref", f"refs/heads/{branch}", commit_hash],
-        cwd=checkout,
-        check=True,
-        capture_output=True,
-        text=True,
-    )
-
-
-def test_export_committed_static_files_rejects_git_tree_traversal(
+def test_list_committed_static_files_skips_unsafe_ls_tree_paths(
     tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    checkout = _init_fake_checkout(
-        tmp_path,
-        remote_url="https://github.com/hashgraph-online/hol-guard.git",
-    )
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
     static_prefix = "src/codex_plugin_scanner/guard/daemon/static"
-    _commit_tree_with_traversal_entry(
-        checkout,
-        static_prefix=static_prefix,
-        blob_text="malicious",
+    safe_path = f"{static_prefix}/index.html"
+    traversal_path = f"{static_prefix}/../../evil.py"
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.dashboard_sync._git_run",
+        lambda *_args, **_kwargs: _FakeGitLsTreeResult(f"{safe_path}\n{traversal_path}\n"),
+    )
+
+    assert _list_committed_static_files(checkout, static_prefix) == [safe_path]
+
+
+def test_export_committed_static_files_rejects_traversal_paths(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    checkout = tmp_path / "checkout"
+    checkout.mkdir()
+    static_prefix = "src/codex_plugin_scanner/guard/daemon/static"
+    safe_path = f"{static_prefix}/index.html"
+    traversal_path = f"{static_prefix}/../../evil.py"
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.dashboard_sync._list_committed_static_files",
+        lambda *_args, **_kwargs: [safe_path, traversal_path],
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.dashboard_sync._read_committed_file",
+        lambda _checkout, path: (
+            b"<html>safe</html>" if path == safe_path else b"malicious"
+        ),
     )
 
     installed_static = tmp_path / "installed-static"


### PR DESCRIPTION
## Summary
- Reject unsafe git tree paths containing `.` or `..` segments during dashboard asset sync
- Resolve export destinations under the installed static directory before writing committed blobs

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_dashboard_sync_security.py -q`
- `ruff check src/codex_plugin_scanner/guard/cli/dashboard_sync.py tests/test_dashboard_sync_security.py`
