### PR TITLE
Require explicit dashboard asset sync source to prevent dashboard poisoning

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
+++ b/src/codex_plugin_scanner/guard/cli/dashboard_sync.py
@@ -2,15 +2,19 @@ from pathlib import Path
 
 from ..redaction import redact_sensitive_text
 
+_DASHBOARD_SYNC_SOURCE_ENV = "HOL_GUARD_DASHBOARD_SYNC_SOURCE"
+
 
 def sync_dashboard_assets() -> dict[str, object] | None:
-    """Copy pre-built dashboard assets from a local source checkout to the installed package.
+    """Copy pre-built dashboard assets from an explicitly configured source checkout.
 
-    When HOL Guard is installed from PyPI/uv/pipx, the wheel may not include the latest
-    dashboard Vite build. This function detects a local source checkout and copies the
-    already-built assets into the installed package's static directory so the running
-    daemon serves fresh UI. No build step is performed; run ``npm run build`` in the
-    dashboard directory first if assets are stale.
+    When HOL Guard is installed from PyPI/uv/pipx, the wheel may not include a local
+    dashboard Vite build that a developer wants to test. This function only uses a
+    source checkout when the operator explicitly points to one with
+    ``HOL_GUARD_DASHBOARD_SYNC_SOURCE``. It intentionally does not discover sources
+    from the current working directory: update commands can be run from untrusted
+    projects, and copying executable dashboard assets from an implicit checkout would
+    let those projects poison the installed local approval-center UI.
     """
     import importlib.util
     import shutil
@@ -26,7 +30,6 @@ def sync_dashboard_assets() -> dict[str, object] | None:
     except OSError:
         return None
 
-    # Find a local source checkout by walking up from cwd looking for hol-guard/dashboard
     try:
         source_checkout = find_source_checkout()
     except OSError:
@@ -110,70 +113,39 @@ def sync_dashboard_assets() -> dict[str, object] | None:
 
 
 def find_source_checkout() -> Path | None:
-    """Return a local hol-guard source checkout if one is detected nearby.
+    """Return an explicitly configured hol-guard source checkout, if any.
 
-    Security: Only returns a directory after VCS verification proves it is the
-    real hashgraph-online/hol-guard repository. Trivial directory markers like
-    dashboard/package.json and src/codex_plugin_scanner are NOT sufficient on
-    their own because any untrusted project can create them.
+    The sync source must be supplied with ``HOL_GUARD_DASHBOARD_SYNC_SOURCE``.
+    Earlier versions walked up from the current working directory and inspected
+    nearby git repositories, but update commands commonly run inside arbitrary
+    workspaces. CWD-based discovery turns a spoofable local repository into a
+    source of executable dashboard assets, so it is deliberately disabled.
     """
+    import os
+
+    source = os.environ.get(_DASHBOARD_SYNC_SOURCE_ENV)
+    if source is None or not source.strip():
+        return None
     try:
-        cwd = Path.cwd().resolve()
+        path = Path(source).expanduser().resolve()
     except OSError:
         return None
-    candidates = [cwd, *cwd.parents]
-    for candidate in candidates:
-        checkout = verify_source_checkout(candidate)
-        if checkout is not None:
-            return checkout
-    # Check one level deeper for repo roots that may contain hol-guard as a sub-project
-    for candidate in candidates:
-        try:
-            for sub in candidate.iterdir():
-                try:
-                    checkout = verify_source_checkout(sub)
-                    if checkout is not None:
-                        return checkout
-                except OSError:
-                    continue
-        except OSError:
-            continue
-    return None
-
-
-_TRUSTED_REPO_KEYWORDS = ("hashgraph-online/hol-guard",)
+    return verify_source_checkout(path)
 
 
 def verify_source_checkout(path: Path) -> Path | None:
-    """Verify a candidate directory is the real hol-guard source checkout.
+    """Verify a user-selected directory has the expected hol-guard source shape.
 
-    Returns *path* only when:
-    - It contains the expected source tree markers.
-    - It is a git repository whose remotes reference the trusted upstream.
-
-    Security: This function reads ``.git/config`` directly instead of executing
-    ``git`` in the candidate directory to avoid triggering repository-local Git
-    hooks or configuration that could lead to arbitrary code execution.
+    This is a sanity check for the explicit sync path, not a trust decision for
+    ambient directories. It intentionally avoids reading ``.git/config`` because
+    repository metadata is attacker-controlled and cannot prove that uncommitted
+    dashboard build outputs are safe to install.
     """
     try:
         if not (path / "dashboard" / "package.json").is_file():
             return None
         if not (path / "src" / "codex_plugin_scanner").is_dir():
             return None
-        if not (path / ".git").is_dir():
-            return None
     except OSError:
         return None
-
-    try:
-        config_path = path / ".git" / "config"
-        if not config_path.is_file():
-            return None
-        remote_text = config_path.read_text(encoding="utf-8", errors="ignore")
-    except OSError:
-        return None
-
-    if not any(kw in remote_text for kw in _TRUSTED_REPO_KEYWORDS):
-        return None
-
     return path

--- a/tests/test_dashboard_sync.py
+++ b/tests/test_dashboard_sync.py
@@ -1,0 +1,95 @@
+"""Tests for dashboard asset sync source selection."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+
+@pytest.fixture()
+def dashboard_sync_module(monkeypatch: pytest.MonkeyPatch) -> ModuleType:
+    """Load dashboard_sync without importing the full guard CLI dependency graph."""
+    for name in [
+        "codex_plugin_scanner",
+        "codex_plugin_scanner.guard",
+        "codex_plugin_scanner.guard.cli",
+    ]:
+        package = types.ModuleType(name)
+        package.__path__ = []
+        monkeypatch.setitem(sys.modules, name, package)
+    redaction = types.ModuleType("codex_plugin_scanner.guard.redaction")
+    redaction.redact_sensitive_text = lambda value: value
+    monkeypatch.setitem(sys.modules, "codex_plugin_scanner.guard.redaction", redaction)
+
+    module_name = "codex_plugin_scanner.guard.cli.dashboard_sync"
+    module_path = (
+        Path(__file__).resolve().parents[1] / "src" / "codex_plugin_scanner" / "guard" / "cli" / "dashboard_sync.py"
+    )
+    spec = importlib.util.spec_from_file_location(module_name, module_path)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_source_markers(path: Path) -> None:
+    (path / "dashboard").mkdir(parents=True)
+    (path / "dashboard" / "package.json").write_text("{}\n", encoding="utf-8")
+    (path / "src" / "codex_plugin_scanner").mkdir(parents=True)
+
+
+def test_find_source_checkout_does_not_discover_spoofed_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dashboard_sync_module: ModuleType,
+) -> None:
+    attacker_checkout = tmp_path / "attacker-project"
+    _write_source_markers(attacker_checkout)
+    (attacker_checkout / ".git").mkdir()
+    (attacker_checkout / ".git" / "config").write_text(
+        '[remote "origin"]\nurl = https://evil.example/repo.git?note=hashgraph-online/hol-guard\n',
+        encoding="utf-8",
+    )
+
+    monkeypatch.chdir(attacker_checkout)
+    monkeypatch.delenv(dashboard_sync_module._DASHBOARD_SYNC_SOURCE_ENV, raising=False)
+
+    assert dashboard_sync_module.find_source_checkout() is None
+
+
+def test_find_source_checkout_requires_explicit_source_env(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    dashboard_sync_module: ModuleType,
+) -> None:
+    source_checkout = tmp_path / "hol-guard"
+    _write_source_markers(source_checkout)
+    unrelated_cwd = tmp_path / "workspace"
+    unrelated_cwd.mkdir()
+
+    monkeypatch.chdir(unrelated_cwd)
+    monkeypatch.setenv(dashboard_sync_module._DASHBOARD_SYNC_SOURCE_ENV, str(source_checkout))
+
+    assert dashboard_sync_module.find_source_checkout() == source_checkout.resolve()
+
+
+def test_verify_source_checkout_ignores_spoofable_git_config(
+    tmp_path: Path,
+    dashboard_sync_module: ModuleType,
+) -> None:
+    source_checkout = tmp_path / "hol-guard"
+    _write_source_markers(source_checkout)
+    (source_checkout / ".git").mkdir()
+    (source_checkout / ".git" / "config").write_text(
+        '[remote "origin"]\nurl = https://evil.example/repo.git?note=hashgraph-online/hol-guard\n',
+        encoding="utf-8",
+    )
+
+    assert dashboard_sync_module.verify_source_checkout(source_checkout) == source_checkout


### PR DESCRIPTION
### Motivation
- The previous dashboard asset sync discovered local checkouts by walking `cwd`/parents and accepted a `.git/config` substring as a trust signal, which allows a local attacker-controlled repo to poison installed dashboard assets. 
- The goal is to eliminate implicit, spoofable source discovery so update runs cannot accidentally copy attacker-controlled executable UI into the installed package.

### Description
- Require the operator to opt-in to asset sync by providing an explicit source path via the `HOL_GUARD_DASHBOARD_SYNC_SOURCE` environment variable and stop scanning `cwd` and nearby directories in `find_source_checkout()`.
- Remove the `.git/config` substring remote check and limit `verify_source_checkout()` to a simple shape/sanity check for an operator-selected path (no VCS-based trust decision). 
- Update `sync_dashboard_assets()` documentation and behavior to only use the explicit source and keep the existing copy logic unchanged. 
- Add regression tests in `tests/test_dashboard_sync.py` covering spoofed cwd repositories, explicit env-based selection, and ignoring spoofable git metadata.

### Testing
- Ran `python -m pytest --noconftest tests/test_dashboard_sync.py` and it passed (`3 passed`).
- Ran linter/format checks with `python -m ruff check src/codex_plugin_scanner/guard/cli/dashboard_sync.py tests/test_dashboard_sync.py` and they passed. 
- Verified bytecode compilation with `python -m py_compile src/codex_plugin_scanner/guard/cli/dashboard_sync.py` and it succeeded. 
- Attempting `python -m pytest tests/test_dashboard_sync.py` without `--noconftest` failed during collection due to the environment missing the `cryptography` dependency, and `pip install -e '.[dev]'` could not complete in this environment due to network/proxy restrictions, so full test-suite runs were not possible here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2832f910ec832db943a59e5c8980e5)