### PR TITLE
fix(guard): bind package approvals to policy gate context

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -21,6 +21,7 @@ from uuid import uuid4
 from codex_plugin_scanner.path_support import resolve_path_within_allowed_roots, resolves_within_root
 
 from .adapters.base import HarnessContext
+from .advisory_model import ProtectTargetIdentity, advisory_matches_target, build_package_url
 from .config import GuardConfig, resolve_risk_action
 from .models import GuardArtifact
 from .package_firewall_entitlement import resolve_package_firewall_entitlement
@@ -779,12 +780,17 @@ def build_package_protect_payload(
         config_path="hol-guard.toml",
         source_scope="project",
     )
-    artifact_hash = _package_request_artifact_hash(artifact, workspace_dir=workspace_dir)
     evaluation = evaluate_package_request_artifact(
         artifact=artifact,
         store=store,
         workspace_dir=workspace_dir,
         now=now,
+    )
+    artifact_hash = _package_request_artifact_hash(
+        artifact,
+        workspace_dir=workspace_dir,
+        store=store,
+        evaluation=evaluation,
     )
     evaluation = _apply_stored_package_policy_override(
         evaluation,
@@ -984,15 +990,145 @@ def _apply_stored_package_policy_override(
     return evaluation
 
 
-def _package_request_artifact_hash(artifact: GuardArtifact, *, workspace_dir: Path) -> str:
+def recompute_package_protect_artifact_hash(
+    command: Sequence[str],
+    *,
+    store: GuardStore,
+    workspace_dir: Path,
+) -> str | None:
+    from .runtime.package_intent_parser import parse_package_intent
+
+    intent = parse_package_intent(shlex.join(command), workspace=workspace_dir)
+    if intent is None:
+        return None
+    sanitized_intent = replace(intent, redacted_command=shlex.join(redacted_command_tokens(command)))
+    artifact = build_package_request_artifact(
+        _LOCAL_SUPPLY_CHAIN_HARNESS,
+        sanitized_intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+    evaluation = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+    )
+    return _package_request_artifact_hash(
+        artifact,
+        workspace_dir=workspace_dir,
+        store=store,
+        evaluation=evaluation,
+    )
+
+
+def _package_target_identities(artifact: GuardArtifact) -> tuple[ProtectTargetIdentity, ...]:
+    metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
+    targets = metadata.get("targets")
+    if not isinstance(targets, list):
+        return ()
+    identities: list[ProtectTargetIdentity] = []
+    for item in targets:
+        if not isinstance(item, dict):
+            continue
+        ecosystem = str(item.get("ecosystem") or "")
+        package_name = item.get("package_name") if isinstance(item.get("package_name"), str) else None
+        raw_spec = str(item.get("raw_spec") or package_name or "")
+        version = item.get("requested_specifier") if isinstance(item.get("requested_specifier"), str) else None
+        source_url = item.get("source_url") if isinstance(item.get("source_url"), str) else None
+        artifact_id = f"{ecosystem}:{package_name or raw_spec}"
+        artifact_name = package_name or raw_spec
+        identities.append(
+            ProtectTargetIdentity(
+                artifact_id=artifact_id,
+                artifact_name=artifact_name,
+                ecosystem=ecosystem,
+                package_name=package_name,
+                package_url=build_package_url(ecosystem, package_name, version),
+                source_url=source_url,
+            )
+        )
+    return tuple(identities)
+
+
+def _package_matched_cached_advisory_ids(store: GuardStore, artifact: GuardArtifact) -> tuple[str, ...]:
+    advisories = store.list_cached_advisories(limit=None)
+    identities = _package_target_identities(artifact)
+    matched_ids: set[str] = set()
+    for advisory in advisories:
+        for identity in identities:
+            if advisory_matches_target(advisory, identity):
+                advisory_id = advisory.get("id")
+                if isinstance(advisory_id, str) and advisory_id:
+                    matched_ids.add(advisory_id)
+                break
+    return tuple(sorted(matched_ids))
+
+
+def _package_feed_snapshot_hash(store: GuardStore) -> str | None:
+    workspace_id = store.get_cloud_workspace_id()
+    if workspace_id is None:
+        return None
+    cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
+    if not isinstance(cached_bundle, dict):
+        return None
+    bundle = cached_bundle.get("bundle")
+    if not isinstance(bundle, dict):
+        return None
+    value = bundle.get("feedSnapshotHash")
+    return value if isinstance(value, str) and value else None
+
+
+def _package_policy_gate_context(
+    store: GuardStore,
+    artifact: GuardArtifact,
+    evaluation: PackageRequestEvaluation,
+) -> dict[str, object]:
+    return {
+        "bundle_version": evaluation.bundle_version,
+        "decision": evaluation.decision,
+        "feed_snapshot_hash": _package_feed_snapshot_hash(store),
+        "matched_advisory_ids": list(_package_matched_cached_advisory_ids(store, artifact)),
+        "matched_rule_id": evaluation.matched_rule_id,
+        "policy_action": evaluation.policy_action,
+        "policy_version": evaluation.policy_version,
+    }
+
+
+def _package_request_artifact_hash(
+    artifact: GuardArtifact,
+    *,
+    workspace_dir: Path,
+    store: GuardStore,
+    evaluation: PackageRequestEvaluation,
+) -> str:
+    policy_gate = _package_policy_gate_context(store, artifact, evaluation)
     metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
     targets = metadata.get("targets")
     if isinstance(targets, list) and any(isinstance(item, dict) for item in targets):
-        return stable_digest_hex(artifact.artifact_id.encode("utf-8"))
+        return stable_digest_hex(
+            json.dumps(
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "policy_gate": policy_gate,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
     manifest_paths = tuple(str(item) for item in metadata.get("manifest_paths", []) if isinstance(item, str))
     lockfile_paths = tuple(str(item) for item in metadata.get("lockfile_paths", []) if isinstance(item, str))
     if not manifest_paths and not lockfile_paths:
-        return stable_digest_hex(artifact.artifact_id.encode("utf-8"))
+        return stable_digest_hex(
+            json.dumps(
+                {
+                    "artifact_id": artifact.artifact_id,
+                    "policy_gate": policy_gate,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        )
     return stable_digest_hex(
         json.dumps(
             {
@@ -1001,6 +1137,7 @@ def _package_request_artifact_hash(artifact: GuardArtifact, *, workspace_dir: Pa
                 "lockfile_paths": list(lockfile_paths),
                 "manifest_hashes": _hash_existing_paths(workspace_dir, manifest_paths),
                 "lockfile_hashes": _hash_existing_paths(workspace_dir, lockfile_paths),
+                "policy_gate": policy_gate,
             },
             sort_keys=True,
             separators=(",", ":"),

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -995,6 +995,7 @@ def recompute_package_protect_artifact_hash(
     *,
     store: GuardStore,
     workspace_dir: Path,
+    now: str | None = None,
 ) -> str | None:
     from .runtime.package_intent_parser import parse_package_intent
 
@@ -1008,11 +1009,12 @@ def recompute_package_protect_artifact_hash(
         config_path="hol-guard.toml",
         source_scope="project",
     )
+    evaluation_timestamp = now or datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
     evaluation = evaluate_package_request_artifact(
         artifact=artifact,
         store=store,
         workspace_dir=workspace_dir,
-        now=datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z"),
+        now=evaluation_timestamp,
     )
     return _package_request_artifact_hash(
         artifact,
@@ -1105,20 +1107,10 @@ def _package_request_artifact_hash(
     policy_gate = _package_policy_gate_context(store, artifact, evaluation)
     metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
     targets = metadata.get("targets")
-    if isinstance(targets, list) and any(isinstance(item, dict) for item in targets):
-        return stable_digest_hex(
-            json.dumps(
-                {
-                    "artifact_id": artifact.artifact_id,
-                    "policy_gate": policy_gate,
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            ).encode("utf-8")
-        )
     manifest_paths = tuple(str(item) for item in metadata.get("manifest_paths", []) if isinstance(item, str))
     lockfile_paths = tuple(str(item) for item in metadata.get("lockfile_paths", []) if isinstance(item, str))
-    if not manifest_paths and not lockfile_paths:
+    has_targets = isinstance(targets, list) and any(isinstance(item, dict) for item in targets)
+    if has_targets or (not manifest_paths and not lockfile_paths):
         return stable_digest_hex(
             json.dumps(
                 {

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -143,6 +143,7 @@ def build_protect_payload(
             store=store,
             workspace_dir=workspace_dir,
             command=command,
+            now=now,
         ):
             return _merge_cached_advisory_into_package_payload(
                 package_payload,
@@ -235,6 +236,7 @@ def _package_saved_approval_covers_current_gate(
     store: GuardStore,
     workspace_dir: Path,
     command: list[str],
+    now: str,
 ) -> bool:
     if not _package_payload_uses_saved_approval(payload):
         return False
@@ -244,7 +246,12 @@ def _package_saved_approval_covers_current_gate(
     stored_hash = receipt.get("artifact_hash")
     if not isinstance(stored_hash, str) or not stored_hash:
         return False
-    current_hash = recompute_package_protect_artifact_hash(command, store=store, workspace_dir=workspace_dir)
+    current_hash = recompute_package_protect_artifact_hash(
+        command,
+        store=store,
+        workspace_dir=workspace_dir,
+        now=now,
+    )
     return current_hash == stored_hash
 
 

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 from .advisory_model import ProtectTargetIdentity, advisory_matches_target, build_package_url
 from .config import GuardConfig
-from .local_supply_chain import build_package_protect_payload
+from .local_supply_chain import build_package_protect_payload, recompute_package_protect_artifact_hash
 from .models import GuardReceipt
 from .receipts import build_receipt
 from .redaction import redact_text
@@ -138,7 +138,12 @@ def build_protect_payload(
         timeout_seconds=_protect_command_timeout_seconds(),
     )
     if package_payload is not None:
-        if cached_gate and not _package_payload_uses_saved_approval(package_payload[0]):
+        if cached_gate and not _package_saved_approval_covers_current_gate(
+            package_payload[0],
+            store=store,
+            workspace_dir=workspace_dir,
+            command=command,
+        ):
             return _merge_cached_advisory_into_package_payload(
                 package_payload,
                 cached_verdict=cached_verdict,
@@ -222,6 +227,25 @@ def build_protect_payload(
             now,
         )
     return (payload, int(execution.returncode))
+
+
+def _package_saved_approval_covers_current_gate(
+    payload: dict[str, object],
+    *,
+    store: GuardStore,
+    workspace_dir: Path,
+    command: list[str],
+) -> bool:
+    if not _package_payload_uses_saved_approval(payload):
+        return False
+    receipt = payload.get("receipt")
+    if not isinstance(receipt, dict):
+        return False
+    stored_hash = receipt.get("artifact_hash")
+    if not isinstance(stored_hash, str) or not stored_hash:
+        return False
+    current_hash = recompute_package_protect_artifact_hash(command, store=store, workspace_dir=workspace_dir)
+    return current_hash == stored_hash
 
 
 def _package_payload_uses_saved_approval(payload: dict[str, object]) -> bool:

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -21,8 +21,10 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import shims as guard_shims_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
+from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.protect import build_protect_payload
+from codex_plugin_scanner.guard.runtime import supply_chain_package_eval as supply_chain_package_eval_module
 from codex_plugin_scanner.guard.shim_probe import SHIM_PROBE_ENV_VALUE, SHIM_PROBE_ENV_VAR
 from codex_plugin_scanner.guard.shims import install_package_shims, package_shim_status
 from codex_plugin_scanner.guard.store import GuardStore
@@ -80,6 +82,9 @@ def _bundle_response(
     ecosystem: str,
     package_name: str,
     package_version: str,
+    feed_snapshot_hash: str = "feed-snapshot-shim-proof",
+    policy_hash: str = "policy-hash-shim-proof",
+    bundle_version: str = "1747612800000-shim-proof",
 ) -> dict[str, object]:
     generated_at = datetime(2026, 5, 19, tzinfo=timezone.utc)
     expires_at = generated_at + timedelta(hours=12)
@@ -100,9 +105,9 @@ def _bundle_response(
                 "title": f"High-risk package: {package_name}",
             }
         ],
-        "bundleVersion": "1747612800000-shim-proof",
+        "bundleVersion": bundle_version,
         "expiresAt": _iso(expires_at),
-        "feedSnapshotHash": "feed-snapshot-shim-proof",
+        "feedSnapshotHash": feed_snapshot_hash,
         "generatedAt": _iso(generated_at),
         "keyId": "guard-bundle-key-2026-05",
         "packages": [
@@ -126,7 +131,7 @@ def _bundle_response(
                 "version": package_version,
             }
         ],
-        "policyHash": "policy-hash-shim-proof",
+        "policyHash": policy_hash,
         "policyRules": [],
         "scoringVersion": "scf-v1",
         "sourceHashes": [{"payloadHash": "ghsa-feed-hash", "sourceKey": "ghsa", "staleStatus": "fresh"}],
@@ -1229,6 +1234,121 @@ def test_guard_protect_denied_retry_with_cloud_block_does_not_requeue_local_pack
     assert "primary_approval_request_id" not in retry_payload
     assert pending == []
     assert len(resolved) == 1
+
+
+def test_guard_protect_saved_approval_does_not_bypass_new_bundle_block_for_unpinned_package(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True, exist_ok=True)
+    marker_path = tmp_path / "npm-somepkg-marker.json"
+    write_fake_manager_script(fake_bin=fake_bin, manager="npm", marker_path=marker_path, exit_code=0)
+    package_name = "somepkg"
+    original_resolved_target_version = supply_chain_package_eval_module._resolved_target_version
+
+    def _resolve_somepkg_version(**kwargs: object) -> str | None:
+        target = kwargs.get("target")
+        if isinstance(target, dict) and str(target.get("normalized_name")) == package_name:
+            return "1.0.0"
+        return original_resolved_target_version(**kwargs)
+
+    monkeypatch.setattr(
+        supply_chain_package_eval_module,
+        "_resolved_target_version",
+        _resolve_somepkg_version,
+    )
+    server, thread, sync_url = _start_cloud_eval_server(
+        decision="allow",
+        package_name=package_name,
+        evaluate_status=401,
+    )
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    try:
+        store = GuardStore(home_dir)
+        _seed_bundle_cache_only(
+            home_dir=home_dir,
+            ecosystem="npm",
+            package_name=package_name,
+            package_version="1.0.0",
+            action="allow",
+        )
+        _seed_workspace_sync_credentials(home_dir, sync_url)
+
+        first_payload, first_exit_code = build_protect_payload(
+            command=["npm", "install", package_name],
+            store=store,
+            workspace_dir=workspace_dir,
+            dry_run=True,
+            now="2026-05-19T00:00:00Z",
+        )
+
+        assert first_exit_code == 2
+        assert first_payload["verdict"]["action"] in {"block", "review"}
+        receipt = first_payload["receipt"]
+        assert isinstance(receipt, dict)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="guard-cli",
+                scope="artifact",
+                action="allow",
+                artifact_id=str(receipt["artifact_id"]),
+                artifact_hash=str(receipt["artifact_hash"]),
+                workspace=None,
+                publisher=None,
+                reason="reviewed",
+            ),
+            "2026-05-19T00:00:00Z",
+        )
+
+        response = _bundle_response(
+            action="block",
+            ecosystem="npm",
+            package_name=package_name,
+            package_version="1.0.0",
+            feed_snapshot_hash="feed-snapshot-block-2",
+            policy_hash="policy-hash-block-2",
+            bundle_version="1747612801000-shim-proof",
+        )
+        store.cache_supply_chain_bundle(WORKSPACE_ID, response, "2026-05-19T01:00:00Z")
+        bundle = response["bundle"]
+        assert isinstance(bundle, dict)
+        store.set_sync_payload(
+            "supply_chain_bundle_entitlement",
+            {
+                "bundle_version": bundle["bundleVersion"],
+                "key_id": bundle["keyId"],
+                "policy_hash": bundle["policyHash"],
+                "tier": bundle["tier"],
+                "workspace_id": WORKSPACE_ID,
+            },
+            "2026-05-19T01:00:00Z",
+        )
+
+        original_path = os.environ.get("PATH", "")
+        monkeypatch.setenv("PATH", os.pathsep.join(filter(None, [str(fake_bin), original_path])))
+        retry_payload, retry_exit_code = build_protect_payload(
+            command=["npm", "install", package_name],
+            store=store,
+            workspace_dir=workspace_dir,
+            dry_run=False,
+            now="2026-05-19T01:00:00Z",
+        )
+    finally:
+        _stop_cloud_eval_server(server, thread)
+
+    assert retry_exit_code == 2
+    assert retry_payload["executed"] is False
+    assert retry_payload["verdict"]["action"] == "block"
+    assert marker_path.exists() is False
+    assert not any(
+        isinstance(reason, dict) and reason.get("code") == "saved_package_approval"
+        for reason in retry_payload["supply_chain_evaluation"]["reasons"]
+    )
 
 
 def test_guard_protect_retry_runs_after_cached_advisory_package_approval(


### PR DESCRIPTION
## Summary

- Bind package approval artifact hashes to supply-chain policy gate context (decision, bundle feed snapshot, matched advisories, and related metadata) so saved approvals cannot bypass later bundle or advisory blocks.
- Recompute protect merge behavior: cached advisory blocks still apply unless a saved approval matches the current gate hash.
- Add regression coverage for stale bundle approval bypass on unpinned package installs.

## Test plan

- [x] `python3 -m pytest tests/test_guard_package_shims.py -k "saved_approval or retry_runs_after" -q`
- [x] Existing approval-retry tests still pass
