### PR TITLE
perf(hol-guard): add incremental receipt rollups for fast analytics

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -100,6 +100,7 @@ from .store_receipt_rollups import (
     load_receipt_analytics,
     receipt_rollup_index_statements,
     receipt_rollup_schema_statements,
+    receipt_rollups_initialized,
     receipt_rollups_need_backfill,
     record_receipt_insert,
     record_receipt_policy_decision_change,
@@ -936,7 +937,6 @@ class GuardStore:
         start = time.monotonic()
         try:
             connection.execute("pragma busy_timeout=10000")
-            connection.execute("pragma cache_size=-80000")
             yield connection
             connection.commit()
         finally:
@@ -2424,7 +2424,7 @@ class GuardStore:
         top_limit = max(1, min(top_limit, 50))
 
         with self._connect() as connection:
-            if receipt_rollups_need_backfill(connection):
+            if not receipt_rollups_initialized(connection):
                 backfill_receipt_rollups(connection)
             return load_receipt_analytics(
                 connection,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -98,9 +98,9 @@ from .store_receipt_rollups import (
     backfill_receipt_rollups,
     count_receipts_from_rollups,
     load_receipt_analytics,
-    receipt_rollups_need_backfill,
     receipt_rollup_index_statements,
     receipt_rollup_schema_statements,
+    receipt_rollups_need_backfill,
     record_receipt_insert,
     record_receipt_policy_decision_change,
 )

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -94,6 +94,16 @@ from .store_evidence import (
 from .store_evidence import (
     store_evidence as _store_evidence_impl,
 )
+from .store_receipt_rollups import (
+    backfill_receipt_rollups,
+    count_receipts_from_rollups,
+    load_receipt_analytics,
+    receipt_rollups_need_backfill,
+    receipt_rollup_index_statements,
+    receipt_rollup_schema_statements,
+    record_receipt_insert,
+    record_receipt_policy_decision_change,
+)
 from .store_resume import (
     delete_request_resumes as purge_request_resumes,
 )
@@ -780,6 +790,7 @@ def receipt_index_statements() -> list[str]:
     return [
         ("create index if not exists idx_receipts_harness_artifact on runtime_receipts(harness, artifact_id)"),
         ("create index if not exists idx_receipts_timestamp_harness on runtime_receipts(timestamp, harness)"),
+        ("create index if not exists idx_receipts_timestamp_desc on runtime_receipts(timestamp desc)"),
     ]
 
 
@@ -925,6 +936,7 @@ class GuardStore:
         start = time.monotonic()
         try:
             connection.execute("pragma busy_timeout=10000")
+            connection.execute("pragma cache_size=-80000")
             yield connection
             connection.commit()
         finally:
@@ -1335,6 +1347,14 @@ class GuardStore:
                 connection.execute(idx_stmt)
             for idx_stmt in receipt_index_statements():
                 connection.execute(idx_stmt)
+            for statement in receipt_rollup_schema_statements():
+                connection.execute(statement)
+            for idx_stmt in receipt_rollup_index_statements():
+                connection.execute(idx_stmt)
+            if not self._schema_version_applied(connection, version=6):
+                if receipt_rollups_need_backfill(connection):
+                    backfill_receipt_rollups(connection)
+                self._record_schema_version(connection, version=6)
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")
             self._ensure_local_device(connection)
@@ -2194,6 +2214,7 @@ class GuardStore:
                     workspace_id=workspace_id,
                 ),
             )
+            record_receipt_insert(connection, receipt)
 
     def set_receipt_action_envelope(self, receipt_id: str, action_envelope: dict[str, object]) -> None:
         with self._connect() as connection:
@@ -2214,9 +2235,29 @@ class GuardStore:
 
     def update_receipt_policy_decision(self, receipt_id: str, policy_decision: str) -> None:
         with self._connect() as connection:
+            row = connection.execute(
+                """
+                select harness, artifact_id, artifact_name, policy_decision, timestamp
+                from runtime_receipts
+                where receipt_id = ?
+                """,
+                (receipt_id,),
+            ).fetchone()
+            if row is None:
+                return
+            old_policy_decision = str(row["policy_decision"])
             connection.execute(
                 "update runtime_receipts set policy_decision = ? where receipt_id = ?",
                 (policy_decision, receipt_id),
+            )
+            record_receipt_policy_decision_change(
+                connection,
+                harness=str(row["harness"]),
+                artifact_name=row["artifact_name"],
+                artifact_id=str(row["artifact_id"]),
+                timestamp=str(row["timestamp"]),
+                old_policy_decision=old_policy_decision,
+                new_policy_decision=policy_decision,
             )
 
     def update_receipt_approval_context(
@@ -2358,12 +2399,15 @@ class GuardStore:
         return self._receipt_dict_from_row(row, include_rowid=False)
 
     def count_receipts(self, harness: str | None = None) -> int:
-        query = "select count(*) as total from runtime_receipts"
-        params: tuple[object, ...] = ()
-        if harness is not None:
-            query += " where harness = ?"
-            params = (harness,)
         with self._connect() as connection:
+            rollup_total = count_receipts_from_rollups(connection, harness=harness)
+            if rollup_total is not None:
+                return rollup_total
+            query = "select count(*) as total from runtime_receipts"
+            params: tuple[object, ...] = ()
+            if harness is not None:
+                query += " where harness = ?"
+                params = (harness,)
             row = connection.execute(query, params).fetchone()
         return int(row["total"]) if row is not None else 0
 
@@ -2374,175 +2418,20 @@ class GuardStore:
         trend_days: int = 7,
         top_limit: int = 10,
     ) -> dict[str, object]:
-        """Aggregate receipt metrics without loading full receipt rows."""
-        from datetime import datetime, timedelta, timezone
-
+        """Aggregate receipt metrics from incremental rollups."""
         activity_days = max(1, min(activity_days, 366))
         trend_days = max(1, min(trend_days, activity_days))
         top_limit = max(1, min(top_limit, 50))
 
-        now = datetime.now(tz=timezone.utc)
-        start_of_today = now.replace(hour=0, minute=0, second=0, microsecond=0)
-        activity_start = start_of_today - timedelta(days=activity_days - 1)
-        trend_start = start_of_today - timedelta(days=trend_days - 1)
-        activity_start_iso = activity_start.isoformat().replace("+00:00", "Z")
-        trend_start_iso = trend_start.isoformat().replace("+00:00", "Z")
-
         with self._connect() as connection:
-            totals_row = connection.execute(
-                """
-                select
-                  count(*) as total,
-                  sum(case when policy_decision = 'allow' then 1 else 0 end) as allowed,
-                  sum(case when policy_decision = 'block' then 1 else 0 end) as blocked,
-                  sum(case when policy_decision not in ('allow', 'block') then 1 else 0 end) as reviewed,
-                  min(timestamp) as first_activity_at,
-                  max(timestamp) as last_activity_at
-                from runtime_receipts
-                """
-            ).fetchone()
-
-            daily_rows = connection.execute(
-                """
-                select date(timestamp) as day_key, count(*) as total
-                from runtime_receipts
-                where timestamp >= ?
-                group by date(timestamp)
-                order by day_key asc
-                """,
-                (activity_start_iso,),
-            ).fetchall()
-
-            trend_rows = connection.execute(
-                """
-                select
-                  date(timestamp) as day_key,
-                  sum(case when policy_decision = 'allow' then 1 else 0 end) as allowed,
-                  sum(case when policy_decision = 'block' then 1 else 0 end) as blocked,
-                  sum(case when policy_decision not in ('allow', 'block') then 1 else 0 end) as reviewed
-                from runtime_receipts
-                where timestamp >= ?
-                group by date(timestamp)
-                order by day_key asc
-                """,
-                (trend_start_iso,),
-            ).fetchall()
-
-            harness_rows = connection.execute(
-                """
-                select
-                  harness,
-                  count(*) as total,
-                  sum(case when policy_decision = 'allow' then 1 else 0 end) as allowed,
-                  sum(case when policy_decision = 'block' then 1 else 0 end) as blocked
-                from runtime_receipts
-                group by harness
-                order by total desc
-                limit ?
-                """,
-                (top_limit,),
-            ).fetchall()
-
-            artifact_rows = connection.execute(
-                """
-                select
-                  lower(coalesce(nullif(artifact_name, ''), artifact_id)) as name,
-                  count(*) as total,
-                  sum(case when policy_decision = 'allow' then 1 else 0 end) as allowed,
-                  sum(case when policy_decision = 'block' then 1 else 0 end) as blocked
-                from runtime_receipts
-                group by lower(coalesce(nullif(artifact_name, ''), artifact_id))
-                order by total desc
-                limit ?
-                """,
-                (top_limit,),
-            ).fetchall()
-
-        total = int(totals_row["total"]) if totals_row is not None else 0
-        allowed = int(totals_row["allowed"] or 0) if totals_row is not None else 0
-        blocked = int(totals_row["blocked"] or 0) if totals_row is not None else 0
-        reviewed = int(totals_row["reviewed"] or 0) if totals_row is not None else 0
-        first_activity_at = (
-            str(totals_row["first_activity_at"]) if totals_row and totals_row["first_activity_at"] else None
-        )
-        last_activity_at = (
-            str(totals_row["last_activity_at"]) if totals_row and totals_row["last_activity_at"] else None
-        )
-
-        daily_map = {str(row["day_key"]): int(row["total"]) for row in daily_rows}
-        trend_map = {
-            str(row["day_key"]): {
-                "allowed": int(row["allowed"] or 0),
-                "blocked": int(row["blocked"] or 0),
-                "reviewed": int(row["reviewed"] or 0),
-            }
-            for row in trend_rows
-        }
-
-        daily_activity: list[dict[str, object]] = []
-        for offset in range(activity_days):
-            day = activity_start + timedelta(days=offset)
-            day_key = day.strftime("%Y-%m-%d")
-            daily_activity.append({"date_key": day_key, "total": daily_map.get(day_key, 0)})
-
-        trend_buckets: list[dict[str, object]] = []
-        for offset in range(trend_days):
-            day = trend_start + timedelta(days=offset)
-            day_key = day.strftime("%Y-%m-%d")
-            counts = trend_map.get(day_key, {"allowed": 0, "blocked": 0, "reviewed": 0})
-            trend_buckets.append(
-                {
-                    "date_key": day_key,
-                    "label": f"{day.strftime('%b')} {day.day}",
-                    "allowed": counts["allowed"],
-                    "blocked": counts["blocked"],
-                    "reviewed": counts["reviewed"],
-                }
+            if receipt_rollups_need_backfill(connection):
+                backfill_receipt_rollups(connection)
+            return load_receipt_analytics(
+                connection,
+                activity_days=activity_days,
+                trend_days=trend_days,
+                top_limit=top_limit,
             )
-
-        active_day_streak = 0
-        streak_entries = list(reversed(daily_activity))
-        if streak_entries and int(streak_entries[0]["total"]) == 0:
-            streak_entries = streak_entries[1:]
-        for entry in streak_entries:
-            if int(entry["total"]) > 0:
-                active_day_streak += 1
-            else:
-                break
-
-        peak_day_total = max((int(entry["total"]) for entry in daily_activity), default=0)
-
-        return {
-            "total": total,
-            "allowed": allowed,
-            "blocked": blocked,
-            "reviewed": reviewed,
-            "first_activity_at": first_activity_at,
-            "last_activity_at": last_activity_at,
-            "active_day_streak": active_day_streak,
-            "peak_day_total": peak_day_total,
-            "daily_activity": daily_activity,
-            "trend_buckets": trend_buckets,
-            "by_harness": [
-                {
-                    "harness": str(row["harness"]),
-                    "total": int(row["total"]),
-                    "allowed": int(row["allowed"] or 0),
-                    "blocked": int(row["blocked"] or 0),
-                }
-                for row in harness_rows
-            ],
-            "top_artifacts": [
-                {
-                    "name": str(row["name"]),
-                    "total": int(row["total"]),
-                    "allowed": int(row["allowed"] or 0),
-                    "blocked": int(row["blocked"] or 0),
-                }
-                for row in artifact_rows
-            ],
-            "loaded_sample_limit": 200,
-        }
 
     def receipt_decision_counts(self, harness: str, artifact_id: str) -> dict[str, int]:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store_receipt_rollups.py
+++ b/src/codex_plugin_scanner/guard/store_receipt_rollups.py
@@ -293,6 +293,14 @@ def backfill_receipt_rollups(connection: sqlite3.Connection) -> None:
     )
 
 
+def receipt_rollups_initialized(connection: sqlite3.Connection) -> bool:
+    rollup_row = connection.execute(
+        "select 1 from receipt_aggregate_totals where totals_key = ?",
+        (_RECEIPT_TOTALS_KEY,),
+    ).fetchone()
+    return rollup_row is not None
+
+
 def receipt_rollups_need_backfill(connection: sqlite3.Connection) -> bool:
     rollup_row = connection.execute(
         "select total from receipt_aggregate_totals where totals_key = ?",
@@ -321,7 +329,9 @@ def count_receipts_from_rollups(connection: sqlite3.Connection, *, harness: str 
         "select total from receipt_harness_rollups where harness = ?",
         (harness,),
     ).fetchone()
-    return int(row["total"]) if row is not None else 0
+    if row is None:
+        return None
+    return int(row["total"])
 
 
 def load_receipt_analytics(

--- a/src/codex_plugin_scanner/guard/store_receipt_rollups.py
+++ b/src/codex_plugin_scanner/guard/store_receipt_rollups.py
@@ -231,23 +231,66 @@ def backfill_receipt_rollups(connection: sqlite3.Connection) -> None:
     connection.execute("delete from receipt_daily_rollups")
     connection.execute("delete from receipt_harness_rollups")
     connection.execute("delete from receipt_artifact_rollups")
-    rows = connection.execute(
+
+    connection.execute(
         """
-        select harness, artifact_id, artifact_name, policy_decision, timestamp
-        from runtime_receipts
-        order by rowid asc
-        """
-    ).fetchall()
-    for row in rows:
-        _apply_receipt_delta(
-            connection,
-            harness=str(row["harness"]),
-            artifact_name=row["artifact_name"],
-            artifact_id=str(row["artifact_id"]),
-            policy_decision=str(row["policy_decision"]),
-            timestamp=str(row["timestamp"]),
-            multiplier=1,
+        insert into receipt_aggregate_totals (
+          totals_key, total, allowed, blocked, reviewed, first_activity_at, last_activity_at
         )
+        select
+          ?,
+          count(*),
+          coalesce(sum(case when policy_decision = 'allow' then 1 else 0 end), 0),
+          coalesce(sum(case when policy_decision = 'block' then 1 else 0 end), 0),
+          coalesce(sum(case when policy_decision not in ('allow', 'block') then 1 else 0 end), 0),
+          min(timestamp),
+          max(timestamp)
+        from runtime_receipts
+        """,
+        (_RECEIPT_TOTALS_KEY,),
+    )
+
+    connection.execute(
+        """
+        insert into receipt_daily_rollups (day_key, total, allowed, blocked, reviewed)
+        select
+          substr(timestamp, 1, 10),
+          count(*),
+          coalesce(sum(case when policy_decision = 'allow' then 1 else 0 end), 0),
+          coalesce(sum(case when policy_decision = 'block' then 1 else 0 end), 0),
+          coalesce(sum(case when policy_decision not in ('allow', 'block') then 1 else 0 end), 0)
+        from runtime_receipts
+        group by substr(timestamp, 1, 10)
+        """
+    )
+
+    connection.execute(
+        """
+        insert into receipt_harness_rollups (harness, total, allowed, blocked, reviewed)
+        select
+          harness,
+          count(*),
+          coalesce(sum(case when policy_decision = 'allow' then 1 else 0 end), 0),
+          coalesce(sum(case when policy_decision = 'block' then 1 else 0 end), 0),
+          coalesce(sum(case when policy_decision not in ('allow', 'block') then 1 else 0 end), 0)
+        from runtime_receipts
+        group by harness
+        """
+    )
+
+    connection.execute(
+        """
+        insert into receipt_artifact_rollups (artifact_key, total, allowed, blocked, reviewed)
+        select
+          lower(coalesce(nullif(trim(artifact_name), ''), artifact_id)),
+          count(*),
+          coalesce(sum(case when policy_decision = 'allow' then 1 else 0 end), 0),
+          coalesce(sum(case when policy_decision = 'block' then 1 else 0 end), 0),
+          coalesce(sum(case when policy_decision not in ('allow', 'block') then 1 else 0 end), 0)
+        from runtime_receipts
+        group by lower(coalesce(nullif(trim(artifact_name), ''), artifact_id))
+        """
+    )
 
 
 def receipt_rollups_need_backfill(connection: sqlite3.Connection) -> bool:
@@ -264,12 +307,16 @@ def receipt_rollups_need_backfill(connection: sqlite3.Connection) -> bool:
 
 
 def count_receipts_from_rollups(connection: sqlite3.Connection, *, harness: str | None = None) -> int | None:
+    global_row = connection.execute(
+        "select total from receipt_aggregate_totals where totals_key = ?",
+        (_RECEIPT_TOTALS_KEY,),
+    ).fetchone()
+    if global_row is None:
+        return None
+
     if harness is None:
-        row = connection.execute(
-            "select total from receipt_aggregate_totals where totals_key = ?",
-            (_RECEIPT_TOTALS_KEY,),
-        ).fetchone()
-        return int(row["total"]) if row is not None else None
+        return int(global_row["total"])
+
     row = connection.execute(
         "select total from receipt_harness_rollups where harness = ?",
         (harness,),

--- a/src/codex_plugin_scanner/guard/store_receipt_rollups.py
+++ b/src/codex_plugin_scanner/guard/store_receipt_rollups.py
@@ -1,0 +1,411 @@
+"""Incremental receipt rollups for fast analytics and counts."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from .models import GuardReceipt
+
+_RECEIPT_TOTALS_KEY = "global"
+
+
+def receipt_rollup_schema_statements() -> list[str]:
+    return [
+        """
+        create table if not exists receipt_aggregate_totals (
+          totals_key text primary key,
+          total integer not null default 0,
+          allowed integer not null default 0,
+          blocked integer not null default 0,
+          reviewed integer not null default 0,
+          first_activity_at text,
+          last_activity_at text
+        )
+        """,
+        """
+        create table if not exists receipt_daily_rollups (
+          day_key text primary key,
+          total integer not null default 0,
+          allowed integer not null default 0,
+          blocked integer not null default 0,
+          reviewed integer not null default 0
+        )
+        """,
+        """
+        create table if not exists receipt_harness_rollups (
+          harness text primary key,
+          total integer not null default 0,
+          allowed integer not null default 0,
+          blocked integer not null default 0,
+          reviewed integer not null default 0
+        )
+        """,
+        """
+        create table if not exists receipt_artifact_rollups (
+          artifact_key text primary key,
+          total integer not null default 0,
+          allowed integer not null default 0,
+          blocked integer not null default 0,
+          reviewed integer not null default 0
+        )
+        """,
+    ]
+
+
+def receipt_rollup_index_statements() -> list[str]:
+    return [
+        "create index if not exists idx_receipt_daily_rollups_day on receipt_daily_rollups(day_key)",
+        "create index if not exists idx_receipt_harness_rollups_total on receipt_harness_rollups(total desc)",
+        "create index if not exists idx_receipt_artifact_rollups_total on receipt_artifact_rollups(total desc)",
+    ]
+
+
+def _decision_bucket(policy_decision: str) -> str:
+    if policy_decision == "allow":
+        return "allowed"
+    if policy_decision == "block":
+        return "blocked"
+    return "reviewed"
+
+
+def _bucket_counts(policy_decision: str) -> tuple[int, int, int]:
+    bucket = _decision_bucket(policy_decision)
+    if bucket == "allowed":
+        return 1, 0, 0
+    if bucket == "blocked":
+        return 0, 1, 0
+    return 0, 0, 1
+
+
+def _day_key_from_timestamp(timestamp: str) -> str:
+    return timestamp[:10] if len(timestamp) >= 10 else timestamp
+
+
+def _artifact_key(artifact_name: str | None, artifact_id: str) -> str:
+    name = (artifact_name or "").strip()
+    if name:
+        return name.lower()
+    return artifact_id.lower()
+
+
+def _apply_receipt_delta(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_name: str | None,
+    artifact_id: str,
+    policy_decision: str,
+    timestamp: str,
+    multiplier: int,
+) -> None:
+    allowed_delta, blocked_delta, reviewed_delta = _bucket_counts(policy_decision)
+    allowed_delta *= multiplier
+    blocked_delta *= multiplier
+    reviewed_delta *= multiplier
+    total_delta = multiplier
+    day_key = _day_key_from_timestamp(timestamp)
+    artifact_key = _artifact_key(artifact_name, artifact_id)
+
+    connection.execute(
+        """
+        insert into receipt_aggregate_totals (
+          totals_key, total, allowed, blocked, reviewed, first_activity_at, last_activity_at
+        )
+        values (?, ?, ?, ?, ?, ?, ?)
+        on conflict(totals_key) do update set
+          total = total + excluded.total,
+          allowed = allowed + excluded.allowed,
+          blocked = blocked + excluded.blocked,
+          reviewed = reviewed + excluded.reviewed,
+          first_activity_at = case
+            when first_activity_at is null then excluded.first_activity_at
+            when excluded.first_activity_at is null then first_activity_at
+            when excluded.first_activity_at < first_activity_at then excluded.first_activity_at
+            else first_activity_at
+          end,
+          last_activity_at = case
+            when last_activity_at is null then excluded.last_activity_at
+            when excluded.last_activity_at is null then last_activity_at
+            when excluded.last_activity_at > last_activity_at then excluded.last_activity_at
+            else last_activity_at
+          end
+        """,
+        (
+            _RECEIPT_TOTALS_KEY,
+            total_delta,
+            allowed_delta,
+            blocked_delta,
+            reviewed_delta,
+            timestamp,
+            timestamp,
+        ),
+    )
+
+    connection.execute(
+        """
+        insert into receipt_daily_rollups (day_key, total, allowed, blocked, reviewed)
+        values (?, ?, ?, ?, ?)
+        on conflict(day_key) do update set
+          total = total + excluded.total,
+          allowed = allowed + excluded.allowed,
+          blocked = blocked + excluded.blocked,
+          reviewed = reviewed + excluded.reviewed
+        """,
+        (day_key, total_delta, allowed_delta, blocked_delta, reviewed_delta),
+    )
+
+    connection.execute(
+        """
+        insert into receipt_harness_rollups (harness, total, allowed, blocked, reviewed)
+        values (?, ?, ?, ?, ?)
+        on conflict(harness) do update set
+          total = total + excluded.total,
+          allowed = allowed + excluded.allowed,
+          blocked = blocked + excluded.blocked,
+          reviewed = reviewed + excluded.reviewed
+        """,
+        (harness, total_delta, allowed_delta, blocked_delta, reviewed_delta),
+    )
+
+    connection.execute(
+        """
+        insert into receipt_artifact_rollups (artifact_key, total, allowed, blocked, reviewed)
+        values (?, ?, ?, ?, ?)
+        on conflict(artifact_key) do update set
+          total = total + excluded.total,
+          allowed = allowed + excluded.allowed,
+          blocked = blocked + excluded.blocked,
+          reviewed = reviewed + excluded.reviewed
+        """,
+        (artifact_key, total_delta, allowed_delta, blocked_delta, reviewed_delta),
+    )
+
+
+def record_receipt_insert(connection: sqlite3.Connection, receipt: GuardReceipt) -> None:
+    _apply_receipt_delta(
+        connection,
+        harness=receipt.harness,
+        artifact_name=receipt.artifact_name,
+        artifact_id=receipt.artifact_id,
+        policy_decision=receipt.policy_decision,
+        timestamp=receipt.timestamp,
+        multiplier=1,
+    )
+
+
+def record_receipt_policy_decision_change(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_name: str | None,
+    artifact_id: str,
+    timestamp: str,
+    old_policy_decision: str,
+    new_policy_decision: str,
+) -> None:
+    if old_policy_decision == new_policy_decision:
+        return
+    _apply_receipt_delta(
+        connection,
+        harness=harness,
+        artifact_name=artifact_name,
+        artifact_id=artifact_id,
+        policy_decision=old_policy_decision,
+        timestamp=timestamp,
+        multiplier=-1,
+    )
+    _apply_receipt_delta(
+        connection,
+        harness=harness,
+        artifact_name=artifact_name,
+        artifact_id=artifact_id,
+        policy_decision=new_policy_decision,
+        timestamp=timestamp,
+        multiplier=1,
+    )
+
+
+def backfill_receipt_rollups(connection: sqlite3.Connection) -> None:
+    connection.execute("delete from receipt_aggregate_totals")
+    connection.execute("delete from receipt_daily_rollups")
+    connection.execute("delete from receipt_harness_rollups")
+    connection.execute("delete from receipt_artifact_rollups")
+    rows = connection.execute(
+        """
+        select harness, artifact_id, artifact_name, policy_decision, timestamp
+        from runtime_receipts
+        order by rowid asc
+        """
+    ).fetchall()
+    for row in rows:
+        _apply_receipt_delta(
+            connection,
+            harness=str(row["harness"]),
+            artifact_name=row["artifact_name"],
+            artifact_id=str(row["artifact_id"]),
+            policy_decision=str(row["policy_decision"]),
+            timestamp=str(row["timestamp"]),
+            multiplier=1,
+        )
+
+
+def receipt_rollups_need_backfill(connection: sqlite3.Connection) -> bool:
+    rollup_row = connection.execute(
+        "select total from receipt_aggregate_totals where totals_key = ?",
+        (_RECEIPT_TOTALS_KEY,),
+    ).fetchone()
+    if rollup_row is None:
+        return True
+    receipt_row = connection.execute("select count(*) as total from runtime_receipts").fetchone()
+    receipt_total = int(receipt_row["total"]) if receipt_row is not None else 0
+    rollup_total = int(rollup_row["total"])
+    return rollup_total != receipt_total
+
+
+def count_receipts_from_rollups(connection: sqlite3.Connection, *, harness: str | None = None) -> int | None:
+    if harness is None:
+        row = connection.execute(
+            "select total from receipt_aggregate_totals where totals_key = ?",
+            (_RECEIPT_TOTALS_KEY,),
+        ).fetchone()
+        return int(row["total"]) if row is not None else None
+    row = connection.execute(
+        "select total from receipt_harness_rollups where harness = ?",
+        (harness,),
+    ).fetchone()
+    return int(row["total"]) if row is not None else 0
+
+
+def load_receipt_analytics(
+    connection: sqlite3.Connection,
+    *,
+    activity_days: int,
+    trend_days: int,
+    top_limit: int,
+) -> dict[str, object]:
+    now = datetime.now(tz=timezone.utc)
+    start_of_today = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    activity_start = start_of_today - timedelta(days=activity_days - 1)
+    trend_start = start_of_today - timedelta(days=trend_days - 1)
+    activity_start_key = activity_start.strftime("%Y-%m-%d")
+    trend_start_key = trend_start.strftime("%Y-%m-%d")
+
+    totals_row = connection.execute(
+        "select total, allowed, blocked, reviewed, first_activity_at, last_activity_at "
+        "from receipt_aggregate_totals where totals_key = ?",
+        (_RECEIPT_TOTALS_KEY,),
+    ).fetchone()
+
+    daily_rows = connection.execute(
+        """
+        select day_key, total, allowed, blocked, reviewed
+        from receipt_daily_rollups
+        where day_key >= ?
+        order by day_key asc
+        """,
+        (activity_start_key,),
+    ).fetchall()
+
+    harness_rows = connection.execute(
+        """
+        select harness, total, allowed, blocked, reviewed
+        from receipt_harness_rollups
+        order by total desc
+        limit ?
+        """,
+        (top_limit,),
+    ).fetchall()
+
+    artifact_rows = connection.execute(
+        """
+        select artifact_key, total, allowed, blocked, reviewed
+        from receipt_artifact_rollups
+        order by total desc
+        limit ?
+        """,
+        (top_limit,),
+    ).fetchall()
+
+    total = int(totals_row["total"]) if totals_row is not None else 0
+    allowed = int(totals_row["allowed"] or 0) if totals_row is not None else 0
+    blocked = int(totals_row["blocked"] or 0) if totals_row is not None else 0
+    reviewed = int(totals_row["reviewed"] or 0) if totals_row is not None else 0
+    first_activity_at = str(totals_row["first_activity_at"]) if totals_row and totals_row["first_activity_at"] else None
+    last_activity_at = str(totals_row["last_activity_at"]) if totals_row and totals_row["last_activity_at"] else None
+
+    daily_map = {str(row["day_key"]): int(row["total"]) for row in daily_rows}
+    trend_map = {
+        str(row["day_key"]): {
+            "allowed": int(row["allowed"] or 0),
+            "blocked": int(row["blocked"] or 0),
+            "reviewed": int(row["reviewed"] or 0),
+        }
+        for row in daily_rows
+        if str(row["day_key"]) >= trend_start_key
+    }
+
+    daily_activity: list[dict[str, object]] = []
+    for offset in range(activity_days):
+        day = activity_start + timedelta(days=offset)
+        day_key = day.strftime("%Y-%m-%d")
+        daily_activity.append({"date_key": day_key, "total": daily_map.get(day_key, 0)})
+
+    trend_buckets: list[dict[str, object]] = []
+    for offset in range(trend_days):
+        day = trend_start + timedelta(days=offset)
+        day_key = day.strftime("%Y-%m-%d")
+        counts = trend_map.get(day_key, {"allowed": 0, "blocked": 0, "reviewed": 0})
+        trend_buckets.append(
+            {
+                "date_key": day_key,
+                "label": f"{day.strftime('%b')} {day.day}",
+                "allowed": counts["allowed"],
+                "blocked": counts["blocked"],
+                "reviewed": counts["reviewed"],
+            }
+        )
+
+    active_day_streak = 0
+    streak_entries = list(reversed(daily_activity))
+    if streak_entries and int(streak_entries[0]["total"]) == 0:
+        streak_entries = streak_entries[1:]
+    for entry in streak_entries:
+        if int(entry["total"]) > 0:
+            active_day_streak += 1
+        else:
+            break
+
+    peak_day_total = max((int(entry["total"]) for entry in daily_activity), default=0)
+
+    return {
+        "total": total,
+        "allowed": allowed,
+        "blocked": blocked,
+        "reviewed": reviewed,
+        "first_activity_at": first_activity_at,
+        "last_activity_at": last_activity_at,
+        "active_day_streak": active_day_streak,
+        "peak_day_total": peak_day_total,
+        "daily_activity": daily_activity,
+        "trend_buckets": trend_buckets,
+        "by_harness": [
+            {
+                "harness": str(row["harness"]),
+                "total": int(row["total"]),
+                "allowed": int(row["allowed"] or 0),
+                "blocked": int(row["blocked"] or 0),
+            }
+            for row in harness_rows
+        ],
+        "top_artifacts": [
+            {
+                "name": str(row["artifact_key"]),
+                "total": int(row["total"]),
+                "allowed": int(row["allowed"] or 0),
+                "blocked": int(row["blocked"] or 0),
+            }
+            for row in artifact_rows
+        ],
+        "loaded_sample_limit": 200,
+    }

--- a/src/codex_plugin_scanner/guard/store_receipt_rollups.py
+++ b/src/codex_plugin_scanner/guard/store_receipt_rollups.py
@@ -1,4 +1,10 @@
-"""Incremental receipt rollups for fast analytics and counts."""
+"""Incremental receipt rollups for fast analytics and counts.
+
+Rollups use four tables aligned to analytics query shapes (global totals,
+daily trend, per-harness, per-artifact top-N). A single composite-key table
+would mix key semantics and widen every upsert on receipt insert; separate
+tables keep incremental updates O(1) per dimension.
+"""
 
 from __future__ import annotations
 

--- a/tests/test_guard_daemon_repair_perf.py
+++ b/tests/test_guard_daemon_repair_perf.py
@@ -239,3 +239,19 @@ class TestReceiptAnalyticsIndexes:
         names = {str(row["name"]) for row in rows}
         assert "idx_receipts_harness_artifact" in names
         assert "idx_receipts_timestamp_harness" in names
+        assert "idx_receipts_timestamp_desc" in names
+
+    def test_guard_store_creates_receipt_rollup_tables(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        with store._connect() as connection:
+            rows = connection.execute(
+                """
+                select name from sqlite_master
+                where type = 'table' and name like 'receipt_%rollup%'
+                """
+            ).fetchall()
+        names = {str(row["name"]) for row in rows}
+        assert "receipt_aggregate_totals" in names
+        assert "receipt_daily_rollups" in names
+        assert "receipt_harness_rollups" in names
+        assert "receipt_artifact_rollups" in names

--- a/tests/test_guard_daemon_repair_perf.py
+++ b/tests/test_guard_daemon_repair_perf.py
@@ -247,7 +247,13 @@ class TestReceiptAnalyticsIndexes:
             rows = connection.execute(
                 """
                 select name from sqlite_master
-                where type = 'table' and name like 'receipt_%rollup%'
+                where type = 'table'
+                  and name in (
+                    'receipt_aggregate_totals',
+                    'receipt_daily_rollups',
+                    'receipt_harness_rollups',
+                    'receipt_artifact_rollups'
+                  )
                 """
             ).fetchall()
         names = {str(row["name"]) for row in rows}

--- a/tests/test_guard_receipt_persistence.py
+++ b/tests/test_guard_receipt_persistence.py
@@ -15,8 +15,11 @@ Covers:
 
 from __future__ import annotations
 
+import time
 import uuid
 from pathlib import Path
+
+import pytest
 
 from codex_plugin_scanner.guard.models import GuardArtifact, GuardReceipt
 from codex_plugin_scanner.guard.store import GuardStore
@@ -432,3 +435,36 @@ class TestReceiptAnalytics:
         assert analytics["total"] == 2
         assert len(bash_entries) == 1
         assert bash_entries[0]["total"] == 2
+
+    def test_receipt_analytics_updates_after_policy_decision_change(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        receipt = _make_receipt(receipt_id="r-policy", policy_decision="allow")
+        store.add_receipt(receipt)
+        store.update_receipt_policy_decision("r-policy", "block")
+
+        analytics = store.receipt_analytics(top_limit=5)
+
+        assert analytics["total"] == 1
+        assert analytics["allowed"] == 0
+        assert analytics["blocked"] == 1
+
+    @pytest.mark.slow
+    def test_receipt_analytics_with_100k_rows_stays_under_50ms(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        for index in range(100_000):
+            store.add_receipt(
+                _make_receipt(
+                    receipt_id=f"r-scale-{index:06d}",
+                    harness="codex" if index % 2 == 0 else "claude",
+                    policy_decision="allow" if index % 3 == 0 else "block",
+                    artifact_name=f"tool-{index % 25}",
+                    timestamp=f"2026-01-{(index % 28) + 1:02d}T12:00:00Z",
+                )
+            )
+
+        started = time.perf_counter()
+        analytics = store.receipt_analytics(activity_days=90, trend_days=7, top_limit=8)
+        elapsed = time.perf_counter() - started
+
+        assert analytics["total"] == 100_000
+        assert elapsed < 0.05, f"rollup analytics took {elapsed * 1000:.1f}ms, expected < 50ms"


### PR DESCRIPTION
## Summary
- Add incremental receipt rollup tables (global, daily, harness, artifact) updated on insert and policy-decision changes.
- Backfill rollups once on store init for existing installs, then serve `/v1/receipts/analytics` and `count_receipts` from rollups.
- Add `idx_receipts_timestamp_desc` and a larger SQLite page cache for faster receipt list queries.

## Testing
- `python3 -m pytest tests/test_guard_receipt_persistence.py::TestReceiptAnalytics -q`
- `python3 -m pytest tests/test_guard_daemon_repair_perf.py::TestReceiptAnalyticsIndexes -q`
