### PR TITLE
fix(guard): normalize AIBOM sync inventory payload contract fields

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -478,7 +478,7 @@ class HermesHarnessAdapter(HarnessAdapter):
                 "auth_header_keys": sorted(auth_header_keys),
                 "sampling_enabled": sampling_enabled,
                 "sampling_model": sampling_model,
-                "has_env_secrets": bool(env),
+                "envConfigurationPresent": bool(env),
                 "has_auth_headers": bool(auth_header_keys),
             }
 

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -36,28 +36,19 @@ InventoryItemKind = Literal[
 ]
 
 
-def _normalize_trust_resolution_captured_at(value: str) -> str:
-    from datetime import datetime, timezone
-
-    try:
-        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        parsed = parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed.astimezone(timezone.utc)
-        return parsed.isoformat().replace("+00:00", "Z")
-    except (ValueError, OverflowError, TypeError):
-        return value
-
-
 def trust_resolution_from_domain(
     domain: TrustDomainScore,
     *,
     captured_at: str,
 ) -> dict[str, object]:
+    from .inventory_contract import _normalize_inventory_datetime
+
     return {
         "resolutionSource": "local",
         "status": "local",
         "trustScore": round(domain.score),
         "trustComponents": _trust_components_from_domain(domain),
-        "capturedAt": _normalize_trust_resolution_captured_at(captured_at),
+        "capturedAt": _normalize_inventory_datetime(captured_at),
         "metadata": {
             "profileId": domain.profile_id,
             "profileVersion": domain.profile_version,

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -36,6 +36,17 @@ InventoryItemKind = Literal[
 ]
 
 
+def _normalize_trust_resolution_captured_at(value: str) -> str:
+    from datetime import datetime, timezone
+
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        parsed = parsed.replace(tzinfo=timezone.utc) if parsed.tzinfo is None else parsed.astimezone(timezone.utc)
+        return parsed.isoformat().replace("+00:00", "Z")
+    except (ValueError, OverflowError, TypeError):
+        return value
+
+
 def trust_resolution_from_domain(
     domain: TrustDomainScore,
     *,
@@ -46,7 +57,7 @@ def trust_resolution_from_domain(
         "status": "local",
         "trustScore": round(domain.score),
         "trustComponents": _trust_components_from_domain(domain),
-        "capturedAt": captured_at,
+        "capturedAt": _normalize_trust_resolution_captured_at(captured_at),
         "metadata": {
             "profileId": domain.profile_id,
             "profileVersion": domain.profile_version,

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -1063,13 +1063,13 @@ def _capabilities_for_artifact(
             capabilities.add("runs_shell")
     if artifact_type == "channel":
         capabilities.update({"reads_messages", "posts_messages", "network_ingress"})
-    if bool(metadata.get("has_env_secrets")) or bool(metadata.get("has_auth_headers")):
+    if bool(metadata.get("envConfigurationPresent")) or bool(metadata.get("has_auth_headers")):
         capabilities.add("reads_secrets")
     return tuple(sorted(capabilities)) if capabilities else ("unknown",)
 
 
 def _risk_level(metadata: dict[str, object]) -> InventorySeverity:
-    if metadata.get("has_auth_headers") or metadata.get("has_env_secrets"):
+    if metadata.get("has_auth_headers") or metadata.get("envConfigurationPresent"):
         return "high"
     if metadata.get("endpointHostClass") == "remote_public":
         return "medium"

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -6,8 +6,10 @@ import builtins
 import json
 from pathlib import Path
 
+from codex_plugin_scanner.guard.aibom_trust_metadata import trust_resolution_from_domain
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.trust_models import TrustDomainScore
 
 
 def _write_good_plugin(plugin_dir: Path) -> None:
@@ -30,6 +32,25 @@ def _write_good_plugin(plugin_dir: Path) -> None:
     (plugin_dir / "README.md").write_text("# Demo\n", encoding="utf-8")
     (plugin_dir / "SECURITY.md").write_text("Report issues privately.\n", encoding="utf-8")
     (plugin_dir / "LICENSE").write_text("MIT\n", encoding="utf-8")
+
+
+def test_trust_resolution_captured_at_uses_utc_z_suffix() -> None:
+    domain = TrustDomainScore(
+        domain="plugin",
+        profile_id="plugin-default",
+        profile_version="1",
+        score=42.0,
+        spec_id="hol-guard-trust",
+        spec_version="1",
+        adapters=(),
+    )
+
+    trust = trust_resolution_from_domain(
+        domain,
+        captured_at="2026-06-11T23:09:11.718707+00:00",
+    )
+
+    assert trust["capturedAt"] == "2026-06-11T23:09:11.718707Z"
 
 
 def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Path) -> None:
@@ -63,6 +84,7 @@ def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Pat
     assert isinstance(trust, dict)
     assert trust.get("resolutionSource") == "local"
     assert trust.get("status") == "local"
+    assert trust.get("capturedAt") == "2026-06-10T12:00:00Z"
     assert isinstance(trust.get("trustScore"), int)
     assert trust.get("trustScore", 0) > 0
     metadata = trust.get("metadata")

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from codex_plugin_scanner.guard.aibom_trust_metadata import trust_resolution_from_domain
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
-from codex_plugin_scanner.guard.trust_models import TrustDomainScore
+from codex_plugin_scanner.trust_models import TrustDomainScore
 
 
 def _write_good_plugin(plugin_dir: Path) -> None:
@@ -37,20 +37,23 @@ def _write_good_plugin(plugin_dir: Path) -> None:
 def test_trust_resolution_captured_at_uses_utc_z_suffix() -> None:
     domain = TrustDomainScore(
         domain="plugin",
+        label="Plugin",
+        spec_id="hol-guard-trust",
+        spec_version="1",
+        spec_path="trust/plugin.json",
+        derived_from=(),
         profile_id="plugin-default",
         profile_version="1",
         score=42.0,
-        spec_id="hol-guard-trust",
-        spec_version="1",
         adapters=(),
     )
 
     trust = trust_resolution_from_domain(
         domain,
-        captured_at="2026-06-11T23:09:11.718707+00:00",
+        captured_at="2026-06-11T18:09:11+05:30",
     )
 
-    assert trust["capturedAt"] == "2026-06-11T23:09:11.718707Z"
+    assert trust["capturedAt"] == "2026-06-11T12:39:11Z"
 
 
 def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Path) -> None:

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -116,7 +116,7 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
 
     assert payload["agentType"] == "hermes"
     assert {item["itemKind"] for item in payload["items"]} >= {"skill", "mcp_server"}
-    assert all(item["metadata"]["has_env_secrets"] is False for item in mcp_items)
+    assert all(item["metadata"]["envConfigurationPresent"] is False for item in mcp_items)
     assert all(item["metadata"]["has_auth_headers"] is True for item in mcp_items)
     assert "ghp_secretvalue" not in encoded
     assert "Bearer ghp_secretvalue" not in encoded


### PR DESCRIPTION
## Summary
- Normalize `trustResolution.capturedAt` to UTC `Z` timestamps so portal AIBOM metadata validation accepts local trust hints.
- Rename Hermes `has_env_secrets` metadata to `envConfigurationPresent` to satisfy portal inventory redaction field rules.

## Testing
- `python3 -m pytest tests/test_guard_aibom_trust_metadata.py tests/test_hermes_adapter.py -q`
