### PR TITLE
docs(guard): package ecosystem support labels (WS2)

### DIFF
--- a/docs/guard/remediation.md
+++ b/docs/guard/remediation.md
@@ -32,7 +32,7 @@ Avoid broad or permanent exceptions.
 
 ## 5. Package firewall recovery
 
-Use the local dashboard Package Firewall panel first when the daemon is paired. It can protect, repair, test, audit, sync, or remove package manager shims with proof receipts.
+Use the local dashboard Package Firewall panel first when the daemon is paired. It can protect, repair, test, audit, sync, or remove package manager shims with signed receipts.
 
 CLI fallback:
 

--- a/docs/guard/testing-matrix.md
+++ b/docs/guard/testing-matrix.md
@@ -23,6 +23,24 @@ This matrix exists so local Guard, Cloud Guard, and CI wrapper behavior stay ali
 - Beta: package ecosystems where Guard can inspect and explain risk but still needs more live coverage.
 - Monitor-only: package managers or platforms where Guard records evidence and receipts without claiming enforcement.
 
+### Ecosystem labels (current Local manager list)
+
+| Ecosystem | Support label | Shim-supported managers |
+| :--- | :--- | :--- |
+| npm | Protected | `npm`, `npx`, `pnpm`, `yarn`, `bun` |
+| PyPI | Protected | `pip`, `pip3`, `pipenv`, `pipx`, `poetry`, `uv`, `uvx` |
+| Cargo | Beta | `cargo` |
+| Go modules | Beta | `go` |
+| Maven/Gradle | Beta | `mvn`, `gradle` |
+| Composer | Beta | `composer` |
+| RubyGems | Beta | `bundle` |
+| Docker base images | Monitor-only | not shim-managed |
+| GitHub Actions | Monitor-only | not shim-managed |
+| System packages | Monitor-only | not shim-managed |
+| NuGet | Monitor-only | not shim-managed |
+
+`package_shim_supported_managers()` in Local Guard is the source of truth for shim-supported package managers.
+
 Use `hol-guard cloud sync-intel` before production rollout so local policy uses the latest cloud intelligence.
 
 ## CI Wrapper Examples


### PR DESCRIPTION
## Summary
- Publish Protected/Beta/Monitor-only ecosystem labels and shim-supported manager mapping in `docs/guard/testing-matrix.md`.
- Clarify package firewall remediation copy in `docs/guard/remediation.md`.

## Test plan
- [x] `pytest tests/test_guard_docs.py::test_static_docs_cover_supply_chain_support_levels`