### PR TITLE
fix(guard): disable Cisco skill scan during inventory trust enrichment

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -6,10 +6,13 @@ from pathlib import Path
 from typing import Literal
 
 from ..checks.skill_security import resolve_skill_security_context
+from ..models import ScanOptions
 from ..trust_mcp_scoring import build_mcp_domain
 from ..trust_models import TrustAdapterScore, TrustComponentScore, TrustDomainScore
 from ..trust_plugin_scoring import build_plugin_domain
 from ..trust_skill_scoring import build_skill_domain
+
+_INVENTORY_TRUST_SCAN_OPTIONS = ScanOptions(cisco_skill_scan="off")
 
 InventoryItemKind = Literal[
     "agent",
@@ -95,7 +98,7 @@ def _local_trust_domain_for_artifact(
     if item_kind == "plugin":
         return build_plugin_domain(trust_root, ())
     if item_kind == "skill":
-        context = resolve_skill_security_context(trust_root)
+        context = resolve_skill_security_context(trust_root, _INVENTORY_TRUST_SCAN_OPTIONS)
         return build_skill_domain(trust_root, context)
     if item_kind == "mcp_server":
         return build_mcp_domain(trust_root, ())

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -92,21 +92,24 @@ def test_inventory_skill_trust_enrichment_disables_cisco_scan(
         return original_import(name, *args, **kwargs)
 
     def _record_cisco_mode(**kwargs: object) -> object:
+        from codex_plugin_scanner.integrations.cisco_skill_scanner import (
+            CiscoIntegrationStatus,
+            CiscoSkillScanSummary,
+        )
+
         mode = kwargs.get("mode")
         assert isinstance(mode, str)
         cisco_modes.append(mode)
-        from codex_plugin_scanner.integrations.cisco_skill_scanner import run_cisco_skill_scan
-
-        skills_dir = kwargs.get("skills_dir")
-        policy_name = kwargs.get("policy_name", "balanced")
-        timeout_seconds = kwargs.get("timeout_seconds")
-        assert isinstance(skills_dir, Path)
-        assert isinstance(policy_name, str)
-        return run_cisco_skill_scan(
-            skills_dir,
-            mode=mode,
-            policy_name=policy_name,
-            timeout_seconds=timeout_seconds if isinstance(timeout_seconds, (int, float)) else None,
+        return CiscoSkillScanSummary(
+            status=CiscoIntegrationStatus.SKIPPED,
+            message="Cisco skill scanning disabled by configuration.",
+            findings=(),
+            skills_scanned=0,
+            skills_skipped=(),
+            analyzers_used=(),
+            policy_name="balanced",
+            total_findings=0,
+            findings_by_severity={"critical": 0, "high": 0, "medium": 0, "low": 0},
         )
 
     monkeypatch.setattr(builtins, "__import__", _guard_import)

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import builtins
 import json
 from pathlib import Path
 
@@ -71,6 +72,77 @@ def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Pat
     components = trust.get("trustComponents")
     assert isinstance(components, list)
     assert components
+
+
+def test_inventory_skill_trust_enrichment_disables_cisco_scan(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    plugin_dir = tmp_path
+    _write_good_plugin(plugin_dir)
+    skills_dir = plugin_dir / "skills" / "demo-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\nname: demo-skill\ndescription: Demo\n---\n", encoding="utf-8")
+    cisco_modes: list[str] = []
+    original_import = builtins.__import__
+
+    def _guard_import(name: str, *args: object, **kwargs: object) -> object:
+        if name == "skill_scanner" or name.startswith("skill_scanner."):
+            raise AssertionError("inventory trust enrichment must not import skill_scanner")
+        return original_import(name, *args, **kwargs)
+
+    def _record_cisco_mode(**kwargs: object) -> object:
+        mode = kwargs.get("mode")
+        assert isinstance(mode, str)
+        cisco_modes.append(mode)
+        from codex_plugin_scanner.integrations.cisco_skill_scanner import run_cisco_skill_scan
+
+        skills_dir = kwargs.get("skills_dir")
+        policy_name = kwargs.get("policy_name", "balanced")
+        timeout_seconds = kwargs.get("timeout_seconds")
+        assert isinstance(skills_dir, Path)
+        assert isinstance(policy_name, str)
+        return run_cisco_skill_scan(
+            skills_dir,
+            mode=mode,
+            policy_name=policy_name,
+            timeout_seconds=timeout_seconds if isinstance(timeout_seconds, (int, float)) else None,
+        )
+
+    monkeypatch.setattr(builtins, "__import__", _guard_import)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.checks.skill_security.run_cisco_skill_scan",
+        _record_cisco_mode,
+    )
+
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(skills_dir / "SKILL.md"),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:skill:demo-skill",
+                name="demo-skill",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="project",
+                config_path=str(skills_dir / "SKILL.md"),
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+    skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
+    trust = skill_item.metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    assert trust.get("resolutionSource") == "local"
+    assert cisco_modes == ["off"]
 
 
 def test_inventory_snapshot_attaches_local_skill_trust_resolution(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Disable Cisco skill scanning during inventory trust enrichment to prevent unsafe skill_scanner imports from untrusted workspaces.
- Add regression test proving inventory trust path uses cisco_skill_scan=off.

## Testing
- `python3 -m pytest tests/test_guard_aibom_trust_metadata.py -q`
