### PR TITLE
feat(hol-guard): supply chain evidence rail and degraded states

### DIFF
--- a/dashboard/src/scsr-phase09c-evidence-rail.test.ts
+++ b/dashboard/src/scsr-phase09c-evidence-rail.test.ts
@@ -1,0 +1,157 @@
+import type { GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
+import {
+  deriveSupplyChainEvidenceRail,
+  resolveSupplyChainCloudDegradedState,
+  supplyChainEvidenceHref,
+} from "./supply-chain-evidence-rail";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const baseSnapshot: GuardRuntimeSnapshot = {
+  generated_at: new Date().toISOString(),
+  approval_center_url: null,
+  runtime_state: {},
+  device: {
+    installation_id: "install-1",
+    device_label: "Test Machine",
+    local_registered: false,
+  },
+  latest_connect_state: null,
+  proof_status: {
+    state: "not_connected",
+    label: "Not connected",
+    detail: "",
+    request_id: null,
+    pairing_completed_at: null,
+    first_synced_at: null,
+    receipts_stored: 0,
+    inventory_items: 0,
+    runtime_session_id: null,
+    runtime_session_synced_at: null,
+  },
+  pending_count: 0,
+  receipt_count: 0,
+  headline_state: "local_only",
+  headline_label: "Local only",
+  headline_detail: "",
+  sync_configured: false,
+  cloud_state: "local_only",
+  cloud_state_label: "Offline, free",
+  cloud_state_detail: "Running locally without Guard Cloud.",
+  cloud_pairing_state: {
+    state: "local_only",
+    label: "Not connected",
+    detail: "",
+    sync_configured: false,
+    dashboard_url: "",
+    inbox_url: "",
+    fleet_url: "",
+    connect_url: "",
+  },
+  cloud_sync_health: {
+    state: "disabled",
+    label: "Sync disabled",
+    detail: "Cloud sync is turned off.",
+    pending_events: 0,
+    last_synced_at: null,
+    next_retry_after: null,
+  },
+  dashboard_url: "",
+  inbox_url: "",
+  fleet_url: "",
+  connect_url: "",
+  items: [],
+  latest_receipts: [],
+  managed_installs: [],
+  supply_chain: undefined,
+};
+
+const blockReceipt: GuardReceipt = {
+  receipt_id: "receipt-block-1",
+  harness: "claude",
+  artifact_id: "package-request:lodash",
+  artifact_hash: "hash-block",
+  policy_decision: "block",
+  capabilities_summary: "Guard blocked lodash before install.",
+  changed_capabilities: [],
+  provenance_summary: "",
+  user_override: null,
+  artifact_name: "lodash@4.17.20",
+  source_scope: "/workspace",
+  timestamp: "2026-06-09T14:00:00.000Z",
+};
+
+const auditReceipt: GuardReceipt = {
+  receipt_id: "receipt-audit-1",
+  harness: "package-firewall",
+  artifact_id: "headless:package-firewall:audit",
+  artifact_hash: "hash-audit",
+  policy_decision: "warn",
+  capabilities_summary: "Workspace audit completed with warn decision across 3 packages.",
+  changed_capabilities: ["audit"],
+  provenance_summary: "",
+  user_override: null,
+  artifact_name: "Workspace supply-chain audit",
+  source_scope: "/workspace",
+  timestamp: "2026-06-09T13:00:00.000Z",
+  scanner_evidence: [
+    {
+      operation: "audit",
+      audit_decision: "warn",
+      blocked_package_count: 1,
+      total_packages: 3,
+    },
+  ] as unknown as GuardReceipt["scanner_evidence"],
+};
+
+const syncReceipt: GuardReceipt = {
+  receipt_id: "receipt-sync-1",
+  harness: "package-firewall",
+  artifact_id: "headless:package-firewall:sync",
+  artifact_hash: "hash-sync",
+  policy_decision: "allow",
+  capabilities_summary: "Guard refreshed local supply-chain policy.",
+  changed_capabilities: ["sync"],
+  provenance_summary: "",
+  user_override: null,
+  artifact_name: "Headless sync",
+  source_scope: "local-daemon",
+  timestamp: "2026-06-09T12:00:00.000Z",
+  scanner_evidence: [
+    {
+      operation: "sync",
+      status: "completed",
+    },
+  ] as unknown as GuardReceipt["scanner_evidence"],
+};
+
+const rail = deriveSupplyChainEvidenceRail([syncReceipt, auditReceipt, blockReceipt]);
+
+assert(rail.block.receiptId === "receipt-block-1", "SCSR154: latest block receipt surfaces on evidence rail");
+assert(rail.block.title.includes("lodash"), "SCSR154: block title includes package name");
+assert(rail.audit.receiptId === "receipt-audit-1", "SCSR154: latest audit receipt surfaces on evidence rail");
+assert(rail.sync.receiptId === "receipt-sync-1", "SCSR154: latest sync receipt surfaces on evidence rail");
+
+const emptyRail = deriveSupplyChainEvidenceRail([]);
+assert(emptyRail.block.timestamp === null, "SCSR154-B: empty receipts keep waiting block state");
+assert(emptyRail.audit.timestamp === null, "SCSR154-B: empty receipts keep waiting audit state");
+assert(emptyRail.sync.timestamp === null, "SCSR154-B: empty receipts keep waiting sync state");
+
+const cloudDegraded = resolveSupplyChainCloudDegradedState(baseSnapshot);
+assert(cloudDegraded.active, "SCSR163: local_only cloud state activates degraded banner");
+assert(
+  cloudDegraded.detail.includes("Running locally without Guard Cloud"),
+  "SCSR163: degraded banner uses snapshot cloud detail",
+);
+
+const pairedSnapshot = { ...baseSnapshot, cloud_state: "paired_active" as const };
+assert(!resolveSupplyChainCloudDegradedState(pairedSnapshot).active, "SCSR163-B: paired cloud clears degraded banner");
+
+const href = supplyChainEvidenceHref("receipt-audit-1");
+assert(href !== null && href.includes("receipt-audit-1"), "SCSR154-C: evidence href encodes receipt id");
+
+console.log("scsr-phase09c-evidence-rail.test.ts: all assertions passed");

--- a/dashboard/src/scsr-phase09c-evidence-rail.test.ts
+++ b/dashboard/src/scsr-phase09c-evidence-rail.test.ts
@@ -151,7 +151,27 @@ assert(
 const pairedSnapshot = { ...baseSnapshot, cloud_state: "paired_active" as const };
 assert(!resolveSupplyChainCloudDegradedState(pairedSnapshot).active, "SCSR163-B: paired cloud clears degraded banner");
 
-const href = supplyChainEvidenceHref("receipt-audit-1");
+const href = supplyChainEvidenceHref("receipt-audit-1", "package-firewall");
 assert(href !== null && href.includes("receipt-audit-1"), "SCSR154-C: evidence href encodes receipt id");
+assert(href !== null && href.includes("harness=package-firewall"), "SCSR154-D: audit evidence href keeps harness");
+
+const blockedHref = supplyChainEvidenceHref("receipt-block-1", "claude");
+assert(blockedHref !== null && blockedHref.includes("harness=claude"), "SCSR154-E: block evidence href uses receipt harness");
+
+const blockedAuditReceipt: GuardReceipt = {
+  ...auditReceipt,
+  receipt_id: "receipt-audit-block-1",
+  policy_decision: "block",
+  timestamp: "2026-06-09T15:00:00.000Z",
+};
+const mixedRail = deriveSupplyChainEvidenceRail([blockedAuditReceipt, blockReceipt]);
+assert(
+  mixedRail.block.receiptId === "receipt-block-1",
+  "SCSR154-F: blocked audit receipts stay in audit slot, not block slot",
+);
+assert(
+  mixedRail.audit.receiptId === "receipt-audit-block-1",
+  "SCSR154-G: blocked audit receipts still surface in audit slot",
+);
 
 console.log("scsr-phase09c-evidence-rail.test.ts: all assertions passed");

--- a/dashboard/src/supply-chain-evidence-rail-panel.tsx
+++ b/dashboard/src/supply-chain-evidence-rail-panel.tsx
@@ -35,7 +35,7 @@ type EvidenceRailRowProps = {
 
 function EvidenceRailRow({ item }: EvidenceRailRowProps) {
   const Icon = kindIcons[item.kind];
-  const href = supplyChainEvidenceHref(item.receiptId);
+  const href = supplyChainEvidenceHref(item.receiptId, item.harness);
   const tagTone = item.tone === "green" ? "green" : item.tone === "attention" ? "attention" : "slate";
 
   return (

--- a/dashboard/src/supply-chain-evidence-rail-panel.tsx
+++ b/dashboard/src/supply-chain-evidence-rail-panel.tsx
@@ -1,0 +1,119 @@
+import {
+  HiMiniArrowTopRightOnSquare,
+  HiMiniArrowPath,
+  HiMiniDocumentMagnifyingGlass,
+  HiMiniShieldExclamation,
+} from "react-icons/hi2";
+import { SectionLabel, Tag } from "./approval-center-primitives";
+import { formatRelativeTime } from "./approval-center-utils";
+import type {
+  SupplyChainCloudDegradedState,
+  SupplyChainEvidenceRailItem,
+  SupplyChainEvidenceRailSnapshot,
+} from "./supply-chain-evidence-rail";
+import { supplyChainEvidenceHref } from "./supply-chain-evidence-rail";
+
+type SupplyChainEvidenceRailProps = {
+  rail: SupplyChainEvidenceRailSnapshot;
+};
+
+const kindLabels: Record<SupplyChainEvidenceRailItem["kind"], string> = {
+  block: "Last block",
+  audit: "Last audit",
+  sync: "Last sync",
+};
+
+const kindIcons: Record<SupplyChainEvidenceRailItem["kind"], typeof HiMiniShieldExclamation> = {
+  block: HiMiniShieldExclamation,
+  audit: HiMiniDocumentMagnifyingGlass,
+  sync: HiMiniArrowPath,
+};
+
+type EvidenceRailRowProps = {
+  item: SupplyChainEvidenceRailItem;
+};
+
+function EvidenceRailRow({ item }: EvidenceRailRowProps) {
+  const Icon = kindIcons[item.kind];
+  const href = supplyChainEvidenceHref(item.receiptId);
+  const tagTone = item.tone === "green" ? "green" : item.tone === "attention" ? "attention" : "slate";
+
+  return (
+    <div className="px-4 py-3">
+      <div className="flex items-start gap-3">
+        <span
+          className="inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-50 text-slate-500"
+          aria-hidden="true"
+        >
+          <Icon className="h-4 w-4" />
+        </span>
+        <div className="min-w-0 flex-1 space-y-1.5">
+          <div className="flex flex-wrap items-center gap-2">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+              {kindLabels[item.kind]}
+            </p>
+            {item.timestamp !== null ? (
+              <Tag tone={tagTone}>{formatRelativeTime(item.timestamp)}</Tag>
+            ) : (
+              <Tag tone="slate">Waiting</Tag>
+            )}
+          </div>
+          <p className="text-sm font-medium text-brand-dark">{item.title}</p>
+          <p className="text-xs leading-relaxed text-slate-500">{item.detail}</p>
+          {href !== null ? (
+            <a
+              href={href}
+              className="inline-flex items-center gap-1 text-xs font-medium text-brand-blue hover:underline focus:outline-none focus:ring-2 focus:ring-brand-blue/30 rounded"
+            >
+              Open evidence
+              <HiMiniArrowTopRightOnSquare className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function SupplyChainEvidenceRail({ rail }: SupplyChainEvidenceRailProps) {
+  return (
+    <section
+      className="overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm"
+      aria-label="Recent supply chain evidence"
+      data-testid="supply-chain-evidence-rail"
+    >
+      <div className="border-b border-slate-100 px-4 py-3">
+        <SectionLabel>Recent evidence</SectionLabel>
+        <p className="mt-1 text-sm text-slate-500">
+          Latest block, audit, and policy sync recorded on this machine.
+        </p>
+      </div>
+      <div className="divide-y divide-slate-100">
+        <EvidenceRailRow item={rail.block} />
+        <EvidenceRailRow item={rail.audit} />
+        <EvidenceRailRow item={rail.sync} />
+      </div>
+    </section>
+  );
+}
+
+type SupplyChainCloudDegradedBannerProps = {
+  state: SupplyChainCloudDegradedState;
+};
+
+export function SupplyChainCloudDegradedBanner({ state }: SupplyChainCloudDegradedBannerProps) {
+  if (!state.active) {
+    return null;
+  }
+
+  return (
+    <div
+      className="rounded-2xl border border-amber-200 bg-amber-50/70 px-4 py-3"
+      role="status"
+      data-testid="supply-chain-cloud-degraded"
+    >
+      <p className="text-sm font-medium text-amber-950">{state.title}</p>
+      <p className="mt-1 text-xs leading-relaxed text-amber-900/90">{state.detail}</p>
+    </div>
+  );
+}

--- a/dashboard/src/supply-chain-evidence-rail.ts
+++ b/dashboard/src/supply-chain-evidence-rail.ts
@@ -1,0 +1,210 @@
+import type { GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
+
+export type SupplyChainEvidenceRailKind = "block" | "audit" | "sync";
+
+export type SupplyChainEvidenceRailItem = {
+  kind: SupplyChainEvidenceRailKind;
+  timestamp: string | null;
+  title: string;
+  detail: string;
+  receiptId: string | null;
+  tone: "green" | "attention" | "slate";
+};
+
+export type SupplyChainEvidenceRailSnapshot = {
+  block: SupplyChainEvidenceRailItem;
+  audit: SupplyChainEvidenceRailItem;
+  sync: SupplyChainEvidenceRailItem;
+};
+
+export type SupplyChainCloudDegradedState = {
+  active: boolean;
+  title: string;
+  detail: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readOperation(value: unknown): string | null {
+  if (!isRecord(value) || typeof value.operation !== "string") {
+    return null;
+  }
+  const trimmed = value.operation.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function receiptEvidenceOperations(receipt: GuardReceipt): string[] {
+  const operations: string[] = [];
+  for (const entry of receipt.scanner_evidence ?? []) {
+    const operation = readOperation(entry);
+    if (operation !== null) {
+      operations.push(operation);
+    }
+  }
+  return operations;
+}
+
+function isPackageBlockReceipt(receipt: GuardReceipt): boolean {
+  if (receipt.policy_decision !== "block") {
+    return false;
+  }
+  if (receipt.harness === "package-firewall") {
+    return true;
+  }
+  const artifactName = receipt.artifact_name?.toLowerCase() ?? "";
+  const artifactId = receipt.artifact_id.toLowerCase();
+  const summary = receipt.capabilities_summary.toLowerCase();
+  return (
+    artifactName.includes("package") ||
+    artifactId.includes("package") ||
+    summary.includes("install") ||
+    summary.includes("package")
+  );
+}
+
+function emptyRailItem(kind: SupplyChainEvidenceRailKind): SupplyChainEvidenceRailItem {
+  const labels: Record<SupplyChainEvidenceRailKind, { title: string; detail: string }> = {
+    block: {
+      title: "No blocked installs yet",
+      detail: "Guard will record the last prevented package install here.",
+    },
+    audit: {
+      title: "No workspace audit yet",
+      detail: "Run an audit to scan lockfiles and manifest paths on this machine.",
+    },
+    sync: {
+      title: "No policy sync yet",
+      detail: "Sync pulls the latest Guard supply-chain policy to this device.",
+    },
+  };
+  return {
+    kind,
+    timestamp: null,
+    title: labels[kind].title,
+    detail: labels[kind].detail,
+    receiptId: null,
+    tone: "slate",
+  };
+}
+
+function blockRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
+  const label = receipt.artifact_name?.trim();
+  return {
+    kind: "block",
+    timestamp: receipt.timestamp,
+    title: label !== undefined && label.length > 0 ? `Blocked: ${label}` : "Blocked package install",
+    detail:
+      receipt.capabilities_summary.trim().length > 0
+        ? receipt.capabilities_summary
+        : "Guard blocked a package install before it completed.",
+    receiptId: receipt.receipt_id,
+    tone: "attention",
+  };
+}
+
+function auditRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
+  const evidence = (receipt.scanner_evidence ?? []).find(
+    (entry) => readOperation(entry) === "audit",
+  );
+  const decision =
+    isRecord(evidence) && typeof evidence.audit_decision === "string"
+      ? evidence.audit_decision
+      : receipt.policy_decision;
+  const blockedCount =
+    isRecord(evidence) && typeof evidence.blocked_package_count === "number"
+      ? evidence.blocked_package_count
+      : 0;
+  const totalPackages =
+    isRecord(evidence) && typeof evidence.total_packages === "number"
+      ? evidence.total_packages
+      : blockedCount;
+  const detail =
+    receipt.capabilities_summary.trim().length > 0
+      ? receipt.capabilities_summary
+      : `Workspace audit returned ${decision} across ${totalPackages} package(s).`;
+  return {
+    kind: "audit",
+    timestamp: receipt.timestamp,
+    title: blockedCount > 0 ? `Audit flagged ${blockedCount} package(s)` : "Workspace audit completed",
+    detail,
+    receiptId: receipt.receipt_id,
+    tone: blockedCount > 0 || decision === "block" ? "attention" : "green",
+  };
+}
+
+function syncRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
+  return {
+    kind: "sync",
+    timestamp: receipt.timestamp,
+    title: "Policy sync completed",
+    detail:
+      receipt.capabilities_summary.trim().length > 0
+        ? receipt.capabilities_summary
+        : "Guard refreshed local supply-chain policy from the connected source.",
+    receiptId: receipt.receipt_id,
+    tone: "green",
+  };
+}
+
+function latestReceiptMatching(
+  receipts: GuardReceipt[],
+  predicate: (receipt: GuardReceipt) => boolean,
+): GuardReceipt | null {
+  const matches = receipts
+    .filter(predicate)
+    .sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp));
+  return matches[0] ?? null;
+}
+
+export function deriveSupplyChainEvidenceRail(
+  receipts: GuardReceipt[],
+): SupplyChainEvidenceRailSnapshot {
+  const blockReceipt = latestReceiptMatching(receipts, isPackageBlockReceipt);
+  const auditReceipt = latestReceiptMatching(receipts, (receipt) => {
+    if (receipt.harness !== "package-firewall") {
+      return false;
+    }
+    return receiptEvidenceOperations(receipt).includes("audit");
+  });
+  const syncReceipt = latestReceiptMatching(receipts, (receipt) => {
+    if (receipt.harness !== "package-firewall") {
+      return false;
+    }
+    return receiptEvidenceOperations(receipt).includes("sync");
+  });
+
+  return {
+    block: blockReceipt !== null ? blockRailItem(blockReceipt) : emptyRailItem("block"),
+    audit: auditReceipt !== null ? auditRailItem(auditReceipt) : emptyRailItem("audit"),
+    sync: syncReceipt !== null ? syncRailItem(syncReceipt) : emptyRailItem("sync"),
+  };
+}
+
+export function resolveSupplyChainCloudDegradedState(
+  snapshot: GuardRuntimeSnapshot,
+): SupplyChainCloudDegradedState {
+  if (snapshot.cloud_state !== "local_only") {
+    return {
+      active: false,
+      title: "",
+      detail: "",
+    };
+  }
+  return {
+    active: true,
+    title: "Guard Cloud unavailable on this device",
+    detail:
+      snapshot.cloud_state_detail.trim().length > 0
+        ? snapshot.cloud_state_detail
+        : "Local protection still runs, but live intel, fleet sync, and cross-device evidence stay offline until you connect Guard Cloud.",
+  };
+}
+
+export function supplyChainEvidenceHref(receiptId: string | null): string | null {
+  if (receiptId === null) {
+    return null;
+  }
+  return `/evidence?harness=package-firewall&search=${encodeURIComponent(receiptId)}`;
+}

--- a/dashboard/src/supply-chain-evidence-rail.ts
+++ b/dashboard/src/supply-chain-evidence-rail.ts
@@ -8,6 +8,7 @@ export type SupplyChainEvidenceRailItem = {
   title: string;
   detail: string;
   receiptId: string | null;
+  harness: string | null;
   tone: "green" | "attention" | "slate";
 };
 
@@ -50,6 +51,10 @@ function isPackageBlockReceipt(receipt: GuardReceipt): boolean {
   if (receipt.policy_decision !== "block") {
     return false;
   }
+  const operations = receiptEvidenceOperations(receipt);
+  if (operations.includes("audit") || operations.includes("sync")) {
+    return false;
+  }
   if (receipt.harness === "package-firewall") {
     return true;
   }
@@ -85,6 +90,7 @@ function emptyRailItem(kind: SupplyChainEvidenceRailKind): SupplyChainEvidenceRa
     title: labels[kind].title,
     detail: labels[kind].detail,
     receiptId: null,
+    harness: null,
     tone: "slate",
   };
 }
@@ -100,6 +106,7 @@ function blockRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
         ? receipt.capabilities_summary
         : "Guard blocked a package install before it completed.",
     receiptId: receipt.receipt_id,
+    harness: receipt.harness,
     tone: "attention",
   };
 }
@@ -130,6 +137,7 @@ function auditRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
     title: blockedCount > 0 ? `Audit flagged ${blockedCount} package(s)` : "Workspace audit completed",
     detail,
     receiptId: receipt.receipt_id,
+    harness: receipt.harness,
     tone: blockedCount > 0 || decision === "block" ? "attention" : "green",
   };
 }
@@ -144,6 +152,7 @@ function syncRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
         ? receipt.capabilities_summary
         : "Guard refreshed local supply-chain policy from the connected source.",
     receiptId: receipt.receipt_id,
+    harness: receipt.harness,
     tone: "green",
   };
 }
@@ -202,9 +211,17 @@ export function resolveSupplyChainCloudDegradedState(
   };
 }
 
-export function supplyChainEvidenceHref(receiptId: string | null): string | null {
+export function supplyChainEvidenceHref(
+  receiptId: string | null,
+  harness: string | null,
+): string | null {
   if (receiptId === null) {
     return null;
   }
-  return `/evidence?harness=package-firewall&search=${encodeURIComponent(receiptId)}`;
+  const params = new URLSearchParams();
+  if (harness !== null && harness.trim().length > 0) {
+    params.set("harness", harness);
+  }
+  params.set("search", receiptId);
+  return `/evidence?${params.toString()}`;
 }

--- a/dashboard/src/supply-chain-firewall-controls.tsx
+++ b/dashboard/src/supply-chain-firewall-controls.tsx
@@ -159,6 +159,7 @@ export function FirewallControlsView({
     [onInstall, onOpenShell, onRepair, onSync, onTest],
   );
 
+  const noDetectedManagers = data.detected_managers.length === 0;
   const filteredManagers = useMemo(() => {
     const shimsByManager = new Map(data.package_shims.map((s) => [s.manager, s]));
     const visibleManagers = data.package_shims
@@ -167,6 +168,8 @@ export function FirewallControlsView({
     let managers =
       visibleManagers.length > 0
         ? Array.from(new Set(visibleManagers)).sort()
+        : noDetectedManagers
+        ? []
         : data.supported_managers;
 
     if (managerFilter) {
@@ -186,7 +189,7 @@ export function FirewallControlsView({
     }
 
     return managers;
-  }, [data, managerFilter, statusFilter]);
+  }, [data, managerFilter, noDetectedManagers, statusFilter]);
 
   return (
     <div className="space-y-4 px-4 py-4">
@@ -256,8 +259,16 @@ export function FirewallControlsView({
 
       {filteredManagers.length === 0 ? (
         <EmptyState
-          title="No package managers found"
-          body="No package managers match the current filter, or Guard has not detected any on this machine."
+          title={
+            noDetectedManagers && managerFilter.length === 0 && statusFilter === "all"
+              ? "No package managers detected"
+              : "No package managers found"
+          }
+          body={
+            noDetectedManagers && managerFilter.length === 0 && statusFilter === "all"
+              ? "Guard did not find npm, pip, pnpm, or other supported managers on this PATH. Install a package manager, open a new shell, then refresh status."
+              : "No package managers match the current filter, or Guard has not detected any on this machine."
+          }
           tone="teach"
         />
       ) : (

--- a/dashboard/src/supply-chain-firewall-controls.tsx
+++ b/dashboard/src/supply-chain-firewall-controls.tsx
@@ -165,12 +165,14 @@ export function FirewallControlsView({
     const visibleManagers = data.package_shims
       .filter((shim) => shim.detected || shim.installed || shim.tested)
       .map((shim) => shim.manager);
-    let managers =
-      visibleManagers.length > 0
-        ? Array.from(new Set(visibleManagers)).sort()
-        : noDetectedManagers
-        ? []
-        : data.supported_managers;
+    let managers: string[];
+    if (visibleManagers.length > 0) {
+      managers = Array.from(new Set(visibleManagers)).sort();
+    } else if (noDetectedManagers) {
+      managers = [];
+    } else {
+      managers = data.supported_managers;
+    }
 
     if (managerFilter) {
       const q = managerFilter.toLowerCase();

--- a/dashboard/src/supply-chain-workspace.tsx
+++ b/dashboard/src/supply-chain-workspace.tsx
@@ -21,6 +21,15 @@ import { derivePackageWorkbenchFromReceipts, fetchReceipts, normalizeSupplyChain
 import { PackageFirewallPanel } from "./supply-chain-firewall-panel";
 import { PackageWorkbenchPanel } from "./package-workbench-panel";
 import { SupplyChainBundlePanel } from "./supply-chain-bundle-panel";
+import {
+  deriveSupplyChainEvidenceRail,
+  resolveSupplyChainCloudDegradedState,
+  type SupplyChainEvidenceRailSnapshot,
+} from "./supply-chain-evidence-rail";
+import {
+  SupplyChainCloudDegradedBanner,
+  SupplyChainEvidenceRail,
+} from "./supply-chain-evidence-rail-panel";
 
 type ManagerCoverageStatus = "protected" | "restart_required" | "path_repair" | "unprotected";
 
@@ -187,25 +196,32 @@ export function SupplyChainWorkspace({
     [snapshot.managed_installs],
   );
   const [auditSnapshot, setAuditSnapshot] = useState<SupplyChainAuditSnapshot | null>(null);
+  const [evidenceRail, setEvidenceRail] = useState<SupplyChainEvidenceRailSnapshot | null>(null);
   const [auditRunning, setAuditRunning] = useState(false);
   const runAuditRef = useRef<(() => void) | null>(null);
+  const cloudDegraded = useMemo(
+    () => resolveSupplyChainCloudDegradedState(snapshot),
+    [snapshot],
+  );
 
   useEffect(() => {
     let cancelled = false;
-    const loadAuditSnapshot = async () => {
+    const loadReceiptEvidence = async () => {
       try {
         const receipts = await fetchReceipts();
         if (cancelled) {
           return;
         }
         setAuditSnapshot(derivePackageWorkbenchFromReceipts(receipts));
+        setEvidenceRail(deriveSupplyChainEvidenceRail(receipts));
       } catch {
         if (!cancelled) {
           setAuditSnapshot(null);
+          setEvidenceRail(null);
         }
       }
     };
-    void loadAuditSnapshot();
+    void loadReceiptEvidence();
     return () => {
       cancelled = true;
     };
@@ -237,6 +253,8 @@ export function SupplyChainWorkspace({
         </ActionButton>
       </div>
 
+      <SupplyChainCloudDegradedBanner state={cloudDegraded} />
+
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard label="Active apps" value={stats.activeApps} tone="green" />
         <StatCard label="Prevented installs" value={stats.preventedInstalls} tone={stats.preventedInstalls > 0 ? "attention" : "slate"} />
@@ -265,6 +283,8 @@ export function SupplyChainWorkspace({
         />
         <StatCard label="Unprotected managers" value={stats.unprotectedManagers} tone={stats.unprotectedManagers > 0 ? "attention" : "slate"} />
       </div>
+
+      {evidenceRail !== null ? <SupplyChainEvidenceRail rail={evidenceRail} /> : null}
 
       <SupplyChainBundlePanel />
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, T as Tag, A as ActionButton, ao as HiMiniArrowPath, H as HiMiniShieldCheck, aw as HiMiniArrowTopRightOnSquare, r as reactExports, g as HiMiniCheckCircle, b as HiMiniExclamationTriangle, f as formatRelativeTime, h as HiMiniXCircle, ay as HiMiniClock, az as IconActionButton, ap as HiMiniTrash, I as HiMiniWrenchScrewdriver, aA as HiMiniBeaker, ab as HiMiniMagnifyingGlass, p as EmptyState, aB as HiMiniBugAnt, aC as fetchPackageFirewallStatus, aD as runPackageFirewallAction, am as GuardHarnessActionError, aE as runPackageAudit, aF as runPackageSync, aG as startPackageFirewallConnect, aH as openPackageFirewallShell, S as SectionLabel, aI as HiMiniArrowDown, aJ as HiMiniArrowUp, aK as fetchSupplyChainBundle, B as Badge, aL as fetchReceipts, n as harnessDisplayName, d as HiMiniChevronUp, e as HiMiniChevronDown } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, T as Tag, A as ActionButton, ao as HiMiniArrowPath, H as HiMiniShieldCheck, aw as HiMiniArrowTopRightOnSquare, r as reactExports, g as HiMiniCheckCircle, b as HiMiniExclamationTriangle, f as formatRelativeTime, h as HiMiniXCircle, ay as HiMiniClock, az as IconActionButton, ap as HiMiniTrash, I as HiMiniWrenchScrewdriver, aA as HiMiniBeaker, ab as HiMiniMagnifyingGlass, p as EmptyState, aB as HiMiniBugAnt, aC as fetchPackageFirewallStatus, aD as runPackageFirewallAction, am as GuardHarnessActionError, aE as runPackageAudit, aF as runPackageSync, aG as startPackageFirewallConnect, aH as openPackageFirewallShell, S as SectionLabel, aI as HiMiniArrowDown, aJ as HiMiniArrowUp, aK as fetchSupplyChainBundle, B as Badge, aL as HiMiniDocumentMagnifyingGlass, aM as HiMiniShieldExclamation, aN as fetchReceipts, n as harnessDisplayName, d as HiMiniChevronUp, e as HiMiniChevronDown } from "../guard-dashboard.js";
 import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 import { b as resolvePackageManagerProtectionCopy } from "./runtime-overview.js";
 const SEVERITY_RANK = {
@@ -15,7 +15,7 @@ const DECISION_RANK = {
   monitor: 1,
   allow: 0
 };
-function isRecord$1(value) {
+function isRecord$2(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function readString$1(value) {
@@ -67,7 +67,7 @@ function normalizeReasons(value) {
   }
   const reasons = [];
   for (const entry of value) {
-    if (!isRecord$1(entry)) {
+    if (!isRecord$2(entry)) {
       continue;
     }
     const message = readString$1(entry.message) ?? readString$1(entry.summary) ?? "Flagged by Guard supply-chain policy.";
@@ -192,7 +192,7 @@ function normalizePackageFindings(value) {
   const findings = [];
   let index = 0;
   for (const entry of value) {
-    if (!isRecord$1(entry)) {
+    if (!isRecord$2(entry)) {
       continue;
     }
     const finding = normalizePackageFinding(entry, index);
@@ -214,17 +214,17 @@ function packageRecordsFromEvaluation(evaluation) {
   return normalizePackageFindings(evaluation.package_findings);
 }
 function isAuditEvidence(value) {
-  return isRecord$1(value) && value.operation === "audit";
+  return isRecord$2(value) && value.operation === "audit";
 }
 function normalizeSupplyChainAuditSnapshot(raw, receiptId = null) {
-  if (!isRecord$1(raw)) {
+  if (!isRecord$2(raw)) {
     return null;
   }
-  const evaluation = isRecord$1(raw.evaluation) ? raw.evaluation : null;
+  const evaluation = isRecord$2(raw.evaluation) ? raw.evaluation : null;
   const findingsFromEvidence = normalizePackageFindings(raw.package_findings);
   const findings = findingsFromEvidence.length > 0 ? findingsFromEvidence : packageRecordsFromEvaluation(evaluation);
   const generatedAt = readString$1(raw.generated_at) ?? readString$1(raw.generatedAt) ?? (/* @__PURE__ */ new Date(0)).toISOString();
-  const inventory = normalizeInventory(isRecord$1(raw.inventory) ? raw.inventory : null);
+  const inventory = normalizeInventory(isRecord$2(raw.inventory) ? raw.inventory : null);
   const decision = normalizeDecision(evaluation?.decision ?? raw.audit_decision);
   const manifestPaths = readStringArray$1(raw.manifest_paths);
   const lockfilePaths = readStringArray$1(raw.lockfile_paths);
@@ -249,7 +249,7 @@ function derivePackageWorkbenchFromReceipts(receipts) {
   ).sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp));
   for (const receipt of auditReceipts) {
     const evidenceRaw = (receipt.scanner_evidence ?? []).find((entry) => isAuditEvidence(entry));
-    if (evidenceRaw === void 0 || !isRecord$1(evidenceRaw)) {
+    if (evidenceRaw === void 0 || !isRecord$2(evidenceRaw)) {
       continue;
     }
     const snapshot = normalizeSupplyChainAuditSnapshot(
@@ -331,7 +331,7 @@ function filterPackageWorkbenchFindings(findings, filters) {
 function packageWorkbenchEcosystems(findings) {
   return Array.from(new Set(findings.map((finding) => finding.ecosystem))).sort();
 }
-function isRecord(value) {
+function isRecord$1(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 function readString(value) {
@@ -348,13 +348,13 @@ function readStringArray(value) {
   return value.filter((entry) => typeof entry === "string" && entry.trim().length > 0).map((entry) => entry.trim());
 }
 function parseAuditActionResult(result) {
-  const evaluation = isRecord(result.evaluation) ? result.evaluation : null;
+  const evaluation = isRecord$1(result.evaluation) ? result.evaluation : null;
   const decision = readString(evaluation?.decision) ?? readString(result.decision) ?? "monitor";
   const manifestPaths = readStringArray(result.manifest_paths);
   const lockfilePaths = readStringArray(result.lockfile_paths);
-  const inventory = isRecord(result.inventory) ? result.inventory : null;
+  const inventory = isRecord$1(result.inventory) ? result.inventory : null;
   const packageCount = typeof inventory?.packages === "number" ? inventory.packages : null;
-  const lockfileWarnings = Array.isArray(result.lockfile_warnings) ? result.lockfile_warnings.filter(isRecord) : [];
+  const lockfileWarnings = Array.isArray(result.lockfile_warnings) ? result.lockfile_warnings.filter(isRecord$1) : [];
   const lines = [];
   if (manifestPaths.length > 0) {
     lines.push(`Manifests scanned: ${manifestPaths.join(", ")}.`);
@@ -415,18 +415,18 @@ function parseTestActionResult(result) {
   };
 }
 function parsePackageFirewallActionResult(op, body) {
-  if (!isRecord(body)) {
+  if (!isRecord$1(body)) {
     return null;
   }
   let result;
-  if (isRecord(body.result)) {
+  if (isRecord$1(body.result)) {
     result = body.result;
-  } else if (isRecord(body.result_detail)) {
+  } else if (isRecord$1(body.result_detail)) {
     result = body.result_detail;
   } else {
     result = body;
   }
-  if (!isRecord(result)) {
+  if (!isRecord$1(result)) {
     return null;
   }
   if (op === "audit") {
@@ -1101,10 +1101,11 @@ function FirewallControlsView({
     },
     [onInstall, onOpenShell, onRepair, onSync, onTest]
   );
+  const noDetectedManagers = data.detected_managers.length === 0;
   const filteredManagers = reactExports.useMemo(() => {
     const shimsByManager = new Map(data.package_shims.map((s) => [s.manager, s]));
     const visibleManagers = data.package_shims.filter((shim) => shim.detected || shim.installed || shim.tested).map((shim) => shim.manager);
-    let managers = visibleManagers.length > 0 ? Array.from(new Set(visibleManagers)).sort() : data.supported_managers;
+    let managers = visibleManagers.length > 0 ? Array.from(new Set(visibleManagers)).sort() : noDetectedManagers ? [] : data.supported_managers;
     if (managerFilter) {
       const q = managerFilter.toLowerCase();
       managers = managers.filter((m) => m.toLowerCase().includes(q));
@@ -1120,7 +1121,7 @@ function FirewallControlsView({
       });
     }
     return managers;
-  }, [data, managerFilter, statusFilter]);
+  }, [data, managerFilter, noDetectedManagers, statusFilter]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-4 py-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(NextActionHero, { action: nextAction, anyPending, onRunAction: handleNextAction }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-2", children: [
@@ -1178,8 +1179,8 @@ function FirewallControlsView({
     filteredManagers.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       EmptyState,
       {
-        title: "No package managers found",
-        body: "No package managers match the current filter, or Guard has not detected any on this machine.",
+        title: noDetectedManagers && managerFilter.length === 0 && statusFilter === "all" ? "No package managers detected" : "No package managers found",
+        body: noDetectedManagers && managerFilter.length === 0 && statusFilter === "all" ? "Guard did not find npm, pip, pnpm, or other supported managers on this PATH. Install a package manager, open a new shell, then refresh status." : "No package managers match the current filter, or Guard has not detected any on this machine.",
         tone: "teach"
       }
     ) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { role: "table", "aria-label": "Package manager firewall status", children: [
@@ -2072,6 +2073,226 @@ function SupplyChainBundlePanel() {
     ] })
   ] });
 }
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function readOperation(value) {
+  if (!isRecord(value) || typeof value.operation !== "string") {
+    return null;
+  }
+  const trimmed = value.operation.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+function receiptEvidenceOperations(receipt) {
+  const operations = [];
+  for (const entry of receipt.scanner_evidence ?? []) {
+    const operation = readOperation(entry);
+    if (operation !== null) {
+      operations.push(operation);
+    }
+  }
+  return operations;
+}
+function isPackageBlockReceipt(receipt) {
+  if (receipt.policy_decision !== "block") {
+    return false;
+  }
+  if (receipt.harness === "package-firewall") {
+    return true;
+  }
+  const artifactName = receipt.artifact_name?.toLowerCase() ?? "";
+  const artifactId = receipt.artifact_id.toLowerCase();
+  const summary = receipt.capabilities_summary.toLowerCase();
+  return artifactName.includes("package") || artifactId.includes("package") || summary.includes("install") || summary.includes("package");
+}
+function emptyRailItem(kind) {
+  const labels = {
+    block: {
+      title: "No blocked installs yet",
+      detail: "Guard will record the last prevented package install here."
+    },
+    audit: {
+      title: "No workspace audit yet",
+      detail: "Run an audit to scan lockfiles and manifest paths on this machine."
+    },
+    sync: {
+      title: "No policy sync yet",
+      detail: "Sync pulls the latest Guard supply-chain policy to this device."
+    }
+  };
+  return {
+    kind,
+    timestamp: null,
+    title: labels[kind].title,
+    detail: labels[kind].detail,
+    receiptId: null,
+    tone: "slate"
+  };
+}
+function blockRailItem(receipt) {
+  const label = receipt.artifact_name?.trim();
+  return {
+    kind: "block",
+    timestamp: receipt.timestamp,
+    title: label !== void 0 && label.length > 0 ? `Blocked: ${label}` : "Blocked package install",
+    detail: receipt.capabilities_summary.trim().length > 0 ? receipt.capabilities_summary : "Guard blocked a package install before it completed.",
+    receiptId: receipt.receipt_id,
+    tone: "attention"
+  };
+}
+function auditRailItem(receipt) {
+  const evidence = (receipt.scanner_evidence ?? []).find(
+    (entry) => readOperation(entry) === "audit"
+  );
+  const decision = isRecord(evidence) && typeof evidence.audit_decision === "string" ? evidence.audit_decision : receipt.policy_decision;
+  const blockedCount = isRecord(evidence) && typeof evidence.blocked_package_count === "number" ? evidence.blocked_package_count : 0;
+  const totalPackages = isRecord(evidence) && typeof evidence.total_packages === "number" ? evidence.total_packages : blockedCount;
+  const detail = receipt.capabilities_summary.trim().length > 0 ? receipt.capabilities_summary : `Workspace audit returned ${decision} across ${totalPackages} package(s).`;
+  return {
+    kind: "audit",
+    timestamp: receipt.timestamp,
+    title: blockedCount > 0 ? `Audit flagged ${blockedCount} package(s)` : "Workspace audit completed",
+    detail,
+    receiptId: receipt.receipt_id,
+    tone: blockedCount > 0 || decision === "block" ? "attention" : "green"
+  };
+}
+function syncRailItem(receipt) {
+  return {
+    kind: "sync",
+    timestamp: receipt.timestamp,
+    title: "Policy sync completed",
+    detail: receipt.capabilities_summary.trim().length > 0 ? receipt.capabilities_summary : "Guard refreshed local supply-chain policy from the connected source.",
+    receiptId: receipt.receipt_id,
+    tone: "green"
+  };
+}
+function latestReceiptMatching(receipts, predicate) {
+  const matches = receipts.filter(predicate).sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp));
+  return matches[0] ?? null;
+}
+function deriveSupplyChainEvidenceRail(receipts) {
+  const blockReceipt = latestReceiptMatching(receipts, isPackageBlockReceipt);
+  const auditReceipt = latestReceiptMatching(receipts, (receipt) => {
+    if (receipt.harness !== "package-firewall") {
+      return false;
+    }
+    return receiptEvidenceOperations(receipt).includes("audit");
+  });
+  const syncReceipt = latestReceiptMatching(receipts, (receipt) => {
+    if (receipt.harness !== "package-firewall") {
+      return false;
+    }
+    return receiptEvidenceOperations(receipt).includes("sync");
+  });
+  return {
+    block: blockReceipt !== null ? blockRailItem(blockReceipt) : emptyRailItem("block"),
+    audit: auditReceipt !== null ? auditRailItem(auditReceipt) : emptyRailItem("audit"),
+    sync: syncReceipt !== null ? syncRailItem(syncReceipt) : emptyRailItem("sync")
+  };
+}
+function resolveSupplyChainCloudDegradedState(snapshot) {
+  if (snapshot.cloud_state !== "local_only") {
+    return {
+      active: false,
+      title: "",
+      detail: ""
+    };
+  }
+  return {
+    active: true,
+    title: "Guard Cloud unavailable on this device",
+    detail: snapshot.cloud_state_detail.trim().length > 0 ? snapshot.cloud_state_detail : "Local protection still runs, but live intel, fleet sync, and cross-device evidence stay offline until you connect Guard Cloud."
+  };
+}
+function supplyChainEvidenceHref(receiptId) {
+  if (receiptId === null) {
+    return null;
+  }
+  return `/evidence?harness=package-firewall&search=${encodeURIComponent(receiptId)}`;
+}
+const kindLabels = {
+  block: "Last block",
+  audit: "Last audit",
+  sync: "Last sync"
+};
+const kindIcons = {
+  block: HiMiniShieldExclamation,
+  audit: HiMiniDocumentMagnifyingGlass,
+  sync: HiMiniArrowPath
+};
+function EvidenceRailRow({ item }) {
+  const Icon = kindIcons[item.kind];
+  const href = supplyChainEvidenceHref(item.receiptId);
+  const tagTone = item.tone === "green" ? "green" : item.tone === "attention" ? "attention" : "slate";
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4 py-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "span",
+      {
+        className: "inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-slate-50 text-slate-500",
+        "aria-hidden": "true",
+        children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4" })
+      }
+    ),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1 space-y-1.5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400", children: kindLabels[item.kind] }),
+        item.timestamp !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: tagTone, children: formatRelativeTime(item.timestamp) }) : /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: "Waiting" })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: item.title }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-slate-500", children: item.detail }),
+      href !== null ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "a",
+        {
+          href,
+          className: "inline-flex items-center gap-1 text-xs font-medium text-brand-blue hover:underline focus:outline-none focus:ring-2 focus:ring-brand-blue/30 rounded",
+          children: [
+            "Open evidence",
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
+          ]
+        }
+      ) : null
+    ] })
+  ] }) });
+}
+function SupplyChainEvidenceRail({ rail }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "section",
+    {
+      className: "overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm",
+      "aria-label": "Recent supply chain evidence",
+      "data-testid": "supply-chain-evidence-rail",
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-b border-slate-100 px-4 py-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Recent evidence" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: "Latest block, audit, and policy sync recorded on this machine." })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "divide-y divide-slate-100", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(EvidenceRailRow, { item: rail.block }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(EvidenceRailRow, { item: rail.audit }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(EvidenceRailRow, { item: rail.sync })
+        ] })
+      ]
+    }
+  );
+}
+function SupplyChainCloudDegradedBanner({ state }) {
+  if (!state.active) {
+    return null;
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      className: "rounded-2xl border border-amber-200 bg-amber-50/70 px-4 py-3",
+      role: "status",
+      "data-testid": "supply-chain-cloud-degraded",
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-amber-950", children: state.title }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-amber-900/90", children: state.detail })
+      ]
+    }
+  );
+}
 function resolveManagerCoverageStatus(protection, manager) {
   if (!protection) return "unprotected";
   if (protection.protected_managers.includes(manager)) return "protected";
@@ -2171,24 +2392,31 @@ function SupplyChainWorkspace({
     [snapshot.managed_installs]
   );
   const [auditSnapshot, setAuditSnapshot] = reactExports.useState(null);
+  const [evidenceRail, setEvidenceRail] = reactExports.useState(null);
   const [auditRunning, setAuditRunning] = reactExports.useState(false);
   const runAuditRef = reactExports.useRef(null);
+  const cloudDegraded = reactExports.useMemo(
+    () => resolveSupplyChainCloudDegradedState(snapshot),
+    [snapshot]
+  );
   reactExports.useEffect(() => {
     let cancelled = false;
-    const loadAuditSnapshot = async () => {
+    const loadReceiptEvidence = async () => {
       try {
         const receipts = await fetchReceipts();
         if (cancelled) {
           return;
         }
         setAuditSnapshot(derivePackageWorkbenchFromReceipts(receipts));
+        setEvidenceRail(deriveSupplyChainEvidenceRail(receipts));
       } catch {
         if (!cancelled) {
           setAuditSnapshot(null);
+          setEvidenceRail(null);
         }
       }
     };
-    void loadAuditSnapshot();
+    void loadReceiptEvidence();
     return () => {
       cancelled = true;
     };
@@ -2208,6 +2436,7 @@ function SupplyChainWorkspace({
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: "Package manager firewall status, prevented installs, and feed health." }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "ghost", onClick: onGoHome, children: "Back to Home" })
     ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainCloudDegradedBanner, { state: cloudDegraded }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2 lg:grid-cols-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Active apps", value: stats.activeApps, tone: "green" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Prevented installs", value: stats.preventedInstalls, tone: stats.preventedInstalls > 0 ? "attention" : "slate" }),
@@ -2221,6 +2450,7 @@ function SupplyChainWorkspace({
       ),
       /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Unprotected managers", value: stats.unprotectedManagers, tone: stats.unprotectedManagers > 0 ? "attention" : "slate" })
     ] }),
+    evidenceRail !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainEvidenceRail, { rail: evidenceRail }) : null,
     /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainBundlePanel, {}),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       PackageFirewallPanel,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1105,7 +1105,14 @@ function FirewallControlsView({
   const filteredManagers = reactExports.useMemo(() => {
     const shimsByManager = new Map(data.package_shims.map((s) => [s.manager, s]));
     const visibleManagers = data.package_shims.filter((shim) => shim.detected || shim.installed || shim.tested).map((shim) => shim.manager);
-    let managers = visibleManagers.length > 0 ? Array.from(new Set(visibleManagers)).sort() : noDetectedManagers ? [] : data.supported_managers;
+    let managers;
+    if (visibleManagers.length > 0) {
+      managers = Array.from(new Set(visibleManagers)).sort();
+    } else if (noDetectedManagers) {
+      managers = [];
+    } else {
+      managers = data.supported_managers;
+    }
     if (managerFilter) {
       const q = managerFilter.toLowerCase();
       managers = managers.filter((m) => m.toLowerCase().includes(q));
@@ -2097,6 +2104,10 @@ function isPackageBlockReceipt(receipt) {
   if (receipt.policy_decision !== "block") {
     return false;
   }
+  const operations = receiptEvidenceOperations(receipt);
+  if (operations.includes("audit") || operations.includes("sync")) {
+    return false;
+  }
   if (receipt.harness === "package-firewall") {
     return true;
   }
@@ -2126,6 +2137,7 @@ function emptyRailItem(kind) {
     title: labels[kind].title,
     detail: labels[kind].detail,
     receiptId: null,
+    harness: null,
     tone: "slate"
   };
 }
@@ -2137,6 +2149,7 @@ function blockRailItem(receipt) {
     title: label !== void 0 && label.length > 0 ? `Blocked: ${label}` : "Blocked package install",
     detail: receipt.capabilities_summary.trim().length > 0 ? receipt.capabilities_summary : "Guard blocked a package install before it completed.",
     receiptId: receipt.receipt_id,
+    harness: receipt.harness,
     tone: "attention"
   };
 }
@@ -2154,6 +2167,7 @@ function auditRailItem(receipt) {
     title: blockedCount > 0 ? `Audit flagged ${blockedCount} package(s)` : "Workspace audit completed",
     detail,
     receiptId: receipt.receipt_id,
+    harness: receipt.harness,
     tone: blockedCount > 0 || decision === "block" ? "attention" : "green"
   };
 }
@@ -2164,6 +2178,7 @@ function syncRailItem(receipt) {
     title: "Policy sync completed",
     detail: receipt.capabilities_summary.trim().length > 0 ? receipt.capabilities_summary : "Guard refreshed local supply-chain policy from the connected source.",
     receiptId: receipt.receipt_id,
+    harness: receipt.harness,
     tone: "green"
   };
 }
@@ -2205,11 +2220,16 @@ function resolveSupplyChainCloudDegradedState(snapshot) {
     detail: snapshot.cloud_state_detail.trim().length > 0 ? snapshot.cloud_state_detail : "Local protection still runs, but live intel, fleet sync, and cross-device evidence stay offline until you connect Guard Cloud."
   };
 }
-function supplyChainEvidenceHref(receiptId) {
+function supplyChainEvidenceHref(receiptId, harness) {
   if (receiptId === null) {
     return null;
   }
-  return `/evidence?harness=package-firewall&search=${encodeURIComponent(receiptId)}`;
+  const params = new URLSearchParams();
+  if (harness !== null && harness.trim().length > 0) {
+    params.set("harness", harness);
+  }
+  params.set("search", receiptId);
+  return `/evidence?${params.toString()}`;
 }
 const kindLabels = {
   block: "Last block",
@@ -2223,7 +2243,7 @@ const kindIcons = {
 };
 function EvidenceRailRow({ item }) {
   const Icon = kindIcons[item.kind];
-  const href = supplyChainEvidenceHref(item.receiptId);
+  const href = supplyChainEvidenceHref(item.receiptId, item.harness);
   const tagTone = item.tone === "green" ? "green" : item.tone === "attention" ? "attention" : "slate";
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4 py-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12712,6 +12712,9 @@ function HiMiniSparkles(props) {
 function HiMiniSignal(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M16.364 3.636a.75.75 0 0 0-1.06 1.06 7.5 7.5 0 0 1 0 10.607.75.75 0 0 0 1.06 1.061 9 9 0 0 0 0-12.728ZM4.697 4.697a.75.75 0 0 0-1.061-1.061 9 9 0 0 0 0 12.728.75.75 0 1 0 1.06-1.06 7.5 7.5 0 0 1 0-10.607Z" }, "child": [] }, { "tag": "path", "attr": { "d": "M12.475 6.464a.75.75 0 0 1 1.06 0 5 5 0 0 1 0 7.072.75.75 0 0 1-1.06-1.061 3.5 3.5 0 0 0 0-4.95.75.75 0 0 1 0-1.06ZM7.525 6.464a.75.75 0 0 1 0 1.061 3.5 3.5 0 0 0 0 4.95.75.75 0 0 1-1.06 1.06 5 5 0 0 1 0-7.07.75.75 0 0 1 1.06 0ZM11 10a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z" }, "child": [] }] })(props);
 }
+function HiMiniShieldExclamation(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M10.339 2.237a.531.531 0 0 0-.678 0 11.947 11.947 0 0 1-7.078 2.75.5.5 0 0 0-.479.425A12.11 12.11 0 0 0 2 7c0 5.163 3.26 9.564 7.834 11.257a.48.48 0 0 0 .332 0C14.74 16.564 18 12.163 18 7c0-.538-.035-1.069-.104-1.589a.5.5 0 0 0-.48-.425 11.947 11.947 0 0 1-7.077-2.75ZM10 6a.75.75 0 0 1 .75.75v3.5a.75.75 0 0 1-1.5 0v-3.5A.75.75 0 0 1 10 6Zm0 9a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
 function HiMiniShieldCheck(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M9.661 2.237a.531.531 0 0 1 .678 0 11.947 11.947 0 0 0 7.078 2.749.5.5 0 0 1 .479.425c.069.52.104 1.05.104 1.59 0 5.162-3.26 9.563-7.834 11.256a.48.48 0 0 1-.332 0C5.26 16.564 2 12.163 2 7c0-.538.035-1.069.104-1.589a.5.5 0 0 1 .48-.425 11.947 11.947 0 0 0 7.077-2.75Zm4.196 5.954a.75.75 0 0 0-1.214-.882l-3.483 4.79-1.88-1.88a.75.75 0 1 0-1.06 1.061l2.5 2.5a.75.75 0 0 0 1.137-.089l4-5.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
@@ -25302,13 +25305,15 @@ export {
   HiMiniArrowDown as aI,
   HiMiniArrowUp as aJ,
   fetchSupplyChainBundle as aK,
-  fetchReceipts as aL,
-  runAuditRemediation as aM,
-  HiMiniDocumentText as aN,
-  guardAwareHref as aO,
-  HiMiniBarsArrowUp as aP,
-  HiMiniBarsArrowDown as aQ,
-  HiMiniSignal as aR,
+  HiMiniDocumentMagnifyingGlass as aL,
+  HiMiniShieldExclamation as aM,
+  fetchReceipts as aN,
+  runAuditRemediation as aO,
+  HiMiniDocumentText as aP,
+  guardAwareHref as aQ,
+  HiMiniBarsArrowUp as aR,
+  HiMiniBarsArrowDown as aS,
+  HiMiniSignal as aT,
   setupDesktopNotifications as aa,
   HiMiniMagnifyingGlass as ab,
   approvalGateCooldownLabel as ac,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -96,6 +96,7 @@
     --color-amber-700: oklch(55.5% .163 48.998);
     --color-amber-800: oklch(47.3% .137 46.201);
     --color-amber-900: oklch(41.4% .112 45.904);
+    --color-amber-950: oklch(27.9% .077 45.635);
     --color-green-50: oklch(98.2% .018 155.826);
     --color-green-700: oklch(52.7% .154 150.069);
     --color-emerald-50: oklch(97.9% .021 166.113);
@@ -3786,6 +3787,20 @@
 
   .text-amber-900 {
     color: var(--color-amber-900);
+  }
+
+  .text-amber-900\/90 {
+    color: #7b3306e6;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .text-amber-900\/90 {
+      color: color-mix(in oklab, var(--color-amber-900) 90%, transparent);
+    }
+  }
+
+  .text-amber-950 {
+    color: var(--color-amber-950);
   }
 
   .text-blue-200 {


### PR DESCRIPTION
## Summary
- Add local Supply Chain evidence rail for last block, audit, and sync receipts (SCSR154).
- Add dedicated empty state when Guard detects no package managers on PATH (SCSR159).
- Add Cloud-unavailable degraded banner when the device runs in local-only mode (SCSR163).

## Testing
- `cd dashboard && ./node_modules/.bin/tsx src/scsr-phase09c-evidence-rail.test.ts`
- `cd dashboard && npm run build`
