### PR TITLE
fix(ci): keep action.yml wheel lookup on one python line

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -235,16 +235,7 @@ runs:
           python3 -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" "plugin-scanner==${SCANNER_VERSION}"
 
           DIST_BASENAME="$(
-            DIST_DIR="$DIST_DIR" python3 -c "
-import os
-import sys
-from pathlib import Path
-
-candidates = sorted(Path(os.environ['DIST_DIR']).glob('plugin_scanner-*.whl'))
-if len(candidates) != 1:
-    sys.exit(f'Expected exactly one downloaded scanner wheel, found {len(candidates)}')
-print(candidates[0].name)
-"
+            DIST_DIR="$DIST_DIR" python3 -c "import os, sys; from pathlib import Path; candidates = sorted(Path(os.environ['DIST_DIR']).glob('plugin_scanner-*.whl')); (len(candidates) == 1) or sys.exit(f'Expected exactly one downloaded scanner wheel, found {len(candidates)}'); print(candidates[0].name)"
           )"
 
           ACTUAL_SHA256="$(

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -5,6 +5,20 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 
 
+def test_action_yaml_is_valid_mapping() -> None:
+    try:
+        import yaml
+    except ImportError:
+        import pytest
+
+        pytest.importorskip("yaml")
+
+    action_text = (ROOT / "action" / "action.yml").read_text(encoding="utf-8")
+    parsed = yaml.safe_load(action_text)
+    assert isinstance(parsed, dict)
+    assert parsed["runs"]["using"] == "composite"
+
+
 def test_action_metadata_includes_marketplace_branding_and_pypi_install() -> None:
     action_text = (ROOT / "action" / "action.yml").read_text(encoding="utf-8")
 

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -2,16 +2,13 @@
 
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parent.parent
 
 
 def test_action_yaml_is_valid_mapping() -> None:
-    try:
-        import yaml
-    except ImportError:
-        import pytest
-
-        pytest.importorskip("yaml")
+    yaml = pytest.importorskip("yaml")
 
     action_text = (ROOT / "action" / "action.yml").read_text(encoding="utf-8")
     parsed = yaml.safe_load(action_text)


### PR DESCRIPTION
## Summary
- Fix invalid YAML in `action/action.yml` caused by unindented multiline Python in the composite `run` block
- Add a regression test that parses `action.yml` as YAML before publish

## Testing
- `uv run pytest tests/test_action_bundle.py -q`
