### PR TITLE
fix: honor saved runtime approvals

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -270,8 +270,7 @@ def apply_approval_resolution(
     request_artifact_id = _string_or_none(request.get("artifact_id"))
     request_artifact_hash = _string_or_none(request.get("artifact_hash"))
     request_publisher = _string_or_none(request.get("publisher"))
-    harness_artifact_id = request_artifact_id if scope == "harness" else None
-    scoped_artifact_id = request_artifact_id if scope == "artifact" else workspace_artifact_id or harness_artifact_id
+    scoped_artifact_id = request_artifact_id if scope in {"artifact", "harness", "global"} else workspace_artifact_id
     decision = PolicyDecision(
         harness="*" if scope == "global" else str(request["harness"]),
         scope=scope,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -211,13 +211,16 @@ def _runtime_stored_policy_action(
         and scope in {"workspace", "publisher", "harness", "global"}
         and _runtime_artifact_risk_classes(artifact)
     ):
+        decision_artifact_id = _optional_string(decision.get("artifact_id"))
         if scope == "workspace":
-            decision_artifact_id = _optional_string(decision.get("artifact_id"))
             decision_artifact_hash = _optional_string(decision.get("artifact_hash"))
             if decision_artifact_id == artifact_id and (
                 decision_artifact_hash is None or decision_artifact_hash == artifact_hash
             ):
                 return action
+            return None
+        if scope in {"harness", "global"}:
+            return action if decision_artifact_id is not None else None
         return None
     return action
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2085,12 +2085,21 @@ class GuardStore:
                       artifact_id is null or artifact_id = ?
                     )
                   )
-                  or scope = 'global'
+                    or (
+                      scope = 'global' and (
+                        artifact_id is null
+                        or artifact_id = ?
+                        or artifact_id = ?
+                      )
+                    )
                 )
                 and (expires_at is null or expires_at > ?)
                 order by case scope when 'artifact' then 0 when 'workspace' then 1 when 'publisher' then 2
-                          when 'harness' then 3 else 4 end,
-                         case when scope = 'workspace' and artifact_id is not null then 0 else 1 end,
+                         when 'harness' then 3 else 4 end,
+                         case
+                           when scope in ('workspace', 'harness', 'global') and artifact_id is not null then 0
+                           else 1
+                         end,
                          updated_at desc
                 """,
                 (
@@ -2104,6 +2113,8 @@ class GuardStore:
                     artifact_hash,
                     artifact_hash,
                     publisher,
+                    action_family_key,
+                    artifact_id,
                     action_family_key,
                     current_time,
                 ),
@@ -2124,7 +2135,7 @@ class GuardStore:
 
     @staticmethod
     def _normalized_policy_keys(decision: PolicyDecision) -> tuple[str | None, str | None, str | None, str | None]:
-        if decision.scope == "harness":
+        if decision.scope in {"harness", "global"}:
             artifact_id = _artifact_family_key(decision.artifact_id)
         else:
             artifact_id = decision.artifact_id if decision.scope in {"artifact", "workspace"} else None

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14157,6 +14157,93 @@ def test_guard_runtime_tool_action_policy_uses_network_egress_when_stricter(tmp_
     assert guard_commands_module._runtime_artifact_policy_action(config, artifact, "codex") == "block"
 
 
+@pytest.mark.parametrize(
+    "scope",
+    [
+        "harness",
+        "global",
+    ],
+)
+def test_guard_runtime_honors_broader_saved_allows_for_risky_tool_actions(
+    tmp_path: Path,
+    scope: str,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    workspace = tmp_path / "workspace"
+    request = GuardApprovalRequest(
+        request_id=f"req-opencode-{scope}",
+        harness="opencode",
+        artifact_id="opencode:project:tool-action:docker-compose-postgres",
+        artifact_name="Bash docker-sensitive command",
+        artifact_type="tool_action_request",
+        artifact_hash="hash-request",
+        publisher=None,
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("tool_action_request",),
+        source_scope="project",
+        config_path=str(workspace / "opencode.json"),
+        workspace=str(workspace),
+        launch_target="docker compose -f scripts/guard-cloud/docker-lab/docker-compose.yml up -d postgres",
+        review_command=f"hol-guard approvals approve req-opencode-{scope}",
+        approval_url=f"http://127.0.0.1:5474/requests/req-opencode-{scope}",
+        action_envelope_json={
+            "schema_version": 1,
+            "action_id": f"req-opencode-{scope}",
+            "harness": "opencode",
+            "event_name": "PreToolUse",
+            "action_type": "shell_command",
+            "workspace": str(workspace),
+            "workspace_hash": "workspace-hash",
+            "tool_name": "Bash",
+            "command": "docker compose -f scripts/guard-cloud/docker-lab/docker-compose.yml up -d postgres",
+            "prompt_excerpt": None,
+            "target_paths": [],
+            "network_hosts": [],
+            "mcp_server": None,
+            "mcp_tool": None,
+            "package_manager": None,
+            "package_name": None,
+            "script_name": None,
+            "raw_payload_redacted": {"tool_name": "Bash"},
+        },
+    )
+    store.add_approval_request(request, "2026-06-12T00:00:00+00:00")
+
+    apply_approval_resolution(
+        store=store,
+        request_id=request.request_id,
+        action="allow",
+        scope=scope,
+        workspace=request.workspace,
+        reason=f"saved for {scope}",
+        now="2026-06-12T00:01:00+00:00",
+    )
+
+    runtime_artifact = GuardArtifact(
+        artifact_id=request.artifact_id,
+        name=request.artifact_name,
+        harness="opencode",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=request.config_path,
+        publisher=None,
+        metadata={"action_class": "docker-sensitive command"},
+    )
+
+    assert (
+        guard_commands_module._runtime_stored_policy_action(
+            store=store,
+            harness="opencode",
+            artifact=runtime_artifact,
+            artifact_id=runtime_artifact.artifact_id,
+            artifact_hash="hash-retry",
+            workspace=str(workspace),
+        )
+        == "allow"
+    )
+
+
 def test_guard_runtime_tool_action_policy_prefers_configured_risk_action_over_default(tmp_path):
     artifact = GuardArtifact(
         artifact_id="codex:test:tool-action:upload",
@@ -17070,10 +17157,13 @@ def test_policy_bundle_version_persists_after_store_reopen(tmp_path):
 
 
 def test_policy_bundle_downgrade_check_ignores_mixed_timezone_formats():
-    assert guard_runner_module._policy_bundle_is_version_downgrade(
-        {"issuedAt": "2026-06-05T13:30:00+00:00"},
-        {"issuedAt": "2026-06-05T13:29:00"},
-    ) is False
+    assert (
+        guard_runner_module._policy_bundle_is_version_downgrade(
+            {"issuedAt": "2026-06-05T13:30:00+00:00"},
+            {"issuedAt": "2026-06-05T13:29:00"},
+        )
+        is False
+    )
 
 
 def test_sync_receipts_uploads_policy_bundle_acknowledgement(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- persist runtime approval decisions saved from the approval center for risky OpenCode/Codex-style tool actions when the user chooses `This App` or `Save everywhere`
- keep ignoring loose broad runtime allow rows that do not carry runtime artifact identity
- add an OpenCode regression covering a docker-sensitive command approved and retried through harness/global scope

## Testing
- `python3 -m pytest tests/test_guard_runtime.py -q`
- `python3 -m pytest tests/test_guard_approvals.py -k "harness_scope_resolution or global_scope_resolution or broad_scope_resolution or daemon_approval_and_diff_api_roundtrip or workspace_package_resolution" -q`
- `python3 -m pytest tests/test_guard_phase05_approval_memory.py -k "GR117 or GR119 or workspace_policy or harness_scope" -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py src/codex_plugin_scanner/guard/store.py tests/test_guard_runtime.py`