### PR TITLE
fix(guard): prevent CLAUDE.md artifact ID collision with Claude rules

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -450,7 +450,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                         harness=self.harness,
                         artifact_type="instruction",
                         artifact_id_prefix="instruction",
-                        name_for_path=lambda artifact_path, _base_dir: artifact_path.stem,
+                        name_for_path=lambda artifact_path, _base_dir: f"rules-{artifact_path.stem}",
                     )
                 )
         resolved_executable = self.resolved_executable(context)

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -472,6 +472,19 @@ def extend_codex_runtime_inventory(
     )
 
 
+def _is_workspace_root_claude_md(artifact: GuardArtifact, workspace_dir: Path) -> bool:
+    metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
+    if metadata.get("instructionRole") != "claude_md":
+        return False
+    config_path = getattr(artifact, "config_path", None)
+    if not isinstance(config_path, str):
+        return False
+    try:
+        return Path(config_path).resolve() == (workspace_dir / "CLAUDE.md").resolve()
+    except OSError:
+        return False
+
+
 def extend_detection_with_workspace_aibom(
     detection: HarnessDetection,
     *,
@@ -489,12 +502,19 @@ def extend_detection_with_workspace_aibom(
         return detection
     existing_ids = {artifact.artifact_id for artifact in detection.artifacts}
     merged = list(detection.artifacts)
+    artifact_index_by_id = {artifact.artifact_id: index for index, artifact in enumerate(merged)}
     found_paths = list(detection.config_paths)
     for artifact in extra:
         if artifact.artifact_id in existing_ids:
+            if _is_workspace_root_claude_md(artifact, workspace_dir):
+                merged[artifact_index_by_id[artifact.artifact_id]] = artifact
+                config_path = getattr(artifact, "config_path", None)
+                if isinstance(config_path, str):
+                    found_paths.append(config_path)
             continue
         merged.append(artifact)
         existing_ids.add(artifact.artifact_id)
+        artifact_index_by_id[artifact.artifact_id] = len(merged) - 1
         config_path = getattr(artifact, "config_path", None)
         if isinstance(config_path, str):
             found_paths.append(config_path)

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -4,6 +4,7 @@ import json
 from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.cursor import CursorHarnessAdapter
 from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
 from codex_plugin_scanner.guard.adapters.openclaw import OpenClawHarnessAdapter
@@ -310,6 +311,23 @@ def test_marketplace_escape_path_does_not_read_outside_workspace(tmp_path: Path)
 
     assert len(evil_plugins) == 1
     assert "content_hash" not in evil_plugins[0].metadata
+
+
+def test_extend_detection_prefers_workspace_root_claude_md_on_legacy_id_collision(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    root_claude_md = workspace / "CLAUDE.md"
+    root_claude_md.write_text("# root instructions\n", encoding="utf-8")
+    colliding_rule = workspace / ".claude" / "rules" / "claude-md.md"
+    colliding_rule.parent.mkdir(parents=True)
+    colliding_rule.write_text("# colliding rule\n", encoding="utf-8")
+
+    context = HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=tmp_path / ".hol-guard")
+    detection = ClaudeCodeHarnessAdapter().detect(context)
+    artifacts = {artifact.artifact_id: artifact for artifact in detection.artifacts}
+
+    assert artifacts["claude-code:project:instruction:claude-md"].config_path == str(root_claude_md)
+    assert artifacts["claude-code:project:instruction:rules-claude-md"].config_path == str(colliding_rule)
 
 
 def test_extend_detection_does_not_mark_harness_installed_from_workspace_files(tmp_path: Path) -> None:

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -640,10 +640,29 @@ def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path
     assert "claude-code:project:userpromptsubmit:0:0" in artifacts
     assert "claude-code:project:skill:review" in artifacts
     assert "claude-code:project:command:deploy" in artifacts
-    assert "claude-code:project:instruction:secrets" in artifacts
+    assert "claude-code:project:instruction:rules-secrets" in artifacts
     claude_instruction = artifacts.get("claude-code:project:instruction:claude-md")
     assert claude_instruction is not None
     assert claude_instruction.metadata.get("instructionRole") == "claude_md"
+
+
+def test_claude_detect_keeps_root_claude_md_when_rules_stem_collides(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    colliding_rule = context.workspace_dir / ".claude" / "rules" / "claude-md.md"
+    colliding_rule.parent.mkdir(parents=True, exist_ok=True)
+    colliding_rule.write_text("# benign rule\n", encoding="utf-8")
+    root_claude_md = context.workspace_dir / "CLAUDE.md"
+    root_claude_md.write_text("# malicious workspace instructions\n", encoding="utf-8")
+
+    detection = adapter.detect(context)
+    artifacts = {artifact.artifact_id: artifact for artifact in detection.artifacts}
+
+    assert "claude-code:project:instruction:rules-claude-md" in artifacts
+    root_instruction = artifacts.get("claude-code:project:instruction:claude-md")
+    assert root_instruction is not None
+    assert root_instruction.config_path == str(root_claude_md)
+    assert root_instruction.metadata.get("instructionRole") == "claude_md"
 
 
 def test_claude_detect_tolerates_unreadable_markdown_artifacts(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary
- Namespace Claude project rule instruction artifact IDs with a rules- prefix so rule stems cannot collide with the legacy root CLAUDE.md ID
- Prefer workspace-root CLAUDE.md during shared AIBOM merge when a legacy ID collision still occurs

## Testing
- `python3 -m pytest tests/test_guard_claude_adapter.py::test_claude_detect_keeps_root_claude_md_when_rules_stem_collides tests/test_guard_aibom_detection.py::test_extend_detection_prefers_workspace_root_claude_md_on_legacy_id_collision tests/test_guard_claude_adapter.py -k claude_detect -q`
- `ruff check src/codex_plugin_scanner/guard/aibom_detection.py src/codex_plugin_scanner/guard/adapters/claude_code.py tests/test_guard_claude_adapter.py tests/test_guard_aibom_detection.py`
