### PR TITLE
feat(guard): accept remote once approvals

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1214,6 +1214,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/policy/sync":
             self._handle_headless_policy_sync(payload)
             return
+        if parsed.path == "/v1/requests/remote-once":
+            self._handle_headless_remote_once(payload)
+            return
         if parsed.path == "/v1/settings":
             self._handle_settings_update(payload)
             return
@@ -1822,6 +1825,111 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             }
         )
 
+    def _handle_headless_remote_once(self, payload: dict[str, object]) -> None:
+        harness = self._optional_string(payload.get("harness"))
+        if harness is None:
+            self._write_json({"error": "missing_harness"}, status=400)
+            return
+        try:
+            adapter = get_adapter(harness)
+        except ValueError:
+            self._write_json({"error": "unknown_harness"}, status=404)
+            return
+        remote_once = self._policy_memory_payload(payload.get("remote_once") or payload.get("remoteOnce"))
+        request_id = self._coalesce_string(remote_once, "request_id", "requestId")
+        request_last_seen_at = self._coalesce_string(remote_once, "request_last_seen_at", "requestLastSeenAt")
+        receipt_id = self._coalesce_string(remote_once, "receipt_id", "receiptId")
+        if request_id is None or request_last_seen_at is None or receipt_id is None:
+            self._write_json({"error": "missing_remote_once_fields"}, status=400)
+            return
+        if self._remote_once_receipt_replayed(receipt_id):
+            self._write_json({"error": "remote_once_replayed"}, status=409)
+            return
+        request_row = self.server.store.get_approval_request(request_id)  # type: ignore[attr-defined]
+        if not isinstance(request_row, dict) or request_row.get("status") != "pending":
+            self._write_json({"error": "remote_once_request_expired"}, status=409)
+            return
+        request_policy_action = self._optional_string(request_row.get("policy_action"))
+        request_recommended_scope = self._optional_string(request_row.get("recommended_scope"))
+        if request_policy_action not in {"review", "require-reapproval"} or request_recommended_scope != "artifact":
+            self._write_json({"error": "remote_once_not_permitted"}, status=409)
+            return
+        if self._optional_string(request_row.get("last_seen_at")) != request_last_seen_at:
+            self._write_json({"error": "remote_once_request_stale"}, status=409)
+            return
+        if not self.server.store.claim_remote_once_receipt(  # type: ignore[attr-defined]
+            receipt_id,
+            request_id=request_id,
+            claimed_at=_now(),
+        ):
+            self._write_json({"error": "remote_once_replayed"}, status=409)
+            return
+        try:
+            result = apply_approval_resolution(
+                store=self.server.store,  # type: ignore[attr-defined]
+                request_id=request_id,
+                action="allow",
+                scope="artifact",
+                workspace=self._optional_string(request_row.get("workspace")),
+                reason=self._optional_string(remote_once.get("reason")) or "Guard Cloud remote once approval",
+                return_queue_result=True,
+                resolve_scope_matches=False,
+                approval_gate_input=approval_gate_input_from_mapping(payload),
+            )
+        except ApprovalRequestNotFoundError:
+            self.server.store.release_remote_once_receipt(receipt_id)  # type: ignore[attr-defined]
+            self._write_json({"error": "remote_once_request_expired"}, status=409)
+            return
+        except ApprovalRequestAlreadyResolvedError:
+            self.server.store.release_remote_once_receipt(receipt_id)  # type: ignore[attr-defined]
+            self._write_json({"error": "remote_once_request_expired"}, status=409)
+            return
+        except ApprovalGateError as error:
+            self._write_approval_gate_error(error)
+            return
+        except ValueError as error:
+            self._write_json({"error": str(error)}, status=400)
+            return
+        if result.get("resolved") is not True:
+            self._write_json({"error": "remote_once_apply_failed"}, status=409)
+            return
+        resolved_request = result.get("resolved_request") if isinstance(result.get("resolved_request"), dict) else {}
+        resolved_at = self._optional_string(resolved_request.get("resolved_at")) or _now()
+        self.server.store.add_event(  # type: ignore[attr-defined]
+            "approval.remote_once_applied",
+            {
+                "approval_url": self._optional_string(resolved_request.get("approval_url")),
+                "receipt_id": receipt_id,
+                "request_id": request_id,
+                "review_command": self._optional_string(resolved_request.get("review_command")),
+                "scope": "artifact",
+            },
+            resolved_at,
+        )
+        artifact_name = self._optional_string(request_row.get("artifact_name")) or request_id
+        receipt = self._record_headless_receipt(
+            harness=adapter.harness,
+            operation="remote_once",
+            payload=payload,
+            result=result,
+            workspace_id=self._optional_string(request_row.get("workspace")),
+            artifact_name=f"Remote once approval for {artifact_name}",
+            scanner_evidence_extra={
+                "receipt_id": receipt_id,
+                "request_id": request_id,
+            },
+        )
+        self._write_json(
+            {
+                "harness": adapter.harness,
+                "operation": "remote_once",
+                "receipt": receipt,
+                "request_id": request_id,
+                "resolved_request": resolved_request,
+                "status": "completed",
+            }
+        )
+
     def _handle_audit_remediation(self, action: str, payload: dict[str, object]) -> None:
         if action != "package_shim_path":
             self._write_json({"error": "unsupported_remediation", "operation": action}, status=404)
@@ -2293,6 +2401,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 return {}
             return parsed if isinstance(parsed, dict) else {}
         return {}
+
+    def _remote_once_receipt_replayed(self, receipt_id: str) -> bool:
+        return self.server.store.has_remote_once_receipt(receipt_id)  # type: ignore[attr-defined]
 
     def _record_headless_receipt(
         self,
@@ -3420,6 +3531,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/operations/start",
             "/v1/operations/block",
             "/v1/requests/clear",
+            "/v1/requests/remote-once",
             "/v1/settings/import",
             "/v1/settings/reset",
             "/v1/policy/clear",
@@ -3691,6 +3803,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/receipts/latest",
             "/v1/requests",
             "/v1/requests/clear",
+            "/v1/requests/remote-once",
             "/v1/runtime",
             "/v1/settings",
             "/v1/settings/export",
@@ -3885,6 +3998,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return value.strip()
         return None
 
+    def _coalesce_string(self, mapping: dict[str, object], *keys: str) -> str | None:
+        for key in keys:
+            value = self._optional_string(mapping.get(key))
+            if value is not None:
+                return value
+        return None
+
     @staticmethod
     def _query_string(query_string: str, key: str) -> str | None:
         value = parse_qs(query_string).get(key, [None])[-1]
@@ -4055,6 +4175,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/policy/clear",
             "/v1/policy/sync",
             "/v1/requests/clear",
+            "/v1/requests/remote-once",
             "/v1/settings",
             "/v1/settings/import",
             "/v1/settings/reset",

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1110,6 +1110,13 @@ class GuardStore:
             )
             """,
             """
+            create table if not exists guard_remote_once_receipts (
+              receipt_id text primary key,
+              request_id text not null,
+              claimed_at text not null
+            )
+            """,
+            """
             create table if not exists guard_cloud_events (
               event_id text primary key,
               idempotency_key text not null unique,
@@ -3472,6 +3479,42 @@ class GuardStore:
                 """,
                 (event_name, json.dumps(payload), now),
             )
+
+    def claim_remote_once_receipt(
+        self,
+        receipt_id: str,
+        *,
+        request_id: str,
+        claimed_at: str,
+    ) -> bool:
+        with self._connect() as connection:
+            connection.execute("begin immediate")
+            try:
+                connection.execute(
+                    """
+                    insert into guard_remote_once_receipts (receipt_id, request_id, claimed_at)
+                    values (?, ?, ?)
+                    """,
+                    (receipt_id, request_id, claimed_at),
+                )
+            except sqlite3.IntegrityError:
+                return False
+            return True
+
+    def release_remote_once_receipt(self, receipt_id: str) -> None:
+        with self._connect() as connection:
+            connection.execute(
+                "delete from guard_remote_once_receipts where receipt_id = ?",
+                (receipt_id,),
+            )
+
+    def has_remote_once_receipt(self, receipt_id: str) -> bool:
+        with self._connect() as connection:
+            row = connection.execute(
+                "select 1 from guard_remote_once_receipts where receipt_id = ?",
+                (receipt_id,),
+            ).fetchone()
+        return row is not None
 
     def list_events(self, limit: int = 100, event_name: str | None = None) -> list[dict[str, object]]:
         query = """

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -17,6 +17,7 @@ import pytest
 
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.approval_gate import ApprovalGateError
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.cli.connect_flow import GuardOAuthTokenExchangeResult
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -24,6 +25,7 @@ from codex_plugin_scanner.guard.daemon import server as daemon_server
 from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_token
 from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
 from codex_plugin_scanner.guard.local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
@@ -122,6 +124,37 @@ def _dashboard_token_with_claims(auth_token: str, claims: dict[str, object]) -> 
     signature = hmac.new(auth_token.encode("utf-8"), payload.encode("utf-8"), hashlib.sha256).digest()
     encoded_signature = base64.urlsafe_b64encode(signature).decode("ascii").rstrip("=")
     return f"gld1.{payload}.{encoded_signature}"
+
+
+def _remote_once_request(
+    request_id: str,
+    *,
+    policy_action: str = "require-reapproval",
+    recommended_scope: str = "artifact",
+) -> GuardApprovalRequest:
+    return GuardApprovalRequest(
+        request_id=request_id,
+        harness="codex",
+        artifact_id=f"codex:project:{request_id}",
+        artifact_name="Remote once request",
+        artifact_type="tool_action_request",
+        artifact_hash=f"hash-{request_id}",
+        publisher=None,
+        policy_action=policy_action,
+        recommended_scope=recommended_scope,
+        changed_fields=("shell_command",),
+        source_scope="project",
+        config_path="/workspace/repo/.guard/config.toml",
+        workspace="/workspace/repo",
+        launch_target="cat /workspace/repo/.npmrc",
+        review_command=f"hol-guard approvals approve {request_id}",
+        approval_url=f"http://127.0.0.1:5474/approvals/{request_id}",
+        action_envelope_json={
+            "action_type": "shell_command",
+            "command": "cat /workspace/repo/.npmrc",
+            "tool_name": "Bash",
+        },
+    )
 
 
 def _dashboard_token_for(store: GuardStore) -> str:
@@ -1853,6 +1886,287 @@ def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> No
     assert bad_payload["status"] == "failed"
     assert bad_payload["error"]["code"] == "unknown_harness"
     assert bad_payload["error"]["retryable"] is False
+
+
+def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = _remote_once_request("req-remote-once")
+    store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remote_once": json.dumps(
+                        {
+                            "receipt_id": "cloud-receipt-1",
+                            "request_id": "req-remote-once",
+                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
+                            "request_policy_action": "require-reapproval",
+                            "request_recommended_scope": "artifact",
+                        }
+                    ),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["operation"] == "remote_once"
+    assert payload["status"] == "completed"
+    assert payload["resolved_request"]["request_id"] == "req-remote-once"
+    assert payload["resolved_request"]["resolution_scope"] == "artifact"
+    events = store.list_events(limit=5, event_name="approval.remote_once_applied")
+    assert events[0]["payload"]["receipt_id"] == "cloud-receipt-1"
+
+
+def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = _remote_once_request("req-remote-replay")
+    store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        stale_status, stale_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remote_once": json.dumps(
+                        {
+                            "receipt_id": "cloud-receipt-stale",
+                            "request_id": "req-remote-replay",
+                            "request_last_seen_at": "2026-05-14T11:58:00+00:00",
+                            "request_policy_action": "require-reapproval",
+                            "request_recommended_scope": "artifact",
+                        }
+                    ),
+                },
+            ),
+        )
+        first_status, _first_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remote_once": json.dumps(
+                        {
+                            "receipt_id": "cloud-receipt-replay",
+                            "request_id": "req-remote-replay",
+                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
+                            "request_policy_action": "require-reapproval",
+                            "request_recommended_scope": "artifact",
+                        }
+                    ),
+                },
+            ),
+        )
+        replay_status, replay_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remote_once": json.dumps(
+                        {
+                            "receipt_id": "cloud-receipt-replay",
+                            "request_id": "req-remote-replay",
+                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
+                            "request_policy_action": "require-reapproval",
+                            "request_recommended_scope": "artifact",
+                        }
+                    ),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert stale_status == 409
+    assert stale_payload["error"] == "remote_once_request_stale"
+    assert first_status == 200
+    assert replay_status == 409
+    assert replay_payload["error"] == "remote_once_replayed"
+
+
+def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = _remote_once_request(
+        "req-remote-spoof",
+        policy_action="block",
+        recommended_scope="workspace",
+    )
+    store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remote_once": json.dumps(
+                        {
+                            "receipt_id": "cloud-receipt-spoof",
+                            "request_id": "req-remote-spoof",
+                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
+                            "request_policy_action": "require-reapproval",
+                            "request_recommended_scope": "artifact",
+                        }
+                    ),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 409
+    assert payload["error"] == "remote_once_not_permitted"
+
+
+def test_headless_remote_once_keeps_claimed_receipts_consumed_after_gate_rejection(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = _remote_once_request("req-remote-gate")
+    store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        daemon_server,
+        "apply_approval_resolution",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            ApprovalGateError(
+                "approval_gate_interactive_required",
+                "Approval password is required from an interactive terminal.",
+            )
+        ),
+    )
+    try:
+        token = _dashboard_token_for(store)
+        first_status, first_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remote_once": json.dumps(
+                        {
+                            "receipt_id": "cloud-receipt-gate",
+                            "request_id": "req-remote-gate",
+                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
+                            "request_policy_action": "require-reapproval",
+                            "request_recommended_scope": "artifact",
+                        }
+                    ),
+                },
+            ),
+        )
+        second_status, second_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload={
+                    "harness": "codex",
+                    "operation": "remote_once",
+                    "remote_once": json.dumps(
+                        {
+                            "receipt_id": "cloud-receipt-gate",
+                            "request_id": "req-remote-gate",
+                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
+                            "request_policy_action": "require-reapproval",
+                            "request_recommended_scope": "artifact",
+                        }
+                    ),
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert first_status == 403
+    assert first_payload["error"] == "approval_gate_interactive_required"
+    assert second_status == 409
+    assert second_payload["error"] == "remote_once_replayed"
+
+
+def test_headless_remote_once_keeps_claimed_receipts_consumed_after_apply_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request = _remote_once_request("req-remote-unresolved")
+    store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    monkeypatch.setattr(
+        daemon_server,
+        "apply_approval_resolution",
+        lambda **_kwargs: {"resolved": False, "error": "unexpected"},
+    )
+    try:
+        token = _dashboard_token_for(store)
+        payload = {
+            "harness": "codex",
+            "operation": "remote_once",
+            "remote_once": json.dumps(
+                {
+                    "receipt_id": "cloud-receipt-unresolved",
+                    "request_id": "req-remote-unresolved",
+                    "request_last_seen_at": "2026-05-14T11:59:00+00:00",
+                    "request_policy_action": "require-reapproval",
+                    "request_recommended_scope": "artifact",
+                }
+            ),
+        }
+        first_status, first_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload=payload,
+            ),
+        )
+        second_status, second_payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/requests/remote-once",
+                token=token,
+                payload=payload,
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert first_status == 409
+    assert first_payload["error"] == "remote_once_apply_failed"
+    assert second_status == 409
+    assert second_payload["error"] == "remote_once_replayed"
 
 
 def test_headless_api_rejects_forged_dashboard_session_token(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add a signed `/v1/requests/remote-once` daemon path that applies a one-time remote approval to an active local request
- reject replayed, stale, expired, and unsupported dangerous remote-once payloads while reusing the existing approval-resolution and headless receipt flow
- extend daemon API tests for remote-once success, stale rejection, replay rejection, and regression coverage for policy sync persistence

## Testing
- `pytest -q tests/test_guard_headless_daemon_api.py -k 'remote_once or headless_policy_sync_persists_policy_and_receipt'`

## Notes
- canonical `hol-guard` checkout had unrelated CLI edits, so Phase 3 work stayed isolated from those files and did not modify them
