### PR TITLE
feat(guard): AIBOM workspace detection and aligned inventory kinds

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -13,8 +13,8 @@ from pathlib import Path
 from urllib.parse import urlencode
 
 from ...path_support import iter_safe_matching_files, resolves_within_root
-from ..daemon import guard_daemon_url_for_home, load_guard_daemon_url
 from ..aibom_detection import extend_detection_with_workspace_aibom
+from ..daemon import guard_daemon_url_for_home, load_guard_daemon_url
 from ..models import GuardArtifact, HarnessDetection
 from ..runtime.harness_attribution import cursor_hook_query_extras
 from ..shims import install_guard_shim, remove_guard_shim

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -14,6 +14,7 @@ from urllib.parse import urlencode
 
 from ...path_support import iter_safe_matching_files, resolves_within_root
 from ..daemon import guard_daemon_url_for_home, load_guard_daemon_url
+from ..aibom_detection import extend_detection_with_workspace_aibom
 from ..models import GuardArtifact, HarnessDetection
 from ..runtime.harness_attribution import cursor_hook_query_extras
 from ..shims import install_guard_shim, remove_guard_shim
@@ -473,13 +474,18 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                     )
                 )
         resolved_executable = self.resolved_executable(context)
-        return HarnessDetection(
+        detection = HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or resolved_executable is not None,
             command_available=resolved_executable is not None,
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
             warnings=(),
+        )
+        return extend_detection_with_workspace_aibom(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
         )
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -15,10 +15,10 @@ try:  # pragma: no cover - Python 3.11+
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10
     import tomli as tomllib  # type: ignore[no-redef]
 
+from ..aibom_detection import enrich_mcp_server_metadata, extend_detection_with_workspace_aibom
 from ..codex_config import dump_toml, read_toml_payload, write_toml_payload
 from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS, load_guard_config
 from ..launcher import merge_guard_launcher_env
-from ..aibom_detection import enrich_mcp_server_metadata, extend_detection_with_workspace_aibom
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _warnings_include_setup_failure

--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -18,6 +18,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 from ..codex_config import dump_toml, read_toml_payload, write_toml_payload
 from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS, load_guard_config
 from ..launcher import merge_guard_launcher_env
+from ..aibom_detection import enrich_mcp_server_metadata, extend_detection_with_workspace_aibom
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _warnings_include_setup_failure
@@ -626,6 +627,23 @@ class CodexHarnessAdapter(HarnessAdapter):
                         continue
                     url = server_config.get("url")
                     env = server_config.get("env")
+                    mcp_metadata = enrich_mcp_server_metadata(
+                        {
+                            "name": name,
+                            "env": {
+                                str(key): str(value)
+                                for key, value in env.items()
+                                if isinstance(key, str) and isinstance(value, str)
+                            }
+                            if isinstance(env, dict)
+                            else {},
+                            "env_keys": sorted(env.keys()) if isinstance(env, dict) else [],
+                        },
+                        command=command if isinstance(command, str) else None,
+                        args=args,
+                        url=url if isinstance(url, str) else None,
+                        transport="http" if isinstance(url, str) else "stdio",
+                    )
                     artifacts.append(
                         GuardArtifact(
                             artifact_id=f"codex:{scope}:{name}",
@@ -638,16 +656,7 @@ class CodexHarnessAdapter(HarnessAdapter):
                             args=args,
                             url=url if isinstance(url, str) else None,
                             transport="http" if isinstance(url, str) else "stdio",
-                            metadata={
-                                "env": {
-                                    str(key): str(value)
-                                    for key, value in env.items()
-                                    if isinstance(key, str) and isinstance(value, str)
-                                }
-                                if isinstance(env, dict)
-                                else {},
-                                "env_keys": sorted(env.keys()) if isinstance(env, dict) else [],
-                            },
+                            metadata=mcp_metadata,
                         )
                     )
         hooks_paths = [context.home_dir / ".codex" / "hooks.json"]
@@ -684,13 +693,18 @@ class CodexHarnessAdapter(HarnessAdapter):
                             command=command if isinstance(command, str) else None,
                         )
                     )
-        return HarnessDetection(
+        detection = HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
             command_available=_command_available(self.executable),
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
             warnings=(),
+        )
+        return extend_detection_with_workspace_aibom(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
         )
 
     def install(self, context: HarnessContext) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/adapters/cursor.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor.py
@@ -7,6 +7,7 @@ import sys
 from hashlib import sha256
 from pathlib import Path
 
+from ..aibom_detection import extend_detection_with_workspace_aibom
 from ..launcher import merge_guard_launcher_env
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import ensure_guard_shim_path_in_shell_profile, install_guard_shim, remove_guard_shim
@@ -115,13 +116,18 @@ class CursorHarnessAdapter(HarnessAdapter):
                     )
                 )
         cli_available = cursor_cli_command_available(context)
-        return HarnessDetection(
+        detection = HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or cli_available,
             command_available=cli_available,
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
             warnings=(),
+        )
+        return extend_detection_with_workspace_aibom(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
         )
 
     def resolved_executable(self, context: HarnessContext) -> str | None:

--- a/src/codex_plugin_scanner/guard/adapters/gemini.py
+++ b/src/codex_plugin_scanner/guard/adapters/gemini.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from pathlib import Path
 
+from ..aibom_detection import extend_detection_with_workspace_aibom
 from ..models import GuardArtifact, HarnessDetection
 from .base import HarnessAdapter, HarnessContext, _command_available, _json_payload
 
@@ -70,13 +71,18 @@ class GeminiHarnessAdapter(HarnessAdapter):
                 self._append_found_path(found_paths, settings_path)
                 self._append_settings_artifacts(artifacts, settings_path, payload, scope)
             self._append_skill_artifacts(artifacts, found_paths, skill_root, scope)
-        return HarnessDetection(
+        detection = HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
             command_available=_command_available(self.executable),
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
             warnings=(),
+        )
+        return extend_detection_with_workspace_aibom(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
         )
 
     def _append_extension_artifacts(

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 
 from ...ecosystems.opencode import _load_json_or_jsonc
+from ..aibom_detection import extend_detection_with_workspace_aibom
 from ..launcher import merge_guard_launcher_env
 from ..models import HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
@@ -150,13 +151,18 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             found_paths=found_paths,
             seen_artifact_ids=seen_artifact_ids,
         )
-        return HarnessDetection(
+        detection = HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
             command_available=_command_available(self.executable),
             config_paths=tuple(found_paths),
             artifacts=tuple(artifacts),
             warnings=(),
+        )
+        return extend_detection_with_workspace_aibom(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
         )
 
     def install(self, context: HarnessContext) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 from ..marketplace_support import extract_marketplace_source, load_marketplace_context
-from ..path_support import iter_safe_matching_files, resolves_within_root
+from ..path_support import is_safe_relative_path, iter_safe_matching_files, resolves_within_root
 from .inventory_contract import fingerprint_mapping, fingerprint_path_tree, fingerprint_text
 from .models import GuardArtifact, HarnessDetection
 
@@ -40,7 +40,8 @@ _CODEX_SKILL_ROOTS = (".agents/skills",)
 
 def file_content_hash(path: Path, *, max_bytes: int = _MAX_FILE_BYTES) -> str | None:
     try:
-        payload = path.read_bytes()[:max_bytes]
+        with path.open("rb") as handle:
+            payload = handle.read(max_bytes)
     except OSError:
         return None
     return fingerprint_text(payload.decode("utf-8", errors="replace"))
@@ -88,8 +89,11 @@ def instruction_role_for_path(path: Path) -> InstructionRole | None:
         return "claude_md"
     if name == "mcp.json":
         return "mcp_json"
-    if path.suffix.lower() in {".md", ".mdc"} and "rules" in path.parts:
-        return "cursor_rules"
+    if path.suffix.lower() in {".md", ".mdc"}:
+        parts = path.parts
+        for index, part in enumerate(parts):
+            if part == ".cursor" and index + 1 < len(parts) and parts[index + 1] == "rules":
+                return "cursor_rules"
     return None
 
 
@@ -102,7 +106,7 @@ def discover_shared_workspace_aibom_artifacts(
     if not workspace_dir.is_dir():
         return ()
     try:
-        workspace_dir.resolve()
+        workspace_dir = workspace_dir.resolve()
     except OSError:
         return ()
     artifacts: list[GuardArtifact] = []
@@ -197,7 +201,6 @@ def _discover_codex_marketplace_plugins(harness: str, *, workspace_dir: Path) ->
                 config_path=str(context.file_path),
                 metadata={
                     "marketplace_root": True,
-                    "legacy_marketplace": context.legacy,
                     "content_hash": manifest_hash,
                     **version_info_metadata(content_hash=manifest_hash, version_label="marketplace.json"),
                 },
@@ -217,13 +220,23 @@ def _discover_codex_marketplace_plugins(harness: str, *, workspace_dir: Path) ->
         }
         plugin_manifest: Path | None = None
         if source_path and source_path.startswith("./"):
-            candidate = workspace_dir / source_path[2:]
-            if candidate.is_dir():
-                for manifest_name in ("plugin.json", ".codex-plugin/plugin.json"):
-                    manifest_candidate = candidate / manifest_name
-                    if manifest_candidate.is_file():
-                        plugin_manifest = manifest_candidate
-                        break
+            relative = source_path[2:]
+            if is_safe_relative_path(workspace_dir, relative, require_exists=False):
+                candidate = workspace_dir / relative
+                if candidate.is_dir() and resolves_within_root(
+                    workspace_dir,
+                    candidate,
+                    require_exists=True,
+                ):
+                    for manifest_name in ("plugin.json", ".codex-plugin/plugin.json"):
+                        manifest_candidate = candidate / manifest_name
+                        if manifest_candidate.is_file() and resolves_within_root(
+                            workspace_dir,
+                            manifest_candidate,
+                            require_exists=True,
+                        ):
+                            plugin_manifest = manifest_candidate
+                            break
         if plugin_manifest is not None and plugin_manifest.is_file():
             manifest_digest = file_content_hash(plugin_manifest)
             if manifest_digest is not None:
@@ -298,7 +311,7 @@ def extend_detection_with_workspace_aibom(
             found_paths.append(config_path)
     return HarnessDetection(
         harness=detection.harness,
-        installed=detection.installed or bool(extra),
+        installed=detection.installed,
         command_available=detection.command_available,
         config_paths=tuple(dict.fromkeys(found_paths)),
         artifacts=tuple(merged),

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import hashlib
-import json
 from pathlib import Path
 from typing import Literal
 

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -1,0 +1,332 @@
+"""Shared AIBOM artifact discovery and content hashing for Guard inventory."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Literal
+
+from ..marketplace_support import extract_marketplace_source, load_marketplace_context
+from ..path_support import iter_safe_matching_files, resolves_within_root
+from .inventory_contract import fingerprint_mapping, fingerprint_path_tree, fingerprint_text
+from .models import GuardArtifact, HarnessDetection
+
+InstructionRole = Literal["agents_md", "cursor_rules", "claude_md", "mcp_json"]
+INVENTORY_ITEM_KINDS: tuple[str, ...] = (
+    "agent",
+    "daemon_plugin",
+    "harness",
+    "model_provider",
+    "package",
+    "prompt_pack",
+    "skill",
+    "mcp_server",
+    "mcp_tool",
+    "plugin",
+    "channel",
+    "hook",
+    "overlay",
+    "repository",
+    "container_image",
+    "policy",
+    "secret_reference",
+    "network_endpoint",
+)
+
+_MAX_FILE_BYTES = 1024 * 1024
+_CURSOR_RULE_PATTERNS = ("*.mdc", "*.md")
+_CODEX_SKILL_ROOTS = (".agents/skills",)
+
+
+def file_content_hash(path: Path, *, max_bytes: int = _MAX_FILE_BYTES) -> str | None:
+    try:
+        payload = path.read_bytes()[:max_bytes]
+    except OSError:
+        return None
+    return fingerprint_text(payload.decode("utf-8", errors="replace"))
+
+
+def directory_content_hash(root: Path, *, home_dir: Path) -> str:
+    return fingerprint_path_tree(root, home_dir=home_dir)
+
+
+def mcp_server_content_hash(
+    *,
+    command: str | None,
+    args: tuple[str, ...],
+    url: str | None,
+    transport: str | None,
+    env_keys: tuple[str, ...] = (),
+) -> str:
+    return fingerprint_mapping(
+        {
+            "command": command,
+            "args": list(args),
+            "url": url,
+            "transport": transport,
+            "env_keys": sorted(env_keys),
+        }
+    )
+
+
+def version_info_metadata(*, content_hash: str, version_label: str) -> dict[str, object]:
+    return {
+        "versionInfo": {
+            "versionLabel": version_label,
+            "hashBasis": "content",
+            "contentHash": content_hash,
+            "changedFields": [],
+        }
+    }
+
+
+def instruction_role_for_path(path: Path) -> InstructionRole | None:
+    name = path.name.lower()
+    if name == "agents.md":
+        return "agents_md"
+    if name == "claude.md":
+        return "claude_md"
+    if name == "mcp.json":
+        return "mcp_json"
+    if path.suffix.lower() in {".md", ".mdc"} and "rules" in path.parts:
+        return "cursor_rules"
+    return None
+
+
+def discover_shared_workspace_aibom_artifacts(
+    harness: str,
+    *,
+    home_dir: Path,
+    workspace_dir: Path,
+) -> tuple[GuardArtifact, ...]:
+    if not workspace_dir.is_dir():
+        return ()
+    try:
+        workspace_dir.resolve()
+    except OSError:
+        return ()
+    artifacts: list[GuardArtifact] = []
+    artifacts.extend(_discover_agents_md(harness, workspace_dir=workspace_dir))
+    artifacts.extend(_discover_cursor_rules(harness, workspace_dir=workspace_dir))
+    artifacts.extend(_discover_codex_skills(harness, workspace_dir=workspace_dir, home_dir=home_dir))
+    artifacts.extend(_discover_codex_marketplace_plugins(harness, workspace_dir=workspace_dir))
+    return tuple(artifacts)
+
+
+def _discover_agents_md(harness: str, *, workspace_dir: Path) -> list[GuardArtifact]:
+    agents_md = workspace_dir / "AGENTS.md"
+    if not agents_md.is_file() or agents_md.is_symlink():
+        return []
+    if not resolves_within_root(workspace_dir, agents_md, require_exists=True):
+        return []
+    return [_instruction_artifact(harness, agents_md, role="agents_md", scope="project")]
+
+
+def _discover_cursor_rules(harness: str, *, workspace_dir: Path) -> list[GuardArtifact]:
+    rules_dir = workspace_dir / ".cursor" / "rules"
+    if not rules_dir.is_dir() or not resolves_within_root(workspace_dir, rules_dir, require_exists=True):
+        return []
+    artifacts: list[GuardArtifact] = []
+    for pattern in _CURSOR_RULE_PATTERNS:
+        for rule_path in iter_safe_matching_files(workspace_dir, rules_dir, pattern):
+            artifacts.append(
+                _instruction_artifact(
+                    harness,
+                    rule_path,
+                    role="cursor_rules",
+                    scope="project",
+                    display_name=rule_path.stem,
+                )
+            )
+    return artifacts
+
+
+def _discover_codex_skills(harness: str, *, workspace_dir: Path, home_dir: Path) -> list[GuardArtifact]:
+    artifacts: list[GuardArtifact] = []
+    for relative_root in _CODEX_SKILL_ROOTS:
+        skill_root = workspace_dir / relative_root
+        if not skill_root.is_dir() or not resolves_within_root(workspace_dir, skill_root, require_exists=True):
+            continue
+        for skill_md in sorted(skill_root.rglob("SKILL.md")):
+            if skill_md.is_symlink() or not skill_md.is_file():
+                continue
+            if not resolves_within_root(workspace_dir, skill_md, require_exists=True):
+                continue
+            skill_dir = skill_md.parent
+            relative_id = skill_dir.relative_to(skill_root).as_posix()
+            content_hash = directory_content_hash(skill_dir, home_dir=home_dir)
+            digest = file_content_hash(skill_md)
+            metadata: dict[str, object] = {
+                "skill_root": relative_root,
+                "content_hash": digest,
+                "directory_hash": content_hash,
+                **version_info_metadata(content_hash=content_hash, version_label=relative_id or skill_dir.name),
+            }
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"{harness}:project:skill:{relative_root}:{relative_id or skill_dir.name}",
+                    name=relative_id or skill_dir.name,
+                    harness=harness,
+                    artifact_type="skill",
+                    source_scope="project",
+                    config_path=str(skill_md),
+                    metadata=metadata,
+                )
+            )
+    return artifacts
+
+
+def _discover_codex_marketplace_plugins(harness: str, *, workspace_dir: Path) -> list[GuardArtifact]:
+    context = load_marketplace_context(workspace_dir)
+    if context is None:
+        return []
+    plugins = context.payload.get("plugins")
+    if not isinstance(plugins, list):
+        return []
+    manifest_hash = file_content_hash(context.file_path)
+    artifacts: list[GuardArtifact] = []
+    marketplace_id = hashlib.sha256(str(context.file_path).encode()).hexdigest()[:12]
+    if manifest_hash is not None:
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=f"{harness}:project:marketplace:{marketplace_id}",
+                name="marketplace.json",
+                harness=harness,
+                artifact_type="plugin",
+                source_scope="project",
+                config_path=str(context.file_path),
+                metadata={
+                    "marketplace_root": True,
+                    "legacy_marketplace": context.legacy,
+                    "content_hash": manifest_hash,
+                    **version_info_metadata(content_hash=manifest_hash, version_label="marketplace.json"),
+                },
+            )
+        )
+    for index, entry in enumerate(plugins):
+        if not isinstance(entry, dict):
+            continue
+        plugin_name = entry.get("name")
+        if not isinstance(plugin_name, str) or not plugin_name.strip():
+            plugin_name = f"plugin_{index}"
+        source_ref, source_path = extract_marketplace_source(entry)
+        metadata: dict[str, object] = {
+            "marketplace_index": index,
+            "source_ref": source_ref,
+            "source_path": source_path,
+        }
+        plugin_manifest: Path | None = None
+        if source_path and source_path.startswith("./"):
+            candidate = workspace_dir / source_path[2:]
+            if candidate.is_dir():
+                for manifest_name in ("plugin.json", ".codex-plugin/plugin.json"):
+                    manifest_candidate = candidate / manifest_name
+                    if manifest_candidate.is_file():
+                        plugin_manifest = manifest_candidate
+                        break
+        if plugin_manifest is not None and plugin_manifest.is_file():
+            manifest_digest = file_content_hash(plugin_manifest)
+            if manifest_digest is not None:
+                metadata["content_hash"] = manifest_digest
+                metadata.update(
+                    version_info_metadata(content_hash=manifest_digest, version_label=plugin_name),
+                )
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=f"{harness}:project:marketplace-plugin:{marketplace_id}:{plugin_name}",
+                name=plugin_name,
+                harness=harness,
+                artifact_type="plugin",
+                source_scope="project",
+                config_path=str(plugin_manifest or context.file_path),
+                metadata=metadata,
+            )
+        )
+    return artifacts
+
+
+def _instruction_artifact(
+    harness: str,
+    path: Path,
+    *,
+    role: InstructionRole,
+    scope: str,
+    display_name: str | None = None,
+) -> GuardArtifact:
+    content_hash = file_content_hash(path) or fingerprint_text(path.name)
+    name = display_name or path.name
+    return GuardArtifact(
+        artifact_id=f"{harness}:{scope}:instruction:{role}:{name}",
+        name=name,
+        harness=harness,
+        artifact_type="instruction",
+        source_scope=scope,
+        config_path=str(path),
+        metadata={
+            "instructionRole": role,
+            "content_hash": content_hash,
+            **version_info_metadata(content_hash=content_hash, version_label=name),
+        },
+    )
+
+
+def extend_detection_with_workspace_aibom(
+    detection: HarnessDetection,
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> HarnessDetection:
+    if workspace_dir is None:
+        return detection
+    extra = discover_shared_workspace_aibom_artifacts(
+        detection.harness,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    )
+    if not extra:
+        return detection
+    existing_ids = {artifact.artifact_id for artifact in detection.artifacts}
+    merged = list(detection.artifacts)
+    found_paths = list(detection.config_paths)
+    for artifact in extra:
+        if artifact.artifact_id in existing_ids:
+            continue
+        merged.append(artifact)
+        existing_ids.add(artifact.artifact_id)
+        config_path = getattr(artifact, "config_path", None)
+        if isinstance(config_path, str):
+            found_paths.append(config_path)
+    return HarnessDetection(
+        harness=detection.harness,
+        installed=detection.installed or bool(extra),
+        command_available=detection.command_available,
+        config_paths=tuple(dict.fromkeys(found_paths)),
+        artifacts=tuple(merged),
+        warnings=detection.warnings,
+    )
+
+
+def enrich_mcp_server_metadata(
+    metadata: dict[str, object],
+    *,
+    command: str | None,
+    args: tuple[str, ...],
+    url: str | None,
+    transport: str | None,
+) -> dict[str, object]:
+    env_keys = metadata.get("env_keys")
+    normalized_env_keys: tuple[str, ...] = ()
+    if isinstance(env_keys, list):
+        normalized_env_keys = tuple(str(key) for key in env_keys if isinstance(key, str))
+    content_hash = mcp_server_content_hash(
+        command=command,
+        args=args,
+        url=url,
+        transport=transport,
+        env_keys=normalized_env_keys,
+    )
+    enriched = dict(metadata)
+    enriched["content_hash"] = content_hash
+    enriched.update(version_info_metadata(content_hash=content_hash, version_label=str(metadata.get("name", "mcp"))))
+    return enriched

--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -103,7 +103,7 @@ def classify_path_class(
                 candidate = candidate.resolve()
         else:
             candidate = candidate.resolve()
-    except OSError:
+    except (OSError, RuntimeError):
         return "unknown"
 
     if workspace_dir is not None and resolves_within_root(workspace_dir, candidate, require_exists=False):
@@ -128,7 +128,7 @@ def fingerprint_redacted_path(
     if not path.is_symlink():
         try:
             candidate = path.resolve()
-        except OSError:
+        except (OSError, RuntimeError):
             candidate = path
     if workspace_dir is not None:
         try:

--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -187,9 +187,7 @@ def _resolve_symlink_chain(
     current = path
 
     for _ in range(_MAX_SYMLINK_HOPS):
-        hop_fingerprints.append(
-            fingerprint_redacted_path(current, home_dir=home_dir, workspace_dir=workspace_dir)
-        )
+        hop_fingerprints.append(fingerprint_redacted_path(current, home_dir=home_dir, workspace_dir=workspace_dir))
         hop_key = hop_fingerprints[-1]
         if hop_key in visited:
             return None, "loop", hop_fingerprints
@@ -209,7 +207,7 @@ def _resolve_symlink_chain(
 
         next_path = Path(link_target)
         if not next_path.is_absolute():
-            next_path = (current.parent / next_path)
+            next_path = current.parent / next_path
         try:
             current = next_path.resolve()
         except OSError:
@@ -245,7 +243,7 @@ def _content_hash_for_target(path: Path, *, home_dir: Path) -> str | None:
         if path.is_dir():
             return fingerprint_path_tree(path, home_dir=home_dir)
         if path.is_file():
-            payload = path.read_bytes()[:1024 * 1024]
+            payload = path.read_bytes()[: 1024 * 1024]
             return fingerprint_text(payload.decode("utf-8", errors="replace"))
     except OSError:
         return None

--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -210,6 +210,8 @@ def _resolve_symlink_chain(
             next_path = current.parent / next_path
         try:
             current = next_path.resolve()
+        except RuntimeError:
+            return None, "loop", hop_fingerprints
         except OSError:
             return None, "broken", hop_fingerprints
 

--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -222,6 +222,24 @@ def _is_within_safe_roots(path: Path, safe_roots: tuple[Path, ...]) -> bool:
     return any(resolves_within_root(root, path, require_exists=False) for root in safe_roots)
 
 
+def source_of_truth_metadata_from_inspection(
+    inspection: AibomSourceInspection,
+    *,
+    source_link_id: str,
+) -> dict[str, object]:
+    return {
+        "sourceLinkId": source_link_id,
+        "sourceFingerprint": inspection.source_fingerprint,
+        "linkKind": inspection.link_kind,
+        "validationState": inspection.validation_state,
+        "pathClass": inspection.path_class,
+        "redactionSummary": inspection.redaction_summary,
+        "metadata": {
+            "targetContentHash": inspection.target_content_hash,
+        },
+    }
+
+
 def _content_hash_for_target(path: Path, *, home_dir: Path) -> str | None:
     try:
         if path.is_dir():

--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -1,0 +1,234 @@
+"""Safe symlink and shared-root inspection for AIBOM source-of-truth metadata."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+from ..path_support import resolves_within_root
+from .inventory_contract import fingerprint_mapping, fingerprint_path_tree, fingerprint_text, redact_local_path
+
+AibomLinkKind = Literal["symlink", "hardlink", "shared_root", "copy"]
+AibomPathClass = Literal["workspace_relative", "home_relative", "config_root", "container_mount", "unknown"]
+AibomValidationState = Literal["valid", "broken", "loop", "escape_blocked", "missing"]
+
+_MAX_SYMLINK_HOPS = 16
+
+
+@dataclass(frozen=True, slots=True)
+class AibomSourceInspection:
+    """Redacted source-of-truth inspection for inventory metadata."""
+
+    source_fingerprint: str
+    path_class: AibomPathClass
+    link_kind: AibomLinkKind
+    validation_state: AibomValidationState
+    target_content_hash: str | None = None
+    redaction_summary: dict[str, object] = field(default_factory=dict)
+
+
+def inspect_aibom_source_path(
+    path: Path,
+    *,
+    safe_roots: tuple[Path, ...],
+    home_dir: Path,
+    workspace_dir: Path | None = None,
+) -> AibomSourceInspection:
+    """Classify a path or symlink without emitting raw local paths."""
+
+    path_class = classify_path_class(path, home_dir=home_dir, workspace_dir=workspace_dir)
+    link_kind: AibomLinkKind = "copy"
+    validation_state: AibomValidationState = "missing"
+    target_content_hash: str | None = None
+    hop_fingerprints: list[str] = []
+
+    if not path.exists() and not path.is_symlink():
+        return _build_inspection(
+            path=path,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            path_class=path_class,
+            link_kind=link_kind,
+            validation_state="missing",
+            target_content_hash=None,
+            hop_fingerprints=hop_fingerprints,
+        )
+
+    if path.is_symlink():
+        link_kind = "symlink"
+        resolved, validation_state, hop_fingerprints = _resolve_symlink_chain(
+            path,
+            safe_roots=safe_roots,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+        if validation_state == "valid" and resolved is not None:
+            target_content_hash = _content_hash_for_target(resolved, home_dir=home_dir)
+    else:
+        if not _is_within_safe_roots(path, safe_roots):
+            validation_state = "escape_blocked"
+        else:
+            validation_state = "valid"
+            target_content_hash = _content_hash_for_target(path, home_dir=home_dir)
+
+    return _build_inspection(
+        path=path,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        path_class=path_class,
+        link_kind=link_kind,
+        validation_state=validation_state,
+        target_content_hash=target_content_hash,
+        hop_fingerprints=hop_fingerprints,
+    )
+
+
+def classify_path_class(
+    path: Path,
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> AibomPathClass:
+    candidate = path
+    try:
+        if candidate.is_symlink():
+            candidate = Path(os.readlink(candidate))
+            if not candidate.is_absolute() and workspace_dir is not None:
+                candidate = (path.parent / candidate).resolve()
+            elif not candidate.is_absolute():
+                candidate = (home_dir / candidate).resolve()
+            else:
+                candidate = candidate.resolve()
+        else:
+            candidate = candidate.resolve()
+    except OSError:
+        return "unknown"
+
+    if workspace_dir is not None and resolves_within_root(workspace_dir, candidate, require_exists=False):
+        return "workspace_relative"
+    if resolves_within_root(home_dir, candidate, require_exists=False):
+        return "home_relative"
+    config_markers = {".config", ".cursor", ".codex", ".claude", ".gemini", ".openclaw", ".hermes"}
+    if any(part in config_markers for part in candidate.parts):
+        return "config_root"
+    if "/mnt/" in candidate.as_posix() or candidate.as_posix().startswith("/var/"):
+        return "container_mount"
+    return "unknown"
+
+
+def fingerprint_redacted_path(
+    path: Path,
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> str:
+    candidate = path
+    if not path.is_symlink():
+        try:
+            candidate = path.resolve()
+        except OSError:
+            candidate = path
+    if workspace_dir is not None:
+        try:
+            relative = candidate.relative_to(workspace_dir.resolve())
+            return fingerprint_text(f"{{workspace}}/{relative.as_posix()}")
+        except (OSError, ValueError):
+            pass
+    return fingerprint_text(redact_local_path(candidate, home_dir=home_dir))
+
+
+def _build_inspection(
+    *,
+    path: Path,
+    home_dir: Path,
+    workspace_dir: Path | None,
+    path_class: AibomPathClass,
+    link_kind: AibomLinkKind,
+    validation_state: AibomValidationState,
+    target_content_hash: str | None,
+    hop_fingerprints: list[str],
+) -> AibomSourceInspection:
+    path_fingerprint = fingerprint_redacted_path(path, home_dir=home_dir, workspace_dir=workspace_dir)
+    source_fingerprint = fingerprint_mapping(
+        {
+            "path": path_fingerprint,
+            "link_kind": link_kind,
+            "path_class": path_class,
+            "validation_state": validation_state,
+            "target_content_hash": target_content_hash,
+            "hop_count": len(hop_fingerprints),
+        }
+    )
+    return AibomSourceInspection(
+        source_fingerprint=source_fingerprint,
+        path_class=path_class,
+        link_kind=link_kind,
+        validation_state=validation_state,
+        target_content_hash=target_content_hash,
+        redaction_summary={
+            "rawPathsIncluded": False,
+            "hopFingerprints": hop_fingerprints,
+            "pathFingerprint": path_fingerprint,
+        },
+    )
+
+
+def _resolve_symlink_chain(
+    path: Path,
+    *,
+    safe_roots: tuple[Path, ...],
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> tuple[Path | None, AibomValidationState, list[str]]:
+    visited: set[str] = set()
+    hop_fingerprints: list[str] = []
+    current = path
+
+    for _ in range(_MAX_SYMLINK_HOPS):
+        hop_fingerprints.append(
+            fingerprint_redacted_path(current, home_dir=home_dir, workspace_dir=workspace_dir)
+        )
+        hop_key = hop_fingerprints[-1]
+        if hop_key in visited:
+            return None, "loop", hop_fingerprints
+        visited.add(hop_key)
+
+        if not current.is_symlink():
+            if not current.exists():
+                return None, "broken", hop_fingerprints
+            if not _is_within_safe_roots(current, safe_roots):
+                return None, "escape_blocked", hop_fingerprints
+            return current, "valid", hop_fingerprints
+
+        try:
+            link_target = os.readlink(current)
+        except OSError:
+            return None, "broken", hop_fingerprints
+
+        next_path = Path(link_target)
+        if not next_path.is_absolute():
+            next_path = (current.parent / next_path)
+        try:
+            current = next_path.resolve()
+        except OSError:
+            return None, "broken", hop_fingerprints
+
+    return None, "loop", hop_fingerprints
+
+
+def _is_within_safe_roots(path: Path, safe_roots: tuple[Path, ...]) -> bool:
+    return any(resolves_within_root(root, path, require_exists=False) for root in safe_roots)
+
+
+def _content_hash_for_target(path: Path, *, home_dir: Path) -> str | None:
+    try:
+        if path.is_dir():
+            return fingerprint_path_tree(path, home_dir=home_dir)
+        if path.is_file():
+            payload = path.read_bytes()[:1024 * 1024]
+            return fingerprint_text(payload.decode("utf-8", errors="replace"))
+    except OSError:
+        return None
+    return None

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -261,12 +261,14 @@ def inventory_snapshot_from_detection(
         )
         for path in config_paths
     )
+    item_tuple = tuple(items)
     cisco_findings = _cisco_inventory_findings(
         cisco_runs,
-        items=tuple(items),
+        items=item_tuple,
         home_dir=home_dir,
         workspace_dir=workspace_dir,
     )
+    symlink_findings = _symlink_findings_from_items(harness, item_tuple)
     sources = (*config_sources, *_cisco_inventory_sources(cisco_runs))
     snapshot_hash = fingerprint_mapping(
         {
@@ -282,8 +284,8 @@ def inventory_snapshot_from_detection(
         agent_type=_agent_type(harness),
         generated_at=generated_at,
         runtime_version=runtime_version,
-        items=tuple(items),
-        findings=cisco_findings,
+        items=item_tuple,
+        findings=(*cisco_findings, *symlink_findings),
         sources=sources,
         redaction_report={
             "rawSecretsIncluded": False,
@@ -404,6 +406,14 @@ def _item_from_artifact(
         artifact,
         item_kind=item_kind,
         metadata=safe_metadata,
+    )
+    safe_metadata = _apply_source_of_truth_metadata(
+        artifact,
+        harness=harness,
+        item_kind=item_kind,
+        metadata=safe_metadata,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
     )
     semantic_text = fingerprint_mapping(
         {
@@ -782,6 +792,84 @@ def _resolve_item_content_hash(metadata: dict[str, object], semantic_text: str) 
         if isinstance(version_hash, str) and version_hash:
             return version_hash
     return semantic_text
+
+
+def _safe_roots_for_inspection(
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> tuple[Path, ...]:
+    roots: list[Path] = [home_dir]
+    if workspace_dir is not None:
+        roots.insert(0, workspace_dir)
+    return tuple(roots)
+
+
+def _apply_source_of_truth_metadata(
+    artifact: object,
+    *,
+    harness: str,
+    item_kind: InventoryItemKind,
+    metadata: dict[str, object],
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> dict[str, object]:
+    from .aibom_symlink import inspect_aibom_source_path, source_of_truth_metadata_from_inspection
+
+    config_path = getattr(artifact, "config_path", None)
+    if not isinstance(config_path, str) or not config_path:
+        return metadata
+    path = Path(config_path)
+    if not path.is_symlink():
+        return metadata
+    inspection = inspect_aibom_source_path(
+        path,
+        safe_roots=_safe_roots_for_inspection(home_dir=home_dir, workspace_dir=workspace_dir),
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    )
+    source_link_id = f"{harness}:{item_kind}:{inspection.source_fingerprint[:24]}"
+    enriched = dict(metadata)
+    enriched["sourceOfTruth"] = source_of_truth_metadata_from_inspection(
+        inspection,
+        source_link_id=source_link_id,
+    )
+    return enriched
+
+
+def _symlink_findings_from_items(
+    harness: str,
+    items: tuple[GuardAgentInventoryItem, ...],
+) -> tuple[GuardAgentInventoryFinding, ...]:
+    findings: list[GuardAgentInventoryFinding] = []
+    for item in items:
+        source_of_truth = item.metadata.get("sourceOfTruth")
+        if not isinstance(source_of_truth, dict):
+            continue
+        validation_state = source_of_truth.get("validationState")
+        if validation_state == "valid":
+            continue
+        if not isinstance(validation_state, str):
+            continue
+        severity: InventorySeverity = "high" if validation_state in {"loop", "escape_blocked"} else "medium"
+        findings.append(
+            GuardAgentInventoryFinding(
+                finding_id=f"{harness}:symlink:{item.item_id}:{validation_state}",
+                source="hol-detector",
+                severity=severity,
+                confidence="high",
+                title=f"Symlink source {validation_state.replace('_', ' ')}",
+                artifact_id=item.item_id,
+                check_id=f"aibom.symlink.{validation_state}",
+                summary=f"Inventory item references a symlink source in state {validation_state}.",
+                evidence={
+                    "validationState": validation_state,
+                    "sourceFingerprint": source_of_truth.get("sourceFingerprint"),
+                    "pathClass": source_of_truth.get("pathClass"),
+                },
+            )
+        )
+    return tuple(findings)
 
 
 def _apply_aibom_metadata_enrichment(

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -13,6 +13,11 @@ from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 InventoryItemKind = Literal[
     "agent",
+    "daemon_plugin",
+    "harness",
+    "model_provider",
+    "package",
+    "prompt_pack",
     "skill",
     "mcp_server",
     "mcp_tool",
@@ -220,8 +225,21 @@ def inventory_snapshot_from_detection(
     runtime_version: str | None = None,
     cisco_runs: tuple[object, ...] = (),
 ) -> GuardAgentInventorySnapshot:
+    from .aibom_detection import discover_shared_workspace_aibom_artifacts
+
     harness = str(getattr(detection, "harness", "unknown"))
-    artifacts = tuple(getattr(detection, "artifacts", ()))
+    artifacts = list(getattr(detection, "artifacts", ()))
+    if workspace_dir is not None:
+        existing_ids = {str(getattr(artifact, "artifact_id", "")) for artifact in artifacts}
+        for artifact in discover_shared_workspace_aibom_artifacts(
+            harness,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        ):
+            if artifact.artifact_id not in existing_ids:
+                artifacts.append(artifact)
+                existing_ids.add(artifact.artifact_id)
+    artifacts = tuple(artifacts)
     items: list[GuardAgentInventoryItem] = []
     for artifact in artifacts:
         item = _item_from_artifact(
@@ -382,6 +400,11 @@ def _item_from_artifact(
     name = str(getattr(artifact, "name", artifact_id))
     safe_metadata = _safe_artifact_metadata(artifact, home_dir=home_dir, workspace_dir=workspace_dir)
     item_kind = _item_kind(artifact_type)
+    safe_metadata = _apply_aibom_metadata_enrichment(
+        artifact,
+        item_kind=item_kind,
+        metadata=safe_metadata,
+    )
     semantic_text = fingerprint_mapping(
         {
             "artifact_id": artifact_id,
@@ -390,12 +413,13 @@ def _item_from_artifact(
             "metadata": safe_metadata,
         }
     )
+    content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
     return GuardAgentInventoryItem(
         item_id=artifact_id,
         item_kind=item_kind,
         display_name=name,
         source_fingerprint=fingerprint_mapping({"harness": harness, "artifact_id": artifact_id}),
-        content_hash=semantic_text,
+        content_hash=content_hash,
         capability_categories=_capabilities_for_artifact(artifact_type, safe_metadata),
         risk_level=_risk_level(safe_metadata),
         scanner_sources=("hol-detector",),
@@ -717,15 +741,65 @@ def _agent_type(value: str) -> AgentInventoryType:
 
 
 def _item_kind(artifact_type: str) -> InventoryItemKind:
-    if artifact_type in {"skill", "skill_file"}:
-        return "skill"
-    if artifact_type == "mcp_server":
-        return "mcp_server"
-    if artifact_type == "channel":
-        return "channel"
-    if artifact_type in {"gateway_config", "config"}:
-        return "agent"
-    return "plugin"
+    mapping: dict[str, InventoryItemKind] = {
+        "skill": "skill",
+        "skill_file": "skill",
+        "mcp_server": "mcp_server",
+        "mcp_tool": "mcp_tool",
+        "channel": "channel",
+        "gateway_config": "agent",
+        "config": "agent",
+        "agent": "agent",
+        "hook": "hook",
+        "instruction": "overlay",
+        "overlay": "overlay",
+        "command": "prompt_pack",
+        "extension": "plugin",
+        "plugin": "plugin",
+        "plugin-file": "plugin",
+        "repository": "repository",
+        "container_image": "container_image",
+        "policy": "policy",
+        "secret_reference": "secret_reference",
+        "network_endpoint": "network_endpoint",
+        "guard_launcher_shim": "harness",
+        "package": "package",
+        "daemon_plugin": "daemon_plugin",
+        "model_provider": "model_provider",
+        "prompt_pack": "prompt_pack",
+    }
+    return mapping.get(artifact_type, "plugin")
+
+
+def _resolve_item_content_hash(metadata: dict[str, object], semantic_text: str) -> str:
+    for key in ("content_hash", "directory_hash"):
+        candidate = metadata.get(key)
+        if isinstance(candidate, str) and candidate:
+            return candidate
+    version_info = metadata.get("versionInfo")
+    if isinstance(version_info, dict):
+        version_hash = version_info.get("contentHash")
+        if isinstance(version_hash, str) and version_hash:
+            return version_hash
+    return semantic_text
+
+
+def _apply_aibom_metadata_enrichment(
+    artifact: object,
+    *,
+    item_kind: InventoryItemKind,
+    metadata: dict[str, object],
+) -> dict[str, object]:
+    from .aibom_detection import instruction_role_for_path
+
+    enriched = dict(metadata)
+    if item_kind == "overlay" and "instructionRole" not in enriched:
+        config_path = getattr(artifact, "config_path", None)
+        if isinstance(config_path, str):
+            role = instruction_role_for_path(Path(config_path))
+            if role is not None:
+                enriched["instructionRole"] = role
+    return enriched
 
 
 def _capabilities_for_artifact(
@@ -734,6 +808,8 @@ def _capabilities_for_artifact(
 ) -> tuple[InventoryCapability, ...]:
     capabilities: set[InventoryCapability] = set()
     if artifact_type in {"skill", "skill_file"}:
+        capabilities.add("reads_files")
+    if artifact_type in {"instruction", "overlay", "command"}:
         capabilities.add("reads_files")
     if artifact_type == "mcp_server":
         capabilities.add("network_egress")

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -8,6 +8,7 @@ from codex_plugin_scanner.guard.aibom_detection import (
     discover_shared_workspace_aibom_artifacts,
     extend_detection_with_workspace_aibom,
     file_content_hash,
+    instruction_role_for_path,
 )
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
@@ -159,6 +160,73 @@ def test_hermes_and_openclaw_inventory_snapshots_include_workspace_agents_md(tmp
         snapshot = adapter.inventory_snapshot(context, generated_at="2026-06-10T00:00:00Z")
         overlay_items = [item for item in snapshot.items if item.item_kind == "overlay"]
         assert any(item.metadata.get("instructionRole") == "agents_md" for item in overlay_items)
+
+
+def test_instruction_role_ignores_unrelated_rules_paths(tmp_path: Path) -> None:
+    unrelated = tmp_path / "src" / "rules" / "guide.md"
+    unrelated.parent.mkdir(parents=True)
+    unrelated.write_text("not cursor\n", encoding="utf-8")
+    cursor_rule = tmp_path / ".cursor" / "rules" / "typescript.mdc"
+    cursor_rule.parent.mkdir(parents=True)
+    cursor_rule.write_text("cursor rule\n", encoding="utf-8")
+
+    assert instruction_role_for_path(unrelated) is None
+    assert instruction_role_for_path(cursor_rule) == "cursor_rules"
+
+
+def test_marketplace_escape_path_does_not_read_outside_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "plugin.json").write_text('{"name":"evil"}\n', encoding="utf-8")
+
+    marketplace_dir = workspace / ".agents" / "plugins"
+    marketplace_dir.mkdir(parents=True)
+    (marketplace_dir / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "demo-market",
+                "plugins": [
+                    {
+                        "name": "evil",
+                        "source": {"source": "local", "path": "./../../outside"},
+                    }
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    artifacts = discover_shared_workspace_aibom_artifacts(
+        "codex",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    evil_plugins = [artifact for artifact in artifacts if artifact.name == "evil"]
+
+    assert len(evil_plugins) == 1
+    assert "content_hash" not in evil_plugins[0].metadata
+
+
+def test_extend_detection_does_not_mark_harness_installed_from_workspace_files(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_text("policy\n", encoding="utf-8")
+
+    extended = extend_detection_with_workspace_aibom(
+        HarnessDetection(
+            harness="codex",
+            installed=False,
+            command_available=False,
+            config_paths=(),
+            artifacts=(),
+        ),
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+
+    assert extended.installed is False
+    assert any(artifact.artifact_type == "instruction" for artifact in extended.artifacts)
 
 
 def test_cursor_detect_extends_workspace_aibom(tmp_path: Path) -> None:

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.aibom_detection import (
+    INVENTORY_ITEM_KINDS,
+    discover_shared_workspace_aibom_artifacts,
+    extend_detection_with_workspace_aibom,
+    file_content_hash,
+)
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
+from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
+from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
+from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
+from codex_plugin_scanner.guard.models import HarnessDetection
+
+
+def test_inventory_item_kinds_align_with_portal_contract() -> None:
+    portal_kinds = {
+        "agent",
+        "daemon_plugin",
+        "harness",
+        "model_provider",
+        "package",
+        "prompt_pack",
+        "skill",
+        "mcp_server",
+        "mcp_tool",
+        "plugin",
+        "channel",
+        "hook",
+        "overlay",
+        "repository",
+        "container_image",
+        "policy",
+        "secret_reference",
+        "network_endpoint",
+    }
+    assert set(INVENTORY_ITEM_KINDS) == portal_kinds
+
+
+def test_discover_agents_md_and_cursor_rules(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    agents_md = workspace / "AGENTS.md"
+    agents_md.write_text("# Agent rules\nAlways use tests.\n", encoding="utf-8")
+    rules_dir = workspace / ".cursor" / "rules"
+    rules_dir.mkdir(parents=True)
+    (rules_dir / "typescript.mdc").write_text("Use strict TS.\n", encoding="utf-8")
+
+    artifacts = discover_shared_workspace_aibom_artifacts(
+        "cursor",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    kinds = {artifact.artifact_type for artifact in artifacts}
+    roles = {
+        artifact.metadata.get("instructionRole")
+        for artifact in artifacts
+        if isinstance(artifact.metadata, dict)
+    }
+
+    assert "instruction" in kinds
+    assert "agents_md" in roles
+    assert "cursor_rules" in roles
+
+
+def test_discover_codex_skills_and_marketplace_plugins(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    plugin_dir = workspace / "plugins" / "demo"
+    plugin_manifest = plugin_dir / ".codex-plugin" / "plugin.json"
+    plugin_manifest.parent.mkdir(parents=True, exist_ok=True)
+    plugin_manifest.write_text('{"name":"demo"}\n', encoding="utf-8")
+
+    marketplace_dir = workspace / ".agents" / "plugins"
+    marketplace_dir.mkdir(parents=True)
+    (marketplace_dir / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "demo-market",
+                "plugins": [{"name": "demo", "source": {"source": "local", "path": "./plugins/demo"}}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    skill_root = workspace / ".agents" / "skills" / "lint"
+    skill_root.mkdir(parents=True)
+    (skill_root / "SKILL.md").write_text("---\nname: lint\n---\n", encoding="utf-8")
+
+    artifacts = discover_shared_workspace_aibom_artifacts(
+        "codex",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    artifact_types = {artifact.artifact_type for artifact in artifacts}
+
+    assert "skill" in artifact_types
+    assert "plugin" in artifact_types
+
+
+def test_content_hash_changes_when_instruction_file_changes(tmp_path: Path) -> None:
+    path = tmp_path / "AGENTS.md"
+    path.write_text("version one\n", encoding="utf-8")
+    first = file_content_hash(path)
+    path.write_text("version two\n", encoding="utf-8")
+    second = file_content_hash(path)
+
+    assert first is not None
+    assert second is not None
+    assert first != second
+
+
+def test_inventory_snapshot_includes_workspace_instructions(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_text("repo policy\n", encoding="utf-8")
+
+    snapshot = inventory_snapshot_from_detection(
+        HarnessDetection(
+            harness="hermes",
+            installed=True,
+            command_available=False,
+            config_paths=(),
+            artifacts=(),
+        ),
+        generated_at="2026-06-10T00:00:00Z",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+
+    overlay_items = [item for item in snapshot.items if item.item_kind == "overlay"]
+    assert len(overlay_items) == 1
+    assert overlay_items[0].metadata.get("instructionRole") == "agents_md"
+
+
+def test_hermes_and_openclaw_inventory_snapshots_include_workspace_agents_md(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_text("shared policy\n", encoding="utf-8")
+    hermes_home = tmp_path / "home" / ".hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("mcp_servers: {}\n", encoding="utf-8")
+    openclaw_home = tmp_path / "home" / ".openclaw"
+    openclaw_home.mkdir(parents=True)
+    (openclaw_home / "openclaw.json").write_text(
+        '{"gateway":{"mode":"local"},"agents":{"defaults":{}},"channels":{},"mcpServers":{}}\n',
+        encoding="utf-8",
+    )
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        guard_home=tmp_path / ".hol-guard",
+    )
+
+    for adapter in (HermesHarnessAdapter(), OpenClawHarnessAdapter()):
+        snapshot = adapter.inventory_snapshot(context, generated_at="2026-06-10T00:00:00Z")
+        overlay_items = [item for item in snapshot.items if item.item_kind == "overlay"]
+        assert any(item.metadata.get("instructionRole") == "agents_md" for item in overlay_items)
+
+
+def test_cursor_detect_extends_workspace_aibom(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_text("policy\n", encoding="utf-8")
+    context = HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=tmp_path / ".hol-guard")
+
+    detection = CursorHarnessAdapter().detect(context)
+    extended = extend_detection_with_workspace_aibom(
+        detection,
+        home_dir=context.home_dir,
+        workspace_dir=context.workspace_dir,
+    )
+
+    assert any(
+        artifact.artifact_type == "instruction"
+        for artifact in extended.artifacts
+    )

--- a/tests/test_guard_aibom_symlink.py
+++ b/tests/test_guard_aibom_symlink.py
@@ -8,6 +8,8 @@ from codex_plugin_scanner.guard.aibom_symlink import (
     fingerprint_redacted_path,
     inspect_aibom_source_path,
 )
+from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 def test_fingerprint_redacted_path_never_emits_raw_home(tmp_path: Path) -> None:
     workspace = tmp_path / "repo"
     workspace.mkdir()
@@ -134,3 +136,71 @@ def test_inspection_serializes_without_raw_paths(tmp_path: Path) -> None:
 
     assert str(tmp_path) not in encoded
     assert "policy" not in encoded
+
+
+def test_inventory_snapshot_attaches_source_of_truth_for_symlink_items(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    shared = workspace / "shared-root"
+    shared.mkdir(parents=True)
+    (shared / "SKILL.md").write_text("name: shared\n", encoding="utf-8")
+    link = workspace / "skills" / "linked" / "SKILL.md"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(shared / "SKILL.md")
+
+    snapshot = inventory_snapshot_from_detection(
+        HarnessDetection(
+            harness="hermes",
+            installed=True,
+            command_available=False,
+            config_paths=(),
+            artifacts=(
+                GuardArtifact(
+                    artifact_id="hermes:skill:linked",
+                    name="linked",
+                    harness="hermes",
+                    artifact_type="skill",
+                    source_scope="project",
+                    config_path=str(link),
+                ),
+            ),
+        ),
+        generated_at="2026-06-10T00:00:00Z",
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+    )
+    item = snapshot.items[0]
+    source_of_truth = item.metadata.get("sourceOfTruth")
+    assert isinstance(source_of_truth, dict)
+    assert source_of_truth.get("validationState") == "valid"
+    assert source_of_truth.get("linkKind") == "symlink"
+
+
+def test_inventory_snapshot_emits_findings_for_broken_symlink_sources(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    broken = workspace / "broken-link"
+    broken.symlink_to(workspace / "missing-target")
+
+    snapshot = inventory_snapshot_from_detection(
+        HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=False,
+            config_paths=(),
+            artifacts=(
+                GuardArtifact(
+                    artifact_id="codex:instruction:broken",
+                    name="broken",
+                    harness="codex",
+                    artifact_type="instruction",
+                    source_scope="project",
+                    config_path=str(broken),
+                ),
+            ),
+        ),
+        generated_at="2026-06-10T00:00:00Z",
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+    )
+
+    assert any(finding.check_id == "aibom.symlink.broken" for finding in snapshot.findings)

--- a/tests/test_guard_aibom_symlink.py
+++ b/tests/test_guard_aibom_symlink.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.aibom_symlink import (
+    classify_path_class,
+    fingerprint_redacted_path,
+    inspect_aibom_source_path,
+)
+def test_fingerprint_redacted_path_never_emits_raw_home(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    target = workspace / "skills" / "shared"
+    target.mkdir(parents=True)
+    home = tmp_path / "home"
+
+    fingerprint = fingerprint_redacted_path(target, home_dir=home, workspace_dir=workspace)
+    payload = json.dumps({"fingerprint": fingerprint})
+
+    assert str(tmp_path) not in payload
+    assert str(home) not in payload
+    assert "workspace" in fingerprint or len(fingerprint) == 64
+
+
+def test_inspect_valid_symlink_reports_source_hash(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    shared = workspace / "shared-root"
+    shared.mkdir(parents=True)
+    (shared / "SKILL.md").write_text("name: shared\n", encoding="utf-8")
+    link = workspace / "skills" / "linked"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(shared, target_is_directory=True)
+
+    inspection = inspect_aibom_source_path(
+        link,
+        safe_roots=(workspace,),
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+    )
+
+    assert inspection.link_kind == "symlink"
+    assert inspection.validation_state == "valid"
+    assert inspection.path_class == "workspace_relative"
+    assert inspection.source_fingerprint
+    assert inspection.target_content_hash
+
+
+def test_inspect_broken_symlink_fails_closed(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    broken = workspace / "broken-link"
+    broken.symlink_to(workspace / "missing-target")
+
+    inspection = inspect_aibom_source_path(
+        broken,
+        safe_roots=(workspace,),
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+    )
+
+    assert inspection.validation_state == "broken"
+
+
+def test_inspect_symlink_loop_fails_closed(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    loop_a = workspace / "loop-a"
+    loop_b = workspace / "loop-b"
+    loop_a.symlink_to(loop_b)
+    loop_b.symlink_to(loop_a)
+
+    inspection = inspect_aibom_source_path(
+        loop_a,
+        safe_roots=(workspace,),
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+    )
+
+    assert inspection.validation_state == "loop"
+
+
+def test_inspect_escape_symlink_blocked(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "secret.txt").write_text("outside\n", encoding="utf-8")
+    escape = workspace / "escape-link"
+    escape.symlink_to(outside)
+
+    inspection = inspect_aibom_source_path(
+        escape,
+        safe_roots=(workspace,),
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+    )
+
+    assert inspection.validation_state == "escape_blocked"
+
+
+def test_classify_workspace_relative_path(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    agents_md = workspace / "AGENTS.md"
+    agents_md.write_text("policy\n", encoding="utf-8")
+
+    assert (
+        classify_path_class(agents_md, home_dir=tmp_path / "home", workspace_dir=workspace)
+        == "workspace_relative"
+    )
+
+
+def test_inspection_serializes_without_raw_paths(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    target = workspace / "AGENTS.md"
+    target.write_text("policy\n", encoding="utf-8")
+
+    inspection = inspect_aibom_source_path(
+        target,
+        safe_roots=(workspace,),
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+    )
+    encoded = json.dumps(
+        {
+            "source_fingerprint": inspection.source_fingerprint,
+            "path_class": inspection.path_class,
+            "validation_state": inspection.validation_state,
+            "redaction_summary": inspection.redaction_summary,
+        }
+    )
+
+    assert str(tmp_path) not in encoded
+    assert "policy" not in encoded


### PR DESCRIPTION
## Summary
- Align local `InventoryItemKind` with portal contract (daemon_plugin, harness, package, prompt_pack, etc.)
- Add shared AIBOM workspace discovery for AGENTS.md, Cursor rules, Codex skills, and marketplace plugins
- Emit content hashes and `instructionRole` metadata for version history and cloud sync

## Testing
- `python3 -m pytest tests/test_guard_aibom_detection.py tests/test_guard_inventory_contract.py -q`

## Notes
- Phase 3 tasks #046-#060 for PR-004 checkpoint; symlink safety (#061+) follows in next PR.
