### PR TITLE
fix(guard): stop keychain prompt loop for sync secrets

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -284,7 +284,6 @@ class KeychainSecretStore:
     def set_secret(self, secret_id: str, value: str) -> None:
         if not self._is_available():
             raise RuntimeError("macOS keychain command is not available")
-        prompt_payload = f"{value}\n{value}\n"
         subprocess.run(
             [
                 "/usr/bin/security",
@@ -295,11 +294,11 @@ class KeychainSecretStore:
                 self.service_name,
                 "-U",
                 "-w",
+                value,
             ],
             check=True,
             capture_output=True,
             text=True,
-            input=prompt_payload,
         )
 
     def get_secret(self, secret_id: str) -> str | None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -284,22 +284,7 @@ class KeychainSecretStore:
     def set_secret(self, secret_id: str, value: str) -> None:
         if not self._is_available():
             raise RuntimeError("macOS keychain command is not available")
-        subprocess.run(
-            [
-                "/usr/bin/security",
-                "add-generic-password",
-                "-a",
-                secret_id,
-                "-s",
-                self.service_name,
-                "-U",
-                "-w",
-                value,
-            ],
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        raise RuntimeError("macOS security CLI does not support noninteractive secret writes without argv exposure")
 
     def get_secret(self, secret_id: str) -> str | None:
         if not self._is_available():

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -581,6 +581,54 @@ def _install_fake_sync_keychain(monkeypatch) -> dict[tuple[str, str], str]:
     return secrets
 
 
+def test_keychain_secret_store_passes_password_as_argument(monkeypatch):
+    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
+    calls: list[dict[str, object]] = []
+
+    def fake_run(
+        args: list[str],
+        *,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+        **kwargs: object,
+    ) -> subprocess.CompletedProcess[str]:
+        calls.append(
+            {
+                "args": args,
+                "check": check,
+                "capture_output": capture_output,
+                "text": text,
+                "kwargs": kwargs,
+            }
+        )
+        return subprocess.CompletedProcess(args, 0, "", "")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    KeychainSecretStore("hol-guard.sync").set_secret("guard-token", "secret-value")
+
+    assert calls == [
+        {
+            "args": [
+                "/usr/bin/security",
+                "add-generic-password",
+                "-a",
+                "guard-token",
+                "-s",
+                "hol-guard.sync",
+                "-U",
+                "-w",
+                "secret-value",
+            ],
+            "check": True,
+            "capture_output": True,
+            "text": True,
+            "kwargs": {},
+        }
+    ]
+
+
 def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available_outside_macos(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -581,9 +581,8 @@ def _install_fake_sync_keychain(monkeypatch) -> dict[tuple[str, str], str]:
     return secrets
 
 
-def test_keychain_secret_store_passes_password_as_argument(monkeypatch):
+def test_keychain_secret_store_rejects_cli_secret_writes(monkeypatch):
     monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-    calls: list[dict[str, object]] = []
 
     def fake_run(
         args: list[str],
@@ -593,40 +592,12 @@ def test_keychain_secret_store_passes_password_as_argument(monkeypatch):
         text: bool,
         **kwargs: object,
     ) -> subprocess.CompletedProcess[str]:
-        calls.append(
-            {
-                "args": args,
-                "check": check,
-                "capture_output": capture_output,
-                "text": text,
-                "kwargs": kwargs,
-            }
-        )
-        return subprocess.CompletedProcess(args, 0, "", "")
+        raise AssertionError("keychain writes must not shell out with secret material")
 
     monkeypatch.setattr(subprocess, "run", fake_run)
 
-    KeychainSecretStore("hol-guard.sync").set_secret("guard-token", "secret-value")
-
-    assert calls == [
-        {
-            "args": [
-                "/usr/bin/security",
-                "add-generic-password",
-                "-a",
-                "guard-token",
-                "-s",
-                "hol-guard.sync",
-                "-U",
-                "-w",
-                "secret-value",
-            ],
-            "check": True,
-            "capture_output": True,
-            "text": True,
-            "kwargs": {},
-        }
-    ]
+    with pytest.raises(RuntimeError, match="argv exposure"):
+        KeychainSecretStore("hol-guard.sync").set_secret("guard-token", "secret-value")
 
 
 def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available_outside_macos(tmp_path, monkeypatch):
@@ -702,11 +673,10 @@ def test_sync_credentials_do_not_shell_out_to_keychain_when_file_store_is_availa
     GuardStore(guard_home)
 
 
-def test_sync_credentials_write_to_keychain_primary_on_macos(tmp_path, monkeypatch):
+def test_sync_credentials_fall_back_when_keychain_cli_rejects_writes_on_macos(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    sync_keychain = _install_fake_sync_keychain(monkeypatch)
     store = GuardStore(guard_home)
 
     store.set_sync_credentials(
@@ -716,14 +686,16 @@ def test_sync_credentials_write_to_keychain_primary_on_macos(tmp_path, monkeypat
         workspace_id="workspace-123",
     )
 
-    assert sync_keychain[("hol-guard.sync", store._sync_token_ref)] == "access-secret-value"
     assert store.get_sync_credentials() == {
         "sync_url": "https://hol.org/api/guard/receipts/sync",
         "token": "access-secret-value",
     }
 
 
-def test_get_sync_credentials_promotes_legacy_file_secret_into_keychain_on_macos(tmp_path, monkeypatch):
+def test_get_sync_credentials_keeps_legacy_file_secret_when_keychain_cli_rejects_writes_on_macos(
+    tmp_path,
+    monkeypatch,
+):
     guard_home = tmp_path / "guard-home"
     monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
     legacy_store = GuardStore(guard_home)
@@ -736,14 +708,12 @@ def test_get_sync_credentials_promotes_legacy_file_secret_into_keychain_on_macos
 
     monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    sync_keychain = _install_fake_sync_keychain(monkeypatch)
     migrated_store = GuardStore(guard_home)
 
     assert migrated_store.get_sync_credentials() == {
         "sync_url": "https://hol.org/api/guard/receipts/sync",
         "token": "legacy-access-secret",
     }
-    assert sync_keychain[("hol-guard.sync", migrated_store._sync_token_ref)] == "legacy-access-secret"
 
 
 def test_oauth_local_credentials_do_not_shell_out_to_keychain_when_system_keyring_is_available(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Stop macOS keychain sync-secret writes from invoking interactive password-data prompts.
- Avoid passing sync secrets through `security add-generic-password` argv; Guard now falls back to encrypted local secret storage when the raw macOS CLI cannot write safely.
- Add regression coverage for the rejected keychain CLI write path and sync-secret fallback behavior.

## Testing
- `pytest tests/test_guard_store_migrations.py -q`
- `pytest tests/test_guard_store_migrations.py tests/test_guard_package_shims.py -q`
- `pytest tests/test_guard_package_shims.py -q`
