### PR TITLE
fix(dashboard): stop insights share modal listener leaks

### DIFF
--- a/dashboard/src/evidence/evidence-activity-heatmap.tsx
+++ b/dashboard/src/evidence/evidence-activity-heatmap.tsx
@@ -322,6 +322,7 @@ export function EvidenceActivityHeatmap({
   }, [displayKey, updateTooltipForKey, weeks]);
 
   useEffect(() => {
+    if (!displayKey) return;
     const onScrollOrResize = () => updateTooltipForKey(displayKey);
     window.addEventListener("scroll", onScrollOrResize, true);
     window.addEventListener("resize", onScrollOrResize);

--- a/dashboard/src/evidence/evidence-insights-home-preview.test.ts
+++ b/dashboard/src/evidence/evidence-insights-home-preview.test.ts
@@ -41,6 +41,9 @@ assert(modalLayerSource.includes("previousCount"), "modal layer: reference count
 assert(heatmapSource.includes("isGuardModalOpen"), "heatmap: suppresses tooltips while modal is open");
 assert(shareModalSource.includes("GuardModalLayer"), "share modal: uses viewport modal layer");
 assert(shareSheetSource.includes("GuardModalLayer"), "share sheet: uses viewport modal layer");
+assert(shareSheetSource.includes("useCopyFeedbackTimeout"), "share sheet: clears copy reset timers");
+assert(modalLayerSource.includes("onCloseRef"), "modal layer: stable escape handler");
+assert(heatmapSource.includes("if (!displayKey) return"), "heatmap: avoids global scroll listeners without active tooltip");
 assert(!shareModalSource.includes('className="fixed inset-0 z-50'), "share modal: no inline fixed overlay");
 
 console.log("evidence-insights-home-preview.test.ts: all tests passed");

--- a/dashboard/src/evidence/evidence-insights-layout.test.ts
+++ b/dashboard/src/evidence/evidence-insights-layout.test.ts
@@ -13,6 +13,7 @@ const panelSource = readFileSync(join(__dirname, "evidence-analytics-panel.tsx")
 const heatmapSource = readFileSync(join(__dirname, "evidence-activity-heatmap.tsx"), "utf8");
 const provenanceSource = readFileSync(join(__dirname, "evidence-data-provenance-strip.tsx"), "utf8");
 const shareModalSource = readFileSync(join(__dirname, "evidence-insights-share-modal.tsx"), "utf8");
+const shareSheetSource = readFileSync(join(__dirname, "evidence-insights-share-sheet.tsx"), "utf8");
 const modalLayerSource = readFileSync(join(__dirname, "../guard-modal-layer.tsx"), "utf8");
 const workspaceSource = readFileSync(join(__dirname, "../receipts-workspace.tsx"), "utf8");
 
@@ -34,6 +35,10 @@ assert(
   "insights workspace: header description mentions full local store",
 );
 assert(shareModalSource.includes("GuardModalLayer"), "insights share modal: uses viewport modal layer");
+assert(shareSheetSource.includes("useCopyFeedbackTimeout"), "insights share sheet: clears copy reset timers");
+assert(surfaceSource.includes("handleShareClose"), "insights surface: stable share modal close handler");
+assert(heatmapSource.includes("if (!displayKey) return"), "insights heatmap: avoids idle global scroll listeners");
+assert(modalLayerSource.includes("onCloseRef"), "insights share modal: stable escape close handler");
 assert(modalLayerSource.includes("createPortal"), "insights share modal: portal layer renders to body");
 
 console.log("evidence-insights-layout.test.ts: all tests passed");

--- a/dashboard/src/evidence/evidence-insights-share-sheet.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-sheet.tsx
@@ -1,8 +1,9 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 import { FiCheck, FiCopy, FiShare2 } from "react-icons/fi";
 import { GuardModalLayer } from "../guard-modal-layer";
+import { useCopyFeedbackTimeout } from "../use-copy-feedback-timeout";
 
 interface EvidenceInsightsShareSheetProps {
   publicUrl: string;
@@ -10,17 +11,16 @@ interface EvidenceInsightsShareSheetProps {
 }
 
 export function EvidenceInsightsShareSheet({ publicUrl, onClose }: EvidenceInsightsShareSheetProps) {
-  const [copied, setCopied] = useState(false);
+  const { copied, flashCopied, resetCopied } = useCopyFeedbackTimeout(2000);
 
   const handleCopy = useCallback(async () => {
     try {
       await navigator.clipboard.writeText(publicUrl);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
+      flashCopied();
     } catch {
-      setCopied(false);
+      resetCopied();
     }
-  }, [publicUrl]);
+  }, [flashCopied, publicUrl, resetCopied]);
 
   const handleNativeShare = useCallback(async () => {
     if (typeof navigator !== "undefined" && navigator.share) {

--- a/dashboard/src/evidence/evidence-insights-surface.tsx
+++ b/dashboard/src/evidence/evidence-insights-surface.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
   GuardReceiptAnalytics,
   GuardReceiptArtifactStat,
@@ -75,6 +75,12 @@ export function EvidenceInsightsSurface({
 }: EvidenceInsightsSurfaceProps) {
   const [mounted, setMounted] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
+  const handleShareOpen = useCallback(() => {
+    setShareOpen(true);
+  }, []);
+  const handleShareClose = useCallback(() => {
+    setShareOpen(false);
+  }, []);
   useEffect(() => {
     setMounted(true);
   }, []);
@@ -98,7 +104,7 @@ export function EvidenceInsightsSurface({
         <EvidenceInsightsShareModal
           analytics={analytics}
           runtime={runtime}
-          onClose={() => setShareOpen(false)}
+          onClose={handleShareClose}
         />
       ) : null}
       <div className={`overflow-hidden rounded-2xl border border-slate-200/80 bg-white shadow-sm ${mounted ? "evidence-insights-mounted" : ""}`}>
@@ -107,7 +113,7 @@ export function EvidenceInsightsSurface({
             <SectionLabel>Your Guard stats</SectionLabel>
             <p className="mt-1 text-sm text-slate-500">All-time local store</p>
           </div>
-          <EvidenceInsightsShareButton onClick={() => setShareOpen(true)} />
+          <EvidenceInsightsShareButton onClick={handleShareOpen} />
         </div>
         <EvidenceInsightsHeadlineBento analytics={analytics} variant="full" />
 

--- a/dashboard/src/guard-modal-layer.tsx
+++ b/dashboard/src/guard-modal-layer.tsx
@@ -17,6 +17,11 @@ export function GuardModalLayer({
 }: GuardModalLayerProps) {
   const [mounted, setMounted] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
+  const onCloseRef = useRef(onClose);
+
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
 
   useFocusTrap(mounted, panelRef);
 
@@ -46,12 +51,12 @@ export function GuardModalLayer({
     function handleKeyDown(event: KeyboardEvent) {
       if (event.key === "Escape") {
         event.preventDefault();
-        onClose();
+        onCloseRef.current();
       }
     }
     document.addEventListener("keydown", handleKeyDown);
     return () => document.removeEventListener("keydown", handleKeyDown);
-  }, [mounted, onClose]);
+  }, [mounted]);
 
   const handleBackdropClick = (event: MouseEvent<HTMLDivElement>) => {
     if (event.target === event.currentTarget) {

--- a/dashboard/src/guard-modal-layer.tsx
+++ b/dashboard/src/guard-modal-layer.tsx
@@ -18,10 +18,7 @@ export function GuardModalLayer({
   const [mounted, setMounted] = useState(false);
   const panelRef = useRef<HTMLDivElement | null>(null);
   const onCloseRef = useRef(onClose);
-
-  useEffect(() => {
-    onCloseRef.current = onClose;
-  }, [onClose]);
+  onCloseRef.current = onClose;
 
   useFocusTrap(mounted, panelRef);
 

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -147,6 +147,12 @@ export function HomeWorkspace(props: {
   const [clearError, setClearError] = useState<string | null>(null);
   const [clearSubmitting, setClearSubmitting] = useState(false);
   const [shareOpen, setShareOpen] = useState(false);
+  const handleShareOpen = useCallback(() => {
+    setShareOpen(true);
+  }, []);
+  const handleShareClose = useCallback(() => {
+    setShareOpen(false);
+  }, []);
   const toastTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const analyticsEnabled = props.runtime.kind === "ready" && (props.runtime.snapshot?.receipt_count ?? 0) > 0;
   const analyticsState = useReceiptAnalytics(analyticsEnabled);
@@ -284,7 +290,7 @@ export function HomeWorkspace(props: {
         <EvidenceInsightsShareModal
           analytics={analyticsState.data}
           runtime={snapshot}
-          onClose={() => setShareOpen(false)}
+          onClose={handleShareClose}
         />
       ) : null}
       {toastMessage && (
@@ -315,7 +321,7 @@ export function HomeWorkspace(props: {
         analyticsLoading={analyticsState.kind === "loading" && analyticsEnabled}
         runtime={snapshot}
         onOpenInsights={props.onOpenInsights}
-        onShare={() => setShareOpen(true)}
+        onShare={handleShareOpen}
       />
 
       <StreakMilestoneBanner streak={streak} />

--- a/dashboard/src/use-copy-feedback-timeout.ts
+++ b/dashboard/src/use-copy-feedback-timeout.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export function useCopyFeedbackTimeout(resetMs: number) {
+  const [copied, setCopied] = useState(false);
+  const resetTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearResetTimeout = useCallback(() => {
+    if (resetTimeoutRef.current !== null) {
+      clearTimeout(resetTimeoutRef.current);
+      resetTimeoutRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      clearResetTimeout();
+    };
+  }, [clearResetTimeout]);
+
+  const flashCopied = useCallback(() => {
+    clearResetTimeout();
+    setCopied(true);
+    resetTimeoutRef.current = setTimeout(() => {
+      resetTimeoutRef.current = null;
+      setCopied(false);
+    }, resetMs);
+  }, [clearResetTimeout, resetMs]);
+
+  const resetCopied = useCallback(() => {
+    clearResetTimeout();
+    setCopied(false);
+  }, [clearResetTimeout]);
+
+  return { copied, flashCopied, resetCopied };
+}


### PR DESCRIPTION
## Summary
- Clear copy reset timers in the insights share sheet after copy/share clicks
- Stabilize share modal escape handlers and idle heatmap scroll listeners

## Testing
- `npx tsx dashboard/src/evidence/evidence-insights-layout.test.ts`
- `npx tsx dashboard/src/evidence/evidence-insights-home-preview.test.ts`
