### PR TITLE
fix(guard): self-repair guard_evidence schema on supply-chain writes

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -86,8 +86,7 @@ from .store_connect import (
 )
 from .store_evidence import (
     EvidenceRecord,
-    evidence_index_statements,
-    evidence_schema_statement,
+    ensure_evidence_schema,
 )
 from .store_evidence import (
     list_evidence as _list_evidence_impl,
@@ -1221,7 +1220,6 @@ class GuardStore:
             connect_request_schema_statement(),
             connect_state_schema_statement(),
             approval_schema_statement(),
-            evidence_schema_statement(),
             supply_chain_bundle_schema_statement(),
             supply_chain_eval_cache_schema_statement(),
             threat_intel_bundle_schema_statement(),
@@ -1230,11 +1228,9 @@ class GuardStore:
         with self._connect() as connection:
             for statement in statements:
                 connection.execute(statement)
+            ensure_evidence_schema(connection)
             if not self._schema_version_applied(connection, version=4):
-                self._ensure_column(connection, "guard_evidence", "action_identity", "text")
                 self._record_schema_version(connection, version=4)
-            for idx_stmt in evidence_index_statements():
-                connection.execute(idx_stmt)
             for idx_stmt in supply_chain_index_statements():
                 connection.execute(idx_stmt)
             for idx_stmt in threat_intel_index_statements():

--- a/src/codex_plugin_scanner/guard/store_evidence.py
+++ b/src/codex_plugin_scanner/guard/store_evidence.py
@@ -86,6 +86,17 @@ def evidence_index_statements() -> list[str]:
     ]
 
 
+def ensure_evidence_schema(connection: sqlite3.Connection) -> None:
+    """Create or repair the evidence table, columns, and indexes."""
+    connection.execute(evidence_schema_statement())
+    rows = connection.execute("pragma table_info(guard_evidence)").fetchall()
+    existing = {str(row["name"]) for row in rows}
+    if "action_identity" not in existing:
+        connection.execute("alter table guard_evidence add column action_identity text")
+    for statement in evidence_index_statements():
+        connection.execute(statement)
+
+
 def _row_to_record(row: sqlite3.Row) -> EvidenceRecord:
     try:
         details: dict[str, object] = json.loads(row["details_json"])
@@ -110,6 +121,7 @@ def _row_to_record(row: sqlite3.Row) -> EvidenceRecord:
 
 
 def store_evidence(conn: sqlite3.Connection, record: EvidenceRecord) -> EvidenceRecord:
+    ensure_evidence_schema(conn)
     conn.execute(
         """
         insert or replace into guard_evidence
@@ -148,6 +160,7 @@ def list_evidence(
     before_cursor: str | None = None,
     limit: int = 100,
 ) -> list[EvidenceRecord]:
+    ensure_evidence_schema(conn)
     clauses: list[str] = []
     params: list[object] = []
 
@@ -185,6 +198,7 @@ def search_evidence(
     *,
     limit: int = 100,
 ) -> list[EvidenceRecord]:
+    ensure_evidence_schema(conn)
     pattern = f"%{query}%"
     rows = conn.execute(
         "select * from guard_evidence where lower(summary) like lower(?) order by created_at desc limit ?",
@@ -200,6 +214,7 @@ def count_evidence(
     category: str | None = None,
     severity: str | None = None,
 ) -> int:
+    ensure_evidence_schema(conn)
     clauses: list[str] = []
     params: list[object] = []
     if harness is not None:
@@ -313,12 +328,14 @@ def _sanitize_csv_formula_cell(value: object) -> object:
 
 
 def clear_evidence(conn: sqlite3.Connection) -> int:
+    ensure_evidence_schema(conn)
     cursor = conn.execute("delete from guard_evidence")
     conn.commit()
     return cursor.rowcount
 
 
 def compact_evidence(conn: sqlite3.Connection, *, retain_days: int = 90) -> int:
+    ensure_evidence_schema(conn)
     cutoff = (
         (datetime.now(timezone.utc) - timedelta(days=retain_days))
         .isoformat(timespec="microseconds")

--- a/src/codex_plugin_scanner/guard/store_evidence.py
+++ b/src/codex_plugin_scanner/guard/store_evidence.py
@@ -86,15 +86,39 @@ def evidence_index_statements() -> list[str]:
     ]
 
 
+_EVIDENCE_SCHEMA_READY: set[str] = set()
+
+
+def _evidence_schema_cache_key(connection: sqlite3.Connection) -> str:
+    row = connection.execute("pragma database_list").fetchone()
+    if row is None:
+        return ":memory:"
+    file_path = row[2]
+    return str(file_path) if file_path else ":memory:"
+
+
 def ensure_evidence_schema(connection: sqlite3.Connection) -> None:
     """Create or repair the evidence table, columns, and indexes."""
+    cache_key = _evidence_schema_cache_key(connection)
+    if cache_key in _EVIDENCE_SCHEMA_READY:
+        row = connection.execute(
+            "select 1 from sqlite_master where type='table' and name='guard_evidence' limit 1"
+        ).fetchone()
+        if row is not None:
+            return
+        _EVIDENCE_SCHEMA_READY.discard(cache_key)
     connection.execute(evidence_schema_statement())
     rows = connection.execute("pragma table_info(guard_evidence)").fetchall()
-    existing = {str(row["name"]) for row in rows}
+    existing = {str(row[1]) for row in rows}
     if "action_identity" not in existing:
-        connection.execute("alter table guard_evidence add column action_identity text")
+        try:
+            connection.execute("alter table guard_evidence add column action_identity text")
+        except sqlite3.OperationalError as error:
+            if "duplicate column name" not in str(error).lower():
+                raise
     for statement in evidence_index_statements():
         connection.execute(statement)
+    _EVIDENCE_SCHEMA_READY.add(cache_key)
 
 
 def _row_to_record(row: sqlite3.Row) -> EvidenceRecord:
@@ -160,7 +184,6 @@ def list_evidence(
     before_cursor: str | None = None,
     limit: int = 100,
 ) -> list[EvidenceRecord]:
-    ensure_evidence_schema(conn)
     clauses: list[str] = []
     params: list[object] = []
 
@@ -198,7 +221,6 @@ def search_evidence(
     *,
     limit: int = 100,
 ) -> list[EvidenceRecord]:
-    ensure_evidence_schema(conn)
     pattern = f"%{query}%"
     rows = conn.execute(
         "select * from guard_evidence where lower(summary) like lower(?) order by created_at desc limit ?",
@@ -214,7 +236,6 @@ def count_evidence(
     category: str | None = None,
     severity: str | None = None,
 ) -> int:
-    ensure_evidence_schema(conn)
     clauses: list[str] = []
     params: list[object] = []
     if harness is not None:
@@ -328,14 +349,12 @@ def _sanitize_csv_formula_cell(value: object) -> object:
 
 
 def clear_evidence(conn: sqlite3.Connection) -> int:
-    ensure_evidence_schema(conn)
     cursor = conn.execute("delete from guard_evidence")
     conn.commit()
     return cursor.rowcount
 
 
 def compact_evidence(conn: sqlite3.Connection, *, retain_days: int = 90) -> int:
-    ensure_evidence_schema(conn)
     cutoff = (
         (datetime.now(timezone.utc) - timedelta(days=retain_days))
         .isoformat(timespec="microseconds")

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -88,7 +88,7 @@ from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.guard.store_evidence import EvidenceRecord
 
 
-def _legacy_evidence_table(connection: sqlite3.Connection) -> None:
+def _incomplete_evidence_table(connection: sqlite3.Connection) -> None:
     connection.execute(
         """
         create table guard_evidence (
@@ -159,7 +159,7 @@ def test_guard_store_repairs_missing_evidence_table_when_schema_v4_is_applied(tm
     assert row[0] == "rule-123"
 
 
-def test_guard_store_repairs_legacy_evidence_table_missing_action_identity(tmp_path):
+def test_guard_store_repairs_incomplete_evidence_table_missing_action_identity(tmp_path):
     guard_home = tmp_path / "guard-home"
     guard_home.mkdir()
     database_path = guard_home / "guard.db"
@@ -170,7 +170,7 @@ def test_guard_store_repairs_legacy_evidence_table_missing_action_identity(tmp_p
         connection.execute(
             "insert into schema_migrations (version, applied_at) values (4, '2026-01-01T00:00:00Z')"
         )
-        _legacy_evidence_table(connection)
+        _incomplete_evidence_table(connection)
 
     store = GuardStore(guard_home)
     store.add_evidence(

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -84,6 +84,153 @@ def _clear_oauth_process_caches() -> None:
     guard_store_module._OAUTH_HEALTH_RESULT_PROCESS_CACHE.clear()
 
 
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_evidence import EvidenceRecord
+
+
+def _legacy_evidence_table(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        create table guard_evidence (
+          evidence_id text primary key,
+          action_id text,
+          request_id text,
+          harness text,
+          workspace text,
+          signal_id text,
+          category text,
+          severity text,
+          confidence real,
+          summary text,
+          details_json text,
+          created_at text
+        )
+        """
+    )
+
+
+def test_guard_store_repairs_missing_evidence_table_when_schema_v4_is_applied(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    database_path = guard_home / "guard.db"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            "create table schema_migrations (version integer primary key, applied_at text not null)"
+        )
+        connection.execute(
+            "insert into schema_migrations (version, applied_at) values (4, '2026-01-01T00:00:00Z')"
+        )
+        connection.execute(
+            """
+            create table harness_installations (
+              harness text primary key,
+              active integer not null,
+              workspace text,
+              config_path text,
+              metadata_json text not null default '{}',
+              updated_at text not null
+            )
+            """
+        )
+
+    store = GuardStore(guard_home)
+    store.add_evidence(
+        EvidenceRecord(
+            evidence_id="evidence-1",
+            action_id="action-1",
+            request_id="request-1",
+            harness="codex",
+            workspace="/workspace",
+            signal_id="block",
+            category="supply-chain",
+            severity="high",
+            confidence=1.0,
+            summary="blocked package install",
+            action_identity="rule-123",
+        )
+    )
+
+    with sqlite3.connect(database_path) as connection:
+        row = connection.execute(
+            "select action_identity from guard_evidence where evidence_id = 'evidence-1'"
+        ).fetchone()
+
+    assert row is not None
+    assert row[0] == "rule-123"
+
+
+def test_guard_store_repairs_legacy_evidence_table_missing_action_identity(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    database_path = guard_home / "guard.db"
+    with sqlite3.connect(database_path) as connection:
+        connection.execute(
+            "create table schema_migrations (version integer primary key, applied_at text not null)"
+        )
+        connection.execute(
+            "insert into schema_migrations (version, applied_at) values (4, '2026-01-01T00:00:00Z')"
+        )
+        _legacy_evidence_table(connection)
+
+    store = GuardStore(guard_home)
+    store.add_evidence(
+        EvidenceRecord(
+            evidence_id="evidence-legacy",
+            action_id="action-legacy",
+            request_id="request-legacy",
+            harness="codex",
+            workspace="/workspace",
+            signal_id="ask",
+            category="supply-chain",
+            severity="medium",
+            confidence=0.8,
+            summary="package install requires review",
+            action_identity="exception-456",
+        )
+    )
+
+    with sqlite3.connect(database_path) as connection:
+        columns = {
+            str(row[1])
+            for row in connection.execute("pragma table_info(guard_evidence)").fetchall()
+        }
+        row = connection.execute(
+            "select action_identity from guard_evidence where evidence_id = 'evidence-legacy'"
+        ).fetchone()
+
+    assert "action_identity" in columns
+    assert row is not None
+    assert row[0] == "exception-456"
+
+
+def test_add_evidence_self_repairs_dropped_evidence_table(tmp_path):
+    store = GuardStore(tmp_path / "guard-home")
+    with sqlite3.connect(store.path) as connection:
+        connection.execute("drop table guard_evidence")
+
+    store.add_evidence(
+        EvidenceRecord(
+            evidence_id="evidence-repair",
+            action_id="action-repair",
+            request_id="request-repair",
+            harness="codex",
+            workspace="/workspace",
+            signal_id="monitor",
+            category="supply-chain",
+            severity="low",
+            confidence=0.5,
+            summary="monitored package install",
+        )
+    )
+
+    with sqlite3.connect(store.path) as connection:
+        row = connection.execute(
+            "select evidence_id from guard_evidence where evidence_id = 'evidence-repair'"
+        ).fetchone()
+
+    assert row is not None
+
+
 def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch, usable_macos_keychain=False)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)


### PR DESCRIPTION
## Summary
- Add `ensure_evidence_schema()` to create or repair the `guard_evidence` table, `action_identity` column, and indexes before reads/writes
- Use the repair helper during store initialization and on every evidence CRUD path so legacy databases no longer fail package-install evidence persistence

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_store_migrations.py::test_guard_store_repairs_missing_evidence_table_when_schema_v4_is_applied tests/test_guard_store_migrations.py::test_guard_store_repairs_legacy_evidence_table_missing_action_identity tests/test_guard_store_migrations.py::test_add_evidence_self_repairs_dropped_evidence_table tests/test_guard_evidence_store.py -q`
