### PR TITLE
feat(hol-guard): package firewall receipt proof metadata (SCSR181-183)

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -90,11 +90,11 @@ from ..desktop_notifications import (
 from ..insights_share import publish_insights_share
 from ..local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE, build_local_dashboard_session_token
 from ..local_supply_chain import (
-    audit_receipt_metadata,
     build_workspace_audit_payload,
     resolve_package_firewall_entitlement_with_refresh,
     resolve_supply_chain_audit_workspace_dir,
 )
+from ..package_firewall_receipts import package_firewall_receipt_metadata
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
 from ..package_firewall_action_rate_limit import PackageFirewallActionRateLimiter
 from ..package_firewall_entitlement import (
@@ -1869,6 +1869,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "manager": manager,
             **activation_result,
         }
+        receipt_overrides = package_firewall_receipt_metadata(
+            operation=action,
+            result=result,
+            managers=(manager,),
+            workspace_dir=context.workspace_dir,
+        )
         receipt = self._record_headless_receipt(
             harness="package-firewall",
             operation=action,
@@ -1876,6 +1882,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             result=result,
             workspace_id=self._optional_string(payload.get("workspace_id"))
             or self.server.store.get_cloud_workspace_id(),  # type: ignore[attr-defined]
+            policy_decision=self._optional_string(receipt_overrides.get("policy_decision")),
+            capabilities_summary=self._optional_string(receipt_overrides.get("capabilities_summary")),
+            artifact_name=self._optional_string(receipt_overrides.get("artifact_name")),
+            scanner_evidence_extra=(
+                receipt_overrides.get("scanner_evidence")
+                if isinstance(receipt_overrides.get("scanner_evidence"), dict)
+                else None
+            ),
         )
         self._write_json(
             {
@@ -1963,9 +1977,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError as error:
             self._write_json({"error": str(error), "operation": operation}, status=400)
             return
-        receipt_overrides: dict[str, object] = {}
-        if operation == "audit":
-            receipt_overrides = audit_receipt_metadata(result)
+        receipt_overrides = package_firewall_receipt_metadata(
+            operation=operation,
+            result=result,
+            managers=managers,
+            workspace_dir=context.workspace_dir,
+        )
         receipt = self._record_headless_receipt(
             harness="package-firewall",
             operation=operation,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -94,7 +94,6 @@ from ..local_supply_chain import (
     resolve_package_firewall_entitlement_with_refresh,
     resolve_supply_chain_audit_workspace_dir,
 )
-from ..package_firewall_receipts import package_firewall_receipt_metadata
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
 from ..package_firewall_action_rate_limit import PackageFirewallActionRateLimiter
 from ..package_firewall_entitlement import (
@@ -103,6 +102,7 @@ from ..package_firewall_entitlement import (
     package_firewall_block_details,
     package_firewall_operation_allowed,
 )
+from ..package_firewall_receipts import package_firewall_receipt_metadata
 from ..package_shim_status import record_package_shim_audit_result
 from ..receipts.manager import build_receipt
 from ..runtime.runner import (

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -464,7 +464,24 @@ def _audit_package_findings_for_receipt(
     return [item for _, _, item in ranked[:limit]]
 
 
-def audit_receipt_metadata(result: dict[str, object]) -> dict[str, object]:
+def workspace_audit_path_hashes(
+    workspace_dir: Path | None,
+    manifest_paths: Sequence[str],
+    lockfile_paths: Sequence[str],
+) -> dict[str, list[str]]:
+    if workspace_dir is None:
+        return {"manifest_hashes": [], "lockfile_hashes": []}
+    return {
+        "manifest_hashes": _hash_existing_paths(workspace_dir, manifest_paths),
+        "lockfile_hashes": _hash_existing_paths(workspace_dir, lockfile_paths),
+    }
+
+
+def audit_receipt_metadata(
+    result: dict[str, object],
+    *,
+    workspace_dir: Path | None = None,
+) -> dict[str, object]:
     evaluation = result.get("evaluation")
     if not isinstance(evaluation, dict):
         return {}
@@ -480,6 +497,9 @@ def audit_receipt_metadata(result: dict[str, object]) -> dict[str, object]:
         policy_decision = "ask"
     inventory = result.get("inventory")
     inventory_summary = inventory if isinstance(inventory, dict) else {}
+    manifest_paths = [str(path) for path in result.get("manifest_paths") or () if isinstance(path, str)]
+    lockfile_paths = [str(path) for path in result.get("lockfile_paths") or () if isinstance(path, str)]
+    path_hashes = workspace_audit_path_hashes(workspace_dir, manifest_paths, lockfile_paths)
     return {
         "policy_decision": policy_decision,
         "capabilities_summary": (
@@ -491,8 +511,10 @@ def audit_receipt_metadata(result: dict[str, object]) -> dict[str, object]:
             "operation": "audit",
             "audit_decision": decision,
             "blocked_package_count": len(blocked_packages),
-            "lockfile_paths": list(result.get("lockfile_paths") or ()),
-            "manifest_paths": list(result.get("manifest_paths") or ()),
+            "lockfile_paths": lockfile_paths,
+            "manifest_paths": manifest_paths,
+            "manifest_hashes": path_hashes["manifest_hashes"],
+            "lockfile_hashes": path_hashes["lockfile_hashes"],
             "total_packages": inventory_summary.get("total_packages", len(package_items)),
             "package_findings": package_findings,
         },

--- a/src/codex_plugin_scanner/guard/package_firewall_receipts.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_receipts.py
@@ -109,8 +109,7 @@ def package_firewall_receipt_metadata(
             if isinstance(proof, dict) and proof.get("evaluator_invoked") is True
         )
         capabilities_summary = (
-            f"Intercept test recorded evaluator proof for {proved_count} of "
-            f"{len(manager_subset)} manager(s)."
+            f"Intercept test recorded evaluator proof for {proved_count} of {len(manager_subset)} manager(s)."
         )
 
     return {

--- a/src/codex_plugin_scanner/guard/package_firewall_receipts.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_receipts.py
@@ -1,0 +1,104 @@
+"""Receipt metadata helpers for package-firewall daemon operations (SCSR181-183)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from .local_supply_chain import audit_receipt_metadata, workspace_audit_path_hashes
+
+
+def _resolve_manager_subset(
+    managers: tuple[str, ...] | None,
+    result: dict[str, object],
+    operation: str,
+) -> list[str]:
+    if managers:
+        return list(managers)
+    tested_managers = result.get("tested_managers")
+    if isinstance(tested_managers, list):
+        return [str(manager) for manager in tested_managers if isinstance(manager, str)]
+    if operation == "audit":
+        package_shims = result.get("package_shims")
+        if isinstance(package_shims, dict):
+            detected = package_shims.get("detected_managers")
+            if isinstance(detected, list):
+                return [str(manager) for manager in detected if isinstance(manager, str)]
+    installed_managers = result.get("installed_managers")
+    if isinstance(installed_managers, list):
+        return [str(manager) for manager in installed_managers if isinstance(manager, str)]
+    return []
+
+
+def _test_intercept_proofs(result: dict[str, object]) -> list[dict[str, object]]:
+    manager_results = result.get("manager_results")
+    if not isinstance(manager_results, list):
+        return []
+    proofs: list[dict[str, object]] = []
+    for entry in manager_results:
+        if not isinstance(entry, dict):
+            continue
+        manager = entry.get("manager")
+        if not isinstance(manager, str):
+            continue
+        proof: dict[str, object] = {"manager": manager}
+        command_hash = entry.get("command_hash")
+        if isinstance(command_hash, str) and command_hash:
+            proof["command_hash"] = command_hash
+        evaluator_source = entry.get("evaluator_source")
+        if isinstance(evaluator_source, str) and evaluator_source:
+            proof["evaluator_source"] = evaluator_source
+        if "evaluator_invoked" in entry:
+            proof["evaluator_invoked"] = bool(entry.get("evaluator_invoked"))
+        proofs.append(proof)
+    return proofs
+
+
+def package_firewall_receipt_metadata(
+    *,
+    operation: str,
+    result: dict[str, object],
+    managers: tuple[str, ...] | None = None,
+    workspace_dir: Path | None = None,
+) -> dict[str, object]:
+    """Build receipt override fields for package-firewall headless operations."""
+
+    manager_subset = _resolve_manager_subset(managers, result, operation)
+    if operation == "audit":
+        metadata = audit_receipt_metadata(result, workspace_dir=workspace_dir)
+        scanner_evidence = metadata.get("scanner_evidence")
+        if isinstance(scanner_evidence, dict):
+            enriched = dict(scanner_evidence)
+            enriched["manager_subset"] = manager_subset
+            metadata = {**metadata, "scanner_evidence": enriched}
+        return metadata
+
+    scanner_evidence: dict[str, object] = {
+        "operation": operation,
+        "manager_subset": manager_subset,
+    }
+    if operation == "test":
+        scanner_evidence["intercept_proofs"] = _test_intercept_proofs(result)
+        intercept_proved = result.get("intercept_proved")
+        if isinstance(intercept_proved, bool):
+            scanner_evidence["intercept_proved"] = intercept_proved
+
+    capabilities_summary = f"Package firewall {operation} completed for {len(manager_subset)} manager(s)."
+    if operation == "test" and scanner_evidence.get("intercept_proofs"):
+        proved_count = sum(
+            1
+            for proof in scanner_evidence["intercept_proofs"]
+            if isinstance(proof, dict) and proof.get("evaluator_invoked") is True
+        )
+        capabilities_summary = (
+            f"Intercept test recorded evaluator proof for {proved_count} of "
+            f"{len(manager_subset)} manager(s)."
+        )
+
+    return {
+        "capabilities_summary": capabilities_summary,
+        "artifact_name": f"Package firewall {operation}",
+        "scanner_evidence": scanner_evidence,
+    }
+
+
+__all__ = ["package_firewall_receipt_metadata"]

--- a/src/codex_plugin_scanner/guard/package_firewall_receipts.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_receipts.py
@@ -4,7 +4,23 @@ from __future__ import annotations
 
 from pathlib import Path
 
-from .local_supply_chain import audit_receipt_metadata, workspace_audit_path_hashes
+from .local_supply_chain import audit_receipt_metadata
+
+
+def _read_string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(manager) for manager in value if isinstance(manager, str)]
+
+
+def _audit_installed_managers(result: dict[str, object]) -> list[str]:
+    supply_chain = result.get("supply_chain")
+    if not isinstance(supply_chain, dict):
+        return []
+    protection = supply_chain.get("package_manager_protection")
+    if not isinstance(protection, dict):
+        return []
+    return _read_string_list(protection.get("installed_managers"))
 
 
 def _resolve_manager_subset(
@@ -13,19 +29,22 @@ def _resolve_manager_subset(
     operation: str,
 ) -> list[str]:
     if managers:
-        return list(managers)
+        return [str(manager) for manager in managers if isinstance(manager, str)]
     tested_managers = result.get("tested_managers")
     if isinstance(tested_managers, list):
-        return [str(manager) for manager in tested_managers if isinstance(manager, str)]
+        return _read_string_list(tested_managers)
     if operation == "audit":
+        installed = _audit_installed_managers(result)
+        if installed:
+            return installed
         package_shims = result.get("package_shims")
         if isinstance(package_shims, dict):
-            detected = package_shims.get("detected_managers")
-            if isinstance(detected, list):
-                return [str(manager) for manager in detected if isinstance(manager, str)]
+            detected = _read_string_list(package_shims.get("detected_managers"))
+            if detected:
+                return detected
     installed_managers = result.get("installed_managers")
     if isinstance(installed_managers, list):
-        return [str(manager) for manager in installed_managers if isinstance(manager, str)]
+        return _read_string_list(installed_managers)
     return []
 
 

--- a/src/codex_plugin_scanner/guard/shim_probe.py
+++ b/src/codex_plugin_scanner/guard/shim_probe.py
@@ -58,8 +58,16 @@ def protect_evaluator_evidence(payload: dict[str, Any]) -> dict[str, object]:
     normalized_evidence_ids = (
         [str(item) for item in evidence_ids if item is not None] if isinstance(evidence_ids, list) else []
     )
+    evaluator_source = supply_chain_dict.get("source")
+    if not isinstance(evaluator_source, str) or not evaluator_source.strip():
+        evaluator_source = supply_chain_dict.get("decision_source")
+    if not isinstance(evaluator_source, str) or not evaluator_source.strip():
+        evaluator_source = verdict_dict.get("source")
+    if not isinstance(evaluator_source, str) or not evaluator_source.strip():
+        evaluator_source = "local-heuristic"
     return {
         "evaluator_invoked": "supply_chain_evaluation" in payload or "verdict" in payload,
+        "evaluator_source": evaluator_source,
         "protect_decision": verdict_dict.get("action"),
         "evidence_ids": normalized_evidence_ids,
         "dry_run": payload.get("dry_run"),

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -14,7 +14,6 @@ from typing import TYPE_CHECKING
 
 from .launcher import merge_guard_launcher_env
 from .package_shim_status import enrich_package_shim_status_payload
-from .stable_digest import stable_digest_hex
 from .shim_probe import (
     SHIM_PROBE_ENV_VALUE,
     SHIM_PROBE_ENV_VAR,
@@ -22,6 +21,7 @@ from .shim_probe import (
     parse_protect_json_stdout,
     protect_evaluator_evidence,
 )
+from .stable_digest import stable_digest_hex
 
 if TYPE_CHECKING:
     from .adapters.base import HarnessContext
@@ -952,7 +952,7 @@ def probe_package_shim_intercepts(
         protect_payload = parse_protect_json_stdout(result.stdout)
         evaluator_evidence = protect_evaluator_evidence(protect_payload)
         command_hash = stable_digest_hex(
-            json.dumps([manager, *probe_args], sort_keys=True).encode("utf-8"),
+            json.dumps([manager, *probe_args]).encode("utf-8"),
         )
         manager_results.append(
             {

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING
 
 from .launcher import merge_guard_launcher_env
 from .package_shim_status import enrich_package_shim_status_payload
+from .stable_digest import stable_digest_hex
 from .shim_probe import (
     SHIM_PROBE_ENV_VALUE,
     SHIM_PROBE_ENV_VAR,
@@ -950,9 +951,14 @@ def probe_package_shim_intercepts(
             continue
         protect_payload = parse_protect_json_stdout(result.stdout)
         evaluator_evidence = protect_evaluator_evidence(protect_payload)
+        command_hash = stable_digest_hex(
+            json.dumps([manager, *probe_args], sort_keys=True).encode("utf-8"),
+        )
         manager_results.append(
             {
+                "command_hash": command_hash,
                 "evaluator_invoked": evaluator_evidence["evaluator_invoked"],
+                "evaluator_source": evaluator_evidence["evaluator_source"],
                 "evidence_ids": evaluator_evidence["evidence_ids"],
                 "intercept_ran": bool(evaluator_evidence["evaluator_invoked"]),
                 "manager": manager,

--- a/tests/test_guard_phase11_package_firewall_receipts.py
+++ b/tests/test_guard_phase11_package_firewall_receipts.py
@@ -1,0 +1,119 @@
+"""Phase 11 package firewall receipt proofs (SCSR181-183)."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codex_plugin_scanner.guard.local_supply_chain import audit_receipt_metadata
+from codex_plugin_scanner.guard.package_firewall_receipts import package_firewall_receipt_metadata
+from codex_plugin_scanner.guard.shims import install_package_shims, probe_package_shim_intercepts
+from codex_plugin_scanner.guard.shim_probe import protect_evaluator_evidence
+from codex_plugin_scanner.guard.stable_digest import stable_digest_hex
+from tests.shim_execution_helpers import write_fake_manager_script
+
+
+def _harness_context(tmp_path: Path) -> MagicMock:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir(parents=True, exist_ok=True)
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    context = MagicMock()
+    context.home_dir = home_dir
+    context.workspace_dir = workspace_dir
+    context.guard_home = guard_home
+    return context
+
+
+def test_protect_evaluator_evidence_includes_evaluator_source() -> None:
+    evidence = protect_evaluator_evidence(
+        {
+            "supply_chain_evaluation": {"source": "guard-cloud", "evidence_ids": ["ev-1"]},
+            "verdict": {"action": "allow"},
+        },
+    )
+    assert evidence["evaluator_source"] == "guard-cloud"
+
+
+def test_package_firewall_receipt_metadata_records_manager_subset_for_test() -> None:
+    metadata = package_firewall_receipt_metadata(
+        operation="test",
+        managers=("npm", "pnpm"),
+        result={
+            "tested_managers": ["npm", "pnpm"],
+            "intercept_proved": True,
+            "manager_results": [
+                {
+                    "manager": "npm",
+                    "command_hash": "abc123",
+                    "evaluator_source": "guard-cloud",
+                    "evaluator_invoked": True,
+                },
+            ],
+        },
+    )
+    evidence = metadata["scanner_evidence"]
+    assert isinstance(evidence, dict)
+    assert evidence["operation"] == "test"
+    assert evidence["manager_subset"] == ["npm", "pnpm"]
+    intercept_proofs = evidence["intercept_proofs"]
+    assert isinstance(intercept_proofs, list)
+    assert intercept_proofs[0]["command_hash"] == "abc123"
+    assert intercept_proofs[0]["evaluator_source"] == "guard-cloud"
+
+
+def test_audit_receipt_metadata_includes_manifest_and_lockfile_hashes(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    manifest_path = workspace_dir / "package.json"
+    lockfile_path = workspace_dir / "package-lock.json"
+    manifest_path.write_text('{"name":"demo"}', encoding="utf-8")
+    lockfile_path.write_text('{"lockfileVersion":1}', encoding="utf-8")
+    manifest_hash = stable_digest_hex(manifest_path.read_bytes())
+    lockfile_hash = stable_digest_hex(lockfile_path.read_bytes())
+
+    metadata = audit_receipt_metadata(
+        {
+            "manifest_paths": ["package.json"],
+            "lockfile_paths": ["package-lock.json"],
+            "inventory": {"total_packages": 1},
+            "evaluation": {"decision": "monitor", "packages": []},
+        },
+        workspace_dir=workspace_dir,
+    )
+    evidence = metadata["scanner_evidence"]
+    assert isinstance(evidence, dict)
+    assert evidence["manifest_hashes"] == [manifest_hash]
+    assert evidence["lockfile_hashes"] == [lockfile_hash]
+
+
+def test_probe_package_shim_intercepts_records_command_hash_and_evaluator_source(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _harness_context(tmp_path)
+    install_package_shims(context, managers=("npm",))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    write_fake_manager_script(
+        fake_bin=fake_bin,
+        manager="npm",
+        marker_path=tmp_path / "npm-probe-marker.json",
+        exit_code=0,
+    )
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shim_dir), str(fake_bin)]))
+
+    result = probe_package_shim_intercepts(context, managers=("npm",), workspace_dir=context.workspace_dir)
+    manager_results = result["manager_results"]
+    assert isinstance(manager_results, list)
+    assert manager_results
+    npm_result = manager_results[0]
+    assert isinstance(npm_result.get("command_hash"), str)
+    assert npm_result["command_hash"]
+    assert isinstance(npm_result.get("evaluator_source"), str)

--- a/tests/test_guard_phase11_package_firewall_receipts.py
+++ b/tests/test_guard_phase11_package_firewall_receipts.py
@@ -40,6 +40,26 @@ def test_protect_evaluator_evidence_includes_evaluator_source() -> None:
     assert evidence["evaluator_source"] == "guard-cloud"
 
 
+def test_package_firewall_receipt_metadata_records_audit_manager_subset_from_posture() -> None:
+    metadata = package_firewall_receipt_metadata(
+        operation="audit",
+        result={
+            "manifest_paths": ["package.json"],
+            "lockfile_paths": ["package-lock.json"],
+            "inventory": {"total_packages": 1},
+            "evaluation": {"decision": "monitor", "packages": []},
+            "supply_chain": {
+                "package_manager_protection": {
+                    "installed_managers": ["npm", "pnpm"],
+                },
+            },
+        },
+    )
+    evidence = metadata["scanner_evidence"]
+    assert isinstance(evidence, dict)
+    assert evidence["manager_subset"] == ["npm", "pnpm"]
+
+
 def test_package_firewall_receipt_metadata_records_manager_subset_for_test() -> None:
     metadata = package_firewall_receipt_metadata(
         operation="test",


### PR DESCRIPTION
## Summary
- Enrich package-firewall daemon receipts with manager subsets for every operation (SCSR181)
- Persist intercept test command hashes and evaluator sources on test receipts (SCSR182)
- Include manifest and lockfile content hashes on audit receipts (SCSR183)

## Testing
- `python3 -m pytest tests/test_guard_phase11_package_firewall_receipts.py -q`
- `python3 -m pytest tests/test_guard_phase06_workspace_audit.py::test_audit_receipt_metadata_includes_prioritized_package_findings -q`
