### PR TITLE
docs(guard): Local vs Guard Cloud subscription boundary (WS0)

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -5,8 +5,9 @@ Install `plugin-scanner` separately when you want maintainer or CI checks for pl
 
 Use it when you want to protect a harness before local MCP servers, skills, hooks, or plugin surfaces run.
 
-Local Guard protects your machine without requiring sign-in. Guard Cloud is optional paid
-service memory, visibility, sync, and management on top of that protection. See
+Local Guard protects your machine without requiring sign-in. Guard Cloud is an optional
+paid service providing cloud history, visibility, sync, and management on top of that
+protection. See
 [Local Guard vs Guard Cloud](./local-vs-cloud.md) for the full subscription
 boundary.
 

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -5,6 +5,11 @@ Install `plugin-scanner` separately when you want maintainer or CI checks for pl
 
 Use it when you want to protect a harness before local MCP servers, skills, hooks, or plugin surfaces run.
 
+Local Guard protects your machine without sign-in. Guard Cloud is optional paid
+memory, visibility, sync, and management on top of that protection. See
+[Local Guard vs Guard Cloud](./local-vs-cloud.md) for the full subscription
+boundary.
+
 ## The everyday flow
 
 1. Start the guided first-run setup:

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -5,8 +5,8 @@ Install `plugin-scanner` separately when you want maintainer or CI checks for pl
 
 Use it when you want to protect a harness before local MCP servers, skills, hooks, or plugin surfaces run.
 
-Local Guard protects your machine without sign-in. Guard Cloud is optional paid
-memory, visibility, sync, and management on top of that protection. See
+Local Guard protects your machine without requiring sign-in. Guard Cloud is optional paid
+service memory, visibility, sync, and management on top of that protection. See
 [Local Guard vs Guard Cloud](./local-vs-cloud.md) for the full subscription
 boundary.
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -1,6 +1,6 @@
 # Harness Support Matrix
 
-Local harness protection works without Guard Cloud sign-in. Cloud adds synced
+Local harness protection works without signing in to Guard Cloud. Cloud adds synced
 history, visibility, and team controls around the same adapters. See
 [Local Guard vs Guard Cloud](./local-vs-cloud.md).
 

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -1,5 +1,9 @@
 # Harness Support Matrix
 
+Local harness protection works without Guard Cloud sign-in. Cloud adds synced
+history, visibility, and team controls around the same adapters. See
+[Local Guard vs Guard Cloud](./local-vs-cloud.md).
+
 Current Guard support in this repo:
 
 - `codex`

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -1,39 +1,105 @@
-# Works Locally First
+# Local Guard vs Guard Cloud
 
-Guard works on your machine before you sign in anywhere.
+Guard protects your machine first. Guard Cloud is optional paid memory,
+visibility, sync, and management around that protection.
 
-Local features available without sign-in:
+## Local Guard baseline
 
-- harness discovery
-- artifact snapshots
-- local diffs
-- local policy decisions
-- wrapper-mode launch enforcement
-- local receipts and explain output
-- local policy overrides from home or workspace config
+Available without a Cloud subscription or sign-in:
 
-Guard does not meter local safety features. You can detect harnesses, install launchers, diff changes, prompt for approval, and inspect receipts without signing in.
+- **Launch interception and wrappers** — `hol-guard install` and `hol-guard run`
+  sit in front of supported AI harnesses before tools, MCP servers, or skills
+  execute.
+- **Local policy decisions** — home config, project overrides, saved allow/deny
+  rules, and built-in recommendations resolve on this machine.
+- **Local blocking and warnings** — Guard can stop or warn on supported risky
+  shell commands, file reads, MCP tool calls, skill loads, and prompt-sensitive
+  actions before side effects occur.
+- **Package-manager protection where supported** — supported managers (for
+  example npm and PyPI) can be intercepted locally through shims and runtime
+  evaluation. Unsupported or monitor-only managers stay advisory only.
+- **Local receipts and explain output** — `hol-guard receipts`, `hol-guard
+  explain`, and the local approval center record what Guard decided and why.
+- **Local approval and review paths** — inline harness approval, the local
+  approval center on `127.0.0.1`, and `hol-guard approvals` resolve decisions
+  without Cloud.
+- **Cloud-outage independence** — if Guard Cloud is unavailable, unsigned out,
+  or never connected, local interception, policy, blocking, receipts, and
+  approvals continue on the machine.
 
-Safe Decode runs locally too. It inspects encoded payload layers for review evidence, but never executes decoded payloads and only syncs redacted summaries when optional cloud receipt sync is enabled.
+Guard does not meter local safety features. You can detect harnesses, install
+launchers, diff changes, prompt for approval, and inspect receipts without
+signing in.
 
-Optional cloud features:
+Safe Decode runs locally too. It inspects encoded payload layers for review
+evidence, but never executes decoded payloads and only syncs redacted summaries
+when optional Cloud receipt sync is enabled.
 
-- receipt sync to an optional Guard endpoint
-- trust enrichment
-- revocation feeds
-- billing and entitlements
-- shared team policy
+## Guard Cloud for individual developers
 
-The local runtime does not require any hosted service. `hol-guard connect` is the canonical way to pair a machine with Guard Cloud later, and `hol-guard connect --headless` uses OAuth Device Code for SSH/CI hosts. `hol-guard login` remains only as a redirecting compatibility alias. These commands do not unlock the core safety workflow.
+Guard Cloud is a personal AI safety cockpit and memory layer. It does not gate
+baseline local protection.
 
-Use these commands when you need to check or repair optional cloud pairing without disturbing local protection:
+Paid Cloud value for a solo developer or vibe coder includes:
+
+- **Synced history** across sessions, devices, and hosted or local agents
+- **Searchable activity** — blocked actions, approvals, package installs,
+  MCP/Skill changes, and risky activity in one timeline
+- **Decision memory and policy suggestions** — safe repeated choices stop
+  becoming repeated interruptions
+- **MCP/Skill drift visibility over time** — changed schemas, commands,
+  transports, scopes, and dependencies stay visible after first trust
+- **Incident-style summaries** — what happened, why it mattered, and what to
+  do next without digging through raw logs
+- **Cloud Firewall UI** — package risk, feed freshness, remediation guidance,
+  and safer fix paths on top of local enforcement
+- **Exports and shareable records** — audit-ready evidence packages when you
+  need to show what Guard handled
+- **Digests and notifications** — calm routing for what needs attention
+
+Optional Cloud pairing commands:
 
 ```bash
+hol-guard connect
 hol-guard connect status
 hol-guard connect repair
 hol-guard sync
 hol-guard supply-chain sync
-hol-guard supply-chain scan
-hol-guard supply-chain explain minimist@1.2.5 --ecosystem npm
-hol-guard explain install-connect
 ```
+
+`hol-guard connect` is the canonical way to pair a machine with Guard Cloud.
+`hol-guard connect --headless` uses OAuth Device Code for SSH/CI hosts.
+`hol-guard login` remains only as a redirecting compatibility alias. These
+commands add sync and visibility; they do not unlock core local protection.
+
+## Guard Cloud for teams
+
+Team plans add shared ownership, routing, RBAC, billing, and evidence exports
+on top of the individual Cloud value:
+
+- **Shared workspaces** with members, roles, service principals, and ownership
+- **Shared review workflow** with assignment, SLA, policy memory, cases, and
+  audit history
+- **Integrations** — Slack, GitHub, Jira, PagerDuty, email, and webhooks where
+  setup and delivery are available
+- **Team package firewall visibility** and exception governance
+- **Billing, plan limits, admin controls, exports, and enterprise materials**
+
+## Quick comparison
+
+| Capability | Local Guard | Guard Cloud |
+| --- | --- | --- |
+| Launch interception and local policy | Included | Included |
+| Local blocking/warnings on supported actions | Included | Included |
+| Local receipts and approvals | Included | Included |
+| Works when Cloud is offline | Yes | Local protection yes; sync pauses |
+| Cross-device history and search | Device-local only | Included on paid plans |
+| Decision memory across machines | No | Included on paid plans |
+| Cloud Firewall UI and exports | No | Included on paid plans |
+| Team RBAC, routing, and shared policy | No | Team plans |
+
+## Related docs
+
+- [Get started](./get-started.md)
+- [Harness support](./harness-support.md)
+- [Remediation](./remediation.md)

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -1,7 +1,7 @@
 # Local Guard vs Guard Cloud
 
-Guard protects your machine first. Guard Cloud is optional paid memory,
-visibility, sync, and management around that protection.
+Guard protects your machine first. Guard Cloud is optional paid service
+memory, visibility, sync, and management around that protection.
 
 ## Local Guard baseline
 
@@ -23,8 +23,8 @@ Available without a Cloud subscription or sign-in:
 - **Local approval and review paths** — inline harness approval, the local
   approval center on `127.0.0.1`, and `hol-guard approvals` resolve decisions
   without Cloud.
-- **Cloud-outage independence** — if Guard Cloud is unavailable, unsigned out,
-  or never connected, local interception, policy, blocking, receipts, and
+- **Cloud-outage independence** — if Guard Cloud is unavailable, you are signed
+  out, or never connected, local interception, policy, blocking, receipts, and
   approvals continue on the machine.
 
 Guard does not meter local safety features. You can detect harnesses, install
@@ -92,7 +92,7 @@ on top of the individual Cloud value:
 | Launch interception and local policy | Included | Included |
 | Local blocking/warnings on supported actions | Included | Included |
 | Local receipts and approvals | Included | Included |
-| Works when Cloud is offline | Yes | Local protection yes; sync pauses |
+| Works when Cloud is offline | Yes | Local protection continues; sync pauses |
 | Cross-device history and search | Device-local only | Included on paid plans |
 | Decision memory across machines | No | Included on paid plans |
 | Cloud Firewall UI and exports | No | Included on paid plans |

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -1,7 +1,7 @@
 # Local Guard vs Guard Cloud
 
-Guard protects your machine first. Guard Cloud is optional paid service
-memory, visibility, sync, and management around that protection.
+Guard protects your machine first. Guard Cloud is an optional paid service
+providing cloud history, visibility, sync, and management around that protection.
 
 ## Local Guard baseline
 


### PR DESCRIPTION
## Summary
- Expand `local-vs-cloud.md` with Local baseline, solo Cloud value, and team Cloud value.
- Link get-started and harness-support docs to the subscription boundary.

## Test plan
- [x] Docs render in markdown preview
- [x] Copy avoids implying Cloud sign-in is required for local protection