### PR TITLE
fix(guard): use platform-aware shell quoting for Kimi managed hooks

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shlex
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -35,6 +36,14 @@ def _json_payload(path: Path) -> dict[str, object]:
 
 def _command_available(command: str) -> bool:
     return shutil.which(command) is not None
+
+
+def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> str:
+    """Return a shell-escaped command string appropriate for the target OS."""
+    is_windows = os.name == "nt" if windows is None else windows
+    if is_windows:
+        return subprocess.list2cmdline(list(command))
+    return shlex.join(command)
 
 
 def _resolve_command(command: str, candidates: tuple[Path, ...] = ()) -> str | None:

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -4,9 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
-import shlex
-import subprocess
 import sys
 from collections.abc import Callable
 from pathlib import Path
@@ -18,7 +15,14 @@ from ..daemon import guard_daemon_url_for_home, load_guard_daemon_url
 from ..models import GuardArtifact, HarnessDetection
 from ..runtime.harness_attribution import cursor_hook_query_extras
 from ..shims import install_guard_shim, remove_guard_shim
-from .base import HarnessAdapter, HarnessContext, _ensure_path_within_root, _json_payload, _run_command_probe
+from .base import (
+    HarnessAdapter,
+    HarnessContext,
+    _ensure_path_within_root,
+    _json_payload,
+    _run_command_probe,
+    _shell_command,
+)
 
 CLAUDE_GUARD_TOOL_MATCHER = "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
 CLAUDE_GUARD_POST_TOOL_MATCHER = f"{CLAUDE_GUARD_TOOL_MATCHER}|AskUserQuestion"
@@ -46,13 +50,6 @@ def _guard_command_handler(
 
 def _claude_managed_settings_path(context: HarnessContext) -> Path:
     return context.home_dir / ".claude" / "settings.json"
-
-
-def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> str:
-    is_windows = os.name == "nt" if windows is None else windows
-    if is_windows:
-        return subprocess.list2cmdline(list(command))
-    return shlex.join(command)
 
 
 def _sync_runtime_hook_groups(hooks: dict[str, object], hook_command: str) -> None:
@@ -491,7 +488,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     @staticmethod
     def _hook_command(context: HarnessContext) -> str:
         command = ClaudeCodeHarnessAdapter._hook_command_parts(context)
-        return subprocess.list2cmdline(list(command))
+        return _shell_command(command, windows=True)
 
     @staticmethod
     def _daemon_hook_command(context: HarnessContext) -> str:
@@ -501,7 +498,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
     @staticmethod
     def _session_start_command(context: HarnessContext) -> str:
         command = ClaudeCodeHarnessAdapter._session_start_command_parts(context)
-        return subprocess.list2cmdline(list(command))
+        return _shell_command(command, windows=True)
 
     @staticmethod
     def _hook_http_url(context: HarnessContext) -> str:

--- a/src/codex_plugin_scanner/guard/adapters/kimi.py
+++ b/src/codex_plugin_scanner/guard/adapters/kimi.py
@@ -4,15 +4,20 @@ from __future__ import annotations
 
 import os
 import re
-import shlex
-import subprocess
 import sys
 from pathlib import Path
 
 from ..aibom_detection import extend_detection_with_workspace_aibom
 from ..models import GuardArtifact, HarnessDetection
 from ..shims import install_guard_shim, remove_guard_shim
-from .base import HarnessAdapter, HarnessContext, _command_available, _ensure_path_within_root, _json_payload
+from .base import (
+    HarnessAdapter,
+    HarnessContext,
+    _command_available,
+    _ensure_path_within_root,
+    _json_payload,
+    _shell_command,
+)
 
 try:
     import tomllib  # type: ignore[attr-defined]
@@ -24,14 +29,6 @@ _KIMI_HOME_ENV_VAR = "KIMI_CODE_HOME"
 _KIMI_DIR = ".kimi-code"
 _KIMI_CONFIG_FILE = "config.toml"
 _KIMI_MCP_FILE = "mcp.json"
-
-
-def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> str:
-    """Return a shell-escaped command string appropriate for the target OS."""
-    is_windows = os.name == "nt" if windows is None else windows
-    if is_windows:
-        return subprocess.list2cmdline(list(command))
-    return shlex.join(command)
 
 
 _GUARD_MANAGED_BEGIN = "# BEGIN HOL GUARD MANAGED HOOKS"

--- a/src/codex_plugin_scanner/guard/adapters/kimi.py
+++ b/src/codex_plugin_scanner/guard/adapters/kimi.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import os
 import re
 import shlex
+import subprocess
 import sys
 from pathlib import Path
 
@@ -23,6 +24,15 @@ _KIMI_HOME_ENV_VAR = "KIMI_CODE_HOME"
 _KIMI_DIR = ".kimi-code"
 _KIMI_CONFIG_FILE = "config.toml"
 _KIMI_MCP_FILE = "mcp.json"
+
+
+def _shell_command(command: tuple[str, ...], *, windows: bool | None = None) -> str:
+    """Return a shell-escaped command string appropriate for the target OS."""
+    is_windows = os.name == "nt" if windows is None else windows
+    if is_windows:
+        return subprocess.list2cmdline(list(command))
+    return shlex.join(command)
+
 
 _GUARD_MANAGED_BEGIN = "# BEGIN HOL GUARD MANAGED HOOKS"
 _GUARD_MANAGED_END = "# END HOL GUARD MANAGED HOOKS"
@@ -235,7 +245,7 @@ class KimiHarnessAdapter(HarnessAdapter):
         _ensure_path_within_root(context.home_dir, config_path, label="Kimi Code")
         config_path.parent.mkdir(parents=True, exist_ok=True)
 
-        hook_command = shlex.join(self._hook_command_parts(context))
+        hook_command = _shell_command(self._hook_command_parts(context))
         managed_block = self._build_managed_block(hook_command)
         existing_text = config_path.read_text(encoding="utf-8") if config_path.is_file() else ""
         cleaned_text = _remove_managed_block(existing_text)

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -8,6 +8,7 @@ try:
     import tomllib
 except ModuleNotFoundError:
     import tomli as tomllib
+import sys
 from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -80,12 +81,12 @@ class TestKimiDetectHooks:
         ctx = _ctx(tmp_path)
         _write_toml(
             ctx.home_dir / ".kimi-code" / "config.toml",
-            '''[[hooks]]
+            """[[hooks]]
 event = "PreToolUse"
 matcher = "Bash"
 command = "bash hook.sh"
 timeout = 10
-''',
+""",
         )
         result = KimiHarnessAdapter().detect(ctx)
         hook_artifacts = [a for a in result.artifacts if a.artifact_type == "hook"]
@@ -99,10 +100,10 @@ timeout = 10
         ctx = _ctx(tmp_path)
         _write_toml(
             ctx.home_dir / ".kimi-code" / "config.toml",
-            '''[[hooks]]
+            """[[hooks]]
 event = "UserPromptSubmit"
 command = "bash prompt-hook.sh"
-''',
+""",
         )
         result = KimiHarnessAdapter().detect(ctx)
         hook_artifacts = [a for a in result.artifacts if a.artifact_type == "hook"]
@@ -112,14 +113,14 @@ command = "bash prompt-hook.sh"
         ctx = _ctx(tmp_path)
         _write_toml(
             ctx.home_dir / ".kimi-code" / "config.toml",
-            '''[[hooks]]
+            """[[hooks]]
 event = "PreToolUse"
 command = "a.sh"
 
 [[hooks]]
 event = "PostToolUse"
 command = "b.sh"
-''',
+""",
         )
         result = KimiHarnessAdapter().detect(ctx)
         hook_ids = {a.artifact_id for a in result.artifacts if a.artifact_type == "hook"}
@@ -131,10 +132,10 @@ command = "b.sh"
         assert ctx.workspace_dir is not None
         _write_toml(
             ctx.workspace_dir / ".kimi-code" / "config.toml",
-            '''[[hooks]]
+            """[[hooks]]
 event = "PreToolUse"
 command = "ws.sh"
-''',
+""",
         )
         result = KimiHarnessAdapter().detect(ctx)
         assert any(a.source_scope == "project" for a in result.artifacts)
@@ -200,10 +201,10 @@ class TestKimiInstallUninstall:
         config_path = ctx.home_dir / ".kimi-code" / "config.toml"
         _write_toml(
             config_path,
-            '''[[hooks]]
+            """[[hooks]]
 event = "PostToolUse"
 command = "user-format.sh"
-''',
+""",
         )
         KimiHarnessAdapter().install(ctx)
         text = config_path.read_text(encoding="utf-8")
@@ -231,6 +232,41 @@ class TestKimiManagedBlock:
         assert len(hooks) == 5
         assert hooks[0]["command"] == command
         assert _toml_escape('a"b\\c') == 'a\\"b\\\\c'
+
+
+class TestKimiHookQuoting:
+    def test_shell_command_uses_posix_quoting_on_unix(self) -> None:
+        from codex_plugin_scanner.guard.adapters.kimi import _shell_command
+
+        cmd = _shell_command(("python", "-c", "echo hello & world"), windows=False)
+        assert cmd == "python -c 'echo hello & world'"
+
+    def test_shell_command_uses_windows_quoting_when_requested(self) -> None:
+        from codex_plugin_scanner.guard.adapters.kimi import _shell_command
+
+        cmd = _shell_command(("python", "-c", "echo hello & world"), windows=True)
+        assert cmd.startswith('python -c "')
+        assert "&" in cmd
+        assert "'" not in cmd
+
+    def test_windows_hook_command_quotes_metacharacters(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.adapters.kimi import _shell_command
+
+        workspace_dir = tmp_path / "workspace & tools"
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+        ctx = HarnessContext(
+            home_dir=tmp_path / "home",
+            workspace_dir=workspace_dir,
+            guard_home=tmp_path / "guard-home",
+        )
+        parts = KimiHarnessAdapter._hook_command_parts(ctx)
+        windows_cmd = _shell_command(parts, windows=True)
+        # The workspace path with '&' must live inside the quoted -c argument,
+        # not be exposed as a cmd.exe metacharacter. list2cmdline quotes the
+        # entire -c argument because it contains spaces.
+        assert windows_cmd.startswith(f'{sys.executable} -c "')
+        assert windows_cmd.endswith('"')
+        assert "workspace & tools" in windows_cmd
 
 
 class TestKimiLaunchCommand:

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -8,10 +8,9 @@ try:
     import tomllib
 except ModuleNotFoundError:
     import tomli as tomllib
-import sys
 from pathlib import Path
 
-from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.base import HarnessContext, _shell_command
 from codex_plugin_scanner.guard.adapters.kimi import KimiHarnessAdapter
 
 
@@ -236,22 +235,16 @@ class TestKimiManagedBlock:
 
 class TestKimiHookQuoting:
     def test_shell_command_uses_posix_quoting_on_unix(self) -> None:
-        from codex_plugin_scanner.guard.adapters.kimi import _shell_command
-
         cmd = _shell_command(("python", "-c", "echo hello & world"), windows=False)
         assert cmd == "python -c 'echo hello & world'"
 
     def test_shell_command_uses_windows_quoting_when_requested(self) -> None:
-        from codex_plugin_scanner.guard.adapters.kimi import _shell_command
-
         cmd = _shell_command(("python", "-c", "echo hello & world"), windows=True)
-        assert cmd.startswith('python -c "')
+        assert ' -c "' in cmd
         assert "&" in cmd
         assert "'" not in cmd
 
     def test_windows_hook_command_quotes_metacharacters(self, tmp_path: Path) -> None:
-        from codex_plugin_scanner.guard.adapters.kimi import _shell_command
-
         workspace_dir = tmp_path / "workspace & tools"
         workspace_dir.mkdir(parents=True, exist_ok=True)
         ctx = HarnessContext(
@@ -264,7 +257,7 @@ class TestKimiHookQuoting:
         # The workspace path with '&' must live inside the quoted -c argument,
         # not be exposed as a cmd.exe metacharacter. list2cmdline quotes the
         # entire -c argument because it contains spaces.
-        assert windows_cmd.startswith(f'{sys.executable} -c "')
+        assert ' -c "' in windows_cmd
         assert windows_cmd.endswith('"')
         assert "workspace & tools" in windows_cmd
 


### PR DESCRIPTION
## Summary
- Fix a Windows command-injection risk in the Kimi harness managed hook command.
- The Kimi adapter now uses `subprocess.list2cmdline()` on Windows and `shlex.join()` on POSIX when serializing the inline Python hook invocation, matching the quoting strategy used by the Claude and Copilot adapters.
- Added regression tests for POSIX and Windows quoting, including a workspace path containing `&`.

## Testing
- `python3 -m pytest tests/test_kimi_adapter.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/kimi.py tests/test_kimi_adapter.py`
- `python3 -m ruff format src/codex_plugin_scanner/guard/adapters/kimi.py tests/test_kimi_adapter.py`
