### PR TITLE
feat(guard): sync Codex runtime enabled state for skills and MCP

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/codex.py
+++ b/src/codex_plugin_scanner/guard/adapters/codex.py
@@ -15,7 +15,11 @@ try:  # pragma: no cover - Python 3.11+
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10
     import tomli as tomllib  # type: ignore[no-redef]
 
-from ..aibom_detection import enrich_mcp_server_metadata, extend_detection_with_workspace_aibom
+from ..aibom_detection import (
+    enrich_mcp_server_metadata,
+    extend_codex_runtime_inventory,
+    extend_detection_with_workspace_aibom,
+)
 from ..codex_config import dump_toml, read_toml_payload, write_toml_payload
 from ..config import MAX_APPROVAL_WAIT_TIMEOUT_SECONDS, load_guard_config
 from ..launcher import merge_guard_launcher_env
@@ -627,9 +631,11 @@ class CodexHarnessAdapter(HarnessAdapter):
                         continue
                     url = server_config.get("url")
                     env = server_config.get("env")
+                    enabled = server_config.get("enabled", True) is not False
                     mcp_metadata = enrich_mcp_server_metadata(
                         {
                             "name": name,
+                            "enabled": enabled,
                             "env": {
                                 str(key): str(value)
                                 for key, value in env.items()
@@ -701,8 +707,13 @@ class CodexHarnessAdapter(HarnessAdapter):
             artifacts=tuple(artifacts),
             warnings=(),
         )
-        return extend_detection_with_workspace_aibom(
+        extended = extend_detection_with_workspace_aibom(
             detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
+        )
+        return extend_codex_runtime_inventory(
+            extended,
             home_dir=context.home_dir,
             workspace_dir=context.workspace_dir,
         )

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -127,16 +127,17 @@ def discover_shared_workspace_aibom_artifacts(
     artifacts: list[GuardArtifact] = []
     artifacts.extend(_discover_agents_md(harness, workspace_dir=workspace_dir))
     artifacts.extend(_discover_cursor_rules(harness, workspace_dir=workspace_dir))
-    artifacts.extend(
-        _discover_codex_skills(
-            harness,
-            workspace_dir=workspace_dir,
-            home_dir=home_dir,
-            skill_roots=_CODEX_WORKSPACE_SKILL_ROOTS,
-            source_scope="project",
-            artifact_scope="project",
+    if harness != "codex":
+        artifacts.extend(
+            _discover_codex_skills(
+                harness,
+                workspace_dir=workspace_dir,
+                home_dir=home_dir,
+                skill_roots=_CODEX_WORKSPACE_SKILL_ROOTS,
+                source_scope="project",
+                artifact_scope="project",
+            )
         )
-    )
     artifacts.extend(_discover_codex_marketplace_plugins(harness, workspace_dir=workspace_dir))
     return tuple(artifacts)
 

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -8,6 +8,7 @@ from typing import Literal
 
 from ..marketplace_support import extract_marketplace_source, load_marketplace_context
 from ..path_support import is_safe_relative_path, iter_safe_matching_files, resolves_within_root
+from .codex_skill_config import load_codex_skill_config_rules, resolve_codex_skill_enabled
 from .inventory_contract import fingerprint_mapping, fingerprint_path_tree, fingerprint_text
 from .models import GuardArtifact, HarnessDetection
 
@@ -35,7 +36,8 @@ INVENTORY_ITEM_KINDS: tuple[str, ...] = (
 
 _READ_CHUNK_BYTES = 65536
 _CURSOR_RULE_PATTERNS = ("*.mdc", "*.md")
-_CODEX_SKILL_ROOTS = (".agents/skills",)
+_CODEX_WORKSPACE_SKILL_ROOTS = (".agents/skills",)
+_CODEX_HOME_SKILL_ROOTS = (".codex/skills", ".agents/skills")
 
 
 def file_content_hash(path: Path, *, max_bytes: int | None = None) -> str | None:
@@ -125,7 +127,16 @@ def discover_shared_workspace_aibom_artifacts(
     artifacts: list[GuardArtifact] = []
     artifacts.extend(_discover_agents_md(harness, workspace_dir=workspace_dir))
     artifacts.extend(_discover_cursor_rules(harness, workspace_dir=workspace_dir))
-    artifacts.extend(_discover_codex_skills(harness, workspace_dir=workspace_dir, home_dir=home_dir))
+    artifacts.extend(
+        _discover_codex_skills(
+            harness,
+            workspace_dir=workspace_dir,
+            home_dir=home_dir,
+            skill_roots=_CODEX_WORKSPACE_SKILL_ROOTS,
+            source_scope="project",
+            artifact_scope="project",
+        )
+    )
     artifacts.extend(_discover_codex_marketplace_plugins(harness, workspace_dir=workspace_dir))
     return tuple(artifacts)
 
@@ -158,9 +169,78 @@ def _discover_cursor_rules(harness: str, *, workspace_dir: Path) -> list[GuardAr
     return artifacts
 
 
-def _discover_codex_skills(harness: str, *, workspace_dir: Path, home_dir: Path) -> list[GuardArtifact]:
+def discover_codex_skill_artifacts(
+    harness: str,
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> tuple[GuardArtifact, ...]:
     artifacts: list[GuardArtifact] = []
-    for relative_root in _CODEX_SKILL_ROOTS:
+    if workspace_dir is not None:
+        artifacts.extend(
+            _discover_codex_skills(
+                harness,
+                workspace_dir=workspace_dir,
+                home_dir=home_dir,
+                skill_roots=_CODEX_WORKSPACE_SKILL_ROOTS,
+                source_scope="project",
+                artifact_scope="project",
+            )
+        )
+    artifacts.extend(
+        _discover_codex_skills(
+            harness,
+            workspace_dir=home_dir,
+            home_dir=home_dir,
+            skill_roots=_CODEX_HOME_SKILL_ROOTS,
+            source_scope="global",
+            artifact_scope="global",
+        )
+    )
+    rules = load_codex_skill_config_rules(home_dir=home_dir, workspace_dir=workspace_dir)
+    if not rules:
+        return tuple(artifacts)
+    enriched: list[GuardArtifact] = []
+    for artifact in artifacts:
+        if artifact.artifact_type != "skill":
+            enriched.append(artifact)
+            continue
+        metadata = dict(artifact.metadata)
+        metadata["enabled"] = resolve_codex_skill_enabled(
+            config_path=artifact.config_path,
+            display_name=artifact.name,
+            rules=rules,
+            home_dir=home_dir,
+        )
+        enriched.append(
+            GuardArtifact(
+                artifact_id=artifact.artifact_id,
+                name=artifact.name,
+                harness=artifact.harness,
+                artifact_type=artifact.artifact_type,
+                source_scope=artifact.source_scope,
+                config_path=artifact.config_path,
+                command=artifact.command,
+                args=artifact.args,
+                url=artifact.url,
+                transport=artifact.transport,
+                metadata=metadata,
+            )
+        )
+    return tuple(enriched)
+
+
+def _discover_codex_skills(
+    harness: str,
+    *,
+    workspace_dir: Path,
+    home_dir: Path,
+    skill_roots: tuple[str, ...],
+    source_scope: str,
+    artifact_scope: str,
+) -> list[GuardArtifact]:
+    artifacts: list[GuardArtifact] = []
+    for relative_root in skill_roots:
         skill_root = workspace_dir / relative_root
         if not skill_root.is_dir() or not resolves_within_root(workspace_dir, skill_root, require_exists=True):
             continue
@@ -174,6 +254,7 @@ def _discover_codex_skills(harness: str, *, workspace_dir: Path, home_dir: Path)
             content_hash = directory_content_hash(skill_dir, home_dir=home_dir)
             digest = file_content_hash(skill_md)
             metadata: dict[str, object] = {
+                "enabled": True,
                 "skill_root": relative_root,
                 "content_hash": digest,
                 "directory_hash": content_hash,
@@ -181,11 +262,11 @@ def _discover_codex_skills(harness: str, *, workspace_dir: Path, home_dir: Path)
             }
             artifacts.append(
                 GuardArtifact(
-                    artifact_id=f"{harness}:project:skill:{relative_root}:{relative_id or skill_dir.name}",
+                    artifact_id=f"{harness}:{artifact_scope}:skill:{relative_root}:{relative_id or skill_dir.name}",
                     name=relative_id or skill_dir.name,
                     harness=harness,
                     artifact_type="skill",
-                    source_scope="project",
+                    source_scope=source_scope,
                     config_path=str(skill_md),
                     metadata=metadata,
                 )
@@ -227,6 +308,7 @@ def _discover_codex_marketplace_plugins(harness: str, *, workspace_dir: Path) ->
             plugin_name = f"plugin_{index}"
         source_ref, source_path = extract_marketplace_source(entry)
         metadata: dict[str, object] = {
+            "enabled": entry.get("enabled", True) is not False,
             "marketplace_index": index,
             "source_ref": source_ref,
             "source_path": source_path,
@@ -293,6 +375,38 @@ def _instruction_artifact(
             "content_hash": content_hash,
             **version_info_metadata(content_hash=content_hash, version_label=name),
         },
+    )
+
+
+def extend_codex_runtime_inventory(
+    detection: HarnessDetection,
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> HarnessDetection:
+    """Replace Codex skill inventory with home + workspace discovery and enablement rules."""
+
+    if detection.harness != "codex":
+        return detection
+    skill_artifacts = discover_codex_skill_artifacts(
+        detection.harness,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    )
+    merged = [artifact for artifact in detection.artifacts if artifact.artifact_type != "skill"]
+    found_paths = list(detection.config_paths)
+    for artifact in skill_artifacts:
+        merged.append(artifact)
+        config_path = getattr(artifact, "config_path", None)
+        if isinstance(config_path, str):
+            found_paths.append(config_path)
+    return HarnessDetection(
+        harness=detection.harness,
+        installed=detection.installed,
+        command_available=detection.command_available,
+        config_paths=tuple(dict.fromkeys(found_paths)),
+        artifacts=tuple(merged),
+        warnings=detection.warnings,
     )
 
 

--- a/src/codex_plugin_scanner/guard/codex_skill_config.py
+++ b/src/codex_plugin_scanner/guard/codex_skill_config.py
@@ -1,0 +1,115 @@
+"""Codex skill enablement rules from config.toml `[[skills.config]]` entries."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+try:  # pragma: no cover - Python 3.11+
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10
+    import tomli as tomllib  # type: ignore[no-redef]
+
+
+@dataclass(frozen=True, slots=True)
+class CodexSkillConfigRule:
+    enabled: bool
+    name: str | None = None
+    path: str | None = None
+
+
+def _read_toml(path: Path) -> dict[str, object]:
+    if not path.is_file():
+        return {}
+    try:
+        with path.open("rb") as handle:
+            payload = tomllib.load(handle)
+        return payload if isinstance(payload, dict) else {}
+    except (OSError, tomllib.TOMLDecodeError):
+        return {}
+
+
+def _normalize_rule_entry(entry: object) -> CodexSkillConfigRule | None:
+    if not isinstance(entry, dict):
+        return None
+    enabled_value = entry.get("enabled")
+    if enabled_value is None:
+        return None
+    enabled = enabled_value is not False
+    path_value = entry.get("path")
+    name_value = entry.get("name")
+    path = path_value.strip() if isinstance(path_value, str) and path_value.strip() else None
+    name = name_value.strip() if isinstance(name_value, str) and name_value.strip() else None
+    if path is None and name is None:
+        return None
+    return CodexSkillConfigRule(enabled=enabled, name=name, path=path)
+
+
+def _rules_from_payload(payload: dict[str, object]) -> tuple[CodexSkillConfigRule, ...]:
+    skills = payload.get("skills")
+    if not isinstance(skills, dict):
+        return ()
+    config_entries = skills.get("config")
+    if not isinstance(config_entries, list):
+        return ()
+    rules: list[CodexSkillConfigRule] = []
+    for entry in config_entries:
+        rule = _normalize_rule_entry(entry)
+        if rule is not None:
+            rules.append(rule)
+    return tuple(rules)
+
+
+def load_codex_skill_config_rules(
+    *,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> tuple[CodexSkillConfigRule, ...]:
+    """Load merged Codex skill rules with later config layers overriding earlier ones."""
+
+    config_paths: list[Path] = [home_dir / ".codex" / "config.toml"]
+    if workspace_dir is not None:
+        config_paths.append(workspace_dir / ".codex" / "config.toml")
+    merged: list[CodexSkillConfigRule] = []
+    for config_path in config_paths:
+        merged.extend(_rules_from_payload(_read_toml(config_path)))
+    return tuple(merged)
+
+
+def _normalize_match_path(value: str, *, home_dir: Path) -> str:
+    candidate = Path(value).expanduser()
+    if not candidate.is_absolute():
+        candidate = (home_dir / candidate).resolve()
+    else:
+        candidate = candidate.resolve()
+    return candidate.as_posix()
+
+
+def resolve_codex_skill_enabled(
+    *,
+    config_path: str,
+    display_name: str,
+    rules: tuple[CodexSkillConfigRule, ...],
+    home_dir: Path,
+) -> bool:
+    if not rules:
+        return True
+    skill_path = Path(config_path).expanduser()
+    if not skill_path.is_absolute():
+        skill_path = (home_dir / skill_path).resolve()
+    else:
+        skill_path = skill_path.resolve()
+    normalized_skill_path = skill_path.as_posix()
+    normalized_name = display_name.strip().lower()
+    resolved: bool | None = None
+    for rule in rules:
+        if rule.path is not None:
+            normalized_rule_path = _normalize_match_path(rule.path, home_dir=home_dir)
+            if normalized_skill_path == normalized_rule_path or normalized_skill_path.endswith(
+                normalized_rule_path
+            ):
+                resolved = rule.enabled
+                continue
+        if rule.name is not None and rule.name.strip().lower() == normalized_name:
+            resolved = rule.enabled
+    return True if resolved is None else resolved

--- a/src/codex_plugin_scanner/guard/codex_skill_config.py
+++ b/src/codex_plugin_scanner/guard/codex_skill_config.py
@@ -78,10 +78,7 @@ def load_codex_skill_config_rules(
 
 def _normalize_match_path(value: str, *, home_dir: Path) -> str:
     candidate = Path(value).expanduser()
-    if not candidate.is_absolute():
-        candidate = (home_dir / candidate).resolve()
-    else:
-        candidate = candidate.resolve()
+    candidate = (home_dir / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
     return candidate.as_posix()
 
 
@@ -95,18 +92,19 @@ def resolve_codex_skill_enabled(
     if not rules:
         return True
     skill_path = Path(config_path).expanduser()
-    if not skill_path.is_absolute():
-        skill_path = (home_dir / skill_path).resolve()
-    else:
-        skill_path = skill_path.resolve()
+    skill_path = (home_dir / skill_path).resolve() if not skill_path.is_absolute() else skill_path.resolve()
+    skill_dir_path = skill_path.parent.as_posix()
     normalized_skill_path = skill_path.as_posix()
     normalized_name = display_name.strip().lower()
     resolved: bool | None = None
     for rule in rules:
         if rule.path is not None:
             normalized_rule_path = _normalize_match_path(rule.path, home_dir=home_dir)
-            if normalized_skill_path == normalized_rule_path or normalized_skill_path.endswith(
-                normalized_rule_path
+            if (
+                normalized_skill_path == normalized_rule_path
+                or skill_dir_path == normalized_rule_path
+                or normalized_skill_path.endswith(normalized_rule_path)
+                or skill_dir_path.endswith(normalized_rule_path)
             ):
                 resolved = rule.enabled
                 continue

--- a/src/codex_plugin_scanner/guard/codex_skill_config.py
+++ b/src/codex_plugin_scanner/guard/codex_skill_config.py
@@ -29,7 +29,7 @@ def _read_toml(path: Path) -> dict[str, object]:
         return {}
 
 
-def _normalize_rule_entry(entry: object) -> CodexSkillConfigRule | None:
+def _normalize_rule_entry(entry: object, *, base_dir: Path) -> CodexSkillConfigRule | None:
     if not isinstance(entry, dict):
         return None
     enabled_value = entry.get("enabled")
@@ -38,14 +38,15 @@ def _normalize_rule_entry(entry: object) -> CodexSkillConfigRule | None:
     enabled = enabled_value is not False
     path_value = entry.get("path")
     name_value = entry.get("name")
-    path = path_value.strip() if isinstance(path_value, str) and path_value.strip() else None
+    raw_path = path_value.strip() if isinstance(path_value, str) and path_value.strip() else None
     name = name_value.strip() if isinstance(name_value, str) and name_value.strip() else None
+    path = _normalize_match_path(raw_path, base_dir=base_dir) if raw_path is not None else None
     if path is None and name is None:
         return None
     return CodexSkillConfigRule(enabled=enabled, name=name, path=path)
 
 
-def _rules_from_payload(payload: dict[str, object]) -> tuple[CodexSkillConfigRule, ...]:
+def _rules_from_payload(payload: dict[str, object], *, base_dir: Path) -> tuple[CodexSkillConfigRule, ...]:
     skills = payload.get("skills")
     if not isinstance(skills, dict):
         return ()
@@ -54,7 +55,7 @@ def _rules_from_payload(payload: dict[str, object]) -> tuple[CodexSkillConfigRul
         return ()
     rules: list[CodexSkillConfigRule] = []
     for entry in config_entries:
-        rule = _normalize_rule_entry(entry)
+        rule = _normalize_rule_entry(entry, base_dir=base_dir)
         if rule is not None:
             rules.append(rule)
     return tuple(rules)
@@ -67,18 +68,18 @@ def load_codex_skill_config_rules(
 ) -> tuple[CodexSkillConfigRule, ...]:
     """Load merged Codex skill rules with later config layers overriding earlier ones."""
 
-    config_paths: list[Path] = [home_dir / ".codex" / "config.toml"]
-    if workspace_dir is not None:
-        config_paths.append(workspace_dir / ".codex" / "config.toml")
     merged: list[CodexSkillConfigRule] = []
-    for config_path in config_paths:
-        merged.extend(_rules_from_payload(_read_toml(config_path)))
+    merged.extend(_rules_from_payload(_read_toml(home_dir / ".codex" / "config.toml"), base_dir=home_dir))
+    if workspace_dir is not None:
+        merged.extend(
+            _rules_from_payload(_read_toml(workspace_dir / ".codex" / "config.toml"), base_dir=workspace_dir)
+        )
     return tuple(merged)
 
 
-def _normalize_match_path(value: str, *, home_dir: Path) -> str:
+def _normalize_match_path(value: str, *, base_dir: Path) -> str:
     candidate = Path(value).expanduser()
-    candidate = (home_dir / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
+    candidate = (base_dir / candidate).resolve() if not candidate.is_absolute() else candidate.resolve()
     return candidate.as_posix()
 
 
@@ -98,16 +99,14 @@ def resolve_codex_skill_enabled(
     normalized_name = display_name.strip().lower()
     resolved: bool | None = None
     for rule in rules:
-        if rule.path is not None:
-            normalized_rule_path = _normalize_match_path(rule.path, home_dir=home_dir)
-            if (
-                normalized_skill_path == normalized_rule_path
-                or skill_dir_path == normalized_rule_path
-                or normalized_skill_path.endswith(normalized_rule_path)
-                or skill_dir_path.endswith(normalized_rule_path)
-            ):
-                resolved = rule.enabled
-                continue
+        if rule.path is not None and (
+            normalized_skill_path == rule.path
+            or skill_dir_path == rule.path
+            or normalized_skill_path.endswith(rule.path)
+            or skill_dir_path.endswith(rule.path)
+        ):
+            resolved = rule.enabled
+            continue
         if rule.name is not None and rule.name.strip().lower() == normalized_name:
             resolved = rule.enabled
     return True if resolved is None else resolved

--- a/src/codex_plugin_scanner/guard/codex_skill_config.py
+++ b/src/codex_plugin_scanner/guard/codex_skill_config.py
@@ -71,9 +71,7 @@ def load_codex_skill_config_rules(
     merged: list[CodexSkillConfigRule] = []
     merged.extend(_rules_from_payload(_read_toml(home_dir / ".codex" / "config.toml"), base_dir=home_dir))
     if workspace_dir is not None:
-        merged.extend(
-            _rules_from_payload(_read_toml(workspace_dir / ".codex" / "config.toml"), base_dir=workspace_dir)
-        )
+        merged.extend(_rules_from_payload(_read_toml(workspace_dir / ".codex" / "config.toml"), base_dir=workspace_dir))
     return tuple(merged)
 
 

--- a/tests/test_codex_skill_config.py
+++ b/tests/test_codex_skill_config.py
@@ -34,7 +34,7 @@ def test_load_codex_skill_config_rules_merges_home_and_workspace(tmp_path: Path)
     rules = load_codex_skill_config_rules(home_dir=home, workspace_dir=workspace)
 
     assert len(rules) == 2
-    assert rules[0].path == "home-skill"
+    assert rules[0].path == str((home / "home-skill").resolve())
     assert rules[0].enabled is False
     assert rules[1].name == "workspace-skill"
     assert rules[1].enabled is False
@@ -85,6 +85,31 @@ def test_resolve_codex_skill_enabled_matches_path_and_name(tmp_path: Path) -> No
         rules=disabled_by_name,
         home_dir=home,
     )
+
+
+def test_workspace_skill_path_rules_resolve_against_workspace_dir(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    workspace.mkdir()
+    (home / ".codex").mkdir()
+    (workspace / ".codex").mkdir()
+    project_skill = workspace / ".agents" / "skills" / "workspace-skill"
+    project_skill.mkdir(parents=True)
+    skill_md = project_skill / "SKILL.md"
+    skill_md.write_text("# workspace\n", encoding="utf-8")
+    (workspace / ".codex" / "config.toml").write_text(
+        f'[[skills.config]]\npath = "{project_skill}"\nenabled = false\n',
+        encoding="utf-8",
+    )
+
+    artifacts = discover_codex_skill_artifacts(
+        "codex",
+        home_dir=home,
+        workspace_dir=workspace,
+    )
+    by_name = {artifact.name: artifact for artifact in artifacts}
+    assert by_name["workspace-skill"].metadata["enabled"] is False
 
 
 def test_discover_codex_skill_artifacts_applies_enablement(tmp_path: Path) -> None:

--- a/tests/test_codex_skill_config.py
+++ b/tests/test_codex_skill_config.py
@@ -1,0 +1,127 @@
+"""Tests for Codex skill enablement config resolution."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.aibom_detection import (
+    discover_codex_skill_artifacts,
+    extend_codex_runtime_inventory,
+)
+from codex_plugin_scanner.guard.codex_skill_config import (
+    load_codex_skill_config_rules,
+    resolve_codex_skill_enabled,
+)
+from codex_plugin_scanner.guard.models import HarnessDetection
+
+
+def test_load_codex_skill_config_rules_merges_home_and_workspace(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    workspace.mkdir()
+    (home / ".codex").mkdir()
+    (workspace / ".codex").mkdir()
+    (home / ".codex" / "config.toml").write_text(
+        '[[skills.config]]\npath = "home-skill"\nenabled = false\n',
+        encoding="utf-8",
+    )
+    (workspace / ".codex" / "config.toml").write_text(
+        '[[skills.config]]\nname = "workspace-skill"\nenabled = false\n',
+        encoding="utf-8",
+    )
+
+    rules = load_codex_skill_config_rules(home_dir=home, workspace_dir=workspace)
+
+    assert len(rules) == 2
+    assert rules[0].path == "home-skill"
+    assert rules[0].enabled is False
+    assert rules[1].name == "workspace-skill"
+    assert rules[1].enabled is False
+
+
+def test_resolve_codex_skill_enabled_matches_path_and_name(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    skill_md = home / ".codex" / "skills" / "lint" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("# lint\n", encoding="utf-8")
+
+    assert resolve_codex_skill_enabled(
+        config_path=str(skill_md),
+        display_name="lint",
+        rules=(),
+        home_dir=home,
+    )
+
+    from codex_plugin_scanner.guard.codex_skill_config import CodexSkillConfigRule
+
+    disabled_by_name = (
+        CodexSkillConfigRule(enabled=False, name="lint"),
+    )
+    assert not resolve_codex_skill_enabled(
+        config_path=str(skill_md),
+        display_name="lint",
+        rules=disabled_by_name,
+        home_dir=home,
+    )
+
+
+def test_discover_codex_skill_artifacts_applies_enablement(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    workspace.mkdir()
+    (home / ".codex").mkdir()
+    (workspace / ".codex").mkdir()
+    (home / ".codex" / "config.toml").write_text(
+        '[[skills.config]]\nname = "global-skill"\nenabled = false\n',
+        encoding="utf-8",
+    )
+
+    global_skill = home / ".codex" / "skills" / "global-skill"
+    global_skill.mkdir(parents=True)
+    (global_skill / "SKILL.md").write_text("# global\n", encoding="utf-8")
+
+    project_skill = workspace / ".agents" / "skills" / "project-skill"
+    project_skill.mkdir(parents=True)
+    (project_skill / "SKILL.md").write_text("# project\n", encoding="utf-8")
+
+    artifacts = discover_codex_skill_artifacts(
+        "codex",
+        home_dir=home,
+        workspace_dir=workspace,
+    )
+    by_name = {artifact.name: artifact for artifact in artifacts}
+
+    assert by_name["global-skill"].metadata["enabled"] is False
+    assert by_name["project-skill"].metadata["enabled"] is True
+
+
+def test_extend_codex_runtime_inventory_replaces_workspace_skills(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    home.mkdir()
+    workspace.mkdir()
+
+    global_skill = home / ".codex" / "skills" / "only-global"
+    global_skill.mkdir(parents=True)
+    (global_skill / "SKILL.md").write_text("# only\n", encoding="utf-8")
+
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(),
+        artifacts=(),
+        warnings=(),
+    )
+    extended = extend_codex_runtime_inventory(
+        detection,
+        home_dir=home,
+        workspace_dir=workspace,
+    )
+
+    assert len(extended.artifacts) == 1
+    assert extended.artifacts[0].name == "only-global"
+    assert extended.artifacts[0].source_scope == "global"

--- a/tests/test_codex_skill_config.py
+++ b/tests/test_codex_skill_config.py
@@ -40,6 +40,26 @@ def test_load_codex_skill_config_rules_merges_home_and_workspace(tmp_path: Path)
     assert rules[1].enabled is False
 
 
+def test_resolve_codex_skill_enabled_matches_skill_directory_path(tmp_path: Path) -> None:
+    home = tmp_path / "home"
+    home.mkdir()
+    skill_md = home / ".codex" / "skills" / "lint" / "SKILL.md"
+    skill_md.parent.mkdir(parents=True)
+    skill_md.write_text("# lint\n", encoding="utf-8")
+    (home / ".codex").mkdir(exist_ok=True)
+    (home / ".codex" / "config.toml").write_text(
+        f'[[skills.config]]\npath = "{skill_md.parent}"\nenabled = false\n',
+        encoding="utf-8",
+    )
+    rules = load_codex_skill_config_rules(home_dir=home, workspace_dir=None)
+    assert not resolve_codex_skill_enabled(
+        config_path=str(skill_md),
+        display_name="lint",
+        rules=rules,
+        home_dir=home,
+    )
+
+
 def test_resolve_codex_skill_enabled_matches_path_and_name(tmp_path: Path) -> None:
     home = tmp_path / "home"
     home.mkdir()

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -9,6 +9,7 @@ from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
 from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
 from codex_plugin_scanner.guard.aibom_detection import (
     INVENTORY_ITEM_KINDS,
+    discover_codex_skill_artifacts,
     discover_shared_workspace_aibom_artifacts,
     extend_detection_with_workspace_aibom,
     file_content_hash,
@@ -92,15 +93,19 @@ def test_discover_codex_skills_and_marketplace_plugins(tmp_path: Path) -> None:
     skill_root.mkdir(parents=True)
     (skill_root / "SKILL.md").write_text("---\nname: lint\n---\n", encoding="utf-8")
 
-    artifacts = discover_shared_workspace_aibom_artifacts(
+    shared_artifacts = discover_shared_workspace_aibom_artifacts(
         "codex",
         home_dir=tmp_path,
         workspace_dir=workspace,
     )
-    artifact_types = {artifact.artifact_type for artifact in artifacts}
+    skill_artifacts = discover_codex_skill_artifacts(
+        "codex",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
 
-    assert "skill" in artifact_types
-    assert "plugin" in artifact_types
+    assert "plugin" in {artifact.artifact_type for artifact in shared_artifacts}
+    assert "skill" in {artifact.artifact_type for artifact in skill_artifacts}
 
 
 def test_content_hash_detects_tail_changes_beyond_one_mebibyte(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Read Codex `[[skills.config]]` rules and set `metadata.enabled` on discovered skills, including `~/.codex/skills` home inventory.
- Pass MCP server `enabled` from Codex config into inventory metadata and mark marketplace plugin entries disabled when configured off.

## Testing
- `python3 -m pytest tests/test_codex_skill_config.py tests/test_guard_aibom_detection.py -q`

