### PR TITLE
fix(guard-aibom): auto-sync inventory on hol-guard sync

### DIFF
--- a/src/codex_plugin_scanner/guard/access_graph_events.py
+++ b/src/codex_plugin_scanner/guard/access_graph_events.py
@@ -187,6 +187,7 @@ def _add_artifact_entities(
                 "fingerprint": fingerprint,
                 "metadata": {
                     "agentId": agent_id,
+                    # agentType and harness both carry the harness slug for portal topology resolution.
                     "agentType": harness,
                     "artifactType": artifact_type,
                     "harness": harness,

--- a/src/codex_plugin_scanner/guard/access_graph_events.py
+++ b/src/codex_plugin_scanner/guard/access_graph_events.py
@@ -51,6 +51,8 @@ def queue_access_graph_snapshot(
         edges=edges,
         artifacts=artifacts,
         agent_fingerprint=agent_fingerprint,
+        harness=detection.harness,
+        agent_id=agent_id,
         now=now,
     )
     snapshot_seed = {
@@ -166,6 +168,8 @@ def _add_artifact_entities(
     edges: list[dict[str, object]],
     artifacts: list[dict[str, object]],
     agent_fingerprint: str,
+    harness: str,
+    agent_id: str,
     now: str,
 ) -> None:
     for artifact in artifacts:
@@ -182,7 +186,10 @@ def _add_artifact_entities(
                 "displayName": _non_empty_string(artifact.get("artifact_name")) or artifact_id,
                 "fingerprint": fingerprint,
                 "metadata": {
+                    "agentId": agent_id,
+                    "agentType": harness,
                     "artifactType": artifact_type,
+                    "harness": harness,
                     "sourceScope": _non_empty_string(artifact.get("source_scope")),
                     "policyAction": _non_empty_string(artifact.get("policy_action")),
                     "present": artifact.get("removed") is not True,

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -159,6 +159,10 @@ def _aibom_sync_is_due(
     prior = store.get_sync_payload("aibom_sync_summary")
     if not isinstance(prior, dict):
         return True
+    if prior.get("synced") is not True:
+        return True
+    if prior.get("snapshots") == 0:
+        return True
     synced_at = prior.get("synced_at")
     if not isinstance(synced_at, str) or not synced_at.strip():
         return True
@@ -312,7 +316,6 @@ def sync_aibom_snapshots(
                 "synced": False,
                 "skipped": True,
                 "reason": "guard_events_endpoint_unavailable",
-                "synced_at": synced_at,
             }
             store.set_sync_payload("aibom_sync_summary", summary, synced_at)
             return summary
@@ -514,7 +517,7 @@ def _aibom_connection_status(store: GuardStore) -> str:
     if store.get_cloud_workspace_id() is None:
         return "workspace_required"
     sync_summary = _sync_summary(store)
-    if sync_summary.get("synced_at"):
+    if sync_summary.get("synced") is True and sync_summary.get("synced_at"):
         return "synced"
     return "sync_required"
 

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -137,6 +137,73 @@ def build_aibom_export_payload(
     return payload
 
 
+_AIBOM_AUTO_SYNC_INTERVAL_SECONDS = 60 * 60
+
+
+def _aibom_sync_is_due(
+    store: GuardStore,
+    *,
+    generated_at: str,
+    min_interval_seconds: int,
+) -> bool:
+    prior = store.get_sync_payload("aibom_sync_summary")
+    if not isinstance(prior, dict):
+        return True
+    synced_at = prior.get("synced_at")
+    if not isinstance(synced_at, str) or not synced_at.strip():
+        return True
+    try:
+        from datetime import datetime
+
+        last_sync = datetime.fromisoformat(synced_at.replace("Z", "+00:00"))
+        now = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        elapsed = (now - last_sync).total_seconds()
+    except ValueError:
+        return True
+    return elapsed >= min_interval_seconds
+
+
+def sync_aibom_snapshots_if_due(
+    store: GuardStore,
+    *,
+    generated_at: str,
+    min_interval_seconds: int = _AIBOM_AUTO_SYNC_INTERVAL_SECONDS,
+    options: AibomCliOptions | None = None,
+) -> dict[str, object]:
+    from .runtime.runner import GuardSyncNotConfiguredError
+
+    if store.get_cloud_workspace_id() is None:
+        return {"synced": False, "skipped": True, "reason": "not_configured"}
+    if not _aibom_sync_is_due(
+        store,
+        generated_at=generated_at,
+        min_interval_seconds=min_interval_seconds,
+    ):
+        prior = store.get_sync_payload("aibom_sync_summary")
+        return {
+            "synced": False,
+            "skipped": True,
+            "reason": "recently_synced",
+            "last_sync_at": prior.get("synced_at") if isinstance(prior, dict) else None,
+        }
+    context = HarnessContext(
+        home_dir=Path.home().resolve(),
+        workspace_dir=None,
+        guard_home=store.guard_home,
+    )
+    try:
+        return sync_aibom_snapshots(
+            store,
+            context,
+            generated_at=generated_at,
+            options=options,
+        )
+    except GuardSyncNotConfiguredError:
+        return {"synced": False, "skipped": True, "reason": "not_configured"}
+    except (OSError, RuntimeError) as error:
+        return {"synced": False, "error": str(error)}
+
+
 def sync_aibom_snapshots(
     store: GuardStore,
     context: HarnessContext,

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -6,7 +6,7 @@ import json
 import os
 import uuid
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -142,6 +142,13 @@ def build_aibom_export_payload(
 _AIBOM_AUTO_SYNC_INTERVAL_SECONDS = 60 * 60
 
 
+def _aware_utc_timestamp(value: str) -> datetime:
+    parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
 def _aibom_sync_is_due(
     store: GuardStore,
     *,
@@ -155,8 +162,8 @@ def _aibom_sync_is_due(
     if not isinstance(synced_at, str) or not synced_at.strip():
         return True
     try:
-        last_sync = datetime.fromisoformat(synced_at.replace("Z", "+00:00"))
-        now = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        last_sync = _aware_utc_timestamp(synced_at)
+        now = _aware_utc_timestamp(generated_at)
         elapsed = (now - last_sync).total_seconds()
     except (ValueError, OverflowError, TypeError):
         return True
@@ -180,11 +187,21 @@ def sync_aibom_snapshots_if_due(
     options: AibomCliOptions | None = None,
     auth_context: dict[str, object] | None = None,
     home_dir: Path | None = None,
+    workspace_dir: Path | None = None,
 ) -> dict[str, object]:
-    from .runtime.runner import GuardSyncNotConfiguredError
+    from .runtime.runner import (
+        GuardSyncNotConfiguredError,
+        _guard_events_endpoint_unavailable_recently,
+    )
 
     if store.get_cloud_workspace_id() is None:
         return {"synced": False, "skipped": True, "reason": "not_configured"}
+    if _guard_events_endpoint_unavailable_recently(store):
+        return {
+            "synced": False,
+            "skipped": True,
+            "reason": "guard_events_endpoint_unavailable",
+        }
     if not _aibom_sync_is_due(
         store,
         generated_at=generated_at,
@@ -199,7 +216,7 @@ def sync_aibom_snapshots_if_due(
         }
     context = HarnessContext(
         home_dir=_resolve_operator_home_dir(home_dir),
-        workspace_dir=None,
+        workspace_dir=workspace_dir,
         guard_home=store.guard_home,
     )
     try:

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import urllib.error
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -292,6 +293,30 @@ def sync_aibom_snapshots(
             timeout_seconds=30,
             retry_timeout_seconds=60,
         )
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            synced_at = generated_at
+            store.set_sync_payload(
+                "guard_events_v1_summary",
+                {
+                    "synced_at": synced_at,
+                    "events": 0,
+                    "accepted": 0,
+                    "skipped": 0,
+                    "sync_skipped": True,
+                    "sync_reason": "guard_events_endpoint_unavailable",
+                },
+                synced_at,
+            )
+            summary = {
+                "synced": False,
+                "skipped": True,
+                "reason": "guard_events_endpoint_unavailable",
+                "synced_at": synced_at,
+            }
+            store.set_sync_payload("aibom_sync_summary", summary, synced_at)
+            return summary
+        raise RuntimeError("Guard Cloud AIBOM sync failed due to an HTTP error.") from error
     except OSError as error:
         raise RuntimeError("Guard Cloud AIBOM sync failed due to a network error.") from error
     accepted = payload.get("accepted")

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 import uuid
 from dataclasses import dataclass
+from datetime import datetime
 from pathlib import Path
 from typing import Literal
 
@@ -153,14 +155,21 @@ def _aibom_sync_is_due(
     if not isinstance(synced_at, str) or not synced_at.strip():
         return True
     try:
-        from datetime import datetime
-
         last_sync = datetime.fromisoformat(synced_at.replace("Z", "+00:00"))
         now = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
         elapsed = (now - last_sync).total_seconds()
-    except ValueError:
+    except (ValueError, OverflowError, TypeError):
         return True
     return elapsed >= min_interval_seconds
+
+
+def _resolve_operator_home_dir(home_dir: Path | None = None) -> Path:
+    if home_dir is not None:
+        return home_dir.expanduser().resolve()
+    home_env = os.environ.get("HOME")
+    if home_env:
+        return Path(home_env).expanduser().resolve()
+    return Path.home().resolve()
 
 
 def sync_aibom_snapshots_if_due(
@@ -169,6 +178,8 @@ def sync_aibom_snapshots_if_due(
     generated_at: str,
     min_interval_seconds: int = _AIBOM_AUTO_SYNC_INTERVAL_SECONDS,
     options: AibomCliOptions | None = None,
+    auth_context: dict[str, object] | None = None,
+    home_dir: Path | None = None,
 ) -> dict[str, object]:
     from .runtime.runner import GuardSyncNotConfiguredError
 
@@ -187,7 +198,7 @@ def sync_aibom_snapshots_if_due(
             "last_sync_at": prior.get("synced_at") if isinstance(prior, dict) else None,
         }
     context = HarnessContext(
-        home_dir=Path.home().resolve(),
+        home_dir=_resolve_operator_home_dir(home_dir),
         workspace_dir=None,
         guard_home=store.guard_home,
     )
@@ -197,9 +208,12 @@ def sync_aibom_snapshots_if_due(
             context,
             generated_at=generated_at,
             options=options,
+            auth_context=auth_context,
         )
     except GuardSyncNotConfiguredError:
         return {"synced": False, "skipped": True, "reason": "not_configured"}
+    except ValueError as error:
+        return {"synced": False, "error": str(error)}
     except (OSError, RuntimeError) as error:
         return {"synced": False, "error": str(error)}
 
@@ -210,6 +224,7 @@ def sync_aibom_snapshots(
     *,
     generated_at: str,
     options: AibomCliOptions | None = None,
+    auth_context: dict[str, object] | None = None,
 ) -> dict[str, object]:
     from .runtime.runner import (
         GuardSyncNotConfiguredError,
@@ -236,7 +251,7 @@ def sync_aibom_snapshots(
         store.set_sync_payload("aibom_sync_summary", summary, synced_at)
         return summary
 
-    resolved_auth_context = _resolve_guard_sync_auth_context(store)
+    resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
     sync_url = _guard_events_sync_url(str(resolved_auth_context["sync_url"]))
     events = [
         _inventory_snapshot_event(

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2826,7 +2826,11 @@ def run_guard_command(
 
     if args.guard_command == "sync":
         try:
-            payload = sync_receipts(store, home_dir=context.home_dir)
+            payload = sync_receipts(
+                store,
+                home_dir=context.home_dir,
+                workspace_dir=context.workspace_dir,
+            )
         except GuardSyncNotConfiguredError as error:
             message = _guard_sync_failure_message(error)
             if getattr(args, "json", False):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -2826,7 +2826,7 @@ def run_guard_command(
 
     if args.guard_command == "sync":
         try:
-            payload = sync_receipts(store)
+            payload = sync_receipts(store, home_dir=context.home_dir)
         except GuardSyncNotConfiguredError as error:
             message = _guard_sync_failure_message(error)
             if getattr(args, "json", False):

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -1655,6 +1655,8 @@ def _resolve_guard_workspace(
     guard_command = getattr(args, "guard_command", None)
     if guard_command in _INSTALL_WORKSPACE_COMMANDS:
         return _resolve_default_install_workspace(args, guard_home=guard_home)
+    if guard_command == "sync":
+        return Path.cwd().resolve()
     if guard_command != "apps":
         return None
     if getattr(args, "apps_command", None) not in {"connect", "disconnect", "repair", "test"}:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1121,6 +1121,7 @@ def sync_receipts(
     persist_connect_state: bool = True,
     auth_context: dict[str, object] | None = None,
     home_dir: Path | None = None,
+    workspace_dir: Path | None = None,
 ) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
@@ -1368,6 +1369,7 @@ def sync_receipts(
         generated_at=now,
         auth_context=resolved_auth_context,
         home_dir=home_dir,
+        workspace_dir=workspace_dir,
     )
     if persist_sync_summary:
         store.set_sync_payload("sync_summary", summary, now)

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1362,7 +1362,11 @@ def sync_receipts(
     summary["guard_events_v1"] = sync_guard_events(store, auth_context=resolved_auth_context)
     from ..aibom_cli import sync_aibom_snapshots_if_due
 
-    summary["aibom_inventory"] = sync_aibom_snapshots_if_due(store, generated_at=now)
+    summary["aibom_inventory"] = sync_aibom_snapshots_if_due(
+        store,
+        generated_at=now,
+        auth_context=resolved_auth_context,
+    )
     if persist_sync_summary:
         store.set_sync_payload("sync_summary", summary, now)
     if persist_connect_state:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1360,6 +1360,9 @@ def sync_receipts(
     if remote_policy_sync_blocked:
         summary["remote_policy_sync_blocked"] = True
     summary["guard_events_v1"] = sync_guard_events(store, auth_context=resolved_auth_context)
+    from ..aibom_cli import sync_aibom_snapshots_if_due
+
+    summary["aibom_inventory"] = sync_aibom_snapshots_if_due(store, generated_at=now)
     if persist_sync_summary:
         store.set_sync_payload("sync_summary", summary, now)
     if persist_connect_state:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1120,6 +1120,7 @@ def sync_receipts(
     persist_sync_summary: bool = True,
     persist_connect_state: bool = True,
     auth_context: dict[str, object] | None = None,
+    home_dir: Path | None = None,
 ) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
@@ -1366,6 +1367,7 @@ def sync_receipts(
         store,
         generated_at=now,
         auth_context=resolved_auth_context,
+        home_dir=home_dir,
     )
     if persist_sync_summary:
         store.set_sync_payload("sync_summary", summary, now)

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -209,6 +209,24 @@ def test_aibom_symlink_flags_control_source_metadata(tmp_path: Path) -> None:
     assert follow_metadata.get("validationState") == "valid"
 
 
+def test_sync_aibom_snapshots_if_due_skips_recent_sync(tmp_path: Path, monkeypatch) -> None:
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots_if_due
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    now = "2026-06-10T13:00:00+00:00"
+    store.set_sync_payload(
+        "aibom_sync_summary",
+        {"synced": True, "synced_at": "2026-06-10T12:30:00+00:00"},
+        "2026-06-10T12:30:00+00:00",
+    )
+
+    summary = sync_aibom_snapshots_if_due(store, generated_at=now)
+
+    assert summary.get("skipped") is True
+    assert summary.get("reason") == "recently_synced"
+
+
 def test_aibom_export_json_includes_redaction_report(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -7274,7 +7274,7 @@ url = http://127.0.0.1:8787/guard-canary
                 "runtime_sessions_visible": 1,
             }
 
-        def fake_sync_receipts(current_store: GuardStore) -> dict[str, object]:
+        def fake_sync_receipts(current_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             assert current_store is not None
             return {
                 "synced_at": now,
@@ -7335,7 +7335,7 @@ url = http://127.0.0.1:8787/guard-canary
                 "runtime_sessions_visible": 1,
             }
 
-        def fake_sync_receipts(current_store: GuardStore) -> dict[str, object]:
+        def fake_sync_receipts(current_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             assert current_store is not None
             return {
                 "synced_at": now,
@@ -8740,7 +8740,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_guard_sync_surfaces_auth_expired_reauth_message(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
 
-        def _fail_sync(_store: GuardStore) -> dict[str, object]:
+        def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             raise guard_commands_module.GuardSyncAuthorizationExpiredError(
                 "Guard authorization expired. Run `hol-guard connect` to sign in again."
             )
@@ -8765,7 +8765,7 @@ url = http://127.0.0.1:8787/guard-canary
             "2026-04-09T00:00:00Z",
         )
 
-        def _fail_sync(_store: GuardStore) -> dict[str, object]:
+        def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             raise guard_commands_module.GuardSyncAuthorizationExpiredError(
                 "Guard authorization expired. Run `hol-guard connect` to sign in again."
             )
@@ -8788,7 +8788,7 @@ url = http://127.0.0.1:8787/guard-canary
             "2026-04-09T00:00:00Z",
         )
 
-        def _bundle_rejected(current_store: GuardStore) -> dict[str, object]:
+        def _bundle_rejected(current_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             current_store.set_sync_payload(
                 "policy_bundle_last_error",
                 {"reason": "bundle_version_downgrade"},
@@ -8821,7 +8821,11 @@ url = http://127.0.0.1:8787/guard-canary
             "2026-04-09T00:00:00Z",
         )
 
-        monkeypatch.setattr(guard_commands_module, "sync_receipts", lambda _store: {"synced": True})
+        monkeypatch.setattr(
+            guard_commands_module,
+            "sync_receipts",
+            lambda _store, **_kwargs: {"synced": True},
+        )
         monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", lambda _store: None)
 
         guard_commands_module._refresh_cloud_policy_bundle(store)

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -61,7 +61,7 @@ def test_daemon_bundle_refresh_stays_quiet_when_not_configured(
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
 
-    def _fail_sync(_store: GuardStore) -> dict[str, object]:
+    def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
         raise GuardSyncNotConfiguredError("Guard is not logged in.")
 
     monkeypatch.setattr(guard_daemon_module, "sync_supply_chain_bundle", _fail_sync)
@@ -92,7 +92,7 @@ def test_daemon_bundle_refresh_reports_auth_expired(
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
 
-    def _fail_sync(_store: GuardStore) -> dict[str, object]:
+    def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
         raise GuardSyncAuthorizationExpiredError(
             "Guard authorization expired. Run `hol-guard connect` to sign in again."
         )
@@ -124,7 +124,7 @@ def test_daemon_bundle_refresh_reports_retryable_error(
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
 
-    def _fail_sync(_store: GuardStore) -> dict[str, object]:
+    def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
         raise RuntimeError("Guard OAuth token refresh failed: oauth upstream down")
 
     monkeypatch.setattr(guard_daemon_module, "sync_supply_chain_bundle", _fail_sync)


### PR DESCRIPTION
## Summary
- Auto-publish AIBOM inventory snapshots during routine `hol-guard sync` (hourly throttle)
- Add harness/agent metadata to access-graph artifact entities for portal topology attachment

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_aibom_cli.py -q`
