### PR TITLE
fix(connect): treat unauthorized pending sync as reconnect required

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -1162,6 +1162,12 @@ def build_connect_status_payload(
         milestone = "first_sync_failed"
         reason = "Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again."
         recovery_command = CONNECT_COMMAND
+    elif not bool(oauth_storage_health.get("configured")) and status == "connected":
+        status = "retry_required"
+        milestone = "first_sync_failed"
+        if not isinstance(reason, str) or not reason.strip():
+            reason = "Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again."
+        recovery_command = CONNECT_COMMAND
     payload: dict[str, object] = {
         "status": status,
         "milestone": milestone,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -1189,6 +1189,8 @@ def build_connect_status_payload(
         payload["repair_message"] = "Run hol-guard connect to start OAuth Device Code approval."
     elif oauth_repair_required and cloud_profile is None:
         payload["repair_message"] = "Run hol-guard connect again to repair local Guard Cloud authorization."
+    elif not bool(oauth_storage_health.get("configured")) and payload["status"] == "retry_required":
+        payload["repair_message"] = "Run hol-guard connect again to repair local Guard Cloud authorization."
     return payload
 
 

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1420,6 +1420,9 @@ def _connect_reason_requires_login(reason: str) -> bool:
             "logged out",
             "login",
             "logout",
+            "unauthorized",
+            "401",
+            "reauthoriz",
         )
     )
 

--- a/src/codex_plugin_scanner/guard/insights_share.py
+++ b/src/codex_plugin_scanner/guard/insights_share.py
@@ -178,8 +178,10 @@ def publish_insights_share(
         _sync_http_error_message,
         _sync_url_error_message,
         _urlopen_json_with_timeout_retry,
+        prepare_guard_cloud_connect_authorization,
     )
 
+    prepare_guard_cloud_connect_authorization(store)
     analytics = store.receipt_analytics(activity_days=90, trend_days=7, top_limit=8)
     overview_stats = {
         "pending": store.count_approval_requests(),

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -122,6 +122,33 @@ def test_connect_repair_copy_points_to_device_code(tmp_path: Path) -> None:
     assert "guardPairSecret" not in rendered
 
 
+def test_connect_status_requires_retry_when_oauth_not_configured(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-11T22:11:11+00:00",
+        request_id="connect-401",
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="connected",
+        milestone="first_sync_pending",
+        now="2026-06-11T22:11:11+00:00",
+        reason="HTTP Error 401: Unauthorized",
+    )
+
+    payload = build_connect_status_payload(
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+        action="status",
+    )
+
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
+    assert payload["recovery_command"] == "hol-guard connect"
+
+
 def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
 

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -147,6 +147,7 @@ def test_connect_status_requires_retry_when_oauth_not_configured(tmp_path: Path)
     assert payload["status"] == "retry_required"
     assert payload["milestone"] == "first_sync_failed"
     assert payload["recovery_command"] == "hol-guard connect"
+    assert payload["repair_message"] == "Run hol-guard connect again to repair local Guard Cloud authorization."
 
 
 def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path) -> None:

--- a/tests/test_guard_render.py
+++ b/tests/test_guard_render.py
@@ -38,6 +38,27 @@ def test_guard_connect_render_clarifies_paid_plan_pending_state(capsys) -> None:
     assert "Upgrade to sync this device to Guard Cloud" in output
 
 
+def test_guard_connect_render_clarifies_unauthorized_pending_state(capsys) -> None:
+    emit_guard_payload(
+        "connect",
+        {
+            "connected": True,
+            "browser_opened": True,
+            "status": "connected",
+            "milestone": "first_sync_pending",
+            "reason": "HTTP Error 401: Unauthorized",
+            "completed_at": "2026-04-17T00:00:00Z",
+            "connect_url": "https://hol.org/guard/connect",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        },
+        False,
+    )
+
+    output = _normalize_render_output(capsys.readouterr().out)
+    assert "This device is protected locally" in output
+    assert "Sign in to finish Guard Cloud setup" in output
+
+
 def test_guard_render_redacts_sensitive_values_before_rich_renderer(monkeypatch) -> None:
     captured: dict[str, object] = {}
 


### PR DESCRIPTION
## Summary
- Treat 401/unauthorized first-sync failures as reconnect-required in connect status rendering
- Downgrade connect status to `retry_required` when OAuth credentials are not configured locally

## Testing
- `python3 -m pytest tests/test_guard_render.py::test_guard_connect_render_clarifies_unauthorized_pending_state tests/test_guard_connect_flow.py::test_connect_status_requires_retry_when_oauth_not_configured -q`

## Notes
- Local share publish E2E was blocked because connect status showed connected while OAuth credentials were missing (`HTTP Error 401: Unauthorized`).
