### PR TITLE
feat(guard): discover impeccable standards files in AIBOM inventory

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -453,23 +453,6 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                         name_for_path=lambda artifact_path, _base_dir: artifact_path.stem,
                     )
                 )
-            project_claude_md = context.workspace_dir / "CLAUDE.md"
-            if project_claude_md.is_file() and resolves_within_root(
-                context.workspace_dir,
-                project_claude_md,
-                require_exists=True,
-            ):
-                artifacts.append(
-                    GuardArtifact(
-                        artifact_id="claude-code:project:instruction:claude-md",
-                        name="CLAUDE.md",
-                        harness=self.harness,
-                        artifact_type="instruction",
-                        source_scope="project",
-                        config_path=str(project_claude_md),
-                        metadata=_metadata_with_digest(project_claude_md),
-                    )
-                )
         resolved_executable = self.resolved_executable(context)
         detection = HarnessDetection(
             harness=self.harness,

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -179,7 +179,7 @@ def _discover_standards_context_files(harness: str, *, workspace_dir: Path) -> l
         if not resolves_within_root(workspace_dir, search_root, require_exists=True):
             continue
         for filename, role in _STANDARDS_INSTRUCTION_FILES:
-            path = search_root / filename if relative_root == "." else workspace_dir / relative_root / filename
+            path = search_root / filename
             if path.is_symlink() or not path.is_file():
                 continue
             if not resolves_within_root(workspace_dir, path, require_exists=True):
@@ -190,6 +190,10 @@ def _discover_standards_context_files(harness: str, *, workspace_dir: Path) -> l
             seen_paths.add(normalized_path)
             relative_id = path.relative_to(workspace_dir).as_posix()
             display_name = path.name if relative_root == "." else f"{path.name} ({relative_root})"
+            artifact_suffix = relative_id.replace("/", ":")
+            legacy_artifact_id: str | None = None
+            if harness == "claude-code" and relative_id == "CLAUDE.md":
+                legacy_artifact_id = f"{harness}:project:instruction:claude-md"
             artifacts.append(
                 _instruction_artifact(
                     harness,
@@ -197,7 +201,8 @@ def _discover_standards_context_files(harness: str, *, workspace_dir: Path) -> l
                     role=role,
                     scope="project",
                     display_name=display_name,
-                    artifact_name=relative_id.replace("/", ":"),
+                    artifact_name=artifact_suffix,
+                    artifact_id=legacy_artifact_id,
                 )
             )
     return artifacts
@@ -414,12 +419,14 @@ def _instruction_artifact(
     scope: str,
     display_name: str | None = None,
     artifact_name: str | None = None,
+    artifact_id: str | None = None,
 ) -> GuardArtifact:
     content_hash = file_content_hash(path) or fingerprint_text(path.name)
     name = display_name or path.name
     artifact_suffix = artifact_name or name
+    resolved_artifact_id = artifact_id or f"{harness}:{scope}:instruction:{role}:{artifact_suffix}"
     return GuardArtifact(
-        artifact_id=f"{harness}:{scope}:instruction:{role}:{artifact_suffix}",
+        artifact_id=resolved_artifact_id,
         name=name,
         harness=harness,
         artifact_type="instruction",

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -12,7 +12,14 @@ from .codex_skill_config import load_codex_skill_config_rules, resolve_codex_ski
 from .inventory_contract import fingerprint_mapping, fingerprint_path_tree, fingerprint_text
 from .models import GuardArtifact, HarnessDetection
 
-InstructionRole = Literal["agents_md", "cursor_rules", "claude_md", "mcp_json"]
+InstructionRole = Literal[
+    "agents_md",
+    "cursor_rules",
+    "claude_md",
+    "design_md",
+    "mcp_json",
+    "product_md",
+]
 INVENTORY_ITEM_KINDS: tuple[str, ...] = (
     "agent",
     "daemon_plugin",
@@ -38,6 +45,12 @@ _READ_CHUNK_BYTES = 65536
 _CURSOR_RULE_PATTERNS = ("*.mdc", "*.md")
 _CODEX_WORKSPACE_SKILL_ROOTS = (".agents/skills",)
 _CODEX_HOME_SKILL_ROOTS = (".codex/skills", ".agents/skills")
+_STANDARDS_CONTEXT_ROOTS = (".", ".agents/context", "docs")
+_STANDARDS_INSTRUCTION_FILES: tuple[tuple[str, InstructionRole], ...] = (
+    ("PRODUCT.md", "product_md"),
+    ("DESIGN.md", "design_md"),
+    ("CLAUDE.md", "claude_md"),
+)
 
 
 def file_content_hash(path: Path, *, max_bytes: int | None = None) -> str | None:
@@ -102,6 +115,10 @@ def instruction_role_for_path(path: Path) -> InstructionRole | None:
         return "agents_md"
     if name == "claude.md":
         return "claude_md"
+    if name == "design.md":
+        return "design_md"
+    if name == "product.md":
+        return "product_md"
     if name == "mcp.json":
         return "mcp_json"
     if path.suffix.lower() in {".md", ".mdc"}:
@@ -126,6 +143,7 @@ def discover_shared_workspace_aibom_artifacts(
         return ()
     artifacts: list[GuardArtifact] = []
     artifacts.extend(_discover_agents_md(harness, workspace_dir=workspace_dir))
+    artifacts.extend(_discover_standards_context_files(harness, workspace_dir=workspace_dir))
     artifacts.extend(_discover_cursor_rules(harness, workspace_dir=workspace_dir))
     if harness != "codex":
         artifacts.extend(
@@ -149,6 +167,40 @@ def _discover_agents_md(harness: str, *, workspace_dir: Path) -> list[GuardArtif
     if not resolves_within_root(workspace_dir, agents_md, require_exists=True):
         return []
     return [_instruction_artifact(harness, agents_md, role="agents_md", scope="project")]
+
+
+def _discover_standards_context_files(harness: str, *, workspace_dir: Path) -> list[GuardArtifact]:
+    artifacts: list[GuardArtifact] = []
+    seen_paths: set[str] = set()
+    for relative_root in _STANDARDS_CONTEXT_ROOTS:
+        search_root = workspace_dir if relative_root == "." else workspace_dir / relative_root
+        if relative_root != "." and not search_root.is_dir():
+            continue
+        if not resolves_within_root(workspace_dir, search_root, require_exists=True):
+            continue
+        for filename, role in _STANDARDS_INSTRUCTION_FILES:
+            path = search_root / filename if relative_root == "." else workspace_dir / relative_root / filename
+            if path.is_symlink() or not path.is_file():
+                continue
+            if not resolves_within_root(workspace_dir, path, require_exists=True):
+                continue
+            normalized_path = path.resolve().as_posix()
+            if normalized_path in seen_paths:
+                continue
+            seen_paths.add(normalized_path)
+            relative_id = path.relative_to(workspace_dir).as_posix()
+            display_name = path.name if relative_root == "." else f"{path.name} ({relative_root})"
+            artifacts.append(
+                _instruction_artifact(
+                    harness,
+                    path,
+                    role=role,
+                    scope="project",
+                    display_name=display_name,
+                    artifact_name=relative_id.replace("/", ":"),
+                )
+            )
+    return artifacts
 
 
 def _discover_cursor_rules(harness: str, *, workspace_dir: Path) -> list[GuardArtifact]:
@@ -361,11 +413,13 @@ def _instruction_artifact(
     role: InstructionRole,
     scope: str,
     display_name: str | None = None,
+    artifact_name: str | None = None,
 ) -> GuardArtifact:
     content_hash = file_content_hash(path) or fingerprint_text(path.name)
     name = display_name or path.name
+    artifact_suffix = artifact_name or name
     return GuardArtifact(
-        artifact_id=f"{harness}:{scope}:instruction:{role}:{name}",
+        artifact_id=f"{harness}:{scope}:instruction:{role}:{artifact_suffix}",
         name=name,
         harness=harness,
         artifact_type="instruction",

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -70,6 +70,49 @@ def test_discover_agents_md_and_cursor_rules(tmp_path: Path) -> None:
     assert "cursor_rules" in roles
 
 
+def test_instruction_role_for_path_recognizes_standards_files() -> None:
+    assert instruction_role_for_path(Path("PRODUCT.md")) == "product_md"
+    assert instruction_role_for_path(Path("DESIGN.md")) == "design_md"
+    assert instruction_role_for_path(Path("CLAUDE.md")) == "claude_md"
+    assert instruction_role_for_path(Path("docs/PRODUCT.md")) == "product_md"
+
+
+def test_discover_standards_context_files_in_root_and_fallback_dirs(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "PRODUCT.md").write_text("# Product\n", encoding="utf-8")
+    (workspace / "DESIGN.md").write_text("# Design\n", encoding="utf-8")
+    (workspace / "CLAUDE.md").write_text("# Claude\n", encoding="utf-8")
+
+    context_dir = workspace / ".agents" / "context"
+    context_dir.mkdir(parents=True)
+    (context_dir / "PRODUCT.md").write_text("# Product context\n", encoding="utf-8")
+
+    docs_dir = workspace / "docs"
+    docs_dir.mkdir()
+    (docs_dir / "DESIGN.md").write_text("# Design docs\n", encoding="utf-8")
+
+    artifacts = discover_shared_workspace_aibom_artifacts(
+        "codex",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    roles = {
+        artifact.metadata.get("instructionRole")
+        for artifact in artifacts
+        if artifact.artifact_type == "instruction" and isinstance(artifact.metadata, dict)
+    }
+    names = {
+        artifact.name
+        for artifact in artifacts
+        if artifact.artifact_type == "instruction"
+    }
+
+    assert roles == {"product_md", "design_md", "claude_md"}
+    assert "PRODUCT.md (.agents/context)" in names
+    assert "DESIGN.md (docs)" in names
+
+
 def test_discover_codex_skills_and_marketplace_plugins(tmp_path: Path) -> None:
     workspace = tmp_path / "repo"
     plugin_dir = workspace / "plugins" / "demo"

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -641,7 +641,9 @@ def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path
     assert "claude-code:project:skill:review" in artifacts
     assert "claude-code:project:command:deploy" in artifacts
     assert "claude-code:project:instruction:secrets" in artifacts
-    assert "claude-code:project:instruction:claude-md" in artifacts
+    claude_instruction = artifacts.get("claude-code:project:instruction:claude_md:CLAUDE.md")
+    assert claude_instruction is not None
+    assert claude_instruction.metadata.get("instructionRole") == "claude_md"
 
 
 def test_claude_detect_tolerates_unreadable_markdown_artifacts(monkeypatch, tmp_path):

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -641,7 +641,7 @@ def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path
     assert "claude-code:project:skill:review" in artifacts
     assert "claude-code:project:command:deploy" in artifacts
     assert "claude-code:project:instruction:secrets" in artifacts
-    claude_instruction = artifacts.get("claude-code:project:instruction:claude_md:CLAUDE.md")
+    claude_instruction = artifacts.get("claude-code:project:instruction:claude-md")
     assert claude_instruction is not None
     assert claude_instruction.metadata.get("instructionRole") == "claude_md"
 


### PR DESCRIPTION
## Summary
- Discover PRODUCT.md, DESIGN.md, and CLAUDE.md under workspace root, `.agents/context`, and `docs`.
- Emit instruction artifacts with `product_md`, `design_md`, and `claude_md` roles for all harnesses.
- Route Claude Code CLAUDE.md through shared workspace discovery with `instructionRole` metadata.

## Testing
- `python3 -m pytest tests/test_guard_aibom_detection.py -q`
- `python3 -m pytest tests/test_guard_claude_adapter.py::test_claude_detect_discovers_nested_hooks_skills_commands_and_rules -q`

## Notes
- Depends on points-portal contract PR for `product_md` and `design_md` ingest validation.
