### PR TITLE
feat(hol-guard): package shim status API fields (SCSR176-180)

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -103,6 +103,7 @@ from ..package_firewall_entitlement import (
     package_firewall_block_details,
     package_firewall_operation_allowed,
 )
+from ..package_shim_status import record_package_shim_audit_result
 from ..receipts.manager import build_receipt
 from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
@@ -123,7 +124,6 @@ from ..shims import (
     package_shim_status,
     package_shim_supported_managers,
     probe_package_shim_intercepts,
-    record_package_shim_audit_result,
     uninstall_package_shims,
 )
 from ..stable_digest import stable_digest_hex

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -123,6 +123,7 @@ from ..shims import (
     package_shim_status,
     package_shim_supported_managers,
     probe_package_shim_intercepts,
+    record_package_shim_audit_result,
     uninstall_package_shims,
 )
 from ..stable_digest import stable_digest_hex
@@ -2027,6 +2028,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 workspace_dir=context.workspace_dir,
             )
             audit_payload["exit_code"] = exit_code
+            if exit_code == 0:
+                record_package_shim_audit_result(context, audited_at=now)
             return audit_payload
         if operation == "sync":
             return sync_supply_chain_bundle(self.server.store)  # type: ignore[attr-defined]

--- a/src/codex_plugin_scanner/guard/package_shim_status.py
+++ b/src/codex_plugin_scanner/guard/package_shim_status.py
@@ -1,0 +1,61 @@
+"""Package shim status enrichment and audit proof persistence."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .adapters.base import HarnessContext
+
+
+def enrich_package_shim_status_payload(
+    status: dict[str, object],
+    manifest: dict[str, object],
+) -> dict[str, object]:
+    bypasses = status.get("bypasses", [])
+    path_broken_managers = sorted(
+        {
+            str(entry["manager"])
+            for entry in bypasses
+            if isinstance(entry, dict) and isinstance(entry.get("manager"), str)
+        }
+    )
+    last_test_at = status.get("last_test_at", {})
+    tested_managers = (
+        sorted(manager for manager in last_test_at if isinstance(manager, str))
+        if isinstance(last_test_at, dict)
+        else []
+    )
+    last_audit_proof_at = manifest.get("last_audit_at")
+    normalized_last_audit = last_audit_proof_at if isinstance(last_audit_proof_at, str) else None
+    normalized_last_tests = last_test_at if isinstance(last_test_at, dict) else {}
+
+    enriched = dict(status)
+    enriched["path_broken_managers"] = path_broken_managers
+    enriched["tested_managers"] = tested_managers
+    enriched["pathBrokenManagers"] = path_broken_managers
+    enriched["testedManagers"] = tested_managers
+    enriched["last_intercept_proof_at"] = normalized_last_tests
+    enriched["lastInterceptProofAt"] = normalized_last_tests
+    enriched["detectedManagers"] = list(status.get("detected_managers", []))
+    enriched["protectedManagers"] = list(status.get("protected_managers", []))
+    enriched["installedManagers"] = list(status.get("installed_managers", []))
+    enriched["activeManagers"] = list(status.get("active_managers", []))
+    enriched["missingManagers"] = list(status.get("missing_managers", []))
+    enriched["undetectedManagers"] = list(status.get("undetected_managers", []))
+    enriched["last_audit_proof_at"] = normalized_last_audit
+    enriched["lastAuditProofAt"] = normalized_last_audit
+    return enriched
+
+
+def record_package_shim_audit_result(
+    context: HarnessContext,
+    *,
+    audited_at: str | None = None,
+) -> None:
+    from .shims import _load_package_shim_manifest, _write_package_shim_manifest
+
+    manifest = _load_package_shim_manifest(context)
+    manifest["last_audit_at"] = audited_at if audited_at is not None else datetime.now(timezone.utc).isoformat()
+    _write_package_shim_manifest(context, manifest)

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .launcher import merge_guard_launcher_env
-from .package_shim_status import enrich_package_shim_status_payload, record_package_shim_audit_result
+from .package_shim_status import enrich_package_shim_status_payload
 from .shim_probe import (
     SHIM_PROBE_ENV_VALUE,
     SHIM_PROBE_ENV_VAR,

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -380,6 +380,47 @@ def activate_package_shims(
     }
 
 
+def _enrich_package_shim_status_payload(
+    status: dict[str, object],
+    manifest: dict[str, object],
+) -> dict[str, object]:
+    bypasses = status.get("bypasses", [])
+    path_broken_managers = sorted(
+        {
+            str(entry["manager"])
+            for entry in bypasses
+            if isinstance(entry, dict) and isinstance(entry.get("manager"), str)
+        }
+    )
+    last_test_at = status.get("last_test_at", {})
+    tested_managers = sorted(
+        manager
+        for manager in last_test_at
+        if isinstance(manager, str) and isinstance(last_test_at, dict)
+    ) if isinstance(last_test_at, dict) else []
+    last_audit_proof_at = manifest.get("last_audit_at")
+    normalized_last_audit = last_audit_proof_at if isinstance(last_audit_proof_at, str) else None
+    normalized_last_tests = last_test_at if isinstance(last_test_at, dict) else {}
+
+    enriched = dict(status)
+    enriched["path_broken_managers"] = path_broken_managers
+    enriched["tested_managers"] = tested_managers
+    enriched["pathBrokenManagers"] = path_broken_managers
+    enriched["testedManagers"] = tested_managers
+    enriched["last_intercept_proof_at"] = normalized_last_tests
+    enriched["lastInterceptProofAt"] = normalized_last_tests
+    enriched["detectedManagers"] = list(status.get("detected_managers", []))
+    enriched["protectedManagers"] = list(status.get("protected_managers", []))
+    enriched["installedManagers"] = list(status.get("installed_managers", []))
+    enriched["activeManagers"] = list(status.get("active_managers", []))
+    enriched["missingManagers"] = list(status.get("missing_managers", []))
+    enriched["undetectedManagers"] = list(status.get("undetected_managers", []))
+    if normalized_last_audit is not None:
+        enriched["last_audit_proof_at"] = normalized_last_audit
+        enriched["lastAuditProofAt"] = normalized_last_audit
+    return enriched
+
+
 def package_shim_status(context: HarnessContext) -> dict[str, object]:
     manifest = _load_package_shim_manifest(context)
     installed_managers = [
@@ -448,7 +489,8 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         path_contains_shim_dir=path_contains_shim_dir,
         shell_profile_configured=bool(profile_status["shell_profile_configured"]),
     )
-    return {
+    return _enrich_package_shim_status_payload(
+        {
         "active_managers": active_managers,
         "detected_managers": detected_managers,
         "installed_managers": installed_managers,
@@ -468,7 +510,9 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         "shim_dir": str(shim_dir),
         "supported_managers": list(package_shim_supported_managers()),
         "undetected_managers": undetected_managers,
-    }
+        },
+        manifest,
+    )
 
 
 def package_shim_cloud_coverage(
@@ -809,6 +853,16 @@ def _load_package_shim_manifest(context: HarnessContext) -> dict[str, object]:
 
 def _write_package_shim_manifest(context: HarnessContext, payload: dict[str, object]) -> None:
     _package_shim_manifest_path(context).write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
+
+
+def record_package_shim_audit_result(
+    context: HarnessContext,
+    *,
+    audited_at: str | None = None,
+) -> None:
+    manifest = _load_package_shim_manifest(context)
+    manifest["last_audit_at"] = audited_at or datetime.now(timezone.utc).isoformat()
+    _write_package_shim_manifest(context, manifest)
 
 
 def _record_package_shim_test_results(

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .launcher import merge_guard_launcher_env
+from .package_shim_status import enrich_package_shim_status_payload, record_package_shim_audit_result
 from .shim_probe import (
     SHIM_PROBE_ENV_VALUE,
     SHIM_PROBE_ENV_VAR,
@@ -380,47 +381,6 @@ def activate_package_shims(
     }
 
 
-def _enrich_package_shim_status_payload(
-    status: dict[str, object],
-    manifest: dict[str, object],
-) -> dict[str, object]:
-    bypasses = status.get("bypasses", [])
-    path_broken_managers = sorted(
-        {
-            str(entry["manager"])
-            for entry in bypasses
-            if isinstance(entry, dict) and isinstance(entry.get("manager"), str)
-        }
-    )
-    last_test_at = status.get("last_test_at", {})
-    tested_managers = sorted(
-        manager
-        for manager in last_test_at
-        if isinstance(manager, str) and isinstance(last_test_at, dict)
-    ) if isinstance(last_test_at, dict) else []
-    last_audit_proof_at = manifest.get("last_audit_at")
-    normalized_last_audit = last_audit_proof_at if isinstance(last_audit_proof_at, str) else None
-    normalized_last_tests = last_test_at if isinstance(last_test_at, dict) else {}
-
-    enriched = dict(status)
-    enriched["path_broken_managers"] = path_broken_managers
-    enriched["tested_managers"] = tested_managers
-    enriched["pathBrokenManagers"] = path_broken_managers
-    enriched["testedManagers"] = tested_managers
-    enriched["last_intercept_proof_at"] = normalized_last_tests
-    enriched["lastInterceptProofAt"] = normalized_last_tests
-    enriched["detectedManagers"] = list(status.get("detected_managers", []))
-    enriched["protectedManagers"] = list(status.get("protected_managers", []))
-    enriched["installedManagers"] = list(status.get("installed_managers", []))
-    enriched["activeManagers"] = list(status.get("active_managers", []))
-    enriched["missingManagers"] = list(status.get("missing_managers", []))
-    enriched["undetectedManagers"] = list(status.get("undetected_managers", []))
-    if normalized_last_audit is not None:
-        enriched["last_audit_proof_at"] = normalized_last_audit
-        enriched["lastAuditProofAt"] = normalized_last_audit
-    return enriched
-
-
 def package_shim_status(context: HarnessContext) -> dict[str, object]:
     manifest = _load_package_shim_manifest(context)
     installed_managers = [
@@ -489,27 +449,27 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         path_contains_shim_dir=path_contains_shim_dir,
         shell_profile_configured=bool(profile_status["shell_profile_configured"]),
     )
-    return _enrich_package_shim_status_payload(
+    return enrich_package_shim_status_payload(
         {
-        "active_managers": active_managers,
-        "detected_managers": detected_managers,
-        "installed_managers": installed_managers,
-        "last_test_at": normalized_last_tests,
-        "protected_managers": protected_managers,
-        "path_active": bool(installed_managers) and len(protected_managers) == len(installed_managers),
-        "path_contains_shim_dir": path_contains_shim_dir,
-        "path_status": activation_path_status,
-        "bypasses": bypasses,
-        "manager_details": manager_details,
-        "manifest_path": str(_package_shim_manifest_path(context)),
-        "missing_managers": missing_managers,
-        "restart_shell_required": activation_path_status == "restart_required",
-        "shell_profile_configured": bool(profile_status["shell_profile_configured"]),
-        "shell_profile_path": profile_status["shell_profile_path"],
-        "shell_hints": _path_export_hints(shim_dir),
-        "shim_dir": str(shim_dir),
-        "supported_managers": list(package_shim_supported_managers()),
-        "undetected_managers": undetected_managers,
+            "active_managers": active_managers,
+            "detected_managers": detected_managers,
+            "installed_managers": installed_managers,
+            "last_test_at": normalized_last_tests,
+            "protected_managers": protected_managers,
+            "path_active": bool(installed_managers) and len(protected_managers) == len(installed_managers),
+            "path_contains_shim_dir": path_contains_shim_dir,
+            "path_status": activation_path_status,
+            "bypasses": bypasses,
+            "manager_details": manager_details,
+            "manifest_path": str(_package_shim_manifest_path(context)),
+            "missing_managers": missing_managers,
+            "restart_shell_required": activation_path_status == "restart_required",
+            "shell_profile_configured": bool(profile_status["shell_profile_configured"]),
+            "shell_profile_path": profile_status["shell_profile_path"],
+            "shell_hints": _path_export_hints(shim_dir),
+            "shim_dir": str(shim_dir),
+            "supported_managers": list(package_shim_supported_managers()),
+            "undetected_managers": undetected_managers,
         },
         manifest,
     )
@@ -853,16 +813,6 @@ def _load_package_shim_manifest(context: HarnessContext) -> dict[str, object]:
 
 def _write_package_shim_manifest(context: HarnessContext, payload: dict[str, object]) -> None:
     _package_shim_manifest_path(context).write_text(json.dumps(payload, sort_keys=True), encoding="utf-8")
-
-
-def record_package_shim_audit_result(
-    context: HarnessContext,
-    *,
-    audited_at: str | None = None,
-) -> None:
-    manifest = _load_package_shim_manifest(context)
-    manifest["last_audit_at"] = audited_at or datetime.now(timezone.utc).isoformat()
-    _write_package_shim_manifest(context, manifest)
 
 
 def _record_package_shim_test_results(

--- a/tests/test_guard_phase11_package_firewall_status.py
+++ b/tests/test_guard_phase11_package_firewall_status.py
@@ -8,11 +8,11 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from codex_plugin_scanner.guard.package_shim_status import record_package_shim_audit_result
 from codex_plugin_scanner.guard.shims import (
     install_package_shims,
     package_shim_status,
     probe_package_shim_intercepts,
-    record_package_shim_audit_result,
 )
 from tests.shim_execution_helpers import write_fake_manager_script
 

--- a/tests/test_guard_phase11_package_firewall_status.py
+++ b/tests/test_guard_phase11_package_firewall_status.py
@@ -1,0 +1,95 @@
+"""Phase 11 package firewall status API field proofs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codex_plugin_scanner.guard.shims import (
+    install_package_shims,
+    package_shim_status,
+    probe_package_shim_intercepts,
+    record_package_shim_audit_result,
+)
+from tests.shim_execution_helpers import write_fake_manager_script
+
+
+def _harness_context(tmp_path: Path) -> MagicMock:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    context = MagicMock()
+    context.home_dir = home_dir
+    context.workspace_dir = workspace_dir
+    context.guard_home = guard_home
+    return context
+
+
+def test_package_shim_status_exposes_phase11_alias_fields(tmp_path: Path) -> None:
+    context = _harness_context(tmp_path)
+    install_package_shims(context, managers=("npm",))
+    record_package_shim_audit_result(context, audited_at="2026-06-10T01:00:00+00:00")
+
+    status = package_shim_status(context)
+
+    assert status["detectedManagers"] == status["detected_managers"]
+    assert status["protectedManagers"] == status["protected_managers"]
+    assert status["installedManagers"] == status["installed_managers"]
+    assert status["pathBrokenManagers"] == status["path_broken_managers"]
+    assert status["lastAuditProofAt"] == "2026-06-10T01:00:00+00:00"
+    assert status["last_audit_proof_at"] == "2026-06-10T01:00:00+00:00"
+    assert isinstance(status["lastInterceptProofAt"], dict)
+    assert status["lastInterceptProofAt"] == status["last_intercept_proof_at"] == status["last_test_at"]
+
+
+def test_package_shim_status_lists_tested_managers_after_probe(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _harness_context(tmp_path)
+    install_package_shims(context, managers=("npm",))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    write_fake_manager_script(
+        fake_bin=fake_bin,
+        manager="npm",
+        marker_path=tmp_path / "npm-probe-marker.json",
+        exit_code=0,
+    )
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shim_dir), str(fake_bin)]))
+
+    probe_package_shim_intercepts(context, managers=("npm",), workspace_dir=context.workspace_dir)
+    status = package_shim_status(context)
+
+    assert "npm" in status["testedManagers"]
+    assert status["lastInterceptProofAt"]["npm"] == status["last_test_at"]["npm"]
+
+
+def test_package_shim_status_lists_path_broken_managers_from_bypasses(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _harness_context(tmp_path)
+    install_package_shims(context, managers=("npm",))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    write_fake_manager_script(
+        fake_bin=fake_bin,
+        manager="npm",
+        marker_path=tmp_path / "npm-path-marker.json",
+        exit_code=0,
+    )
+    monkeypatch.setenv("PATH", os.pathsep.join([str(fake_bin), str(shim_dir)]))
+
+    status = package_shim_status(context)
+
+    assert "npm" in status["pathBrokenManagers"]
+    assert status["path_broken_managers"] == status["pathBrokenManagers"]

--- a/tests/test_guard_phase11_package_firewall_status.py
+++ b/tests/test_guard_phase11_package_firewall_status.py
@@ -34,6 +34,8 @@ def _harness_context(tmp_path: Path) -> MagicMock:
 def test_package_shim_status_exposes_phase11_alias_fields(tmp_path: Path) -> None:
     context = _harness_context(tmp_path)
     install_package_shims(context, managers=("npm",))
+    status_before = package_shim_status(context)
+    assert status_before["lastAuditProofAt"] is None
     record_package_shim_audit_result(context, audited_at="2026-06-10T01:00:00+00:00")
 
     status = package_shim_status(context)


### PR DESCRIPTION
## Summary
- Add camelCase package shim status aliases for Cloud and portal consumers
- Expose pathBrokenManagers, testedManagers, lastInterceptProofAt, and lastAuditProofAt
- Persist audit completion timestamps in the package shim manifest

## Testing
- `python3 -m pytest tests/test_guard_phase11_package_firewall_status.py tests/test_guard_phase05_manager_coverage.py -q`
