### PR TITLE
fix(guard-aibom): emit camelCase inventory snapshots for Guard Cloud sync

### DIFF
--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -289,11 +289,7 @@ def _normalize_inventory_datetime(value: object) -> object:
         return value
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        parsed = (
-            parsed.replace(tzinfo=timezone.utc)
-            if parsed.tzinfo is None
-            else parsed.astimezone(timezone.utc)
-        )
+        parsed = parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed.astimezone(timezone.utc)
         return parsed.isoformat().replace("+00:00", "Z")
     except (ValueError, OverflowError, TypeError):
         return value

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -283,6 +283,8 @@ _INVENTORY_DATETIME_KEYS = frozenset(
 
 _FREE_FORM_RECORD_KEYS = frozenset({"metadata", "evidence"})
 
+_OPTIONAL_ONLY_CONTRACT_KEYS = frozenset({"summary"})
+
 
 def _normalize_inventory_datetime(value: object) -> object:
     if not isinstance(value, str) or not value.strip():
@@ -302,6 +304,8 @@ def _inventory_contract_json(value: object) -> object:
         normalized: dict[str, object] = {}
         for key, item in value.items():
             camel_key = _snake_to_camel_case_key(str(key))
+            if item is None and camel_key in _OPTIONAL_ONLY_CONTRACT_KEYS:
+                continue
             if camel_key in _FREE_FORM_RECORD_KEYS:
                 normalized[camel_key] = item
                 continue

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -303,7 +303,7 @@ def _inventory_contract_json(value: object) -> object:
         for key, item in value.items():
             camel_key = _snake_to_camel_case_key(str(key))
             if camel_key in _FREE_FORM_RECORD_KEYS:
-                normalized[camel_key] = _safe_json(item) if isinstance(item, dict) else item
+                normalized[camel_key] = item
                 continue
             if camel_key == "redactionReport":
                 normalized[camel_key] = _normalize_redaction_report(item)

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -258,7 +258,9 @@ def _normalize_redaction_report(report: object) -> dict[str, object]:
         return {"rawSecretsIncluded": False, "redactedFields": []}
     raw_secrets = report.get("rawSecretsIncluded")
     if raw_secrets is None:
-        raw_secrets = report.get("raw_secret_values", False)
+        raw_secrets = report.get("raw_secret_values")
+    if raw_secrets is None:
+        raw_secrets = report.get("raw_secrets_included", False)
     redacted_fields = report.get("redactedFields")
     if redacted_fields is None:
         redacted_fields = report.get("redacted_fields", [])
@@ -279,16 +281,19 @@ _INVENTORY_DATETIME_KEYS = frozenset(
     }
 )
 
+_FREE_FORM_RECORD_KEYS = frozenset({"metadata", "evidence"})
+
 
 def _normalize_inventory_datetime(value: object) -> object:
     if not isinstance(value, str) or not value.strip():
         return value
     try:
         parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        else:
-            parsed = parsed.astimezone(timezone.utc)
+        parsed = (
+            parsed.replace(tzinfo=timezone.utc)
+            if parsed.tzinfo is None
+            else parsed.astimezone(timezone.utc)
+        )
         return parsed.isoformat().replace("+00:00", "Z")
     except (ValueError, OverflowError, TypeError):
         return value
@@ -301,6 +306,9 @@ def _inventory_contract_json(value: object) -> object:
         normalized: dict[str, object] = {}
         for key, item in value.items():
             camel_key = _snake_to_camel_case_key(str(key))
+            if camel_key in _FREE_FORM_RECORD_KEYS:
+                normalized[camel_key] = _safe_json(item) if isinstance(item, dict) else item
+                continue
             if camel_key == "redactionReport":
                 normalized[camel_key] = _normalize_redaction_report(item)
                 continue

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -7,6 +7,7 @@ import ipaddress
 import json
 import re
 from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Literal
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
@@ -245,12 +246,81 @@ class GuardAgentInventorySnapshot:
     redaction_report: dict[str, object] = field(default_factory=dict)
 
 
+def _snake_to_camel_case_key(key: str) -> str:
+    if "_" not in key:
+        return key
+    head, *tail = key.split("_")
+    return head + "".join(part[:1].upper() + part[1:] if part else "" for part in tail)
+
+
+def _normalize_redaction_report(report: object) -> dict[str, object]:
+    if not isinstance(report, dict):
+        return {"rawSecretsIncluded": False, "redactedFields": []}
+    raw_secrets = report.get("rawSecretsIncluded")
+    if raw_secrets is None:
+        raw_secrets = report.get("raw_secret_values", False)
+    redacted_fields = report.get("redactedFields")
+    if redacted_fields is None:
+        redacted_fields = report.get("redacted_fields", [])
+    return {
+        "rawSecretsIncluded": raw_secrets is True,
+        "redactedFields": list(redacted_fields) if isinstance(redacted_fields, (list, tuple)) else [],
+    }
+
+
+_INVENTORY_DATETIME_KEYS = frozenset(
+    {
+        "capturedAt",
+        "completedAt",
+        "firstSeenAt",
+        "generatedAt",
+        "lastSeenAt",
+        "startedAt",
+    }
+)
+
+
+def _normalize_inventory_datetime(value: object) -> object:
+    if not isinstance(value, str) or not value.strip():
+        return value
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        else:
+            parsed = parsed.astimezone(timezone.utc)
+        return parsed.isoformat().replace("+00:00", "Z")
+    except (ValueError, OverflowError, TypeError):
+        return value
+
+
+def _inventory_contract_json(value: object) -> object:
+    if isinstance(value, list):
+        return [_inventory_contract_json(item) for item in value]
+    if isinstance(value, dict):
+        normalized: dict[str, object] = {}
+        for key, item in value.items():
+            camel_key = _snake_to_camel_case_key(str(key))
+            if camel_key == "redactionReport":
+                normalized[camel_key] = _normalize_redaction_report(item)
+                continue
+            if camel_key in _INVENTORY_DATETIME_KEYS:
+                normalized[camel_key] = _normalize_inventory_datetime(item)
+                continue
+            normalized[camel_key] = _inventory_contract_json(item)
+        return normalized
+    return value
+
+
 def serialize_inventory_snapshot(snapshot: GuardAgentInventorySnapshot) -> dict[str, object]:
     payload = _safe_json(asdict(snapshot))
     if not isinstance(payload, dict):
         raise TypeError("Inventory snapshot serialization produced invalid payload.")
-    _assert_serialized_inventory_payload_safe(payload)
-    return payload
+    contract = _inventory_contract_json(payload)
+    if not isinstance(contract, dict):
+        raise TypeError("Inventory snapshot serialization produced invalid payload.")
+    _assert_serialized_inventory_payload_safe(contract)
+    return contract
 
 
 def extract_aibom_metadata_extensions(metadata: dict[str, object]) -> dict[str, object]:

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -87,6 +87,38 @@ def test_inventory_snapshot_serialization_redacts_raw_secrets(tmp_path: Path) ->
     assert payload["items"][0]["metadata"]["headers"]["x-trace"] == "present"
 
 
+def test_inventory_snapshot_serialization_preserves_free_form_metadata_keys() -> None:
+    snapshot = GuardAgentInventorySnapshot(
+        snapshot_id="snap-cursor-1",
+        agent_id="cursor:local",
+        agent_type="cursor",
+        generated_at="2026-05-10T00:00:00Z",
+        items=(
+            GuardAgentInventoryItem(
+                item_id="cursor:mcp:local",
+                item_kind="mcp_server",
+                display_name="Local MCP",
+                source_fingerprint="sha256:source",
+                content_hash="sha256:content",
+                capability_categories=(),
+                metadata={
+                    "tool_schemas": [
+                        {
+                            "name": "read_file",
+                            "input_schema": {"properties": {"file_path": {"type": "string"}}},
+                        }
+                    ]
+                },
+            ),
+        ),
+    )
+
+    payload = serialize_inventory_snapshot(snapshot)
+    schema = payload["items"][0]["metadata"]["tool_schemas"][0]["input_schema"]
+
+    assert schema["properties"]["file_path"]["type"] == "string"
+
+
 def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) -> None:
     config_a = {"b": [2, 1], "a": {"nested": True}}
     config_b = {"a": {"nested": True}, "b": [2, 1]}

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -74,6 +74,11 @@ def test_inventory_snapshot_serialization_redacts_raw_secrets(tmp_path: Path) ->
     payload = serialize_inventory_snapshot(snapshot)
     encoded = json.dumps(payload, sort_keys=True)
 
+    assert payload["agentId"] == "agent-hermes"
+    assert payload["snapshotId"] == "snap-hermes-1"
+    assert payload["items"][0]["itemId"] == "skill-danger"
+    assert payload["redactionReport"]["rawSecretsIncluded"] is False
+
     assert "sk-testsecretvalue" not in encoded
     assert "Bearer secret" not in encoded
     assert "user:pass" not in encoded
@@ -463,9 +468,9 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
     assert payload["findings"][0]["source"] == "cisco-skill-scanner"
     assert payload["findings"][0]["severity"] == "high"
     assert payload["findings"][0]["confidence"] == "high"
-    assert payload["findings"][0]["artifact_id"] == "hermes:skill:ops:reviewer"
+    assert payload["findings"][0]["artifactId"] == "hermes:skill:ops:reviewer"
     assert payload["findings"][0]["evidence"]["durationMs"] == 42
     assert payload["findings"][0]["evidence"]["riskComponent"]["scoreDelta"] == -25
-    assert payload["sources"][-1]["source_type"] == "scanner"
+    assert payload["sources"][-1]["sourceType"] == "scanner"
     assert "fixture_secretvalue" not in encoded
     assert str(tmp_path) not in encoded

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -87,6 +87,30 @@ def test_inventory_snapshot_serialization_redacts_raw_secrets(tmp_path: Path) ->
     assert payload["items"][0]["metadata"]["headers"]["x-trace"] == "present"
 
 
+def test_inventory_snapshot_omits_null_optional_finding_summary() -> None:
+    snapshot = GuardAgentInventorySnapshot(
+        snapshot_id="snap-hermes-2",
+        agent_id="agent-hermes",
+        agent_type="hermes",
+        generated_at="2026-05-10T00:00:00Z",
+        findings=(
+            GuardAgentInventoryFinding(
+                finding_id="finding-1",
+                source="hol-detector",
+                severity="high",
+                confidence="high",
+                title="Secret access",
+                artifact_id="skill-danger",
+                check_id="secret-access",
+            ),
+        ),
+    )
+
+    payload = serialize_inventory_snapshot(snapshot)
+
+    assert "summary" not in payload["findings"][0]
+
+
 def test_inventory_snapshot_serialization_preserves_free_form_metadata_keys() -> None:
     snapshot = GuardAgentInventorySnapshot(
         snapshot_id="snap-cursor-1",

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -112,10 +112,10 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
     snapshot = HermesHarnessAdapter().inventory_snapshot(context, generated_at="2026-05-10T00:00:00Z")
     payload = serialize_inventory_snapshot(snapshot)
     encoded = json.dumps(payload, sort_keys=True)
-    mcp_items = [item for item in payload["items"] if item["item_kind"] == "mcp_server"]
+    mcp_items = [item for item in payload["items"] if item["itemKind"] == "mcp_server"]
 
-    assert payload["agent_type"] == "hermes"
-    assert {item["item_kind"] for item in payload["items"]} >= {"skill", "mcp_server"}
+    assert payload["agentType"] == "hermes"
+    assert {item["itemKind"] for item in payload["items"]} >= {"skill", "mcp_server"}
     assert all(item["metadata"]["has_env_secrets"] is False for item in mcp_items)
     assert all(item["metadata"]["has_auth_headers"] is True for item in mcp_items)
     assert "ghp_secretvalue" not in encoded

--- a/tests/test_openclaw_adapter.py
+++ b/tests/test_openclaw_adapter.py
@@ -149,8 +149,8 @@ def test_inventory_snapshot_redacts_openclaw_channels_mcp_and_skills(tmp_path: P
     payload = serialize_inventory_snapshot(snapshot)
     encoded = json.dumps(payload, sort_keys=True)
 
-    assert payload["agent_type"] == "openclaw"
-    assert {item["item_kind"] for item in payload["items"]} >= {"channel", "mcp_server", "skill"}
+    assert payload["agentType"] == "openclaw"
+    assert {item["itemKind"] for item in payload["items"]} >= {"channel", "mcp_server", "skill"}
     assert "ghp_secretvalue" not in encoded
     assert str(context.home_dir) not in encoded
     assert str(context.workspace_dir) not in encoded


### PR DESCRIPTION
## Summary
- Serialize hol-guard inventory snapshots with Guard Cloud camelCase field names (`agentId`, `itemKind`, `generatedAt`, etc.)
- Normalize redaction report and datetime values so portal Zod validation accepts real sync payloads

## Testing
- `python3 -m pytest tests/test_guard_inventory_contract.py tests/test_guard_aibom_cli.py -q`
