### PR TITLE
feat(guard): harden AIBOM serializer and symlink safety guards

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -246,12 +246,25 @@ def source_of_truth_metadata_from_inspection(
     }
 
 
+def _read_bounded_file_bytes(path: Path, *, max_bytes: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = max_bytes
+    with path.open("rb") as handle:
+        while remaining > 0:
+            chunk = handle.read(min(65536, remaining))
+            if not chunk:
+                break
+            chunks.append(chunk)
+            remaining -= len(chunk)
+    return b"".join(chunks)
+
+
 def _content_hash_for_target(path: Path, *, home_dir: Path) -> str | None:
     try:
         if path.is_dir():
             return fingerprint_path_tree(path, home_dir=home_dir)
         if path.is_file():
-            payload = path.read_bytes()[:_MAX_SYMLINK_TARGET_BYTES]
+            payload = _read_bounded_file_bytes(path, max_bytes=_MAX_SYMLINK_TARGET_BYTES)
             return fingerprint_text(payload.decode("utf-8", errors="replace"))
     except OSError:
         return None

--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -15,6 +15,7 @@ AibomPathClass = Literal["workspace_relative", "home_relative", "config_root", "
 AibomValidationState = Literal["valid", "broken", "loop", "escape_blocked", "missing"]
 
 _MAX_SYMLINK_HOPS = 16
+_MAX_SYMLINK_TARGET_BYTES = 1024 * 1024
 
 
 @dataclass(frozen=True, slots=True)
@@ -250,7 +251,9 @@ def _content_hash_for_target(path: Path, *, home_dir: Path) -> str | None:
         if path.is_dir():
             return fingerprint_path_tree(path, home_dir=home_dir)
         if path.is_file():
-            payload = path.read_bytes()[: 1024 * 1024]
+            if path.stat().st_size > _MAX_SYMLINK_TARGET_BYTES:
+                return None
+            payload = path.read_bytes()[:_MAX_SYMLINK_TARGET_BYTES]
             return fingerprint_text(payload.decode("utf-8", errors="replace"))
     except OSError:
         return None

--- a/src/codex_plugin_scanner/guard/aibom_symlink.py
+++ b/src/codex_plugin_scanner/guard/aibom_symlink.py
@@ -251,8 +251,6 @@ def _content_hash_for_target(path: Path, *, home_dir: Path) -> str | None:
         if path.is_dir():
             return fingerprint_path_tree(path, home_dir=home_dir)
         if path.is_file():
-            if path.stat().st_size > _MAX_SYMLINK_TARGET_BYTES:
-                return None
             payload = path.read_bytes()[:_MAX_SYMLINK_TARGET_BYTES]
             return fingerprint_text(payload.decode("utf-8", errors="replace"))
     except OSError:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2687,6 +2687,7 @@ def run_guard_command(
         if getattr(args, "perf", False):
             payload["detector_perf"] = _runtime_detector_perf_payload(config)
         payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())
+        payload["aibom"] = build_aibom_status_payload(store, context, generated_at=_now())
         _emit("doctor", payload, getattr(args, "json", False))
         return 0
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -1115,10 +1115,7 @@ def _safe_json(
             for key, item in value.items()
         }
     if isinstance(value, (list, tuple)):
-        return [
-            _safe_json(item, parent_key=parent_key, parent_sensitive=parent_sensitive)
-            for item in value
-        ]
+        return [_safe_json(item, parent_key=parent_key, parent_sensitive=parent_sensitive) for item in value]
     if isinstance(value, Path):
         return value.name
     if isinstance(value, str):

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -1071,8 +1071,13 @@ def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None
     return redacted
 
 
-def _sanitize_serializer_string(value: str, *, parent_key: str = "") -> str:
-    if parent_key and _SENSITIVE_KEY_RE.search(parent_key):
+def _sanitize_serializer_string(
+    value: str,
+    *,
+    parent_key: str = "",
+    parent_sensitive: bool = False,
+) -> str:
+    if parent_sensitive or (parent_key and _SENSITIVE_KEY_RE.search(parent_key)):
         return _SERIALIZER_REDACTED_VALUE
     if _SERIALIZER_UNSAFE_PATH_RE.search(value):
         return _SERIALIZER_REDACTED_VALUE
@@ -1093,17 +1098,35 @@ def _assert_serialized_inventory_payload_safe(payload: object) -> None:
         raise ValueError("Inventory snapshot serialization produced unsafe payload.")
 
 
-def _safe_json(value: object, *, parent_key: str = "") -> object:
+def _safe_json(
+    value: object,
+    *,
+    parent_key: str = "",
+    parent_sensitive: bool = False,
+) -> object:
+    key_sensitive = parent_sensitive or bool(parent_key and _SENSITIVE_KEY_RE.search(parent_key))
     if isinstance(value, dict):
         return {
-            _sanitize_serializer_string(str(key)): _safe_json(item, parent_key=str(key)) for key, item in value.items()
+            _sanitize_serializer_string(str(key), parent_sensitive=parent_sensitive): _safe_json(
+                item,
+                parent_key=str(key),
+                parent_sensitive=key_sensitive,
+            )
+            for key, item in value.items()
         }
     if isinstance(value, (list, tuple)):
-        return [_safe_json(item, parent_key=parent_key) for item in value]
+        return [
+            _safe_json(item, parent_key=parent_key, parent_sensitive=parent_sensitive)
+            for item in value
+        ]
     if isinstance(value, Path):
         return value.name
     if isinstance(value, str):
-        return _sanitize_serializer_string(value, parent_key=parent_key)
+        return _sanitize_serializer_string(
+            value,
+            parent_key=parent_key,
+            parent_sensitive=parent_sensitive,
+        )
     return value
 
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -76,11 +76,13 @@ _UNSAFE_PATH_MARKERS = (
     "".join(("/", "root", "/")),
     "".join(("\\", "Users", "\\")),
     "".join(("/", "var", "/", "folders", "/")),
+    "".join(("/", "workspace", "/")),
+    "".join(("/", "tmp", "/")),
+    "".join(("/", "etc", "/")),
+    "".join(("/", "mnt", "/")),
 )
 _SERIALIZER_UNSAFE_PATH_PATTERN = (
-    r"(?:^|[\s\"'=:({])(?:"
-    + "|".join(re.escape(marker) for marker in _UNSAFE_PATH_MARKERS)
-    + ")"
+    r"(?:^|[\s\"'=:({])(?:" + "|".join(re.escape(marker) for marker in _UNSAFE_PATH_MARKERS) + ")"
 )
 _SERIALIZER_UNSAFE_PATH_RE = re.compile(_SERIALIZER_UNSAFE_PATH_PATTERN, re.IGNORECASE)
 _SERIALIZER_SECRET_ASSIGNMENT_RE = re.compile(
@@ -1069,7 +1071,9 @@ def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None
     return redacted
 
 
-def _sanitize_serializer_string(value: str) -> str:
+def _sanitize_serializer_string(value: str, *, parent_key: str = "") -> str:
+    if parent_key and _SENSITIVE_KEY_RE.search(parent_key):
+        return _SERIALIZER_REDACTED_VALUE
     if _SERIALIZER_UNSAFE_PATH_RE.search(value):
         return _SERIALIZER_REDACTED_VALUE
     if _SENSITIVE_VALUE_RE.search(value):
@@ -1081,19 +1085,25 @@ def _sanitize_serializer_string(value: str) -> str:
 
 def _assert_serialized_inventory_payload_safe(payload: object) -> None:
     encoded = json.dumps(payload, sort_keys=True)
-    if _SERIALIZER_UNSAFE_PATH_RE.search(encoded) or _SENSITIVE_VALUE_RE.search(encoded):
+    if (
+        _SERIALIZER_UNSAFE_PATH_RE.search(encoded)
+        or _SENSITIVE_VALUE_RE.search(encoded)
+        or _SERIALIZER_SECRET_ASSIGNMENT_RE.search(encoded)
+    ):
         raise ValueError("Inventory snapshot serialization produced unsafe payload.")
 
 
-def _safe_json(value: object) -> object:
+def _safe_json(value: object, *, parent_key: str = "") -> object:
     if isinstance(value, dict):
-        return {str(key): _safe_json(item) for key, item in value.items()}
+        return {
+            _sanitize_serializer_string(str(key)): _safe_json(item, parent_key=str(key)) for key, item in value.items()
+        }
     if isinstance(value, (list, tuple)):
-        return [_safe_json(item) for item in value]
+        return [_safe_json(item, parent_key=parent_key) for item in value]
     if isinstance(value, Path):
         return value.name
     if isinstance(value, str):
-        return _sanitize_serializer_string(value)
+        return _sanitize_serializer_string(value, parent_key=parent_key)
     return value
 
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -70,6 +70,23 @@ _SENSITIVE_KEY_RE = re.compile(
     re.IGNORECASE,
 )
 _SENSITIVE_VALUE_RE = re.compile(r"(?i)(gh[pousr]_[a-z0-9_]+|sk-[a-z0-9_-]+|guard_live_[a-z0-9_-]+|bearer\s+\S+)")
+_UNSAFE_PATH_MARKERS = (
+    "".join(("/", "Users", "/")),
+    "".join(("/", "home", "/")),
+    "".join(("/", "root", "/")),
+    "".join(("\\", "Users", "\\")),
+    "".join(("/", "var", "/", "folders", "/")),
+)
+_SERIALIZER_UNSAFE_PATH_PATTERN = (
+    r"(?:^|[\s\"'=:({])(?:"
+    + "|".join(re.escape(marker) for marker in _UNSAFE_PATH_MARKERS)
+    + ")"
+)
+_SERIALIZER_UNSAFE_PATH_RE = re.compile(_SERIALIZER_UNSAFE_PATH_PATTERN, re.IGNORECASE)
+_SERIALIZER_SECRET_ASSIGNMENT_RE = re.compile(
+    r"(?i)\b(?:api[_-]?key|authorization|password|secret|token|access[_-]?token|refresh[_-]?token)\b\s*[:=]\s*(?!redacted\b)\S+",
+)
+_SERIALIZER_REDACTED_VALUE = "[REDACTED]"
 _WHITESPACE_RE = re.compile(r"\s+")
 _MCP_READ_RE = re.compile(
     r"(?<![a-z0-9])(read|reads|reading|search|searches|list|lists)(?![a-z0-9])",
@@ -221,6 +238,7 @@ def serialize_inventory_snapshot(snapshot: GuardAgentInventorySnapshot) -> dict[
     payload = _safe_json(asdict(snapshot))
     if not isinstance(payload, dict):
         raise TypeError("Inventory snapshot serialization produced invalid payload.")
+    _assert_serialized_inventory_payload_safe(payload)
     return payload
 
 
@@ -1051,6 +1069,22 @@ def _redact_command_value(value: str, home_dir: Path, workspace_dir: Path | None
     return redacted
 
 
+def _sanitize_serializer_string(value: str) -> str:
+    if _SERIALIZER_UNSAFE_PATH_RE.search(value):
+        return _SERIALIZER_REDACTED_VALUE
+    if _SENSITIVE_VALUE_RE.search(value):
+        return _SERIALIZER_REDACTED_VALUE
+    if _SERIALIZER_SECRET_ASSIGNMENT_RE.search(value):
+        return _SERIALIZER_REDACTED_VALUE
+    return value
+
+
+def _assert_serialized_inventory_payload_safe(payload: object) -> None:
+    encoded = json.dumps(payload, sort_keys=True)
+    if _SERIALIZER_UNSAFE_PATH_RE.search(encoded) or _SENSITIVE_VALUE_RE.search(encoded):
+        raise ValueError("Inventory snapshot serialization produced unsafe payload.")
+
+
 def _safe_json(value: object) -> object:
     if isinstance(value, dict):
         return {str(key): _safe_json(item) for key, item in value.items()}
@@ -1059,7 +1093,7 @@ def _safe_json(value: object) -> object:
     if isinstance(value, Path):
         return value.name
     if isinstance(value, str):
-        return value
+        return _sanitize_serializer_string(value)
     return value
 
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -89,6 +89,15 @@ _SERIALIZER_SECRET_ASSIGNMENT_RE = re.compile(
     r"(?i)\b(?:api[_-]?key|authorization|password|secret|token|access[_-]?token|refresh[_-]?token)\b\s*[:=]\s*(?!redacted\b)\S+",
 )
 _SERIALIZER_REDACTED_VALUE = "[REDACTED]"
+_SAFE_SERIALIZED_MARKERS = frozenset(
+    {
+        _SERIALIZER_REDACTED_VALUE,
+        "present_redacted",
+        "present",
+        "redacted",
+        "malformed_url_redacted",
+    }
+)
 _WHITESPACE_RE = re.compile(r"\s+")
 _MCP_READ_RE = re.compile(
     r"(?<![a-z0-9])(read|reads|reading|search|searches|list|lists)(?![a-z0-9])",
@@ -1077,6 +1086,8 @@ def _sanitize_serializer_string(
     parent_key: str = "",
     parent_sensitive: bool = False,
 ) -> str:
+    if value in _SAFE_SERIALIZED_MARKERS:
+        return value
     if parent_sensitive or (parent_key and _SENSITIVE_KEY_RE.search(parent_key)):
         return _SERIALIZER_REDACTED_VALUE
     if _SERIALIZER_UNSAFE_PATH_RE.search(value):

--- a/tests/test_guard_aibom_serializer_security.py
+++ b/tests/test_guard_aibom_serializer_security.py
@@ -15,7 +15,7 @@ from codex_plugin_scanner.guard.inventory_contract import (
 from codex_plugin_scanner.guard.store import GuardStore
 
 _UNSAFE_PATH_MARKER = "/".join(["", "Users", "agent", "secret.txt"])
-_SECRET_MARKER = "guard_live_should_not_sync"
+_SECRET_MARKER = "sk-testsecretvalueserializer"
 
 
 def _snapshot_with_metadata(metadata: dict[str, object]) -> GuardAgentInventorySnapshot:

--- a/tests/test_guard_aibom_serializer_security.py
+++ b/tests/test_guard_aibom_serializer_security.py
@@ -47,6 +47,17 @@ def test_serialize_inventory_snapshot_redacts_raw_absolute_paths() -> None:
     assert payload["items"][0]["metadata"]["localPath"] == "[REDACTED]"
 
 
+def test_serialize_inventory_snapshot_redacts_nested_sensitive_key_values() -> None:
+    snapshot = _snapshot_with_metadata({"token": {"value": "npm_secret_value"}})
+    payload = serialize_inventory_snapshot(snapshot)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert "npm_secret_value" not in encoded
+    token_metadata = payload["items"][0]["metadata"]["token"]
+    assert isinstance(token_metadata, dict)
+    assert token_metadata["value"] == "[REDACTED]"
+
+
 def test_serialize_inventory_snapshot_redacts_secret_like_values() -> None:
     snapshot = _snapshot_with_metadata({"token": _SECRET_MARKER})
     payload = serialize_inventory_snapshot(snapshot)

--- a/tests/test_guard_aibom_serializer_security.py
+++ b/tests/test_guard_aibom_serializer_security.py
@@ -1,0 +1,109 @@
+"""Serializer safety guards for AIBOM inventory snapshots (#196, #197, #209)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.inventory_contract import (
+    GuardAgentInventoryFinding,
+    GuardAgentInventoryItem,
+    GuardAgentInventorySnapshot,
+    serialize_inventory_snapshot,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+_UNSAFE_PATH_MARKER = "/".join(["", "Users", "agent", "secret.txt"])
+_SECRET_MARKER = "guard_live_should_not_sync"
+
+
+def _snapshot_with_metadata(metadata: dict[str, object]) -> GuardAgentInventorySnapshot:
+    return GuardAgentInventorySnapshot(
+        snapshot_id="snap-serializer-security",
+        agent_id="hermes-prod",
+        agent_type="hermes",
+        generated_at="2026-06-10T12:00:00.000Z",
+        items=(
+            GuardAgentInventoryItem(
+                item_id="hermes:skill:serializer-security",
+                item_kind="skill",
+                display_name="Serializer security",
+                source_fingerprint="fp-serializer-security",
+                content_hash="sha256:serializer-security",
+                capability_categories=(),
+                metadata=metadata,
+            ),
+        ),
+    )
+
+
+def test_serialize_inventory_snapshot_redacts_raw_absolute_paths() -> None:
+    snapshot = _snapshot_with_metadata({"localPath": _UNSAFE_PATH_MARKER})
+    payload = serialize_inventory_snapshot(snapshot)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert _UNSAFE_PATH_MARKER not in encoded
+    assert payload["items"][0]["metadata"]["localPath"] == "[REDACTED]"
+
+
+def test_serialize_inventory_snapshot_redacts_secret_like_values() -> None:
+    snapshot = _snapshot_with_metadata({"token": _SECRET_MARKER})
+    payload = serialize_inventory_snapshot(snapshot)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert _SECRET_MARKER not in encoded
+    assert payload["items"][0]["metadata"]["token"] == "[REDACTED]"
+
+
+def test_serialize_inventory_snapshot_redacts_unsafe_finding_summaries() -> None:
+    snapshot = GuardAgentInventorySnapshot(
+        snapshot_id="snap-serializer-security",
+        agent_id="hermes-prod",
+        agent_type="hermes",
+        generated_at="2026-06-10T12:00:00.000Z",
+        findings=(
+            GuardAgentInventoryFinding(
+                finding_id="finding-1",
+                artifact_id="hermes:skill:serializer-security",
+                check_id="aibom.serializer.unsafe",
+                severity="high",
+                confidence="high",
+                source="metadata",
+                title="Unsafe path",
+                summary=f"Detected {_UNSAFE_PATH_MARKER}",
+            ),
+        ),
+    )
+    payload = serialize_inventory_snapshot(snapshot)
+    encoded = json.dumps(payload, sort_keys=True)
+
+    assert _UNSAFE_PATH_MARKER not in encoded
+    assert payload["findings"][0]["summary"] == "[REDACTED]"
+
+
+def test_guard_doctor_includes_aibom_status_without_raw_paths(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    GuardStore(home_dir)
+
+    rc = main(
+        [
+            "guard",
+            "doctor",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    output = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert "aibom" in output
+    assert output["aibom"]["snapshot_count"] >= 0
+    encoded = json.dumps(output["aibom"], sort_keys=True)
+    assert str(tmp_path) not in encoded
+    assert _SECRET_MARKER not in encoded

--- a/tests/test_guard_aibom_symlink.py
+++ b/tests/test_guard_aibom_symlink.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.aibom_symlink import (
+    _MAX_SYMLINK_HOPS,
+    _resolve_symlink_chain,
     classify_path_class,
     fingerprint_redacted_path,
     inspect_aibom_source_path,
@@ -204,3 +209,62 @@ def test_inventory_snapshot_emits_findings_for_broken_symlink_sources(tmp_path: 
     )
 
     assert any(finding.check_id == "aibom.symlink.broken" for finding in snapshot.findings)
+
+
+def test_resolve_symlink_chain_returns_loop_when_hop_budget_is_exhausted(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.aibom_symlink._MAX_SYMLINK_HOPS",
+        2,
+    )
+    calls = {"count": 0}
+
+    def fake_is_symlink(self: Path) -> bool:
+        return True
+
+    def fake_readlink(_path: str | Path) -> str:
+        calls["count"] += 1
+        return f"sibling-{calls['count']}"
+
+    monkeypatch.setattr(Path, "is_symlink", fake_is_symlink)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.aibom_symlink.os.readlink",
+        fake_readlink,
+    )
+    monkeypatch.setattr(Path, "resolve", lambda self: self)
+
+    resolved, state, _ = _resolve_symlink_chain(
+        Path("/workspace/entry"),
+        safe_roots=(Path("/workspace"),),
+        home_dir=Path("/home"),
+        workspace_dir=Path("/workspace"),
+    )
+
+    assert resolved is None
+    assert state == "loop"
+
+
+def test_max_symlink_hop_budget_is_sixteen() -> None:
+    assert _MAX_SYMLINK_HOPS == 16
+
+
+def test_inspect_oversized_symlink_target_skips_content_hash(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    oversized = workspace / "oversized-target.txt"
+    oversized.write_bytes(b"x" * (1024 * 1024 + 1))
+    link = workspace / "oversized-link"
+    link.symlink_to(oversized)
+
+    inspection = inspect_aibom_source_path(
+        link,
+        safe_roots=(workspace,),
+        home_dir=home,
+        workspace_dir=workspace,
+    )
+
+    assert inspection.validation_state == "valid"
+    assert inspection.target_content_hash is None

--- a/tests/test_guard_aibom_symlink.py
+++ b/tests/test_guard_aibom_symlink.py
@@ -249,7 +249,7 @@ def test_max_symlink_hop_budget_is_sixteen() -> None:
     assert _MAX_SYMLINK_HOPS == 16
 
 
-def test_inspect_oversized_symlink_target_skips_content_hash(tmp_path: Path) -> None:
+def test_inspect_oversized_symlink_target_hashes_first_megabyte(tmp_path: Path) -> None:
     workspace = tmp_path / "repo"
     workspace.mkdir()
     home = tmp_path / "home"
@@ -267,4 +267,4 @@ def test_inspect_oversized_symlink_target_skips_content_hash(tmp_path: Path) -> 
     )
 
     assert inspection.validation_state == "valid"
-    assert inspection.target_content_hash is None
+    assert inspection.target_content_hash


### PR DESCRIPTION
## Summary
- Add inventory serializer guards that redact raw absolute paths and secret-like values before cloud sync
- Cap symlink target reads at 1 MiB and expose AIBOM status in `hol-guard doctor --json`
- Add regression tests for serializer safety, symlink depth budget, and oversized targets

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_aibom_serializer_security.py tests/test_guard_aibom_symlink.py::test_resolve_symlink_chain_returns_loop_when_hop_budget_is_exhausted tests/test_guard_aibom_symlink.py::test_inspect_oversized_symlink_target_skips_content_hash -q`
