### PR TITLE
fix(guard): preserve reconnect gate from connect state

### DIFF
--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -141,9 +141,6 @@ def _oauth_entitlement(credentials: dict[str, object] | None, *, now: datetime) 
 
 
 def _connect_state_entitlement(store: GuardStore, *, now: datetime) -> dict[str, object] | None:
-    oauth_health = store.get_oauth_local_credential_health()
-    if not isinstance(oauth_health, dict) or not bool(oauth_health.get("configured")):
-        return None
     oauth_payload = store.get_sync_payload("oauth_local_credentials")
     oauth_fields = _oauth_entitlement_fields_from_sync_payload(oauth_payload)
     if isinstance(oauth_fields, dict):
@@ -164,8 +161,6 @@ def _connect_state_entitlement(store: GuardStore, *, now: datetime) -> dict[str,
     tier = "unknown"
     if isinstance(oauth_fields, dict):
         tier = _optional_string(oauth_fields.get("supply_chain_plan_id")) or tier
-    elif isinstance(oauth_health.get("workspace_id"), str):
-        tier = "unknown"
     return {
         "allowed": False,
         "reason": "guard_cloud_reconnect_required",

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -75,6 +75,22 @@ def _seed_retry_required_oauth_connect(home_dir: Path) -> None:
     )
 
 
+def _seed_retry_required_connect_state(home_dir: Path) -> None:
+    store = GuardStore(home_dir)
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-05T01:39:51+00:00",
+        request_id="connect-1",
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-06-05T01:40:10+00:00",
+        reason="Guard authorization expired. Run `hol-guard connect` again.",
+    )
+
+
 def _install_local_package_shim(guard_home: Path, home_dir: Path, manager: str) -> None:
     install_package_shims(
         HarnessContext(
@@ -249,6 +265,26 @@ def test_package_shims_install_requires_reconnect_when_cloud_auth_expired(
     assert rc == 2
     assert payload["error"] == "guard_cloud_reconnect_required"
     assert payload["entitlement"]["tier"] == "unknown"
+
+
+def test_package_shims_status_requires_reconnect_for_retry_required_connect_state_without_oauth_storage(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _seed_retry_required_connect_state(guard_home)
+
+    rc = main(["guard", "package-shims", "status", "--home", str(guard_home), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["entitlement"] == {
+        "allowed": False,
+        "reason": "guard_cloud_reconnect_required",
+        "tier": "unknown",
+        "upgrade_cta": "Reconnect HOL Guard Cloud to refresh package firewall access.",
+    }
+    assert payload["actions"]["install"] == "reconnect_required"
 
 
 def test_package_shims_install_self_heals_retry_required_cloud_auth(


### PR DESCRIPTION
## Summary
- preserve `guard_cloud_reconnect_required` when a paired Guard connect state is already `retry_required` or `first_sync_failed`, even if local OAuth storage is gone
- cover the package-shims status regression that showed `connect_required` after live `hol-guard connect status` had already moved to `retry_required`

## Testing
- `pytest -q tests/test_guard_package_shims_cli.py tests/test_guard_connect_flow.py`
