### PR TITLE
feat(guard): add layered local aibom trust

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -16,9 +16,14 @@ InstructionRole = Literal[
     "agents_md",
     "cursor_rules",
     "claude_md",
-    "design_md",
     "mcp_json",
+    "design_md",
     "product_md",
+    "roadmap_md",
+    "security_md",
+    "policy_md",
+    "standards_md",
+    "unknown_instruction",
 ]
 INVENTORY_ITEM_KINDS: tuple[str, ...] = (
     "agent",
@@ -46,11 +51,26 @@ _CURSOR_RULE_PATTERNS = ("*.mdc", "*.md")
 _CODEX_WORKSPACE_SKILL_ROOTS = (".agents/skills",)
 _CODEX_HOME_SKILL_ROOTS = (".codex/skills", ".agents/skills")
 _STANDARDS_CONTEXT_ROOTS = (".", ".agents/context", "docs")
-_STANDARDS_INSTRUCTION_FILES: tuple[tuple[str, InstructionRole], ...] = (
-    ("PRODUCT.md", "product_md"),
-    ("DESIGN.md", "design_md"),
+_ROOT_INSTRUCTION_ROLE_NAMES: tuple[tuple[str, InstructionRole], ...] = (
     ("CLAUDE.md", "claude_md"),
+    ("DESIGN.md", "design_md"),
+    ("PRODUCT.md", "product_md"),
+    ("ROADMAP.md", "roadmap_md"),
+    ("SECURITY.md", "security_md"),
+    ("POLICY.md", "policy_md"),
+    ("POLICIES.md", "policy_md"),
+    ("STANDARDS.md", "standards_md"),
 )
+_DOC_DIRECTORY_ROLES: tuple[tuple[str, InstructionRole], ...] = (
+    ("design", "design_md"),
+    ("product", "product_md"),
+    ("standards", "standards_md"),
+    ("policy", "policy_md"),
+    ("policies", "policy_md"),
+    ("security", "security_md"),
+    ("roadmap", "roadmap_md"),
+)
+_STANDARDS_INSTRUCTION_FILES = _ROOT_INSTRUCTION_ROLE_NAMES
 
 
 def file_content_hash(path: Path, *, max_bytes: int | None = None) -> str | None:
@@ -119,6 +139,14 @@ def instruction_role_for_path(path: Path) -> InstructionRole | None:
         return "design_md"
     if name == "product.md":
         return "product_md"
+    if name == "roadmap.md":
+        return "roadmap_md"
+    if name == "security.md":
+        return "security_md"
+    if name in {"policy.md", "policies.md"}:
+        return "policy_md"
+    if name == "standards.md":
+        return "standards_md"
     if name == "mcp.json":
         return "mcp_json"
     if path.suffix.lower() in {".md", ".mdc"}:
@@ -126,6 +154,11 @@ def instruction_role_for_path(path: Path) -> InstructionRole | None:
         for index, part in enumerate(parts):
             if part == ".cursor" and index + 1 < len(parts) and parts[index + 1] == "rules":
                 return "cursor_rules"
+            if part == "docs" and index + 1 < len(parts):
+                child = parts[index + 1].lower()
+                for directory_name, role in _DOC_DIRECTORY_ROLES:
+                    if child == directory_name:
+                        return role
     return None
 
 
@@ -205,6 +238,30 @@ def _discover_standards_context_files(harness: str, *, workspace_dir: Path) -> l
                     artifact_id=legacy_artifact_id,
                 )
             )
+        docs_root = search_root / "docs"
+        if not docs_root.is_dir() or not resolves_within_root(workspace_dir, docs_root, require_exists=True):
+            continue
+        for directory_name, _role in _DOC_DIRECTORY_ROLES:
+            base_dir = docs_root / directory_name
+            if not base_dir.is_dir() or not resolves_within_root(workspace_dir, base_dir, require_exists=True):
+                continue
+            for doc_path in _iter_recursive_markdown_files(workspace_dir, base_dir):
+                normalized_path = doc_path.resolve().as_posix()
+                if normalized_path in seen_paths:
+                    continue
+                seen_paths.add(normalized_path)
+                role = instruction_role_for_path(doc_path) or "unknown_instruction"
+                relative_id = doc_path.relative_to(workspace_dir).as_posix()
+                artifacts.append(
+                    _instruction_artifact(
+                        harness,
+                        doc_path,
+                        role=role,
+                        scope="project",
+                        display_name=relative_id,
+                        artifact_name=relative_id.replace("/", ":"),
+                    )
+                )
     return artifacts
 
 
@@ -225,6 +282,16 @@ def _discover_cursor_rules(harness: str, *, workspace_dir: Path) -> list[GuardAr
                 )
             )
     return artifacts
+
+
+def _iter_recursive_markdown_files(root: Path, base_dir: Path) -> tuple[Path, ...]:
+    return tuple(
+        candidate
+        for candidate in sorted(base_dir.rglob("*.md"))
+        if candidate.is_file()
+        and not candidate.is_symlink()
+        and resolves_within_root(root, candidate, require_exists=True)
+    )
 
 
 def discover_codex_skill_artifacts(

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -70,9 +70,6 @@ def trust_resolution_from_domain(
         ),
     }
 
-    trust_components = _trust_components_from_domain(domain)
-    normalized_captured_at = _normalize_inventory_datetime(captured_at)
-
     return {
         "resolutionSource": "local",
         "status": "local",
@@ -193,9 +190,6 @@ def _trust_layer_from_domain(
     captured_at: str,
 ) -> dict[str, object]:
     from .inventory_contract import _normalize_inventory_datetime
-
-    trust_components = _trust_components_from_domain(domain)
-    normalized_captured_at = _normalize_inventory_datetime(captured_at)
 
     trust_components = _trust_components_from_domain(domain)
     normalized_captured_at = _normalize_inventory_datetime(captured_at)

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from pathlib import Path
 from typing import Literal
 
 from ..checks.skill_security import resolve_skill_security_context
 from ..models import ScanOptions
+from ..trust_instruction_scoring import build_instruction_domain
 from ..trust_mcp_scoring import build_mcp_domain
 from ..trust_models import TrustAdapterScore, TrustComponentScore, TrustDomainScore
 from ..trust_plugin_scoring import build_plugin_domain
@@ -35,6 +38,8 @@ InventoryItemKind = Literal[
     "skill",
 ]
 
+TrustLayerType = Literal["local_baseline", "cisco_skill_scanner", "cisco_mcp_scanner"]
+
 
 def trust_resolution_from_domain(
     domain: TrustDomainScore,
@@ -43,20 +48,38 @@ def trust_resolution_from_domain(
 ) -> dict[str, object]:
     from .inventory_contract import _normalize_inventory_datetime
 
+    trust_components = _trust_components_from_domain(domain)
+    normalized_captured_at = _normalize_inventory_datetime(captured_at)
+    metadata = {
+        "profileId": domain.profile_id,
+        "profileVersion": domain.profile_version,
+        "scorer": "hol-guard-local",
+        "specId": domain.spec_id,
+        "specVersion": domain.spec_version,
+        "trustDomain": domain.domain,
+        "attestationStatus": "unsigned",
+        "evidenceHash": _trust_evidence_hash(
+            {
+                "capturedAt": normalized_captured_at,
+                "resolutionSource": "local",
+                "status": "local",
+                "trustScore": round(domain.score),
+                "trustComponents": trust_components,
+                "trustDomain": domain.domain,
+            }
+        ),
+    }
+
+    trust_components = _trust_components_from_domain(domain)
+    normalized_captured_at = _normalize_inventory_datetime(captured_at)
+
     return {
         "resolutionSource": "local",
         "status": "local",
         "trustScore": round(domain.score),
-        "trustComponents": _trust_components_from_domain(domain),
-        "capturedAt": _normalize_inventory_datetime(captured_at),
-        "metadata": {
-            "profileId": domain.profile_id,
-            "profileVersion": domain.profile_version,
-            "scorer": "hol-guard-local",
-            "specId": domain.spec_id,
-            "specVersion": domain.spec_version,
-            "trustDomain": domain.domain,
-        },
+        "trustComponents": trust_components,
+        "capturedAt": normalized_captured_at,
+        "metadata": metadata,
     }
 
 
@@ -67,24 +90,37 @@ def apply_local_trust_metadata(
     item_kind: InventoryItemKind,
     metadata: dict[str, object],
     workspace_dir: Path | None,
+    cisco_runs: tuple[object, ...] = (),
 ) -> dict[str, object]:
-    if item_kind not in {"skill", "plugin", "mcp_server"}:
-        return metadata
-    if isinstance(metadata.get("trustResolution"), dict):
-        return metadata
-    if isinstance(metadata.get("registryIdentity"), dict):
-        return metadata
-
-    domain = _local_trust_domain_for_artifact(
-        artifact,
-        item_kind=item_kind,
-        workspace_dir=workspace_dir,
-    )
-    if domain is None:
-        return metadata
-
     enriched = dict(metadata)
-    enriched["trustResolution"] = trust_resolution_from_domain(domain, captured_at=captured_at)
+    trust_layers: list[dict[str, object]] = []
+
+    if item_kind in {"skill", "plugin", "mcp_server", "overlay", "policy", "prompt_pack"} and not isinstance(
+        metadata.get("trustResolution"),
+        dict,
+    ):
+        domain = _local_trust_domain_for_artifact(
+            artifact,
+            item_kind=item_kind,
+            metadata=metadata,
+            workspace_dir=workspace_dir,
+        )
+        if domain is not None:
+            enriched["trustResolution"] = trust_resolution_from_domain(domain, captured_at=captured_at)
+            trust_layers.append(_trust_layer_from_domain(domain, captured_at=captured_at))
+
+    trust_layers.extend(
+        _cisco_trust_layers_for_artifact(
+            artifact,
+            item_kind=item_kind,
+            captured_at=captured_at,
+            cisco_runs=cisco_runs,
+            workspace_dir=workspace_dir,
+        )
+    )
+
+    if trust_layers:
+        enriched["trustLayers"] = _merge_trust_layers(metadata.get("trustLayers"), trust_layers)
     return enriched
 
 
@@ -92,6 +128,7 @@ def _local_trust_domain_for_artifact(
     artifact: object,
     *,
     item_kind: InventoryItemKind,
+    metadata: dict[str, object],
     workspace_dir: Path | None,
 ) -> TrustDomainScore | None:
     trust_root = _trust_root_for_artifact(artifact, item_kind=item_kind, workspace_dir=workspace_dir)
@@ -104,6 +141,10 @@ def _local_trust_domain_for_artifact(
         return build_skill_domain(trust_root, context)
     if item_kind == "mcp_server":
         return build_mcp_domain(trust_root, ())
+    if item_kind in {"overlay", "policy", "prompt_pack"}:
+        role = metadata.get("instructionRole")
+        normalized_role = role if isinstance(role, str) and role else "unknown_instruction"
+        return build_instruction_domain(trust_root, role=normalized_role, item_kind=item_kind)
     return None
 
 
@@ -140,7 +181,267 @@ def _trust_root_for_artifact(
         parent = path.parent
         return parent if parent.is_dir() else None
 
+    if item_kind in {"overlay", "policy", "prompt_pack"}:
+        return path if path.is_file() else None
+
     return None
+
+
+def _trust_layer_from_domain(
+    domain: TrustDomainScore,
+    *,
+    captured_at: str,
+) -> dict[str, object]:
+    from .inventory_contract import _normalize_inventory_datetime
+
+    trust_components = _trust_components_from_domain(domain)
+    normalized_captured_at = _normalize_inventory_datetime(captured_at)
+
+    trust_components = _trust_components_from_domain(domain)
+    normalized_captured_at = _normalize_inventory_datetime(captured_at)
+
+    return {
+        "layerId": "local_baseline",
+        "layerType": "local_baseline",
+        "status": "local",
+        "trustScore": round(domain.score),
+        "trustComponents": trust_components,
+        "capturedAt": normalized_captured_at,
+        "metadata": {
+            "profileId": domain.profile_id,
+            "profileVersion": domain.profile_version,
+            "scorer": "hol-guard-local",
+            "specId": domain.spec_id,
+            "specVersion": domain.spec_version,
+            "trustDomain": domain.domain,
+            "attestationStatus": "unsigned",
+            "evidenceHash": _trust_evidence_hash(
+                {
+                    "capturedAt": normalized_captured_at,
+                    "layerId": "local_baseline",
+                    "layerType": "local_baseline",
+                    "status": "local",
+                    "trustScore": round(domain.score),
+                    "trustComponents": trust_components,
+                    "trustDomain": domain.domain,
+                }
+            ),
+        },
+    }
+
+
+def _merge_trust_layers(
+    existing: object,
+    additions: list[dict[str, object]],
+) -> list[dict[str, object]]:
+    merged: dict[str, dict[str, object]] = {}
+    if isinstance(existing, list):
+        for raw_layer in existing:
+            if not isinstance(raw_layer, dict):
+                continue
+            layer_type = raw_layer.get("layerType")
+            if isinstance(layer_type, str) and layer_type:
+                merged[layer_type] = dict(raw_layer)
+    for layer in additions:
+        layer_type = layer.get("layerType")
+        if isinstance(layer_type, str) and layer_type:
+            merged[layer_type] = layer
+    return list(merged.values())
+
+
+def _cisco_trust_layers_for_artifact(
+    artifact: object,
+    *,
+    item_kind: InventoryItemKind,
+    captured_at: str,
+    cisco_runs: tuple[object, ...],
+    workspace_dir: Path | None,
+) -> list[dict[str, object]]:
+    layers: list[dict[str, object]] = []
+    for run in cisco_runs:
+        source = getattr(run, "source", None)
+        if source == "cisco-skill-scanner" and item_kind in {"skill", "plugin"}:
+            if _matches_skill_cisco_run(artifact, item_kind=item_kind, run=run, workspace_dir=workspace_dir):
+                layers.append(
+                    _cisco_trust_layer(
+                        run,
+                        captured_at=captured_at,
+                        layer_id="cisco_skill_scanner",
+                        component_id="cisco.skill.score",
+                        label="Cisco Skill Scanner",
+                    )
+                )
+        if source == "cisco-mcp-scanner" and item_kind == "mcp_server":
+            if _matches_mcp_cisco_run(artifact, run=run):
+                layers.append(
+                    _cisco_trust_layer(
+                        run,
+                        captured_at=captured_at,
+                        layer_id="cisco_mcp_scanner",
+                        component_id="cisco.mcp.score",
+                        label="Cisco MCP Scanner",
+                    )
+                )
+    return layers
+
+
+def _matches_skill_cisco_run(
+    artifact: object,
+    *,
+    item_kind: InventoryItemKind,
+    run: object,
+    workspace_dir: Path | None,
+) -> bool:
+    run_target = _cisco_run_target_path(run)
+    if run_target is None:
+        return False
+    trust_root = _trust_root_for_artifact(artifact, item_kind=item_kind, workspace_dir=workspace_dir)
+    if trust_root is None:
+        return False
+    return _paths_related(trust_root, run_target)
+
+
+def _matches_mcp_cisco_run(artifact: object, *, run: object) -> bool:
+    run_target = _cisco_run_target_path(run)
+    config_path = getattr(artifact, "config_path", None)
+    if run_target is None or not isinstance(config_path, str) or not config_path.strip():
+        return False
+    path = Path(config_path)
+    if path.is_file() and (_paths_related(path, run_target) or _paths_related(path.parent, run_target)):
+        return True
+    return _paths_related(path, run_target)
+
+
+def _paths_related(left: Path, right: Path) -> bool:
+    try:
+        left_resolved = left.resolve()
+        right_resolved = right.resolve()
+    except OSError:
+        return False
+    return (
+        left_resolved == right_resolved
+        or left_resolved in right_resolved.parents
+        or right_resolved in left_resolved.parents
+    )
+
+
+def _cisco_run_target_path(run: object) -> Path | None:
+    metadata = getattr(run, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    target = metadata.get("target")
+    if not isinstance(target, str) or not target.strip() or target == "missing":
+        return None
+    return Path(target)
+
+
+def _cisco_trust_layer(
+    run: object,
+    *,
+    captured_at: str,
+    layer_id: TrustLayerType,
+    component_id: str,
+    label: str,
+) -> dict[str, object]:
+    from .inventory_contract import _normalize_inventory_datetime
+
+    status = str(getattr(run, "status", "unknown"))
+    message = str(getattr(run, "message", ""))
+    severity_counts = _cisco_severity_counts(run)
+    trust_score = _cisco_layer_score(severity_counts) if status == "enabled" else None
+    trust_components: list[dict[str, object]] = []
+    if trust_score is not None:
+        component_status = "positive"
+        if trust_score < 40:
+            component_status = "critical"
+        elif trust_score < 70:
+            component_status = "warning"
+        trust_components.append(
+            {
+                "componentId": component_id,
+                "confidence": 90,
+                "label": label,
+                "score": trust_score,
+                "status": component_status,
+                "summary": message or f"{label} completed with {sum(severity_counts.values())} findings.",
+                "weight": 1.0,
+            }
+        )
+
+    run_metadata = getattr(run, "metadata", None)
+    safe_metadata: dict[str, object] = {
+        "scannerSource": str(getattr(run, "source", "unknown")),
+        "message": message,
+        "durationMs": getattr(run, "duration_ms", None) if isinstance(getattr(run, "duration_ms", None), int) else None,
+        "totalFindings": sum(severity_counts.values()),
+        "findingsBySeverity": severity_counts,
+    }
+    if isinstance(run_metadata, dict):
+        for key in (
+            "analyzersUsed",
+            "policyName",
+            "scanMode",
+            "mode",
+            "targetsScanned",
+            "skillsScanned",
+            "skillsSkipped",
+        ):
+            value = run_metadata.get(key)
+            if value is not None:
+                safe_metadata[key] = value
+    safe_metadata["attestationStatus"] = "unsigned"
+    safe_metadata["evidenceHash"] = _trust_evidence_hash(
+        {
+            "capturedAt": _normalize_inventory_datetime(captured_at),
+            "layerId": layer_id,
+            "layerType": layer_id,
+            "status": status,
+            "trustScore": trust_score,
+            "trustComponents": trust_components,
+            "metadata": {
+                key: value
+                for key, value in safe_metadata.items()
+                if key not in {"attestationStatus", "evidenceHash"}
+            },
+        }
+    )
+
+    return {
+        "layerId": layer_id,
+        "layerType": layer_id,
+        "status": status,
+        "trustScore": trust_score,
+        "trustComponents": trust_components,
+        "capturedAt": _normalize_inventory_datetime(captured_at),
+        "metadata": safe_metadata,
+    }
+
+
+def _cisco_severity_counts(run: object) -> dict[str, int]:
+    counts = {"critical": 0, "high": 0, "medium": 0, "low": 0}
+    metadata = getattr(run, "metadata", None)
+    if isinstance(metadata, dict):
+        raw_counts = metadata.get("findingsBySeverity")
+        if isinstance(raw_counts, dict):
+            for key in counts:
+                value = raw_counts.get(key)
+                counts[key] = value if isinstance(value, int) and value >= 0 else 0
+            return counts
+    for finding in tuple(getattr(run, "findings", ()) or ()):
+        severity = getattr(getattr(finding, "severity", None), "value", getattr(finding, "severity", None))
+        if isinstance(severity, str) and severity in counts:
+            counts[severity] += 1
+    return counts
+
+
+def _cisco_layer_score(severity_counts: dict[str, int]) -> int:
+    raw_score = 100 - (
+        30 * severity_counts["critical"]
+        + 12 * severity_counts["high"]
+        + 4 * severity_counts["medium"]
+        + severity_counts["low"]
+    )
+    return max(0, min(100, raw_score))
 
 
 def _trust_components_from_domain(domain: TrustDomainScore) -> list[dict[str, object]]:
@@ -180,3 +481,8 @@ def _trust_component_row(
     if component.evidence:
         payload["evidence"] = {"lines": list(component.evidence)}
     return payload
+
+
+def _trust_evidence_hash(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+    return hashlib.sha256(encoded.encode("utf-8")).hexdigest()

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -254,28 +254,39 @@ def _cisco_trust_layers_for_artifact(
     layers: list[dict[str, object]] = []
     for run in cisco_runs:
         source = getattr(run, "source", None)
-        if source == "cisco-skill-scanner" and item_kind in {"skill", "plugin"}:
-            if _matches_skill_cisco_run(artifact, item_kind=item_kind, run=run, workspace_dir=workspace_dir):
-                layers.append(
-                    _cisco_trust_layer(
-                        run,
-                        captured_at=captured_at,
-                        layer_id="cisco_skill_scanner",
-                        component_id="cisco.skill.score",
-                        label="Cisco Skill Scanner",
-                    )
+        if (
+            source == "cisco-skill-scanner"
+            and item_kind in {"skill", "plugin"}
+            and _matches_skill_cisco_run(
+                artifact,
+                item_kind=item_kind,
+                run=run,
+                workspace_dir=workspace_dir,
+            )
+        ):
+            layers.append(
+                _cisco_trust_layer(
+                    run,
+                    captured_at=captured_at,
+                    layer_id="cisco_skill_scanner",
+                    component_id="cisco.skill.score",
+                    label="Cisco Skill Scanner",
                 )
-        if source == "cisco-mcp-scanner" and item_kind == "mcp_server":
-            if _matches_mcp_cisco_run(artifact, run=run):
-                layers.append(
-                    _cisco_trust_layer(
-                        run,
-                        captured_at=captured_at,
-                        layer_id="cisco_mcp_scanner",
-                        component_id="cisco.mcp.score",
-                        label="Cisco MCP Scanner",
-                    )
+            )
+        if (
+            source == "cisco-mcp-scanner"
+            and item_kind == "mcp_server"
+            and _matches_mcp_cisco_run(artifact, run=run)
+        ):
+            layers.append(
+                _cisco_trust_layer(
+                    run,
+                    captured_at=captured_at,
+                    layer_id="cisco_mcp_scanner",
+                    component_id="cisco.mcp.score",
+                    label="Cisco MCP Scanner",
                 )
+            )
     return layers
 
 

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -273,11 +273,7 @@ def _cisco_trust_layers_for_artifact(
                     label="Cisco Skill Scanner",
                 )
             )
-        if (
-            source == "cisco-mcp-scanner"
-            and item_kind == "mcp_server"
-            and _matches_mcp_cisco_run(artifact, run=run)
-        ):
+        if source == "cisco-mcp-scanner" and item_kind == "mcp_server" and _matches_mcp_cisco_run(artifact, run=run):
             layers.append(
                 _cisco_trust_layer(
                     run,
@@ -404,9 +400,7 @@ def _cisco_trust_layer(
             "trustScore": trust_score,
             "trustComponents": trust_components,
             "metadata": {
-                key: value
-                for key, value in safe_metadata.items()
-                if key not in {"attestationStatus", "evidenceHash"}
+                key: value for key, value in safe_metadata.items() if key not in {"attestationStatus", "evidenceHash"}
             },
         }
     )

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -146,6 +146,7 @@ _AIBOM_METADATA_KEYS = (
     "registryIdentity",
     "sourceLinks",
     "sourceOfTruth",
+    "trustLayers",
     "trustResolution",
     "versionInfo",
 )
@@ -365,7 +366,7 @@ def inventory_snapshot_from_detection(
     from .aibom_detection import discover_shared_workspace_aibom_artifacts
 
     harness = str(getattr(detection, "harness", "unknown"))
-    artifacts = list(getattr(detection, "artifacts", ()))
+    artifacts: list[object] = list(getattr(detection, "artifacts", ()))
     if workspace_dir is not None:
         existing_ids = {str(getattr(artifact, "artifact_id", "")) for artifact in artifacts}
         for artifact in discover_shared_workspace_aibom_artifacts(
@@ -376,15 +377,16 @@ def inventory_snapshot_from_detection(
             if artifact.artifact_id not in existing_ids:
                 artifacts.append(artifact)
                 existing_ids.add(artifact.artifact_id)
-    artifacts = tuple(artifacts)
+    artifact_tuple = tuple(artifacts)
     items: list[GuardAgentInventoryItem] = []
-    for artifact in artifacts:
+    for artifact in artifact_tuple:
         item = _item_from_artifact(
             harness,
             artifact,
             generated_at=generated_at,
             home_dir=home_dir,
             workspace_dir=workspace_dir,
+            cisco_runs=cisco_runs,
             include_symlinks=include_symlinks,
             follow_unsafe_symlinks=follow_unsafe_symlinks,
         )
@@ -537,6 +539,7 @@ def _item_from_artifact(
     generated_at: str,
     home_dir: Path,
     workspace_dir: Path | None,
+    cisco_runs: tuple[object, ...] = (),
     include_symlinks: bool = True,
     follow_unsafe_symlinks: bool = False,
 ) -> GuardAgentInventoryItem:
@@ -551,6 +554,7 @@ def _item_from_artifact(
         item_kind=item_kind,
         metadata=safe_metadata,
         workspace_dir=workspace_dir,
+        cisco_runs=cisco_runs,
     )
     if include_symlinks:
         safe_metadata = _apply_source_of_truth_metadata(
@@ -600,6 +604,12 @@ def _mcp_tool_items_from_artifact(
         return ()
 
     items: list[GuardAgentInventoryItem] = []
+    raw_trust_layers = server_item.metadata.get("trustLayers")
+    inherited_layers: list[dict[str, object]] = []
+    if isinstance(raw_trust_layers, list):
+        for layer in raw_trust_layers:
+            if isinstance(layer, dict) and layer.get("layerType") == "cisco_mcp_scanner":
+                inherited_layers.append(dict(layer))
     for raw_tool in raw_tools:
         if not isinstance(raw_tool, dict):
             continue
@@ -622,6 +632,21 @@ def _mcp_tool_items_from_artifact(
             "annotations": safe_annotations,
             "schemaPresent": input_schema is not None or output_schema is not None,
         }
+        if inherited_layers:
+            inherited_tool_layers: list[dict[str, object]] = []
+            for layer in inherited_layers:
+                raw_layer_metadata = layer.get("metadata")
+                layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
+                inherited_tool_layers.append(
+                    {
+                        **layer,
+                        "metadata": {
+                            **layer_metadata,
+                            "inheritedFromServerItemId": server_item.item_id,
+                        },
+                    }
+                )
+            metadata["trustLayers"] = inherited_tool_layers
         capabilities = _capabilities_for_mcp_tool(name, description, input_schema, safe_annotations)
         semantic_hash = fingerprint_mapping(
             {
@@ -835,15 +860,25 @@ def _cisco_inventory_sources(cisco_runs: tuple[object, ...]) -> tuple[GuardInven
 
 def _cisco_source(run: object) -> InventoryFindingSource | None:
     source = str(getattr(run, "source", ""))
-    if source in {"cisco-mcp-scanner", "cisco-skill-scanner"}:
-        return source
+    if source == "cisco-mcp-scanner":
+        return "cisco-mcp-scanner"
+    if source == "cisco-skill-scanner":
+        return "cisco-skill-scanner"
     return None
 
 
 def _inventory_severity(value: object) -> InventorySeverity:
     severity_value = str(getattr(value, "value", value)).strip().lower()
-    if severity_value in {"critical", "high", "medium", "low", "info"}:
-        return severity_value
+    if severity_value == "critical":
+        return "critical"
+    if severity_value == "high":
+        return "high"
+    if severity_value == "medium":
+        return "medium"
+    if severity_value == "low":
+        return "low"
+    if severity_value == "info":
+        return "info"
     return "info"
 
 
@@ -1028,6 +1063,7 @@ def _apply_aibom_metadata_enrichment(
     item_kind: InventoryItemKind,
     metadata: dict[str, object],
     workspace_dir: Path | None,
+    cisco_runs: tuple[object, ...] = (),
 ) -> dict[str, object]:
     from .aibom_detection import instruction_role_for_path
     from .aibom_trust_metadata import apply_local_trust_metadata
@@ -1045,6 +1081,7 @@ def _apply_aibom_metadata_enrichment(
         item_kind=item_kind,
         metadata=enriched,
         workspace_dir=workspace_dir,
+        cisco_runs=cisco_runs,
     )
 
 
@@ -1085,6 +1122,8 @@ def _safe_artifact_metadata(
     artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
     raw_metadata = getattr(artifact, "metadata", {})
     metadata = _sanitize_paths(raw_metadata if isinstance(raw_metadata, dict) else {}, home_dir, workspace_dir)
+    if not isinstance(metadata, dict):
+        metadata = {}
     config_path = getattr(artifact, "config_path", None)
     command = getattr(artifact, "command", None)
     url = getattr(artifact, "url", None)

--- a/src/codex_plugin_scanner/trust_instruction_scoring.py
+++ b/src/codex_plugin_scanner/trust_instruction_scoring.py
@@ -1,0 +1,241 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from .trust_helpers import build_adapter_score, build_domain_score
+from .trust_models import TrustDomainScore
+from .trust_specs import INSTRUCTION_TRUST_SPEC
+
+_BOUNDARY_TERMS = (
+    "must",
+    "must not",
+    "never",
+    "only",
+    "do not",
+    "allowed",
+    "forbidden",
+    "required",
+)
+_CAPABILITY_TERMS = (
+    "shell",
+    "command",
+    "tool",
+    "network",
+    "write",
+    "delete",
+    "execute",
+    "model",
+)
+_SECRET_TERMS = ("secret", "token", "password", "credential", "api key")
+_SCOPE_TERMS = (
+    "scope",
+    "purpose",
+    "overview",
+    "requirements",
+    "constraints",
+    "responsibilities",
+)
+_GOVERNANCE_TERMS = (
+    "review",
+    "approval",
+    "owner",
+    "version",
+    "change",
+    "maintainer",
+)
+_PROVENANCE_TERMS = (
+    "source",
+    "repository",
+    "repo",
+    "commit",
+    "homepage",
+    "reference",
+    "standard",
+)
+_OPERATIONAL_ROLES = frozenset(
+    {
+        "agents_md",
+        "claude_md",
+        "cursor_rules",
+        "mcp_json",
+        "policy_md",
+        "security_md",
+        "prompt_pack",
+        "unknown_instruction",
+    }
+)
+
+
+def build_instruction_domain(
+    path: Path,
+    *,
+    role: str,
+    item_kind: str,
+) -> TrustDomainScore | None:
+    try:
+        content = path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+    text = content.strip()
+    if not text:
+        return None
+
+    lines = tuple(line.strip() for line in content.splitlines() if line.strip())
+    text_lower = text.lower()
+    headings = tuple(line for line in lines if line.startswith("#"))
+    is_json = path.suffix.lower() == ".json"
+    json_valid = _is_valid_json(text) if is_json else False
+
+    structure_score = _structure_score(lines=lines, headings=headings, json_valid=json_valid)
+    scope_terms = _matched_terms(text_lower, _SCOPE_TERMS)
+    boundary_terms = _matched_terms(text_lower, _BOUNDARY_TERMS)
+    capability_terms = _matched_terms(text_lower, _CAPABILITY_TERMS)
+    secret_terms = _matched_terms(text_lower, _SECRET_TERMS)
+    governance_terms = _matched_terms(text_lower, _GOVERNANCE_TERMS)
+    provenance_terms = _matched_terms(text_lower, _PROVENANCE_TERMS)
+    if "http://" in text_lower or "https://" in text_lower:
+        provenance_terms = _append_unique(provenance_terms, "url")
+
+    scope_score = _score_by_count(len(scope_terms), high=95.0, medium=75.0, low=55.0, zero=35.0)
+    boundaries_score = _boundaries_score(
+        boundary_terms=boundary_terms,
+        capability_terms=capability_terms,
+        secret_terms=secret_terms,
+    )
+    governance_score = _score_by_count(len(governance_terms), high=90.0, medium=70.0, low=55.0, zero=30.0)
+    provenance_score = _score_by_count(len(provenance_terms), high=100.0, medium=75.0, low=55.0, zero=25.0)
+
+    adapters = (
+        build_adapter_score(
+            INSTRUCTION_TRUST_SPEC.adapters[0],
+            component_scores={"score": structure_score},
+            rationales={
+                "score": (
+                    "Instruction content has enough structure to support deterministic local analysis."
+                    if structure_score >= 80
+                    else "Instruction content is sparse or weakly structured, which lowers baseline trust."
+                )
+            },
+            evidence={"score": headings[:3] if headings else lines[:3]},
+        ),
+        build_adapter_score(
+            INSTRUCTION_TRUST_SPEC.adapters[1],
+            component_scores={"score": scope_score},
+            rationales={
+                "score": (
+                    "Instruction content explicitly describes scope, purpose, or requirements."
+                    if scope_terms
+                    else "Instruction content does not clearly state scope or purpose."
+                )
+            },
+            evidence={"score": tuple(scope_terms[:5])},
+        ),
+        build_adapter_score(
+            INSTRUCTION_TRUST_SPEC.adapters[2],
+            component_scores={"score": boundaries_score} if role in _OPERATIONAL_ROLES or item_kind == "prompt_pack" else None,
+            rationales={
+                "score": (
+                    "Operational guidance includes capability boundaries and safety language."
+                    if boundary_terms or capability_terms or secret_terms
+                    else "Operational guidance lacks explicit capability boundaries or safety constraints."
+                )
+            },
+            evidence={"score": tuple((boundary_terms + capability_terms + secret_terms)[:6])},
+            applicable=role in _OPERATIONAL_ROLES or item_kind == "prompt_pack",
+        ),
+        build_adapter_score(
+            INSTRUCTION_TRUST_SPEC.adapters[3],
+            component_scores={"score": governance_score},
+            rationales={
+                "score": (
+                    "Instruction content includes governance or change-control language."
+                    if governance_terms
+                    else "No review, ownership, or versioning language was found in the instruction content."
+                )
+            },
+            evidence={"score": tuple(governance_terms[:5])},
+        ),
+        build_adapter_score(
+            INSTRUCTION_TRUST_SPEC.adapters[4],
+            component_scores={"score": provenance_score},
+            rationales={
+                "score": (
+                    "Instruction content includes provenance or source references."
+                    if provenance_terms
+                    else "Instruction content does not reference an external source, repository, or standard."
+                )
+            },
+            evidence={"score": tuple(provenance_terms[:5])},
+        ),
+    )
+
+    return build_domain_score(domain="instructions", spec=INSTRUCTION_TRUST_SPEC, adapters=adapters)
+
+
+def _is_valid_json(text: str) -> bool:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(payload, dict)
+
+
+def _matched_terms(text: str, terms: tuple[str, ...]) -> list[str]:
+    return [term for term in terms if term in text]
+
+
+def _append_unique(values: list[str], value: str) -> list[str]:
+    if value in values:
+        return values
+    return [*values, value]
+
+
+def _structure_score(
+    *,
+    lines: tuple[str, ...],
+    headings: tuple[str, ...],
+    json_valid: bool,
+) -> float:
+    if json_valid:
+        return 95.0
+    if len(lines) >= 6 and headings:
+        return 92.0
+    if len(lines) >= 4:
+        return 78.0
+    if len(lines) >= 2:
+        return 60.0
+    return 35.0
+
+
+def _boundaries_score(
+    *,
+    boundary_terms: list[str],
+    capability_terms: list[str],
+    secret_terms: list[str],
+) -> float:
+    if boundary_terms and (capability_terms or secret_terms):
+        return 95.0
+    if boundary_terms:
+        return 78.0
+    if capability_terms or secret_terms:
+        return 58.0
+    return 35.0
+
+
+def _score_by_count(
+    count: int,
+    *,
+    high: float,
+    medium: float,
+    low: float,
+    zero: float,
+) -> float:
+    if count >= 3:
+        return high
+    if count == 2:
+        return medium
+    if count == 1:
+        return low
+    return zero

--- a/src/codex_plugin_scanner/trust_instruction_scoring.py
+++ b/src/codex_plugin_scanner/trust_instruction_scoring.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 from .trust_helpers import build_adapter_score, build_domain_score
@@ -8,14 +9,15 @@ from .trust_models import TrustDomainScore
 from .trust_specs import INSTRUCTION_TRUST_SPEC
 
 _BOUNDARY_TERMS = (
-    "must",
     "must not",
     "never",
-    "only",
     "do not",
     "allowed",
     "forbidden",
     "required",
+    "read-only",
+    "write access",
+    "network access",
 )
 _CAPABILITY_TERMS = (
     "shell",
@@ -25,7 +27,7 @@ _CAPABILITY_TERMS = (
     "write",
     "delete",
     "execute",
-    "model",
+    "remote code",
 )
 _SECRET_TERMS = ("secret", "token", "password", "credential", "api key")
 _SCOPE_TERMS = (
@@ -40,9 +42,10 @@ _GOVERNANCE_TERMS = (
     "review",
     "approval",
     "owner",
-    "version",
-    "change",
     "maintainer",
+    "change control",
+    "versioned",
+    "reviewed by",
 )
 _PROVENANCE_TERMS = (
     "source",
@@ -183,7 +186,18 @@ def _is_valid_json(text: str) -> bool:
 
 
 def _matched_terms(text: str, terms: tuple[str, ...]) -> list[str]:
-    return [term for term in terms if term in text]
+    matches: list[str] = []
+    for term in terms:
+        if _term_matches(text, term):
+            matches.append(term)
+    return matches
+
+
+def _term_matches(text: str, term: str) -> bool:
+    if " " in term or "-" in term:
+        return term in text
+    pattern = rf"\b{re.escape(term)}\b"
+    return re.search(pattern, text) is not None
 
 
 def _append_unique(values: list[str], value: str) -> list[str]:

--- a/src/codex_plugin_scanner/trust_instruction_scoring.py
+++ b/src/codex_plugin_scanner/trust_instruction_scoring.py
@@ -110,6 +110,8 @@ def build_instruction_domain(
     governance_score = _score_by_count(len(governance_terms), high=90.0, medium=70.0, low=55.0, zero=30.0)
     provenance_score = _score_by_count(len(provenance_terms), high=100.0, medium=75.0, low=55.0, zero=25.0)
 
+    operational_role = role in _OPERATIONAL_ROLES or item_kind == "prompt_pack"
+
     adapters = (
         build_adapter_score(
             INSTRUCTION_TRUST_SPEC.adapters[0],
@@ -137,7 +139,7 @@ def build_instruction_domain(
         ),
         build_adapter_score(
             INSTRUCTION_TRUST_SPEC.adapters[2],
-            component_scores={"score": boundaries_score} if role in _OPERATIONAL_ROLES or item_kind == "prompt_pack" else None,
+            component_scores={"score": boundaries_score} if operational_role else None,
             rationales={
                 "score": (
                     "Operational guidance includes capability boundaries and safety language."
@@ -146,7 +148,7 @@ def build_instruction_domain(
                 )
             },
             evidence={"score": tuple((boundary_terms + capability_terms + secret_terms)[:6])},
-            applicable=role in _OPERATIONAL_ROLES or item_kind == "prompt_pack",
+            applicable=operational_role,
         ),
         build_adapter_score(
             INSTRUCTION_TRUST_SPEC.adapters[3],

--- a/src/codex_plugin_scanner/trust_specs.py
+++ b/src/codex_plugin_scanner/trust_specs.py
@@ -284,3 +284,50 @@ PLUGIN_TRUST_SPEC = TrustSpecDefinition(
         ),
     ),
 )
+
+INSTRUCTION_TRUST_SPEC = TrustSpecDefinition(
+    spec_id="HOL-HCS-INSTRUCTION-TRUST-DRAFT",
+    version="0.1.0",
+    label="Instruction Trust",
+    spec_path="docs/trust/instruction-trust-draft.md",
+    derived_from=("HCS-26", "HCS-28"),
+    profile_id="hol-instruction-trust/baseline",
+    profile_version="0.1",
+    adapters=(
+        TrustAdapterSpec(
+            adapter_id="instruction.structure",
+            label="Instruction Structure",
+            weight=0.25,
+            component_keys=("score",),
+            contribution_mode="universal",
+        ),
+        TrustAdapterSpec(
+            adapter_id="instruction.scope-clarity",
+            label="Scope Clarity",
+            weight=0.20,
+            component_keys=("score",),
+            contribution_mode="universal",
+        ),
+        TrustAdapterSpec(
+            adapter_id="instruction.operational-boundaries",
+            label="Operational Boundaries",
+            weight=0.25,
+            component_keys=("score",),
+            contribution_mode="conditional",
+        ),
+        TrustAdapterSpec(
+            adapter_id="instruction.governance",
+            label="Governance",
+            weight=0.15,
+            component_keys=("score",),
+            contribution_mode="universal",
+        ),
+        TrustAdapterSpec(
+            adapter_id="instruction.provenance",
+            label="Provenance",
+            weight=0.15,
+            component_keys=("score",),
+            contribution_mode="universal",
+        ),
+    ),
+)

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -279,6 +279,35 @@ def test_instruction_role_ignores_unrelated_rules_paths(tmp_path: Path) -> None:
     assert instruction_role_for_path(cursor_rule) == "cursor_rules"
 
 
+def test_discover_named_instruction_docs(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "DESIGN.md").write_text("# Design\n", encoding="utf-8")
+    (workspace / "SECURITY.md").write_text("# Security\n", encoding="utf-8")
+    standards_dir = workspace / "docs" / "standards"
+    standards_dir.mkdir(parents=True)
+    (standards_dir / "api.md").write_text("# Standards\n", encoding="utf-8")
+    policies_dir = workspace / "docs" / "policies"
+    policies_dir.mkdir(parents=True)
+    (policies_dir / "access.md").write_text("# Policy\n", encoding="utf-8")
+
+    artifacts = discover_shared_workspace_aibom_artifacts(
+        "cursor",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    roles = {
+        artifact.metadata.get("instructionRole")
+        for artifact in artifacts
+        if isinstance(artifact.metadata, dict)
+    }
+
+    assert "design_md" in roles
+    assert "security_md" in roles
+    assert "standards_md" in roles
+    assert "policy_md" in roles
+
+
 def test_marketplace_escape_path_does_not_read_outside_workspace(tmp_path: Path) -> None:
     workspace = tmp_path / "repo"
     outside = tmp_path / "outside"

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import builtins
 import json
 from pathlib import Path
+from typing import Mapping
 
 from codex_plugin_scanner.guard.aibom_trust_metadata import trust_resolution_from_domain
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
@@ -32,6 +33,17 @@ def _write_good_plugin(plugin_dir: Path) -> None:
     (plugin_dir / "README.md").write_text("# Demo\n", encoding="utf-8")
     (plugin_dir / "SECURITY.md").write_text("Report issues privately.\n", encoding="utf-8")
     (plugin_dir / "LICENSE").write_text("MIT\n", encoding="utf-8")
+
+
+def _trust_layer_types(item_metadata: dict[str, object]) -> set[str]:
+    layers = item_metadata.get("trustLayers")
+    if not isinstance(layers, list):
+        return set()
+    return {
+        str(layer.get("layerType"))
+        for layer in layers
+        if isinstance(layer, dict) and isinstance(layer.get("layerType"), str)
+    }
 
 
 def test_trust_resolution_captured_at_uses_utc_z_suffix() -> None:
@@ -94,9 +106,12 @@ def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Pat
     assert isinstance(metadata, dict)
     assert metadata.get("trustDomain") == "plugin"
     assert metadata.get("scorer") == "hol-guard-local"
+    assert metadata.get("attestationStatus") == "unsigned"
+    assert isinstance(metadata.get("evidenceHash"), str)
     components = trust.get("trustComponents")
     assert isinstance(components, list)
     assert components
+    assert "local_baseline" in _trust_layer_types(plugin_item.metadata)
 
 
 def test_inventory_skill_trust_enrichment_disables_cisco_scan(
@@ -111,10 +126,16 @@ def test_inventory_skill_trust_enrichment_disables_cisco_scan(
     cisco_modes: list[str] = []
     original_import = builtins.__import__
 
-    def _guard_import(name: str, *args: object, **kwargs: object) -> object:
+    def _guard_import(
+        name: str,
+        globals: Mapping[str, object] | None = None,
+        locals: Mapping[str, object] | None = None,
+        fromlist: tuple[str, ...] = (),
+        level: int = 0,
+    ) -> object:
         if name == "skill_scanner" or name.startswith("skill_scanner."):
             raise AssertionError("inventory trust enrichment must not import skill_scanner")
-        return original_import(name, *args, **kwargs)
+        return original_import(name, globals, locals, fromlist, level)
 
     def _record_cisco_mode(**kwargs: object) -> object:
         from codex_plugin_scanner.integrations.cisco_skill_scanner import (
@@ -171,6 +192,7 @@ def test_inventory_skill_trust_enrichment_disables_cisco_scan(
     assert isinstance(trust, dict)
     assert trust.get("resolutionSource") == "local"
     assert cisco_modes == ["off"]
+    assert "local_baseline" in _trust_layer_types(skill_item.metadata)
 
 
 def test_inventory_snapshot_attaches_local_skill_trust_resolution(tmp_path: Path) -> None:
@@ -208,10 +230,13 @@ def test_inventory_snapshot_attaches_local_skill_trust_resolution(tmp_path: Path
     metadata = trust.get("metadata")
     assert isinstance(metadata, dict)
     assert metadata.get("trustDomain") == "skills"
+    assert metadata.get("attestationStatus") == "unsigned"
+    assert isinstance(metadata.get("evidenceHash"), str)
     components = trust.get("trustComponents")
     assert isinstance(components, list)
     assert len(components) > 0
     assert all(isinstance(component.get("componentId"), str) for component in components)
+    assert "local_baseline" in _trust_layer_types(skill_item.metadata)
 
 
 def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) -> None:
@@ -261,3 +286,94 @@ def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) 
     metadata = trust.get("metadata")
     assert isinstance(metadata, dict)
     assert metadata.get("trustDomain") == "mcp"
+    assert "local_baseline" in _trust_layer_types(mcp_item.metadata)
+
+
+def test_registry_identified_skill_still_gets_local_baseline(tmp_path: Path) -> None:
+    plugin_dir = tmp_path
+    _write_good_plugin(plugin_dir)
+    skills_dir = plugin_dir / "skills" / "registry-skill"
+    skills_dir.mkdir(parents=True)
+    (skills_dir / "SKILL.md").write_text("---\nname: registry-skill\ndescription: Demo\n---\n", encoding="utf-8")
+
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(skills_dir / "SKILL.md"),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:skill:registry-skill",
+                name="registry-skill",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="project",
+                config_path=str(skills_dir / "SKILL.md"),
+                metadata={
+                    "registryIdentity": {
+                        "entityId": "hol-skill-registry-skill",
+                        "entityType": "skill",
+                        "name": "registry-skill",
+                        "version": "1.0.0",
+                    }
+                },
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+    skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
+
+    trust_resolution = skill_item.metadata.get("trustResolution")
+    assert isinstance(trust_resolution, dict)
+    assert trust_resolution.get("resolutionSource") == "local"
+    assert "local_baseline" in _trust_layer_types(skill_item.metadata)
+
+
+def test_inventory_snapshot_attaches_instruction_trust_resolution(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    design_doc = workspace / "DESIGN.md"
+    design_doc.write_text(
+        "# Design\n\n## Scope\nOnly write reviewed changes.\n\n## Governance\nOwner: Platform. Review required.\n",
+        encoding="utf-8",
+    )
+
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(design_doc),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:instruction:design",
+                name="DESIGN.md",
+                harness="codex",
+                artifact_type="instruction",
+                source_scope="project",
+                config_path=str(design_doc),
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    overlay_item = next(item for item in snapshot.items if item.item_kind == "overlay")
+    trust = overlay_item.metadata.get("trustResolution")
+
+    assert overlay_item.metadata.get("instructionRole") == "design_md"
+    assert isinstance(trust, dict)
+    assert trust.get("resolutionSource") == "local"
+    trust_metadata = trust.get("metadata")
+    assert isinstance(trust_metadata, dict)
+    assert trust_metadata.get("trustDomain") == "instructions"
+    assert "local_baseline" in _trust_layer_types(overlay_item.metadata)

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -273,6 +273,180 @@ def test_inventory_snapshot_extracts_mcp_tool_items(tmp_path: Path) -> None:
     assert items["hermes:mcp:json:tools:tool:delete_file"].risk_level == "high"
 
 
+def test_inventory_snapshot_attaches_cisco_skill_trust_layer(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    skill_dir = workspace / "skills" / "demo-skill"
+    skill_dir.mkdir(parents=True)
+    skill_file = skill_dir / "SKILL.md"
+    skill_file.write_text("---\nname: demo-skill\ndescription: Demo\n---\n", encoding="utf-8")
+
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(skill_file),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:skill:demo-skill",
+                name="demo-skill",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="project",
+                config_path=str(skill_file),
+            ),
+        ),
+    )
+    cisco_run = CiscoInventoryRun(
+        source="cisco-skill-scanner",
+        status="enabled",
+        message="Cisco skill scan completed.",
+        findings=(
+            Finding(
+                rule_id="cisco.high",
+                severity=Severity.HIGH,
+                category="security",
+                title="High finding",
+                description="Review shell access.",
+                file_path=str(skill_file),
+            ),
+        ),
+        duration_ms=42,
+        metadata={
+            "target": str(skill_dir),
+            "skillsScanned": 1,
+            "skillsSkipped": [],
+            "totalFindings": 1,
+            "findingsBySeverity": {"critical": 0, "high": 1, "medium": 0, "low": 0},
+            "analyzersUsed": ["owasp"],
+            "policyName": "balanced",
+            "mode": "auto",
+        },
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T00:00:00Z",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+        cisco_runs=(cisco_run,),
+    )
+    skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
+    trust_layers = skill_item.metadata.get("trustLayers")
+    encoded = json.dumps(serialize_inventory_snapshot(snapshot), sort_keys=True)
+
+    assert isinstance(trust_layers, list)
+    cisco_layer = next(
+        layer for layer in trust_layers if isinstance(layer, dict) and layer.get("layerType") == "cisco_skill_scanner"
+    )
+    assert cisco_layer.get("trustScore") == 88
+    assert str(skill_dir) not in encoded
+
+
+def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    mcp_file = workspace / ".mcp.json"
+    mcp_file.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "local-demo": {
+                        "command": "python",
+                        "args": ["-m", "demo_server"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(mcp_file),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:mcp:local-demo",
+                name="local-demo",
+                harness="codex",
+                artifact_type="mcp_server",
+                source_scope="project",
+                config_path=str(mcp_file),
+                transport="stdio",
+                metadata={
+                    "tools": [
+                        {
+                            "name": "search_docs",
+                            "title": "Search docs",
+                            "description": "Read-only search over project documentation.",
+                            "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                            "annotations": {"readOnlyHint": True},
+                        }
+                    ]
+                },
+            ),
+        ),
+    )
+    cisco_run = CiscoInventoryRun(
+        source="cisco-mcp-scanner",
+        status="enabled",
+        message="Cisco MCP scan completed.",
+        findings=(
+            Finding(
+                rule_id="cisco.mcp.critical",
+                severity=Severity.CRITICAL,
+                category="transport",
+                title="Critical transport finding",
+                description="Remote unauthenticated endpoint.",
+                file_path=str(mcp_file),
+            ),
+        ),
+        duration_ms=21,
+        metadata={
+            "target": str(workspace),
+            "targetsScanned": 1,
+            "totalFindings": 1,
+            "findingsBySeverity": {"critical": 1, "high": 0, "medium": 0, "low": 0},
+            "analyzersUsed": ["owasp"],
+            "scanMode": "static",
+            "mode": "auto",
+        },
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T00:00:00Z",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+        cisco_runs=(cisco_run,),
+    )
+    server_item = next(item for item in snapshot.items if item.item_kind == "mcp_server")
+    tool_item = next(item for item in snapshot.items if item.item_kind == "mcp_tool")
+    encoded = json.dumps(serialize_inventory_snapshot(snapshot), sort_keys=True)
+
+    server_layers = server_item.metadata.get("trustLayers")
+    tool_layers = tool_item.metadata.get("trustLayers")
+    assert isinstance(server_layers, list)
+    assert any(
+        isinstance(layer, dict)
+        and layer.get("layerType") == "cisco_mcp_scanner"
+        and layer.get("trustScore") == 70
+        and isinstance(layer.get("metadata"), dict)
+        and layer["metadata"].get("attestationStatus") == "unsigned"
+        and isinstance(layer["metadata"].get("evidenceHash"), str)
+        for layer in server_layers
+    )
+    assert isinstance(tool_layers, list)
+    assert any(
+        isinstance(layer, dict)
+        and layer.get("layerType") == "cisco_mcp_scanner"
+        and isinstance(layer.get("metadata"), dict)
+        and layer["metadata"].get("inheritedFromServerItemId") == server_item.item_id
+        for layer in tool_layers
+    )
+    assert str(workspace) not in encoded
+
 def test_inventory_snapshot_handles_missing_mcp_tool_schema_and_scale(tmp_path: Path) -> None:
     tools = [{"name": f"tool_{index}", "description": "No schema available."} for index in range(500)]
     detection = HarnessDetection(


### PR DESCRIPTION
## Summary
- add local baseline AIBOM trust for registry-identified assets, instruction docs, policies, and prompt-pack style artifacts
- emit first-class `trustLayers` metadata for local baseline plus Cisco skill and MCP scanner evidence

## Testing
- `pytest tests/test_guard_aibom_trust_metadata.py tests/test_guard_aibom_detection.py tests/test_guard_inventory_contract.py`

## Notes
- compatibility `trustResolution` remains fast and deterministic while Cisco scanner evidence is emitted separately in `trustLayers`
