### PR TITLE
feat(guard): add Kimi Code CLI harness adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
   Guard respects Cursor’s native tool approval and focuses on artifact trust before launch.
 - `opencode`
   Guard authors package-level policy while OpenCode keeps native once, always, or reject prompts for managed MCP tools.
+- `kimi`
+  Guard installs managed `PreToolUse` and `UserPromptSubmit` hooks in `~/.kimi-code/config.toml`, blocks with exit code `2` and a JSON `permissionDecision: "deny"` response, and fails open on hook crash or timeout.
 - `hermes`
   Guard installs a managed Hermes overlay bundle, routes MCP servers through Guard proxies, and prefers native-or-center delivery for blocked requests.
 - `gemini`

--- a/dashboard/src/app-routing.test.ts
+++ b/dashboard/src/app-routing.test.ts
@@ -9,6 +9,7 @@ function assert(condition: boolean, message: string): void {
 
 assert(parseAppDetail("/apps/opencode") === "opencode", "valid app route parses harness slug");
 assert(parseAppDetail("/apps/claude-code") === "claude-code", "hyphenated app route parses harness slug");
+assert(parseAppDetail("/apps/kimi") === "kimi", "kimi app route parses harness slug");
 assert(parseAppDetail("/apps/OpenCode") === "opencode", "app route normalizes case");
 assert(parseAppDetail("/apps/*") === null, "wildcard app route is rejected");
 assert(parseAppDetail("/apps/%2A") === null, "encoded wildcard app route is rejected");

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -550,6 +550,8 @@ export function harnessDisplayName(harness: string): string {
       return "Hermes";
     case "openclaw":
       return "OpenClaw";
+    case "kimi":
+      return "Kimi";
     default:
       return capitalizeHarness(normalized);
   }

--- a/dashboard/src/apps/app-catalog.ts
+++ b/dashboard/src/apps/app-catalog.ts
@@ -7,15 +7,16 @@ export const SUPPORTED_APP_SLUGS = [
   "gemini",
   "hermes",
   "openclaw",
+  "kimi",
 ] as const;
 
 export type SupportedAppSlug = (typeof SUPPORTED_APP_SLUGS)[number];
 
 export const SUPPORTED_APPS_BRIEF =
-  "Guard works with Codex, Claude Code, OpenCode, Copilot, Cursor, Gemini, Hermes, and OpenClaw.";
+  "Guard works with Codex, Claude Code, OpenCode, Copilot, Cursor, Gemini, Hermes, OpenClaw, and Kimi.";
 
 export const SUPPORTED_APPS_FULL =
-  "Guard works with Codex, Claude Code, OpenCode, Copilot, Cursor, Gemini, Hermes, OpenClaw, and more. Run your AI app once and Guard will detect it automatically.";
+  "Guard works with Codex, Claude Code, OpenCode, Copilot, Cursor, Gemini, Hermes, OpenClaw, Kimi, and more. Run your AI app once and Guard will detect it automatically.";
 
 export type AppInstallStatus = "active" | "partial" | "observed" | "not_installed";
 

--- a/dashboard/src/fleet-workspace-phase11.test.ts
+++ b/dashboard/src/fleet-workspace-phase11.test.ts
@@ -10,11 +10,11 @@ function assert(condition: boolean, message: string): void {
 }
 
 function testSupportedAppSlugs(): void {
-  const expected = ["codex", "claude-code", "opencode", "copilot", "cursor", "gemini", "hermes", "openclaw"];
+  const expected = ["codex", "claude-code", "opencode", "copilot", "cursor", "gemini", "hermes", "openclaw", "kimi"];
   for (const slug of expected) {
     assert(SUPPORTED_APP_SLUGS.includes(slug as typeof SUPPORTED_APP_SLUGS[number]), `SUPPORTED_APP_SLUGS missing: ${slug}`);
   }
-  assert(SUPPORTED_APP_SLUGS.length === 8, `Expected 8 slugs, got ${SUPPORTED_APP_SLUGS.length}`);
+  assert(SUPPORTED_APP_SLUGS.length === 9, `Expected 9 slugs, got ${SUPPORTED_APP_SLUGS.length}`);
 }
 
 function testSupportedAppsBriefMentionsAllApps(): void {

--- a/dashboard/src/home-dashboard.test.ts
+++ b/dashboard/src/home-dashboard.test.ts
@@ -139,6 +139,7 @@ const displayNames = [
   { harness: "cursor", expected: "Cursor" },
   { harness: "hermes", expected: "Hermes" },
   { harness: "openclaw", expected: "OpenClaw" },
+  { harness: "kimi", expected: "Kimi" },
 ];
 
 for (const { harness, expected } of displayNames) {

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -72,7 +72,7 @@ export function resolveCloudUpsellVisible(
 export function buildEmptyStateCopy(): { title: string; body: string; installHint: string } {
   return {
     title: "No apps connected",
-    body: "Connect an AI app so Guard can start protecting it. Guard works with Codex, Claude Code, Cursor, Hermes, and more.",
+    body: "Connect an AI app so Guard can start protecting it. Guard works with Codex, Claude Code, Cursor, Hermes, Kimi, and more.",
     installHint: "hol-guard apps connect <app>",
   };
 }

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -2,7 +2,7 @@ import { ActionButton, Badge, KeyValueGrid, SectionLabel, Surface, Tag, ProofStr
 import { harnessDisplayName, formatRelativeTime } from "./approval-center-utils";
 import type { GuardCloudSyncHealth, GuardInventoryItem, GuardProofStatus, GuardReceipt, GuardRuntimeDevice, GuardRuntimeSnapshot, PackageManagerProtection } from "./guard-types";
 
-const WATCHED_HARNESSES = ["codex", "claude-code", "opencode", "copilot", "gemini", "cursor", "hermes", "openclaw"] as const;
+const WATCHED_HARNESSES = ["codex", "claude-code", "opencode", "copilot", "gemini", "cursor", "hermes", "openclaw", "kimi"] as const;
 
 type WatchedHarnessName = (typeof WATCHED_HARNESSES)[number];
 

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -4,7 +4,7 @@ Guard lives inside `codex_plugin_scanner` and is the local product surface for h
 
 The runtime is split into:
 
-- `guard/adapters`: harness discovery for Codex, Claude Code, Copilot CLI, Cursor, Gemini, and OpenCode
+- `guard/adapters`: harness discovery for Codex, Claude Code, Copilot CLI, Cursor, Gemini, Kimi, and OpenCode
 - `guard/shims`: local launcher shims that route harness launches through Guard
 - `guard/consumer`: orchestration for detection, policy evaluation, and consumer-mode scan output
 - `guard/policy`: local action resolution for allow, review, warn, and block decisions

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -330,6 +330,10 @@ Current strategy:
 - `gemini`
   scans `.gemini/settings.json`, extension manifests, hooks, MCP registrations, and Gemini skill directories before
   launch, then routes blocked changes to the approval center
+- `kimi`
+  installs Guard-owned `PreToolUse` and `UserPromptSubmit` hooks in `~/.kimi-code/config.toml`, blocks dangerous tool
+  calls and prompts with exit code `2` plus a JSON `permissionDecision: "deny"` response, and fails open on hook crash
+  or timeout
 
 Guard does not claim VS Code Copilot extension-host interception in this pass. A VS Code inline tool prompt by itself is
 not proof that Guard blocked the action, because that prompt can come from VS Code's own permission surface. For Copilot,

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -75,6 +75,14 @@ Current Guard support in this repo:
   - blocks newly introduced OpenCode MCP, plugin, and skill artifacts before launch when local Guard policy requires
     approval
   - native shell and managed MCP package-manager calls now share the same package-request evaluator, evidence fields, and approval-center copy
+- `kimi`
+  - detects `~/.kimi-code/config.toml`, legacy `~/.kimi/config.toml`, and workspace `.kimi-code/config.toml`
+  - detects `~/.kimi-code/mcp.json` and legacy `~/.kimi/mcp.json` MCP server registrations
+  - detects existing `[[hooks]]` entries in Kimi Code's TOML config
+  - installs Guard-owned `PreToolUse`, `UserPromptSubmit`, `PostToolUse`, `SessionStart`, and `Stop` hooks in `~/.kimi-code/config.toml` by calling `hol-guard hook --harness kimi`
+  - blocks dangerous tool calls and prompts by returning exit code `2` and a JSON `permissionDecision: "deny"` response in `hookSpecificOutput`
+  - fails open if a hook crashes or times out, so Kimi Code keeps working when Guard is unreachable
+  - uses the same JSON stdin/stdout wire protocol as Codex and Claude Code
 
 Approval tiers:
 
@@ -133,3 +141,4 @@ Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
 | `hermes` | `hermes` | ❌ | ✅ | ❌ | shell, mcp_tool, prompt |
 | `openclaw` | `openclaw` | ❌ | ✅ | ❌ | mcp_tool |
 | `antigravity` | `antigravity` | ❌ | ✅ | ❌ | mcp_tool, prompt |
+| `kimi` | `kimi`, `kimi-code`, `kimi-cli` | ❌ | ✅ | ❌ | shell, prompt |

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -76,8 +76,8 @@ Current Guard support in this repo:
     approval
   - native shell and managed MCP package-manager calls now share the same package-request evaluator, evidence fields, and approval-center copy
 - `kimi`
-  - detects `~/.kimi-code/config.toml`, legacy `~/.kimi/config.toml`, and workspace `.kimi-code/config.toml`
-  - detects `~/.kimi-code/mcp.json` and legacy `~/.kimi/mcp.json` MCP server registrations
+  - detects `~/.kimi-code/config.toml` and workspace `.kimi-code/config.toml`
+  - detects `~/.kimi-code/mcp.json` MCP server registrations
   - detects existing `[[hooks]]` entries in Kimi Code's TOML config
   - installs Guard-owned `PreToolUse`, `UserPromptSubmit`, `PostToolUse`, `SessionStart`, and `Stop` hooks in `~/.kimi-code/config.toml` by calling `hol-guard hook --harness kimi`
   - blocks dangerous tool calls and prompts by returning exit code `2` and a JSON `permissionDecision: "deny"` response in `hookSpecificOutput`

--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -10,6 +10,7 @@ from .copilot import CopilotHarnessAdapter
 from .cursor import CursorHarnessAdapter
 from .gemini import GeminiHarnessAdapter
 from .hermes import HermesHarnessAdapter
+from .kimi import KimiHarnessAdapter
 from .openclaw import OpenClawHarnessAdapter
 from .opencode import OpenCodeHarnessAdapter
 
@@ -21,6 +22,7 @@ ADAPTERS: tuple[HarnessAdapter, ...] = (
     AntigravityHarnessAdapter(),
     GeminiHarnessAdapter(),
     HermesHarnessAdapter(),
+    KimiHarnessAdapter(),
     OpenClawHarnessAdapter(),
     OpenCodeHarnessAdapter(),
 )

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -137,6 +137,7 @@ _DISPLAY_NAMES = {
     "hermes": "Hermes",
     "openclaw": "OpenClaw",
     "antigravity": "Antigravity",
+    "kimi": "Kimi",
 }
 
 
@@ -279,6 +280,20 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
             "Guard intercepts extensions and MCP registrations via scan at launch time."
         ),
         smoke_command="hol-guard install antigravity --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="kimi",
+        install_aliases=("kimi", "kimi-code", "kimi-cli"),
+        config_paths=("~/.kimi-code/config.toml", "~/.kimi/config.toml"),
+        event_surfaces=("shell", "prompt"),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Tool output post-processing and inline edits applied without a tool call are not visible to Guard. "
+            "Hooks run in parallel and fail open on crash or timeout."
+        ),
+        smoke_command="hol-guard install kimi --dry-run",
     ),
 )
 

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -284,7 +284,7 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
     HarnessProtectionContract(
         harness="kimi",
         install_aliases=("kimi", "kimi-code", "kimi-cli"),
-        config_paths=("~/.kimi-code/config.toml", "~/.kimi/config.toml"),
+        config_paths=("~/.kimi-code/config.toml",),
         event_surfaces=("shell", "prompt"),
         native_approval=False,
         browser_fallback=True,

--- a/src/codex_plugin_scanner/guard/adapters/kimi.py
+++ b/src/codex_plugin_scanner/guard/adapters/kimi.py
@@ -152,11 +152,7 @@ class KimiHarnessAdapter(HarnessAdapter):
             if isinstance(timeout, (int, float)):
                 metadata["timeout"] = timeout
             artifact_id = f"kimi:{scope}:hook:{event_name.lower() or 'unknown'}:{index}"
-            name = (
-                f"{event_name or 'hook'}:{matcher}"
-                if isinstance(matcher, str) and matcher
-                else event_name or "hook"
-            )
+            name = f"{event_name or 'hook'}:{matcher}" if isinstance(matcher, str) and matcher else event_name or "hook"
             artifacts.append(
                 GuardArtifact(
                     artifact_id=artifact_id,
@@ -289,19 +285,21 @@ class KimiHarnessAdapter(HarnessAdapter):
             "# The hooks below are managed by HOL Guard. Do not edit manually.",
         ]
         for event in ("PreToolUse", "UserPromptSubmit", "PostToolUse", "SessionStart", "Stop"):
-            lines.extend([
-                "[[hooks]]",
-                f'event = "{event}"',
-                f'command = "{escaped_command}"',
-                "timeout = 30",
-            ])
+            lines.extend(
+                [
+                    "[[hooks]]",
+                    f'event = "{event}"',
+                    f'command = "{escaped_command}"',
+                    "timeout = 30",
+                ]
+            )
         lines.append(_GUARD_MANAGED_END)
         return "\n".join(lines)
 
 
 def _toml_escape(value: str) -> str:
     """Escape backslashes and double quotes for a TOML double-quoted string."""
-    return value.replace("\\", "\\\\").replace('"', "\\\"")
+    return value.replace("\\", "\\\\").replace('"', '\\"')
 
 
 def _remove_managed_block(text: str) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/kimi.py
+++ b/src/codex_plugin_scanner/guard/adapters/kimi.py
@@ -33,7 +33,7 @@ class KimiHarnessAdapter(HarnessAdapter):
     """Discover Kimi Code CLI settings, hooks, MCP servers, and manage Guard hooks."""
 
     harness = "kimi"
-    aliases = ("kimi",)
+    aliases = ("kimi", "kimi-code", "kimi-cli")
     executable = "kimi"
     launcher_name = "kimi"
     approval_tier = "approval-center"

--- a/src/codex_plugin_scanner/guard/adapters/kimi.py
+++ b/src/codex_plugin_scanner/guard/adapters/kimi.py
@@ -19,9 +19,8 @@ except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]
 
 
-_KIMI_HOME_ENV_VARS = ("KIMI_CODE_HOME", "KIMI_HOME")
-_KIMI_PRIMARY_DIR = ".kimi-code"
-_KIMI_LEGACY_DIR = ".kimi"
+_KIMI_HOME_ENV_VAR = "KIMI_CODE_HOME"
+_KIMI_DIR = ".kimi-code"
 _KIMI_CONFIG_FILE = "config.toml"
 _KIMI_MCP_FILE = "mcp.json"
 
@@ -46,32 +45,29 @@ class KimiHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _kimi_home_dir(context: HarnessContext) -> Path:
-        for env_var in _KIMI_HOME_ENV_VARS:
-            value = os.environ.get(env_var)
-            if value:
-                return Path(value).expanduser().resolve()
+        value = os.environ.get(_KIMI_HOME_ENV_VAR)
+        if value:
+            return Path(value).expanduser().resolve()
         return context.home_dir
 
     @classmethod
     def _config_candidates(cls, context: HarnessContext) -> list[tuple[Path, str]]:
         home = cls._kimi_home_dir(context)
-        candidates: list[tuple[Path, str]] = []
-        for base_dir in (_KIMI_PRIMARY_DIR, _KIMI_LEGACY_DIR):
-            candidates.append((home / base_dir / _KIMI_CONFIG_FILE, "global"))
+        candidates: list[tuple[Path, str]] = [
+            (home / _KIMI_DIR / _KIMI_CONFIG_FILE, "global"),
+        ]
         if context.workspace_dir is not None:
-            for base_dir in (_KIMI_PRIMARY_DIR, _KIMI_LEGACY_DIR):
-                candidates.append((context.workspace_dir / base_dir / _KIMI_CONFIG_FILE, "project"))
+            candidates.append((context.workspace_dir / _KIMI_DIR / _KIMI_CONFIG_FILE, "project"))
         return candidates
 
     @classmethod
     def _mcp_candidates(cls, context: HarnessContext) -> list[tuple[Path, str]]:
         home = cls._kimi_home_dir(context)
-        candidates: list[tuple[Path, str]] = []
-        for base_dir in (_KIMI_PRIMARY_DIR, _KIMI_LEGACY_DIR):
-            candidates.append((home / base_dir / _KIMI_MCP_FILE, "global"))
+        candidates: list[tuple[Path, str]] = [
+            (home / _KIMI_DIR / _KIMI_MCP_FILE, "global"),
+        ]
         if context.workspace_dir is not None:
-            for base_dir in (_KIMI_PRIMARY_DIR, _KIMI_LEGACY_DIR):
-                candidates.append((context.workspace_dir / base_dir / _KIMI_MCP_FILE, "project"))
+            candidates.append((context.workspace_dir / _KIMI_DIR / _KIMI_MCP_FILE, "project"))
         return candidates
 
     @staticmethod
@@ -88,12 +84,12 @@ class KimiHarnessAdapter(HarnessAdapter):
     def policy_path(self, context: HarnessContext) -> Path:
         home = self._kimi_home_dir(context)
         if context.workspace_dir is not None:
-            return context.workspace_dir / _KIMI_PRIMARY_DIR / _KIMI_CONFIG_FILE
-        return home / _KIMI_PRIMARY_DIR / _KIMI_CONFIG_FILE
+            return context.workspace_dir / _KIMI_DIR / _KIMI_CONFIG_FILE
+        return home / _KIMI_DIR / _KIMI_CONFIG_FILE
 
     def _managed_config_path(self, context: HarnessContext) -> Path:
         home = self._kimi_home_dir(context)
-        return home / _KIMI_PRIMARY_DIR / _KIMI_CONFIG_FILE
+        return home / _KIMI_DIR / _KIMI_CONFIG_FILE
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
         artifacts: list[GuardArtifact] = []
@@ -287,6 +283,7 @@ class KimiHarnessAdapter(HarnessAdapter):
 
     @staticmethod
     def _build_managed_block(hook_command: str) -> str:
+        escaped_command = _toml_escape(hook_command)
         lines = [
             _GUARD_MANAGED_BEGIN,
             "# The hooks below are managed by HOL Guard. Do not edit manually.",
@@ -295,11 +292,16 @@ class KimiHarnessAdapter(HarnessAdapter):
             lines.extend([
                 "[[hooks]]",
                 f'event = "{event}"',
-                f'command = "{hook_command}"',
+                f'command = "{escaped_command}"',
                 "timeout = 30",
             ])
         lines.append(_GUARD_MANAGED_END)
         return "\n".join(lines)
+
+
+def _toml_escape(value: str) -> str:
+    """Escape backslashes and double quotes for a TOML double-quoted string."""
+    return value.replace("\\", "\\\\").replace('"', "\\\"")
 
 
 def _remove_managed_block(text: str) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/kimi.py
+++ b/src/codex_plugin_scanner/guard/adapters/kimi.py
@@ -1,0 +1,313 @@
+"""Kimi Code CLI harness adapter for HOL Guard."""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import sys
+from pathlib import Path
+
+from ..aibom_detection import extend_detection_with_workspace_aibom
+from ..models import GuardArtifact, HarnessDetection
+from ..shims import install_guard_shim, remove_guard_shim
+from .base import HarnessAdapter, HarnessContext, _command_available, _ensure_path_within_root, _json_payload
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+_KIMI_HOME_ENV_VARS = ("KIMI_CODE_HOME", "KIMI_HOME")
+_KIMI_PRIMARY_DIR = ".kimi-code"
+_KIMI_LEGACY_DIR = ".kimi"
+_KIMI_CONFIG_FILE = "config.toml"
+_KIMI_MCP_FILE = "mcp.json"
+
+_GUARD_MANAGED_BEGIN = "# BEGIN HOL GUARD MANAGED HOOKS"
+_GUARD_MANAGED_END = "# END HOL GUARD MANAGED HOOKS"
+_GUARD_MANAGED_MARKER = "HOL GUARD MANAGED HOOKS"
+
+
+class KimiHarnessAdapter(HarnessAdapter):
+    """Discover Kimi Code CLI settings, hooks, MCP servers, and manage Guard hooks."""
+
+    harness = "kimi"
+    aliases = ("kimi",)
+    executable = "kimi"
+    launcher_name = "kimi"
+    approval_tier = "approval-center"
+    approval_summary = (
+        "Guard scans Kimi Code config, hooks, and MCP registrations before launch "
+        "and routes blocked changes to the local approval center."
+    )
+    fallback_hint = "Kimi Code gets preflight approval through Guard until it exposes a richer native approval surface."
+
+    @staticmethod
+    def _kimi_home_dir(context: HarnessContext) -> Path:
+        for env_var in _KIMI_HOME_ENV_VARS:
+            value = os.environ.get(env_var)
+            if value:
+                return Path(value).expanduser().resolve()
+        return context.home_dir
+
+    @classmethod
+    def _config_candidates(cls, context: HarnessContext) -> list[tuple[Path, str]]:
+        home = cls._kimi_home_dir(context)
+        candidates: list[tuple[Path, str]] = []
+        for base_dir in (_KIMI_PRIMARY_DIR, _KIMI_LEGACY_DIR):
+            candidates.append((home / base_dir / _KIMI_CONFIG_FILE, "global"))
+        if context.workspace_dir is not None:
+            for base_dir in (_KIMI_PRIMARY_DIR, _KIMI_LEGACY_DIR):
+                candidates.append((context.workspace_dir / base_dir / _KIMI_CONFIG_FILE, "project"))
+        return candidates
+
+    @classmethod
+    def _mcp_candidates(cls, context: HarnessContext) -> list[tuple[Path, str]]:
+        home = cls._kimi_home_dir(context)
+        candidates: list[tuple[Path, str]] = []
+        for base_dir in (_KIMI_PRIMARY_DIR, _KIMI_LEGACY_DIR):
+            candidates.append((home / base_dir / _KIMI_MCP_FILE, "global"))
+        if context.workspace_dir is not None:
+            for base_dir in (_KIMI_PRIMARY_DIR, _KIMI_LEGACY_DIR):
+                candidates.append((context.workspace_dir / base_dir / _KIMI_MCP_FILE, "project"))
+        return candidates
+
+    @staticmethod
+    def _read_toml(path: Path) -> dict[str, object]:
+        if not path.is_file():
+            return {}
+        try:
+            with path.open("rb") as handle:
+                payload = tomllib.load(handle)
+        except (OSError, tomllib.TOMLDecodeError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    def policy_path(self, context: HarnessContext) -> Path:
+        home = self._kimi_home_dir(context)
+        if context.workspace_dir is not None:
+            return context.workspace_dir / _KIMI_PRIMARY_DIR / _KIMI_CONFIG_FILE
+        return home / _KIMI_PRIMARY_DIR / _KIMI_CONFIG_FILE
+
+    def _managed_config_path(self, context: HarnessContext) -> Path:
+        home = self._kimi_home_dir(context)
+        return home / _KIMI_PRIMARY_DIR / _KIMI_CONFIG_FILE
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
+        artifacts: list[GuardArtifact] = []
+        found_paths: list[str] = []
+
+        for config_path, scope in self._config_candidates(context):
+            if not config_path.is_file():
+                continue
+            found_paths.append(str(config_path))
+            payload = self._read_toml(config_path)
+            if payload:
+                self._append_hook_artifacts(artifacts, payload, config_path, scope)
+
+        for mcp_path, scope in self._mcp_candidates(context):
+            if not mcp_path.is_file():
+                continue
+            found_paths.append(str(mcp_path))
+            payload = _json_payload(mcp_path)
+            if payload:
+                self._append_mcp_artifacts(artifacts, payload, mcp_path, scope)
+
+        installed = bool(found_paths) or _command_available(self.executable)
+        detection = HarnessDetection(
+            harness=self.harness,
+            installed=installed,
+            command_available=_command_available(self.executable),
+            config_paths=tuple(found_paths),
+            artifacts=tuple(artifacts),
+            warnings=(),
+        )
+        return extend_detection_with_workspace_aibom(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
+        )
+
+    def _append_hook_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        payload: dict[str, object],
+        config_path: Path,
+        scope: str,
+    ) -> None:
+        hooks = payload.get("hooks")
+        if not isinstance(hooks, list):
+            return
+        for index, entry in enumerate(hooks):
+            if not isinstance(entry, dict):
+                continue
+            command = entry.get("command")
+            if not isinstance(command, str) or not command.strip():
+                continue
+            event = entry.get("event")
+            event_name = event if isinstance(event, str) else ""
+            matcher = entry.get("matcher")
+            timeout = entry.get("timeout")
+            metadata: dict[str, object] = {"event": event_name, "command": command}
+            if isinstance(matcher, str):
+                metadata["matcher"] = matcher
+            if isinstance(timeout, (int, float)):
+                metadata["timeout"] = timeout
+            artifact_id = f"kimi:{scope}:hook:{event_name.lower() or 'unknown'}:{index}"
+            name = (
+                f"{event_name or 'hook'}:{matcher}"
+                if isinstance(matcher, str) and matcher
+                else event_name or "hook"
+            )
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=artifact_id,
+                    name=name,
+                    harness=self.harness,
+                    artifact_type="hook",
+                    source_scope=scope,
+                    config_path=str(config_path),
+                    command=command,
+                    metadata=metadata,
+                )
+            )
+
+    def _append_mcp_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        payload: dict[str, object],
+        mcp_path: Path,
+        scope: str,
+    ) -> None:
+        servers = payload.get("mcpServers")
+        if not isinstance(servers, dict):
+            return
+        for server_name, server_config in servers.items():
+            if not isinstance(server_name, str) or not isinstance(server_config, dict):
+                continue
+            command = server_config.get("command")
+            url = server_config.get("url")
+            if not isinstance(command, str) and not isinstance(url, str):
+                continue
+            raw_args = server_config.get("args")
+            args = tuple(str(value) for value in raw_args) if isinstance(raw_args, list) else ()
+            transport = "http" if isinstance(url, str) else "stdio"
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"kimi:{scope}:mcp:{server_name}",
+                    name=server_name,
+                    harness=self.harness,
+                    artifact_type="mcp_server",
+                    source_scope=scope,
+                    config_path=str(mcp_path),
+                    command=command if isinstance(command, str) else None,
+                    args=args,
+                    url=url if isinstance(url, str) else None,
+                    transport=transport,
+                )
+            )
+
+    @staticmethod
+    def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+        guard_args = [
+            "guard",
+            "hook",
+            "--guard-home",
+            str(context.guard_home),
+            "--harness",
+            "kimi",
+        ]
+        if context.home_dir.resolve() != Path.home().resolve():
+            guard_args.extend(["--home", str(context.home_dir)])
+        if context.workspace_dir is not None:
+            guard_args.extend(["--workspace", str(context.workspace_dir)])
+        package_root = Path(__file__).resolve().parents[3]
+        code = (
+            "import sys;"
+            f"sys.path.insert(0, {str(package_root)!r});"
+            "from codex_plugin_scanner.cli import main;"
+            f"raise SystemExit(main({guard_args!r}))"
+        )
+        return (sys.executable, "-c", code)
+
+    def install(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = install_guard_shim(
+            self.harness,
+            context,
+            launcher_name=self.launcher_name,
+            display_name="kimi",
+        )
+        config_path = self._managed_config_path(context)
+        _ensure_path_within_root(context.home_dir, config_path, label="Kimi Code")
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        hook_command = shlex.join(self._hook_command_parts(context))
+        managed_block = self._build_managed_block(hook_command)
+        existing_text = config_path.read_text(encoding="utf-8") if config_path.is_file() else ""
+        cleaned_text = _remove_managed_block(existing_text)
+        new_text = f"{cleaned_text.rstrip()}\n\n{managed_block}\n".lstrip()
+        config_path.write_text(new_text, encoding="utf-8")
+
+        return {
+            "harness": self.harness,
+            "active": True,
+            "config_path": str(config_path),
+            **shim_manifest,
+            "notes": [
+                "Guard hook entries added to ~/.kimi-code/config.toml",
+                *[str(note) for note in shim_manifest.get("notes", [])],
+            ],
+        }
+
+    def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = remove_guard_shim(
+            self.harness,
+            context,
+            launcher_name=self.launcher_name,
+            display_name="kimi",
+        )
+        config_path = self._managed_config_path(context)
+        if config_path.is_file():
+            _ensure_path_within_root(context.home_dir, config_path, label="Kimi Code")
+            existing_text = config_path.read_text(encoding="utf-8")
+            cleaned_text = _remove_managed_block(existing_text)
+            config_path.write_text(cleaned_text.rstrip() + "\n", encoding="utf-8")
+        return {
+            "harness": self.harness,
+            "active": False,
+            "config_path": str(config_path),
+            **shim_manifest,
+            "notes": [
+                "Guard hook entries removed from ~/.kimi-code/config.toml",
+                *[str(note) for note in shim_manifest.get("notes", [])],
+            ],
+        }
+
+    @staticmethod
+    def _build_managed_block(hook_command: str) -> str:
+        lines = [
+            _GUARD_MANAGED_BEGIN,
+            "# The hooks below are managed by HOL Guard. Do not edit manually.",
+        ]
+        for event in ("PreToolUse", "UserPromptSubmit", "PostToolUse", "SessionStart", "Stop"):
+            lines.extend([
+                "[[hooks]]",
+                f'event = "{event}"',
+                f'command = "{hook_command}"',
+                "timeout = 30",
+            ])
+        lines.append(_GUARD_MANAGED_END)
+        return "\n".join(lines)
+
+
+def _remove_managed_block(text: str) -> str:
+    pattern = re.compile(
+        rf"^\s*{re.escape(_GUARD_MANAGED_BEGIN)}.*?{re.escape(_GUARD_MANAGED_END)}\s*\n?",
+        re.MULTILINE | re.DOTALL,
+    )
+    cleaned = pattern.sub("", text)
+    # Also remove any leftover marker-only lines from partial edits.
+    cleaned = re.sub(rf"^\s*#.*{re.escape(_GUARD_MANAGED_MARKER)}.*$\n?", "", cleaned, flags=re.MULTILINE)
+    return cleaned

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3988,7 +3988,16 @@ def run_guard_command(
                         raw_runtime_reason,
                         approval_context,
                     )
-                _emit_native_hook_block_stderr(native_block_reason)
+                if _canonical_harness_name(args.harness) == "kimi":
+                    _emit_native_hook_response(
+                        harness=args.harness,
+                        policy_action=policy_action,
+                        event_name=event_name,
+                        reason=native_block_reason,
+                        output_stream=output_stream,
+                    )
+                else:
+                    _emit_native_hook_block_stderr(native_block_reason)
                 _record_harness_usage_for_hook(
                     store=store,
                     action_envelope=action_envelope,
@@ -4176,13 +4185,21 @@ def run_guard_command(
         )
         approval_context = _native_approval_center_context(payload, harness=args.harness)
         if _should_emit_native_hook_exit_block(args, event_name=hook_event_name, policy_action=policy_action):
-            _emit_native_hook_block_stderr(
-                _native_hook_reason_for_harness(
-                    args.harness,
-                    incoming_reason,
-                    approval_context,
-                )
+            block_reason = _native_hook_reason_for_harness(
+                args.harness,
+                incoming_reason,
+                approval_context,
             )
+            if _canonical_harness_name(args.harness) == "kimi":
+                _emit_native_hook_response(
+                    harness=args.harness,
+                    policy_action=policy_action,
+                    event_name=hook_event_name,
+                    reason=block_reason,
+                    output_stream=output_stream,
+                )
+            else:
+                _emit_native_hook_block_stderr(block_reason)
             return 2
         if _canonical_harness_name(args.harness) == "codex" and (
             hook_event_name == "UserPromptSubmit" or approval_context is not None
@@ -4276,7 +4293,10 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
 
 
 def _should_emit_native_hook_response(args: argparse.Namespace) -> bool:
-    return _canonical_harness_name(args.harness) in {"claude-code", "codex"} and not getattr(args, "json", False)
+    canonical = _canonical_harness_name(args.harness)
+    if canonical in {"claude-code", "codex"} and not getattr(args, "json", False):
+        return True
+    return canonical == "kimi" and not getattr(args, "json", False)
 
 
 def _should_emit_claude_native_pretooluse_notice(
@@ -4302,6 +4322,8 @@ def _should_emit_native_hook_json_response(
     harness = _canonical_harness_name(args.harness)
     if harness == "codex" and getattr(args, "json", False) and event_name == "UserPromptSubmit":
         return True
+    if harness == "kimi" and getattr(args, "json", False) and output_stream is not None:
+        return event_name in {"PreToolUse", "UserPromptSubmit"}
     return (
         harness in {"claude-code", "codex"}
         and getattr(args, "json", False)
@@ -4314,9 +4336,11 @@ def _should_emit_native_hook_json_response(
 
 
 def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name: str, policy_action: str) -> bool:
-    del args, event_name, policy_action
     # Codex v0.133 logs non-zero PreToolUse hooks as failed but still executes
     # the tool. Blocking must be communicated through the JSON hook response.
+    canonical = _canonical_harness_name(args.harness)
+    if canonical == "kimi" and event_name in {"PreToolUse", "UserPromptSubmit"}:
+        return policy_action in {"block", "sandbox-required", "require-reapproval"}
     return False
 
 
@@ -6851,12 +6875,19 @@ def _emit_native_hook_response(
         if policy_action in {"block", "sandbox-required", "require-reapproval"} and not additional_context:
             payload["decision"] = "block"
             payload["reason"] = reason
-            if _canonical_harness_name(harness) == "codex":
+            canonical = _canonical_harness_name(harness)
+            if canonical == "codex":
                 payload["continue"] = False
                 payload["stopReason"] = reason
                 payload["hookSpecificOutput"] = {
                     "hookEventName": event_name,
                     "additionalContext": reason,
+                }
+            elif canonical == "kimi":
+                payload["hookSpecificOutput"] = {
+                    "hookEventName": event_name,
+                    "permissionDecision": "deny",
+                    "permissionDecisionReason": reason,
                 }
         elif additional_context:
             payload["hookSpecificOutput"] = {
@@ -6944,7 +6975,7 @@ def _native_hook_permission_decision(policy_action: str, *, harness: str) -> str
     if policy_action in {"block", "sandbox-required"}:
         return "deny"
     if policy_action == "require-reapproval":
-        if harness == "codex":
+        if harness in {"codex", "kimi"}:
             return "deny"
         return "ask"
     if harness == "codex":
@@ -7262,7 +7293,25 @@ def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     if arguments is not None:
         normalized["tool_input"] = arguments
         normalized["arguments"] = arguments
+    normalized["prompt"] = _normalize_kimi_prompt(normalized.get("prompt"))
     return normalized
+
+
+def _normalize_kimi_prompt(value: object | None) -> str | None:
+    """Flatten Kimi Code's ContentPart[] prompt into a single string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts) if parts else None
+    return None
 
 
 def _normalize_hook_arguments(*values: object | None) -> object | None:

--- a/src/codex_plugin_scanner/guard/cli/commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands.py
@@ -3025,11 +3025,15 @@ def run_guard_command(
             args.harness = runtime_harness.strip()
         else:
             args.harness = resolve_runtime_hook_harness(args.harness)
-        payload = _load_hook_payload(getattr(args, "event_file", None), input_text=input_text)
+        payload = _load_hook_payload(
+            getattr(args, "event_file", None),
+            input_text=input_text,
+            harness=args.harness,
+        )
         if _canonical_harness_name(args.harness) == "cursor":
             from ..adapters.cursor_hooks import prepare_cursor_hook_payload
 
-            payload = _normalize_hook_payload(prepare_cursor_hook_payload(payload))
+            payload = _normalize_hook_payload(prepare_cursor_hook_payload(payload), harness=args.harness)
         managed_install = _managed_install_for(store, args.harness)
         workspace_was_explicit = workspace is not None
         runtime_workspace = workspace
@@ -4294,9 +4298,7 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
 
 def _should_emit_native_hook_response(args: argparse.Namespace) -> bool:
     canonical = _canonical_harness_name(args.harness)
-    if canonical in {"claude-code", "codex"} and not getattr(args, "json", False):
-        return True
-    return canonical == "kimi" and not getattr(args, "json", False)
+    return canonical in {"claude-code", "codex", "kimi"} and not getattr(args, "json", False)
 
 
 def _should_emit_claude_native_pretooluse_notice(
@@ -7220,15 +7222,20 @@ def _approval_surface_policy_for_flow(config_policy: str, approval_flow: dict[st
     return config_policy
 
 
-def _load_hook_payload(event_file: str | None, *, input_text: str | None = None) -> dict[str, object]:
+def _load_hook_payload(
+    event_file: str | None,
+    *,
+    input_text: str | None = None,
+    harness: str | None = None,
+) -> dict[str, object]:
     if event_file:
         payload = json.loads(Path(event_file).read_text(encoding="utf-8"))
-        return _normalize_hook_payload(payload) if isinstance(payload, dict) else {}
+        return _normalize_hook_payload(payload, harness=harness) if isinstance(payload, dict) else {}
     raw = input_text.strip() if isinstance(input_text, str) else sys.stdin.read().strip()
     if not raw:
         return {}
     payload = json.loads(raw)
-    return _normalize_hook_payload(payload) if isinstance(payload, dict) else {}
+    return _normalize_hook_payload(payload, harness=harness) if isinstance(payload, dict) else {}
 
 
 _ACTION_ENVELOPE_HARNESSES = frozenset(
@@ -7259,7 +7266,11 @@ def _action_envelope_json(envelope: GuardActionEnvelope | None) -> dict[str, obj
     return envelope.to_dict() if envelope is not None else None
 
 
-def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
+def _normalize_hook_payload(
+    payload: dict[str, object],
+    *,
+    harness: str | None = None,
+) -> dict[str, object]:
     normalized = dict(payload)
     for source_key, target_key in (
         ("artifactId", "artifact_id"),
@@ -7293,7 +7304,8 @@ def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     if arguments is not None:
         normalized["tool_input"] = arguments
         normalized["arguments"] = arguments
-    normalized["prompt"] = _normalize_kimi_prompt(normalized.get("prompt"))
+    if harness is not None and _canonical_harness_name(harness) == "kimi":
+        normalized["prompt"] = _normalize_kimi_prompt(normalized.get("prompt"))
     return normalized
 
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -55,7 +55,16 @@ InventorySeverity = Literal["critical", "high", "medium", "low", "info"]
 InventoryConfidence = Literal["high", "medium", "low", "unknown"]
 InventoryDriftState = Literal["new", "changed", "removed", "unchanged"]
 DockerProofStatus = Literal["passed", "failed", "skipped", "stale"]
-AgentInventoryType = Literal["hermes", "openclaw", "codex", "claude-code", "cursor", "gemini", "opencode"]
+AgentInventoryType = Literal[
+    "hermes",
+    "openclaw",
+    "codex",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "opencode",
+    "kimi",
+]
 _AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
     "hermes",
     "openclaw",
@@ -64,6 +73,7 @@ _AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
     "cursor",
     "gemini",
     "opencode",
+    "kimi",
 )
 
 _SENSITIVE_KEY_RE = re.compile(

--- a/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
+++ b/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
@@ -49,7 +49,8 @@
         "gemini",
         "hermes",
         "openclaw",
-        "antigravity"
+        "antigravity",
+        "kimi"
     ],
     "action_categories": [
         "secrets",

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -1,0 +1,235 @@
+"""Tests for the Kimi Code CLI harness adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.kimi import KimiHarnessAdapter
+
+
+def _ctx(tmp_path: Path, *, workspace: bool = False) -> HarnessContext:
+    workspace_dir = tmp_path / "workspace" if workspace else None
+    if workspace_dir is not None:
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _write_toml(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def _write_json(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestKimiAdapterIdentity:
+    def test_harness_identifier_is_kimi(self) -> None:
+        assert KimiHarnessAdapter.harness == "kimi"
+
+    def test_executable_is_kimi(self) -> None:
+        assert KimiHarnessAdapter.executable == "kimi"
+
+    def test_approval_tier_is_approval_center(self) -> None:
+        assert KimiHarnessAdapter.approval_tier == "approval-center"
+
+
+class TestKimiPolicyPath:
+    def test_policy_path_uses_workspace_when_provided(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        assert ctx.workspace_dir is not None
+        expected = ctx.workspace_dir / ".kimi-code" / "config.toml"
+        assert KimiHarnessAdapter().policy_path(ctx) == expected
+
+    def test_policy_path_falls_back_to_home_without_workspace(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        expected = (tmp_path / "home") / ".kimi-code" / "config.toml"
+        assert KimiHarnessAdapter().policy_path(ctx) == expected
+
+
+class TestKimiDetectEmptyConfig:
+    def test_empty_dir_returns_no_artifacts(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        result = KimiHarnessAdapter().detect(ctx)
+        assert result.harness == "kimi"
+        assert result.artifacts == ()
+        assert result.config_paths == ()
+
+    def test_empty_config_toml_yields_no_artifacts(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_toml(ctx.home_dir / ".kimi-code" / "config.toml", "")
+        result = KimiHarnessAdapter().detect(ctx)
+        assert result.artifacts == ()
+        assert str(ctx.home_dir / ".kimi-code" / "config.toml") in result.config_paths
+
+
+class TestKimiDetectHooks:
+    def test_pretooluse_hook_detected(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_toml(
+            ctx.home_dir / ".kimi-code" / "config.toml",
+            '''[[hooks]]
+event = "PreToolUse"
+matcher = "Bash"
+command = "bash hook.sh"
+timeout = 10
+''',
+        )
+        result = KimiHarnessAdapter().detect(ctx)
+        hook_artifacts = [a for a in result.artifacts if a.artifact_type == "hook"]
+        assert len(hook_artifacts) == 1
+        assert hook_artifacts[0].artifact_id == "kimi:global:hook:pretooluse:0"
+        assert hook_artifacts[0].command == "bash hook.sh"
+        assert hook_artifacts[0].metadata["matcher"] == "Bash"
+        assert hook_artifacts[0].metadata["timeout"] == 10
+
+    def test_user_prompt_submit_hook_detected(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_toml(
+            ctx.home_dir / ".kimi-code" / "config.toml",
+            '''[[hooks]]
+event = "UserPromptSubmit"
+command = "bash prompt-hook.sh"
+''',
+        )
+        result = KimiHarnessAdapter().detect(ctx)
+        hook_artifacts = [a for a in result.artifacts if a.artifact_type == "hook"]
+        assert hook_artifacts[0].artifact_id == "kimi:global:hook:userpromptsubmit:0"
+
+    def test_multiple_hooks_create_indexed_artifacts(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_toml(
+            ctx.home_dir / ".kimi-code" / "config.toml",
+            '''[[hooks]]
+event = "PreToolUse"
+command = "a.sh"
+
+[[hooks]]
+event = "PostToolUse"
+command = "b.sh"
+''',
+        )
+        result = KimiHarnessAdapter().detect(ctx)
+        hook_ids = {a.artifact_id for a in result.artifacts if a.artifact_type == "hook"}
+        assert "kimi:global:hook:pretooluse:0" in hook_ids
+        assert "kimi:global:hook:posttooluse:1" in hook_ids
+
+    def test_legacy_kimi_home_config_detected(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_toml(
+            ctx.home_dir / ".kimi" / "config.toml",
+            '''[[hooks]]
+event = "PreToolUse"
+command = "legacy.sh"
+''',
+        )
+        result = KimiHarnessAdapter().detect(ctx)
+        assert any(a.artifact_id == "kimi:global:hook:pretooluse:0" for a in result.artifacts)
+
+    def test_workspace_config_detected(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        assert ctx.workspace_dir is not None
+        _write_toml(
+            ctx.workspace_dir / ".kimi-code" / "config.toml",
+            '''[[hooks]]
+event = "PreToolUse"
+command = "ws.sh"
+''',
+        )
+        result = KimiHarnessAdapter().detect(ctx)
+        assert any(a.source_scope == "project" for a in result.artifacts)
+
+    def test_invalid_toml_is_skipped_gracefully(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_toml(ctx.home_dir / ".kimi-code" / "config.toml", "not valid toml [[")
+        result = KimiHarnessAdapter().detect(ctx)
+        assert result.artifacts == ()
+
+
+class TestKimiDetectMCP:
+    def test_mcp_server_in_mcp_json_detected(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_json(
+            ctx.home_dir / ".kimi-code" / "mcp.json",
+            {"mcpServers": {"my-server": {"command": "node", "args": ["server.js"]}}},
+        )
+        result = KimiHarnessAdapter().detect(ctx)
+        ids = [a.artifact_id for a in result.artifacts]
+        assert "kimi:global:mcp:my-server" in ids
+
+    def test_mcp_server_with_url_gets_http_transport(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_json(
+            ctx.home_dir / ".kimi-code" / "mcp.json",
+            {"mcpServers": {"remote": {"url": "http://localhost:8080/mcp"}}},
+        )
+        result = KimiHarnessAdapter().detect(ctx)
+        art = result.artifacts[0]
+        assert art.transport == "http"
+        assert art.url == "http://localhost:8080/mcp"
+
+
+class TestKimiInstallUninstall:
+    def test_install_writes_managed_hooks(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        manifest = KimiHarnessAdapter().install(ctx)
+        assert manifest["harness"] == "kimi"
+        assert manifest["active"] is True
+        config_path = Path(str(manifest["config_path"]))
+        assert config_path.is_file()
+        text = config_path.read_text(encoding="utf-8")
+        assert "# BEGIN HOL GUARD MANAGED HOOKS" in text
+        assert "# END HOL GUARD MANAGED HOOKS" in text
+        assert 'event = "PreToolUse"' in text
+        assert 'event = "UserPromptSubmit"' in text
+        assert "hol-guard" in text or "codex_plugin_scanner.cli" in text
+
+    def test_uninstall_removes_managed_hooks(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        adapter = KimiHarnessAdapter()
+        adapter.install(ctx)
+        manifest = adapter.uninstall(ctx)
+        assert manifest["active"] is False
+        config_path = Path(str(manifest["config_path"]))
+        text = config_path.read_text(encoding="utf-8")
+        assert "BEGIN HOL GUARD MANAGED HOOKS" not in text
+        assert "END HOL GUARD MANAGED HOOKS" not in text
+
+    def test_install_preserves_user_hooks(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config_path = ctx.home_dir / ".kimi-code" / "config.toml"
+        _write_toml(
+            config_path,
+            '''[[hooks]]
+event = "PostToolUse"
+command = "user-format.sh"
+''',
+        )
+        KimiHarnessAdapter().install(ctx)
+        text = config_path.read_text(encoding="utf-8")
+        assert "user-format.sh" in text
+        assert "BEGIN HOL GUARD MANAGED HOOKS" in text
+
+    def test_install_idempotent(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        adapter = KimiHarnessAdapter()
+        adapter.install(ctx)
+        adapter.install(ctx)
+        config_path = ctx.home_dir / ".kimi-code" / "config.toml"
+        text = config_path.read_text(encoding="utf-8")
+        assert text.count("BEGIN HOL GUARD MANAGED HOOKS") == 1
+
+
+class TestKimiLaunchCommand:
+    def test_launch_command_passes_workspace(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        command = KimiHarnessAdapter().launch_command(ctx, ["--version"])
+        assert "kimi" in command[0]
+        assert "--version" in command

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+
 try:
     import tomllib
 except ModuleNotFoundError:

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -3,6 +3,10 @@
 from __future__ import annotations
 
 import json
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
 from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -121,18 +125,6 @@ command = "b.sh"
         assert "kimi:global:hook:pretooluse:0" in hook_ids
         assert "kimi:global:hook:posttooluse:1" in hook_ids
 
-    def test_legacy_kimi_home_config_detected(self, tmp_path: Path) -> None:
-        ctx = _ctx(tmp_path)
-        _write_toml(
-            ctx.home_dir / ".kimi" / "config.toml",
-            '''[[hooks]]
-event = "PreToolUse"
-command = "legacy.sh"
-''',
-        )
-        result = KimiHarnessAdapter().detect(ctx)
-        assert any(a.artifact_id == "kimi:global:hook:pretooluse:0" for a in result.artifacts)
-
     def test_workspace_config_detected(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=True)
         assert ctx.workspace_dir is not None
@@ -225,6 +217,19 @@ command = "user-format.sh"
         config_path = ctx.home_dir / ".kimi-code" / "config.toml"
         text = config_path.read_text(encoding="utf-8")
         assert text.count("BEGIN HOL GUARD MANAGED HOOKS") == 1
+
+
+class TestKimiManagedBlock:
+    def test_managed_block_escapes_quotes_and_backslashes(self) -> None:
+        from codex_plugin_scanner.guard.adapters.kimi import _toml_escape
+
+        command = 'python -c "print(\\"hello\\")"'
+        block = KimiHarnessAdapter._build_managed_block(command)
+        parsed = tomllib.loads(block)
+        hooks = parsed.get("hooks", [])
+        assert len(hooks) == 5
+        assert hooks[0]["command"] == command
+        assert _toml_escape('a"b\\c') == 'a\\"b\\\\c'
 
 
 class TestKimiLaunchCommand:


### PR DESCRIPTION
## Summary
- Add HOL Guard protection for the Kimi Code CLI.
- Detect Kimi Code config, hooks, and MCP servers from `~/.kimi-code` and legacy `~/.kimi` paths.
- Install Guard-managed `PreToolUse`, `UserPromptSubmit`, `PostToolUse`, `SessionStart`, and `Stop` hooks in `~/.kimi-code/config.toml`.
- Block dangerous tool calls and prompts with exit code `2` and a JSON `permissionDecision: "deny"` response.
- Normalize Kimi Code `ContentPart[]` prompts to strings for Guard policy evaluation.
- Register Kimi in the adapter registry, inventory contract, and harness protection contracts.
- Update the dashboard catalog, harness display name, watched harnesses, and related tests.
- Update README, architecture, get-started, and harness-support docs.

## Testing
- `python3 -m pytest tests/test_kimi_adapter.py`
- `python3 -m pytest tests/test_gemini_adapter.py tests/test_cursor_adapter.py tests/test_opencode_adapter.py tests/test_openclaw_adapter.py tests/test_hermes_adapter.py tests/test_guard_copilot_adapter.py tests/test_guard_claude_adapter.py tests/test_guard_phase04_harness_contracts.py`
- `python3 -m pytest tests/test_guard_codex_install.py tests/test_guard_package_hook.py`
- Manual `hol-guard hook --harness kimi` smoke tests for allow and block paths.
