### PR TITLE
fix(update): report stale pipx upgrades accurately

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -134,12 +134,15 @@ def run_guard_update(
     )
     payload["status"] = _success_status(payload)
     payload["changed"] = payload["status"] == "updated"
+    stale_retry_command = _stale_retry_command(payload)
+    if stale_retry_command:
+        payload["retry_command"] = stale_retry_command
     payload["message"] = _success_message(
         status=str(payload["status"]),
         current_version=current_version,
         resulting_version=resulting_version,
         version_check=payload.get("version_check"),
-        retry_command=_stale_retry_command(payload),
+        retry_command=stale_retry_command,
     )
     notes = _success_notes(payload)
     if notes:
@@ -248,8 +251,6 @@ def _success_status(payload: dict[str, object]) -> str:
 
 
 def _is_stale_install(payload: dict[str, object]) -> bool:
-    if payload.get("vcs_install") is None and payload.get("upgrade_source") != "pypi":
-        return False
     version_check = payload.get("version_check")
     return isinstance(version_check, dict) and version_check.get("update_available") is True
 
@@ -285,7 +286,8 @@ def _merge_version_checks(
 
 
 def _stale_retry_command(payload: dict[str, object]) -> str:
-    if payload.get("vcs_install") is not None or payload.get("upgrade_source") == "pypi":
+    version_check = payload.get("version_check")
+    if isinstance(version_check, dict) and version_check.get("update_available") is True:
         installer = str(payload.get("installer") or "pip")
         return _shell_command(_update_command(installer, use_pypi=True))
     retry_command = payload.get("retry_command")
@@ -313,10 +315,7 @@ def _success_message(
                 latest_version = latest.strip()
         installed_version = resulting_version or current_version
         if latest_version and installed_version not in {"", "unknown"}:
-            message = (
-                f"HOL Guard {installed_version} is behind PyPI {latest_version}. "
-                "The installed package source is not tracking PyPI releases."
-            )
+            message = f"HOL Guard {installed_version} is behind PyPI {latest_version} after the update attempt."
         else:
             message = "HOL Guard is behind the latest PyPI release."
         if retry_command:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -133,7 +133,7 @@ def run_guard_update(
         resulting_version,
     )
     payload["status"] = _success_status(payload)
-    payload["changed"] = payload["status"] == "updated"
+    payload["changed"] = _version_changed(current_version, resulting_version) or payload["status"] == "updated"
     stale_retry_command = _stale_retry_command(payload)
     if stale_retry_command:
         payload["retry_command"] = stale_retry_command
@@ -253,6 +253,16 @@ def _success_status(payload: dict[str, object]) -> str:
 def _is_stale_install(payload: dict[str, object]) -> bool:
     version_check = payload.get("version_check")
     return isinstance(version_check, dict) and version_check.get("update_available") is True
+
+
+def _version_changed(current_version: str, resulting_version: str) -> bool:
+    return (
+        bool(current_version)
+        and bool(resulting_version)
+        and current_version != "unknown"
+        and resulting_version != "unknown"
+        and current_version != resulting_version
+    )
 
 
 def _merge_version_checks(

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -160,8 +160,8 @@ def run_guard_update(
         payload["managed_installs"] = repaired_installs
         if len(repaired_installs) == 1:
             payload["managed_install"] = repaired_installs[0]
-    # Sync dashboard static assets after package update so the daemon serves fresh UI.
-    if not dry_run and payload.get("status") in {"updated", "current"}:
+    # Sync dashboard assets when the package changed, even if the install still trails PyPI.
+    if not dry_run and (payload.get("status") in {"updated", "current"} or payload.get("changed") is True):
         dashboard_sync = _sync_dashboard_assets()
         if dashboard_sync:
             payload["dashboard_sync"] = dashboard_sync

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3760,6 +3760,7 @@ args = ["workspace-skill.js", "--changed"]
         monkeypatch.setattr(guard_update_commands_module.sys, "executable", "/opt/guard-venv/bin/python")
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.18")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.18")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -3782,6 +3783,7 @@ args = ["workspace-skill.js", "--changed"]
         monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/mock-home/.local/pipx/venvs/hol-guard")
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.18")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.18")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -3850,6 +3852,7 @@ args = ["workspace-skill.js", "--changed"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "unknown")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.36")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.36")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -3981,6 +3984,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -4018,6 +4022,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -4056,6 +4061,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -4093,6 +4099,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -4128,6 +4135,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -4171,6 +4179,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
 
         rc = main(["guard", "update", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -4213,6 +4222,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
         monkeypatch.setattr(
             guard_update_commands_module,
             "apply_managed_install",
@@ -4255,6 +4265,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
         original_get_managed_install = GuardStore.get_managed_install
         lookup_calls: list[str] = []
 
@@ -4311,6 +4322,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
         original_get_managed_install = GuardStore.get_managed_install
         lookup_calls: list[str] = []
 
@@ -4356,6 +4368,7 @@ args = ["-lc", "echo hi"]
         monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
         monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.39")
         monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.39")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.39")
         original_get_managed_install = GuardStore.get_managed_install
         lookup_calls: list[str] = []
 

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -314,7 +314,7 @@ def test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change(
     monkeypatch.setattr(
         update_commands.shutil,
         "which",
-        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -304,6 +304,34 @@ def test_update_marks_partial_pypi_repair_as_stale(monkeypatch: pytest.MonkeyPat
     assert "behind PyPI 2.0.489" in str(payload["message"])
 
 
+def test_update_syncs_dashboard_assets_after_partial_stale_upgrade(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.400")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.489")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+    monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: {"notes": ["synced dashboard"]})
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["pipx", "upgrade", "hol-guard"]
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.400", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert payload["status"] == "stale"
+    assert payload["changed"] is True
+    assert payload["dashboard_sync"] == {"notes": ["synced dashboard"]}
+    assert "synced dashboard" in payload["notes"]
+
+
 def test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -299,6 +299,7 @@ def test_update_marks_partial_pypi_repair_as_stale(monkeypatch: pytest.MonkeyPat
 
     assert exit_code == 0
     assert payload["status"] == "stale"
+    assert payload["changed"] is True
     assert payload["resulting_version"] == "2.0.400"
     assert "behind PyPI 2.0.489" in str(payload["message"])
 

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -121,7 +121,7 @@ def test_update_binary_diagnostics_treats_pipx_shim_as_healthy(monkeypatch: pyte
     monkeypatch.setattr(
         update_commands.shutil,
         "which",
-        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
     )
 
     payload, exit_code = update_commands.run_guard_update(dry_run=True)
@@ -144,7 +144,7 @@ def test_update_skips_existing_local_source_install(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(
         update_commands.shutil,
         "which",
-        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
     )
 
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
@@ -171,7 +171,7 @@ def test_update_repairs_missing_pipx_local_source_install(monkeypatch: pytest.Mo
     monkeypatch.setattr(
         update_commands.shutil,
         "which",
-        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
     )
 
     captured_commands: list[list[str]] = []
@@ -301,6 +301,41 @@ def test_update_marks_partial_pypi_repair_as_stale(monkeypatch: pytest.MonkeyPat
     assert payload["status"] == "stale"
     assert payload["resulting_version"] == "2.0.400"
     assert "behind PyPI 2.0.489" in str(payload["message"])
+
+
+def test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.584")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.584")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.585")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/Users/test/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["pipx", "upgrade", "hol-guard"]
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            "hol-guard is already at latest version 2.0.584",
+            "upgrading shared libraries...\nupgrading hol-guard...\n",
+        )
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert payload["status"] == "stale"
+    assert payload["changed"] is False
+    assert payload["resulting_version"] == "2.0.584"
+    assert payload["retry_command"] == "pipx install --force hol-guard"
+    assert "behind PyPI 2.0.585 after the update attempt" in str(payload["message"])
 
 
 def test_update_switches_git_install_to_pypi_when_release_is_newer(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- mark `hol-guard guard update` as `stale` when a plain installer run still leaves the installed version behind PyPI
- emit the forced PyPI reinstall command as the retry path and cover the stale `pipx` case with regression tests

## Testing
- `python3 -m pytest tests/test_guard_phase03_local_install.py -q -k 'marks_partial_pypi_repair_as_stale or marks_plain_pipx_upgrade_as_stale_when_version_does_not_change'`

## Notes
- discovered during post-merge verification for `#751` after `hol-guard guard update --json` reported `status:"current"` while `latest_version` exceeded `resulting_version`
