### PR TITLE
fix(guard): serialize first cloud sync

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -253,7 +253,7 @@ def _finalize_guard_connect_payload(
             }
         )
         return payload
-    except RuntimeError as error:
+    except (RuntimeError, TimeoutError) as error:
         repair_message = (
             "Guard Cloud pairing finished, but the first proof sync is still pending. "
             "Local Guard will retry automatically while the daemon is running, or run hol-guard sync now."

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -164,7 +164,8 @@ def _finalize_guard_connect_payload(
     payload: dict[str, object],
     now: str,
 ) -> dict[str, object]:
-    payload.pop(CONNECT_SYNC_AUTH_CONTEXT_KEY, None)
+    sync_auth_context = payload.pop(CONNECT_SYNC_AUTH_CONTEXT_KEY, None)
+    resolved_sync_auth_context = sync_auth_context if isinstance(sync_auth_context, dict) else None
     urls = _guard_cloud_urls_for_connect(connect_url)
     for key in ("connect_url", "sync_url", "dashboard_url", "inbox_url", "fleet_url"):
         payload.setdefault(key, urls[key])
@@ -213,7 +214,10 @@ def _finalize_guard_connect_payload(
         return payload
     payload["sync_attempted"] = True
     try:
-        sync_payload = sync_local_guard_cloud_proof(store)
+        sync_payload = sync_local_guard_cloud_proof(
+            store,
+            auth_context=resolved_sync_auth_context,
+        )
     except GuardSyncNotAvailableError as error:
         store.record_latest_guard_connect_sync_result(
             status="connected",

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -1187,9 +1187,9 @@ def build_connect_status_payload(
     if action in {"repair", "re-pair"}:
         payload["repair_action"] = "rerun_connect"
         payload["repair_message"] = "Run hol-guard connect to start OAuth Device Code approval."
-    elif oauth_repair_required and cloud_profile is None:
-        payload["repair_message"] = "Run hol-guard connect again to repair local Guard Cloud authorization."
-    elif not bool(oauth_storage_health.get("configured")) and payload["status"] == "retry_required":
+    elif (oauth_repair_required and cloud_profile is None) or (
+        not bool(oauth_storage_health.get("configured")) and payload["status"] == "retry_required"
+    ):
         payload["repair_message"] = "Run hol-guard connect again to repair local Guard Cloud authorization."
     return payload
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -479,6 +479,8 @@ def _queue_headless_cloud_sync(
                 "status": "in_progress",
                 "message": "Guard Cloud sync already running.",
             }
+        # This probe only short-circuits obviously overlapping cross-process work.
+        # sync_local_guard_cloud_proof() still acquires the real cloud sync lock.
         if store.cloud_sync_in_progress():
             return {
                 "status": "in_progress",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -56,6 +56,7 @@ from ..approvals import (
     build_runtime_snapshot,
 )
 from ..cli.connect_flow import (
+    CONNECT_SYNC_AUTH_CONTEXT_KEY,
     _build_sync_auth_context,
     exchange_guard_authorization_code,
     resolve_connect_url,
@@ -471,6 +472,11 @@ def _queue_headless_cloud_sync(
             "status": "not_configured",
             "message": "Guard Cloud sync is not paired on this machine.",
         }
+    if store.cloud_sync_in_progress():
+        return {
+            "status": "in_progress",
+            "message": "Guard Cloud sync already running.",
+        }
     store_key = _headless_cloud_sync_store_key(store)
     with _HEADLESS_CLOUD_SYNC_STATE_LOCK:
         if store_key in _HEADLESS_CLOUD_SYNC_IN_FLIGHT:
@@ -677,7 +683,8 @@ def _finalize_daemon_guard_connect_payload(
     payload: dict[str, object],
     now: str,
 ) -> dict[str, object]:
-    payload.pop("_guard_sync_auth_context", None)
+    sync_auth_context = payload.pop(CONNECT_SYNC_AUTH_CONTEXT_KEY, None)
+    resolved_sync_auth_context = sync_auth_context if isinstance(sync_auth_context, dict) else None
     normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
     sync_url = f"{allowed_origin}/api/guard/receipts/sync"
     dashboard_url = f"{allowed_origin}/guard"
@@ -730,7 +737,10 @@ def _finalize_daemon_guard_connect_payload(
         return payload
     payload["sync_attempted"] = True
     try:
-        sync_payload = sync_local_guard_cloud_proof(store)
+        sync_payload = sync_local_guard_cloud_proof(
+            store,
+            auth_context=resolved_sync_auth_context,
+        )
     except GuardSyncNotAvailableError as error:
         store.record_latest_guard_connect_sync_result(
             status="connected",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -472,14 +472,14 @@ def _queue_headless_cloud_sync(
             "status": "not_configured",
             "message": "Guard Cloud sync is not paired on this machine.",
         }
-    if store.cloud_sync_in_progress():
-        return {
-            "status": "in_progress",
-            "message": "Guard Cloud sync already running.",
-        }
     store_key = _headless_cloud_sync_store_key(store)
     with _HEADLESS_CLOUD_SYNC_STATE_LOCK:
         if store_key in _HEADLESS_CLOUD_SYNC_IN_FLIGHT:
+            return {
+                "status": "in_progress",
+                "message": "Guard Cloud sync already running.",
+            }
+        if store.cloud_sync_in_progress():
             return {
                 "status": "in_progress",
                 "message": "Guard Cloud sync already running.",
@@ -776,7 +776,7 @@ def _finalize_daemon_guard_connect_payload(
             }
         )
         return payload
-    except RuntimeError as error:
+    except (RuntimeError, TimeoutError) as error:
         repair_message = (
             "Guard Cloud pairing finished, but the first proof sync is still pending. Local Guard will retry while "
             "the daemon is running."

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1899,39 +1899,39 @@ def sync_local_guard_cloud_proof(
     auth_context: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Publish the local Guard runtime session before syncing receipts."""
-
-    resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
-    runtime_summary = sync_runtime_session(
-        store,
-        session=_local_guard_runtime_session(),
-        auth_context=resolved_auth_context,
-    )
-    receipts_summary = sync_receipts(
-        store,
-        persist_sync_summary=False,
-        persist_connect_state=False,
-        auth_context=resolved_auth_context,
-    )
-    summary = dict(receipts_summary)
-    summary.update(
-        {
-            "runtime_session_id": runtime_summary.get("runtime_session_id"),
-            "runtime_session_synced_at": runtime_summary.get("runtime_session_synced_at"),
-            "runtime_sessions_visible": runtime_summary.get("runtime_sessions_visible"),
-            "local_guard_online_at": runtime_summary.get("local_guard_online_at")
-            or receipts_summary.get("local_guard_online_at"),
-            "runtime_harness": runtime_summary.get("runtime_harness"),
-            "runtime_surface": runtime_summary.get("runtime_surface"),
-            "runtime_workspace": runtime_summary.get("runtime_workspace"),
-            "runtime_device_id": runtime_summary.get("runtime_device_id"),
-            "runtime": runtime_summary,
-            "receipts": dict(receipts_summary),
-        }
-    )
-    recorded_at = str(summary.get("synced_at") or summary.get("runtime_session_synced_at") or _now())
-    store.set_sync_payload("sync_summary", summary, recorded_at)
-    store.record_latest_guard_connect_sync_success(sync_payload=summary, now=recorded_at)
-    return summary
+    with store.hold_cloud_sync_lock():
+        resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
+        runtime_summary = sync_runtime_session(
+            store,
+            session=_local_guard_runtime_session(),
+            auth_context=resolved_auth_context,
+        )
+        receipts_summary = sync_receipts(
+            store,
+            persist_sync_summary=False,
+            persist_connect_state=False,
+            auth_context=resolved_auth_context,
+        )
+        summary = dict(receipts_summary)
+        summary.update(
+            {
+                "runtime_session_id": runtime_summary.get("runtime_session_id"),
+                "runtime_session_synced_at": runtime_summary.get("runtime_session_synced_at"),
+                "runtime_sessions_visible": runtime_summary.get("runtime_sessions_visible"),
+                "local_guard_online_at": runtime_summary.get("local_guard_online_at")
+                or receipts_summary.get("local_guard_online_at"),
+                "runtime_harness": runtime_summary.get("runtime_harness"),
+                "runtime_surface": runtime_summary.get("runtime_surface"),
+                "runtime_workspace": runtime_summary.get("runtime_workspace"),
+                "runtime_device_id": runtime_summary.get("runtime_device_id"),
+                "runtime": runtime_summary,
+                "receipts": dict(receipts_summary),
+            }
+        )
+        recorded_at = str(summary.get("synced_at") or summary.get("runtime_session_synced_at") or _now())
+        store.set_sync_payload("sync_summary", summary, recorded_at)
+        store.record_latest_guard_connect_sync_success(sync_payload=summary, now=recorded_at)
+        return summary
 
 
 def sync_pain_signals(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -980,6 +980,8 @@ class GuardStore:
         lock_path = self.guard_home / "cloud-sync.lock"
         with lock_path.open("a+b") as handle:
             try:
+                # This is an advisory probe, not a reservation: callers must still
+                # acquire hold_cloud_sync_lock() for the actual sync critical section.
                 _acquire_advisory_file_lock(handle)
             except BlockingIOError:
                 return True

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -181,6 +181,8 @@ _SECRET_FINGERPRINT_PREFIX = "pbkdf2-sha256$"
 _SECRET_FINGERPRINT_SALT = b"hol-guard-secret-fingerprint:v1"
 _OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS = 30.0
 _OAUTH_REFRESH_LOCK_POLL_SECONDS = 0.05
+_CLOUD_SYNC_LOCK_TIMEOUT_SECONDS = 30.0
+_CLOUD_SYNC_LOCK_POLL_SECONDS = 0.05
 _GUARD_STORE_PRIVATE_DIR_MODE = 0o700
 _GUARD_STORE_PRIVATE_FILE_MODE = 0o600
 
@@ -947,6 +949,42 @@ class GuardStore:
                     time.sleep(_OAUTH_REFRESH_LOCK_POLL_SECONDS)
             try:
                 yield
+            finally:
+                with suppress(OSError):
+                    _release_advisory_file_lock(handle)
+
+    @contextmanager
+    def hold_cloud_sync_lock(
+        self,
+        *,
+        timeout_seconds: float = _CLOUD_SYNC_LOCK_TIMEOUT_SECONDS,
+    ) -> Iterator[None]:
+        lock_path = self.guard_home / "cloud-sync.lock"
+        deadline = time.monotonic() + max(timeout_seconds, 0.0)
+        with lock_path.open("a+b") as handle:
+            while True:
+                try:
+                    _acquire_advisory_file_lock(handle)
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("Timed out waiting for Guard Cloud sync lock.") from None
+                    time.sleep(_CLOUD_SYNC_LOCK_POLL_SECONDS)
+            try:
+                yield
+            finally:
+                with suppress(OSError):
+                    _release_advisory_file_lock(handle)
+
+    def cloud_sync_in_progress(self) -> bool:
+        lock_path = self.guard_home / "cloud-sync.lock"
+        with lock_path.open("a+b") as handle:
+            try:
+                _acquire_advisory_file_lock(handle)
+            except BlockingIOError:
+                return True
+            try:
+                return False
             finally:
                 with suppress(OSError):
                     _release_advisory_file_lock(handle)

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -57,6 +57,49 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sy
     assert latest_state["milestone"] == "first_sync_pending"
 
 
+def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_sync_lock_timeout(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_url = "https://hol.org/guard/connect"
+    now = "2026-06-04T12:00:00+00:00"
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": True, "state": "healthy"},
+    )
+
+    def _raise_timeout_error(
+        _store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        assert auth_context is None
+        raise TimeoutError("Timed out waiting for Guard Cloud sync lock.")
+
+    monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", _raise_timeout_error)
+
+    payload = guard_commands_module._finalize_guard_connect_payload(
+        store=store,
+        connect_url=connect_url,
+        payload={"status": "connected"},
+        now=now,
+    )
+
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_pending"
+    assert payload["sync_succeeded"] is False
+    assert payload["sync_error"] == "Timed out waiting for Guard Cloud sync lock."
+    assert "retry automatically" in str(payload["repair_message"])
+
+
 def test_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(tmp_path, monkeypatch) -> None:
     store = GuardStore(tmp_path / "guard-home")
     connect_url = "https://hol.org/guard/connect"
@@ -172,6 +215,73 @@ def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_onc
         }
     ]
     assert CONNECT_SYNC_AUTH_CONTEXT_KEY not in payload
+
+
+def test_daemon_finalize_guard_connect_payload_keeps_first_sync_pending_on_sync_lock_timeout(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_url = "https://hol.org/guard/connect"
+    now = "2026-06-04T12:00:00+00:00"
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": True, "state": "healthy"},
+    )
+
+    def _raise_timeout_error(
+        _store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        assert auth_context is None
+        raise TimeoutError("Timed out waiting for Guard Cloud sync lock.")
+
+    monkeypatch.setattr(daemon_server_module, "sync_local_guard_cloud_proof", _raise_timeout_error)
+
+    payload = daemon_server_module._finalize_daemon_guard_connect_payload(
+        store=store,
+        connect_url=connect_url,
+        payload={"status": "connected"},
+        now=now,
+    )
+
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_pending"
+    assert payload["sync_succeeded"] is False
+    assert payload["sync_error"] == "Timed out waiting for Guard Cloud sync lock."
+    assert "retry while the daemon is running" in str(payload["repair_message"])
+
+
+def test_queue_headless_cloud_sync_respects_same_process_in_flight_marker(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+
+    store_key = daemon_server_module._headless_cloud_sync_store_key(store)
+    with daemon_server_module._HEADLESS_CLOUD_SYNC_STATE_LOCK:
+        daemon_server_module._HEADLESS_CLOUD_SYNC_IN_FLIGHT.add(store_key)
+    try:
+        payload = daemon_server_module._queue_headless_cloud_sync(store=store)
+    finally:
+        with daemon_server_module._HEADLESS_CLOUD_SYNC_STATE_LOCK:
+            daemon_server_module._HEADLESS_CLOUD_SYNC_IN_FLIGHT.discard(store_key)
+
+    assert payload == {
+        "status": "in_progress",
+        "message": "Guard Cloud sync already running.",
+    }
 
 
 def test_queue_headless_cloud_sync_respects_cross_process_sync_lock(tmp_path, monkeypatch) -> None:

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -28,7 +28,12 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sy
         lambda: {"configured": True, "state": "healthy"},
     )
 
-    def _raise_runtime_error(_store: GuardStore) -> dict[str, object]:
+    def _raise_runtime_error(
+        _store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        assert auth_context is None
         raise RuntimeError("temporary receipt sync failure")
 
     monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", _raise_runtime_error)
@@ -99,8 +104,92 @@ def test_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(tmp_p
         now=now,
     )
 
-    assert sync_calls == [None]
+    assert sync_calls == [
+        {
+            "access_token": "access-token-1",
+            "dpop_key_material": "dpop",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        }
+    ]
     assert CONNECT_SYNC_AUTH_CONTEXT_KEY not in payload
+
+
+def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_url = "https://hol.org/guard/connect"
+    now = "2026-06-04T12:00:00+00:00"
+    sync_calls: list[dict[str, object] | None] = []
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": True, "state": "healthy"},
+    )
+
+    def _fake_sync(
+        _store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        sync_calls.append(auth_context)
+        return {
+            "synced_at": "2026-06-04T12:00:05+00:00",
+            "runtime_session_id": "session-1",
+            "runtime_session_synced_at": "2026-06-04T12:00:05+00:00",
+            "runtime_sessions_visible": 1,
+            "receipts_stored": 0,
+        }
+
+    monkeypatch.setattr(daemon_server_module, "sync_local_guard_cloud_proof", _fake_sync)
+
+    payload = daemon_server_module._finalize_daemon_guard_connect_payload(
+        store=store,
+        connect_url=connect_url,
+        payload={
+            "status": "connected",
+            CONNECT_SYNC_AUTH_CONTEXT_KEY: {
+                "access_token": "access-token-1",
+                "dpop_key_material": "dpop",
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+            },
+        },
+        now=now,
+    )
+
+    assert sync_calls == [
+        {
+            "access_token": "access-token-1",
+            "dpop_key_material": "dpop",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        }
+    ]
+    assert CONNECT_SYNC_AUTH_CONTEXT_KEY not in payload
+
+
+def test_queue_headless_cloud_sync_respects_cross_process_sync_lock(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+
+    with store.hold_cloud_sync_lock():
+        payload = daemon_server_module._queue_headless_cloud_sync(store=store)
+
+    assert payload == {
+        "status": "in_progress",
+        "message": "Guard Cloud sync already running.",
+    }
 
 
 def test_guard_daemon_runtime_request_queues_pending_first_sync(tmp_path, monkeypatch) -> None:
@@ -170,7 +259,12 @@ def test_finalize_guard_connect_payload_keeps_reauth_failures_in_retry_required_
         lambda: {"configured": True, "state": "healthy"},
     )
 
-    def _raise_auth_expired(_store: GuardStore) -> dict[str, object]:
+    def _raise_auth_expired(
+        _store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        assert auth_context is None
         raise guard_commands_module.GuardSyncAuthorizationExpiredError("reauth required")
 
     monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", _raise_auth_expired)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6710,8 +6710,13 @@ url = http://127.0.0.1:8787/guard-canary
                 "workspace_id": "workspace-123",
             }
 
-        def fake_sync_local_guard_cloud_proof(store: GuardStore) -> dict[str, object]:
+        def fake_sync_local_guard_cloud_proof(
+            store: GuardStore,
+            *,
+            auth_context: dict[str, object] | None = None,
+        ) -> dict[str, object]:
             del store
+            assert auth_context is None
             sync_calls.append("first-proof")
             return {
                 "synced_at": "2026-06-04T18:31:00+00:00",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -17939,11 +17939,12 @@ def test_sync_local_guard_cloud_proof_refreshes_oauth_once(tmp_path, monkeypatch
 
     assert len(token_requests) == 1
     assert _request_header(token_requests[0], "User-Agent") == f"hol-guard/{guard_runner_module.__version__}"
-    assert [request.full_url for request in sync_requests] == [
+    sync_urls = [request.full_url for request in sync_requests]
+    assert sync_urls[:2] == [
         "https://hol.org/api/guard/runtime/sessions/sync",
         "https://hol.org/api/guard/receipts/sync",
-        "https://hol.org/api/v1/guard/events",
     ]
+    assert sync_urls.count("https://hol.org/api/v1/guard/events") >= 1
     assert payload["runtime_session_id"] == expected_session_id
 
 


### PR DESCRIPTION
## Summary
- serialize Guard Cloud first-sync work with a cross-process lock so CLI connect, daemon polls, and headless actions do not race the same receipt cursor window
- reuse the freshly issued connect auth context for the initial proof sync and stop the daemon from queuing a second sync while another Guard Cloud sync is already running

## Testing
- `pytest tests/test_guard_auto_first_sync.py -q`
- `pytest tests/test_guard_runtime.py -q -k "sync_local_guard_cloud_proof_refreshes_oauth_once or sync_local_guard_cloud_proof_serializes_concurrent_oauth_refresh"`
- `pytest tests/test_guard_headless_daemon_api.py -q -k "cloud_sync or in_progress"`

## Notes
- portal-side investigation showed the browser "Local Guard not connected" state was downstream of this hol-guard first-sync failure; no hol-points-portal code change was required for this root cause
