### PR TITLE
fix(guard): hash full AIBOM file bytes for approval drift

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -33,18 +33,31 @@ INVENTORY_ITEM_KINDS: tuple[str, ...] = (
     "network_endpoint",
 )
 
-_MAX_FILE_BYTES = 1024 * 1024
+_READ_CHUNK_BYTES = 65536
 _CURSOR_RULE_PATTERNS = ("*.mdc", "*.md")
 _CODEX_SKILL_ROOTS = (".agents/skills",)
 
 
-def file_content_hash(path: Path, *, max_bytes: int = _MAX_FILE_BYTES) -> str | None:
+def file_content_hash(path: Path, *, max_bytes: int | None = None) -> str | None:
+    """Return a SHA-256 digest of the full file bytes used for approval drift detection.
+
+    When ``max_bytes`` is set, only that prefix is hashed. Production callers must
+    leave ``max_bytes`` unset so tail edits cannot bypass change detection.
+    """
     try:
+        digest = hashlib.sha256()
         with path.open("rb") as handle:
-            payload = handle.read(max_bytes)
+            if max_bytes is None:
+                while True:
+                    chunk = handle.read(_READ_CHUNK_BYTES)
+                    if not chunk:
+                        break
+                    digest.update(chunk)
+            else:
+                digest.update(handle.read(max_bytes))
+        return digest.hexdigest()
     except OSError:
         return None
-    return fingerprint_text(payload.decode("utf-8", errors="replace"))
 
 
 def directory_content_hash(root: Path, *, home_dir: Path) -> str:

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -3,6 +3,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
+from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
+from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
 from codex_plugin_scanner.guard.aibom_detection import (
     INVENTORY_ITEM_KINDS,
     discover_shared_workspace_aibom_artifacts,
@@ -10,10 +14,7 @@ from codex_plugin_scanner.guard.aibom_detection import (
     file_content_hash,
     instruction_role_for_path,
 )
-from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
-from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
-from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
+from codex_plugin_scanner.guard.consumer.service import artifact_hash, diff_artifact
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import HarnessDetection
 
@@ -100,6 +101,57 @@ def test_discover_codex_skills_and_marketplace_plugins(tmp_path: Path) -> None:
 
     assert "skill" in artifact_types
     assert "plugin" in artifact_types
+
+
+def test_content_hash_detects_tail_changes_beyond_one_mebibyte(tmp_path: Path) -> None:
+    prefix = b"A" * (1024 * 1024)
+    path = tmp_path / "AGENTS.md"
+    path.write_bytes(prefix + b"tail-version-one\n")
+    first = file_content_hash(path)
+    path.write_bytes(prefix + b"tail-version-two\n")
+    second = file_content_hash(path)
+
+    assert first is not None
+    assert second is not None
+    assert first != second
+
+
+def test_diff_artifact_detects_tail_only_instruction_change(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    agents_md = workspace / "AGENTS.md"
+    prefix = b"policy-" * (1024 * 1024 // len(b"policy-") + 1)
+    prefix = prefix[: 1024 * 1024]
+    agents_md.write_bytes(prefix + b"approved-tail\n")
+
+    artifacts_v1 = discover_shared_workspace_aibom_artifacts(
+        "codex",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    artifact_v1 = next(
+        artifact for artifact in artifacts_v1 if artifact.artifact_type == "instruction"
+    )
+    previous = {
+        **artifact_v1.to_dict(),
+        "artifact_hash": artifact_hash(artifact_v1),
+        "env_keys": [],
+    }
+
+    agents_md.write_bytes(prefix + b"malicious-tail\n")
+    artifacts_v2 = discover_shared_workspace_aibom_artifacts(
+        "codex",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    artifact_v2 = next(
+        artifact for artifact in artifacts_v2 if artifact.artifact_type == "instruction"
+    )
+
+    diff = diff_artifact(previous, artifact_v2)
+
+    assert diff["changed"] is True
+    assert diff["previous_hash"] != diff["current_hash"]
 
 
 def test_content_hash_changes_when_instruction_file_changes(tmp_path: Path) -> None:

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -130,8 +130,10 @@ def test_diff_artifact_detects_tail_only_instruction_change(tmp_path: Path) -> N
         workspace_dir=workspace,
     )
     artifact_v1 = next(
-        artifact for artifact in artifacts_v1 if artifact.artifact_type == "instruction"
+        (artifact for artifact in artifacts_v1 if artifact.artifact_type == "instruction"),
+        None,
     )
+    assert artifact_v1 is not None, "Expected an instruction artifact in v1 discovery"
     previous = {
         **artifact_v1.to_dict(),
         "artifact_hash": artifact_hash(artifact_v1),
@@ -145,8 +147,10 @@ def test_diff_artifact_detects_tail_only_instruction_change(tmp_path: Path) -> N
         workspace_dir=workspace,
     )
     artifact_v2 = next(
-        artifact for artifact in artifacts_v2 if artifact.artifact_type == "instruction"
+        (artifact for artifact in artifacts_v2 if artifact.artifact_type == "instruction"),
+        None,
     )
+    assert artifact_v2 is not None, "Expected an instruction artifact in v2 discovery"
 
     diff = diff_artifact(previous, artifact_v2)
 


### PR DESCRIPTION
## Summary
- Hash the full byte stream for workspace AIBOM files instead of only the first 1 MiB prefix.
- Tail-only edits to large AGENTS.md, Cursor rules, SKILL.md, and plugin manifests now change `content_hash`, `artifact_hash`, and `diff_artifact`.

## Testing
- `python3 -m pytest tests/test_guard_aibom_detection.py -q`

## Notes
- Existing approvals for large artifacts may require reapproval after upgrade because digest basis changed from prefix-only to full-file SHA-256.
