### PR TITLE
fix(guard): throttle empty AIBOM sync and isolate 404 backoff

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -141,6 +141,9 @@ def build_aibom_export_payload(
 
 
 _AIBOM_AUTO_SYNC_INTERVAL_SECONDS = 60 * 60
+_AIBOM_EMPTY_SYNC_RETRY_SECONDS = 5 * 60
+_AIBOM_GUARD_EVENTS_BACKOFF_KEY = "aibom_guard_events_backoff"
+_AIBOM_GUARD_EVENTS_BACKOFF_HOURS = 24
 
 
 def _aware_utc_timestamp(value: str) -> datetime:
@@ -161,18 +164,37 @@ def _aibom_sync_is_due(
         return True
     if prior.get("synced") is not True:
         return True
-    if prior.get("snapshots") == 0:
-        return True
     synced_at = prior.get("synced_at")
     if not isinstance(synced_at, str) or not synced_at.strip():
         return True
+    retry_interval = min_interval_seconds
+    if prior.get("snapshots") == 0:
+        retry_interval = min(min_interval_seconds, _AIBOM_EMPTY_SYNC_RETRY_SECONDS)
     try:
         last_sync = _aware_utc_timestamp(synced_at)
         now = _aware_utc_timestamp(generated_at)
         elapsed = (now - last_sync).total_seconds()
     except (ValueError, OverflowError, TypeError):
         return True
-    return elapsed >= min_interval_seconds
+    return elapsed >= retry_interval
+
+
+def _aibom_guard_events_endpoint_unavailable_recently(store: GuardStore) -> bool:
+    from datetime import timedelta
+
+    summary = store.get_sync_payload(_AIBOM_GUARD_EVENTS_BACKOFF_KEY)
+    if not isinstance(summary, dict):
+        return False
+    if summary.get("sync_reason") != "guard_events_endpoint_unavailable":
+        return False
+    synced_at = summary.get("synced_at")
+    if not isinstance(synced_at, str):
+        return True
+    try:
+        parsed = _aware_utc_timestamp(synced_at)
+    except (ValueError, OverflowError, TypeError):
+        return True
+    return datetime.now(timezone.utc) - parsed < timedelta(hours=_AIBOM_GUARD_EVENTS_BACKOFF_HOURS)
 
 
 def _resolve_operator_home_dir(home_dir: Path | None = None) -> Path:
@@ -194,14 +216,11 @@ def sync_aibom_snapshots_if_due(
     home_dir: Path | None = None,
     workspace_dir: Path | None = None,
 ) -> dict[str, object]:
-    from .runtime.runner import (
-        GuardSyncNotConfiguredError,
-        _guard_events_endpoint_unavailable_recently,
-    )
+    from .runtime.runner import GuardSyncNotConfiguredError
 
     if store.get_cloud_workspace_id() is None:
         return {"synced": False, "skipped": True, "reason": "not_configured"}
-    if _guard_events_endpoint_unavailable_recently(store):
+    if _aibom_guard_events_endpoint_unavailable_recently(store):
         return {
             "synced": False,
             "skipped": True,
@@ -301,7 +320,7 @@ def sync_aibom_snapshots(
         if error.code == 404:
             synced_at = generated_at
             store.set_sync_payload(
-                "guard_events_v1_summary",
+                _AIBOM_GUARD_EVENTS_BACKOFF_KEY,
                 {
                     "synced_at": synced_at,
                     "events": 0,

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -188,12 +188,12 @@ def _aibom_guard_events_endpoint_unavailable_recently(store: GuardStore) -> bool
     if summary.get("sync_reason") != "guard_events_endpoint_unavailable":
         return False
     synced_at = summary.get("synced_at")
-    if not isinstance(synced_at, str):
-        return True
+    if not isinstance(synced_at, str) or not synced_at.strip():
+        return False
     try:
         parsed = _aware_utc_timestamp(synced_at)
     except (ValueError, OverflowError, TypeError):
-        return True
+        return False
     return datetime.now(timezone.utc) - parsed < timedelta(hours=_AIBOM_GUARD_EVENTS_BACKOFF_HOURS)
 
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -151,6 +151,8 @@ _GUARD_CLOUD_RESET_STATE_KEYS = (
     "alert_preferences",
     "team_policy_pack",
     "guard_events_v1_summary",
+    "aibom_guard_events_backoff",
+    "aibom_sync_summary",
     "runtime_session_summary",
     "supply_chain_bundle_summary",
     "supply_chain_bundle_entitlement",

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -227,6 +227,123 @@ def test_sync_aibom_snapshots_if_due_skips_recent_sync(tmp_path: Path, monkeypat
     assert summary.get("reason") == "recently_synced"
 
 
+def test_sync_aibom_snapshots_if_due_skips_recent_empty_sync(tmp_path: Path, monkeypatch) -> None:
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots_if_due
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    now = "2026-06-10T12:03:00+00:00"
+    store.set_sync_payload(
+        "aibom_sync_summary",
+        {
+            "synced": True,
+            "synced_at": "2026-06-10T12:00:00+00:00",
+            "snapshots": 0,
+            "accepted": 0,
+        },
+        "2026-06-10T12:00:00+00:00",
+    )
+
+    summary = sync_aibom_snapshots_if_due(store, generated_at=now)
+
+    assert summary.get("skipped") is True
+    assert summary.get("reason") == "recently_synced"
+
+
+def test_sync_aibom_snapshots_if_due_retries_empty_sync_after_interval(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots_if_due
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    calls: list[str] = []
+
+    def _fake_sync(*_args, **_kwargs):
+        calls.append("sync")
+        return {"synced": True, "synced_at": "2026-06-10T12:06:00+00:00", "snapshots": 1, "accepted": 1}
+
+    monkeypatch.setattr(aibom_cli, "sync_aibom_snapshots", _fake_sync)
+    store.set_sync_payload(
+        "aibom_sync_summary",
+        {
+            "synced": True,
+            "synced_at": "2026-06-10T12:00:00+00:00",
+            "snapshots": 0,
+            "accepted": 0,
+        },
+        "2026-06-10T12:00:00+00:00",
+    )
+
+    summary = sync_aibom_snapshots_if_due(store, generated_at="2026-06-10T12:06:00+00:00")
+
+    assert calls == ["sync"]
+    assert summary.get("synced") is True
+
+
+def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    import urllib.error
+
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots
+    from codex_plugin_scanner.guard.inventory_contract import GuardAgentInventorySnapshot
+    from codex_plugin_scanner.guard.runtime import runner
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    store.set_sync_payload(
+        "guard_events_v1_summary",
+        {"synced_at": "2026-06-10T11:00:00+00:00", "events": 12, "accepted": 12},
+        "2026-06-10T11:00:00+00:00",
+    )
+    snapshot = GuardAgentInventorySnapshot(
+        snapshot_id="cursor-proof",
+        agent_id="cursor:local",
+        agent_type="cursor",
+        generated_at="2026-06-10T12:00:00+00:00",
+        runtime_version="test",
+    )
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", lambda *_args, **_kwargs: (snapshot,))
+
+    def _raise_404(*_args, **_kwargs):
+        raise urllib.error.HTTPError(
+            url="https://hol.test/api/v1/guard/events",
+            code=404,
+            msg="Not Found",
+            hdrs=None,
+            fp=None,
+        )
+
+    monkeypatch.setattr(runner, "_urlopen_json_with_timeout_retry", _raise_404)
+    monkeypatch.setattr(runner, "_guard_events_sync_url", lambda url: url)
+    monkeypatch.setattr(runner, "_guard_sync_request", lambda *_args, **_kwargs: object())
+
+    summary = sync_aibom_snapshots(
+        store,
+        HarnessContext(home_dir=tmp_path / "home", workspace_dir=tmp_path / "workspace", guard_home=store.guard_home),
+        generated_at="2026-06-10T12:00:00+00:00",
+        auth_context={
+            "sync_url": "https://hol.test/api/v1/guard/events",
+            "token": "test-token",
+        },
+    )
+
+    guard_events_summary = store.get_sync_payload("guard_events_v1_summary")
+    aibom_backoff = store.get_sync_payload("aibom_guard_events_backoff")
+
+    assert summary.get("reason") == "guard_events_endpoint_unavailable"
+    assert isinstance(guard_events_summary, dict)
+    assert guard_events_summary.get("events") == 12
+    assert isinstance(aibom_backoff, dict)
+    assert aibom_backoff.get("sync_reason") == "guard_events_endpoint_unavailable"
+
+
 def test_aibom_export_json_includes_redaction_report(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- Throttle empty AIBOM snapshot sync retries to a 5-minute window instead of every `hol-guard sync`
- Store AIBOM 404 backoff in a dedicated sync payload so guard event uploads are not blocked

## Testing
- `python3 -m pytest tests/test_guard_aibom_cli.py -q`
