### PR TITLE
feat(hol-guard): supply chain local vs cloud capabilities

### DIFF
--- a/dashboard/src/scsr-phase09g-cloud-capabilities.test.ts
+++ b/dashboard/src/scsr-phase09g-cloud-capabilities.test.ts
@@ -1,0 +1,107 @@
+import { resolveSupplyChainCloudCapabilities } from "./supply-chain-cloud-capabilities";
+import type { GuardRuntimeSnapshot } from "./guard-types";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const baseSnapshot: GuardRuntimeSnapshot = {
+  generated_at: new Date().toISOString(),
+  approval_center_url: null,
+  runtime_state: {},
+  device: {
+    installation_id: "install-1",
+    device_label: "Test Machine",
+    local_registered: false,
+  },
+  latest_connect_state: null,
+  proof_status: {
+    state: "not_connected",
+    label: "Not connected",
+    detail: "",
+    request_id: null,
+    pairing_completed_at: null,
+    first_synced_at: null,
+    receipts_stored: 0,
+    inventory_items: 0,
+    runtime_session_id: null,
+    runtime_session_synced_at: null,
+  },
+  pending_count: 0,
+  receipt_count: 0,
+  headline_state: "local_only",
+  headline_label: "Local only",
+  headline_detail: "",
+  sync_configured: false,
+  cloud_state: "local_only",
+  cloud_state_label: "Local only",
+  cloud_state_detail: "",
+  cloud_pairing_state: {
+    state: "local_only",
+    label: "Local only",
+    detail: "",
+    sync_configured: false,
+    dashboard_url: "",
+    inbox_url: "",
+    fleet_url: "",
+    connect_url: "",
+  },
+  cloud_sync_health: {
+    state: "healthy",
+    label: "Healthy",
+    detail: "",
+    pending_events: 0,
+    last_synced_at: null,
+    next_retry_after: null,
+  },
+  dashboard_url: "",
+  inbox_url: "",
+  fleet_url: "",
+  connect_url: "",
+  items: [],
+  latest_receipts: [],
+  managed_installs: [],
+  supply_chain: undefined,
+};
+
+const localOnly = resolveSupplyChainCloudCapabilities(baseSnapshot);
+assert(localOnly.mode === "local_only", "SCSR156: local-only mode resolves free vs cloud capabilities");
+assert(
+  localOnly.localCapabilities.every((item) => item.available),
+  "SCSR156: local free capabilities are marked available",
+);
+assert(
+  localOnly.cloudCapabilities.every((item) => !item.available),
+  "SCSR156: cloud capabilities stay unavailable without pairing",
+);
+
+const pairedActive = resolveSupplyChainCloudCapabilities({
+  ...baseSnapshot,
+  cloud_state: "paired_active",
+  cloud_state_label: "Connected",
+  cloud_state_detail: "Live feed active",
+});
+assert(pairedActive.mode === "paired_active", "SCSR155: paired active resolves connected state");
+assert(
+  pairedActive.detail.includes("Local protection still runs"),
+  "SCSR155: paired active copy keeps local protection visible",
+);
+assert(
+  pairedActive.cloudCapabilities.every((item) => item.available),
+  "SCSR155: paired active marks cloud capabilities available",
+);
+
+const pairedWaiting = resolveSupplyChainCloudCapabilities({
+  ...baseSnapshot,
+  cloud_state: "paired_waiting",
+  cloud_state_label: "Pairing",
+});
+assert(pairedWaiting.mode === "paired_waiting", "SCSR155-B: paired waiting resolves in-progress state");
+assert(
+  pairedWaiting.localCapabilities.every((item) => item.available),
+  "SCSR155-B: pairing state keeps local capabilities available",
+);
+
+console.log("scsr-phase09g-cloud-capabilities.test.ts: all assertions passed");

--- a/dashboard/src/supply-chain-cloud-capabilities-panel.tsx
+++ b/dashboard/src/supply-chain-cloud-capabilities-panel.tsx
@@ -1,0 +1,73 @@
+import { HiMiniCheckCircle, HiMiniCloud, HiMiniComputerDesktop } from "react-icons/hi2";
+import type { SupplyChainCapabilityItem, SupplyChainCloudCapabilitiesState } from "./supply-chain-cloud-capabilities";
+
+type SupplyChainCloudCapabilitiesPanelProps = {
+  state: SupplyChainCloudCapabilitiesState;
+};
+
+type CapabilityListProps = {
+  heading: string;
+  icon: typeof HiMiniComputerDesktop;
+  items: SupplyChainCapabilityItem[];
+};
+
+function CapabilityList({ heading, icon: Icon, items }: CapabilityListProps) {
+  return (
+    <div className="min-w-0 rounded-xl border border-slate-100 bg-white/80 p-4">
+      <div className="mb-3 flex items-center gap-2">
+        <Icon className="h-4 w-4 shrink-0 text-slate-500" aria-hidden="true" />
+        <h3 className="text-sm font-semibold text-brand-dark">{heading}</h3>
+      </div>
+      <ul className="space-y-2">
+        {items.map((item) => (
+          <li key={item.label} className="flex min-w-0 items-start gap-2 text-xs leading-relaxed">
+            <HiMiniCheckCircle
+              className={`mt-0.5 h-3.5 w-3.5 shrink-0 ${
+                item.available ? "text-brand-green" : "text-slate-300"
+              }`}
+              aria-hidden="true"
+            />
+            <span className={item.available ? "text-slate-600" : "text-slate-400"}>{item.label}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function panelToneClass(tone: SupplyChainCloudCapabilitiesState["tone"]): string {
+  if (tone === "green") {
+    return "border-brand-green/20 bg-brand-green/[0.04]";
+  }
+  if (tone === "blue") {
+    return "border-brand-blue/20 bg-brand-blue/[0.04]";
+  }
+  return "border-slate-200 bg-slate-50/80";
+}
+
+export function SupplyChainCloudCapabilitiesPanel({ state }: SupplyChainCloudCapabilitiesPanelProps) {
+  return (
+    <section
+      className={`rounded-2xl border px-4 py-4 ${panelToneClass(state.tone)}`}
+      aria-label="Local and Guard Cloud capabilities"
+      data-testid="supply-chain-cloud-capabilities"
+    >
+      <div className="min-w-0 space-y-1">
+        <p className="text-sm font-medium text-brand-dark">{state.title}</p>
+        <p className="text-xs leading-relaxed text-slate-600">{state.detail}</p>
+      </div>
+      <div className="mt-4 grid min-w-0 gap-3 md:grid-cols-2">
+        <CapabilityList
+          heading={state.localHeading}
+          icon={HiMiniComputerDesktop}
+          items={state.localCapabilities}
+        />
+        <CapabilityList
+          heading={state.cloudHeading}
+          icon={HiMiniCloud}
+          items={state.cloudCapabilities}
+        />
+      </div>
+    </section>
+  );
+}

--- a/dashboard/src/supply-chain-cloud-capabilities.ts
+++ b/dashboard/src/supply-chain-cloud-capabilities.ts
@@ -1,0 +1,85 @@
+import type { GuardRuntimeSnapshot } from "./guard-types";
+
+export type SupplyChainCapabilityItem = {
+  label: string;
+  available: boolean;
+};
+
+export type SupplyChainCloudCapabilitiesState = {
+  mode: GuardRuntimeSnapshot["cloud_state"];
+  title: string;
+  detail: string;
+  tone: "blue" | "green" | "slate";
+  localHeading: string;
+  cloudHeading: string;
+  localCapabilities: SupplyChainCapabilityItem[];
+  cloudCapabilities: SupplyChainCapabilityItem[];
+};
+
+const LOCAL_FREE_CAPABILITIES: SupplyChainCapabilityItem[] = [
+  { label: "Block risky package installs on this device", available: true },
+  { label: "Install and repair package tool protection", available: true },
+  { label: "Run workspace audits with on-device rules", available: true },
+  { label: "Review recent blocks and audits on this machine", available: true },
+];
+
+const CLOUD_CAPABILITIES: SupplyChainCapabilityItem[] = [
+  { label: "Live package warnings from Guard Cloud", available: false },
+  { label: "Sync policy and evidence across devices", available: false },
+  { label: "Fleet visibility for connected machines", available: false },
+  { label: "Cloud-backed audit and sync actions", available: false },
+];
+
+const CLOUD_ACTIVE_CAPABILITIES: SupplyChainCapabilityItem[] = CLOUD_CAPABILITIES.map(
+  (item) => ({ ...item, available: true }),
+);
+
+export function resolveSupplyChainCloudCapabilities(
+  snapshot: GuardRuntimeSnapshot,
+): SupplyChainCloudCapabilitiesState {
+  if (snapshot.cloud_state === "paired_active") {
+    return {
+      mode: "paired_active",
+      title: "Guard Cloud connected",
+      detail:
+        snapshot.cloud_state_detail.trim().length > 0
+          ? `${snapshot.cloud_state_detail} Local protection still runs on this device.`
+          : "Live package warnings and synced policy are active. Local protection still runs on this device.",
+      tone: "green",
+      localHeading: "Still on this device",
+      cloudHeading: "Now from Guard Cloud",
+      localCapabilities: LOCAL_FREE_CAPABILITIES,
+      cloudCapabilities: CLOUD_ACTIVE_CAPABILITIES,
+    };
+  }
+
+  if (snapshot.cloud_state === "paired_waiting") {
+    return {
+      mode: "paired_waiting",
+      title: "Guard Cloud pairing in progress",
+      detail:
+        snapshot.cloud_state_detail.trim().length > 0
+          ? snapshot.cloud_state_detail
+          : "Finish connecting this machine to Guard Cloud. Local package protection stays available while pairing completes.",
+      tone: "blue",
+      localHeading: "Available now on this device",
+      cloudHeading: "Unlocks after pairing",
+      localCapabilities: LOCAL_FREE_CAPABILITIES,
+      cloudCapabilities: CLOUD_CAPABILITIES,
+    };
+  }
+
+  return {
+    mode: "local_only",
+    title: "Local protection works on this device",
+    detail:
+      snapshot.cloud_state_detail.trim().length > 0
+        ? snapshot.cloud_state_detail
+        : "You can block installs and run audits locally for free. Connect Guard Cloud for live warnings, synced policy, and cross-device evidence.",
+    tone: "slate",
+    localHeading: "Free on this device",
+    cloudHeading: "Adds with Guard Cloud",
+    localCapabilities: LOCAL_FREE_CAPABILITIES,
+    cloudCapabilities: CLOUD_CAPABILITIES,
+  };
+}

--- a/dashboard/src/supply-chain-workspace.tsx
+++ b/dashboard/src/supply-chain-workspace.tsx
@@ -31,6 +31,8 @@ import {
   SupplyChainCloudDegradedBanner,
   SupplyChainEvidenceRail,
 } from "./supply-chain-evidence-rail-panel";
+import { resolveSupplyChainCloudCapabilities } from "./supply-chain-cloud-capabilities";
+import { SupplyChainCloudCapabilitiesPanel } from "./supply-chain-cloud-capabilities-panel";
 import { resolveSupplyChainPostureAlerts } from "./supply-chain-posture";
 import { SupplyChainPostureBanners } from "./supply-chain-posture-banners";
 import {
@@ -164,6 +166,10 @@ export function SupplyChainWorkspace({
     () => resolveSupplyChainPostureAlerts(snapshot),
     [snapshot],
   );
+  const cloudCapabilities = useMemo(
+    () => resolveSupplyChainCloudCapabilities(snapshot),
+    [snapshot],
+  );
   const protectedManagersStat = useMemo(
     () => resolveProtectedManagersStat(stats),
     [stats],
@@ -222,6 +228,8 @@ export function SupplyChainWorkspace({
       <SupplyChainCloudDegradedBanner state={cloudDegraded} />
 
       <SupplyChainPostureBanners alerts={postureAlerts} />
+
+      <SupplyChainCloudCapabilitiesPanel state={cloudCapabilities} />
 
       <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
         <StatCard label="Active apps" value={stats.activeApps} tone="green" />

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,8 +1,9 @@
-import { j as jsxRuntimeExports, a8 as Tag, A as ActionButton, am as HiMiniArrowPath, l as HiMiniShieldCheck, au as HiMiniArrowTopRightOnSquare, r as reactExports, d as HiMiniCheckCircle, v as HiMiniExclamationTriangle, m as formatRelativeTime, D as HiMiniXCircle, aw as HiMiniClock, ax as IconActionButton, an as HiMiniTrash, C as HiMiniWrenchScrewdriver, ay as HiMiniBeaker, a9 as HiMiniMagnifyingGlass, b as EmptyState, az as HiMiniBugAnt, o as HiMiniXMark, aA as fetchPackageFirewallStatus, aB as runPackageFirewallAction, ak as GuardHarnessActionError, aC as runPackageAudit, aD as runPackageSync, aE as startPackageFirewallConnect, aF as openPackageFirewallShell, S as SectionLabel, aG as HiMiniArrowDown, aH as HiMiniArrowUp, aI as fetchSupplyChainBundle, B as Badge, aJ as HiMiniDocumentMagnifyingGlass, aK as HiMiniShieldExclamation, aL as HiMiniInformationCircle, aM as fetchReceipts, h as harnessDisplayName, p as HiMiniChevronUp, q as HiMiniChevronDown } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, a8 as Tag, A as ActionButton, am as HiMiniArrowPath, l as HiMiniShieldCheck, au as HiMiniArrowTopRightOnSquare, r as reactExports, d as HiMiniCheckCircle, v as HiMiniExclamationTriangle, m as formatRelativeTime, D as HiMiniXCircle, aw as HiMiniClock, ax as IconActionButton, an as HiMiniTrash, C as HiMiniWrenchScrewdriver, ay as HiMiniBeaker, a9 as HiMiniMagnifyingGlass, b as EmptyState, az as HiMiniBugAnt, o as HiMiniXMark, aA as fetchPackageFirewallStatus, aB as runPackageFirewallAction, ak as GuardHarnessActionError, aC as runPackageAudit, aD as runPackageSync, aE as startPackageFirewallConnect, aF as openPackageFirewallShell, S as SectionLabel, aG as HiMiniArrowDown, aH as HiMiniArrowUp, aI as fetchSupplyChainBundle, B as Badge, aJ as HiMiniDocumentMagnifyingGlass, aK as HiMiniShieldExclamation, aL as HiMiniComputerDesktop, s as HiMiniCloud, aM as HiMiniInformationCircle, aN as fetchReceipts, h as harnessDisplayName, p as HiMiniChevronUp, q as HiMiniChevronDown } from "../guard-dashboard.js";
 import { u as useResolvedApprovalGate, A as ApprovalProofModal } from "./use-resolved-approval-gate.js";
 import { b as resolvePackageManagerProtectionCopy } from "./runtime-overview.js";
 import { resolveFeedStaleness } from "./feed-health-workspace.js";
 import { r as resolveHomeProtectionStatus } from "./home-protection-module.js";
+import { r as resolveProtectedManagersStat, S as SUPPLY_CHAIN_WORKSPACE_SHELL_CLASS } from "./supply-chain-hub-workspace.js";
 const SEVERITY_RANK = {
   critical: 4,
   high: 3,
@@ -2721,6 +2722,118 @@ function SupplyChainCloudDegradedBanner({ state }) {
     }
   );
 }
+const LOCAL_FREE_CAPABILITIES = [
+  { label: "Block risky package installs on this device", available: true },
+  { label: "Install and repair package tool protection", available: true },
+  { label: "Run workspace audits with on-device rules", available: true },
+  { label: "Review recent blocks and audits on this machine", available: true }
+];
+const CLOUD_CAPABILITIES = [
+  { label: "Live package warnings from Guard Cloud", available: false },
+  { label: "Sync policy and evidence across devices", available: false },
+  { label: "Fleet visibility for connected machines", available: false },
+  { label: "Cloud-backed audit and sync actions", available: false }
+];
+const CLOUD_ACTIVE_CAPABILITIES = CLOUD_CAPABILITIES.map(
+  (item) => ({ ...item, available: true })
+);
+function resolveSupplyChainCloudCapabilities(snapshot) {
+  if (snapshot.cloud_state === "paired_active") {
+    return {
+      mode: "paired_active",
+      title: "Guard Cloud connected",
+      detail: snapshot.cloud_state_detail.trim().length > 0 ? `${snapshot.cloud_state_detail} Local protection still runs on this device.` : "Live package warnings and synced policy are active. Local protection still runs on this device.",
+      tone: "green",
+      localHeading: "Still on this device",
+      cloudHeading: "Now from Guard Cloud",
+      localCapabilities: LOCAL_FREE_CAPABILITIES,
+      cloudCapabilities: CLOUD_ACTIVE_CAPABILITIES
+    };
+  }
+  if (snapshot.cloud_state === "paired_waiting") {
+    return {
+      mode: "paired_waiting",
+      title: "Guard Cloud pairing in progress",
+      detail: snapshot.cloud_state_detail.trim().length > 0 ? snapshot.cloud_state_detail : "Finish connecting this machine to Guard Cloud. Local package protection stays available while pairing completes.",
+      tone: "blue",
+      localHeading: "Available now on this device",
+      cloudHeading: "Unlocks after pairing",
+      localCapabilities: LOCAL_FREE_CAPABILITIES,
+      cloudCapabilities: CLOUD_CAPABILITIES
+    };
+  }
+  return {
+    mode: "local_only",
+    title: "Local protection works on this device",
+    detail: snapshot.cloud_state_detail.trim().length > 0 ? snapshot.cloud_state_detail : "You can block installs and run audits locally for free. Connect Guard Cloud for live warnings, synced policy, and cross-device evidence.",
+    tone: "slate",
+    localHeading: "Free on this device",
+    cloudHeading: "Adds with Guard Cloud",
+    localCapabilities: LOCAL_FREE_CAPABILITIES,
+    cloudCapabilities: CLOUD_CAPABILITIES
+  };
+}
+function CapabilityList({ heading, icon: Icon, items }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 rounded-xl border border-slate-100 bg-white/80 p-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-3 flex items-center gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4 shrink-0 text-slate-500", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-brand-dark", children: heading })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "space-y-2", children: items.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex min-w-0 items-start gap-2 text-xs leading-relaxed", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        HiMiniCheckCircle,
+        {
+          className: `mt-0.5 h-3.5 w-3.5 shrink-0 ${item.available ? "text-brand-green" : "text-slate-300"}`,
+          "aria-hidden": "true"
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: item.available ? "text-slate-600" : "text-slate-400", children: item.label })
+    ] }, item.label)) })
+  ] });
+}
+function panelToneClass(tone) {
+  if (tone === "green") {
+    return "border-brand-green/20 bg-brand-green/[0.04]";
+  }
+  if (tone === "blue") {
+    return "border-brand-blue/20 bg-brand-blue/[0.04]";
+  }
+  return "border-slate-200 bg-slate-50/80";
+}
+function SupplyChainCloudCapabilitiesPanel({ state }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "section",
+    {
+      className: `rounded-2xl border px-4 py-4 ${panelToneClass(state.tone)}`,
+      "aria-label": "Local and Guard Cloud capabilities",
+      "data-testid": "supply-chain-cloud-capabilities",
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 space-y-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: state.title }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-slate-600", children: state.detail })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 grid min-w-0 gap-3 md:grid-cols-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            CapabilityList,
+            {
+              heading: state.localHeading,
+              icon: HiMiniComputerDesktop,
+              items: state.localCapabilities
+            }
+          ),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            CapabilityList,
+            {
+              heading: state.cloudHeading,
+              icon: HiMiniCloud,
+              items: state.cloudCapabilities
+            }
+          )
+        ] })
+      ]
+    }
+  );
+}
 function resolveSupplyChainPostureAlerts(snapshot) {
   const alerts = [];
   const protection = snapshot.supply_chain?.package_manager_protection;
@@ -2834,28 +2947,6 @@ function SupplyChainPostureBanners({ alerts }) {
     }
   );
 }
-const SUPPLY_CHAIN_WORKSPACE_SHELL_CLASS = "min-w-0 max-w-full space-y-6 overflow-x-hidden";
-function resolveProtectedManagersStat(stats) {
-  if (stats.stagedManagers > 0) {
-    return {
-      label: "Ready after restart",
-      value: stats.stagedManagers,
-      tone: "blue"
-    };
-  }
-  if (stats.repairRequiredManagers > 0) {
-    return {
-      label: "Needs path fix",
-      value: stats.repairRequiredManagers,
-      tone: "attention"
-    };
-  }
-  return {
-    label: "Protected tools",
-    value: stats.protectedManagers,
-    tone: "green"
-  };
-}
 function StatCard({ label, value, tone = "slate" }) {
   const toneClass = tone === "green" ? "text-brand-green" : tone === "attention" ? "text-brand-attention" : tone === "blue" ? "text-brand-blue" : "text-brand-dark";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-white p-4 shadow-sm", children: [
@@ -2931,6 +3022,10 @@ function SupplyChainWorkspace({
     () => resolveSupplyChainPostureAlerts(snapshot),
     [snapshot]
   );
+  const cloudCapabilities = reactExports.useMemo(
+    () => resolveSupplyChainCloudCapabilities(snapshot),
+    [snapshot]
+  );
   const protectedManagersStat = reactExports.useMemo(
     () => resolveProtectedManagersStat(stats),
     [stats]
@@ -2974,6 +3069,7 @@ function SupplyChainWorkspace({
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainCloudDegradedBanner, { state: cloudDegraded }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainPostureBanners, { alerts: postureAlerts }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SupplyChainCloudCapabilitiesPanel, { state: cloudCapabilities }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 sm:grid-cols-2 lg:grid-cols-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Active apps", value: stats.activeApps, tone: "green" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(StatCard, { label: "Prevented installs", value: stats.preventedInstalls, tone: stats.preventedInstalls > 0 ? "attention" : "slate" }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12787,6 +12787,9 @@ function HiMiniCube(props) {
 function HiMiniCpuChip(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M14 6H6v8h8V6Z" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M9.25 3V1.75a.75.75 0 0 1 1.5 0V3h1.5V1.75a.75.75 0 0 1 1.5 0V3h.5A2.75 2.75 0 0 1 17 5.75v.5h1.25a.75.75 0 0 1 0 1.5H17v1.5h1.25a.75.75 0 0 1 0 1.5H17v1.5h1.25a.75.75 0 0 1 0 1.5H17v.5A2.75 2.75 0 0 1 14.25 17h-.5v1.25a.75.75 0 0 1-1.5 0V17h-1.5v1.25a.75.75 0 0 1-1.5 0V17h-1.5v1.25a.75.75 0 0 1-1.5 0V17h-.5A2.75 2.75 0 0 1 3 14.25v-.5H1.75a.75.75 0 0 1 0-1.5H3v-1.5H1.75a.75.75 0 0 1 0-1.5H3v-1.5H1.75a.75.75 0 0 1 0-1.5H3v-.5A2.75 2.75 0 0 1 5.75 3h.5V1.75a.75.75 0 0 1 1.5 0V3h1.5ZM4.5 5.75c0-.69.56-1.25 1.25-1.25h8.5c.69 0 1.25.56 1.25 1.25v8.5c0 .69-.56 1.25-1.25 1.25h-8.5c-.69 0-1.25-.56-1.25-1.25v-8.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
+function HiMiniComputerDesktop(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M2 4.25A2.25 2.25 0 0 1 4.25 2h11.5A2.25 2.25 0 0 1 18 4.25v8.5A2.25 2.25 0 0 1 15.75 15h-3.105a3.501 3.501 0 0 0 1.1 1.677A.75.75 0 0 1 13.26 18H6.74a.75.75 0 0 1-.484-1.323A3.501 3.501 0 0 0 7.355 15H4.25A2.25 2.25 0 0 1 2 12.75v-8.5Zm1.5 0a.75.75 0 0 1 .75-.75h11.5a.75.75 0 0 1 .75.75v7.5a.75.75 0 0 1-.75.75H4.25a.75.75 0 0 1-.75-.75v-7.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
 function HiMiniCommandLine(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M3.25 3A2.25 2.25 0 0 0 1 5.25v9.5A2.25 2.25 0 0 0 3.25 17h13.5A2.25 2.25 0 0 0 19 14.75v-9.5A2.25 2.25 0 0 0 16.75 3H3.25Zm.943 8.752a.75.75 0 0 1 .055-1.06L6.128 9l-1.88-1.693a.75.75 0 1 1 1.004-1.114l2.5 2.25a.75.75 0 0 1 0 1.114l-2.5 2.25a.75.75 0 0 1-1.06-.055ZM9.75 10.25a.75.75 0 0 0 0 1.5h2.5a.75.75 0 0 0 0-1.5h-2.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
@@ -20235,7 +20238,7 @@ function WorkspacePageHeader({
       description ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: description }) : null
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-start sm:justify-end sm:gap-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full min-w-0 sm:w-auto [&>div]:flex-wrap", children: /* @__PURE__ */ jsxRuntimeExports.jsx(TabBar, { tabs, active: activeTab, onChange: onTabChange }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full min-w-0 sm:w-auto", children: /* @__PURE__ */ jsxRuntimeExports.jsx(TabBar, { tabs, active: activeTab, onChange: onTabChange }) }),
       actions ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex shrink-0 flex-wrap items-center justify-end gap-2", children: actions }) : null
     ] })
   ] });
@@ -24638,7 +24641,7 @@ const SettingsWorkspace = reactExports.lazy(() => __vitePreload(() => import("./
 const AppDetailWorkspace = reactExports.lazy(() => __vitePreload(() => import("./chunks/app-detail-workspace.js"), true ? [] : void 0).then((m) => ({ default: m.AppDetailWorkspace })));
 const HelpModal = reactExports.lazy(() => __vitePreload(() => import("./chunks/help-modal.js"), true ? [] : void 0).then((m) => ({ default: m.HelpModal })));
 const SupplyChainHubWorkspace = reactExports.lazy(
-  () => __vitePreload(() => import("./chunks/supply-chain-hub-workspace.js"), true ? [] : void 0).then((m) => ({ default: m.SupplyChainHubWorkspace }))
+  () => __vitePreload(() => import("./chunks/supply-chain-hub-workspace.js").then((n) => n.s), true ? [] : void 0).then((m) => ({ default: m.SupplyChainHubWorkspace }))
 );
 const AboutWorkspace = reactExports.lazy(
   () => __vitePreload(() => import("./chunks/about-workspace.js"), true ? [] : void 0).then((m) => ({ default: m.AboutWorkspace }))
@@ -25305,15 +25308,16 @@ export {
   fetchSupplyChainBundle as aI,
   HiMiniDocumentMagnifyingGlass as aJ,
   HiMiniShieldExclamation as aK,
-  HiMiniInformationCircle as aL,
-  fetchReceipts as aM,
-  HiMiniArrowRight as aN,
-  runAuditRemediation as aO,
-  HiMiniDocumentText as aP,
-  guardAwareHref as aQ,
-  HiMiniBarsArrowUp as aR,
-  HiMiniBarsArrowDown as aS,
-  HiMiniSignal as aT,
+  HiMiniComputerDesktop as aL,
+  HiMiniInformationCircle as aM,
+  fetchReceipts as aN,
+  HiMiniArrowRight as aO,
+  runAuditRemediation as aP,
+  HiMiniDocumentText as aQ,
+  guardAwareHref as aR,
+  HiMiniBarsArrowUp as aS,
+  HiMiniBarsArrowDown as aT,
+  HiMiniSignal as aU,
   approvalGateCooldownLabel as aa,
   fetchApprovalPage as ab,
   fetchPolicy as ac,


### PR DESCRIPTION
## Summary
- Add a supply chain capabilities panel that compares free on-device protection with Guard Cloud features (SCSR155, SCSR156).
- Keep local protection visible when Guard Cloud is connected or still pairing.

## Testing
- `cd dashboard && ./node_modules/.bin/tsx src/scsr-phase09g-cloud-capabilities.test.ts`
- `cd dashboard && npm run build`
