### PR TITLE
feat(guard): attach local HCS trust domains to AIBOM inventory

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -1,0 +1,177 @@
+"""Attach local HCS trust domain evidence to AIBOM inventory metadata."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Literal
+
+from ..checks.skill_security import resolve_skill_security_context
+from ..trust_mcp_scoring import build_mcp_domain
+from ..trust_plugin_scoring import build_plugin_domain
+from ..trust_skill_scoring import build_skill_domain
+from ..trust_models import TrustAdapterScore, TrustComponentScore, TrustDomainScore
+
+InventoryItemKind = Literal[
+    "agent",
+    "channel",
+    "container_image",
+    "daemon_plugin",
+    "harness",
+    "hook",
+    "mcp_server",
+    "mcp_tool",
+    "model_provider",
+    "network_endpoint",
+    "overlay",
+    "package",
+    "plugin",
+    "policy",
+    "prompt_pack",
+    "repository",
+    "secret_reference",
+    "skill",
+]
+
+
+def trust_resolution_from_domain(
+    domain: TrustDomainScore,
+    *,
+    captured_at: str,
+) -> dict[str, object]:
+    return {
+        "resolutionSource": "local",
+        "status": "local",
+        "trustScore": int(round(domain.score)),
+        "trustComponents": _trust_components_from_domain(domain),
+        "capturedAt": captured_at,
+        "metadata": {
+            "profileId": domain.profile_id,
+            "profileVersion": domain.profile_version,
+            "scorer": "hol-guard-local",
+            "specId": domain.spec_id,
+            "specVersion": domain.spec_version,
+            "trustDomain": domain.domain,
+        },
+    }
+
+
+def apply_local_trust_metadata(
+    artifact: object,
+    *,
+    captured_at: str,
+    item_kind: InventoryItemKind,
+    metadata: dict[str, object],
+    workspace_dir: Path | None,
+) -> dict[str, object]:
+    if item_kind not in {"skill", "plugin", "mcp_server"}:
+        return metadata
+    if isinstance(metadata.get("trustResolution"), dict):
+        return metadata
+    if isinstance(metadata.get("registryIdentity"), dict):
+        return metadata
+
+    domain = _local_trust_domain_for_artifact(
+        artifact,
+        item_kind=item_kind,
+        workspace_dir=workspace_dir,
+    )
+    if domain is None:
+        return metadata
+
+    enriched = dict(metadata)
+    enriched["trustResolution"] = trust_resolution_from_domain(domain, captured_at=captured_at)
+    return enriched
+
+
+def _local_trust_domain_for_artifact(
+    artifact: object,
+    *,
+    item_kind: InventoryItemKind,
+    workspace_dir: Path | None,
+) -> TrustDomainScore | None:
+    trust_root = _trust_root_for_artifact(artifact, item_kind=item_kind, workspace_dir=workspace_dir)
+    if trust_root is None:
+        return None
+    if item_kind == "plugin":
+        return build_plugin_domain(trust_root, ())
+    if item_kind == "skill":
+        context = resolve_skill_security_context(trust_root)
+        return build_skill_domain(trust_root, context)
+    if item_kind == "mcp_server":
+        return build_mcp_domain(trust_root, ())
+    return None
+
+
+def _trust_root_for_artifact(
+    artifact: object,
+    *,
+    item_kind: InventoryItemKind,
+    workspace_dir: Path | None,
+) -> Path | None:
+    config_path = getattr(artifact, "config_path", None)
+    if not isinstance(config_path, str) or not config_path.strip():
+        return None
+    path = Path(config_path)
+    if not path.exists():
+        return None
+
+    if item_kind == "skill":
+        skill_dir = path.parent if path.name.lower() == "skill.md" else path
+        for candidate in (skill_dir, *skill_dir.parents):
+            if (candidate / ".codex-plugin" / "plugin.json").is_file():
+                return candidate
+            if workspace_dir is not None and candidate.resolve() == workspace_dir.resolve():
+                break
+        return skill_dir if skill_dir.is_dir() else None
+
+    if item_kind == "mcp_server":
+        if path.is_file():
+            return path.parent
+        return path if path.is_dir() else None
+
+    if item_kind == "plugin":
+        if path.is_dir():
+            return path
+        parent = path.parent
+        return parent if parent.is_dir() else None
+
+    return None
+
+
+def _trust_components_from_domain(domain: TrustDomainScore) -> list[dict[str, object]]:
+    components: list[dict[str, object]] = []
+    for adapter in domain.adapters:
+        if not adapter.emitted:
+            continue
+        components.extend(_trust_components_from_adapter(adapter))
+        if len(components) >= 32:
+            break
+    return components[:32]
+
+
+def _trust_components_from_adapter(adapter: TrustAdapterScore) -> list[dict[str, object]]:
+    return [_trust_component_row(adapter, component) for component in adapter.components]
+
+
+def _trust_component_row(
+    adapter: TrustAdapterScore,
+    component: TrustComponentScore,
+) -> dict[str, object]:
+    score = int(round(component.score))
+    status = "positive"
+    if score < 40:
+        status = "critical"
+    elif score < 70:
+        status = "warning"
+    payload: dict[str, object] = {
+        "componentId": f"{adapter.adapter_id}:{component.key}",
+        "confidence": 85,
+        "label": adapter.label,
+        "score": score,
+        "status": status,
+        "summary": component.rationale,
+        "weight": adapter.weight,
+    }
+    if component.evidence:
+        payload["evidence"] = {"lines": list(component.evidence)}
+    return payload

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -7,9 +7,9 @@ from typing import Literal
 
 from ..checks.skill_security import resolve_skill_security_context
 from ..trust_mcp_scoring import build_mcp_domain
+from ..trust_models import TrustAdapterScore, TrustComponentScore, TrustDomainScore
 from ..trust_plugin_scoring import build_plugin_domain
 from ..trust_skill_scoring import build_skill_domain
-from ..trust_models import TrustAdapterScore, TrustComponentScore, TrustDomainScore
 
 InventoryItemKind = Literal[
     "agent",
@@ -41,7 +41,7 @@ def trust_resolution_from_domain(
     return {
         "resolutionSource": "local",
         "status": "local",
-        "trustScore": int(round(domain.score)),
+        "trustScore": round(domain.score),
         "trustComponents": _trust_components_from_domain(domain),
         "capturedAt": captured_at,
         "metadata": {
@@ -157,7 +157,7 @@ def _trust_component_row(
     adapter: TrustAdapterScore,
     component: TrustComponentScore,
 ) -> dict[str, object]:
-    score = int(round(component.score))
+    score = round(component.score)
     status = "positive"
     if score < 40:
         status = "critical"

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -245,6 +245,7 @@ def inventory_snapshot_from_detection(
         item = _item_from_artifact(
             harness,
             artifact,
+            generated_at=generated_at,
             home_dir=home_dir,
             workspace_dir=workspace_dir,
         )
@@ -394,6 +395,7 @@ def _item_from_artifact(
     harness: str,
     artifact: object,
     *,
+    generated_at: str,
     home_dir: Path,
     workspace_dir: Path | None,
 ) -> GuardAgentInventoryItem:
@@ -404,8 +406,10 @@ def _item_from_artifact(
     item_kind = _item_kind(artifact_type)
     safe_metadata = _apply_aibom_metadata_enrichment(
         artifact,
+        captured_at=generated_at,
         item_kind=item_kind,
         metadata=safe_metadata,
+        workspace_dir=workspace_dir,
     )
     safe_metadata = _apply_source_of_truth_metadata(
         artifact,
@@ -875,10 +879,13 @@ def _symlink_findings_from_items(
 def _apply_aibom_metadata_enrichment(
     artifact: object,
     *,
+    captured_at: str,
     item_kind: InventoryItemKind,
     metadata: dict[str, object],
+    workspace_dir: Path | None,
 ) -> dict[str, object]:
     from .aibom_detection import instruction_role_for_path
+    from .aibom_trust_metadata import apply_local_trust_metadata
 
     enriched = dict(metadata)
     if item_kind == "overlay" and "instructionRole" not in enriched:
@@ -887,7 +894,13 @@ def _apply_aibom_metadata_enrichment(
             role = instruction_role_for_path(Path(config_path))
             if role is not None:
                 enriched["instructionRole"] = role
-    return enriched
+    return apply_local_trust_metadata(
+        artifact,
+        captured_at=captured_at,
+        item_kind=item_kind,
+        metadata=enriched,
+        workspace_dir=workspace_dir,
+    )
 
 
 def _capabilities_for_artifact(

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -21,6 +21,7 @@ def _write_good_plugin(plugin_dir: Path) -> None:
                 "author": {"name": "Hashgraph Online"},
                 "homepage": "https://example.com/plugin",
                 "repository": "https://github.com/hashgraph-online/hol-guard",
+                "skills": "skills",
             }
         ),
         encoding="utf-8",
@@ -70,6 +71,47 @@ def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Pat
     components = trust.get("trustComponents")
     assert isinstance(components, list)
     assert components
+
+
+def test_inventory_snapshot_attaches_local_skill_trust_resolution(tmp_path: Path) -> None:
+    plugin_dir = tmp_path
+    _write_good_plugin(plugin_dir)
+    skills_dir = plugin_dir / "skills" / "demo-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\nname: demo-skill\ndescription: Demo\n---\n", encoding="utf-8")
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(skills_dir / "SKILL.md"),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:skill:demo-skill",
+                name="demo-skill",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="project",
+                config_path=str(skills_dir / "SKILL.md"),
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+    skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
+    trust = skill_item.metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    metadata = trust.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("trustDomain") == "skills"
+    components = trust.get("trustComponents")
+    assert isinstance(components, list)
+    assert len(components) > 0
+    assert all(isinstance(component.get("componentId"), str) for component in components)
 
 
 def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) -> None:

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -1,0 +1,121 @@
+"""AIBOM local trust metadata tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+
+
+def _write_good_plugin(plugin_dir: Path) -> None:
+    manifest_dir = plugin_dir / ".codex-plugin"
+    manifest_dir.mkdir(parents=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": "trust-demo",
+                "version": "1.0.0",
+                "description": "Trust scoring demo plugin",
+                "author": {"name": "Hashgraph Online"},
+                "homepage": "https://example.com/plugin",
+                "repository": "https://github.com/hashgraph-online/hol-guard",
+            }
+        ),
+        encoding="utf-8",
+    )
+    (plugin_dir / "README.md").write_text("# Demo\n", encoding="utf-8")
+    (plugin_dir / "SECURITY.md").write_text("Report issues privately.\n", encoding="utf-8")
+    (plugin_dir / "LICENSE").write_text("MIT\n", encoding="utf-8")
+
+
+def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Path) -> None:
+    plugin_dir = tmp_path
+    _write_good_plugin(plugin_dir)
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(plugin_dir / ".codex-plugin" / "plugin.json"),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:plugin:trust-demo",
+                name="trust-demo",
+                harness="codex",
+                artifact_type="plugin",
+                source_scope="project",
+                config_path=str(plugin_dir),
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+    plugin_item = next(item for item in snapshot.items if item.item_kind == "plugin")
+    trust = plugin_item.metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    assert trust.get("resolutionSource") == "local"
+    assert trust.get("status") == "local"
+    assert isinstance(trust.get("trustScore"), int)
+    assert trust.get("trustScore", 0) > 0
+    metadata = trust.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("trustDomain") == "plugin"
+    assert metadata.get("scorer") == "hol-guard-local"
+    components = trust.get("trustComponents")
+    assert isinstance(components, list)
+    assert components
+
+
+def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) -> None:
+    plugin_dir = tmp_path
+    _write_good_plugin(plugin_dir)
+    (plugin_dir / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "local-demo": {
+                        "command": "python",
+                        "args": ["-m", "demo_server"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(plugin_dir / ".mcp.json"),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:mcp:local-demo",
+                name="local-demo",
+                harness="codex",
+                artifact_type="mcp_server",
+                source_scope="project",
+                config_path=str(plugin_dir / ".mcp.json"),
+                transport="stdio",
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+    mcp_item = next(item for item in snapshot.items if item.item_kind == "mcp_server")
+    trust = mcp_item.metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    assert trust.get("resolutionSource") == "local"
+    metadata = trust.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("trustDomain") == "mcp"


### PR DESCRIPTION
## Summary
- Attach local HCS trust domain scores to AIBOM inventory metadata as trustResolution hints
- Cover plugin, skill, and MCP trust domains with adapter component evidence for cloud sync

## Testing
- `python3 -m pytest tests/test_guard_aibom_trust_metadata.py -q`
