### PR TITLE
fix(guard): surface Kimi hook block reason and approval link in chat via stderr

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -149,6 +149,8 @@ def _run_hook_generic_payload(
                 reason=block_reason,
                 output_stream=output_stream,
             )
+            # Kimi surfaces stderr to the user as the blocking explanation.
+            _emit_native_hook_block_stderr(block_reason)
         else:
             _emit_native_hook_block_stderr(block_reason)
         return 2

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -149,10 +149,8 @@ def _run_hook_generic_payload(
                 reason=block_reason,
                 output_stream=output_stream,
             )
-            # Kimi surfaces stderr to the user as the blocking explanation.
-            _emit_native_hook_block_stderr(block_reason)
-        else:
-            _emit_native_hook_block_stderr(block_reason)
+        # Kimi surfaces stderr to the user as the blocking explanation.
+        _emit_native_hook_block_stderr(block_reason)
         return 2
     if _canonical_harness_name(args.harness) == "codex" and (
         hook_event_name == "UserPromptSubmit" or approval_context is not None

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
@@ -87,10 +87,8 @@ def _finalize_runtime_artifact_hook(
                 reason=native_block_reason,
                 output_stream=output_stream,
             )
-            # Kimi surfaces stderr to the user as the blocking explanation.
-            _emit_native_hook_block_stderr(native_block_reason)
-        else:
-            _emit_native_hook_block_stderr(native_block_reason)
+        # Kimi surfaces stderr to the user as the blocking explanation.
+        _emit_native_hook_block_stderr(native_block_reason)
         _record_harness_usage_for_hook(
             store=store,
             action_envelope=action_envelope,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
@@ -87,6 +87,8 @@ def _finalize_runtime_artifact_hook(
                 reason=native_block_reason,
                 output_stream=output_stream,
             )
+            # Kimi surfaces stderr to the user as the blocking explanation.
+            _emit_native_hook_block_stderr(native_block_reason)
         else:
             _emit_native_hook_block_stderr(native_block_reason)
         _record_harness_usage_for_hook(

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -76,7 +76,6 @@ def _native_approval_center_context(response_payload: dict[str, object], *, harn
         "guard-cli": "package install",
         "opencode": "OpenCode",
         "kimi": "Kimi",
-        "kimi-code": "Kimi Code",
     }.get(canonical_harness, "the harness")
     if canonical_harness in {
         "npm",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -75,6 +75,8 @@ def _native_approval_center_context(response_payload: dict[str, object], *, harn
         "copilot": "Copilot",
         "guard-cli": "package install",
         "opencode": "OpenCode",
+        "kimi": "Kimi",
+        "kimi-code": "Kimi Code",
     }.get(canonical_harness, "the harness")
     if canonical_harness in {
         "npm",

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -263,6 +263,44 @@ class TestKimiHookQuoting:
         assert "workspace & tools" in windows_cmd
 
 
+class TestKimiHookChatUx:
+    def test_kimi_block_emits_reason_to_stderr(self, tmp_path: Path) -> None:
+        import io
+        from contextlib import redirect_stderr
+
+        from codex_plugin_scanner.guard.cli.commands_hook_generic import (
+            _run_hook_generic_payload,
+        )
+        from codex_plugin_scanner.guard.config import GuardConfig
+        from codex_plugin_scanner.guard.store import GuardStore
+
+        guard_home = tmp_path / ".hol-guard"
+        store = GuardStore(guard_home)
+        config = GuardConfig(guard_home=guard_home, workspace=tmp_path)
+        args = argparse.Namespace(
+            harness="kimi",
+            json=False,
+            policy_action="block",
+            artifact_id=None,
+            artifact_name=None,
+        )
+        payload = {"hookEventName": "UserPromptSubmit", "prompt": "delete all files"}
+        stderr_capture = io.StringIO()
+        stdout_capture = io.StringIO()
+        with redirect_stderr(stderr_capture):
+            rc = _run_hook_generic_payload(
+                args,
+                action_envelope=None,
+                config=config,
+                output_stream=stdout_capture,
+                payload=payload,
+                runtime_workspace=tmp_path,
+                store=store,
+            )
+        assert rc == 2
+        assert "HOL Guard flagged" in stderr_capture.getvalue()
+
+
 class TestKimiLaunchCommand:
     def test_launch_command_passes_workspace(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=True)

--- a/tests/test_kimi_adapter.py
+++ b/tests/test_kimi_adapter.py
@@ -299,6 +299,7 @@ class TestKimiHookChatUx:
             )
         assert rc == 2
         assert "HOL Guard flagged" in stderr_capture.getvalue()
+        assert '"decision":"block"' in stdout_capture.getvalue()
 
 
 class TestKimiLaunchCommand:


### PR DESCRIPTION
## Summary
Kimi Code shows hook stderr to the user when a hook exits with code 2, but Guard was only emitting the structured JSON response to stdout. As a result, Kimi blocked actions without explaining why or offering an approval link in the chat.

This change mirrors Codex’s UX by also printing the block reason (which already includes the HOL Guard approval URL) to stderr for Kimi `PreToolUse` and `UserPromptSubmit` hooks. It also adds "Kimi" / "Kimi Code" labels to the approval-center context message.

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_kimi_adapter.py -q`
- New regression test verifies a Kimi block emits the reason to stderr.
