### PR TITLE
feat(guard): add hol-guard aibom CLI status sync and export

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -1,0 +1,472 @@
+"""AIBOM CLI helpers for status, export, inventory enrichment, and cloud sync."""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from .adapters.base import HarnessContext
+from .consumer import detect_all
+from .inventory_contract import (
+    GuardAgentInventorySnapshot,
+    extract_aibom_metadata_extensions,
+    inventory_snapshot_from_detection,
+    redact_local_path,
+    serialize_inventory_snapshot,
+)
+from .store import GuardStore
+
+AibomExportFormat = Literal["json", "markdown"]
+
+
+@dataclass(frozen=True, slots=True)
+class AibomCliOptions:
+    include_symlinks: bool = True
+    follow_unsafe_symlinks: bool = False
+
+
+def collect_aibom_snapshots(
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+) -> tuple[GuardAgentInventorySnapshot, ...]:
+    resolved = options or AibomCliOptions()
+    snapshots: list[GuardAgentInventorySnapshot] = []
+    for detection in detect_all(context):
+        if not detection.installed and not detection.artifacts:
+            continue
+        snapshots.append(
+            inventory_snapshot_from_detection(
+                detection,
+                generated_at=generated_at,
+                home_dir=context.home_dir,
+                workspace_dir=context.workspace_dir,
+                include_symlinks=resolved.include_symlinks,
+                follow_unsafe_symlinks=resolved.follow_unsafe_symlinks,
+            )
+        )
+    return tuple(snapshots)
+
+
+def build_inventory_json_payload(
+    store: GuardStore,
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+) -> dict[str, object]:
+    snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
+    metadata_by_artifact = _metadata_lookup_from_snapshots(snapshots)
+    items: list[dict[str, object]] = []
+    for item in store.list_inventory():
+        enriched = _redact_inventory_store_item(item, home_dir=context.home_dir)
+        artifact_id = str(item.get("artifact_id") or "")
+        harness = str(item.get("harness") or "")
+        extensions = metadata_by_artifact.get((harness, artifact_id))
+        if extensions:
+            enriched.update(extensions)
+        items.append(enriched)
+    redaction_report = _aggregate_redaction_report(snapshots)
+    return {
+        "generated_at": generated_at,
+        "items": items,
+        "snapshots": [serialize_inventory_snapshot(snapshot) for snapshot in snapshots],
+        "redaction_report": redaction_report,
+    }
+
+
+def build_aibom_status_payload(
+    store: GuardStore,
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+) -> dict[str, object]:
+    snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
+    sync_summary = _sync_summary(store)
+    layer_summary = summarize_aibom_layers(snapshots, generated_at=generated_at)
+    trust_summary = summarize_aibom_trust(snapshots)
+    drift_summary = summarize_aibom_drift(snapshots)
+    return {
+        "generated_at": generated_at,
+        "status": _aibom_connection_status(store),
+        "layer_summary": layer_summary,
+        "trust_summary": trust_summary,
+        "drift_summary": drift_summary,
+        "redaction_report": _aggregate_redaction_report(snapshots),
+        "last_sync_at": sync_summary.get("synced_at"),
+        "snapshot_count": len(snapshots),
+        "artifact_inventory_count": len(store.list_inventory()),
+    }
+
+
+def build_aibom_export_payload(
+    store: GuardStore,
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+    export_format: AibomExportFormat = "json",
+) -> dict[str, object]:
+    snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
+    serialized_snapshots = [serialize_inventory_snapshot(snapshot) for snapshot in snapshots]
+    artifacts = _artifact_rows_from_store(store, snapshots)
+    layer_summary = summarize_aibom_layers(snapshots, generated_at=generated_at)
+    trust_summary = summarize_aibom_trust(snapshots)
+    drift_summary = summarize_aibom_drift(snapshots)
+    sync_summary = _sync_summary(store)
+    payload: dict[str, object] = {
+        "generated_at": generated_at,
+        "artifact_count": len(artifacts),
+        "artifacts": artifacts,
+        "snapshots": serialized_snapshots,
+        "layer_summary": layer_summary,
+        "trust_summary": trust_summary,
+        "drift_summary": drift_summary,
+        "redaction_report": _aggregate_redaction_report(snapshots),
+        "last_sync_at": sync_summary.get("synced_at"),
+    }
+    if export_format == "markdown":
+        payload["markdown"] = _render_aibom_markdown(payload)
+    return payload
+
+
+def sync_aibom_snapshots(
+    store: GuardStore,
+    context: HarnessContext,
+    *,
+    generated_at: str,
+    options: AibomCliOptions | None = None,
+) -> dict[str, object]:
+    from .runtime.runner import (
+        GuardSyncNotConfiguredError,
+        _guard_events_sync_url,
+        _guard_sync_request,
+        _resolve_guard_sync_auth_context,
+        _urlopen_json_with_timeout_retry,
+    )
+
+    workspace_id = store.get_cloud_workspace_id()
+    if workspace_id is None:
+        raise GuardSyncNotConfiguredError("Guard Cloud workspace is not configured. Run `hol-guard connect` first.")
+
+    snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
+    if not snapshots:
+        synced_at = generated_at
+        summary = {
+            "synced": True,
+            "synced_at": synced_at,
+            "snapshots": 0,
+            "accepted": 0,
+            "message": "No installed harness snapshots were available to sync.",
+        }
+        store.set_sync_payload("aibom_sync_summary", summary, synced_at)
+        return summary
+
+    resolved_auth_context = _resolve_guard_sync_auth_context(store)
+    sync_url = _guard_events_sync_url(str(resolved_auth_context["sync_url"]))
+    events = [
+        _inventory_snapshot_event(
+            snapshot=snapshot,
+            workspace_id=workspace_id,
+            generated_at=generated_at,
+        )
+        for snapshot in snapshots
+    ]
+    body = json.dumps({"events": events}).encode("utf-8")
+    request = _guard_sync_request(
+        resolved_auth_context,
+        request_url=sync_url,
+        method="POST",
+        data=body,
+        extra_headers=None,
+    )
+    payload = _urlopen_json_with_timeout_retry(request=request, timeout_seconds=30, retry_timeout_seconds=60)
+    accepted = payload.get("accepted")
+    synced_at = _sync_timestamp_from_payload(payload) or generated_at
+    summary = {
+        "synced": True,
+        "synced_at": synced_at,
+        "snapshots": len(snapshots),
+        "accepted": accepted if isinstance(accepted, int) else len(snapshots),
+        "rejected": payload.get("rejected"),
+        "statuses": payload.get("statuses"),
+    }
+    store.set_sync_payload("aibom_sync_summary", summary, synced_at)
+    return summary
+
+
+def summarize_aibom_layers(
+    snapshots: tuple[GuardAgentInventorySnapshot, ...],
+    *,
+    generated_at: str,
+) -> dict[str, object]:
+    counts = {
+        "instructions": 0,
+        "skills": 0,
+        "mcp": 0,
+        "plugins": 0,
+        "policies": 0,
+        "findings": 0,
+        "trust": 0,
+        "sources": 0,
+    }
+    for snapshot in snapshots:
+        counts["findings"] += len(snapshot.findings)
+        counts["sources"] += len(snapshot.sources)
+        for item in snapshot.items:
+            if item.item_kind in {"overlay", "prompt_pack"}:
+                counts["instructions"] += 1
+            elif item.item_kind == "skill":
+                counts["skills"] += 1
+            elif item.item_kind in {"mcp_server", "mcp_tool"}:
+                counts["mcp"] += 1
+            elif item.item_kind in {"plugin", "daemon_plugin"}:
+                counts["plugins"] += 1
+            elif item.item_kind == "policy":
+                counts["policies"] += 1
+            if isinstance(item.metadata.get("trustResolution"), dict):
+                counts["trust"] += 1
+            source_links = item.metadata.get("sourceLinks")
+            source_of_truth = item.metadata.get("sourceOfTruth")
+            if isinstance(source_links, list) and source_links:
+                counts["sources"] += len(source_links)
+            elif isinstance(source_of_truth, dict):
+                counts["sources"] += 1
+    drift = summarize_aibom_drift(snapshots)
+    trust = summarize_aibom_trust(snapshots)
+    return {
+        **counts,
+        "driftCount": drift.get("total", 0),
+        "highRiskCount": drift.get("high_risk", 0),
+        "lowTrustCount": trust.get("low_trust", 0),
+        "generatedAt": generated_at,
+        "staleSnapshot": False,
+    }
+
+
+def summarize_aibom_trust(snapshots: tuple[GuardAgentInventorySnapshot, ...]) -> dict[str, object]:
+    covered = 0
+    eligible = 0
+    low_trust = 0
+    scores: list[int] = []
+    for snapshot in snapshots:
+        for item in snapshot.items:
+            if item.item_kind not in {"skill", "plugin", "mcp_server"}:
+                continue
+            eligible += 1
+            trust = item.metadata.get("trustResolution")
+            if not isinstance(trust, dict):
+                continue
+            covered += 1
+            score = trust.get("trustScore")
+            if isinstance(score, int):
+                scores.append(score)
+                if score < 70:
+                    low_trust += 1
+    coverage_percent = round((covered / eligible) * 100) if eligible else 100
+    average_score = round(sum(scores) / len(scores)) if scores else None
+    return {
+        "eligible": eligible,
+        "covered": covered,
+        "coverage_percent": coverage_percent,
+        "low_trust": low_trust,
+        "average_score": average_score,
+    }
+
+
+def summarize_aibom_drift(snapshots: tuple[GuardAgentInventorySnapshot, ...]) -> dict[str, object]:
+    counts = {"new": 0, "changed": 0, "removed": 0, "unchanged": 0, "high_risk": 0}
+    for snapshot in snapshots:
+        for item in snapshot.items:
+            state = item.drift_state
+            if state in counts:
+                counts[state] += 1
+            if item.risk_level in {"critical", "high"}:
+                counts["high_risk"] += 1
+        for drift in snapshot.drift:
+            state = drift.state
+            if state in counts:
+                counts[state] += 1
+    total = counts["new"] + counts["changed"] + counts["removed"]
+    return {
+        "new": counts["new"],
+        "changed": counts["changed"],
+        "removed": counts["removed"],
+        "unchanged": counts["unchanged"],
+        "high_risk": counts["high_risk"],
+        "total": total,
+    }
+
+
+def _metadata_lookup_from_snapshots(
+    snapshots: tuple[GuardAgentInventorySnapshot, ...],
+) -> dict[tuple[str, str], dict[str, object]]:
+    lookup: dict[tuple[str, str], dict[str, object]] = {}
+    for snapshot in snapshots:
+        harness = snapshot.agent_type
+        for item in snapshot.items:
+            extensions = extract_aibom_metadata_extensions(item.metadata)
+            if not extensions:
+                continue
+            lookup[(harness, item.item_id)] = extensions
+    return lookup
+
+
+def _artifact_rows_from_store(
+    store: GuardStore,
+    snapshots: tuple[GuardAgentInventorySnapshot, ...],
+) -> list[dict[str, object]]:
+    metadata_by_artifact = _metadata_lookup_from_snapshots(snapshots)
+    artifacts: list[dict[str, object]] = []
+    for item in store.list_inventory():
+        trust_verdict = str(item.get("last_policy_action") or "unknown")
+        harness = str(item.get("harness") or "")
+        artifact_id = str(item.get("artifact_id") or "")
+        row = {**item, "trust_verdict": trust_verdict}
+        extensions = metadata_by_artifact.get((harness, artifact_id))
+        if extensions:
+            row.update(extensions)
+        artifacts.append(row)
+    return artifacts
+
+
+def _aggregate_redaction_report(
+    snapshots: tuple[GuardAgentInventorySnapshot, ...],
+) -> dict[str, object]:
+    redacted_fields: set[str] = set()
+    raw_secrets = False
+    symlink_items = 0
+    for snapshot in snapshots:
+        report = snapshot.redaction_report
+        if report.get("rawSecretsIncluded") is True:
+            raw_secrets = True
+        fields = report.get("redactedFields")
+        if isinstance(fields, (list, tuple)):
+            redacted_fields.update(str(field) for field in fields)
+        for item in snapshot.items:
+            source_of_truth = item.metadata.get("sourceOfTruth")
+            source_links = item.metadata.get("sourceLinks")
+            if isinstance(source_of_truth, dict) or (isinstance(source_links, list) and source_links):
+                symlink_items += 1
+    return {
+        "rawValuesIncluded": raw_secrets,
+        "redactedFields": sorted(redacted_fields),
+        "symlinkItems": symlink_items,
+        "snapshots": len(snapshots),
+    }
+
+
+def _redact_inventory_store_item(
+    item: dict[str, object],
+    *,
+    home_dir: Path,
+) -> dict[str, object]:
+    redacted = dict(item)
+    config_path = item.get("config_path")
+    if isinstance(config_path, str) and config_path:
+        redacted["config_path"] = redact_local_path(Path(config_path), home_dir=home_dir)
+    return redacted
+
+
+def _aibom_connection_status(store: GuardStore) -> str:
+    if store.get_cloud_sync_profile() is None:
+        return "not_connected"
+    if store.get_cloud_workspace_id() is None:
+        return "workspace_required"
+    sync_summary = _sync_summary(store)
+    if sync_summary.get("synced_at"):
+        return "synced"
+    return "sync_required"
+
+
+def _sync_summary(store: GuardStore) -> dict[str, object]:
+    payload = store.get_sync_payload("aibom_sync_summary")
+    return payload if isinstance(payload, dict) else {}
+
+
+def _inventory_snapshot_event(
+    *,
+    snapshot: GuardAgentInventorySnapshot,
+    workspace_id: str,
+    generated_at: str,
+) -> dict[str, object]:
+    event_id = str(uuid.uuid4())
+    return {
+        "eventId": event_id,
+        "eventType": "agent.inventory_snapshot",
+        "idempotencyKey": snapshot.snapshot_id,
+        "occurredAt": generated_at,
+        "source": "edge",
+        "workspaceId": workspace_id,
+        "payload": {"snapshot": serialize_inventory_snapshot(snapshot)},
+    }
+
+
+def _sync_timestamp_from_payload(payload: dict[str, object]) -> str | None:
+    for key in ("syncedAt", "synced_at", "acceptedAt"):
+        value = payload.get(key)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _render_aibom_markdown(payload: dict[str, object]) -> str:
+    layer_summary = payload.get("layer_summary")
+    trust_summary = payload.get("trust_summary")
+    lines = [
+        "# HOL Guard AIBOM",
+        "",
+        "## Layer summary",
+        "",
+    ]
+    if isinstance(layer_summary, dict):
+        lines.extend(
+            [
+                f"- Instructions: {layer_summary.get('instructions', 0)}",
+                f"- Skills: {layer_summary.get('skills', 0)}",
+                f"- MCP: {layer_summary.get('mcp', 0)}",
+                f"- Plugins: {layer_summary.get('plugins', 0)}",
+                f"- Policies: {layer_summary.get('policies', 0)}",
+                f"- Findings: {layer_summary.get('findings', 0)}",
+                f"- Trust: {layer_summary.get('trust', 0)}",
+                f"- Sources: {layer_summary.get('sources', 0)}",
+                f"- Drift: {layer_summary.get('driftCount', 0)}",
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "## Artifacts",
+            "",
+            "| Artifact | Harness | Type | Scope | Verdict | Present |",
+            "| --- | --- | --- | --- | --- | --- |",
+        ]
+    )
+    artifacts = payload.get("artifacts")
+    if isinstance(artifacts, list):
+        for item in artifacts:
+            if not isinstance(item, dict):
+                continue
+            lines.append(
+                "| "
+                f"{item.get('artifact_name', '')} | {item.get('harness', '')} | {item.get('artifact_type', '')} | "
+                f"{item.get('source_scope', '')} | {item.get('trust_verdict', '')} | "
+                f"{'yes' if item.get('present') else 'no'} |"
+            )
+    if isinstance(trust_summary, dict):
+        lines.extend(
+            [
+                "",
+                "## Trust coverage",
+                "",
+                f"- Covered: {trust_summary.get('covered', 0)} / {trust_summary.get('eligible', 0)}",
+                f"- Coverage: {trust_summary.get('coverage_percent', 0)}%",
+                "",
+            ]
+        )
+    return "\n".join(lines) + "\n"

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -88,9 +88,10 @@ def build_aibom_status_payload(
 ) -> dict[str, object]:
     snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
     sync_summary = _sync_summary(store)
-    layer_summary = summarize_aibom_layers(snapshots, generated_at=generated_at)
-    trust_summary = summarize_aibom_trust(snapshots)
-    drift_summary = summarize_aibom_drift(snapshots)
+    layer_summary, trust_summary, drift_summary = summarize_aibom_layers(
+        snapshots,
+        generated_at=generated_at,
+    )
     return {
         "generated_at": generated_at,
         "status": _aibom_connection_status(store),
@@ -115,9 +116,10 @@ def build_aibom_export_payload(
     snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
     serialized_snapshots = [serialize_inventory_snapshot(snapshot) for snapshot in snapshots]
     artifacts = _artifact_rows_from_store(store, snapshots)
-    layer_summary = summarize_aibom_layers(snapshots, generated_at=generated_at)
-    trust_summary = summarize_aibom_trust(snapshots)
-    drift_summary = summarize_aibom_drift(snapshots)
+    layer_summary, trust_summary, drift_summary = summarize_aibom_layers(
+        snapshots,
+        generated_at=generated_at,
+    )
     sync_summary = _sync_summary(store)
     payload: dict[str, object] = {
         "generated_at": generated_at,
@@ -185,7 +187,14 @@ def sync_aibom_snapshots(
         data=body,
         extra_headers=None,
     )
-    payload = _urlopen_json_with_timeout_retry(request=request, timeout_seconds=30, retry_timeout_seconds=60)
+    try:
+        payload = _urlopen_json_with_timeout_retry(
+            request=request,
+            timeout_seconds=30,
+            retry_timeout_seconds=60,
+        )
+    except OSError as error:
+        raise RuntimeError("Guard Cloud AIBOM sync failed due to a network error.") from error
     accepted = payload.get("accepted")
     synced_at = _sync_timestamp_from_payload(payload) or generated_at
     summary = {
@@ -204,7 +213,7 @@ def summarize_aibom_layers(
     snapshots: tuple[GuardAgentInventorySnapshot, ...],
     *,
     generated_at: str,
-) -> dict[str, object]:
+) -> tuple[dict[str, object], dict[str, object], dict[str, object]]:
     counts = {
         "instructions": 0,
         "skills": 0,
@@ -214,10 +223,11 @@ def summarize_aibom_layers(
         "findings": 0,
         "trust": 0,
         "sources": 0,
+        "configSources": 0,
     }
     for snapshot in snapshots:
         counts["findings"] += len(snapshot.findings)
-        counts["sources"] += len(snapshot.sources)
+        counts["configSources"] += len(snapshot.sources)
         for item in snapshot.items:
             if item.item_kind in {"overlay", "prompt_pack"}:
                 counts["instructions"] += 1
@@ -239,7 +249,7 @@ def summarize_aibom_layers(
                 counts["sources"] += 1
     drift = summarize_aibom_drift(snapshots)
     trust = summarize_aibom_trust(snapshots)
-    return {
+    layer_summary = {
         **counts,
         "driftCount": drift.get("total", 0),
         "highRiskCount": drift.get("high_risk", 0),
@@ -247,6 +257,7 @@ def summarize_aibom_layers(
         "generatedAt": generated_at,
         "staleSnapshot": False,
     }
+    return layer_summary, trust, drift
 
 
 def summarize_aibom_trust(snapshots: tuple[GuardAgentInventorySnapshot, ...]) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -35,6 +35,7 @@ def inspect_aibom_source_path(
     safe_roots: tuple[Path, ...],
     home_dir: Path,
     workspace_dir: Path | None = None,
+    follow_unsafe_symlinks: bool = False,
 ) -> AibomSourceInspection:
     """Classify a path or symlink without emitting raw local paths."""
 
@@ -63,11 +64,12 @@ def inspect_aibom_source_path(
             safe_roots=safe_roots,
             home_dir=home_dir,
             workspace_dir=workspace_dir,
+            follow_unsafe_symlinks=follow_unsafe_symlinks,
         )
         if validation_state == "valid" and resolved is not None:
             target_content_hash = _content_hash_for_target(resolved, home_dir=home_dir)
     else:
-        if not _is_within_safe_roots(path, safe_roots):
+        if not follow_unsafe_symlinks and not _is_within_safe_roots(path, safe_roots):
             validation_state = "escape_blocked"
         else:
             validation_state = "valid"
@@ -181,6 +183,7 @@ def _resolve_symlink_chain(
     safe_roots: tuple[Path, ...],
     home_dir: Path,
     workspace_dir: Path | None,
+    follow_unsafe_symlinks: bool = False,
 ) -> tuple[Path | None, AibomValidationState, list[str]]:
     visited: set[str] = set()
     hop_fingerprints: list[str] = []
@@ -196,7 +199,7 @@ def _resolve_symlink_chain(
         if not current.is_symlink():
             if not current.exists():
                 return None, "broken", hop_fingerprints
-            if not _is_within_safe_roots(current, safe_roots):
+            if not follow_unsafe_symlinks and not _is_within_safe_roots(current, safe_roots):
                 return None, "escape_blocked", hop_fingerprints
             return current, "valid", hop_fingerprints
 

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -30,6 +30,13 @@ from ...argparse_utils import FriendlyArgumentParser
 from ...models import ScanOptions
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
+from ..aibom_cli import (
+    AibomCliOptions,
+    build_aibom_export_payload,
+    build_aibom_status_payload,
+    build_inventory_json_payload,
+    sync_aibom_snapshots,
+)
 from ..approval_gate import (
     ApprovalGateError,
     ApprovalGateInput,
@@ -274,7 +281,8 @@ _GUARD_HELP_GROUPS = (
     "  scan         Run a consumer-mode artifact scan\n"
     "  diff         Compare current artifacts to stored snapshots\n"
     "  inventory    Inspect tracked artifacts\n"
-    "  abom         Export the local AI-BOM\n"
+    "  abom         Export the local artifact bill of materials\n"
+    "  aibom        Export the local AIBOM with trust and source metadata\n"
     "  explain      Show evidence for one artifact\n"
     "  policies     Inspect local Guard policy state\n"
     "  settings     Settings: show or update local Guard rules\n"
@@ -402,7 +410,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         parser_class=FriendlyArgumentParser,
         metavar=(
             "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
-            "receipts,inventory,abom,approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,"
+            "receipts,inventory,abom,aibom,approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,"
             "remote-pair,disconnect,"
             "login,sync,device,bridge}"
         ),
@@ -587,11 +595,35 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
     inventory_parser = guard_subparsers.add_parser("inventory", help="List the local Guard artifact inventory")
     _add_guard_common_args(inventory_parser)
     inventory_parser.add_argument("--json", action="store_true")
+    _add_aibom_cli_args(inventory_parser)
 
     abom_parser = guard_subparsers.add_parser("abom", help="Export a local Guard artifact bill of materials")
     _add_guard_common_args(abom_parser)
     abom_parser.add_argument("--json", action="store_true")
     abom_parser.add_argument("--format", choices=("markdown", "json"), default="markdown")
+
+    aibom_parser = guard_subparsers.add_parser(
+        "aibom",
+        help="Inspect or export the local AIBOM with trust and source metadata",
+    )
+    _add_guard_common_args(aibom_parser)
+    aibom_sub = aibom_parser.add_subparsers(dest="aibom_command", metavar="COMMAND")
+    aibom_status_parser = aibom_sub.add_parser("status", help="Show local AIBOM status and trust coverage")
+    _add_guard_common_args(aibom_status_parser)
+    _add_aibom_cli_args(aibom_status_parser)
+    aibom_status_parser.add_argument("--json", action="store_true")
+    aibom_sync_parser = aibom_sub.add_parser("sync", help="Sync local AIBOM snapshots to Guard Cloud")
+    _add_guard_common_args(aibom_sync_parser)
+    _add_aibom_cli_args(aibom_sync_parser)
+    aibom_sync_parser.add_argument("--json", action="store_true")
+    aibom_export_parser = aibom_sub.add_parser("export", help="Export the local AIBOM")
+    _add_guard_common_args(aibom_export_parser)
+    _add_aibom_cli_args(aibom_export_parser)
+    aibom_export_parser.add_argument("--json", action="store_true")
+    aibom_export_parser.add_argument("--format", choices=("markdown", "json"), default="json")
+    _add_aibom_cli_args(aibom_parser)
+    aibom_parser.add_argument("--json", action="store_true")
+    aibom_parser.add_argument("--format", choices=("markdown", "json"), default="json")
 
     add_approval_parser(guard_subparsers, _add_guard_common_args)
 
@@ -1181,6 +1213,28 @@ def _add_guard_common_args(
     parser.add_argument("--home", default=default)
     parser.add_argument("--guard-home", default=default)
     parser.add_argument("--workspace", default=default)
+
+
+def _add_aibom_cli_args(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument(
+        "--include-symlinks",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Include symlink source-of-truth metadata in AIBOM output (default: enabled).",
+    )
+    parser.add_argument(
+        "--follow-unsafe-symlinks",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Follow symlink targets outside safe roots (default: disabled).",
+    )
+
+
+def _aibom_cli_options_from_args(args: argparse.Namespace) -> AibomCliOptions:
+    return AibomCliOptions(
+        include_symlinks=bool(getattr(args, "include_symlinks", True)),
+        follow_unsafe_symlinks=bool(getattr(args, "follow_unsafe_symlinks", False)),
+    )
 
 
 def _add_guard_cisco_mode_arg(parser: argparse.ArgumentParser) -> None:
@@ -2260,7 +2314,68 @@ def run_guard_command(
         return 1
 
     if args.guard_command == "inventory":
-        _emit("inventory", {"generated_at": _now(), "items": store.list_inventory()}, getattr(args, "json", False))
+        generated_at = _now()
+        if getattr(args, "json", False):
+            payload = build_inventory_json_payload(
+                store,
+                context,
+                generated_at=generated_at,
+                options=_aibom_cli_options_from_args(args),
+            )
+        else:
+            payload = {"generated_at": generated_at, "items": store.list_inventory()}
+        _emit("inventory", payload, getattr(args, "json", False))
+        return 0
+
+    if args.guard_command == "aibom":
+        generated_at = _now()
+        aibom_options = _aibom_cli_options_from_args(args)
+        aibom_command = getattr(args, "aibom_command", None)
+        if aibom_command == "status":
+            payload = build_aibom_status_payload(
+                store,
+                context,
+                generated_at=generated_at,
+                options=aibom_options,
+            )
+            _emit("aibom.status", payload, getattr(args, "json", False))
+            return 0
+        if aibom_command == "sync":
+            try:
+                payload = sync_aibom_snapshots(
+                    store,
+                    context,
+                    generated_at=generated_at,
+                    options=aibom_options,
+                )
+            except GuardSyncNotConfiguredError as error:
+                message = _guard_sync_failure_message(error)
+                if getattr(args, "json", False):
+                    _emit("aibom.sync", {"synced": False, "error": message}, True)
+                else:
+                    print(message, file=sys.stderr)
+                return 1
+            except RuntimeError as error:
+                if getattr(args, "json", False):
+                    _emit("aibom.sync", {"synced": False, "error": str(error)}, True)
+                else:
+                    print(str(error), file=sys.stderr)
+                return 1
+            _emit("aibom.sync", payload, getattr(args, "json", False))
+            return 0
+        export_format = getattr(args, "format", "json")
+        resolved_format = export_format if export_format in {"json", "markdown"} else "json"
+        payload = build_aibom_export_payload(
+            store,
+            context,
+            generated_at=generated_at,
+            options=aibom_options,
+            export_format=resolved_format,
+        )
+        if resolved_format == "markdown" and not getattr(args, "json", False):
+            print(str(payload.get("markdown", "")))
+            return 0
+        _emit("aibom", payload, True)
         return 0
 
     if args.guard_command == "abom":

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2355,11 +2355,12 @@ def run_guard_command(
                 else:
                     print(message, file=sys.stderr)
                 return 1
-            except RuntimeError as error:
+            except (OSError, RuntimeError) as error:
+                message = str(error) if isinstance(error, RuntimeError) else "Guard Cloud AIBOM sync failed."
                 if getattr(args, "json", False):
-                    _emit("aibom.sync", {"synced": False, "error": str(error)}, True)
+                    _emit("aibom.sync", {"synced": False, "error": message}, True)
                 else:
-                    print(str(error), file=sys.stderr)
+                    print(message, file=sys.stderr)
                 return 1
             _emit("aibom.sync", payload, getattr(args, "json", False))
             return 0

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -102,6 +102,14 @@ _MCP_PERMISSION_RE = re.compile(
 )
 _IGNORED_TREE_DIR_NAMES = {".git", ".hg", ".svn", "__pycache__", ".mypy_cache", ".ruff_cache", ".venv", "node_modules"}
 _MAX_FINGERPRINT_FILE_BYTES = 1024 * 1024
+_AIBOM_METADATA_KEYS = (
+    "instructionRole",
+    "registryIdentity",
+    "sourceLinks",
+    "sourceOfTruth",
+    "trustResolution",
+    "versionInfo",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -216,6 +224,20 @@ def serialize_inventory_snapshot(snapshot: GuardAgentInventorySnapshot) -> dict[
     return payload
 
 
+def extract_aibom_metadata_extensions(metadata: dict[str, object]) -> dict[str, object]:
+    """Return redacted AIBOM metadata extensions for CLI and inventory JSON output."""
+
+    extensions = {
+        key: _safe_json(metadata[key])
+        for key in _AIBOM_METADATA_KEYS
+        if key in metadata
+    }
+    source_of_truth = extensions.get("sourceOfTruth")
+    if "sourceLinks" not in extensions and isinstance(source_of_truth, dict):
+        extensions["sourceLinks"] = [_safe_json(source_of_truth)]
+    return extensions
+
+
 def inventory_snapshot_from_detection(
     detection: object,
     *,
@@ -224,6 +246,8 @@ def inventory_snapshot_from_detection(
     workspace_dir: Path | None = None,
     runtime_version: str | None = None,
     cisco_runs: tuple[object, ...] = (),
+    include_symlinks: bool = True,
+    follow_unsafe_symlinks: bool = False,
 ) -> GuardAgentInventorySnapshot:
     from .aibom_detection import discover_shared_workspace_aibom_artifacts
 
@@ -248,6 +272,8 @@ def inventory_snapshot_from_detection(
             generated_at=generated_at,
             home_dir=home_dir,
             workspace_dir=workspace_dir,
+            include_symlinks=include_symlinks,
+            follow_unsafe_symlinks=follow_unsafe_symlinks,
         )
         items.append(item)
         items.extend(_mcp_tool_items_from_artifact(harness, artifact, item))
@@ -269,7 +295,9 @@ def inventory_snapshot_from_detection(
         home_dir=home_dir,
         workspace_dir=workspace_dir,
     )
-    symlink_findings = _symlink_findings_from_items(harness, item_tuple)
+    symlink_findings = (
+        _symlink_findings_from_items(harness, item_tuple) if include_symlinks else ()
+    )
     sources = (*config_sources, *_cisco_inventory_sources(cisco_runs))
     snapshot_hash = fingerprint_mapping(
         {
@@ -398,6 +426,8 @@ def _item_from_artifact(
     generated_at: str,
     home_dir: Path,
     workspace_dir: Path | None,
+    include_symlinks: bool = True,
+    follow_unsafe_symlinks: bool = False,
 ) -> GuardAgentInventoryItem:
     artifact_id = str(getattr(artifact, "artifact_id", "artifact"))
     artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
@@ -411,14 +441,16 @@ def _item_from_artifact(
         metadata=safe_metadata,
         workspace_dir=workspace_dir,
     )
-    safe_metadata = _apply_source_of_truth_metadata(
-        artifact,
-        harness=harness,
-        item_kind=item_kind,
-        metadata=safe_metadata,
-        home_dir=home_dir,
-        workspace_dir=workspace_dir,
-    )
+    if include_symlinks:
+        safe_metadata = _apply_source_of_truth_metadata(
+            artifact,
+            harness=harness,
+            item_kind=item_kind,
+            metadata=safe_metadata,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            follow_unsafe_symlinks=follow_unsafe_symlinks,
+        )
     semantic_text = fingerprint_mapping(
         {
             "artifact_id": artifact_id,
@@ -817,6 +849,7 @@ def _apply_source_of_truth_metadata(
     metadata: dict[str, object],
     home_dir: Path,
     workspace_dir: Path | None,
+    follow_unsafe_symlinks: bool = False,
 ) -> dict[str, object]:
     from .aibom_symlink import inspect_aibom_source_path, source_of_truth_metadata_from_inspection
 
@@ -831,6 +864,7 @@ def _apply_source_of_truth_metadata(
         safe_roots=_safe_roots_for_inspection(home_dir=home_dir, workspace_dir=workspace_dir),
         home_dir=home_dir,
         workspace_dir=workspace_dir,
+        follow_unsafe_symlinks=follow_unsafe_symlinks,
     )
     source_link_id = f"{harness}:{item_kind}:{inspection.source_fingerprint[:24]}"
     enriched = dict(metadata)

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -227,11 +227,7 @@ def serialize_inventory_snapshot(snapshot: GuardAgentInventorySnapshot) -> dict[
 def extract_aibom_metadata_extensions(metadata: dict[str, object]) -> dict[str, object]:
     """Return redacted AIBOM metadata extensions for CLI and inventory JSON output."""
 
-    extensions = {
-        key: _safe_json(metadata[key])
-        for key in _AIBOM_METADATA_KEYS
-        if key in metadata
-    }
+    extensions = {key: _safe_json(metadata[key]) for key in _AIBOM_METADATA_KEYS if key in metadata}
     source_of_truth = extensions.get("sourceOfTruth")
     if "sourceLinks" not in extensions and isinstance(source_of_truth, dict):
         extensions["sourceLinks"] = [_safe_json(source_of_truth)]
@@ -295,9 +291,7 @@ def inventory_snapshot_from_detection(
         home_dir=home_dir,
         workspace_dir=workspace_dir,
     )
-    symlink_findings = (
-        _symlink_findings_from_items(harness, item_tuple) if include_symlinks else ()
-    )
+    symlink_findings = _symlink_findings_from_items(harness, item_tuple) if include_symlinks else ()
     sources = (*config_sources, *_cisco_inventory_sources(cisco_runs))
     snapshot_hash = fingerprint_mapping(
         {

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _write_text(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _build_codex_fixture(home_dir: Path, workspace_dir: Path) -> None:
+    _write_text(
+        home_dir / ".codex" / "config.toml",
+        """
+[mcp_servers.global_tools]
+command = "python"
+args = ["-m", "http.server", "9000"]
+""".strip()
+        + "\n",
+    )
+    _write_text(
+        workspace_dir / ".codex" / "config.toml",
+        """
+[mcp_servers.workspace_skill]
+command = "node"
+args = ["workspace-skill.js"]
+""".strip()
+        + "\n",
+    )
+
+
+def _seed_inventory(store: GuardStore, artifact: GuardArtifact, *, now: str) -> None:
+    store.record_inventory_artifact(
+        artifact=artifact,
+        artifact_hash="hash-1",
+        policy_action="allow",
+        changed=False,
+        now=now,
+        approved=True,
+    )
+
+
+def test_aibom_status_json_includes_layer_and_trust_summary(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_codex_fixture(home_dir, workspace_dir)
+    guard_home = tmp_path / "guard"
+    store = GuardStore(guard_home)
+    now = "2026-06-10T12:00:00+00:00"
+    _seed_inventory(
+        store,
+        GuardArtifact(
+            artifact_id="codex:global:global_tools",
+            name="global_tools",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="global",
+            config_path=str(home_dir / ".codex" / "config.toml"),
+        ),
+        now=now,
+    )
+
+    rc = main(
+        [
+            "guard",
+            "aibom",
+            "status",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--guard-home",
+            str(guard_home),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert output["layer_summary"]["mcp"] >= 1
+    assert "trust_summary" in output
+    assert "redaction_report" in output
+    assert output["redaction_report"]["rawValuesIncluded"] is False
+    assert output["status"] in {"not_connected", "workspace_required", "sync_required", "synced"}
+
+
+def test_inventory_json_includes_aibom_metadata_extensions(tmp_path: Path, capsys) -> None:
+    workspace = tmp_path / "repo"
+    shared = workspace / "shared-root"
+    shared.mkdir(parents=True)
+    (shared / "rule.mdc").write_text("---\ndescription: demo\n---\n", encoding="utf-8")
+    rules_dir = workspace / ".cursor" / "rules"
+    rules_dir.mkdir(parents=True)
+    link = rules_dir / "demo.mdc"
+    link.symlink_to(shared / "rule.mdc")
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    _build_codex_fixture(home_dir, workspace)
+    store = GuardStore(guard_home)
+    _seed_inventory(
+        store,
+        GuardArtifact(
+            artifact_id="codex:global:global_tools",
+            name="global_tools",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="global",
+            config_path=str(home_dir / ".codex" / "config.toml"),
+        ),
+        now="2026-06-10T12:00:00+00:00",
+    )
+
+    rc = main(
+        [
+            "guard",
+            "inventory",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace),
+            "--guard-home",
+            str(guard_home),
+            "--json",
+        ]
+    )
+    encoded = capsys.readouterr().out
+    output = json.loads(encoded)
+
+    assert rc == 0
+    assert str(tmp_path) not in encoded
+    snapshot_metadata = [
+        item.get("metadata", {})
+        for snapshot in output.get("snapshots", [])
+        if isinstance(snapshot, dict)
+        for item in snapshot.get("items", [])
+        if isinstance(item, dict)
+    ]
+    assert any(
+        isinstance(metadata.get("sourceOfTruth"), dict) or isinstance(metadata.get("sourceLinks"), list)
+        for metadata in snapshot_metadata
+        if isinstance(metadata, dict)
+    )
+    assert output["redaction_report"]["rawValuesIncluded"] is False
+
+
+def test_aibom_symlink_flags_control_source_metadata(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    (outside / "SKILL.md").write_text("name: outside\n", encoding="utf-8")
+    link = workspace / "skills" / "escaped" / "SKILL.md"
+    link.parent.mkdir(parents=True)
+    link.symlink_to(outside / "SKILL.md")
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:skill:escaped",
+                name="escaped",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="project",
+                config_path=str(link),
+            ),
+        ),
+    )
+
+    with_symlinks = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        include_symlinks=True,
+        follow_unsafe_symlinks=False,
+    )
+    without_symlinks = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        include_symlinks=False,
+    )
+    follow_unsafe = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        include_symlinks=True,
+        follow_unsafe_symlinks=True,
+    )
+
+    with_metadata = with_symlinks.items[0].metadata.get("sourceOfTruth")
+    without_metadata = without_symlinks.items[0].metadata.get("sourceOfTruth")
+    follow_metadata = follow_unsafe.items[0].metadata.get("sourceOfTruth")
+
+    assert isinstance(with_metadata, dict)
+    assert with_metadata.get("validationState") == "escape_blocked"
+    assert without_metadata is None
+    assert isinstance(follow_metadata, dict)
+    assert follow_metadata.get("validationState") == "valid"
+
+
+def test_aibom_export_json_includes_redaction_report(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_codex_fixture(home_dir, workspace_dir)
+
+    rc = main(
+        [
+            "guard",
+            "aibom",
+            "export",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--format",
+            "json",
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert "layer_summary" in output
+    assert "trust_summary" in output
+    assert output["redaction_report"]["rawValuesIncluded"] is False
+    assert "snapshots" in output


### PR DESCRIPTION
## Summary
- Add `hol-guard aibom` CLI with status, sync, and export subcommands.
- Extend `inventory --json` with AIBOM metadata extensions and symlink-safe flags.
- Add local layer/trust/drift summaries and redaction reporting for operators.

## Testing
- `python3 -m pytest tests/test_guard_aibom_cli.py -q`
- `python3 -m pytest tests/test_guard_aibom_symlink.py tests/test_guard_inventory_contract.py -q`
