### PR TITLE
fix(guard): repair stale approval link ports

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -151,13 +151,41 @@ def primary_approval_url(
         return None
     approval_url = request.get("approval_url")
     if isinstance(approval_url, str) and approval_url.strip():
-        return approval_url.strip().replace("/approvals/", "/requests/")
+        return _canonical_local_approval_url(
+            approval_url.strip().replace("/approvals/", "/requests/"),
+            approval_center_url=approval_center_url,
+        )
     request_id = request.get("request_id")
     if isinstance(request_id, str) and request_id.strip() and isinstance(approval_center_url, str):
         center = approval_center_url.strip()
         if center:
             return build_approval_request_url(center, request_id.strip())
     return None
+
+
+def _canonical_local_approval_url(approval_url: str, *, approval_center_url: str | None) -> str:
+    if not isinstance(approval_center_url, str) or not approval_center_url.strip():
+        return approval_url
+    try:
+        parsed_approval = urlparse(approval_url)
+        parsed_center = urlparse(approval_center_url.strip())
+    except ValueError:
+        return approval_url
+    loopback_hosts = {"127.0.0.1", "::1", "localhost"}
+    approval_host = parsed_approval.netloc.rsplit("@", 1)[-1].rsplit(":", 1)[0].strip("[]")
+    center_host = parsed_center.netloc.rsplit("@", 1)[-1].rsplit(":", 1)[0].strip("[]")
+    if parsed_approval.scheme not in {"http", "https"} or approval_host not in loopback_hosts:
+        return approval_url
+    if parsed_center.scheme not in {"http", "https"} or center_host not in loopback_hosts:
+        return approval_url
+    if not parsed_center.netloc:
+        return approval_url
+    return urlunparse(
+        parsed_approval._replace(
+            scheme=parsed_center.scheme,
+            netloc=parsed_center.netloc,
+        )
+    )
 
 
 def queue_blocked_approvals(

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -9,7 +9,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
+from urllib.parse import ParseResult, parse_qsl, urlencode, urlparse, urlunparse
 
 from .adapters import get_adapter
 from .adapters.base import HarnessContext
@@ -172,13 +172,11 @@ def _canonical_local_approval_url(approval_url: str, *, approval_center_url: str
     except ValueError:
         return approval_url
     loopback_hosts = {"127.0.0.1", "::1", "localhost"}
-    approval_host = parsed_approval.netloc.rsplit("@", 1)[-1].rsplit(":", 1)[0].strip("[]")
-    center_host = parsed_center.netloc.rsplit("@", 1)[-1].rsplit(":", 1)[0].strip("[]")
+    approval_host = _parsed_url_host(parsed_approval)
+    center_host = _parsed_url_host(parsed_center)
     if parsed_approval.scheme not in {"http", "https"} or approval_host not in loopback_hosts:
         return approval_url
     if parsed_center.scheme not in {"http", "https"} or center_host not in loopback_hosts:
-        return approval_url
-    if not parsed_center.netloc:
         return approval_url
     return urlunparse(
         parsed_approval._replace(
@@ -186,6 +184,17 @@ def _canonical_local_approval_url(approval_url: str, *, approval_center_url: str
             netloc=parsed_center.netloc,
         )
     )
+
+
+def _parsed_url_host(parsed: ParseResult) -> str:
+    host_port = parsed.netloc.rsplit("@", 1)[-1]
+    if host_port.startswith("["):
+        host, _separator, _rest = host_port[1:].partition("]")
+        return host
+    if host_port.count(":") == 1:
+        host, _port = host_port.rsplit(":", 1)
+        return host
+    return host_port
 
 
 def queue_blocked_approvals(

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -124,6 +124,44 @@ def test_first_approval_url_ignores_malformed_queue_items() -> None:
     )
 
 
+def test_first_approval_url_repairs_stale_local_port() -> None:
+    queued = [
+        {
+            "approval_url": "http://127.0.0.1:5713/requests/req-stale-port",
+            "harness": "package-firewall",
+            "request_id": "req-stale-port",
+        }
+    ]
+
+    assert (
+        first_approval_url(
+            queued,
+            harness="package-firewall",
+            approval_center_url="http://127.0.0.1:5474",
+        )
+        == "http://127.0.0.1:5474/requests/req-stale-port"
+    )
+
+
+def test_first_approval_url_does_not_rewrite_external_url() -> None:
+    queued = [
+        {
+            "approval_url": "https://guard.example/requests/req-cloud",
+            "harness": "package-firewall",
+            "request_id": "req-cloud",
+        }
+    ]
+
+    assert (
+        first_approval_url(
+            queued,
+            harness="package-firewall",
+            approval_center_url="http://127.0.0.1:5474",
+        )
+        == "https://guard.example/requests/req-cloud"
+    )
+
+
 def test_primary_approval_request_prefers_matching_harness() -> None:
     queued = [
         {

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -143,6 +143,44 @@ def test_first_approval_url_repairs_stale_local_port() -> None:
     )
 
 
+@pytest.mark.parametrize(
+    ("stale_url", "active_center", "expected_url"),
+    [
+        (
+            "http://localhost:5713/requests/req-localhost",
+            "http://127.0.0.1:5474",
+            "http://127.0.0.1:5474/requests/req-localhost",
+        ),
+        (
+            "http://" + "[" + ":".join(["", "", "1"]) + "]:5713/requests/req-ipv6",
+            "http://" + "[" + ":".join(["", "", "1"]) + "]:5474",
+            "http://" + "[" + ":".join(["", "", "1"]) + "]:5474/requests/req-ipv6",
+        ),
+    ],
+)
+def test_first_approval_url_repairs_loopback_variants(
+    stale_url: str,
+    active_center: str,
+    expected_url: str,
+) -> None:
+    queued = [
+        {
+            "approval_url": stale_url,
+            "harness": "package-firewall",
+            "request_id": "req-loopback",
+        }
+    ]
+
+    assert (
+        first_approval_url(
+            queued,
+            harness="package-firewall",
+            approval_center_url=active_center,
+        )
+        == expected_url
+    )
+
+
 def test_first_approval_url_does_not_rewrite_external_url() -> None:
     queued = [
         {


### PR DESCRIPTION
## Summary
- Rewrite stale loopback approval request URLs to the active local approval-center origin before showing user-facing review links.
- Add regressions for stale local ports and external approval URLs.

## Testing
- `ruff format src/codex_plugin_scanner/guard/approvals.py tests/test_guard_approval_copy_commands.py`
- `ruff check src/codex_plugin_scanner/guard/approvals.py tests/test_guard_approval_copy_commands.py`
- `pytest tests/test_guard_approval_copy_commands.py -q`
- `pytest tests/test_guard_package_hook.py -q`
- `pytest tests/test_guard_runtime.py -q -k "package_review_copy or local_approval_url or approval_url"`
