### PR TITLE
feat(guard): verify policy memory bundles

### DIFF
--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import base64
 import hashlib
 import json
+
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
 _POLICY_BUNDLE_CORE_KEYS = (
     "contractVersion",
@@ -52,6 +58,18 @@ def computed_policy_bundle_hash(policy_bundle: dict[str, object]) -> str:
         if key not in policy_bundle:
             raise ValueError(f"missing_policy_bundle_key:{key}")
         bundle_core[key] = policy_bundle[key]
+    verifier = bundle_core.get("verifier")
+    if isinstance(verifier, dict):
+        normalized_verifier = dict(verifier)
+        if verifier.get("algorithm") == "rsa-pss-sha256":
+            normalized_verifier["publicKeyPem"] = None
+        else:
+            normalized_verifier.pop("publicKeyPem", None)
+        normalized_verifier["signature"] = None
+        bundle_core["verifier"] = normalized_verifier
+    workspace_id = policy_bundle.get("workspaceId")
+    if workspace_id is not None:
+        bundle_core["workspaceId"] = workspace_id
     min_daemon_version = _non_empty_string(policy_bundle.get("minDaemonVersion"))
     if min_daemon_version is not None:
         bundle_core["minDaemonVersion"] = min_daemon_version
@@ -75,6 +93,18 @@ def _policy_bundle_rule_is_valid(rule: object) -> bool:
         return False
     if not isinstance(rule.get("reason"), str):
         return False
+    source_receipt_id = rule.get("sourceReceiptId")
+    if source_receipt_id is not None and _non_empty_string(source_receipt_id) is None:
+        return False
+    source_local_request_id = rule.get("sourceLocalRequestId")
+    if source_local_request_id is not None and _non_empty_string(source_local_request_id) is None:
+        return False
+    source_receipt_ids = rule.get("sourceReceiptIds")
+    if source_receipt_ids is not None and not _policy_bundle_string_list(source_receipt_ids):
+        return False
+    audit_event_ids = rule.get("auditEventIds")
+    if audit_event_ids is not None and not _policy_bundle_string_list(audit_event_ids):
+        return False
     scope = rule.get("scope")
     return isinstance(scope, dict) and all(
         _policy_bundle_string_list(scope.get(key)) for key in _POLICY_BUNDLE_SCOPE_KEYS
@@ -95,6 +125,72 @@ def _policy_bundle_acknowledgement_is_valid(acknowledgement: object) -> bool:
     return acknowledgement.get("status") in {"pending", "synced", "failed", "offline"}
 
 
+def canonical_policy_bundle_payload(policy_bundle: dict[str, object]) -> bytes:
+    bundle_core: dict[str, object] = {}
+    for key in _POLICY_BUNDLE_CORE_KEYS:
+        if key not in policy_bundle:
+            raise ValueError(f"missing_policy_bundle_key:{key}")
+        bundle_core[key] = policy_bundle[key]
+    verifier = bundle_core.get("verifier")
+    if isinstance(verifier, dict):
+        normalized_verifier = dict(verifier)
+        normalized_verifier["signature"] = None
+        bundle_core["verifier"] = normalized_verifier
+    workspace_id = policy_bundle.get("workspaceId")
+    if workspace_id is not None:
+        bundle_core["workspaceId"] = workspace_id
+    acknowledgements = policy_bundle.get("acknowledgements")
+    if acknowledgements is None:
+        raise ValueError("missing_policy_bundle_key:acknowledgements")
+    bundle_core["acknowledgements"] = acknowledgements
+    min_daemon_version = _non_empty_string(policy_bundle.get("minDaemonVersion"))
+    if min_daemon_version is not None:
+        bundle_core["minDaemonVersion"] = min_daemon_version
+    return _stable_serialize(bundle_core).encode("utf-8")
+
+
+def payload_hash_for_policy_bundle(policy_bundle: dict[str, object]) -> str:
+    return hashlib.sha256(canonical_policy_bundle_payload(policy_bundle)).hexdigest()
+
+
+def _verify_policy_bundle_signature(
+    policy_bundle: dict[str, object],
+    canonical_payload: bytes,
+) -> str | None:
+    verifier = policy_bundle.get("verifier")
+    if not isinstance(verifier, dict):
+        return "invalid_verifier"
+    algorithm = verifier.get("algorithm")
+    if algorithm == "sha256":
+        return None
+    if algorithm != "rsa-pss-sha256":
+        return "invalid_verifier"
+    public_key_pem = _non_empty_string(verifier.get("publicKeyPem"))
+    signature = _non_empty_string(verifier.get("signature"))
+    if public_key_pem is None or signature is None:
+        return "invalid_verifier"
+    try:
+        public_key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+    except (UnsupportedAlgorithm, ValueError, TypeError):
+        return "invalid_verifier"
+    if not isinstance(public_key, RSAPublicKey):
+        return "invalid_verifier"
+    try:
+        signature_bytes = base64.b64decode(signature)
+    except Exception:
+        return "invalid_verifier"
+    try:
+        public_key.verify(
+            signature_bytes,
+            canonical_payload,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.AUTO),
+            hashes.SHA256(),
+        )
+    except (InvalidSignature, ValueError, TypeError):
+        return "bundle_signature_invalid"
+    return None
+
+
 def validated_policy_bundle_payload(
     policy_bundle: dict[str, object],
 ) -> tuple[dict[str, object] | None, str | None]:
@@ -111,14 +207,18 @@ def validated_policy_bundle_payload(
     expires_at = policy_bundle.get("expiresAt")
     if expires_at is not None and _non_empty_string(expires_at) is None:
         return None, "invalid_expires_at"
+    workspace_id = policy_bundle.get("workspaceId")
+    if workspace_id is not None and _non_empty_string(workspace_id) is None:
+        return None, "invalid_workspace_id"
     verifier = policy_bundle.get("verifier")
     if not isinstance(verifier, dict):
         return None, "invalid_verifier"
-    if verifier.get("algorithm") != "sha256" or _non_empty_string(verifier.get("keyId")) is None:
+    if (
+        verifier.get("algorithm") not in {"sha256", "rsa-pss-sha256"}
+        or _non_empty_string(verifier.get("keyId")) is None
+    ):
         return None, "invalid_verifier"
     signature = verifier.get("signature")
-    # `signature` is forward-compatible bundle metadata today; the enforced integrity check is the
-    # stable bundle hash computed from the signed core fields below.
     if signature is not None and _non_empty_string(signature) is None:
         return None, "invalid_verifier"
     if policy_bundle.get("rolloutState") not in _POLICY_BUNDLE_ROLLOUT_STATES:
@@ -148,13 +248,20 @@ def validated_policy_bundle_payload(
         _policy_bundle_acknowledgement_is_valid(acknowledgement) for acknowledgement in acknowledgements
     ):
         return None, "invalid_acknowledgements"
+    canonical_payload = canonical_policy_bundle_payload(policy_bundle)
+    payload_hash = _non_empty_string(policy_bundle.get("payloadHash"))
+    if payload_hash is not None and payload_hash != hashlib.sha256(canonical_payload).hexdigest():
+        return None, "payload_hash_mismatch"
     bundle_hash = _non_empty_string(policy_bundle.get("bundleHash"))
     if bundle_hash is None:
         return None, "invalid_bundle_hash"
     computed_hash = computed_policy_bundle_hash(policy_bundle)
     if bundle_hash != computed_hash:
         return None, "bundle_hash_mismatch"
-    return {
+    signature_error = _verify_policy_bundle_signature(policy_bundle, canonical_payload)
+    if signature_error is not None:
+        return None, signature_error
+    payload = {
         "contractVersion": policy_bundle["contractVersion"],
         "bundleVersion": policy_bundle["bundleVersion"],
         "bundleHash": bundle_hash,
@@ -170,7 +277,12 @@ def validated_policy_bundle_payload(
         "policyDefaults": defaults,
         "rules": rules,
         "acknowledgements": acknowledgements,
-    }, None
+    }
+    if payload_hash is not None:
+        payload["payloadHash"] = payload_hash
+    if workspace_id is not None:
+        payload["workspaceId"] = workspace_id
+    return payload, None
 
 
 non_empty_string = _non_empty_string

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1246,6 +1246,18 @@ def sync_receipts(
         ):
             validated_policy_bundle = None
             policy_bundle_rejection_reason = "bundle_version_downgrade"
+        bundle_workspace_id = non_empty_string(
+            validated_policy_bundle.get("workspaceId") if isinstance(validated_policy_bundle, dict) else None
+        )
+        cloud_workspace_id = store.get_cloud_workspace_id()
+        if (
+            validated_policy_bundle is not None
+            and bundle_workspace_id is not None
+            and cloud_workspace_id is not None
+            and bundle_workspace_id != cloud_workspace_id
+        ):
+            validated_policy_bundle = None
+            policy_bundle_rejection_reason = "wrong_workspace"
         if validated_policy_bundle is not None:
             store.set_sync_payload("policy_bundle", validated_policy_bundle, now)
             store.set_sync_payload("policy_bundle_last_good", validated_policy_bundle, now)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -17322,6 +17322,76 @@ def test_sync_receipts_uploads_policy_bundle_acknowledgement_to_sync_route(tmp_p
     }
 
 
+def test_sync_receipts_rejects_policy_bundle_for_the_wrong_workspace(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "guard-live-token",
+        "2026-06-05T13:30:00+00:00",
+        workspace_id="workspace-a",
+    )
+    bundle = {
+        "contractVersion": "guard-policy-bundle.v1",
+        "bundleVersion": "policy-2026-06-05.5",
+        "bundleHash": "",
+        "issuedAt": "2026-06-05T13:30:00+00:00",
+        "expiresAt": None,
+        "verifier": {
+            "algorithm": "sha256",
+            "keyId": "guard-policy-bundle-v1",
+            "signature": None,
+        },
+        "rolloutState": "enforcing",
+        "workspaceId": "workspace-b",
+        "policyDefaults": {
+            "mode": "enforce",
+            "defaultAction": "warn",
+            "unknownPublisherAction": "review",
+            "changedHashAction": "require-reapproval",
+            "newNetworkDomainAction": "warn",
+            "subprocessAction": "block",
+            "telemetryEnabled": False,
+            "syncEnabled": True,
+        },
+        "rules": [],
+        "acknowledgements": [],
+    }
+    bundle["bundleHash"] = guard_runner_module._computed_policy_bundle_hash(bundle)
+
+    class _Response:
+        def __init__(self, payload: dict[str, object]) -> None:
+            self._payload = payload
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self) -> bytes:
+            return json.dumps(self._payload).encode("utf-8")
+
+    def _fake_urlopen(request, timeout):
+        if request.full_url.endswith("/api/v1/guard/events"):
+            return _Response({"accepted": 0, "rejected": 0, "statuses": []})
+        return _Response(
+            {
+                "syncedAt": "2026-06-05T13:30:01+00:00",
+                "receiptsStored": 0,
+                "policyBundle": bundle,
+            }
+        )
+
+    monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _fake_urlopen)
+    monkeypatch.setattr(guard_runner_module, "sync_pain_signals", lambda _store, auth_context=None: 0)
+
+    guard_runner_module.sync_receipts(store)
+
+    assert store.get_sync_payload("policy_bundle") is None
+    assert store.get_sync_payload("policy_bundle_last_good") is None
+    assert store.get_sync_payload("policy_bundle_last_error") == {"reason": "wrong_workspace"}
+
+
 def test_policy_bundle_decision_resolves_before_receipt_persistence(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     workspace = tmp_path / "workspace"

--- a/tests/test_policy_bundle_parser.py
+++ b/tests/test_policy_bundle_parser.py
@@ -2,10 +2,16 @@
 
 from __future__ import annotations
 
+import base64
 from pathlib import Path
 
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
 from codex_plugin_scanner.guard.policy_bundle_parser import (
+    canonical_policy_bundle_payload,
     computed_policy_bundle_hash,
+    payload_hash_for_policy_bundle,
     validated_policy_bundle_payload,
 )
 from codex_plugin_scanner.guard.store import GuardStore
@@ -63,6 +69,33 @@ def _sample_policy_bundle(*, bundle_hash: str | None = None) -> dict[str, object
     return bundle
 
 
+def _signed_policy_bundle() -> dict[str, object]:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode('utf-8')
+    bundle = _sample_policy_bundle()
+    bundle['workspaceId'] = 'workspace-1'
+    verifier = dict(bundle['verifier']) if isinstance(bundle['verifier'], dict) else {}
+    verifier['algorithm'] = 'rsa-pss-sha256'
+    verifier['keyId'] = 'guard-policy-bundle-test-key'
+    verifier['publicKeyPem'] = public_key_pem
+    verifier['signature'] = None
+    bundle['verifier'] = verifier
+    bundle['bundleHash'] = computed_policy_bundle_hash(bundle)
+    bundle['payloadHash'] = payload_hash_for_policy_bundle(bundle)
+    verifier['signature'] = base64.b64encode(
+        private_key.sign(
+            canonical_policy_bundle_payload(bundle),
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+    ).decode('utf-8')
+    bundle['verifier'] = verifier
+    return bundle
+
+
 def test_hgc071_valid_policy_bundle_parses() -> None:
     bundle = _sample_policy_bundle()
 
@@ -73,6 +106,68 @@ def test_hgc071_valid_policy_bundle_parses() -> None:
     assert validated_bundle["bundleVersion"] == "policy-2026-04-19.1"
     assert validated_bundle["bundleHash"] == computed_policy_bundle_hash(bundle)
     assert validated_bundle["rules"] == bundle["rules"]
+
+
+def test_hgc071_signed_policy_bundle_parses() -> None:
+    bundle = _signed_policy_bundle()
+
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+
+    assert reason is None
+    assert validated_bundle is not None
+    assert validated_bundle["workspaceId"] == "workspace-1"
+    assert validated_bundle["payloadHash"] == payload_hash_for_policy_bundle(bundle)
+    verifier = validated_bundle["verifier"]
+    assert isinstance(verifier, dict)
+    assert verifier["algorithm"] == "rsa-pss-sha256"
+
+
+def test_hgc073_signed_policy_bundle_rejects_invalid_signature() -> None:
+    bundle = _signed_policy_bundle()
+    verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}
+    verifier["signature"] = base64.b64encode(b"tampered-signature").decode('utf-8')
+    bundle["verifier"] = verifier
+
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+
+    assert validated_bundle is None
+    assert reason == "bundle_signature_invalid"
+
+
+def test_hgc073_bundle_hash_ignores_public_key_rotation() -> None:
+    first_bundle = _signed_policy_bundle()
+    second_bundle = _signed_policy_bundle()
+    first_verifier = first_bundle["verifier"]
+    second_verifier = second_bundle["verifier"]
+
+    assert isinstance(first_verifier, dict)
+    assert isinstance(second_verifier, dict)
+
+    assert first_bundle["bundleHash"] == computed_policy_bundle_hash(first_bundle)
+    assert second_bundle["bundleHash"] == computed_policy_bundle_hash(second_bundle)
+    assert first_bundle["bundleHash"] == second_bundle["bundleHash"]
+    assert first_verifier["publicKeyPem"] != second_verifier["publicKeyPem"]
+
+
+def test_hgc071_legacy_sha256_bundle_omits_workspace_id_when_unset() -> None:
+    bundle = _sample_policy_bundle()
+
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+
+    assert reason is None
+    assert validated_bundle is not None
+    assert "payloadHash" not in validated_bundle
+    assert "workspaceId" not in validated_bundle
+
+
+def test_hgc071_sha256_bundle_hash_ignores_public_key_field() -> None:
+    bundle = _sample_policy_bundle()
+    legacy_hash = computed_policy_bundle_hash(bundle)
+    verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}
+    verifier["publicKeyPem"] = "unused-public-key"
+    bundle["verifier"] = verifier
+
+    assert computed_policy_bundle_hash(bundle) == legacy_hash
 
 
 def test_hgc072_invalid_schema_rejected() -> None:


### PR DESCRIPTION
## Summary
- extend the local policy bundle parser and receipt-sync runtime to validate signed policy bundle metadata and reject wrong-workspace bundles before they replace last-known-good state
- preserve the existing policy sync and acknowledgement flow while keeping bundle hash/version reporting and last-known-good storage intact
- add focused local parser/runtime tests for signed bundle verification, wrong-workspace rejection, and existing bundle acknowledgement behavior

## Testing
- `pytest -q tests/test_policy_bundle_parser.py -k 'hgc071 or hgc073'`
- `pytest -q tests/test_guard_headless_daemon_api.py -k 'policy_bundle or headless_policy_sync_accepts_policy_bundle'`
- `pytest -q tests/test_guard_runtime.py -k 'wrong_workspace or policy_bundle_acknowledgement or policy_bundle_version_persists_after_store_reopen'`

## Notes
- This Phase 6 slice stayed within the existing receipt-sync and policy-bundle paths; no new sync channel was introduced.
