### PR TITLE
fix(guard): restore Kimi hook blocking and stop persisting remote-once approvals

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/kimi_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/kimi_hooks.py
@@ -1,0 +1,25 @@
+"""Helpers for Kimi Code CLI hook payloads."""
+
+from __future__ import annotations
+
+
+def normalize_kimi_prompt(value: object | None) -> object | None:
+    """Flatten Kimi Code's ContentPart[] prompt into a single string.
+
+    Returns the original value unchanged if it is not a string or a list of
+    text-bearing content parts, so image-only or non-standard payloads are not
+    silently replaced with ``None``.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if not isinstance(value, list):
+        return value
+    parts: list[str] = []
+    for item in value:
+        if isinstance(item, dict):
+            text = item.get("text")
+            if isinstance(text, str):
+                parts.append(text)
+    return "\n".join(parts) if parts else value

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -255,6 +255,7 @@ def apply_approval_resolution(
     return_queue_result: bool = False,
     resolve_scope_matches: bool = True,
     approval_gate_input: ApprovalGateInput | None = None,
+    persist_policy: bool = True,
 ) -> dict[str, object]:
     request = store.get_approval_request(request_id)
     if request is None:
@@ -289,7 +290,8 @@ def apply_approval_resolution(
         approval_gate_input=approval_gate_input,
         now=resolved_at,
     )
-    store.upsert_policy(decision, resolved_at, approval_gate_grant=approval_gate_grant)
+    if persist_policy:
+        store.upsert_policy(decision, resolved_at, approval_gate_grant=approval_gate_grant)
     resolution_harness = None if scope == "global" else str(request["harness"])
     if return_queue_result:
         result = store.resolve_request_with_queue_result(

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -38,11 +38,15 @@ def _run_guard_hook_command(
         args.harness = runtime_harness.strip()
     else:
         args.harness = resolve_runtime_hook_harness(args.harness)
-    payload = _load_hook_payload(getattr(args, "event_file", None), input_text=input_text)
+    payload = _load_hook_payload(
+        getattr(args, "event_file", None),
+        input_text=input_text,
+        harness=args.harness,
+    )
     if _canonical_harness_name(args.harness) == "cursor":
         from ..adapters.cursor_hooks import prepare_cursor_hook_payload
 
-        payload = _normalize_hook_payload(prepare_cursor_hook_payload(payload))
+        payload = _normalize_hook_payload(prepare_cursor_hook_payload(payload), harness=args.harness)
     managed_install = _managed_install_for(store, args.harness)
     workspace_was_explicit = workspace is not None
     runtime_workspace = workspace

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -136,13 +136,21 @@ def _run_hook_generic_payload(
     )
     approval_context = _native_approval_center_context(payload, harness=args.harness)
     if _should_emit_native_hook_exit_block(args, event_name=hook_event_name, policy_action=policy_action):
-        _emit_native_hook_block_stderr(
-            _native_hook_reason_for_harness(
-                args.harness,
-                incoming_reason,
-                approval_context,
-            )
+        block_reason = _native_hook_reason_for_harness(
+            args.harness,
+            incoming_reason,
+            approval_context,
         )
+        if _canonical_harness_name(args.harness) == "kimi":
+            _emit_native_hook_response(
+                harness=args.harness,
+                policy_action=policy_action,
+                event_name=hook_event_name,
+                reason=block_reason,
+                output_stream=output_stream,
+            )
+        else:
+            _emit_native_hook_block_stderr(block_reason)
         return 2
     if _canonical_harness_name(args.harness) == "codex" and (
         hook_event_name == "UserPromptSubmit" or approval_context is not None

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
@@ -79,7 +79,16 @@ def _finalize_runtime_artifact_hook(
                 raw_runtime_reason,
                 approval_context,
             )
-        _emit_native_hook_block_stderr(native_block_reason)
+        if _canonical_harness_name(args.harness) == "kimi":
+            _emit_native_hook_response(
+                harness=args.harness,
+                policy_action=policy_action,
+                event_name=event_name,
+                reason=native_block_reason,
+                output_stream=output_stream,
+            )
+        else:
+            _emit_native_hook_block_stderr(native_block_reason)
         _record_harness_usage_for_hook(
             store=store,
             action_envelope=action_envelope,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
@@ -112,13 +112,14 @@ def _emit_native_hook_notification_stderr(reason: str) -> None:
     print(reason, file=sys.stderr)
 
 def _native_hook_permission_decision(policy_action: str, *, harness: str) -> str | None:
+    canonical = _canonical_harness_name(harness)
     if policy_action in {"block", "sandbox-required"}:
         return "deny"
     if policy_action == "require-reapproval":
-        if harness == "codex":
+        if canonical in {"codex", "kimi"}:
             return "deny"
         return "ask"
-    if harness == "codex":
+    if canonical == "codex":
         return None
     return "allow"
 
@@ -352,15 +353,20 @@ def _approval_surface_policy_for_flow(config_policy: str, approval_flow: dict[st
         return "never-auto-open"
     return config_policy
 
-def _load_hook_payload(event_file: str | None, *, input_text: str | None = None) -> dict[str, object]:
+def _load_hook_payload(
+    event_file: str | None,
+    *,
+    input_text: str | None = None,
+    harness: str | None = None,
+) -> dict[str, object]:
     if event_file:
         payload = json.loads(Path(event_file).read_text(encoding="utf-8"))
-        return _normalize_hook_payload(payload) if isinstance(payload, dict) else {}
+        return _normalize_hook_payload(payload, harness=harness) if isinstance(payload, dict) else {}
     raw = input_text.strip() if isinstance(input_text, str) else sys.stdin.read().strip()
     if not raw:
         return {}
     payload = json.loads(raw)
-    return _normalize_hook_payload(payload) if isinstance(payload, dict) else {}
+    return _normalize_hook_payload(payload, harness=harness) if isinstance(payload, dict) else {}
 
 _ACTION_ENVELOPE_HARNESSES = frozenset(
     {"codex", "claude-code", "opencode", "copilot", "gemini", "hermes", "openclaw", "cursor"}
@@ -387,7 +393,11 @@ def _hook_action_envelope(
 def _action_envelope_json(envelope: GuardActionEnvelope | None) -> dict[str, object] | None:
     return envelope.to_dict() if envelope is not None else None
 
-def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
+def _normalize_hook_payload(
+    payload: dict[str, object],
+    *,
+    harness: str | None = None,
+) -> dict[str, object]:
     normalized = dict(payload)
     for source_key, target_key in (
         ("artifactId", "artifact_id"),
@@ -421,7 +431,26 @@ def _normalize_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     if arguments is not None:
         normalized["tool_input"] = arguments
         normalized["arguments"] = arguments
+    if harness is not None and _canonical_harness_name(harness) == "kimi":
+        normalized["prompt"] = _normalize_kimi_prompt(normalized.get("prompt"))
     return normalized
+
+
+def _normalize_kimi_prompt(value: object | None) -> str | None:
+    """Flatten Kimi Code's ContentPart[] prompt into a single string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        parts: list[str] = []
+        for item in value:
+            if isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts) if parts else None
+    return None
 
 def _normalize_hook_arguments(*values: object | None) -> object | None:
     for value in values:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ._commands_shared import *
 from .commands_parser_helpers import *
+from ..adapters.kimi_hooks import normalize_kimi_prompt
 
 def _emit_native_hook_response(
     *,
@@ -432,25 +433,8 @@ def _normalize_hook_payload(
         normalized["tool_input"] = arguments
         normalized["arguments"] = arguments
     if harness is not None and _canonical_harness_name(harness) == "kimi":
-        normalized["prompt"] = _normalize_kimi_prompt(normalized.get("prompt"))
+        normalized["prompt"] = normalize_kimi_prompt(normalized.get("prompt"))
     return normalized
-
-
-def _normalize_kimi_prompt(value: object | None) -> str | None:
-    """Flatten Kimi Code's ContentPart[] prompt into a single string."""
-    if value is None:
-        return None
-    if isinstance(value, str):
-        return value
-    if isinstance(value, list):
-        parts: list[str] = []
-        for item in value:
-            if isinstance(item, dict):
-                text = item.get("text")
-                if isinstance(text, str):
-                    parts.append(text)
-        return "\n".join(parts) if parts else None
-    return None
 
 def _normalize_hook_arguments(*values: object | None) -> object | None:
     for value in values:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -247,7 +247,10 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
     return args.harness == "copilot" and not getattr(args, "json", False)
 
 def _should_emit_native_hook_response(args: argparse.Namespace) -> bool:
-    return _canonical_harness_name(args.harness) in {"claude-code", "codex"} and not getattr(args, "json", False)
+    return (
+        _canonical_harness_name(args.harness) in {"claude-code", "codex", "kimi"}
+        and not getattr(args, "json", False)
+    )
 
 def _should_emit_claude_native_pretooluse_notice(
     args: argparse.Namespace,
@@ -282,9 +285,11 @@ def _should_emit_native_hook_json_response(
     )
 
 def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name: str, policy_action: str) -> bool:
-    del args, event_name, policy_action
     # Codex v0.133 logs non-zero PreToolUse hooks as failed but still executes
     # the tool. Blocking must be communicated through the JSON hook response.
+    canonical = _canonical_harness_name(args.harness)
+    if canonical == "kimi" and event_name in {"PreToolUse", "UserPromptSubmit"}:
+        return policy_action in {"block", "sandbox-required", "require-reapproval"}
     return False
 
 def _codex_browser_approval_decision(

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -1187,9 +1187,10 @@ def build_connect_status_payload(
     if action in {"repair", "re-pair"}:
         payload["repair_action"] = "rerun_connect"
         payload["repair_message"] = "Run hol-guard connect to start OAuth Device Code approval."
-    elif oauth_repair_required and cloud_profile is None:
-        payload["repair_message"] = "Run hol-guard connect again to repair local Guard Cloud authorization."
-    elif not bool(oauth_storage_health.get("configured")) and payload["status"] == "retry_required":
+    elif (
+        (oauth_repair_required and cloud_profile is None)
+        or (not bool(oauth_storage_health.get("configured")) and payload["status"] == "retry_required")
+    ):
         payload["repair_message"] = "Run hol-guard connect again to repair local Guard Cloud authorization."
     return payload
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1875,6 +1875,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 return_queue_result=True,
                 resolve_scope_matches=False,
                 approval_gate_input=approval_gate_input_from_mapping(payload),
+                persist_policy=False,
             )
         except ApprovalRequestNotFoundError:
             self.server.store.release_remote_once_receipt(receipt_id)  # type: ignore[attr-defined]

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -1926,6 +1926,14 @@ def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_pa
     assert payload["resolved_request"]["resolution_scope"] == "artifact"
     events = store.list_events(limit=5, event_name="approval.remote_once_applied")
     assert events[0]["payload"]["receipt_id"] == "cloud-receipt-1"
+    # Remote-once must resolve the queued request without persisting an artifact policy.
+    persisted_action = store.resolve_policy(
+        "codex",
+        request.artifact_id,
+        artifact_hash=request.artifact_hash,
+        workspace=request.workspace,
+    )
+    assert persisted_action is None
 
 
 def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path) -> None:

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import json
 
 try:
@@ -268,3 +269,60 @@ class TestKimiLaunchCommand:
         command = KimiHarnessAdapter().launch_command(ctx, ["--version"])
         assert "kimi" in command[0]
         assert "--version" in command
+
+
+class TestKimiNativeHookBlocking:
+    def test_kimi_emits_native_hook_response(self) -> None:
+        from codex_plugin_scanner.guard.cli.commands_support_interaction import (
+            _should_emit_native_hook_response,
+        )
+
+        args = argparse.Namespace(harness="kimi", json=False)
+        assert _should_emit_native_hook_response(args) is True
+
+    def test_kimi_exit_block_on_blocking_actions(self) -> None:
+        from codex_plugin_scanner.guard.cli.commands_support_interaction import (
+            _should_emit_native_hook_exit_block,
+        )
+
+        args = argparse.Namespace(harness="kimi", json=False)
+        assert _should_emit_native_hook_exit_block(args, event_name="PreToolUse", policy_action="block") is True
+        assert (
+            _should_emit_native_hook_exit_block(args, event_name="UserPromptSubmit", policy_action="sandbox-required")
+            is True
+        )
+        assert _should_emit_native_hook_exit_block(args, event_name="PreToolUse", policy_action="allow") is False
+        assert _should_emit_native_hook_exit_block(args, event_name="SessionStart", policy_action="block") is False
+
+    def test_kimi_permission_decision_is_deny_for_blocking(self) -> None:
+        from codex_plugin_scanner.guard.cli.commands_support_hook_payload import (
+            _native_hook_permission_decision,
+        )
+
+        assert _native_hook_permission_decision("block", harness="kimi") == "deny"
+        assert _native_hook_permission_decision("sandbox-required", harness="kimi") == "deny"
+        assert _native_hook_permission_decision("require-reapproval", harness="kimi") == "deny"
+        assert _native_hook_permission_decision("allow", harness="kimi") == "allow"
+
+    def test_normalize_hook_payload_flattens_kimi_content_parts(self) -> None:
+        from codex_plugin_scanner.guard.cli.commands_support_hook_payload import (
+            _normalize_hook_payload,
+        )
+
+        payload = {
+            "prompt": [
+                {"role": "user", "text": "Hello"},
+                {"role": "user", "text": "World"},
+            ],
+        }
+        normalized = _normalize_hook_payload(payload, harness="kimi")
+        assert normalized["prompt"] == "Hello\nWorld"
+
+    def test_normalize_hook_payload_leaves_other_harnesses_untouched(self) -> None:
+        from codex_plugin_scanner.guard.cli.commands_support_hook_payload import (
+            _normalize_hook_payload,
+        )
+
+        payload = {"prompt": [{"text": "Hello"}]}
+        normalized = _normalize_hook_payload(payload, harness="codex")
+        assert normalized["prompt"] == [{"text": "Hello"}]

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -326,3 +326,11 @@ class TestKimiNativeHookBlocking:
         payload = {"prompt": [{"text": "Hello"}]}
         normalized = _normalize_hook_payload(payload, harness="codex")
         assert normalized["prompt"] == [{"text": "Hello"}]
+
+    def test_normalize_kimi_prompt_preserves_non_text_payloads(self) -> None:
+        from codex_plugin_scanner.guard.adapters.kimi_hooks import normalize_kimi_prompt
+
+        image_only = [{"image_url": "https://example.com/img.png"}]
+        assert normalize_kimi_prompt(image_only) is image_only
+        assert normalize_kimi_prompt("plain text") == "plain text"
+        assert normalize_kimi_prompt(None) is None


### PR DESCRIPTION
## Summary
- Restore Kimi native hook blocking that was dropped during the CLI facade refactor.
  - Kimi is now included in native hook response and exit-block predicates.
  - Kimi blocking `PreToolUse` and `UserPromptSubmit` hooks emit the deny JSON response and return exit code 2.
  - Kimi `require-reapproval` resolves to `permissionDecision: deny` so the harness blocks instead of prompting.
- Restore Kimi `ContentPart[]` prompt flattening in hook payload normalization by passing the harness into `_normalize_hook_payload`.
- Fix remote-once approvals so they resolve the queued request without persisting an artifact-scoped allow policy.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_kimi_adapter.py tests/test_guard_headless_daemon_api.py tests/test_guard_claude_adapter.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_support_interaction.py src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py src/codex_plugin_scanner/guard/cli/commands_hook.py src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py src/codex_plugin_scanner/guard/cli/commands_hook_generic.py src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_kimi_adapter.py tests/test_guard_headless_daemon_api.py`
