### PR TITLE
fix(dashboard): format insights share stats and parse cloud errors

### DIFF
--- a/dashboard/src/evidence/evidence-insights-share-errors.ts
+++ b/dashboard/src/evidence/evidence-insights-share-errors.ts
@@ -2,8 +2,14 @@ export function insightsSharePublishErrorMessage(raw: string): string {
   const message = raw.trim();
   const lower = message.toLowerCase();
 
-  if (lower.includes("insights") && lower.includes("not enabled")) {
+  if (
+    (lower.includes("insights") && lower.includes("not enabled")) ||
+    (lower.includes("insights") && lower.includes("not live"))
+  ) {
     return "Guard insights sharing is not live on Guard Cloud yet. If you just updated, wait a few minutes and try again.";
+  }
+  if (lower.includes("guard cloud is unavailable")) {
+    return "Guard Cloud could not publish this share link right now. Local Guard keeps protecting this machine. Try again in a few minutes or reconnect with hol-guard connect.";
   }
 
   if (

--- a/dashboard/src/evidence/evidence-insights-share-modal.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-modal.tsx
@@ -7,6 +7,7 @@ import { EvidenceInsightsShareSheet } from "./evidence-insights-share-sheet";
 import { GuardStatMetric } from "./guard-stat-metric";
 import { HomeInsightsMetrics } from "./evidence-insights-headline-bento";
 import { EvidenceActivityHeatmapMini, getHeatmapLevel } from "./evidence-activity-heatmap-mini";
+import { formatEvidenceCount } from "./evidence-format";
 import { insightsSharePublishErrorMessage, isInsightsShareScopeError } from "./evidence-insights-share-errors";
 
 interface EvidenceInsightsShareModalProps {
@@ -107,17 +108,17 @@ export function EvidenceInsightsShareModal({
                 <div className="grid grid-cols-3 gap-px bg-slate-100">
                   <GuardStatMetric
                     label="Pending"
-                    value={String(runtime?.pending_count ?? 0)}
+                    value={formatEvidenceCount(runtime?.pending_count ?? 0)}
                     compact
                   />
                   <GuardStatMetric
                     label="Apps"
-                    value={String(runtime?.managed_installs?.length ?? 0)}
+                    value={formatEvidenceCount(runtime?.managed_installs?.length ?? 0)}
                     compact
                   />
                   <GuardStatMetric
                     label="Recorded"
-                    value={String(runtime?.receipt_count ?? 0)}
+                    value={formatEvidenceCount(runtime?.receipt_count ?? 0)}
                     compact
                   />
                 </div>

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -164,7 +164,7 @@ function EvidenceWorkbench({ receiptItems, runtime, onClearEvidence, onNavigate 
     setFilters((prev) => ({
       ...prev,
       view,
-      ...(view !== "actions" ? { day: "" } : {}),
+      ...(view === "insights" ? { day: "" } : {}),
     }));
   }, []);
 

--- a/dashboard/src/receipts-workspace.tsx
+++ b/dashboard/src/receipts-workspace.tsx
@@ -164,7 +164,7 @@ function EvidenceWorkbench({ receiptItems, runtime, onClearEvidence, onNavigate 
     setFilters((prev) => ({
       ...prev,
       view,
-      ...(view === "insights" ? { day: "" } : {}),
+      ...(view !== "actions" ? { day: "" } : {}),
     }));
   }, []);
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20385,7 +20385,7 @@ function EvidenceWorkbench({ receiptItems, runtime, onClearEvidence, onNavigate 
     setFilters((prev) => ({
       ...prev,
       view,
-      ...view !== "actions" ? { day: "" } : {}
+      ...view === "insights" ? { day: "" } : {}
     }));
   }, []);
   const handleOpenExport = reactExports.useCallback(() => {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16665,6 +16665,12 @@ function formatDayLabel(dateKey) {
   });
 }
 function receiptUtcDateKey(iso) {
+  if (!iso) {
+    return "";
+  }
+  if (iso.length >= 10 && iso[10] === "T" && iso.endsWith("Z")) {
+    return iso.slice(0, 10);
+  }
   const parsed = new Date(iso);
   if (Number.isNaN(parsed.getTime())) {
     return "";
@@ -18785,8 +18791,11 @@ function EvidenceActivityHeatmapMini({ cells }) {
 function insightsSharePublishErrorMessage(raw) {
   const message = raw.trim();
   const lower = message.toLowerCase();
-  if (lower.includes("insights") && lower.includes("not enabled")) {
+  if (lower.includes("insights") && lower.includes("not enabled") || lower.includes("insights") && lower.includes("not live")) {
     return "Guard insights sharing is not live on Guard Cloud yet. If you just updated, wait a few minutes and try again.";
+  }
+  if (lower.includes("guard cloud is unavailable")) {
+    return "Guard Cloud could not publish this share link right now. Local Guard keeps protecting this machine. Try again in a few minutes or reconnect with hol-guard connect.";
   }
   if (lower.includes("guard:insights.share") || lower.includes("insufficient scope") || lower.includes("missing scope")) {
     return "Reconnect Guard Cloud to grant insights sharing permission, then try again.";
@@ -18880,7 +18889,7 @@ function EvidenceInsightsShareModal({
               GuardStatMetric,
               {
                 label: "Pending",
-                value: String(runtime?.pending_count ?? 0),
+                value: formatEvidenceCount(runtime?.pending_count ?? 0),
                 compact: true
               }
             ),
@@ -18888,7 +18897,7 @@ function EvidenceInsightsShareModal({
               GuardStatMetric,
               {
                 label: "Apps",
-                value: String(runtime?.managed_installs?.length ?? 0),
+                value: formatEvidenceCount(runtime?.managed_installs?.length ?? 0),
                 compact: true
               }
             ),
@@ -18896,7 +18905,7 @@ function EvidenceInsightsShareModal({
               GuardStatMetric,
               {
                 label: "Recorded",
-                value: String(runtime?.receipt_count ?? 0),
+                value: formatEvidenceCount(runtime?.receipt_count ?? 0),
                 compact: true
               }
             )
@@ -20376,7 +20385,7 @@ function EvidenceWorkbench({ receiptItems, runtime, onClearEvidence, onNavigate 
     setFilters((prev) => ({
       ...prev,
       view,
-      ...view === "insights" ? { day: "" } : {}
+      ...view !== "actions" ? { day: "" } : {}
     }));
   }, []);
   const handleOpenExport = reactExports.useCallback(() => {

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2625,6 +2625,20 @@ def _guard_sync_request_with_nonce(
     )
 
 
+def _read_guard_cloud_error_message(payload: dict[str, object]) -> str | None:
+    for key in ("err", "message", "error"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    guard_error = payload.get("guardError")
+    if isinstance(guard_error, dict):
+        for key in ("msg", "message"):
+            nested = guard_error.get(key)
+            if isinstance(nested, str) and nested.strip():
+                return nested.strip()
+    return None
+
+
 def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     try:
         raw_body = error.read().decode("utf-8")
@@ -2635,9 +2649,9 @@ def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     except json.JSONDecodeError:
         payload = None
     if isinstance(payload, dict):
-        message = payload.get("error")
-        if isinstance(message, str) and message.strip():
-            return message.strip()
+        message = _read_guard_cloud_error_message(payload)
+        if message is not None:
+            return message
     normalized_body = raw_body.strip()
     if normalized_body:
         return normalized_body

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2626,22 +2626,22 @@ def _guard_sync_request_with_nonce(
 
 
 def _read_guard_cloud_error_message(payload: dict[str, object]) -> str | None:
-    for key in ("err", "message", "error"):
-        value = payload.get(key)
-        if isinstance(value, str) and value.strip():
-            return value.strip()
     guard_error = payload.get("guardError")
     if isinstance(guard_error, dict):
         for key in ("msg", "message"):
             nested = guard_error.get(key)
             if isinstance(nested, str) and nested.strip():
                 return nested.strip()
+    for key in ("err", "message", "error"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
     return None
 
 
 def _sync_http_error_message(error: urllib.error.HTTPError) -> str:
     try:
-        raw_body = error.read().decode("utf-8")
+        raw_body = error.read().decode("utf-8", errors="replace")
     except OSError:
         raw_body = ""
     try:

--- a/tests/test_guard_sync_http_error_message.py
+++ b/tests/test_guard_sync_http_error_message.py
@@ -5,6 +5,16 @@ import urllib.error
 from codex_plugin_scanner.guard.runtime.runner import _sync_http_error_message
 
 
+def _http_error(body: str, *, code: int = 500, reason: str = "Error") -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        url="https://hol.org/api/guard/insights/shares",
+        code=code,
+        msg=reason,
+        hdrs={},
+        fp=io.BytesIO(body.encode("utf-8")),
+    )
+
+
 def test_sync_http_error_message_reads_guard_cloud_err_field() -> None:
     body = json.dumps(
         {
@@ -12,15 +22,25 @@ def test_sync_http_error_message_reads_guard_cloud_err_field() -> None:
             "err": "Guard insights sharing is not live on Guard Cloud yet.",
         }
     )
-    error = urllib.error.HTTPError(
-        url="https://hol.org/api/guard/insights/shares",
-        code=503,
-        msg="Service Unavailable",
-        hdrs={},
-        fp=io.BytesIO(body.encode("utf-8")),
+    assert (
+        _sync_http_error_message(_http_error(body, code=503, reason="Service Unavailable"))
+        == "Guard insights sharing is not live on Guard Cloud yet."
+    )
+
+
+def test_sync_http_error_message_prefers_guard_error_msg_over_top_level_error() -> None:
+    body = json.dumps(
+        {
+            "ok": False,
+            "error": "insights_share_failed",
+            "guardError": {
+                "code": "guard_insights_share_unavailable",
+                "msg": "Guard insights sharing is not live on Guard Cloud yet.",
+            },
+        }
     )
     assert (
-        _sync_http_error_message(error)
+        _sync_http_error_message(_http_error(body))
         == "Guard insights sharing is not live on Guard Cloud yet."
     )
 
@@ -35,14 +55,21 @@ def test_sync_http_error_message_reads_guard_error_msg_field() -> None:
             },
         }
     )
-    error = urllib.error.HTTPError(
-        url="https://hol.org/api/guard/insights/shares",
-        code=524,
-        msg="Gateway Timeout",
-        hdrs={},
-        fp=io.BytesIO(body.encode("utf-8")),
-    )
     assert (
-        _sync_http_error_message(error)
+        _sync_http_error_message(_http_error(body, code=524, reason="Gateway Timeout"))
         == "Guard Cloud timed out. Local Guard keeps protecting this machine."
     )
+
+
+def test_sync_http_error_message_reads_legacy_error_field() -> None:
+    body = json.dumps({"error": "Invalid Guard insights share payload."})
+    assert _sync_http_error_message(_http_error(body, code=400)) == "Invalid Guard insights share payload."
+
+
+def test_sync_http_error_message_falls_back_to_raw_body() -> None:
+    body = "upstream unavailable"
+    assert _sync_http_error_message(_http_error(body)) == "upstream unavailable"
+
+
+def test_sync_http_error_message_falls_back_to_http_reason() -> None:
+    assert _sync_http_error_message(_http_error("", code=502, reason="Bad Gateway")) == "HTTP Error 502: Bad Gateway"

--- a/tests/test_guard_sync_http_error_message.py
+++ b/tests/test_guard_sync_http_error_message.py
@@ -1,0 +1,48 @@
+import io
+import json
+import urllib.error
+
+from codex_plugin_scanner.guard.runtime.runner import _sync_http_error_message
+
+
+def test_sync_http_error_message_reads_guard_cloud_err_field() -> None:
+    body = json.dumps(
+        {
+            "ok": False,
+            "err": "Guard insights sharing is not live on Guard Cloud yet.",
+        }
+    )
+    error = urllib.error.HTTPError(
+        url="https://hol.org/api/guard/insights/shares",
+        code=503,
+        msg="Service Unavailable",
+        hdrs={},
+        fp=io.BytesIO(body.encode("utf-8")),
+    )
+    assert (
+        _sync_http_error_message(error)
+        == "Guard insights sharing is not live on Guard Cloud yet."
+    )
+
+
+def test_sync_http_error_message_reads_guard_error_msg_field() -> None:
+    body = json.dumps(
+        {
+            "ok": False,
+            "guardError": {
+                "code": "guard_unavailable",
+                "msg": "Guard Cloud timed out. Local Guard keeps protecting this machine.",
+            },
+        }
+    )
+    error = urllib.error.HTTPError(
+        url="https://hol.org/api/guard/insights/shares",
+        code=524,
+        msg="Gateway Timeout",
+        hdrs={},
+        fp=io.BytesIO(body.encode("utf-8")),
+    )
+    assert (
+        _sync_http_error_message(error)
+        == "Guard Cloud timed out. Local Guard keeps protecting this machine."
+    )


### PR DESCRIPTION
## Summary
- Format pending/apps/recorded counts in the insights share modal with `formatEvidenceCount`
- Parse Guard Cloud `err` and `guardError.msg` fields from sync HTTP failures instead of returning raw JSON
- Improve share publish error copy when Guard Cloud is unavailable

## Testing
- `python3 -m pytest tests/test_guard_sync_http_error_message.py tests/test_insights_share.py -q`
- `node ./node_modules/vite/bin/vite.js build` (dashboard)
