### PR TITLE
feat(guard): repair stale package shims from doctor

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -286,12 +286,12 @@ def _run_guard_doctor_command(
             for manager in package_shims_payload.get("installed_managers", [])
             if isinstance(manager, str) and manager.strip()
         )
-        package_shims_payload["repair"] = (
-            activate_package_shims(context, managers=installed_managers, repair=True)
-            if installed_managers
-            else {"nothing_to_repair": True, "repaired": [], "repaired_count": 0}
-        )
-        package_shims_payload["after_repair"] = package_shim_status(context)
+        if installed_managers:
+            repair_payload = activate_package_shims(context, managers=installed_managers, repair=True)
+            package_shims_payload["repair"] = repair_payload
+            package_shims_payload["after_repair"] = repair_payload["package_shims"]
+        else:
+            package_shims_payload["repair"] = {"nothing_to_repair": True, "repaired": [], "repaired_count": 0}
     package_shims_payload["issues"] = package_shim_issues
     payload["package_shims"] = package_shims_payload
     payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -262,6 +262,38 @@ def _run_guard_doctor_command(
         }
     if getattr(args, "perf", False):
         payload["detector_perf"] = _runtime_detector_perf_payload(config)
+    package_shims_payload = package_shim_status(context)
+    package_shim_issues = [
+        {
+            "kind": "package_shim_integrity",
+            "manager": str(detail.get("manager")),
+            "integrity": str(detail.get("integrity")),
+            "repair": "Run `hol-guard doctor --repair` to regenerate package-manager shims.",
+        }
+        for detail in package_shims_payload.get("manager_details", [])
+        if isinstance(detail, dict) and detail.get("integrity") in {"missing", "stale", "tampered"}
+    ]
+    if not bool(package_shims_payload.get("path_active")) and package_shims_payload.get("installed_managers"):
+        package_shim_issues.append(
+            {
+                "kind": "package_shim_path",
+                "repair": "Run `hol-guard doctor --repair`, then open a new shell if PATH changed.",
+            }
+        )
+    if getattr(args, "repair", False):
+        installed_managers = tuple(
+            str(manager)
+            for manager in package_shims_payload.get("installed_managers", [])
+            if isinstance(manager, str) and manager.strip()
+        )
+        package_shims_payload["repair"] = (
+            activate_package_shims(context, managers=installed_managers, repair=True)
+            if installed_managers
+            else {"nothing_to_repair": True, "repaired": [], "repaired_count": 0}
+        )
+        package_shims_payload["after_repair"] = package_shim_status(context)
+    package_shims_payload["issues"] = package_shim_issues
+    payload["package_shims"] = package_shims_payload
     payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())
     payload["aibom"] = build_aibom_status_payload(store, context, generated_at=_now())
     _emit("doctor", payload, getattr(args, "json", False))

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -230,6 +230,12 @@ def _configure_guard_policy_parsers(
     )
     doctor_parser.add_argument("--perf", action="store_true", help="Include detector performance timings")
     doctor_parser.add_argument(
+        "--repair",
+        "--fix",
+        action="store_true",
+        help="Repair common local Guard issues such as stale package-manager shims",
+    )
+    doctor_parser.add_argument(
         "--notifications",
         action="store_true",
         help="Send a notification preview and open macOS notification settings when needed",

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -242,11 +242,7 @@ def _normalized_base_command_repr(line: str) -> str:
         if index == 0 and isinstance(item, str):
             normalized.append("<python>")
             continue
-        if (
-            isinstance(item, str)
-            and index + 1 < len(value)
-            and value[index + 1] == "codex_plugin_scanner.cli"
-        ):
+        if isinstance(item, str) and index + 1 < len(value) and value[index + 1] == "codex_plugin_scanner.cli":
             normalized.append("<import-root>")
             continue
         if skip_path_after is not None:

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -430,10 +430,14 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
             active_managers.append(manager)
             current_hash = build_shim_content_hash(shim_path.read_bytes())
             stored_hash = stored_hashes.get(manager)
-            if stored_hash is None:
-                integrity = "unknown"
-            elif current_hash == stored_hash:
+            expected_content = _build_package_manager_python_shim(context, command).encode("utf-8")
+            expected_hash = build_shim_content_hash(expected_content)
+            if current_hash == expected_hash:
                 integrity = "ok"
+            elif stored_hash == current_hash:
+                integrity = "stale"
+            elif stored_hash is None:
+                integrity = "unknown"
             else:
                 integrity = "tampered"
         else:
@@ -589,7 +593,7 @@ def repair_package_shims(
             continue
         if selected_managers is not None and manager not in selected_managers:
             continue
-        if detail.get("integrity") in ("missing", "tampered"):
+        if detail.get("integrity") in ("missing", "stale", "tampered"):
             managers_to_repair.append(manager)
         elif not bool(detail.get("path_active")):
             path_repair_required.append(manager)

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import hashlib
 import json
 import os
@@ -198,6 +199,64 @@ def _home_override_args(context: HarnessContext) -> list[str]:
 def build_shim_content_hash(content: bytes) -> str:
     """Return hex SHA-256 of shim content bytes."""
     return hashlib.sha256(content).hexdigest()
+
+
+def _normalized_package_shim_content(content: bytes) -> str:
+    """Return generated-shim content with install-specific paths masked."""
+    try:
+        text = content.decode("utf-8")
+    except UnicodeDecodeError:
+        return ""
+    normalized_lines: list[str] = []
+    for line in text.splitlines():
+        if line.startswith("#!"):
+            normalized_lines.append("#!<python>")
+            continue
+        if line.startswith("base_command = "):
+            normalized_lines.append(f"base_command = {_normalized_base_command_repr(line)}")
+            continue
+        if line.startswith("guard_cwd = "):
+            normalized_lines.append("guard_cwd = '<path>'")
+            continue
+        if line.startswith("guard_has_explicit_workspace = "):
+            normalized_lines.append("guard_has_explicit_workspace = <workspace-mode>")
+            continue
+        if line.startswith("shim_dir = "):
+            normalized_lines.append("shim_dir = '<path>'")
+            continue
+        normalized_lines.append(line)
+    return "\n".join(normalized_lines)
+
+
+def _normalized_base_command_repr(line: str) -> str:
+    raw_value = line.split("=", 1)[1].strip()
+    try:
+        value = ast.literal_eval(raw_value)
+    except (SyntaxError, ValueError):
+        return raw_value
+    if not isinstance(value, list):
+        return raw_value
+    normalized: list[object] = []
+    skip_path_after: str | None = None
+    for index, item in enumerate(value):
+        if index == 0 and isinstance(item, str):
+            normalized.append("<python>")
+            continue
+        if (
+            isinstance(item, str)
+            and index + 1 < len(value)
+            and value[index + 1] == "codex_plugin_scanner.cli"
+        ):
+            normalized.append("<import-root>")
+            continue
+        if skip_path_after is not None:
+            normalized.append(f"<{skip_path_after}>")
+            skip_path_after = None
+            continue
+        normalized.append(item)
+        if item in {"--guard-home", "--home", "--workspace"}:
+            skip_path_after = str(item).lstrip("-")
+    return repr(normalized)
 
 
 def get_real_binary_info(
@@ -428,11 +487,14 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         path_status = get_path_order_status(context, manager=manager)
         if exists:
             active_managers.append(manager)
-            current_hash = build_shim_content_hash(shim_path.read_bytes())
+            current_content = shim_path.read_bytes()
+            current_hash = build_shim_content_hash(current_content)
             stored_hash = stored_hashes.get(manager)
             expected_content = _build_package_manager_python_shim(context, command).encode("utf-8")
             expected_hash = build_shim_content_hash(expected_content)
-            if current_hash == expected_hash:
+            if current_hash == expected_hash or _normalized_package_shim_content(
+                current_content
+            ) == _normalized_package_shim_content(expected_content):
                 integrity = "ok"
             elif stored_hash == current_hash:
                 integrity = "stale"

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -660,6 +660,24 @@ def test_guard_package_shims_repair_command_regenerates_stale_manager(tmp_path: 
     assert shim_path.read_text(encoding="utf-8") == current_content
 
 
+def test_guard_package_shims_status_ignores_dynamic_generated_paths(tmp_path: Path) -> None:
+    home_dir = tmp_path / "guard-home"
+    install_workspace = tmp_path / "workspace-a"
+    status_workspace = tmp_path / "workspace-b"
+    install_workspace.mkdir(parents=True, exist_ok=True)
+    status_workspace.mkdir(parents=True, exist_ok=True)
+    install_package_shims(
+        HarnessContext(home_dir=home_dir, workspace_dir=install_workspace, guard_home=home_dir),
+        managers=("npm",),
+    )
+
+    status = package_shim_status(
+        HarnessContext(home_dir=home_dir, workspace_dir=status_workspace, guard_home=home_dir),
+    )
+
+    assert status["manager_details"][0]["integrity"] == "ok"
+
+
 def test_guard_package_shims_install_does_not_mutate_path_environment(
     tmp_path: Path,
     capsys,

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -618,7 +618,7 @@ def test_guard_package_shims_repair_command_regenerates_stale_manager(tmp_path: 
     shim_path = Path(str(install_payload["shim_dir"])) / "npm"
     manifest_path = Path(str(install_payload["manifest_path"]))
     current_content = shim_path.read_text(encoding="utf-8")
-    stale_content = "#!/bin/sh\nexec npm \"$@\"\n"
+    stale_content = '#!/bin/sh\nexec npm "$@"\n'
     shim_path.write_text(stale_content, encoding="utf-8")
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
     manifest["content_hashes"]["npm"] = build_shim_content_hash(stale_content.encode("utf-8"))

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -21,12 +21,12 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import shims as guard_shims_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
-from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.protect import build_protect_payload
 from codex_plugin_scanner.guard.runtime import supply_chain_package_eval as supply_chain_package_eval_module
 from codex_plugin_scanner.guard.shim_probe import SHIM_PROBE_ENV_VALUE, SHIM_PROBE_ENV_VAR
-from codex_plugin_scanner.guard.shims import install_package_shims, package_shim_status
+from codex_plugin_scanner.guard.shims import build_shim_content_hash, install_package_shims, package_shim_status
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.shim_execution_helpers import write_fake_manager_script
 from tests.test_guard_protect import _seed_bundle_cache_only, _SyncAndEvaluateHandler
@@ -591,6 +591,73 @@ def test_guard_package_shims_repair_command_restores_selected_manager(tmp_path: 
     assert repair_payload["repaired"] == ["npm"]
     assert (shim_dir / "npm").exists()
     assert not (shim_dir / "pip").exists()
+
+
+def test_guard_package_shims_repair_command_regenerates_stale_manager(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    _seed_paid_bundle_entitlement(home_dir)
+
+    install_rc = main(
+        [
+            "guard",
+            "package-shims",
+            "install",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--manager",
+            "npm",
+            "--json",
+        ]
+    )
+    install_payload = json.loads(capsys.readouterr().out)
+    assert install_rc == 0
+    shim_path = Path(str(install_payload["shim_dir"])) / "npm"
+    manifest_path = Path(str(install_payload["manifest_path"]))
+    current_content = shim_path.read_text(encoding="utf-8")
+    stale_content = "#!/bin/sh\nexec npm \"$@\"\n"
+    shim_path.write_text(stale_content, encoding="utf-8")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["content_hashes"]["npm"] = build_shim_content_hash(stale_content.encode("utf-8"))
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+
+    status_rc = main(
+        [
+            "guard",
+            "package-shims",
+            "status",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    status_payload = json.loads(capsys.readouterr().out)
+    repair_rc = main(
+        [
+            "guard",
+            "package-shims",
+            "repair",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--manager",
+            "npm",
+            "--json",
+        ]
+    )
+    repair_payload = json.loads(capsys.readouterr().out)
+
+    assert status_rc == 0
+    assert status_payload["manager_details"][0]["integrity"] == "stale"
+    assert repair_rc == 0
+    assert repair_payload["repaired"] == ["npm"]
+    assert shim_path.read_text(encoding="utf-8") == current_content
 
 
 def test_guard_package_shims_install_does_not_mutate_path_environment(

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -11,7 +11,7 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
-from codex_plugin_scanner.guard.shims import install_package_shims
+from codex_plugin_scanner.guard.shims import build_shim_content_hash, install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -407,6 +407,58 @@ def test_package_shims_repair_runs_without_guard_cloud_connect(
     assert payload["profile"]["changed"] is True
     profile_path = Path(str(payload["profile"]["profile_path"]))
     assert str(guard_home / "package-shims" / "bin") in profile_path.read_text(encoding="utf-8")
+
+
+def test_guard_doctor_repair_regenerates_stale_package_shim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    guard_home = tmp_path / "guard-home"
+    _install_local_package_shim(guard_home, home_dir, "npm")
+    shim_path = guard_home / "package-shims" / "bin" / "npm"
+    current_content = shim_path.read_text(encoding="utf-8")
+    stale_content = "#!/bin/sh\nexec npm \"$@\"\n"
+    shim_path.write_text(stale_content, encoding="utf-8")
+    manifest_path = guard_home / "package-shims" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["content_hashes"]["npm"] = build_shim_content_hash(stale_content.encode("utf-8"))
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+
+    rc = main(
+        [
+            "guard",
+            "doctor",
+            "--repair",
+            "--home",
+            str(home_dir),
+            "--guard-home",
+            str(guard_home),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["package_shims"]["issues"] == [
+        {
+            "kind": "package_shim_integrity",
+            "manager": "npm",
+            "integrity": "stale",
+            "repair": "Run `hol-guard doctor --repair` to regenerate package-manager shims.",
+        },
+        {
+            "kind": "package_shim_path",
+            "repair": "Run `hol-guard doctor --repair`, then open a new shell if PATH changed.",
+        },
+    ]
+    assert payload["package_shims"]["repair"]["repaired"] == ["npm"]
+    assert payload["package_shims"]["after_repair"]["manager_details"][0]["integrity"] == "ok"
+    assert shim_path.read_text(encoding="utf-8") == current_content
 
 
 def test_package_shims_uninstall_runs_without_guard_cloud_connect(

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -422,7 +422,7 @@ def test_guard_doctor_repair_regenerates_stale_package_shim(
     _install_local_package_shim(guard_home, home_dir, "npm")
     shim_path = guard_home / "package-shims" / "bin" / "npm"
     current_content = shim_path.read_text(encoding="utf-8")
-    stale_content = "#!/bin/sh\nexec npm \"$@\"\n"
+    stale_content = '#!/bin/sh\nexec npm "$@"\n'
     shim_path.write_text(stale_content, encoding="utf-8")
     manifest_path = guard_home / "package-shims" / "manifest.json"
     manifest = json.loads(manifest_path.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- Add `hol-guard doctor --repair` for common local repair, starting with package-manager shims.
- Detect stale package shims by comparing on-disk wrappers to the current generated template, not only the stored manifest hash.
- Regenerate stale package shims through both `doctor --repair` and existing package-shim repair flows.

## Testing
- `pytest tests/test_guard_package_shims_cli.py -q`
- `pytest tests/test_guard_package_shims.py -q`
- `ruff check src/codex_plugin_scanner/guard/shims.py src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py src/codex_plugin_scanner/guard/cli/commands_parser_policy.py tests/test_guard_package_shims.py tests/test_guard_package_shims_cli.py`
