### PR TITLE
fix(guard): clear revoked OAuth sign-in blocking insights share

### DIFF
--- a/dashboard/src/evidence/evidence-insights-share-errors.ts
+++ b/dashboard/src/evidence/evidence-insights-share-errors.ts
@@ -14,6 +14,15 @@ export function insightsSharePublishErrorMessage(raw: string): string {
     return "Reconnect Guard Cloud to grant insights sharing permission, then try again.";
   }
 
+  if (
+    lower.includes("invalid_grant") ||
+    lower.includes("already consumed") ||
+    lower.includes("no longer valid") ||
+    lower.includes("hol-guard disconnect")
+  ) {
+    return "Guard Cloud sign-in on this device expired. Run hol-guard disconnect, then hol-guard connect, and try again.";
+  }
+
   if (lower.includes("unauthorized") || lower.includes("401")) {
     return "Guard Cloud session expired. Reconnect from Settings, then try again.";
   }

--- a/dashboard/src/evidence/evidence-insights-share-errors.ts
+++ b/dashboard/src/evidence/evidence-insights-share-errors.ts
@@ -17,8 +17,7 @@ export function insightsSharePublishErrorMessage(raw: string): string {
   if (
     lower.includes("invalid_grant") ||
     lower.includes("already consumed") ||
-    lower.includes("no longer valid") ||
-    lower.includes("hol-guard disconnect")
+    lower.includes("no longer valid")
   ) {
     return "Guard Cloud sign-in on this device expired. Run hol-guard disconnect, then hol-guard connect, and try again.";
   }

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -215,6 +215,7 @@ from .connect_flow import (
     connect_recovery_command,
     resolve_connect_url,
     run_guard_browser_connect_command,
+    run_guard_connect_repair_command,
     run_guard_device_connect_command,
     run_guard_disconnect_command,
 )
@@ -2723,13 +2724,22 @@ def run_guard_command(
 
     if args.guard_command == "connect":
         connect_subcommand = getattr(args, "connect_command", None)
-        if connect_subcommand in {"status", "repair", "re-pair"}:
+        if connect_subcommand == "repair":
+            payload = run_guard_connect_repair_command(
+                store=store,
+                sync_url=args.sync_url,
+                connect_url=args.connect_url,
+            )
+        elif connect_subcommand in {"status", "re-pair"}:
             payload = build_connect_status_payload(
                 store=store,
                 sync_url=args.sync_url,
                 connect_url=args.connect_url,
                 action=str(connect_subcommand),
             )
+        else:
+            payload = None
+        if connect_subcommand in {"status", "repair", "re-pair"}:
             _emit("connect", payload, getattr(args, "json", False))
             return 0
         try:

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -20,6 +20,7 @@ from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 from ...version import __version__
 from ..package_firewall_entitlement import build_oauth_package_firewall_entitlement
+from ..runtime.runner import prepare_guard_cloud_connect_authorization
 from ..store import GuardStore
 from .oauth_client import (
     GuardDpopKeyMaterial,
@@ -931,6 +932,31 @@ def run_guard_disconnect_command(
     }
 
 
+def run_guard_connect_repair_command(
+    *,
+    store: GuardStore,
+    sync_url: str,
+    connect_url: str,
+) -> dict[str, object]:
+    repair_result = prepare_guard_cloud_connect_authorization(store)
+    payload = build_connect_status_payload(
+        store=store,
+        sync_url=sync_url,
+        connect_url=connect_url,
+        action="repair",
+    )
+    payload.update(repair_result)
+    if repair_result.get("cleared_stale_sign_in"):
+        payload["repair_message"] = (
+            "Cleared expired Guard Cloud sign-in on this device. Run hol-guard connect to sign in again."
+        )
+        payload["recovery_command"] = CONNECT_COMMAND
+    elif not repair_result.get("existing_sign_in_valid"):
+        payload["repair_message"] = "Run hol-guard connect to sign in to Guard Cloud on this device."
+        payload["recovery_command"] = CONNECT_COMMAND
+    return payload
+
+
 def run_guard_device_connect_command(
     *,
     store: GuardStore,
@@ -946,7 +972,7 @@ def run_guard_device_connect_command(
     machine_label: str | None = None,
     include_sync_auth_context: bool = False,
 ) -> dict[str, object]:
-    store.repair_oauth_local_credential_storage_from_primary()
+    prepare_guard_cloud_connect_authorization(store)
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
     oauth_client = resolve_guard_oauth_client_config(allowed_origin)
@@ -1042,7 +1068,7 @@ def run_guard_browser_connect_command(
     wait_timeout_seconds: float = 180,
     include_sync_auth_context: bool = False,
 ) -> dict[str, object]:
-    store.repair_oauth_local_credential_storage_from_primary()
+    prepare_guard_cloud_connect_authorization(store)
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
     oauth_client = resolve_guard_oauth_client_config(allowed_origin)

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2236,6 +2236,81 @@ def _guard_oauth_reauthorization_message() -> str:
     return "Guard authorization expired. Run `hol-guard connect` to sign in again."
 
 
+def _guard_oauth_reconnect_after_revoked_message() -> str:
+    return (
+        "Guard Cloud sign-in on this device is no longer valid. "
+        "Run `hol-guard disconnect` then `hol-guard connect` to sign in again."
+    )
+
+
+def _oauth_token_http_error_details(error: urllib.error.HTTPError) -> tuple[str | None, str | None]:
+    payload = _http_error_payload(error)
+    if isinstance(payload, dict):
+        return _optional_string(payload.get("error")), _optional_string(payload.get("error_description"))
+    return None, None
+
+
+def _invalid_grant_oauth_http_error(error: urllib.error.HTTPError) -> bool:
+    error_code, description = _oauth_token_http_error_details(error)
+    return _invalid_grant_oauth_error_details(error_code, description)
+
+
+def _invalid_grant_oauth_payload(payload: object) -> bool:
+    if not isinstance(payload, dict):
+        return False
+    return _invalid_grant_oauth_error_details(
+        _optional_string(payload.get("error")),
+        _optional_string(payload.get("error_description")),
+    )
+
+
+def _invalid_grant_oauth_error_details(
+    error_code: str | None,
+    description: str | None,
+) -> bool:
+    if error_code == "invalid_grant":
+        return True
+    if description is not None and "missing, expired, or already consumed" in description.lower():
+        return True
+    return False
+
+
+def _oauth_authorization_error_requires_fresh_sign_in(error: Exception) -> bool:
+    message = str(error).strip().lower()
+    return (
+        "invalid_grant" in message
+        or "missing, expired, or already consumed" in message
+        or _guard_oauth_reconnect_after_revoked_message().lower() in message
+    )
+
+
+def clear_revoked_guard_oauth_sign_in(store: GuardStore) -> bool:
+    """Drop stale local OAuth material when refresh proves the grant is revoked."""
+    credentials = store.get_oauth_local_credentials(allow_primary=True)
+    if credentials is None:
+        return False
+    try:
+        _resolve_guard_sync_auth_context_from_oauth_credentials(store, credentials)
+    except GuardSyncAuthorizationExpiredError as error:
+        if not _oauth_authorization_error_requires_fresh_sign_in(error):
+            return False
+        store.clear_oauth_local_credentials()
+        return True
+    return False
+
+
+def prepare_guard_cloud_connect_authorization(store: GuardStore) -> dict[str, object]:
+    """Repair local OAuth storage and clear revoked sign-in before reconnect."""
+    repaired_storage = store.repair_oauth_local_credential_storage_from_primary()
+    cleared_stale_sign_in = clear_revoked_guard_oauth_sign_in(store)
+    existing_sign_in_valid = store.get_oauth_local_credentials(allow_primary=True) is not None
+    return {
+        "repaired_storage": repaired_storage,
+        "cleared_stale_sign_in": cleared_stale_sign_in,
+        "existing_sign_in_valid": existing_sign_in_valid,
+    }
+
+
 def _guard_sync_reconnect_message() -> str:
     return "Guard Cloud sync endpoint is not trusted. Run `hol-guard connect` to restore Cloud sync."
 
@@ -2286,17 +2361,20 @@ def _refresh_guard_oauth_access_token(
             with urllib.request.urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
-            payload = _http_error_payload(error) if error.code in {400, 401} else None
+            payload = _http_error_payload(error) if error.code in {400, 401, 403} else None
             challenge_nonce = _dpop_nonce_from_http_error(error, payload)
             if challenge_nonce is not None and challenge_nonce != dpop_nonce and nonce_retry_count < 3:
                 dpop_nonce = challenge_nonce
                 nonce_retry_count += 1
                 continue
-            refresh_error_message = _oauth_refresh_error_message(error)
             if error.code in {400, 401, 403}:
+                if _invalid_grant_oauth_payload(payload):
+                    raise GuardSyncAuthorizationExpiredError(_guard_oauth_reconnect_after_revoked_message()) from error
+                refresh_error_message = _oauth_refresh_error_message(error)
                 raise GuardSyncAuthorizationExpiredError(
                     f"{_guard_oauth_reauthorization_message()} {refresh_error_message}"
                 ) from error
+            refresh_error_message = _oauth_refresh_error_message(error)
             raise RuntimeError(f"Guard OAuth token refresh failed: {refresh_error_message}") from error
         except OSError as error:
             raise RuntimeError(_sync_url_error_message(error)) from error
@@ -2405,12 +2483,17 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
         oauth_client = resolve_guard_oauth_client_config(issuer)
     except ValueError as error:
         raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
-    refreshed = _refresh_guard_oauth_access_token(
-        token_endpoint=oauth_client.token_endpoint,
-        client_id=client_id,
-        refresh_token=refresh_token,
-        dpop_key_material=dpop_key_material,
-    )
+    try:
+        refreshed = _refresh_guard_oauth_access_token(
+            token_endpoint=oauth_client.token_endpoint,
+            client_id=client_id,
+            refresh_token=refresh_token,
+            dpop_key_material=dpop_key_material,
+        )
+    except GuardSyncAuthorizationExpiredError as error:
+        if _oauth_authorization_error_requires_fresh_sign_in(error):
+            store.clear_oauth_local_credentials()
+        raise
     rotated_refresh_token = str(refreshed["refresh_token"])
     package_firewall_entitlement = (
         refreshed["package_firewall_entitlement"]

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2243,18 +2243,6 @@ def _guard_oauth_reconnect_after_revoked_message() -> str:
     )
 
 
-def _oauth_token_http_error_details(error: urllib.error.HTTPError) -> tuple[str | None, str | None]:
-    payload = _http_error_payload(error)
-    if isinstance(payload, dict):
-        return _optional_string(payload.get("error")), _optional_string(payload.get("error_description"))
-    return None, None
-
-
-def _invalid_grant_oauth_http_error(error: urllib.error.HTTPError) -> bool:
-    error_code, description = _oauth_token_http_error_details(error)
-    return _invalid_grant_oauth_error_details(error_code, description)
-
-
 def _invalid_grant_oauth_payload(payload: object) -> bool:
     if not isinstance(payload, dict):
         return False
@@ -2268,11 +2256,9 @@ def _invalid_grant_oauth_error_details(
     error_code: str | None,
     description: str | None,
 ) -> bool:
-    if error_code == "invalid_grant":
-        return True
-    if description is not None and "missing, expired, or already consumed" in description.lower():
-        return True
-    return False
+    return error_code == "invalid_grant" or (
+        description is not None and "missing, expired, or already consumed" in description.lower()
+    )
 
 
 def _oauth_authorization_error_requires_fresh_sign_in(error: Exception) -> bool:
@@ -2285,17 +2271,18 @@ def _oauth_authorization_error_requires_fresh_sign_in(error: Exception) -> bool:
 
 
 def clear_revoked_guard_oauth_sign_in(store: GuardStore) -> bool:
-    """Drop stale local OAuth material when refresh proves the grant is revoked."""
-    credentials = store.get_oauth_local_credentials(allow_primary=True)
-    if credentials is None:
+    """Return True when refresh proves the local OAuth grant was revoked and cleared."""
+    if store.get_oauth_local_credentials(allow_primary=True) is None:
         return False
     try:
+        credentials = store.get_oauth_local_credentials(allow_primary=True)
+        if credentials is None:
+            return False
         _resolve_guard_sync_auth_context_from_oauth_credentials(store, credentials)
     except GuardSyncAuthorizationExpiredError as error:
-        if not _oauth_authorization_error_requires_fresh_sign_in(error):
-            return False
-        store.clear_oauth_local_credentials()
-        return True
+        if _oauth_authorization_error_requires_fresh_sign_in(error):
+            return store.get_oauth_local_credentials(allow_primary=True) is None
+        return False
     return False
 
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2283,6 +2283,8 @@ def clear_revoked_guard_oauth_sign_in(store: GuardStore) -> bool:
         if _oauth_authorization_error_requires_fresh_sign_in(error):
             return store.get_oauth_local_credentials(allow_primary=True) is None
         return False
+    except (RuntimeError, OSError):
+        return False
     return False
 
 

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -1,0 +1,102 @@
+"""Tests for clearing revoked Guard Cloud OAuth sign-in before reconnect."""
+
+from __future__ import annotations
+
+import json
+import urllib.error
+
+import pytest
+
+from codex_plugin_scanner.guard.cli.connect_flow import run_guard_connect_repair_command
+from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _store_with_oauth_credentials(tmp_path) -> GuardStore:
+    store = GuardStore(tmp_path / "guard-home")
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    return store
+
+
+def _invalid_grant_http_error() -> urllib.error.HTTPError:
+    class _ErrorResponse:
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "error": "invalid_grant",
+                    "error_description": "The grant is missing, expired, or already consumed.",
+                }
+            ).encode("utf-8")
+
+        def close(self) -> None:
+            return None
+
+    return urllib.error.HTTPError(
+        "https://hol.org/api/guard/oauth/token",
+        400,
+        "Bad Request",
+        hdrs=None,
+        fp=_ErrorResponse(),
+    )
+
+
+def test_prepare_guard_cloud_connect_authorization_clears_revoked_sign_in(tmp_path, monkeypatch) -> None:
+    store = _store_with_oauth_credentials(tmp_path)
+
+    def _fake_urlopen(request, timeout):
+        raise _invalid_grant_http_error()
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    result = guard_runner_module.prepare_guard_cloud_connect_authorization(store)
+
+    assert result["cleared_stale_sign_in"] is True
+    assert result["existing_sign_in_valid"] is False
+    assert store.get_oauth_local_credentials(allow_primary=True) is None
+
+
+def test_connect_repair_clears_revoked_sign_in_and_points_to_connect(tmp_path, monkeypatch) -> None:
+    store = _store_with_oauth_credentials(tmp_path)
+
+    def _fake_urlopen(request, timeout):
+        raise _invalid_grant_http_error()
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    payload = run_guard_connect_repair_command(
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+    )
+
+    assert payload["cleared_stale_sign_in"] is True
+    assert payload["recovery_command"] == "hol-guard connect"
+    assert "Cleared expired Guard Cloud sign-in" in str(payload["repair_message"])
+
+
+def test_invalid_grant_refresh_uses_disconnect_reconnect_message(tmp_path, monkeypatch) -> None:
+    store = _store_with_oauth_credentials(tmp_path)
+
+    def _fake_urlopen(request, timeout):
+        raise _invalid_grant_http_error()
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    with pytest.raises(guard_runner_module.GuardSyncAuthorizationExpiredError) as error:
+        guard_runner_module._resolve_guard_sync_auth_context(store)
+
+    assert "hol-guard disconnect" in str(error.value)
+    assert store.get_oauth_local_credentials(allow_primary=True) is None

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -100,3 +100,18 @@ def test_invalid_grant_refresh_uses_disconnect_reconnect_message(tmp_path, monke
 
     assert "hol-guard disconnect" in str(error.value)
     assert store.get_oauth_local_credentials(allow_primary=True) is None
+
+
+def test_prepare_guard_cloud_connect_authorization_tolerates_network_errors(tmp_path, monkeypatch) -> None:
+    store = _store_with_oauth_credentials(tmp_path)
+
+    def _fake_urlopen(request, timeout):
+        raise OSError("network unreachable")
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    result = guard_runner_module.prepare_guard_cloud_connect_authorization(store)
+
+    assert result["cleared_stale_sign_in"] is False
+    assert result["existing_sign_in_valid"] is True
+    assert store.get_oauth_local_credentials(allow_primary=True) is not None


### PR DESCRIPTION
## Summary
- Detect revoked Guard Cloud refresh tokens (`invalid_grant`) and clear stale local OAuth sign-in instead of looping on dead credentials
- Make `hol-guard connect repair` actually repair expired sign-in and point users to a fresh connect
- Improve insights share auth errors to recommend disconnect + reconnect when Cloud sign-in is invalid

## Testing
- `uv run pytest tests/test_guard_oauth_reconnect.py tests/test_insights_share.py -q`

## Notes
- Repro on affected machines: refresh returned `invalid_grant` while local OAuth health still showed `healthy`, so repeated `hol-guard connect` never replaced the consumed grant.
