### PR TITLE
fix(action): isolate composite python execution

### DIFF
--- a/action/action.yml
+++ b/action/action.yml
@@ -201,10 +201,10 @@ runs:
         PYTHONNOUSERSITE: "1"
         PYTHONSAFEPATH: "1"
       run: |
-        ACTION_RUNTIME_ROOT="${RUNNER_TEMP:-$GITHUB_ACTION_PATH/.tmp}"
+        ACTION_RUNTIME_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
         mkdir -p "$ACTION_RUNTIME_ROOT"
         ACTION_RUNTIME_DIR="$(mktemp -d "$ACTION_RUNTIME_ROOT/hol-guard-action-XXXXXX")"
-        trap 'rm -rf "$ACTION_RUNTIME_DIR"' EXIT
+        trap 'cd "$ACTION_RUNTIME_ROOT" && rm -rf "$ACTION_RUNTIME_DIR"' EXIT
         cd "$ACTION_RUNTIME_DIR"
 
         LOCAL_SOURCE=""

--- a/action/action.yml
+++ b/action/action.yml
@@ -202,9 +202,8 @@ runs:
         PYTHONSAFEPATH: "1"
       run: |
         ACTION_RUNTIME_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
-        mkdir -p "$ACTION_RUNTIME_ROOT"
         ACTION_RUNTIME_DIR="$(mktemp -d "$ACTION_RUNTIME_ROOT/hol-guard-action-XXXXXX")"
-        trap 'cd "$ACTION_RUNTIME_ROOT" && rm -rf "$ACTION_RUNTIME_DIR"' EXIT
+        trap 'cd "$ACTION_RUNTIME_ROOT" 2>/dev/null || cd /; rm -rf "$ACTION_RUNTIME_DIR"' EXIT
         cd "$ACTION_RUNTIME_DIR"
 
         LOCAL_SOURCE=""

--- a/action/action.yml
+++ b/action/action.yml
@@ -198,7 +198,15 @@ runs:
       env:
         INSTALL_SOURCE: ${{ inputs.install_source }}
         INSTALL_CISCO: ${{ inputs.install_cisco }}
+        PYTHONNOUSERSITE: "1"
+        PYTHONSAFEPATH: "1"
       run: |
+        ACTION_RUNTIME_ROOT="${RUNNER_TEMP:-$GITHUB_ACTION_PATH/.tmp}"
+        mkdir -p "$ACTION_RUNTIME_ROOT"
+        ACTION_RUNTIME_DIR="$(mktemp -d "$ACTION_RUNTIME_ROOT/hol-guard-action-XXXXXX")"
+        trap 'rm -rf "$ACTION_RUNTIME_DIR"' EXIT
+        cd "$ACTION_RUNTIME_DIR"
+
         LOCAL_SOURCE=""
         for candidate in "$GITHUB_ACTION_PATH" "$GITHUB_ACTION_PATH/.."; do
           if [ -f "$candidate/pyproject.toml" ] && [ -d "$candidate/src/codex_plugin_scanner" ]; then
@@ -212,7 +220,7 @@ runs:
             echo "install_source=local requires the hol-guard source checkout (for example: uses: ./action inside hol-guard)." >&2
             exit 1
           fi
-          python3 -m pip install "$LOCAL_SOURCE[cisco]"
+          python3 -P -m pip install "$LOCAL_SOURCE[cisco]"
         elif [ "$INSTALL_SOURCE" = "pypi" ]; then
           SCANNER_VERSION_FILE="$GITHUB_ACTION_PATH/scanner-version.txt"
           SCANNER_SHA256_FILE="$GITHUB_ACTION_PATH/scanner-sha256.txt"
@@ -228,18 +236,18 @@ runs:
           CISCO_VERSION="$(tr -d '[:space:]' < "$CISCO_VERSION_FILE")"
           PYPI_ATTESTATIONS_VERSION="$(tr -d '[:space:]' < "$PYPI_ATTESTATIONS_VERSION_FILE")"
           SCANNER_REPOSITORY="https://github.com/hashgraph-online/hol-guard"
-          DIST_DIR="${RUNNER_TEMP:-$GITHUB_WORKSPACE/.ai-plugin-scanner-dist}"
+          DIST_DIR="$ACTION_RUNTIME_DIR/ai-plugin-scanner-dist"
           mkdir -p "$DIST_DIR"
 
-          python3 -m pip install "pypi-attestations==${PYPI_ATTESTATIONS_VERSION}"
-          python3 -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" "plugin-scanner==${SCANNER_VERSION}"
+          python3 -P -m pip install "pypi-attestations==${PYPI_ATTESTATIONS_VERSION}"
+          python3 -P -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" "plugin-scanner==${SCANNER_VERSION}"
 
           DIST_BASENAME="$(
-            DIST_DIR="$DIST_DIR" python3 -c "import os, sys; from pathlib import Path; candidates = sorted(Path(os.environ['DIST_DIR']).glob('plugin_scanner-*.whl')); (len(candidates) == 1) or sys.exit(f'Expected exactly one downloaded scanner wheel, found {len(candidates)}'); print(candidates[0].name)"
+            DIST_DIR="$DIST_DIR" python3 -P -c "import os, sys; from pathlib import Path; candidates = sorted(Path(os.environ['DIST_DIR']).glob('plugin_scanner-*.whl')); (len(candidates) == 1) or sys.exit(f'Expected exactly one downloaded scanner wheel, found {len(candidates)}'); print(candidates[0].name)"
           )"
 
           ACTUAL_SHA256="$(
-            DIST_DIR="$DIST_DIR" DIST_BASENAME="$DIST_BASENAME" python3 -c "import hashlib, os; from pathlib import Path; wheel = Path(os.environ['DIST_DIR']) / os.environ['DIST_BASENAME']; print(hashlib.sha256(wheel.read_bytes()).hexdigest())"
+            DIST_DIR="$DIST_DIR" DIST_BASENAME="$DIST_BASENAME" python3 -P -c "import hashlib, os; from pathlib import Path; wheel = Path(os.environ['DIST_DIR']) / os.environ['DIST_BASENAME']; print(hashlib.sha256(wheel.read_bytes()).hexdigest())"
           )"
           if [ "$ACTUAL_SHA256" != "$EXPECTED_SHA256" ]; then
             echo "Downloaded scanner wheel SHA256 does not match scanner-sha256.txt." >&2
@@ -247,16 +255,16 @@ runs:
           fi
 
           WHEEL_PATH="$DIST_DIR/$DIST_BASENAME"
-          if ! python3 -m pypi_attestations verify pypi \
+          if ! python3 -P -m pypi_attestations verify pypi \
             --repository "$SCANNER_REPOSITORY" \
             "$WHEEL_PATH"; then
             echo "Failed to verify PyPI provenance for plugin-scanner==${SCANNER_VERSION}." >&2
             exit 1
           fi
 
-          python3 -m pip install "$WHEEL_PATH"
+          python3 -P -m pip install "$WHEEL_PATH"
           if [ "$INSTALL_CISCO" = "true" ]; then
-            python3 -m pip install "cisco-ai-skill-scanner==${CISCO_VERSION}"
+            python3 -P -m pip install "cisco-ai-skill-scanner==${CISCO_VERSION}"
           fi
         else
           echo "Unsupported install_source: $INSTALL_SOURCE" >&2
@@ -296,7 +304,9 @@ runs:
         PR_COMMENT_STYLE: ${{ inputs.pr_comment_style }}
         PR_COMMENT_MAX_FINDINGS: ${{ inputs.pr_comment_max_findings }}
         GITHUB_STEP_SUMMARY: ${{ env.GITHUB_STEP_SUMMARY }}
-      run: python3 -m codex_plugin_scanner.action_runner
+        PYTHONNOUSERSITE: "1"
+        PYTHONSAFEPATH: "1"
+      run: python3 -P -m codex_plugin_scanner.action_runner
 
     - name: Upload SARIF
       if: ${{ inputs.upload_sarif == 'true' && inputs.mode == 'scan' && steps.scan.outputs.report_path != '' }}

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -37,7 +37,7 @@ def test_action_metadata_includes_marketplace_branding_and_pypi_install() -> Non
     assert 'PYTHONSAFEPATH: "1"' in action_text
     assert 'ACTION_RUNTIME_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"' in action_text
     assert 'ACTION_RUNTIME_DIR="$(mktemp -d "$ACTION_RUNTIME_ROOT/hol-guard-action-XXXXXX")"' in action_text
-    assert 'trap \'cd "$ACTION_RUNTIME_ROOT" && rm -rf "$ACTION_RUNTIME_DIR"\' EXIT' in action_text
+    assert 'trap \'cd "$ACTION_RUNTIME_ROOT" 2>/dev/null || cd /; rm -rf "$ACTION_RUNTIME_DIR"\' EXIT' in action_text
     assert 'cd "$ACTION_RUNTIME_DIR"' in action_text
     assert 'if [ "$INSTALL_CISCO" = "true" ]; then' in action_text
     assert 'if [ "$INSTALL_SOURCE" = "local" ]; then' in action_text
@@ -103,12 +103,17 @@ def test_python_safe_path_blocks_workspace_module_shadowing(tmp_path: Path) -> N
         "raise SystemExit('workspace-shadowed')\n",
         encoding="utf-8",
     )
-    env = {**os.environ, "PYTHONPATH": str(trusted_root)}
+    hijacked_env = {
+        key: value
+        for key, value in os.environ.items()
+        if key not in {"PYTHONSAFEPATH", "PYTHONNOUSERSITE"}
+    }
+    hijacked_env["PYTHONPATH"] = str(trusted_root)
 
     hijacked = subprocess.run(
         [sys.executable, "-m", module_name],
         cwd=workspace,
-        env=env,
+        env=hijacked_env,
         capture_output=True,
         text=True,
         check=False,
@@ -119,13 +124,13 @@ def test_python_safe_path_blocks_workspace_module_shadowing(tmp_path: Path) -> N
     protected = subprocess.run(
         [sys.executable, "-P", "-m", module_name],
         cwd=workspace,
-        env=env,
+        env=hijacked_env,
         capture_output=True,
         text=True,
         check=False,
     )
     assert protected.returncode == 0
-    assert "trusted-module" in f"{protected.stdout}{protected.stderr}"
+    assert "trusted-module" in protected.stdout
     assert "workspace-shadowed" not in f"{protected.stdout}{protected.stderr}"
 
 

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -1,5 +1,8 @@
 """Regression checks for the GitHub Action bundle and Marketplace packaging."""
 
+import os
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -24,28 +27,33 @@ def test_action_metadata_includes_marketplace_branding_and_pypi_install() -> Non
     assert 'icon: "check-circle"' in action_text
     assert 'color: "blue"' in action_text
     assert "actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405" in action_text
-    assert 'python3 -m pip install "pypi-attestations==' in action_text
+    assert 'python3 -P -m pip install "pypi-attestations==' in action_text
     assert "install_source:" in action_text
     assert 'default: "pypi"' in action_text
     assert "INSTALL_SOURCE: ${{ inputs.install_source }}" in action_text
     assert "install_cisco:" in action_text
     assert "INSTALL_CISCO: ${{ inputs.install_cisco }}" in action_text
+    assert 'PYTHONNOUSERSITE: "1"' in action_text
+    assert 'PYTHONSAFEPATH: "1"' in action_text
+    assert 'ACTION_RUNTIME_ROOT="${RUNNER_TEMP:-$GITHUB_ACTION_PATH/.tmp}"' in action_text
+    assert 'ACTION_RUNTIME_DIR="$(mktemp -d "$ACTION_RUNTIME_ROOT/hol-guard-action-XXXXXX")"' in action_text
+    assert 'cd "$ACTION_RUNTIME_DIR"' in action_text
     assert 'if [ "$INSTALL_CISCO" = "true" ]; then' in action_text
     assert 'if [ "$INSTALL_SOURCE" = "local" ]; then' in action_text
     assert "install_source=local requires the hol-guard source checkout" in action_text
-    assert 'python3 -m pip install "$LOCAL_SOURCE[cisco]"' in action_text
+    assert 'python3 -P -m pip install "$LOCAL_SOURCE[cisco]"' in action_text
     assert 'elif [ "$INSTALL_SOURCE" = "pypi" ]; then' in action_text
     assert (
-        'python3 -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" '
+        'python3 -P -m pip download --only-binary=:all: --no-deps --dest "$DIST_DIR" '
         '"plugin-scanner==${SCANNER_VERSION}"'
     ) in action_text
     assert "scanner-sha256.txt" in action_text
     assert 'SCANNER_SHA256_FILE="$GITHUB_ACTION_PATH/scanner-sha256.txt"' in action_text
     assert 'echo "Downloaded scanner wheel SHA256 does not match scanner-sha256.txt."' in action_text
-    assert "python3 -m pypi_attestations verify pypi \\" in action_text
+    assert "python3 -P -m pypi_attestations verify pypi" in action_text
     assert '"$WHEEL_PATH"' in action_text
-    assert 'python3 -m pip install "$WHEEL_PATH"' in action_text
-    assert 'python3 -m pip install "cisco-ai-skill-scanner==${CISCO_VERSION}"' in action_text
+    assert 'python3 -P -m pip install "$WHEEL_PATH"' in action_text
+    assert 'python3 -P -m pip install "cisco-ai-skill-scanner==${CISCO_VERSION}"' in action_text
     assert "scanner-version.txt" in action_text
     scanner_version = (ROOT / "action" / "scanner-version.txt").read_text(encoding="utf-8").strip()
     scanner_sha256 = (ROOT / "action" / "scanner-sha256.txt").read_text(encoding="utf-8").strip()
@@ -54,8 +62,70 @@ def test_action_metadata_includes_marketplace_branding_and_pypi_install() -> Non
     assert "cisco-version.txt" in action_text
     assert "pypi-attestations-version.txt" in action_text
     assert 'SCANNER_REPOSITORY="https://github.com/hashgraph-online/hol-guard"' in action_text
-    assert "python3 -m codex_plugin_scanner.action_runner" in action_text
+    assert "python3 -P -m codex_plugin_scanner.action_runner" in action_text
     assert "github/codeql-action/upload-sarif@" in action_text
+
+
+def test_action_steps_enable_python_safe_path() -> None:
+    yaml = pytest.importorskip("yaml")
+
+    parsed = yaml.safe_load((ROOT / "action" / "action.yml").read_text(encoding="utf-8"))
+    steps = parsed["runs"]["steps"]
+    install_step = next(step for step in steps if step["name"] == "Install scanner")
+    scan_step = next(step for step in steps if step["name"] == "Run scanner")
+
+    assert install_step["env"]["PYTHONNOUSERSITE"] == "1"
+    assert install_step["env"]["PYTHONSAFEPATH"] == "1"
+    assert 'cd "$ACTION_RUNTIME_DIR"' in install_step["run"]
+    assert "python3 -P -m pip install" in install_step["run"]
+    assert scan_step["env"]["PYTHONNOUSERSITE"] == "1"
+    assert scan_step["env"]["PYTHONSAFEPATH"] == "1"
+    assert scan_step["run"] == "python3 -P -m codex_plugin_scanner.action_runner"
+
+
+def test_python_safe_path_blocks_workspace_module_shadowing(tmp_path: Path) -> None:
+    if sys.version_info < (3, 11):
+        pytest.skip("python -P requires Python 3.11+")
+
+    module_name = "shadowdemo_pkg"
+    trusted_root = tmp_path / "trusted-root"
+    trusted_package = trusted_root / module_name
+    trusted_package.mkdir(parents=True)
+    (trusted_package / "__main__.py").write_text(
+        "print('trusted-module')\n",
+        encoding="utf-8",
+    )
+    workspace = tmp_path / "workspace"
+    shadow_package = workspace / module_name
+    shadow_package.mkdir(parents=True)
+    (shadow_package / "__main__.py").write_text(
+        "raise SystemExit('workspace-shadowed')\n",
+        encoding="utf-8",
+    )
+    env = {**os.environ, "PYTHONPATH": str(trusted_root)}
+
+    hijacked = subprocess.run(
+        [sys.executable, "-m", module_name],
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert hijacked.returncode != 0
+    assert "workspace-shadowed" in f"{hijacked.stdout}{hijacked.stderr}"
+
+    protected = subprocess.run(
+        [sys.executable, "-P", "-m", module_name],
+        cwd=workspace,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert protected.returncode == 0
+    assert "trusted-module" in f"{protected.stdout}{protected.stderr}"
+    assert "workspace-shadowed" not in f"{protected.stdout}{protected.stderr}"
 
 
 def test_publish_action_repo_workflow_syncs_action_repository() -> None:

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -35,8 +35,9 @@ def test_action_metadata_includes_marketplace_branding_and_pypi_install() -> Non
     assert "INSTALL_CISCO: ${{ inputs.install_cisco }}" in action_text
     assert 'PYTHONNOUSERSITE: "1"' in action_text
     assert 'PYTHONSAFEPATH: "1"' in action_text
-    assert 'ACTION_RUNTIME_ROOT="${RUNNER_TEMP:-$GITHUB_ACTION_PATH/.tmp}"' in action_text
+    assert 'ACTION_RUNTIME_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"' in action_text
     assert 'ACTION_RUNTIME_DIR="$(mktemp -d "$ACTION_RUNTIME_ROOT/hol-guard-action-XXXXXX")"' in action_text
+    assert 'trap \'cd "$ACTION_RUNTIME_ROOT" && rm -rf "$ACTION_RUNTIME_DIR"\' EXIT' in action_text
     assert 'cd "$ACTION_RUNTIME_DIR"' in action_text
     assert 'if [ "$INSTALL_CISCO" = "true" ]; then' in action_text
     assert 'if [ "$INSTALL_SOURCE" = "local" ]; then' in action_text


### PR DESCRIPTION
## Summary
- isolate the composite action install step in a temp runtime directory outside the caller checkout
- run Python module entrypoints with safe-path mode and add regression coverage for workspace module shadowing

## Testing
- `python3 -m pytest tests/test_action_bundle.py -q`

## Notes
- the scan step keeps caller workspace semantics for `plugin_dir='.'` while removing the workspace from Python module resolution
