### PR TITLE
fix(guard): route top-level doctor repair

### DIFF
--- a/src/codex_plugin_scanner/_scanner_commands.py
+++ b/src/codex_plugin_scanner/_scanner_commands.py
@@ -1,0 +1,320 @@
+"""Scanner command runners for the combined CLI."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import zipfile
+from collections.abc import Callable
+from dataclasses import asdict, replace
+from pathlib import Path
+
+from .cli_ui import build_plain_text, build_verification_text, emit_hint, emit_scan_provenance
+from .config import DEFAULT_CONFIG_FILES, ConfigError, load_baseline_rule_ids, load_scanner_config
+from .lint_fixes import apply_safe_autofixes
+from .models import ScanOptions, get_grade
+from .policy import POLICY_PROFILES, build_rule_inventory, evaluate_policy, resolve_profile
+from .quality_artifact import build_quality_artifact, write_quality_artifact
+from .reporting import format_json as render_json
+from .reporting import format_markdown, format_sarif, should_fail_for_severity
+from .rules import get_rule_spec, list_rule_specs
+from .scanner import scan_plugin
+from .suppressions import apply_severity_overrides, apply_suppressions, compute_effective_score
+from .verification import build_doctor_report, build_verification_payload, verify_plugin
+
+RuleSpecLookup = Callable[[str], object | None]
+
+
+def _format_scan_json(
+    result,
+    *,
+    profile: str = "default",
+    policy_pass: bool = True,
+    verify_pass: bool = True,
+    raw_score: int | None = None,
+    effective_score: int | None = None,
+) -> str:
+    return render_json(
+        result,
+        profile=profile,
+        policy_pass=policy_pass,
+        verify_pass=verify_pass,
+        raw_score=raw_score,
+        effective_score=effective_score,
+    )
+
+
+def _print_lint_rules() -> None:
+    for spec in list_rule_specs():
+        print(f"{spec.rule_id}\t{spec.category}\t{spec.default_severity.value}\tfixable={spec.fixable}")
+
+
+def _print_lint_explain(rule_id: str, *, get_rule_spec_fn: RuleSpecLookup = get_rule_spec) -> int:
+    spec = get_rule_spec_fn(rule_id)
+    if spec is None:
+        print(f"Unknown rule id: {rule_id}", file=sys.stderr)
+        emit_hint("run `lint --list-rules` to inspect the available rule identifiers.")
+        return 1
+    print(json.dumps(asdict(spec), indent=2, default=str))
+    return 0
+
+
+def _resolve_scanner_config_path(plugin_dir: Path, config_path: str | None) -> Path | None:
+    if config_path:
+        candidate = Path(config_path)
+        return candidate if candidate.is_absolute() else (plugin_dir / candidate)
+    for name in DEFAULT_CONFIG_FILES:
+        candidate = plugin_dir / name
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _resolve_baseline_path(plugin_dir: Path, baseline_path: str | None) -> Path | None:
+    if not baseline_path:
+        return None
+    candidate = Path(baseline_path)
+    return candidate if candidate.is_absolute() else (plugin_dir / candidate)
+
+
+def _resolve_policy_profile(args: argparse.Namespace, plugin_dir: Path):
+    config_path = _resolve_scanner_config_path(plugin_dir, getattr(args, "config", None))
+    try:
+        config = load_scanner_config(plugin_dir, getattr(args, "config", None))
+        baseline_path = getattr(args, "baseline", None) or config.baseline_file
+        baseline_ids = load_baseline_rule_ids(plugin_dir, baseline_path)
+    except ConfigError as exc:
+        print(str(exc), file=sys.stderr)
+        raise
+
+    profile = resolve_profile(getattr(args, "profile", None) or config.profile)
+    return profile, config, baseline_ids, config_path, _resolve_baseline_path(plugin_dir, baseline_path)
+
+
+def _scan_with_policy(args: argparse.Namespace, plugin_dir: Path):
+    profile, config, baseline_ids, config_path, baseline_path = _resolve_policy_profile(args, plugin_dir)
+    raw_result = scan_plugin(
+        plugin_dir,
+        ScanOptions(
+            cisco_skill_scan=getattr(args, "cisco_skill_scan", "auto"),
+            cisco_mcp_scan=getattr(args, "cisco_mcp_scan", "auto"),
+            cisco_policy=getattr(args, "cisco_policy", "balanced"),
+            ecosystem=getattr(args, "ecosystem", "auto"),
+        ),
+    )
+    result = apply_suppressions(
+        raw_result,
+        enabled_rules=config.enabled_rules,
+        disabled_rules=config.disabled_rules,
+        baseline_ids=baseline_ids,
+        ignore_paths=config.ignore_paths,
+    )
+    result = apply_severity_overrides(result, config.severity_overrides)
+    executed_rules = {
+        spec.rule_id for spec in list_rule_specs() if not config.enabled_rules or spec.rule_id in config.enabled_rules
+    }
+    executed_rules -= set(config.disabled_rules)
+    inventory = build_rule_inventory(result.findings, executed_rules)
+    policy_eval = evaluate_policy(result.findings, profile, rule_inventory=inventory)
+    effective_score = compute_effective_score(result)
+    result = replace(result, score=effective_score, grade=get_grade(effective_score))
+    return raw_result, result, profile, policy_eval, effective_score, config_path, baseline_path
+
+
+def run_scan(args: argparse.Namespace) -> int:
+    plugin_dir = getattr(args, "plugin_dir", ".")
+    resolved = Path(plugin_dir).resolve()
+    if not resolved.is_dir():
+        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
+        return 1
+    try:
+        raw_result, result, profile, policy_eval, effective_score, config_path, baseline_path = _scan_with_policy(
+            args,
+            resolved,
+        )
+    except ConfigError:
+        return 1
+
+    output_format = "json" if args.json else args.format
+    if output_format == "text":
+        emit_scan_provenance(profile=profile, config_path=config_path, baseline_path=baseline_path)
+    if output_format == "json":
+        output = _format_scan_json(
+            result,
+            profile=profile,
+            policy_pass=policy_eval.policy_pass,
+            verify_pass=True,
+            raw_score=raw_result.score,
+            effective_score=effective_score,
+        )
+    elif output_format == "markdown":
+        output = format_markdown(result)
+    elif output_format == "sarif":
+        output = format_sarif(result)
+    else:
+        output = build_plain_text(result)
+        print(output)
+
+    if args.output:
+        Path(args.output).write_text(output, encoding="utf-8")
+        print(f"Report written to {args.output}")
+    elif output_format != "text":
+        print(output)
+
+    min_score = args.min_score
+    if result.score < min_score:
+        print(f"Score {result.score} is below threshold {min_score}", file=sys.stderr)
+        if output_format == "text":
+            emit_hint(
+                "review the highest-severity findings above, then rerun with --format json if you need automation."
+            )
+        return 1
+    if should_fail_for_severity(result, args.fail_on_severity):
+        print(
+            f'Findings met or exceeded the "{args.fail_on_severity}" severity threshold.',
+            file=sys.stderr,
+        )
+        emit_hint("adjust --fail-on-severity only if your policy allows reporting without a blocking gate.")
+        return 1
+    if args.strict and result.findings:
+        print("Strict mode failed because findings were present.", file=sys.stderr)
+        emit_hint("rerun without --strict to inspect findings without turning the report into a failing gate.")
+        return 1
+    if not policy_eval.policy_pass:
+        print(f'Policy profile "{profile}" failed.', file=sys.stderr)
+        emit_hint("use a different --profile only when that matches your documented review policy.")
+        return 1
+    return 0
+
+
+def run_lint(args: argparse.Namespace, *, get_rule_spec_fn: RuleSpecLookup = get_rule_spec) -> int:
+    if args.list_rules:
+        _print_lint_rules()
+        return 0
+    if args.explain:
+        return _print_lint_explain(args.explain, get_rule_spec_fn=get_rule_spec_fn)
+
+    resolved = Path(args.plugin_dir).resolve()
+    if not resolved.is_dir():
+        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
+        return 1
+    if args.fix:
+        for change in apply_safe_autofixes(resolved):
+            print(f"- {change}")
+
+    try:
+        _raw, result, profile, policy_eval, effective_score, _config_path, _baseline_path = _scan_with_policy(
+            args,
+            resolved,
+        )
+    except ConfigError:
+        return 1
+
+    payload = {
+        "profile": profile,
+        "policy_pass": policy_eval.policy_pass,
+        "effective_score": effective_score,
+        "findings": [
+            {
+                "rule_id": finding.rule_id,
+                "severity": finding.severity.value,
+                "category": finding.category,
+                "title": finding.title,
+                "description": finding.description,
+                "fixable": bool((spec := get_rule_spec_fn(finding.rule_id)) and spec.fixable),
+            }
+            for finding in result.findings
+        ],
+    }
+    if args.format == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print(f"Lint profile: {profile} | policy_pass={policy_eval.policy_pass} | effective_score={effective_score}")
+        for finding in result.findings:
+            print(f"- {finding.rule_id} [{finding.severity.value}] {finding.title}")
+
+    if args.strict and result.findings:
+        return 1
+    return 0 if policy_eval.policy_pass else 1
+
+
+def run_verify(args: argparse.Namespace) -> int:
+    resolved = Path(args.plugin_dir).resolve()
+    if not resolved.is_dir():
+        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
+        return 1
+    verification = verify_plugin(resolved, online=args.online)
+    payload = build_verification_payload(verification)
+    if args.format == "json":
+        print(json.dumps(payload, indent=2))
+    else:
+        print(build_verification_text(payload))
+    return 0 if verification.verify_pass else 1
+
+
+def run_submit(args: argparse.Namespace) -> int:
+    resolved = Path(args.plugin_dir).resolve()
+    if not resolved.is_dir():
+        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
+        return 1
+    try:
+        raw_result, result, profile, policy_eval, _effective_score, _config_path, _baseline_path = _scan_with_policy(
+            args,
+            resolved,
+        )
+    except ConfigError:
+        return 1
+    if getattr(result, "scope", "plugin") != "plugin":
+        print(
+            "Submission requires a single plugin directory. Target one plugin path instead of a repo marketplace root.",
+            file=sys.stderr,
+        )
+        return 1
+    verification = verify_plugin(resolved, online=args.online)
+    min_score = args.min_score if args.min_score is not None else POLICY_PROFILES[profile].min_score
+    if result.score < min_score or not policy_eval.policy_pass or not verification.verify_pass:
+        print("Submission blocked: scan/policy/verify gates did not all pass.", file=sys.stderr)
+        return 1
+    artifact = build_quality_artifact(
+        resolved,
+        result,
+        verification,
+        policy_eval,
+        profile,
+        raw_score=raw_result.score,
+    )
+    write_quality_artifact(Path(args.attest), artifact)
+    print(f"Submission artifact written to {args.attest}")
+    return 0
+
+
+def run_doctor(args: argparse.Namespace) -> int:
+    resolved = Path(args.plugin_dir).resolve()
+    if not resolved.is_dir():
+        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
+        return 1
+    report = build_doctor_report(resolved, args.component)
+    rendered = json.dumps(report, indent=2)
+    if args.bundle:
+        bundle_path = Path(args.bundle)
+        bundle_path.parent.mkdir(parents=True, exist_ok=True)
+        with zipfile.ZipFile(bundle_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            zf.writestr("doctor-report.json", rendered)
+            zf.writestr("environment.txt", f"cwd={resolved}\npython={sys.version}\nos={os.name}\n")
+            zf.writestr(
+                "workspace-manifest.txt",
+                f"workspace={report.get('workspace', '')}\ncomponent={args.component}\n",
+            )
+            zf.writestr(
+                "command-metadata.json",
+                json.dumps({"command": "doctor", "component": args.component}, indent=2),
+            )
+            zf.writestr("stdout.log", str(report.get("stdout_log", "")))
+            zf.writestr("stderr.log", str(report.get("stderr_log", "")))
+            zf.writestr("timeout-markers.txt", str(report.get("timeout_markers", "none\n")))
+        print(f"Doctor bundle written to {bundle_path}")
+    else:
+        print(rendered)
+    return 0

--- a/src/codex_plugin_scanner/action_runner.py
+++ b/src/codex_plugin_scanner/action_runner.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 
 from . import __version__
-from .cli import _scan_with_policy
+from ._scanner_commands import _scan_with_policy
 from .cli_ui import build_plain_text, build_verification_text
 from .config import ConfigError, load_scanner_config
 from .github_reporting import (

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -214,6 +214,25 @@ def _resolve_legacy_args(
         if resolved_guard_args is None:
             return ["guard"]
         return ["guard", *resolved_guard_args]
+    guard_doctor_flags = {
+        "--fix",
+        "--force-notification-settings",
+        "--guard-home",
+        "--harnesses",
+        "--home",
+        "--json",
+        "--notifications",
+        "--perf",
+        "--repair",
+        "--workspace",
+    }
+    if program_mode == "combined" and argv[0] == "doctor":
+        has_guard_doctor_flag = any(arg in guard_doctor_flags for arg in argv[1:])
+        is_hol_guard_doctor_help = _is_hol_guard_program(program_name) and (
+            len(argv) == 1 or "-h" in argv[1:] or "--help" in argv[1:]
+        )
+        if has_guard_doctor_flag or is_hol_guard_doctor_help:
+            return ["guard", *argv]
     known_commands = {
         "scan",
         "lint",

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -3,35 +3,16 @@
 from __future__ import annotations
 
 import argparse
-import json
-import os
 import sys
-import zipfile
-from dataclasses import asdict, replace
 from pathlib import Path
 
+from ._scanner_commands import run_doctor, run_lint, run_scan, run_submit, run_verify
 from .argparse_utils import FriendlyArgumentParser, should_default_to_scan_target
-from .cli_ui import (
-    build_cli_epilog,
-    build_plain_text,
-    build_scan_help_epilog,
-    build_verification_text,
-    emit_hint,
-    emit_scan_provenance,
-)
-from .config import DEFAULT_CONFIG_FILES, ConfigError, load_baseline_rule_ids, load_scanner_config
+from .cli_ui import build_cli_epilog, build_plain_text, build_scan_help_epilog
 from .ecosystems.registry import list_supported_ecosystems
 from .guard.cli import add_guard_parser, add_guard_root_parser, run_guard_command
-from .lint_fixes import apply_safe_autofixes
-from .models import ScanOptions, get_grade
-from .policy import POLICY_PROFILES, build_rule_inventory, evaluate_policy, resolve_profile
-from .quality_artifact import build_quality_artifact, write_quality_artifact
 from .reporting import format_json as render_json
-from .reporting import format_markdown, format_sarif, should_fail_for_severity
-from .rules import get_rule_spec, list_rule_specs
-from .scanner import scan_plugin
-from .suppressions import apply_severity_overrides, apply_suppressions, compute_effective_score
-from .verification import build_doctor_report, build_verification_payload, verify_plugin
+from .rules import get_rule_spec
 from .version import __version__
 
 
@@ -228,10 +209,10 @@ def _resolve_legacy_args(
     }
     if program_mode == "combined" and argv[0] == "doctor":
         has_guard_doctor_flag = any(arg in guard_doctor_flags for arg in argv[1:])
-        is_hol_guard_doctor_help = _is_hol_guard_program(program_name) and (
+        is_hol_guard_default_doctor = _is_hol_guard_program(program_name) and (
             len(argv) == 1 or "-h" in argv[1:] or "--help" in argv[1:]
         )
-        if has_guard_doctor_flag or is_hol_guard_doctor_help:
+        if has_guard_doctor_flag or is_hol_guard_default_doctor:
             return ["guard", *argv]
     known_commands = {
         "scan",
@@ -304,280 +285,6 @@ def _resolve_legacy_args(
     return ["scan", *argv]
 
 
-def _print_lint_rules() -> None:
-    for spec in list_rule_specs():
-        print(f"{spec.rule_id}\t{spec.category}\t{spec.default_severity.value}\tfixable={spec.fixable}")
-
-
-def _print_lint_explain(rule_id: str) -> int:
-    spec = get_rule_spec(rule_id)
-    if spec is None:
-        print(f"Unknown rule id: {rule_id}", file=sys.stderr)
-        emit_hint("run `lint --list-rules` to inspect the available rule identifiers.")
-        return 1
-    print(json.dumps(asdict(spec), indent=2, default=str))
-    return 0
-
-
-def _resolve_scanner_config_path(plugin_dir: Path, config_path: str | None) -> Path | None:
-    if config_path:
-        candidate = Path(config_path)
-        return candidate if candidate.is_absolute() else (plugin_dir / candidate)
-    for name in DEFAULT_CONFIG_FILES:
-        candidate = plugin_dir / name
-        if candidate.exists():
-            return candidate
-    return None
-
-
-def _resolve_baseline_path(plugin_dir: Path, baseline_path: str | None) -> Path | None:
-    if not baseline_path:
-        return None
-    candidate = Path(baseline_path)
-    return candidate if candidate.is_absolute() else (plugin_dir / candidate)
-
-
-def _resolve_policy_profile(args: argparse.Namespace, plugin_dir: Path):
-    config_path = _resolve_scanner_config_path(plugin_dir, getattr(args, "config", None))
-    try:
-        config = load_scanner_config(plugin_dir, getattr(args, "config", None))
-        baseline_path = getattr(args, "baseline", None) or config.baseline_file
-        baseline_ids = load_baseline_rule_ids(plugin_dir, baseline_path)
-    except ConfigError as exc:
-        print(str(exc), file=sys.stderr)
-        raise
-
-    profile = resolve_profile(getattr(args, "profile", None) or config.profile)
-    return profile, config, baseline_ids, config_path, _resolve_baseline_path(plugin_dir, baseline_path)
-
-
-def _scan_with_policy(args: argparse.Namespace, plugin_dir: Path):
-    profile, config, baseline_ids, config_path, baseline_path = _resolve_policy_profile(args, plugin_dir)
-    raw_result = scan_plugin(
-        plugin_dir,
-        ScanOptions(
-            cisco_skill_scan=getattr(args, "cisco_skill_scan", "auto"),
-            cisco_mcp_scan=getattr(args, "cisco_mcp_scan", "auto"),
-            cisco_policy=getattr(args, "cisco_policy", "balanced"),
-            ecosystem=getattr(args, "ecosystem", "auto"),
-        ),
-    )
-    result = apply_suppressions(
-        raw_result,
-        enabled_rules=config.enabled_rules,
-        disabled_rules=config.disabled_rules,
-        baseline_ids=baseline_ids,
-        ignore_paths=config.ignore_paths,
-    )
-    result = apply_severity_overrides(result, config.severity_overrides)
-    executed_rules = {
-        spec.rule_id for spec in list_rule_specs() if not config.enabled_rules or spec.rule_id in config.enabled_rules
-    }
-    executed_rules -= set(config.disabled_rules)
-    inventory = build_rule_inventory(result.findings, executed_rules)
-    policy_eval = evaluate_policy(result.findings, profile, rule_inventory=inventory)
-    effective_score = compute_effective_score(result)
-    result = replace(result, score=effective_score, grade=get_grade(effective_score))
-    return raw_result, result, profile, policy_eval, effective_score, config_path, baseline_path
-
-
-def _run_scan(args: argparse.Namespace) -> int:
-    plugin_dir = getattr(args, "plugin_dir", ".")
-    resolved = Path(plugin_dir).resolve()
-    if not resolved.is_dir():
-        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
-        return 1
-    try:
-        raw_result, result, profile, policy_eval, effective_score, config_path, baseline_path = _scan_with_policy(
-            args,
-            resolved,
-        )
-    except ConfigError:
-        return 1
-
-    output_format = "json" if args.json else args.format
-    if output_format == "text":
-        emit_scan_provenance(profile=profile, config_path=config_path, baseline_path=baseline_path)
-    if output_format == "json":
-        output = format_json(
-            result,
-            profile=profile,
-            policy_pass=policy_eval.policy_pass,
-            verify_pass=True,
-            raw_score=raw_result.score,
-            effective_score=effective_score,
-        )
-    elif output_format == "markdown":
-        output = format_markdown(result)
-    elif output_format == "sarif":
-        output = format_sarif(result)
-    else:
-        output = build_plain_text(result)
-        print(output)
-
-    if args.output:
-        Path(args.output).write_text(output, encoding="utf-8")
-        print(f"Report written to {args.output}")
-    elif output_format != "text":
-        print(output)
-
-    min_score = args.min_score
-    if result.score < min_score:
-        print(f"Score {result.score} is below threshold {min_score}", file=sys.stderr)
-        if output_format == "text":
-            emit_hint(
-                "review the highest-severity findings above, then rerun with --format json if you need automation."
-            )
-        return 1
-    if should_fail_for_severity(result, args.fail_on_severity):
-        print(
-            f'Findings met or exceeded the "{args.fail_on_severity}" severity threshold.',
-            file=sys.stderr,
-        )
-        emit_hint("adjust --fail-on-severity only if your policy allows reporting without a blocking gate.")
-        return 1
-    if args.strict and result.findings:
-        print("Strict mode failed because findings were present.", file=sys.stderr)
-        emit_hint("rerun without --strict to inspect findings without turning the report into a failing gate.")
-        return 1
-    if not policy_eval.policy_pass:
-        print(f'Policy profile "{profile}" failed.', file=sys.stderr)
-        emit_hint("use a different --profile only when that matches your documented review policy.")
-        return 1
-    return 0
-
-
-def _run_lint(args: argparse.Namespace) -> int:
-    if args.list_rules:
-        _print_lint_rules()
-        return 0
-    if args.explain:
-        return _print_lint_explain(args.explain)
-
-    resolved = Path(args.plugin_dir).resolve()
-    if not resolved.is_dir():
-        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
-        return 1
-    if args.fix:
-        for change in apply_safe_autofixes(resolved):
-            print(f"- {change}")
-
-    try:
-        _raw, result, profile, policy_eval, effective_score, _config_path, _baseline_path = _scan_with_policy(
-            args,
-            resolved,
-        )
-    except ConfigError:
-        return 1
-
-    payload = {
-        "profile": profile,
-        "policy_pass": policy_eval.policy_pass,
-        "effective_score": effective_score,
-        "findings": [
-            {
-                "rule_id": finding.rule_id,
-                "severity": finding.severity.value,
-                "category": finding.category,
-                "title": finding.title,
-                "description": finding.description,
-                "fixable": bool((spec := get_rule_spec(finding.rule_id)) and spec.fixable),
-            }
-            for finding in result.findings
-        ],
-    }
-    if args.format == "json":
-        print(json.dumps(payload, indent=2))
-    else:
-        print(f"Lint profile: {profile} | policy_pass={policy_eval.policy_pass} | effective_score={effective_score}")
-        for finding in result.findings:
-            print(f"- {finding.rule_id} [{finding.severity.value}] {finding.title}")
-
-    if args.strict and result.findings:
-        return 1
-    return 0 if policy_eval.policy_pass else 1
-
-
-def _run_verify(args: argparse.Namespace) -> int:
-    resolved = Path(args.plugin_dir).resolve()
-    if not resolved.is_dir():
-        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
-        return 1
-    verification = verify_plugin(resolved, online=args.online)
-    payload = build_verification_payload(verification)
-    if args.format == "json":
-        print(json.dumps(payload, indent=2))
-    else:
-        print(build_verification_text(payload))
-    return 0 if verification.verify_pass else 1
-
-
-def _run_submit(args: argparse.Namespace) -> int:
-    resolved = Path(args.plugin_dir).resolve()
-    if not resolved.is_dir():
-        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
-        return 1
-    try:
-        raw_result, result, profile, policy_eval, _effective_score, _config_path, _baseline_path = _scan_with_policy(
-            args,
-            resolved,
-        )
-    except ConfigError:
-        return 1
-    if getattr(result, "scope", "plugin") != "plugin":
-        print(
-            "Submission requires a single plugin directory. Target one plugin path instead of a repo marketplace root.",
-            file=sys.stderr,
-        )
-        return 1
-    verification = verify_plugin(resolved, online=args.online)
-    min_score = args.min_score if args.min_score is not None else POLICY_PROFILES[profile].min_score
-    if result.score < min_score or not policy_eval.policy_pass or not verification.verify_pass:
-        print("Submission blocked: scan/policy/verify gates did not all pass.", file=sys.stderr)
-        return 1
-    artifact = build_quality_artifact(
-        resolved,
-        result,
-        verification,
-        policy_eval,
-        profile,
-        raw_score=raw_result.score,
-    )
-    write_quality_artifact(Path(args.attest), artifact)
-    print(f"Submission artifact written to {args.attest}")
-    return 0
-
-
-def _run_doctor(args: argparse.Namespace) -> int:
-    resolved = Path(args.plugin_dir).resolve()
-    if not resolved.is_dir():
-        print(f'Error: "{resolved}" is not a directory.', file=sys.stderr)
-        return 1
-    report = build_doctor_report(resolved, args.component)
-    rendered = json.dumps(report, indent=2)
-    if args.bundle:
-        bundle_path = Path(args.bundle)
-        bundle_path.parent.mkdir(parents=True, exist_ok=True)
-        with zipfile.ZipFile(bundle_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
-            zf.writestr("doctor-report.json", rendered)
-            zf.writestr("environment.txt", f"cwd={resolved}\npython={sys.version}\nos={os.name}\n")
-            zf.writestr(
-                "workspace-manifest.txt",
-                f"workspace={report.get('workspace', '')}\ncomponent={args.component}\n",
-            )
-            zf.writestr(
-                "command-metadata.json",
-                json.dumps({"command": "doctor", "component": args.component}, indent=2),
-            )
-            zf.writestr("stdout.log", str(report.get("stdout_log", "")))
-            zf.writestr("stderr.log", str(report.get("stderr_log", "")))
-            zf.writestr("timeout-markers.txt", str(report.get("timeout_markers", "none\n")))
-        print(f"Doctor bundle written to {bundle_path}")
-    else:
-        print(rendered)
-    return 0
-
-
 def main(argv: list[str] | None = None) -> int:
     program_name = Path(sys.argv[0]).name or "plugin-scanner"
     if _is_guard_program(program_name):
@@ -600,15 +307,15 @@ def main(argv: list[str] | None = None) -> int:
     if getattr(args, "diff_base", None):
         parser.error("--diff-base is not implemented yet. Remove the flag and rerun without diff-aware gating.")
     if args.command in {None, "scan"}:
-        return _run_scan(args)
+        return run_scan(args)
     if args.command == "lint":
-        return _run_lint(args)
+        return run_lint(args, get_rule_spec_fn=get_rule_spec)
     if args.command == "verify":
-        return _run_verify(args)
+        return run_verify(args)
     if args.command == "submit":
-        return _run_submit(args)
+        return run_submit(args)
     if args.command == "doctor":
-        return _run_doctor(args)
+        return run_doctor(args)
     if args.command == "guard":
         try:
             return run_guard_command(args)

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -475,6 +475,7 @@ def test_top_level_guard_doctor_repair_regenerates_stale_package_shim(
     guard_home = tmp_path / "guard-home"
     _install_local_package_shim(guard_home, home_dir, "npm")
     shim_path = guard_home / "package-shims" / "bin" / "npm"
+    current_content = shim_path.read_text(encoding="utf-8")
     stale_content = '#!/bin/sh\nexec npm "$@"\n'
     shim_path.write_text(stale_content, encoding="utf-8")
     manifest_path = guard_home / "package-shims" / "manifest.json"
@@ -488,6 +489,7 @@ def test_top_level_guard_doctor_repair_regenerates_stale_package_shim(
     assert rc == 0
     assert payload["package_shims"]["repair"]["repaired"] == ["npm"]
     assert payload["package_shims"]["after_repair"]["manager_details"][0]["integrity"] == "ok"
+    assert shim_path.read_text(encoding="utf-8") == current_content
 
 
 def test_package_shims_uninstall_runs_without_guard_cloud_connect(

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -459,6 +460,34 @@ def test_guard_doctor_repair_regenerates_stale_package_shim(
     assert payload["package_shims"]["repair"]["repaired"] == ["npm"]
     assert payload["package_shims"]["after_repair"]["manager_details"][0]["integrity"] == "ok"
     assert shim_path.read_text(encoding="utf-8") == current_content
+
+
+def test_top_level_guard_doctor_repair_regenerates_stale_package_shim(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    home_dir.mkdir()
+    monkeypatch.setattr(sys, "argv", ["hol-guard"])
+    monkeypatch.setenv("HOME", str(home_dir))
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+    guard_home = tmp_path / "guard-home"
+    _install_local_package_shim(guard_home, home_dir, "npm")
+    shim_path = guard_home / "package-shims" / "bin" / "npm"
+    stale_content = '#!/bin/sh\nexec npm "$@"\n'
+    shim_path.write_text(stale_content, encoding="utf-8")
+    manifest_path = guard_home / "package-shims" / "manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    manifest["content_hashes"]["npm"] = build_shim_content_hash(stale_content.encode("utf-8"))
+    manifest_path.write_text(json.dumps(manifest, sort_keys=True), encoding="utf-8")
+
+    rc = main(["doctor", "--repair", "--home", str(home_dir), "--guard-home", str(guard_home), "--json"])
+
+    payload = json.loads(capsys.readouterr().out)
+    assert rc == 0
+    assert payload["package_shims"]["repair"]["repaired"] == ["npm"]
+    assert payload["package_shims"]["after_repair"]["manager_details"][0]["integrity"] == "ok"
 
 
 def test_package_shims_uninstall_runs_without_guard_cloud_connect(

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -469,6 +469,19 @@ args = ["workspace-skill.js", "--changed"]
         assert "doctor       Run local diagnostics" in output
         assert "Use status for Home posture" in output
 
+    def test_hol_guard_top_level_doctor_help_shows_guard_doctor(self, capsys, monkeypatch):
+        monkeypatch.setattr(sys, "argv", ["hol-guard"])
+
+        with pytest.raises(SystemExit) as excinfo:
+            main(["doctor", "--help"])
+
+        output = capsys.readouterr().out
+
+        assert excinfo.value.code == 0
+        assert "--repair, --fix" in output
+        assert "Repair common local Guard issues" in output
+        assert "--component" not in output
+
     def test_guard_status_softens_refresh_race_copy_when_local_protection_stays_active(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         guard_home = home_dir / ".hol-guard"


### PR DESCRIPTION
Summary:
- Route top-level `hol-guard doctor --repair/--json` to Guard doctor repair flows
- Make `hol-guard doctor --help` show Guard doctor help for the hol-guard entrypoint
- Keep plugin doctor behavior available for plugin paths/component diagnostics

Testing:
- `ruff format src/codex_plugin_scanner/cli.py tests/test_guard_package_shims_cli.py tests/test_guard_product_flow.py`
- `ruff check src/codex_plugin_scanner/cli.py tests/test_guard_package_shims_cli.py tests/test_guard_product_flow.py`
- `pytest tests/test_guard_package_shims_cli.py -q`
- `pytest tests/test_guard_product_flow.py -q`