### PR TITLE
fix(opencode): surface approval links in block responses

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -72,23 +72,92 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
   return { exitCode, stdout, stderr };
 }
 
-function guardBlockMessage(stdout: string, stderr: string): string {
-  try {
-    const payload = JSON.parse(stdout) as {
-      review_hint?: string;
-      decision_v2_json?: { harness_message?: string; retry_instruction?: string };
-    };
-    const decision = payload.decision_v2_json;
-    return (
-      payload.review_hint ||
-      decision?.retry_instruction ||
-      decision?.harness_message ||
-      stderr.trim() ||
-      "HOL Guard blocked this OpenCode action."
-    );
-  } catch {
+function parseGuardPayload(stdout: string): Record<string, unknown> | null {
+  const trimmed = stdout.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const parseCandidate = (candidate: string): Record<string, unknown> | null => {
+    try {
+      const parsed = JSON.parse(candidate);
+      if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+        return parsed as Record<string, unknown>;
+      }
+    } catch {}
+    return null;
+  };
+  const direct = parseCandidate(trimmed);
+  if (direct !== null) {
+    return direct;
+  }
+  const lines = trimmed.split(/\\r?\\n/);
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const candidate = lines[index]?.trim();
+    if (!candidate) {
+      continue;
+    }
+    const parsed = parseCandidate(candidate);
+    if (parsed !== null) {
+      return parsed;
+    }
+  }
+  return null;
+}
+
+function guardReviewUrl(payload: Record<string, unknown>): string | null {
+  const primary = typeof payload.primary_approval_url === "string" ? payload.primary_approval_url.trim() : "";
+  if (primary) {
+    return primary;
+  }
+  const reviewUrl = typeof payload.review_url === "string" ? payload.review_url.trim() : "";
+  if (reviewUrl) {
+    return reviewUrl;
+  }
+  const queued = payload.approval_requests;
+  if (Array.isArray(queued)) {
+    for (const item of queued) {
+      if (!item || typeof item !== "object") {
+        continue;
+      }
+      const approvalUrl = (item as { approval_url?: unknown }).approval_url;
+      if (typeof approvalUrl === "string" && approvalUrl.trim()) {
+        return approvalUrl.trim().replace(/\\/approvals\\//g, "/requests/");
+      }
+    }
+  }
+  const center = typeof payload.approval_center_url === "string" ? payload.approval_center_url.trim() : "";
+  return center || null;
+}
+
+export function guardBlockMessage(stdout: string, stderr: string): string {
+  const payload = parseGuardPayload(stdout);
+  if (payload === null) {
     return stderr.trim() || "HOL Guard blocked this OpenCode action.";
   }
+  const decision = payload.decision_v2_json;
+  const decisionPayload =
+    decision && typeof decision === "object"
+      ? (decision as { harness_message?: unknown; retry_instruction?: unknown })
+      : null;
+  const reviewHint = typeof payload.review_hint === "string" ? payload.review_hint.trim() : "";
+  const retryInstruction =
+    typeof decisionPayload?.retry_instruction === "string" ? decisionPayload.retry_instruction.trim() : "";
+  const harnessMessage =
+    typeof decisionPayload?.harness_message === "string" ? decisionPayload.harness_message.trim() : "";
+  const baseMessage =
+    reviewHint ||
+    retryInstruction ||
+    harnessMessage ||
+    stderr.trim() ||
+    "HOL Guard blocked this OpenCode action.";
+  const reviewUrl = guardReviewUrl(payload);
+  if (!reviewUrl || baseMessage.includes(reviewUrl)) {
+    return baseMessage;
+  }
+  return (
+    `${baseMessage} Open HOL Guard to approve or keep this blocked: ${reviewUrl}. `
+    + "After you choose, retry the same OpenCode action."
+  );
 }
 
 export const HolGuardPretoolPlugin = async ({

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
+import subprocess
 import sys
 from pathlib import Path
 
@@ -39,6 +41,33 @@ def _ctx(tmp_path: Path, *, workspace: bool = False) -> HarnessContext:
     )
 
 
+def _run_generated_guard_block_message(tmp_path: Path, *, stdout: str, stderr: str = "") -> str:
+    bun = shutil.which("bun")
+    if bun is None:
+        pytest.skip("bun not installed")
+    source = pretool_plugin_source(_ctx(tmp_path))
+    plugin_path = tmp_path / "guard-block-plugin.ts"
+    plugin_path.write_text(source, encoding="utf-8")
+    script_path = tmp_path / "guard-block-runner.ts"
+    script_path.write_text(
+        "import { guardBlockMessage } from './guard-block-plugin';\n"
+        + "console.log(guardBlockMessage("
+        + json.dumps(stdout)
+        + ", "
+        + json.dumps(stderr)
+        + "));\n",
+        encoding="utf-8",
+    )
+    completed = subprocess.run(
+        [bun, str(script_path)],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert completed.returncode == 0, completed.stderr
+    return completed.stdout.strip()
+
+
 def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     ctx = _ctx(tmp_path)
     source = pretool_plugin_source(ctx)
@@ -64,6 +93,39 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
 def test_pretool_plugin_source_normalizes_argv_array_commands(tmp_path: Path) -> None:
     source = pretool_plugin_source(_ctx(tmp_path))
     assert "Array.isArray(command)" in source
+
+
+def test_pretool_plugin_guard_block_message_appends_primary_approval_url(tmp_path: Path) -> None:
+    message = _run_generated_guard_block_message(
+        tmp_path,
+        stdout=json.dumps(
+            {
+                "decision_v2_json": {
+                    "harness_message": "HOL Guard blocked this OpenCode action.",
+                },
+                "primary_approval_url": "http://127.0.0.1:4455/requests/req-opencode",
+            }
+        ),
+    )
+    assert "http://127.0.0.1:4455/requests/req-opencode" in message
+    assert "Open HOL Guard to approve or keep this blocked" in message
+
+
+def test_pretool_plugin_guard_block_message_recovers_last_json_line(tmp_path: Path) -> None:
+    message = _run_generated_guard_block_message(
+        tmp_path,
+        stdout="Guard queued approval request\n"
+        + json.dumps(
+            {
+                "review_hint": "HOL Guard queued this OpenCode action for review.",
+                "approval_requests": [
+                    {"approval_url": "http://127.0.0.1:4455/approvals/req-opencode"},
+                ],
+            }
+        ),
+    )
+    assert "http://127.0.0.1:4455/requests/req-opencode" in message
+    assert message.count("http://127.0.0.1:4455/requests/req-opencode") == 1
 
 
 def test_pretool_hook_launcher_ignores_workspace_package_hijack(


### PR DESCRIPTION
## Summary
- recover Guard block payloads from noisy OpenCode pretool stdout before surfacing the error
- always include the approval request URL in OpenCode block responses, with Bun-backed regression coverage

## Testing
- `python3 -m pytest tests/test_opencode_pretool.py tests/test_guard_opencode_proxy.py -q`
