### PR TITLE
fix(guard): serialize reconnect oauth refresh preflight

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2283,18 +2283,17 @@ def _oauth_authorization_error_requires_fresh_sign_in(error: Exception) -> bool:
 
 def clear_revoked_guard_oauth_sign_in(store: GuardStore) -> bool:
     """Return True when refresh proves the local OAuth grant was revoked and cleared."""
-    if store.get_oauth_local_credentials(allow_primary=True) is None:
-        return False
     try:
-        credentials = store.get_oauth_local_credentials(allow_primary=True)
-        if credentials is None:
-            return False
-        _resolve_guard_sync_auth_context_from_oauth_credentials(store, credentials)
+        with _guard_sync_auth_lock(store):
+            credentials = store.get_oauth_local_credentials(allow_primary=True)
+            if credentials is None:
+                return False
+            _resolve_guard_sync_auth_context_from_oauth_credentials(store, credentials)
     except GuardSyncAuthorizationExpiredError as error:
         if _oauth_authorization_error_requires_fresh_sign_in(error):
             return store.get_oauth_local_credentials(allow_primary=True) is None
         return False
-    except (RuntimeError, OSError):
+    except (RuntimeError, OSError, TimeoutError):
         return False
     return False
 

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from contextlib import contextmanager
 import json
 import urllib.error
 
@@ -109,6 +110,44 @@ def test_prepare_guard_cloud_connect_authorization_tolerates_network_errors(tmp_
         raise OSError("network unreachable")
 
     monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+
+    result = guard_runner_module.prepare_guard_cloud_connect_authorization(store)
+
+    assert result["cleared_stale_sign_in"] is False
+    assert result["existing_sign_in_valid"] is True
+    assert store.get_oauth_local_credentials(allow_primary=True) is not None
+
+
+def test_prepare_guard_cloud_connect_authorization_refreshes_under_lock(tmp_path, monkeypatch) -> None:
+    store = _store_with_oauth_credentials(tmp_path)
+    lock_state = {"held": False}
+
+    @contextmanager
+    def _fake_refresh_lock(*, timeout_seconds: float = 30.0):
+        del timeout_seconds
+        assert lock_state["held"] is False
+        lock_state["held"] = True
+        try:
+            yield
+        finally:
+            lock_state["held"] = False
+
+    def _fake_resolve(_store, credentials, *, persist_recovered_secret: bool = False):
+        del _store, persist_recovered_secret
+        assert lock_state["held"] is True
+        assert credentials["refresh_token"] == "refresh-token-1"
+        return {
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "access-token-1",
+            "dpop_key_material": None,
+        }
+
+    monkeypatch.setattr(store, "hold_oauth_refresh_lock", _fake_refresh_lock)
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_resolve_guard_sync_auth_context_from_oauth_credentials",
+        _fake_resolve,
+    )
 
     result = guard_runner_module.prepare_guard_cloud_connect_authorization(store)
 

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -156,6 +156,27 @@ def test_prepare_guard_cloud_connect_authorization_refreshes_under_lock(tmp_path
     assert store.get_oauth_local_credentials(allow_primary=True) is not None
 
 
+def test_prepare_guard_cloud_connect_authorization_tolerates_refresh_lock_timeout(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = _store_with_oauth_credentials(tmp_path)
+
+    @contextmanager
+    def _fake_refresh_lock(*, timeout_seconds: float = 30.0):
+        del timeout_seconds
+        raise TimeoutError("refresh lock busy")
+        yield
+
+    monkeypatch.setattr(store, "hold_oauth_refresh_lock", _fake_refresh_lock)
+
+    result = guard_runner_module.prepare_guard_cloud_connect_authorization(store)
+
+    assert result["cleared_stale_sign_in"] is False
+    assert result["existing_sign_in_valid"] is True
+    assert store.get_oauth_local_credentials(allow_primary=True) is not None
+
+
 def test_invalid_dpop_curve_refresh_uses_reconnect_message(tmp_path, monkeypatch) -> None:
     store = _store_with_oauth_credentials(tmp_path)
 


### PR DESCRIPTION
## Summary
- serialize the reconnect preflight OAuth refresh under the shared Guard refresh lock
- add regression coverage so `hol-guard connect` cannot validate a stale refresh token outside that lock

## Testing
- `pytest tests/test_guard_oauth_reconnect.py tests/test_guard_oauth_device_connect.py tests/test_guard_headless_daemon_api.py -q`
