### PR TITLE
feat(guard): add Grok Build CLI harness adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
   Guard authors package-level policy while OpenCode keeps native once, always, or reject prompts for managed MCP tools.
 - `kimi`
   Guard installs managed `PreToolUse` and `UserPromptSubmit` hooks in `~/.kimi-code/config.toml`, blocks with exit code `2` and a JSON `permissionDecision: "deny"` response, and fails open on hook crash or timeout.
+- `grok`
+  Guard installs managed Grok hook JSON under `~/.grok/hooks/` plus permission deny rules in `~/.grok/managed_config.toml`, blocks with exit code `2` and a Grok-native `{"decision":"deny"}` response, and never reads `~/.grok/auth`.
 - `hermes`
   Guard installs a managed Hermes overlay bundle, routes MCP servers through Guard proxies, and prefers native-or-center delivery for blocked requests.
 - `gemini`

--- a/dashboard/src/app-routing.test.ts
+++ b/dashboard/src/app-routing.test.ts
@@ -43,6 +43,8 @@ assert(isDisplayableHarness("codex"), "real app harness is displayable");
 assert(!isDisplayableHarness("*"), "wildcard pseudo-harness is not displayable");
 assert(!isDisplayableHarness("Ce2b7ac2ccab4fab9902347b033bf25e"), "token-like pseudo-harness is not displayable");
 assert(harnessDisplayName("*") === "All apps", "wildcard pseudo-harness never renders as raw star");
+assert(harnessDisplayName("grok") === "Grok", "grok harness displays as Grok");
+assert(harnessDisplayName("grok") !== "*", "grok harness never renders as wildcard");
 assert(
   harnessDisplayName("Ce2b7ac2ccab4fab9902347b033bf25e") === "Unknown app",
   "token-like pseudo-harness never renders raw"

--- a/dashboard/src/app-routing.test.ts
+++ b/dashboard/src/app-routing.test.ts
@@ -10,6 +10,7 @@ function assert(condition: boolean, message: string): void {
 assert(parseAppDetail("/apps/opencode") === "opencode", "valid app route parses harness slug");
 assert(parseAppDetail("/apps/claude-code") === "claude-code", "hyphenated app route parses harness slug");
 assert(parseAppDetail("/apps/kimi") === "kimi", "kimi app route parses harness slug");
+assert(parseAppDetail("/apps/grok") === "grok", "grok app route parses harness slug");
 assert(parseAppDetail("/apps/OpenCode") === "opencode", "app route normalizes case");
 assert(parseAppDetail("/apps/*") === null, "wildcard app route is rejected");
 assert(parseAppDetail("/apps/%2A") === null, "encoded wildcard app route is rejected");

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -455,7 +455,7 @@ function normalizeDuplicateReviewText(value: string): string {
 
 function stripDuplicateReviewContextPrefix(value: string): string | null {
   const stripped = value.replace(
-    /^\s*(codex|claude|claude code|claudecode|copilot|opencode|gemini)?\s*(prompt|command|tool)\s+for\s+[`"']?[^:`"']+[`"']?\s*:\s*/i,
+    /^\s*(codex|claude|claude code|claudecode|copilot|opencode|gemini|grok|kimi)?\s*(prompt|command|tool)\s+for\s+[`"']?[^:`"']+[`"']?\s*:\s*/i,
     "",
   );
   return stripped === value ? null : stripped;

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -552,6 +552,8 @@ export function harnessDisplayName(harness: string): string {
       return "OpenClaw";
     case "kimi":
       return "Kimi";
+    case "grok":
+      return "Grok";
     default:
       return capitalizeHarness(normalized);
   }

--- a/dashboard/src/apps/app-catalog.ts
+++ b/dashboard/src/apps/app-catalog.ts
@@ -8,15 +8,16 @@ export const SUPPORTED_APP_SLUGS = [
   "hermes",
   "openclaw",
   "kimi",
+  "grok",
 ] as const;
 
 export type SupportedAppSlug = (typeof SUPPORTED_APP_SLUGS)[number];
 
 export const SUPPORTED_APPS_BRIEF =
-  "Guard works with Codex, Claude Code, OpenCode, Copilot, Cursor, Gemini, Hermes, OpenClaw, and Kimi.";
+  "Guard works with Codex, Claude Code, OpenCode, Copilot, Cursor, Gemini, Hermes, OpenClaw, Kimi, and Grok.";
 
 export const SUPPORTED_APPS_FULL =
-  "Guard works with Codex, Claude Code, OpenCode, Copilot, Cursor, Gemini, Hermes, OpenClaw, Kimi, and more. Run your AI app once and Guard will detect it automatically.";
+  "Guard works with Codex, Claude Code, OpenCode, Copilot, Cursor, Gemini, Hermes, OpenClaw, Kimi, Grok, and more. Run your AI app once and Guard will detect it automatically.";
 
 export type AppInstallStatus = "active" | "partial" | "observed" | "not_installed";
 

--- a/dashboard/src/evidence/evidence-filters.test.ts
+++ b/dashboard/src/evidence/evidence-filters.test.ts
@@ -201,6 +201,11 @@ assert(scopeWs.length === 1 && scopeWs[0].receipt_id === "r1", "sourceScope: wor
 const scopeEmpty = filterBySourceScope(ALL, "");
 assert(scopeEmpty.length === ALL.length, "sourceScope: empty returns all");
 
+const rGrok = makeReceipt("rgrok", { harness: "grok", policy_decision: "block", artifact_name: "grok-bash" });
+const grokFiltered = filterByHarness([...ALL, rGrok], "grok");
+assert(grokFiltered.every((r) => r.harness === "grok"), "harness: grok filter keeps grok receipts only");
+assert(grokFiltered.length === 1, "harness: grok filter returns one receipt");
+
 // filterEvidence combined
 const filters: EvidenceFilterState = {
   ...DEFAULT_FILTER_STATE,

--- a/dashboard/src/fleet-workspace-phase11.test.ts
+++ b/dashboard/src/fleet-workspace-phase11.test.ts
@@ -10,11 +10,11 @@ function assert(condition: boolean, message: string): void {
 }
 
 function testSupportedAppSlugs(): void {
-  const expected = ["codex", "claude-code", "opencode", "copilot", "cursor", "gemini", "hermes", "openclaw", "kimi"];
+  const expected = ["codex", "claude-code", "opencode", "copilot", "cursor", "gemini", "hermes", "openclaw", "kimi", "grok"];
   for (const slug of expected) {
     assert(SUPPORTED_APP_SLUGS.includes(slug as typeof SUPPORTED_APP_SLUGS[number]), `SUPPORTED_APP_SLUGS missing: ${slug}`);
   }
-  assert(SUPPORTED_APP_SLUGS.length === 9, `Expected 9 slugs, got ${SUPPORTED_APP_SLUGS.length}`);
+  assert(SUPPORTED_APP_SLUGS.length === 10, `Expected 10 slugs, got ${SUPPORTED_APP_SLUGS.length}`);
 }
 
 function testSupportedAppsBriefMentionsAllApps(): void {

--- a/dashboard/src/fleet-workspace-phase11.test.ts
+++ b/dashboard/src/fleet-workspace-phase11.test.ts
@@ -22,6 +22,7 @@ function testSupportedAppsBriefMentionsAllApps(): void {
   assert(brief.includes("codex"), "SUPPORTED_APPS_BRIEF should mention Codex");
   assert(brief.includes("copilot"), "SUPPORTED_APPS_BRIEF should mention Copilot");
   assert(brief.includes("cursor"), "SUPPORTED_APPS_BRIEF should mention Cursor");
+  assert(brief.includes("grok"), "SUPPORTED_APPS_BRIEF should mention Grok");
   assert(SUPPORTED_APPS_BRIEF.length > 20, "SUPPORTED_APPS_BRIEF should be a non-trivial string");
 }
 

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -119,6 +119,19 @@ assert(
   "T760: harness setup fallback command should use real hol-guard apps connect command"
 );
 assert(
+  formatHarnessCommand(["hol-guard", "apps", "connect", "grok"]) === "hol-guard apps connect grok",
+  "T760b: grok setup command formats correctly"
+);
+assert(
+  formatHarnessCommand(["hol-guard", "apps", "repair", "grok"]) === "hol-guard apps repair grok",
+  "grok repair command formats correctly"
+);
+assert(
+  formatHarnessCommand(["hol-guard", "apps", "disconnect", "grok", "--confirm", "disconnect-grok"])
+    === "hol-guard apps disconnect grok --confirm disconnect-grok",
+  "grok disconnect command formats correctly"
+);
+assert(
   formatHarnessCommand(["hol-guard", "apps", "connect", "claude code"]) === 'hol-guard apps connect "claude code"',
   "T760: harness setup fallback command should quote spaced args"
 );

--- a/dashboard/src/home-dashboard.test.ts
+++ b/dashboard/src/home-dashboard.test.ts
@@ -140,6 +140,7 @@ const displayNames = [
   { harness: "hermes", expected: "Hermes" },
   { harness: "openclaw", expected: "OpenClaw" },
   { harness: "kimi", expected: "Kimi" },
+  { harness: "grok", expected: "Grok" },
 ];
 
 for (const { harness, expected } of displayNames) {

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -72,7 +72,7 @@ export function resolveCloudUpsellVisible(
 export function buildEmptyStateCopy(): { title: string; body: string; installHint: string } {
   return {
     title: "No apps connected",
-    body: "Connect an AI app so Guard can start protecting it. Guard works with Codex, Claude Code, Cursor, Hermes, Kimi, and more.",
+    body: "Connect an AI app so Guard can start protecting it. Guard works with Codex, Claude Code, Cursor, Grok, Hermes, Kimi, and more.",
     installHint: "hol-guard apps connect <app>",
   };
 }

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -2,7 +2,7 @@ import { ActionButton, Badge, KeyValueGrid, SectionLabel, Surface, Tag, ProofStr
 import { harnessDisplayName, formatRelativeTime } from "./approval-center-utils";
 import type { GuardCloudSyncHealth, GuardInventoryItem, GuardProofStatus, GuardReceipt, GuardRuntimeDevice, GuardRuntimeSnapshot, PackageManagerProtection } from "./guard-types";
 
-const WATCHED_HARNESSES = ["codex", "claude-code", "opencode", "copilot", "gemini", "cursor", "hermes", "openclaw", "kimi"] as const;
+const WATCHED_HARNESSES = ["codex", "claude-code", "opencode", "copilot", "gemini", "cursor", "hermes", "openclaw", "kimi", "grok"] as const;
 
 type WatchedHarnessName = (typeof WATCHED_HARNESSES)[number];
 

--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -4,7 +4,7 @@ Guard lives inside `codex_plugin_scanner` and is the local product surface for h
 
 The runtime is split into:
 
-- `guard/adapters`: harness discovery for Codex, Claude Code, Copilot CLI, Cursor, Gemini, Kimi, and OpenCode
+- `guard/adapters`: harness discovery for Codex, Claude Code, Copilot CLI, Cursor, Gemini, Grok, Kimi, and OpenCode
 - `guard/shims`: local launcher shims that route harness launches through Guard
 - `guard/consumer`: orchestration for detection, policy evaluation, and consumer-mode scan output
 - `guard/policy`: local action resolution for allow, review, warn, and block decisions

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -334,6 +334,10 @@ Current strategy:
   installs Guard-owned `PreToolUse` and `UserPromptSubmit` hooks in `~/.kimi-code/config.toml`, blocks dangerous tool
   calls and prompts with exit code `2` plus a JSON `permissionDecision: "deny"` response, and fails open on hook crash
   or timeout
+- `grok`
+  installs Guard-owned Grok hook JSON in `~/.grok/hooks/` and permission deny rules in `~/.grok/managed_config.toml`,
+  blocks with Grok-native stdout JSON `{"decision":"deny"}` plus approval-center copy, never reads `~/.grok/auth`, and
+  treats `--always-approve` or `bypassPermissions` as degraded protection when detected
 
 Guard does not claim VS Code Copilot extension-host interception in this pass. A VS Code inline tool prompt by itself is
 not proof that Guard blocked the action, because that prompt can come from VS Code's own permission surface. For Copilot,

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -83,6 +83,13 @@ Current Guard support in this repo:
   - blocks dangerous tool calls and prompts by returning exit code `2` and a JSON `permissionDecision: "deny"` response in `hookSpecificOutput`
   - fails open if a hook crashes or times out, so Kimi Code keeps working when Guard is unreachable
   - uses the same JSON stdin/stdout wire protocol as Codex and Claude Code
+- `grok`
+  - detects the `grok` executable, `~/.grok/config.toml`, `~/.grok/managed_config.toml`, `~/.grok/hooks/`, skills, plugins, and project `.grok/` surfaces
+  - installs Guard-owned `PreToolUse` hooks for `Bash`, `Read`, `Edit`, `Grep`, `MCPTool`, and `WebFetch` plus `UserPromptSubmit` prompt screening in `~/.grok/hooks/hol-guard-*.json`
+  - installs Guard-managed deny rules in `~/.grok/managed_config.toml` without touching user `~/.grok/config.toml` or `~/.grok/auth`
+  - blocks by returning exit code `2` and Grok-native stdout JSON `{"decision":"deny","reason":"..."}` with approval-center copy in stderr
+  - surfaces `--always-approve`, `bypassPermissions`, and sandbox `off` as degraded protection states when detected in Grok config
+  - fails open if a hook crashes or times out, so Grok keeps working when Guard is unreachable
 
 Approval tiers:
 
@@ -142,3 +149,4 @@ Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
 | `openclaw` | `openclaw` | ❌ | ✅ | ❌ | mcp_tool |
 | `antigravity` | `antigravity` | ❌ | ✅ | ❌ | mcp_tool, prompt |
 | `kimi` | `kimi`, `kimi-code`, `kimi-cli` | ❌ | ✅ | ❌ | shell, prompt |
+| `grok` | `grok`, `grok-build`, `grok-build-cli`, `xai-grok` | ❌ | ✅ | ❌ | shell, prompt, mcp_tool, file_read |

--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -9,6 +9,7 @@ from .codex import CodexHarnessAdapter
 from .copilot import CopilotHarnessAdapter
 from .cursor import CursorHarnessAdapter
 from .gemini import GeminiHarnessAdapter
+from .grok import GrokHarnessAdapter
 from .hermes import HermesHarnessAdapter
 from .kimi import KimiHarnessAdapter
 from .openclaw import OpenClawHarnessAdapter
@@ -21,6 +22,7 @@ ADAPTERS: tuple[HarnessAdapter, ...] = (
     CursorHarnessAdapter(),
     AntigravityHarnessAdapter(),
     GeminiHarnessAdapter(),
+    GrokHarnessAdapter(),
     HermesHarnessAdapter(),
     KimiHarnessAdapter(),
     OpenClawHarnessAdapter(),

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -138,6 +138,7 @@ _DISPLAY_NAMES = {
     "openclaw": "OpenClaw",
     "antigravity": "Antigravity",
     "kimi": "Kimi",
+    "grok": "Grok",
 }
 
 
@@ -294,6 +295,24 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
             "Hooks run in parallel and fail open on crash or timeout."
         ),
         smoke_command="hol-guard install kimi --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="grok",
+        install_aliases=("grok", "grok-build", "grok-build-cli", "xai-grok"),
+        config_paths=(
+            "~/.grok/config.toml",
+            "~/.grok/managed_config.toml",
+            "~/.grok/hooks/",
+        ),
+        event_surfaces=("shell", "prompt", "mcp_tool", "file_read"),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Grok hooks fail open on crash or timeout. --always-approve and bypassPermissions weaken "
+            "prompt policy but PreToolUse hooks still run when installed."
+        ),
+        smoke_command="hol-guard install grok --dry-run",
     ),
 )
 

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import json
 import os
-import re
 import shutil
 import sys
 from pathlib import Path
@@ -21,6 +20,26 @@ from .base import (
     _run_command_probe,
     _shell_command,
 )
+from .grok_config import (
+    GROK_CONFIG_FILE,
+    GROK_DIR,
+    GROK_HOOKS_DIR,
+    GROK_MANAGED_CONFIG_FILE,
+    GROK_REQUIREMENTS_FILE,
+    GUARD_HOOK_PRETOOL_FILE,
+    GUARD_HOOK_PROMPT_FILE,
+    GUARD_MANAGED_BEGIN,
+    SYSTEM_MANAGED_CONFIG,
+    SYSTEM_REQUIREMENTS,
+    append_found_path,
+    append_hooks_dir_artifacts,
+    append_mcp_artifacts,
+    append_permission_artifacts,
+    build_managed_config_block,
+    build_pretool_hook_json,
+    degraded_mode_warnings,
+    remove_managed_block,
+)
 
 try:
     import tomllib  # type: ignore[attr-defined]
@@ -28,28 +47,6 @@ except ModuleNotFoundError:
     import tomli as tomllib  # type: ignore[no-redef]
 
 _GROK_HOME_ENV_VAR = "GROK_HOME"
-_GROK_DIR = ".grok"
-_GROK_CONFIG_FILE = "config.toml"
-_GROK_MANAGED_CONFIG_FILE = "managed_config.toml"
-_GROK_REQUIREMENTS_FILE = "requirements.toml"
-_GROK_HOOKS_DIR = "hooks"
-_GUARD_MANAGED_BEGIN = "# BEGIN HOL GUARD MANAGED GROK"
-_GUARD_MANAGED_END = "# END HOL GUARD MANAGED GROK"
-_GUARD_MANAGED_MARKER = "HOL GUARD MANAGED GROK"
-_GUARD_HOOK_PRETOOL_FILE = "hol-guard-pretooluse.json"
-_GUARD_HOOK_PROMPT_FILE = "hol-guard-prompt.json"
-_PRETOOL_MATCHERS = ("Bash", "Read", "Edit", "Grep", "MCPTool", "WebFetch")
-_SYSTEM_MANAGED_CONFIG = Path("/etc/grok/managed_config.toml")
-_SYSTEM_REQUIREMENTS = Path("/etc/grok/requirements.toml")
-_DEGRADED_MODE_MARKERS = (
-    "always-approve",
-    "bypasspermissions",
-    "bypass_permissions",
-    'defaultmode = "bypasspermissions"',
-    'defaultMode": "bypassPermissions"',
-    'sandbox = "off"',
-    'sandbox="off"',
-)
 
 
 class GrokHarnessAdapter(HarnessAdapter):
@@ -78,34 +75,34 @@ class GrokHarnessAdapter(HarnessAdapter):
 
     @classmethod
     def _grok_root(cls, context: HarnessContext) -> Path:
-        return cls._grok_home_dir(context) / _GROK_DIR
+        return cls._grok_home_dir(context) / GROK_DIR
 
     @classmethod
     def _managed_config_path(cls, context: HarnessContext) -> Path:
-        return cls._grok_root(context) / _GROK_MANAGED_CONFIG_FILE
+        return cls._grok_root(context) / GROK_MANAGED_CONFIG_FILE
 
     @classmethod
     def _config_path(cls, context: HarnessContext) -> Path:
-        return cls._grok_root(context) / _GROK_CONFIG_FILE
+        return cls._grok_root(context) / GROK_CONFIG_FILE
 
     @classmethod
     def _requirements_path(cls, context: HarnessContext) -> Path:
-        return cls._grok_root(context) / _GROK_REQUIREMENTS_FILE
+        return cls._grok_root(context) / GROK_REQUIREMENTS_FILE
 
     @classmethod
     def _hooks_dir(cls, context: HarnessContext) -> Path:
-        return cls._grok_root(context) / _GROK_HOOKS_DIR
+        return cls._grok_root(context) / GROK_HOOKS_DIR
 
     @classmethod
     def _project_grok_root(cls, context: HarnessContext) -> Path | None:
         if context.workspace_dir is None:
             return None
-        return context.workspace_dir / _GROK_DIR
+        return context.workspace_dir / GROK_DIR
 
     def policy_path(self, context: HarnessContext) -> Path:
         project_root = self._project_grok_root(context)
-        if project_root is not None and (project_root / _GROK_CONFIG_FILE).is_file():
-            return project_root / _GROK_CONFIG_FILE
+        if project_root is not None and (project_root / GROK_CONFIG_FILE).is_file():
+            return project_root / GROK_CONFIG_FILE
         return self._config_path(context)
 
     @staticmethod
@@ -135,33 +132,56 @@ class GrokHarnessAdapter(HarnessAdapter):
             self._requirements_path(context),
         ):
             if config_path.is_file():
-                self._append_found_path(found_paths, config_path)
+                append_found_path(found_paths, config_path)
                 payload = self._read_toml(config_path)
                 if payload:
-                    self._append_permission_artifacts(artifacts, payload, config_path, "global")
-                    self._append_mcp_artifacts(artifacts, payload, config_path, "global")
-                    degraded = self._degraded_mode_warnings(config_path, payload)
-                    warnings.extend(degraded)
+                    append_permission_artifacts(
+                        harness=self.harness,
+                        artifacts=artifacts,
+                        payload=payload,
+                        config_path=config_path,
+                        scope="global",
+                    )
+                    append_mcp_artifacts(
+                        harness=self.harness,
+                        artifacts=artifacts,
+                        payload=payload,
+                        config_path=config_path,
+                        scope="global",
+                    )
+                    warnings.extend(degraded_mode_warnings(config_path, payload))
 
-        for system_path in (_SYSTEM_MANAGED_CONFIG, _SYSTEM_REQUIREMENTS):
+        for system_path in (SYSTEM_MANAGED_CONFIG, SYSTEM_REQUIREMENTS):
             if system_path.is_file() and os.access(system_path, os.R_OK):
-                self._append_found_path(found_paths, system_path)
+                append_found_path(found_paths, system_path)
                 warnings.append(f"Enterprise Grok policy detected at {system_path.name}.")
 
-        self._append_hooks_dir_artifacts(artifacts, found_paths, self._hooks_dir(context), "global")
+        append_hooks_dir_artifacts(
+            harness=self.harness,
+            artifacts=artifacts,
+            found_paths=found_paths,
+            hooks_dir=self._hooks_dir(context),
+            scope="global",
+        )
         project_root = self._project_grok_root(context)
         if project_root is not None:
-            if (project_root / _GROK_CONFIG_FILE).is_file():
-                self._append_found_path(found_paths, project_root / _GROK_CONFIG_FILE)
-            self._append_hooks_dir_artifacts(artifacts, found_paths, project_root / _GROK_HOOKS_DIR, "project")
+            if (project_root / GROK_CONFIG_FILE).is_file():
+                append_found_path(found_paths, project_root / GROK_CONFIG_FILE)
+            append_hooks_dir_artifacts(
+                harness=self.harness,
+                artifacts=artifacts,
+                found_paths=found_paths,
+                hooks_dir=project_root / GROK_HOOKS_DIR,
+                scope="project",
+            )
 
         hooks_paths_file = grok_root / "hooks-paths"
         if hooks_paths_file.is_file():
-            self._append_found_path(found_paths, hooks_paths_file)
+            append_found_path(found_paths, hooks_paths_file)
 
         marketplaces_file = grok_root / "plugins" / "known_marketplaces.json"
         if marketplaces_file.is_file():
-            self._append_found_path(found_paths, marketplaces_file)
+            append_found_path(found_paths, marketplaces_file)
             payload = _json_payload(marketplaces_file)
             if payload:
                 artifacts.append(
@@ -179,23 +199,23 @@ class GrokHarnessAdapter(HarnessAdapter):
         for relative in ("skills", "plugins", "plugins/marketplaces", "plugins/known_marketplaces.json", "sessions"):
             candidate = grok_root / relative
             if candidate.exists():
-                self._append_found_path(found_paths, candidate)
+                append_found_path(found_paths, candidate)
 
         if project_root is not None:
             for relative in ("skills", "plugins", "hooks"):
                 candidate = project_root / relative
                 if candidate.exists():
-                    self._append_found_path(found_paths, candidate)
+                    append_found_path(found_paths, candidate)
 
         for agents_path in (context.home_dir / ".agents" / "skills", context.home_dir / ".agents" / "commands"):
             if agents_path.exists():
-                self._append_found_path(found_paths, agents_path)
+                append_found_path(found_paths, agents_path)
 
         if context.workspace_dir is not None:
             for agents_file in ("AGENTS.md", "CLAUDE.md"):
                 candidate = context.workspace_dir / agents_file
                 if candidate.is_file():
-                    self._append_found_path(found_paths, candidate)
+                    append_found_path(found_paths, candidate)
                     artifacts.append(
                         GuardArtifact(
                             artifact_id=f"grok:project:instruction:{agents_file.lower()}",
@@ -227,141 +247,6 @@ class GrokHarnessAdapter(HarnessAdapter):
             workspace_dir=context.workspace_dir,
         )
 
-    @staticmethod
-    def _append_found_path(found_paths: list[str], path: Path) -> None:
-        candidate = str(path)
-        if candidate not in found_paths:
-            found_paths.append(candidate)
-
-    def _append_hooks_dir_artifacts(
-        self,
-        artifacts: list[GuardArtifact],
-        found_paths: list[str],
-        hooks_dir: Path,
-        scope: str,
-    ) -> None:
-        if not hooks_dir.is_dir():
-            return
-        for hook_file in sorted(hooks_dir.glob("*.json")):
-            payload = _json_payload(hook_file)
-            if not payload:
-                continue
-            self._append_found_path(found_paths, hook_file)
-            hooks = payload.get("hooks")
-            if not isinstance(hooks, dict):
-                continue
-            for event_name, entries in hooks.items():
-                if not isinstance(event_name, str) or not isinstance(entries, list):
-                    continue
-                for index, entry in enumerate(entries):
-                    if not isinstance(entry, dict):
-                        continue
-                    nested = entry.get("hooks")
-                    matcher = entry.get("matcher")
-                    if isinstance(nested, list):
-                        for nested_index, hook_entry in enumerate(nested):
-                            if not isinstance(hook_entry, dict):
-                                continue
-                            command = hook_entry.get("command")
-                            if not isinstance(command, str) or not command.strip():
-                                continue
-                            artifacts.append(
-                                GuardArtifact(
-                                    artifact_id=f"grok:{scope}:hook:{event_name.lower()}:{index}:{nested_index}",
-                                    name=f"{event_name}:{matcher}" if isinstance(matcher, str) else event_name,
-                                    harness=self.harness,
-                                    artifact_type="hook",
-                                    source_scope=scope,
-                                    config_path=str(hook_file),
-                                    command=command,
-                                    metadata={"event": event_name, "matcher": matcher},
-                                )
-                            )
-
-    def _append_permission_artifacts(
-        self,
-        artifacts: list[GuardArtifact],
-        payload: dict[str, object],
-        config_path: Path,
-        scope: str,
-    ) -> None:
-        permission = payload.get("permission")
-        if not isinstance(permission, dict):
-            return
-        for key in ("allow", "deny", "ask", "rules"):
-            value = permission.get(key)
-            if isinstance(value, list) and value:
-                artifacts.append(
-                    GuardArtifact(
-                        artifact_id=f"grok:{scope}:permission:{key}",
-                        name=f"permission:{key}",
-                        harness=self.harness,
-                        artifact_type="policy",
-                        source_scope=scope,
-                        config_path=str(config_path),
-                        metadata={"entries": len(value)},
-                    )
-                )
-
-    def _append_mcp_artifacts(
-        self,
-        artifacts: list[GuardArtifact],
-        payload: dict[str, object],
-        config_path: Path,
-        scope: str,
-    ) -> None:
-        servers: dict[str, object] = {}
-        nested = payload.get("mcp_servers")
-        if isinstance(nested, dict):
-            servers.update(nested)
-        for key, value in payload.items():
-            if not isinstance(key, str) or not key.startswith("mcp_servers."):
-                continue
-            if isinstance(value, dict):
-                servers[key.split(".", 1)[1]] = value
-        for server_name, server_config in servers.items():
-            if not isinstance(server_name, str) or not isinstance(server_config, dict):
-                continue
-            command = server_config.get("command")
-            url = server_config.get("url")
-            if not isinstance(command, str) and not isinstance(url, str):
-                continue
-            raw_args = server_config.get("args")
-            args = tuple(str(item) for item in raw_args) if isinstance(raw_args, list) else ()
-            artifacts.append(
-                GuardArtifact(
-                    artifact_id=f"grok:{scope}:mcp:{server_name}",
-                    name=server_name,
-                    harness=self.harness,
-                    artifact_type="mcp_server",
-                    source_scope=scope,
-                    config_path=str(config_path),
-                    command=command if isinstance(command, str) else None,
-                    args=args,
-                    url=url if isinstance(url, str) else None,
-                    transport="http" if isinstance(url, str) else "stdio",
-                )
-            )
-
-    def _degraded_mode_warnings(self, config_path: Path, payload: dict[str, object]) -> list[str]:
-        warnings: list[str] = []
-        serialized = json.dumps(payload, sort_keys=True).lower()
-        raw_text = config_path.read_text(encoding="utf-8").lower() if config_path.is_file() else ""
-        for marker in _DEGRADED_MODE_MARKERS:
-            marker_lower = marker.lower()
-            if marker_lower in serialized or marker_lower in raw_text:
-                warnings.append(
-                    f"Degraded Grok protection signal in {config_path.name}: {marker}. "
-                    "Guard hooks still run, but Grok may auto-approve some actions."
-                )
-        sandbox = payload.get("sandbox")
-        if isinstance(sandbox, str) and sandbox.strip().lower() == "off":
-            warnings.append(
-                f"Degraded Grok protection signal in {config_path.name}: sandbox off. "
-                "Guard hooks still run, but Grok may auto-approve some actions."
-            )
-        return warnings
-
     def _managed_state_dir(self, context: HarnessContext) -> Path:
         return context.guard_home / "managed" / "grok"
 
@@ -381,7 +266,7 @@ class GrokHarnessAdapter(HarnessAdapter):
         managed_config = self._managed_config_path(context)
         if managed_config.is_file():
             text = managed_config.read_text(encoding="utf-8")
-            return text.count(_GUARD_MANAGED_BEGIN) > 1
+            return text.count(GUARD_MANAGED_BEGIN) > 1
         return False
 
     @staticmethod
@@ -407,43 +292,6 @@ class GrokHarnessAdapter(HarnessAdapter):
         )
         return (sys.executable, "-c", code)
 
-    @classmethod
-    def _build_pretool_hook_json(cls, hook_command: str) -> dict[str, object]:
-        entries: list[dict[str, object]] = []
-        for matcher in _PRETOOL_MATCHERS:
-            entries.append(
-                {
-                    "matcher": matcher,
-                    "hooks": [
-                        {
-                            "type": "command",
-                            "command": hook_command,
-                            "timeout": 30,
-                        }
-                    ],
-                }
-            )
-        return {"hooks": {"PreToolUse": entries, "UserPromptSubmit": [{"hooks": [{"type": "command", "command": hook_command, "timeout": 30}]}]}}
-
-    @classmethod
-    def _build_managed_config_block(cls) -> str:
-        lines = [
-            _GUARD_MANAGED_BEGIN,
-            "# Permission rules below are managed by HOL Guard. Do not edit manually.",
-            "[permission]",
-            "deny = [",
-            '  "Bash(hol-guard apps disconnect grok*)",',
-            '  "Bash(rm -rf ~/.grok/hooks/hol-guard*)",',
-            '  "Read(~/.grok/auth/**)",',
-            '  "Read(~/.env)",',
-            '  "Read(**/.env)",',
-            '  "Read(**/.npmrc)",',
-            '  "Read(~/.ssh/**)",',
-            "]",
-            _GUARD_MANAGED_END,
-        ]
-        return "\n".join(lines)
-
     def install(self, context: HarnessContext) -> dict[str, object]:
         shim_manifest = install_guard_shim(
             self.harness,
@@ -464,13 +312,13 @@ class GrokHarnessAdapter(HarnessAdapter):
             shutil.copy2(managed_config_path, self._backup_path(context, "managed_config.toml"))
 
         hook_command = _shell_command(self._hook_command_parts(context))
-        pretool_path = hooks_dir / _GUARD_HOOK_PRETOOL_FILE
-        prompt_path = hooks_dir / _GUARD_HOOK_PROMPT_FILE
+        pretool_path = hooks_dir / GUARD_HOOK_PRETOOL_FILE
+        prompt_path = hooks_dir / GUARD_HOOK_PROMPT_FILE
         for hook_path in (pretool_path, prompt_path):
             if hook_path.is_file() and not self._backup_path(context, hook_path.name).exists():
                 shutil.copy2(hook_path, self._backup_path(context, hook_path.name))
 
-        pretool_payload = self._build_pretool_hook_json(hook_command)
+        pretool_payload = build_pretool_hook_json(hook_command)
         pretool_path.write_text(json.dumps(pretool_payload, indent=2) + "\n", encoding="utf-8")
         prompt_payload = {
             "hooks": {
@@ -490,8 +338,8 @@ class GrokHarnessAdapter(HarnessAdapter):
         prompt_path.write_text(json.dumps(prompt_payload, indent=2) + "\n", encoding="utf-8")
 
         existing_text = managed_config_path.read_text(encoding="utf-8") if managed_config_path.is_file() else ""
-        cleaned_text = _remove_managed_block(existing_text)
-        managed_block = self._build_managed_config_block()
+        cleaned_text = remove_managed_block(existing_text)
+        managed_block = build_managed_config_block()
         managed_config_path.write_text(f"{cleaned_text.rstrip()}\n\n{managed_block}\n".lstrip(), encoding="utf-8")
 
         self._state_path(context).write_text(
@@ -513,8 +361,8 @@ class GrokHarnessAdapter(HarnessAdapter):
             "config_path": str(managed_config_path),
             **shim_manifest,
             "notes": [
-                "Guard hooks installed in ~/.grok/hooks/hol-guard-*.json",
-                "Guard permission rules installed in ~/.grok/managed_config.toml",
+                "Guard hooks installed in .grok/hooks/hol-guard-*.json",
+                "Guard permission rules installed in .grok/managed_config.toml",
                 *[str(note) for note in shim_manifest.get("notes", [])],
             ],
         }
@@ -531,9 +379,9 @@ class GrokHarnessAdapter(HarnessAdapter):
         if managed_config_path.is_file():
             _ensure_path_within_root(context.home_dir, managed_config_path, label="Grok")
             existing_text = managed_config_path.read_text(encoding="utf-8")
-            managed_config_path.write_text(_remove_managed_block(existing_text).rstrip() + "\n", encoding="utf-8")
+            managed_config_path.write_text(remove_managed_block(existing_text).rstrip() + "\n", encoding="utf-8")
 
-        for hook_name in (_GUARD_HOOK_PRETOOL_FILE, _GUARD_HOOK_PROMPT_FILE):
+        for hook_name in (GUARD_HOOK_PRETOOL_FILE, GUARD_HOOK_PROMPT_FILE):
             hook_path = hooks_dir / hook_name
             backup_path = self._backup_path(context, hook_name)
             if backup_path.is_file():
@@ -553,17 +401,12 @@ class GrokHarnessAdapter(HarnessAdapter):
             **shim_manifest,
             "notes": [
                 "Guard-managed Grok hooks and permission rules removed.",
-                "User ~/.grok/config.toml, auth, skills, plugins, and sessions were preserved.",
+                "User .grok/config.toml, auth, skills, plugins, and sessions were preserved.",
                 *[str(note) for note in shim_manifest.get("notes", [])],
             ],
         }
 
 
-def _remove_managed_block(text: str) -> str:
-    pattern = re.compile(
-        rf"^\s*{re.escape(_GUARD_MANAGED_BEGIN)}.*?{re.escape(_GUARD_MANAGED_END)}\s*\n?",
-        re.MULTILINE | re.DOTALL,
-    )
-    cleaned = pattern.sub("", text)
-    cleaned = re.sub(rf"^\s*#.*{re.escape(_GUARD_MANAGED_MARKER)}.*$\n?", "", cleaned, flags=re.MULTILINE)
-    return cleaned
+_remove_managed_block = remove_managed_block
+
+__all__ = ["GrokHarnessAdapter", "_remove_managed_block"]

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -139,6 +139,7 @@ class GrokHarnessAdapter(HarnessAdapter):
                 payload = self._read_toml(config_path)
                 if payload:
                     self._append_permission_artifacts(artifacts, payload, config_path, "global")
+                    self._append_mcp_artifacts(artifacts, payload, config_path, "global")
                     degraded = self._degraded_mode_warnings(config_path, payload)
                     warnings.extend(degraded)
 
@@ -157,6 +158,23 @@ class GrokHarnessAdapter(HarnessAdapter):
         hooks_paths_file = grok_root / "hooks-paths"
         if hooks_paths_file.is_file():
             self._append_found_path(found_paths, hooks_paths_file)
+
+        marketplaces_file = grok_root / "plugins" / "known_marketplaces.json"
+        if marketplaces_file.is_file():
+            self._append_found_path(found_paths, marketplaces_file)
+            payload = _json_payload(marketplaces_file)
+            if payload:
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id="grok:global:marketplace-metadata",
+                        name="known_marketplaces",
+                        harness=self.harness,
+                        artifact_type="marketplace",
+                        source_scope="global",
+                        config_path=str(marketplaces_file),
+                        metadata={"entries": len(payload) if isinstance(payload, dict) else 0},
+                    )
+                )
 
         for relative in ("skills", "plugins", "plugins/marketplaces", "plugins/known_marketplaces.json", "sessions"):
             candidate = grok_root / relative
@@ -285,15 +303,63 @@ class GrokHarnessAdapter(HarnessAdapter):
                     )
                 )
 
+    def _append_mcp_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        payload: dict[str, object],
+        config_path: Path,
+        scope: str,
+    ) -> None:
+        servers: dict[str, object] = {}
+        nested = payload.get("mcp_servers")
+        if isinstance(nested, dict):
+            servers.update(nested)
+        for key, value in payload.items():
+            if not isinstance(key, str) or not key.startswith("mcp_servers."):
+                continue
+            if isinstance(value, dict):
+                servers[key.split(".", 1)[1]] = value
+        for server_name, server_config in servers.items():
+            if not isinstance(server_name, str) or not isinstance(server_config, dict):
+                continue
+            command = server_config.get("command")
+            url = server_config.get("url")
+            if not isinstance(command, str) and not isinstance(url, str):
+                continue
+            raw_args = server_config.get("args")
+            args = tuple(str(item) for item in raw_args) if isinstance(raw_args, list) else ()
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"grok:{scope}:mcp:{server_name}",
+                    name=server_name,
+                    harness=self.harness,
+                    artifact_type="mcp_server",
+                    source_scope=scope,
+                    config_path=str(config_path),
+                    command=command if isinstance(command, str) else None,
+                    args=args,
+                    url=url if isinstance(url, str) else None,
+                    transport="http" if isinstance(url, str) else "stdio",
+                )
+            )
+
     def _degraded_mode_warnings(self, config_path: Path, payload: dict[str, object]) -> list[str]:
         warnings: list[str] = []
         serialized = json.dumps(payload, sort_keys=True).lower()
+        raw_text = config_path.read_text(encoding="utf-8").lower() if config_path.is_file() else ""
         for marker in _DEGRADED_MODE_MARKERS:
-            if marker.lower() in serialized:
+            marker_lower = marker.lower()
+            if marker_lower in serialized or marker_lower in raw_text:
                 warnings.append(
                     f"Degraded Grok protection signal in {config_path.name}: {marker}. "
                     "Guard hooks still run, but Grok may auto-approve some actions."
                 )
+        sandbox = payload.get("sandbox")
+        if isinstance(sandbox, str) and sandbox.strip().lower() == "off":
+            warnings.append(
+                f"Degraded Grok protection signal in {config_path.name}: sandbox off. "
+                "Guard hooks still run, but Grok may auto-approve some actions."
+            )
         return warnings
 
     def _managed_state_dir(self, context: HarnessContext) -> Path:

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -1,0 +1,503 @@
+"""Grok Build CLI harness adapter for HOL Guard."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import sys
+from pathlib import Path
+
+from ..aibom_detection import extend_detection_with_workspace_aibom
+from ..models import GuardArtifact, HarnessDetection
+from ..shims import install_guard_shim, remove_guard_shim
+from .base import (
+    HarnessAdapter,
+    HarnessContext,
+    _command_available,
+    _ensure_path_within_root,
+    _json_payload,
+    _run_command_probe,
+    _shell_command,
+)
+
+try:
+    import tomllib  # type: ignore[attr-defined]
+except ModuleNotFoundError:
+    import tomli as tomllib  # type: ignore[no-redef]
+
+_GROK_HOME_ENV_VAR = "GROK_HOME"
+_GROK_DIR = ".grok"
+_GROK_CONFIG_FILE = "config.toml"
+_GROK_MANAGED_CONFIG_FILE = "managed_config.toml"
+_GROK_REQUIREMENTS_FILE = "requirements.toml"
+_GROK_HOOKS_DIR = "hooks"
+_GUARD_MANAGED_BEGIN = "# BEGIN HOL GUARD MANAGED GROK"
+_GUARD_MANAGED_END = "# END HOL GUARD MANAGED GROK"
+_GUARD_MANAGED_MARKER = "HOL GUARD MANAGED GROK"
+_GUARD_HOOK_PRETOOL_FILE = "hol-guard-pretooluse.json"
+_GUARD_HOOK_PROMPT_FILE = "hol-guard-prompt.json"
+_PRETOOL_MATCHERS = ("Bash", "Read", "Edit", "Grep", "MCPTool", "WebFetch")
+_SYSTEM_MANAGED_CONFIG = Path("/etc/grok/managed_config.toml")
+_SYSTEM_REQUIREMENTS = Path("/etc/grok/requirements.toml")
+_DEGRADED_MODE_MARKERS = (
+    "always-approve",
+    "bypasspermissions",
+    "bypass_permissions",
+    'defaultmode = "bypasspermissions"',
+    'defaultMode": "bypassPermissions"',
+    'sandbox = "off"',
+    'sandbox="off"',
+)
+
+
+class GrokHarnessAdapter(HarnessAdapter):
+    """Discover Grok Build settings, hooks, plugins, and manage Guard protection."""
+
+    harness = "grok"
+    aliases = ("grok-build", "grok-build-cli", "xai-grok")
+    executable = "grok"
+    launcher_name = "grok"
+    approval_tier = "approval-center"
+    approval_summary = (
+        "Guard intercepts Grok tool calls through native PreToolUse hooks and routes blocked "
+        "actions to the local approval center."
+    )
+    fallback_hint = (
+        "Grok receives plain-language allow or deny responses from Guard hooks. "
+        "Use `hol-guard approvals` if you want to resolve pending requests from the terminal."
+    )
+
+    @staticmethod
+    def _grok_home_dir(context: HarnessContext) -> Path:
+        value = os.environ.get(_GROK_HOME_ENV_VAR)
+        if value:
+            return Path(value).expanduser().resolve()
+        return context.home_dir
+
+    @classmethod
+    def _grok_root(cls, context: HarnessContext) -> Path:
+        return cls._grok_home_dir(context) / _GROK_DIR
+
+    @classmethod
+    def _managed_config_path(cls, context: HarnessContext) -> Path:
+        return cls._grok_root(context) / _GROK_MANAGED_CONFIG_FILE
+
+    @classmethod
+    def _config_path(cls, context: HarnessContext) -> Path:
+        return cls._grok_root(context) / _GROK_CONFIG_FILE
+
+    @classmethod
+    def _requirements_path(cls, context: HarnessContext) -> Path:
+        return cls._grok_root(context) / _GROK_REQUIREMENTS_FILE
+
+    @classmethod
+    def _hooks_dir(cls, context: HarnessContext) -> Path:
+        return cls._grok_root(context) / _GROK_HOOKS_DIR
+
+    @classmethod
+    def _project_grok_root(cls, context: HarnessContext) -> Path | None:
+        if context.workspace_dir is None:
+            return None
+        return context.workspace_dir / _GROK_DIR
+
+    def policy_path(self, context: HarnessContext) -> Path:
+        project_root = self._project_grok_root(context)
+        if project_root is not None and (project_root / _GROK_CONFIG_FILE).is_file():
+            return project_root / _GROK_CONFIG_FILE
+        return self._config_path(context)
+
+    @staticmethod
+    def _read_toml(path: Path) -> dict[str, object]:
+        if not path.is_file():
+            return {}
+        try:
+            with path.open("rb") as handle:
+                payload = tomllib.load(handle)
+        except (OSError, tomllib.TOMLDecodeError):
+            return {}
+        return payload if isinstance(payload, dict) else {}
+
+    @staticmethod
+    def _version_probe() -> dict[str, object]:
+        return _run_command_probe(["grok", "--no-auto-update", "--version"], timeout_seconds=8)
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
+        artifacts: list[GuardArtifact] = []
+        found_paths: list[str] = []
+        warnings: list[str] = []
+        grok_root = self._grok_root(context)
+
+        for config_path in (
+            self._config_path(context),
+            self._managed_config_path(context),
+            self._requirements_path(context),
+        ):
+            if config_path.is_file():
+                self._append_found_path(found_paths, config_path)
+                payload = self._read_toml(config_path)
+                if payload:
+                    self._append_permission_artifacts(artifacts, payload, config_path, "global")
+                    degraded = self._degraded_mode_warnings(config_path, payload)
+                    warnings.extend(degraded)
+
+        for system_path in (_SYSTEM_MANAGED_CONFIG, _SYSTEM_REQUIREMENTS):
+            if system_path.is_file() and os.access(system_path, os.R_OK):
+                self._append_found_path(found_paths, system_path)
+                warnings.append(f"Enterprise Grok policy detected at {system_path.name}.")
+
+        self._append_hooks_dir_artifacts(artifacts, found_paths, self._hooks_dir(context), "global")
+        project_root = self._project_grok_root(context)
+        if project_root is not None:
+            if (project_root / _GROK_CONFIG_FILE).is_file():
+                self._append_found_path(found_paths, project_root / _GROK_CONFIG_FILE)
+            self._append_hooks_dir_artifacts(artifacts, found_paths, project_root / _GROK_HOOKS_DIR, "project")
+
+        hooks_paths_file = grok_root / "hooks-paths"
+        if hooks_paths_file.is_file():
+            self._append_found_path(found_paths, hooks_paths_file)
+
+        for relative in ("skills", "plugins", "plugins/marketplaces", "plugins/known_marketplaces.json", "sessions"):
+            candidate = grok_root / relative
+            if candidate.exists():
+                self._append_found_path(found_paths, candidate)
+
+        if project_root is not None:
+            for relative in ("skills", "plugins", "hooks"):
+                candidate = project_root / relative
+                if candidate.exists():
+                    self._append_found_path(found_paths, candidate)
+
+        for agents_path in (context.home_dir / ".agents" / "skills", context.home_dir / ".agents" / "commands"):
+            if agents_path.exists():
+                self._append_found_path(found_paths, agents_path)
+
+        if context.workspace_dir is not None:
+            for agents_file in ("AGENTS.md", "CLAUDE.md"):
+                candidate = context.workspace_dir / agents_file
+                if candidate.is_file():
+                    self._append_found_path(found_paths, candidate)
+                    artifacts.append(
+                        GuardArtifact(
+                            artifact_id=f"grok:project:instruction:{agents_file.lower()}",
+                            name=agents_file,
+                            harness=self.harness,
+                            artifact_type="instruction_surface",
+                            source_scope="project",
+                            config_path=str(candidate),
+                        )
+                    )
+
+        version_probe = self._version_probe()
+        command_available = _command_available(self.executable) or bool(version_probe.get("ok"))
+        installed = bool(found_paths) or command_available
+        if self._has_stale_guard_entries(context):
+            warnings.append("Stale or duplicate Guard-managed Grok entries detected.")
+
+        detection = HarnessDetection(
+            harness=self.harness,
+            installed=installed,
+            command_available=command_available,
+            config_paths=tuple(found_paths),
+            artifacts=tuple(artifacts),
+            warnings=tuple(dict.fromkeys(warnings)),
+        )
+        return extend_detection_with_workspace_aibom(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
+        )
+
+    @staticmethod
+    def _append_found_path(found_paths: list[str], path: Path) -> None:
+        candidate = str(path)
+        if candidate not in found_paths:
+            found_paths.append(candidate)
+
+    def _append_hooks_dir_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        found_paths: list[str],
+        hooks_dir: Path,
+        scope: str,
+    ) -> None:
+        if not hooks_dir.is_dir():
+            return
+        for hook_file in sorted(hooks_dir.glob("*.json")):
+            payload = _json_payload(hook_file)
+            if not payload:
+                continue
+            self._append_found_path(found_paths, hook_file)
+            hooks = payload.get("hooks")
+            if not isinstance(hooks, dict):
+                continue
+            for event_name, entries in hooks.items():
+                if not isinstance(event_name, str) or not isinstance(entries, list):
+                    continue
+                for index, entry in enumerate(entries):
+                    if not isinstance(entry, dict):
+                        continue
+                    nested = entry.get("hooks")
+                    matcher = entry.get("matcher")
+                    if isinstance(nested, list):
+                        for nested_index, hook_entry in enumerate(nested):
+                            if not isinstance(hook_entry, dict):
+                                continue
+                            command = hook_entry.get("command")
+                            if not isinstance(command, str) or not command.strip():
+                                continue
+                            artifacts.append(
+                                GuardArtifact(
+                                    artifact_id=f"grok:{scope}:hook:{event_name.lower()}:{index}:{nested_index}",
+                                    name=f"{event_name}:{matcher}" if isinstance(matcher, str) else event_name,
+                                    harness=self.harness,
+                                    artifact_type="hook",
+                                    source_scope=scope,
+                                    config_path=str(hook_file),
+                                    command=command,
+                                    metadata={"event": event_name, "matcher": matcher},
+                                )
+                            )
+
+    def _append_permission_artifacts(
+        self,
+        artifacts: list[GuardArtifact],
+        payload: dict[str, object],
+        config_path: Path,
+        scope: str,
+    ) -> None:
+        permission = payload.get("permission")
+        if not isinstance(permission, dict):
+            return
+        for key in ("allow", "deny", "ask", "rules"):
+            value = permission.get(key)
+            if isinstance(value, list) and value:
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"grok:{scope}:permission:{key}",
+                        name=f"permission:{key}",
+                        harness=self.harness,
+                        artifact_type="policy",
+                        source_scope=scope,
+                        config_path=str(config_path),
+                        metadata={"entries": len(value)},
+                    )
+                )
+
+    def _degraded_mode_warnings(self, config_path: Path, payload: dict[str, object]) -> list[str]:
+        warnings: list[str] = []
+        serialized = json.dumps(payload, sort_keys=True).lower()
+        for marker in _DEGRADED_MODE_MARKERS:
+            if marker.lower() in serialized:
+                warnings.append(
+                    f"Degraded Grok protection signal in {config_path.name}: {marker}. "
+                    "Guard hooks still run, but Grok may auto-approve some actions."
+                )
+        return warnings
+
+    def _managed_state_dir(self, context: HarnessContext) -> Path:
+        return context.guard_home / "managed" / "grok"
+
+    def _backup_path(self, context: HarnessContext, label: str) -> Path:
+        return self._managed_state_dir(context) / f"{label}.backup"
+
+    def _state_path(self, context: HarnessContext) -> Path:
+        return self._managed_state_dir(context) / "install.state.json"
+
+    def _has_stale_guard_entries(self, context: HarnessContext) -> bool:
+        hooks_dir = self._hooks_dir(context)
+        if not hooks_dir.is_dir():
+            return False
+        managed_files = list(hooks_dir.glob("hol-guard-*.json"))
+        if len(managed_files) > 2:
+            return True
+        managed_config = self._managed_config_path(context)
+        if managed_config.is_file():
+            text = managed_config.read_text(encoding="utf-8")
+            return text.count(_GUARD_MANAGED_BEGIN) > 1
+        return False
+
+    @staticmethod
+    def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+        guard_args = [
+            "guard",
+            "hook",
+            "--guard-home",
+            str(context.guard_home),
+            "--harness",
+            "grok",
+        ]
+        if context.home_dir.resolve() != Path.home().resolve():
+            guard_args.extend(["--home", str(context.home_dir)])
+        if context.workspace_dir is not None:
+            guard_args.extend(["--workspace", str(context.workspace_dir)])
+        package_root = Path(__file__).resolve().parents[3]
+        code = (
+            "import sys;"
+            f"sys.path.insert(0, {str(package_root)!r});"
+            "from codex_plugin_scanner.cli import main;"
+            f"raise SystemExit(main({guard_args!r}))"
+        )
+        return (sys.executable, "-c", code)
+
+    @classmethod
+    def _build_pretool_hook_json(cls, hook_command: str) -> dict[str, object]:
+        entries: list[dict[str, object]] = []
+        for matcher in _PRETOOL_MATCHERS:
+            entries.append(
+                {
+                    "matcher": matcher,
+                    "hooks": [
+                        {
+                            "type": "command",
+                            "command": hook_command,
+                            "timeout": 30,
+                        }
+                    ],
+                }
+            )
+        return {"hooks": {"PreToolUse": entries, "UserPromptSubmit": [{"hooks": [{"type": "command", "command": hook_command, "timeout": 30}]}]}}
+
+    @classmethod
+    def _build_managed_config_block(cls) -> str:
+        lines = [
+            _GUARD_MANAGED_BEGIN,
+            "# Permission rules below are managed by HOL Guard. Do not edit manually.",
+            "[permission]",
+            "deny = [",
+            '  "Bash(hol-guard apps disconnect grok*)",',
+            '  "Bash(rm -rf ~/.grok/hooks/hol-guard*)",',
+            '  "Read(~/.grok/auth/**)",',
+            '  "Read(~/.env)",',
+            '  "Read(**/.env)",',
+            '  "Read(**/.npmrc)",',
+            '  "Read(~/.ssh/**)",',
+            "]",
+            _GUARD_MANAGED_END,
+        ]
+        return "\n".join(lines)
+
+    def install(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = install_guard_shim(
+            self.harness,
+            context,
+            launcher_name=self.launcher_name,
+            display_name="grok",
+        )
+        grok_root = self._grok_root(context)
+        managed_config_path = self._managed_config_path(context)
+        hooks_dir = self._hooks_dir(context)
+        _ensure_path_within_root(context.home_dir, managed_config_path, label="Grok")
+        grok_root.mkdir(parents=True, exist_ok=True)
+        hooks_dir.mkdir(parents=True, exist_ok=True)
+        state_dir = self._managed_state_dir(context)
+        state_dir.mkdir(parents=True, exist_ok=True)
+
+        if managed_config_path.is_file() and not self._backup_path(context, "managed_config.toml").exists():
+            shutil.copy2(managed_config_path, self._backup_path(context, "managed_config.toml"))
+
+        hook_command = _shell_command(self._hook_command_parts(context))
+        pretool_path = hooks_dir / _GUARD_HOOK_PRETOOL_FILE
+        prompt_path = hooks_dir / _GUARD_HOOK_PROMPT_FILE
+        for hook_path in (pretool_path, prompt_path):
+            if hook_path.is_file() and not self._backup_path(context, hook_path.name).exists():
+                shutil.copy2(hook_path, self._backup_path(context, hook_path.name))
+
+        pretool_payload = self._build_pretool_hook_json(hook_command)
+        pretool_path.write_text(json.dumps(pretool_payload, indent=2) + "\n", encoding="utf-8")
+        prompt_payload = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": hook_command,
+                                "timeout": 30,
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+        prompt_path.write_text(json.dumps(prompt_payload, indent=2) + "\n", encoding="utf-8")
+
+        existing_text = managed_config_path.read_text(encoding="utf-8") if managed_config_path.is_file() else ""
+        cleaned_text = _remove_managed_block(existing_text)
+        managed_block = self._build_managed_config_block()
+        managed_config_path.write_text(f"{cleaned_text.rstrip()}\n\n{managed_block}\n".lstrip(), encoding="utf-8")
+
+        self._state_path(context).write_text(
+            json.dumps(
+                {
+                    "managed_config_path": str(managed_config_path),
+                    "pretool_hook_path": str(pretool_path),
+                    "prompt_hook_path": str(prompt_path),
+                },
+                indent=2,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+
+        return {
+            "harness": self.harness,
+            "active": True,
+            "config_path": str(managed_config_path),
+            **shim_manifest,
+            "notes": [
+                "Guard hooks installed in ~/.grok/hooks/hol-guard-*.json",
+                "Guard permission rules installed in ~/.grok/managed_config.toml",
+                *[str(note) for note in shim_manifest.get("notes", [])],
+            ],
+        }
+
+    def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = remove_guard_shim(
+            self.harness,
+            context,
+            launcher_name=self.launcher_name,
+            display_name="grok",
+        )
+        managed_config_path = self._managed_config_path(context)
+        hooks_dir = self._hooks_dir(context)
+        if managed_config_path.is_file():
+            _ensure_path_within_root(context.home_dir, managed_config_path, label="Grok")
+            existing_text = managed_config_path.read_text(encoding="utf-8")
+            managed_config_path.write_text(_remove_managed_block(existing_text).rstrip() + "\n", encoding="utf-8")
+
+        for hook_name in (_GUARD_HOOK_PRETOOL_FILE, _GUARD_HOOK_PROMPT_FILE):
+            hook_path = hooks_dir / hook_name
+            backup_path = self._backup_path(context, hook_name)
+            if backup_path.is_file():
+                shutil.copy2(backup_path, hook_path)
+                backup_path.unlink(missing_ok=True)
+            elif hook_path.is_file():
+                hook_path.unlink()
+
+        state_path = self._state_path(context)
+        if state_path.is_file():
+            state_path.unlink()
+
+        return {
+            "harness": self.harness,
+            "active": False,
+            "config_path": str(managed_config_path),
+            **shim_manifest,
+            "notes": [
+                "Guard-managed Grok hooks and permission rules removed.",
+                "User ~/.grok/config.toml, auth, skills, plugins, and sessions were preserved.",
+                *[str(note) for note in shim_manifest.get("notes", [])],
+            ],
+        }
+
+
+def _remove_managed_block(text: str) -> str:
+    pattern = re.compile(
+        rf"^\s*{re.escape(_GUARD_MANAGED_BEGIN)}.*?{re.escape(_GUARD_MANAGED_END)}\s*\n?",
+        re.MULTILINE | re.DOTALL,
+    )
+    cleaned = pattern.sub("", text)
+    cleaned = re.sub(rf"^\s*#.*{re.escape(_GUARD_MANAGED_MARKER)}.*$\n?", "", cleaned, flags=re.MULTILINE)
+    return cleaned

--- a/src/codex_plugin_scanner/guard/adapters/grok_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_config.py
@@ -1,0 +1,232 @@
+"""Grok Build CLI config, hook JSON, and detection helpers for HOL Guard."""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+
+from ..models import GuardArtifact
+from .base import _json_payload
+
+GROK_DIR = ".grok"
+GROK_CONFIG_FILE = "config.toml"
+GROK_MANAGED_CONFIG_FILE = "managed_config.toml"
+GROK_REQUIREMENTS_FILE = "requirements.toml"
+GROK_HOOKS_DIR = "hooks"
+GUARD_MANAGED_BEGIN = "# BEGIN HOL GUARD MANAGED GROK"
+GUARD_MANAGED_END = "# END HOL GUARD MANAGED GROK"
+GUARD_MANAGED_MARKER = "HOL GUARD MANAGED GROK"
+GUARD_HOOK_PRETOOL_FILE = "hol-guard-pretooluse.json"
+GUARD_HOOK_PROMPT_FILE = "hol-guard-prompt.json"
+PRETOOL_MATCHERS = (
+    "Bash",
+    "Read",
+    "Edit",
+    "Grep",
+    "MCPTool",
+    "WebFetch",
+    "write",
+    "search_replace",
+)
+SYSTEM_MANAGED_CONFIG = Path("/etc/grok/managed_config.toml")
+SYSTEM_REQUIREMENTS = Path("/etc/grok/requirements.toml")
+DEGRADED_MODE_MARKERS = (
+    "always-approve",
+    "bypasspermissions",
+    "bypass_permissions",
+    'defaultmode = "bypasspermissions"',
+    'defaultMode": "bypassPermissions"',
+    'sandbox = "off"',
+    'sandbox="off"',
+)
+
+
+def build_pretool_hook_json(hook_command: str) -> dict[str, object]:
+    entries: list[dict[str, object]] = []
+    for matcher in PRETOOL_MATCHERS:
+        entries.append(
+            {
+                "matcher": matcher,
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": hook_command,
+                        "timeout": 30,
+                    }
+                ],
+            }
+        )
+    return {"hooks": {"PreToolUse": entries}}
+
+
+def build_managed_config_block() -> str:
+    home = "~"
+    lines = [
+        GUARD_MANAGED_BEGIN,
+        "# Permission rules below are managed by HOL Guard. Do not edit manually.",
+        "[permission]",
+        "deny = [",
+        '  "Bash(hol-guard apps disconnect grok*)",',
+        f'  "Bash(rm -rf {home}/.grok/hooks/hol-guard*)",',
+        f'  "Read({home}/.grok/auth/**)",',
+        f'  "Read({home}/.env)",',
+        '  "Read(**/.env)",',
+        '  "Read(**/.npmrc)",',
+        f'  "Read({home}/.ssh/**)",',
+        "]",
+        GUARD_MANAGED_END,
+    ]
+    return "\n".join(lines)
+
+
+def remove_managed_block(text: str) -> str:
+    pattern = re.compile(
+        rf"^\s*{re.escape(GUARD_MANAGED_BEGIN)}.*?{re.escape(GUARD_MANAGED_END)}\s*\n?",
+        re.MULTILINE | re.DOTALL,
+    )
+    cleaned = pattern.sub("", text)
+    cleaned = re.sub(rf"^\s*#.*{re.escape(GUARD_MANAGED_MARKER)}.*$\n?", "", cleaned, flags=re.MULTILINE)
+    return cleaned
+
+
+def append_hooks_dir_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    found_paths: list[str],
+    hooks_dir: Path,
+    scope: str,
+) -> None:
+    if not hooks_dir.is_dir():
+        return
+    for hook_file in sorted(hooks_dir.glob("*.json")):
+        payload = _json_payload(hook_file)
+        if not payload:
+            continue
+        append_found_path(found_paths, hook_file)
+        hooks = payload.get("hooks")
+        if not isinstance(hooks, dict):
+            continue
+        for event_name, entries in hooks.items():
+            if not isinstance(event_name, str) or not isinstance(entries, list):
+                continue
+            for index, entry in enumerate(entries):
+                if not isinstance(entry, dict):
+                    continue
+                nested = entry.get("hooks")
+                matcher = entry.get("matcher")
+                if isinstance(nested, list):
+                    for nested_index, hook_entry in enumerate(nested):
+                        if not isinstance(hook_entry, dict):
+                            continue
+                        command = hook_entry.get("command")
+                        if not isinstance(command, str) or not command.strip():
+                            continue
+                        artifacts.append(
+                            GuardArtifact(
+                                artifact_id=f"{harness}:{scope}:hook:{event_name.lower()}:{index}:{nested_index}",
+                                name=f"{event_name}:{matcher}" if isinstance(matcher, str) else event_name,
+                                harness=harness,
+                                artifact_type="hook",
+                                source_scope=scope,
+                                config_path=str(hook_file),
+                                command=command,
+                                metadata={"event": event_name, "matcher": matcher},
+                            )
+                        )
+
+
+def append_permission_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    payload: dict[str, object],
+    config_path: Path,
+    scope: str,
+) -> None:
+    permission = payload.get("permission")
+    if not isinstance(permission, dict):
+        return
+    for key in ("allow", "deny", "ask", "rules"):
+        value = permission.get(key)
+        if isinstance(value, list) and value:
+            artifacts.append(
+                GuardArtifact(
+                    artifact_id=f"{harness}:{scope}:permission:{key}",
+                    name=f"permission:{key}",
+                    harness=harness,
+                    artifact_type="policy",
+                    source_scope=scope,
+                    config_path=str(config_path),
+                    metadata={"entries": len(value)},
+                )
+            )
+
+
+def append_mcp_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    payload: dict[str, object],
+    config_path: Path,
+    scope: str,
+) -> None:
+    servers: dict[str, object] = {}
+    nested = payload.get("mcp_servers")
+    if isinstance(nested, dict):
+        servers.update(nested)
+    for key, value in payload.items():
+        if not isinstance(key, str) or not key.startswith("mcp_servers."):
+            continue
+        if isinstance(value, dict):
+            servers[key.split(".", 1)[1]] = value
+    for server_name, server_config in servers.items():
+        if not isinstance(server_name, str) or not isinstance(server_config, dict):
+            continue
+        command = server_config.get("command")
+        url = server_config.get("url")
+        if not isinstance(command, str) and not isinstance(url, str):
+            continue
+        raw_args = server_config.get("args")
+        args = tuple(str(item) for item in raw_args) if isinstance(raw_args, list) else ()
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=f"{harness}:{scope}:mcp:{server_name}",
+                name=server_name,
+                harness=harness,
+                artifact_type="mcp_server",
+                source_scope=scope,
+                config_path=str(config_path),
+                command=command if isinstance(command, str) else None,
+                args=args,
+                url=url if isinstance(url, str) else None,
+                transport="http" if isinstance(url, str) else "stdio",
+            )
+        )
+
+
+def degraded_mode_warnings(config_path: Path, payload: dict[str, object]) -> list[str]:
+    warnings: list[str] = []
+    serialized = json.dumps(payload, sort_keys=True).lower()
+    raw_text = config_path.read_text(encoding="utf-8").lower() if config_path.is_file() else ""
+    for marker in DEGRADED_MODE_MARKERS:
+        marker_lower = marker.lower()
+        if marker_lower in serialized or marker_lower in raw_text:
+            warnings.append(
+                f"Degraded Grok protection signal in {config_path.name}: {marker}. "
+                "Guard hooks still run, but Grok may auto-approve some actions."
+            )
+    sandbox = payload.get("sandbox")
+    if isinstance(sandbox, str) and sandbox.strip().lower() == "off":
+        warnings.append(
+            f"Degraded Grok protection signal in {config_path.name}: sandbox off. "
+            "Guard hooks still run, but Grok may auto-approve some actions."
+        )
+    return warnings
+
+
+def append_found_path(found_paths: list[str], path: Path) -> None:
+    candidate = str(path)
+    if candidate not in found_paths:
+        found_paths.append(candidate)

--- a/src/codex_plugin_scanner/guard/adapters/grok_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_config.py
@@ -26,6 +26,11 @@ PRETOOL_MATCHERS = (
     "Grep",
     "MCPTool",
     "WebFetch",
+    "run_terminal_command",
+    "read_file",
+    "grep",
+    "web_fetch",
+    "web_search",
     "write",
     "search_replace",
 )

--- a/src/codex_plugin_scanner/guard/adapters/grok_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_hooks.py
@@ -1,0 +1,111 @@
+"""Grok Build CLI hook payload and response helpers for HOL Guard."""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from typing import TextIO
+
+_GROK_TOOL_ALIASES: dict[str, str] = {
+    "run_terminal_command": "Bash",
+    "read_file": "Read",
+    "search_replace": "Edit",
+    "write": "Edit",
+    "grep": "Grep",
+    "web_fetch": "WebFetch",
+    "web_search": "WebFetch",
+}
+
+
+def _raw_hook_event_name(payload: Mapping[str, object]) -> str:
+    for key in ("hook_event_name", "hookEventName"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _canonical_grok_event_name(raw_event: str) -> str:
+    normalized = raw_event.replace("_", "").replace("-", "").lower()
+    mapping = {
+        "pretooluse": "PreToolUse",
+        "userpromptsubmit": "UserPromptSubmit",
+        "posttooluse": "PostToolUse",
+        "sessionstart": "SessionStart",
+        "stop": "Stop",
+    }
+    return mapping.get(normalized, raw_event or "PreToolUse")
+
+
+def _canonical_grok_tool_name(raw_tool: object | None) -> str | None:
+    if not isinstance(raw_tool, str) or not raw_tool.strip():
+        return None
+    stripped = raw_tool.strip()
+    lowered = stripped.lower()
+    return _GROK_TOOL_ALIASES.get(lowered, stripped)
+
+
+def prepare_grok_hook_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    """Map Grok hook stdin JSON into Guard hook normalization shape."""
+
+    normalized = dict(payload)
+    raw_event = _raw_hook_event_name(normalized)
+    if raw_event:
+        normalized["hook_event_name"] = _canonical_grok_event_name(raw_event)
+    tool_name = normalized.get("tool_name")
+    if tool_name is None:
+        tool_name = normalized.get("toolName")
+    canonical_tool = _canonical_grok_tool_name(tool_name)
+    if canonical_tool is not None:
+        normalized["tool_name"] = canonical_tool
+    tool_input = normalized.get("tool_input")
+    if tool_input is None:
+        tool_input = normalized.get("toolInput")
+    if tool_input is not None:
+        normalized["tool_input"] = tool_input
+    session_id = normalized.get("session_id")
+    if session_id is None and isinstance(normalized.get("sessionId"), str):
+        normalized["session_id"] = normalized["sessionId"]
+    workspace_root = normalized.get("workspace_root")
+    if workspace_root is None and isinstance(normalized.get("workspaceRoot"), str):
+        normalized["workspace_root"] = normalized["workspaceRoot"]
+    if workspace_root is None and isinstance(normalized.get("cwd"), str):
+        normalized["workspace_root"] = normalized["cwd"]
+    prompt = normalized.get("prompt")
+    if prompt is None and isinstance(normalized.get("userPrompt"), str):
+        normalized["prompt"] = normalized["userPrompt"]
+    return normalized
+
+
+def grok_hook_response_from_guard(*, policy_action: str, reason: str) -> dict[str, object]:
+    """Translate Guard policy action into Grok PreToolUse stdout JSON."""
+
+    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+        cleaned_reason = reason.strip() if isinstance(reason, str) else "Blocked by HOL Guard."
+        return {"decision": "deny", "reason": cleaned_reason or "Blocked by HOL Guard."}
+    return {"decision": "allow"}
+
+
+def emit_grok_hook_response(
+    *,
+    policy_action: str,
+    reason: str,
+    output_stream: TextIO | None = None,
+) -> None:
+    payload = grok_hook_response_from_guard(policy_action=policy_action, reason=reason)
+    stream = output_stream if output_stream is not None else sys.stdout
+    stream.write(json.dumps(payload, separators=(",", ":")) + "\n")
+    stream.flush()
+
+
+def grok_hook_should_block(*, policy_action: str) -> bool:
+    return policy_action in {"block", "sandbox-required", "require-reapproval"}
+
+
+__all__ = [
+    "emit_grok_hook_response",
+    "grok_hook_response_from_guard",
+    "grok_hook_should_block",
+    "prepare_grok_hook_payload",
+]

--- a/src/codex_plugin_scanner/guard/adapters/grok_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_hooks.py
@@ -82,9 +82,25 @@ def grok_hook_response_from_guard(*, policy_action: str, reason: str) -> dict[st
     """Translate Guard policy action into Grok PreToolUse stdout JSON."""
 
     if policy_action in {"block", "sandbox-required", "require-reapproval"}:
-        cleaned_reason = reason.strip() if isinstance(reason, str) else "Blocked by HOL Guard."
-        return {"decision": "deny", "reason": cleaned_reason or "Blocked by HOL Guard."}
+        cleaned_reason = _dedupe_grok_block_reason(reason.strip() if isinstance(reason, str) else "")
+        return {
+            "decision": "deny",
+            "reason": cleaned_reason or "Blocked by HOL Guard.",
+        }
     return {"decision": "allow"}
+
+
+def _dedupe_grok_block_reason(reason: str) -> str:
+    if not reason:
+        return reason
+    marker = "Open HOL Guard to approve or keep this blocked:"
+    first = reason.find(marker)
+    if first == -1:
+        return reason
+    second = reason.find(marker, first + len(marker))
+    if second == -1:
+        return reason
+    return reason[:second].rstrip()
 
 
 def emit_grok_hook_response(

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -47,6 +47,10 @@ def _run_guard_hook_command(
         from ..adapters.cursor_hooks import prepare_cursor_hook_payload
 
         payload = _normalize_hook_payload(prepare_cursor_hook_payload(payload), harness=args.harness)
+    if _canonical_harness_name(args.harness) == "grok":
+        from ..adapters.grok_hooks import prepare_grok_hook_payload
+
+        payload = _normalize_hook_payload(prepare_grok_hook_payload(payload), harness=args.harness)
     managed_install = _managed_install_for(store, args.harness)
     workspace_was_explicit = workspace is not None
     runtime_workspace = workspace

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -149,6 +149,14 @@ def _run_hook_generic_payload(
                 reason=block_reason,
                 output_stream=output_stream,
             )
+        elif _canonical_harness_name(args.harness) == "grok":
+            from ..adapters.grok_hooks import emit_grok_hook_response
+
+            emit_grok_hook_response(
+                policy_action=policy_action,
+                reason=block_reason,
+                output_stream=output_stream,
+            )
         # Kimi surfaces stderr to the user as the blocking explanation.
         _emit_native_hook_block_stderr(block_reason)
         return 2
@@ -178,6 +186,15 @@ def _run_hook_generic_payload(
         event_name=hook_event_name,
         output_stream=output_stream,
     ):
+        if _canonical_harness_name(args.harness) == "grok":
+            from ..adapters.grok_hooks import emit_grok_hook_response
+
+            emit_grok_hook_response(
+                policy_action=policy_action,
+                reason=reason,
+                output_stream=output_stream,
+            )
+            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
         system_message = None
         canonical_harness = _canonical_harness_name(args.harness)
         if (

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
@@ -87,6 +87,14 @@ def _finalize_runtime_artifact_hook(
                 reason=native_block_reason,
                 output_stream=output_stream,
             )
+        elif _canonical_harness_name(args.harness) == "grok":
+            from ..adapters.grok_hooks import emit_grok_hook_response
+
+            emit_grok_hook_response(
+                policy_action=policy_action,
+                reason=native_block_reason,
+                output_stream=output_stream,
+            )
         # Kimi surfaces stderr to the user as the blocking explanation.
         _emit_native_hook_block_stderr(native_block_reason)
         _record_harness_usage_for_hook(
@@ -136,6 +144,21 @@ def _finalize_runtime_artifact_hook(
                 policy_action=policy_action,
                 native_reason=runtime_reason,
             )
+        if canonical_harness == "grok":
+            from ..adapters.grok_hooks import emit_grok_hook_response
+
+            emit_grok_hook_response(
+                policy_action=policy_action,
+                reason=runtime_reason,
+                output_stream=output_stream,
+            )
+            _record_harness_usage_for_hook(
+                store=store,
+                action_envelope=action_envelope,
+                payload=payload,
+                policy_action=policy_action,
+            )
+            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
         _emit_native_hook_response(
             harness=args.harness,
             policy_action=policy_action,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
@@ -117,7 +117,7 @@ def _native_hook_permission_decision(policy_action: str, *, harness: str) -> str
     if policy_action in {"block", "sandbox-required"}:
         return "deny"
     if policy_action == "require-reapproval":
-        if canonical in {"codex", "kimi"}:
+        if canonical in {"codex", "kimi", "grok"}:
             return "deny"
         return "ask"
     if canonical == "codex":
@@ -370,7 +370,7 @@ def _load_hook_payload(
     return _normalize_hook_payload(payload, harness=harness) if isinstance(payload, dict) else {}
 
 _ACTION_ENVELOPE_HARNESSES = frozenset(
-    {"codex", "claude-code", "opencode", "copilot", "gemini", "hermes", "openclaw", "cursor"}
+    {"codex", "claude-code", "opencode", "copilot", "gemini", "hermes", "openclaw", "cursor", "grok"}
 )
 
 def _hook_action_envelope(

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -248,7 +248,7 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
 
 def _should_emit_native_hook_response(args: argparse.Namespace) -> bool:
     return (
-        _canonical_harness_name(args.harness) in {"claude-code", "codex", "kimi"}
+        _canonical_harness_name(args.harness) in {"claude-code", "codex", "kimi", "grok"}
         and not getattr(args, "json", False)
     )
 
@@ -288,7 +288,7 @@ def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name:
     # Codex v0.133 logs non-zero PreToolUse hooks as failed but still executes
     # the tool. Blocking must be communicated through the JSON hook response.
     canonical = _canonical_harness_name(args.harness)
-    if canonical == "kimi" and event_name in {"PreToolUse", "UserPromptSubmit"}:
+    if canonical in {"kimi", "grok"} and event_name in {"PreToolUse", "UserPromptSubmit"}:
         return policy_action in {"block", "sandbox-required", "require-reapproval"}
     return False
 

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -78,6 +78,7 @@ def _native_approval_center_context(response_payload: dict[str, object], *, harn
         "guard-cli": "package install",
         "opencode": "OpenCode",
         "kimi": "Kimi",
+        "grok": "Grok",
     }.get(canonical_harness, "the harness")
     if canonical_harness in {
         "npm",

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -206,6 +206,8 @@ def build_harness_verification(
     }
     if adapter.harness == "opencode":
         verification.update(_opencode_protection_checks(context, store))
+    if adapter.harness == "grok":
+        verification.update(_grok_protection_checks(context))
     payload: dict[str, object] = {
         "harness": adapter.harness,
         "safe": True,
@@ -309,6 +311,38 @@ def _opencode_protection_checks(context: HarnessContext, store: GuardStore | Non
         "mcp_proxy_configured": mcp_proxy_configured,
         "launch_shim_installed": shim_path.is_file(),
         "managed_install_active": bool(managed and managed.get("active")),
+        "warnings": warnings,
+        "ready": not warnings,
+    }
+
+
+def _grok_protection_checks(context: HarnessContext) -> dict[str, object]:
+    from ..adapters.grok import GrokHarnessAdapter
+
+    adapter = GrokHarnessAdapter()
+    hooks_dir = adapter._hooks_dir(context)
+    managed_config = adapter._managed_config_path(context)
+    pretool_hook = hooks_dir / "hol-guard-pretooluse.json"
+    prompt_hook = hooks_dir / "hol-guard-prompt.json"
+    warnings: list[str] = []
+    if not pretool_hook.is_file() or not prompt_hook.is_file():
+        warnings.append("Grok Guard hook files are missing from ~/.grok/hooks/. Re-run `hol-guard apps connect grok`.")
+    if not managed_config.is_file() or "BEGIN HOL GUARD MANAGED GROK" not in managed_config.read_text(encoding="utf-8"):
+        warnings.append(
+            "Grok managed permission rules are missing from ~/.grok/managed_config.toml. "
+            "Re-run `hol-guard apps connect grok`."
+        )
+    shim_path = context.guard_home / "bin" / "guard-grok"
+    if not shim_path.is_file():
+        warnings.append(
+            f"guard-grok launcher shim is missing. Add {context.guard_home / 'bin'} to PATH or launch with "
+            "`hol-guard run grok` for pre-launch checks."
+        )
+    return {
+        "pretool_hook_installed": pretool_hook.is_file(),
+        "prompt_hook_installed": prompt_hook.is_file(),
+        "managed_config_installed": managed_config.is_file(),
+        "launch_shim_installed": shim_path.is_file(),
         "warnings": warnings,
         "ready": not warnings,
     }

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -64,6 +64,7 @@ AgentInventoryType = Literal[
     "gemini",
     "opencode",
     "kimi",
+    "grok",
 ]
 _AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
     "hermes",
@@ -74,6 +75,7 @@ _AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
     "gemini",
     "opencode",
     "kimi",
+    "grok",
 )
 
 _SENSITIVE_KEY_RE = re.compile(

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -395,6 +395,25 @@ def normalize_cursor_hook_payload(
     )
 
 
+def normalize_grok_hook_payload(
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize a Grok Build CLI hook payload into a typed action envelope."""
+
+    from ..adapters.grok_hooks import prepare_grok_hook_payload
+
+    return _normalize_action_payload(
+        prepare_grok_hook_payload(payload),
+        harness="grok",
+        default_event_name=None,
+        workspace=workspace,
+        home_dir=home_dir,
+    )
+
+
 def normalize_harness_payload(
     harness: str,
     event_name: str,
@@ -416,6 +435,7 @@ def normalize_harness_payload(
         "hermes": normalize_hermes_payload,
         "openclaw": normalize_openclaw_payload,
         "cursor": normalize_cursor_hook_payload,
+        "grok": normalize_grok_hook_payload,
     }
     normalizer = normalizers.get(normalized_harness)
     if normalizer is None:

--- a/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
+++ b/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
@@ -1,644 +1,645 @@
 {
-  "version": "guard-product-model.v1",
-  "personas": [
-    "vibe_coder",
-    "solo",
-    "team_manager",
-    "security_lead",
-    "agent_operator"
-  ],
-  "activation_stages": [
-    "not_installed",
-    "installed_local",
-    "cloud_connected",
-    "team_started",
-    "agents_started",
-    "paid_value_ready"
-  ],
-  "guard_actions": [
-    "allow",
-    "warn",
-    "review",
-    "block",
-    "sandbox-required",
-    "require-reapproval"
-  ],
-  "decision_scopes": [
-    "global",
-    "harness",
-    "workspace",
-    "artifact",
-    "publisher"
-  ],
-  "canonical_harnesses": [
-    "codex",
-    "claude-code",
-    "opencode",
-    "copilot",
-    "cursor",
-    "gemini",
-    "hermes",
-    "openclaw"
-  ],
-  "supported_harnesses": [
-    "codex",
-    "claude-code",
-    "opencode",
-    "copilot",
-    "cursor",
-    "gemini",
-    "hermes",
-    "openclaw",
-    "antigravity",
-    "kimi"
-  ],
-  "action_categories": [
-    "secrets",
-    "network",
-    "destructive",
-    "mcp",
-    "skill",
-    "supply_chain",
-    "config",
-    "unknown"
-  ],
-  "severity_labels": {
-    "info": {
-      "label": "Info",
-      "plain": "For awareness"
-    },
-    "low": {
-      "label": "Low",
-      "plain": "Safe to review later"
-    },
-    "medium": {
-      "label": "Medium",
-      "plain": "Worth a look"
-    },
-    "high": {
-      "label": "High",
-      "plain": "Act soon"
-    },
-    "critical": {
-      "label": "Critical",
-      "plain": "Stop and review now"
-    }
-  },
-  "manager_fields": [
-    "team_members",
-    "roles",
-    "coverage",
-    "incidents",
-    "notifications",
-    "agent_risk"
-  ],
-  "vibe_coder_fields": [
-    "headline",
-    "safe_explanation",
-    "primary_action",
-    "learn_more"
-  ],
-  "paid_value_fields": [
-    "shared_memory",
-    "alerts",
-    "fleet",
-    "agents",
-    "incident_response",
-    "export"
-  ],
-  "redaction_forbidden_fields": [
-    "token",
-    "api_key",
-    "secret",
-    "password",
-    "credential",
-    "private_key",
-    "authorization",
-    "cookie",
-    "session"
-  ],
-  "stable_id_prefixes": {
-    "action": "sha256_hex",
-    "request": "uuid_hex",
-    "receipt": "guard-receipt",
-    "incident": "inc",
-    "agent_snapshot": "snap"
-  },
-  "settings_groups": [
-    "preset",
-    "custom",
-    "per_harness",
-    "per_category",
-    "per_secret_source"
-  ],
-  "external_intel_sources": [
-    "cve",
-    "advisory",
-    "cisco",
-    "openssf",
-    "slsa",
-    "trust_score"
-  ],
-  "runtime_models": {
-    "hermes": {
-      "runtime": "hermes",
-      "display_name": "Hermes",
-      "inventory": true,
-      "docker_proof": true,
-      "drift": true,
-      "messenger_channels": [
-        "telegram",
-        "terminal",
-        "api"
-      ],
-      "token_scopes": [
-        "runtime:sync",
-        "runtime:read",
-        "capabilities:read",
-        "messenger:bind"
-      ]
-    },
-    "openclaw": {
-      "runtime": "openclaw",
-      "display_name": "OpenClaw",
-      "inventory": true,
-      "docker_proof": true,
-      "drift": true,
-      "messenger_channels": [
-        "terminal",
-        "api"
-      ],
-      "token_scopes": [
-        "runtime:sync",
-        "runtime:read",
-        "capabilities:read",
-        "messenger:bind"
-      ]
-    }
-  },
-  "billing_plans": [
-    "free",
-    "pro",
-    "team",
-    "enterprise"
-  ],
-  "affiliate_fields": [
-    "affiliate",
-    "link",
-    "click",
-    "commission",
-    "payout",
-    "points",
-    "compliance",
-    "fraud"
-  ],
-  "seo_content_types": [
-    "warning",
-    "harness_page",
-    "cve_page",
-    "lab",
-    "shareable_report"
-  ],
-  "funnel_events": [
-    "ad_click",
-    "landing",
-    "signup",
-    "install",
-    "connect",
-    "first_block",
-    "upgrade"
-  ],
-  "event_privacy_tiers": [
-    "public",
-    "internal",
-    "redacted"
-  ],
-  "copy_lint_banned_terms": [
-    "artifact",
-    "daemon",
-    "receipt",
-    "attestation",
-    "provenance",
-    "SBOM"
-  ],
-  "brand_token_keys": [
-    "product_name",
-    "logo_mark",
-    "primary_color",
-    "accent_color",
-    "surface_color"
-  ],
-  "local_routes": [
-    {
-      "route": "/",
-      "persona": [
+    "version": "guard-product-model.v1",
+    "personas": [
         "vibe_coder",
-        "solo"
-      ],
-      "auth_required": false,
-      "writes_state": false
-    },
-    {
-      "route": "/home",
-      "persona": [
-        "vibe_coder",
-        "solo"
-      ],
-      "auth_required": false,
-      "writes_state": false
-    },
-    {
-      "route": "/dashboard",
-      "persona": [
-        "vibe_coder",
-        "solo"
-      ],
-      "auth_required": false,
-      "writes_state": false
-    },
-    {
-      "route": "/inbox",
-      "persona": [
-        "vibe_coder",
-        "solo"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/requests",
-      "persona": [
-        "vibe_coder",
-        "solo"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/requests/{id}",
-      "persona": [
-        "vibe_coder",
-        "solo"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/approvals",
-      "persona": [
-        "vibe_coder",
-        "solo"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/approvals/{id}",
-      "persona": [
-        "vibe_coder",
-        "solo"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/protect",
-      "persona": [
         "solo",
-        "team_manager"
-      ],
-      "auth_required": true,
-      "writes_state": true
+        "team_manager",
+        "security_lead",
+        "agent_operator"
+    ],
+    "activation_stages": [
+        "not_installed",
+        "installed_local",
+        "cloud_connected",
+        "team_started",
+        "agents_started",
+        "paid_value_ready"
+    ],
+    "guard_actions": [
+        "allow",
+        "warn",
+        "review",
+        "block",
+        "sandbox-required",
+        "require-reapproval"
+    ],
+    "decision_scopes": [
+        "global",
+        "harness",
+        "workspace",
+        "artifact",
+        "publisher"
+    ],
+    "canonical_harnesses": [
+        "codex",
+        "claude-code",
+        "opencode",
+        "copilot",
+        "cursor",
+        "gemini",
+        "hermes",
+        "openclaw"
+    ],
+    "supported_harnesses": [
+        "codex",
+        "claude-code",
+        "opencode",
+        "copilot",
+        "cursor",
+        "gemini",
+        "hermes",
+        "openclaw",
+        "antigravity",
+        "kimi",
+        "grok"
+    ],
+    "action_categories": [
+        "secrets",
+        "network",
+        "destructive",
+        "mcp",
+        "skill",
+        "supply_chain",
+        "config",
+        "unknown"
+    ],
+    "severity_labels": {
+        "info": {
+            "label": "Info",
+            "plain": "For awareness"
+        },
+        "low": {
+            "label": "Low",
+            "plain": "Safe to review later"
+        },
+        "medium": {
+            "label": "Medium",
+            "plain": "Worth a look"
+        },
+        "high": {
+            "label": "High",
+            "plain": "Act soon"
+        },
+        "critical": {
+            "label": "Critical",
+            "plain": "Stop and review now"
+        }
     },
-    {
-      "route": "/apps/{slug}",
-      "persona": [
-        "solo",
-        "team_manager"
-      ],
-      "auth_required": true,
-      "writes_state": true
+    "manager_fields": [
+        "team_members",
+        "roles",
+        "coverage",
+        "incidents",
+        "notifications",
+        "agent_risk"
+    ],
+    "vibe_coder_fields": [
+        "headline",
+        "safe_explanation",
+        "primary_action",
+        "learn_more"
+    ],
+    "paid_value_fields": [
+        "shared_memory",
+        "alerts",
+        "fleet",
+        "agents",
+        "incident_response",
+        "export"
+    ],
+    "redaction_forbidden_fields": [
+        "token",
+        "api_key",
+        "secret",
+        "password",
+        "credential",
+        "private_key",
+        "authorization",
+        "cookie",
+        "session"
+    ],
+    "stable_id_prefixes": {
+        "action": "sha256_hex",
+        "request": "uuid_hex",
+        "receipt": "guard-receipt",
+        "incident": "inc",
+        "agent_snapshot": "snap"
     },
-    {
-      "route": "/evidence",
-      "persona": [
-        "solo",
-        "security_lead"
-      ],
-      "auth_required": true,
-      "writes_state": true
+    "settings_groups": [
+        "preset",
+        "custom",
+        "per_harness",
+        "per_category",
+        "per_secret_source"
+    ],
+    "external_intel_sources": [
+        "cve",
+        "advisory",
+        "cisco",
+        "openssf",
+        "slsa",
+        "trust_score"
+    ],
+    "runtime_models": {
+        "hermes": {
+            "runtime": "hermes",
+            "display_name": "Hermes",
+            "inventory": true,
+            "docker_proof": true,
+            "drift": true,
+            "messenger_channels": [
+                "telegram",
+                "terminal",
+                "api"
+            ],
+            "token_scopes": [
+                "runtime:sync",
+                "runtime:read",
+                "capabilities:read",
+                "messenger:bind"
+            ]
+        },
+        "openclaw": {
+            "runtime": "openclaw",
+            "display_name": "OpenClaw",
+            "inventory": true,
+            "docker_proof": true,
+            "drift": true,
+            "messenger_channels": [
+                "terminal",
+                "api"
+            ],
+            "token_scopes": [
+                "runtime:sync",
+                "runtime:read",
+                "capabilities:read",
+                "messenger:bind"
+            ]
+        }
     },
-    {
-      "route": "/supply-chain",
-      "persona": [
-        "solo",
-        "security_lead"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/audit",
-      "persona": [
-        "solo",
-        "security_lead"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/policy",
-      "persona": [
-        "solo",
-        "team_manager"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/feed-health",
-      "persona": [
-        "solo",
-        "team_manager"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "route": "/settings",
-      "persona": [
-        "solo"
-      ],
-      "auth_required": true,
-      "writes_state": true
-    }
-  ],
-  "local_apis": [
-    {
-      "path": "/v1/initialize",
-      "method": "POST",
-      "category": "config",
-      "auth_required": false,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/connect/state",
-      "method": "GET",
-      "category": "config",
-      "auth_required": false,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/connect/requests",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/connect/complete",
-      "method": "POST",
-      "category": "config",
-      "auth_required": false,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/connect/result",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/runtime",
-      "method": "GET",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/cloud/connect",
-      "method": "GET",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/cloud/connect",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/harnesses",
-      "method": "GET",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/harnesses/{harness}/install",
-      "method": "POST",
-      "category": "supply_chain",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/harnesses/{harness}/verify",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/harnesses/{harness}/repair",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/harnesses/{harness}/uninstall",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/inventory",
-      "method": "GET",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/requests",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/requests/{id}",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/requests/{id}/approve",
-      "method": "POST",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/requests/{id}/block",
-      "method": "POST",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/approvals/{id}/decision",
-      "method": "POST",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/approvals/{id}/decision",
-      "method": "POST",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/receipts",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/receipts/analytics",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/receipts/latest",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/receipts/{id}",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/policy",
-      "method": "GET",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/policy/decisions",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/policy/clear",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/requests/clear",
-      "method": "POST",
-      "category": "destructive",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/artifacts/{id}/diff",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/evidence",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/evidence",
-      "method": "DELETE",
-      "category": "destructive",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/evidence/export",
-      "method": "GET",
-      "category": "unknown",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/daemon/repair",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/settings",
-      "method": "GET",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/settings",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/settings/export",
-      "method": "GET",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": false
-    },
-    {
-      "path": "/v1/settings/import",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    },
-    {
-      "path": "/v1/settings/reset",
-      "method": "POST",
-      "category": "config",
-      "auth_required": true,
-      "writes_state": true
-    }
-  ]
+    "billing_plans": [
+        "free",
+        "pro",
+        "team",
+        "enterprise"
+    ],
+    "affiliate_fields": [
+        "affiliate",
+        "link",
+        "click",
+        "commission",
+        "payout",
+        "points",
+        "compliance",
+        "fraud"
+    ],
+    "seo_content_types": [
+        "warning",
+        "harness_page",
+        "cve_page",
+        "lab",
+        "shareable_report"
+    ],
+    "funnel_events": [
+        "ad_click",
+        "landing",
+        "signup",
+        "install",
+        "connect",
+        "first_block",
+        "upgrade"
+    ],
+    "event_privacy_tiers": [
+        "public",
+        "internal",
+        "redacted"
+    ],
+    "copy_lint_banned_terms": [
+        "artifact",
+        "daemon",
+        "receipt",
+        "attestation",
+        "provenance",
+        "SBOM"
+    ],
+    "brand_token_keys": [
+        "product_name",
+        "logo_mark",
+        "primary_color",
+        "accent_color",
+        "surface_color"
+    ],
+    "local_routes": [
+        {
+            "route": "/",
+            "persona": [
+                "vibe_coder",
+                "solo"
+            ],
+            "auth_required": false,
+            "writes_state": false
+        },
+        {
+            "route": "/home",
+            "persona": [
+                "vibe_coder",
+                "solo"
+            ],
+            "auth_required": false,
+            "writes_state": false
+        },
+        {
+            "route": "/dashboard",
+            "persona": [
+                "vibe_coder",
+                "solo"
+            ],
+            "auth_required": false,
+            "writes_state": false
+        },
+        {
+            "route": "/inbox",
+            "persona": [
+                "vibe_coder",
+                "solo"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/requests",
+            "persona": [
+                "vibe_coder",
+                "solo"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/requests/{id}",
+            "persona": [
+                "vibe_coder",
+                "solo"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/approvals",
+            "persona": [
+                "vibe_coder",
+                "solo"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/approvals/{id}",
+            "persona": [
+                "vibe_coder",
+                "solo"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/protect",
+            "persona": [
+                "solo",
+                "team_manager"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/apps/{slug}",
+            "persona": [
+                "solo",
+                "team_manager"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/evidence",
+            "persona": [
+                "solo",
+                "security_lead"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/supply-chain",
+            "persona": [
+                "solo",
+                "security_lead"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/audit",
+            "persona": [
+                "solo",
+                "security_lead"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/policy",
+            "persona": [
+                "solo",
+                "team_manager"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/feed-health",
+            "persona": [
+                "solo",
+                "team_manager"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "route": "/settings",
+            "persona": [
+                "solo"
+            ],
+            "auth_required": true,
+            "writes_state": true
+        }
+    ],
+    "local_apis": [
+        {
+            "path": "/v1/initialize",
+            "method": "POST",
+            "category": "config",
+            "auth_required": false,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/connect/state",
+            "method": "GET",
+            "category": "config",
+            "auth_required": false,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/connect/requests",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/connect/complete",
+            "method": "POST",
+            "category": "config",
+            "auth_required": false,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/connect/result",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/runtime",
+            "method": "GET",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/cloud/connect",
+            "method": "GET",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/cloud/connect",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/harnesses",
+            "method": "GET",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/harnesses/{harness}/install",
+            "method": "POST",
+            "category": "supply_chain",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/harnesses/{harness}/verify",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/harnesses/{harness}/repair",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/harnesses/{harness}/uninstall",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/inventory",
+            "method": "GET",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/requests",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/requests/{id}",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/requests/{id}/approve",
+            "method": "POST",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/requests/{id}/block",
+            "method": "POST",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/approvals/{id}/decision",
+            "method": "POST",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/approvals/{id}/decision",
+            "method": "POST",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/receipts",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/receipts/analytics",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/receipts/latest",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/receipts/{id}",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/policy",
+            "method": "GET",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/policy/decisions",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/policy/clear",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/requests/clear",
+            "method": "POST",
+            "category": "destructive",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/artifacts/{id}/diff",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/evidence",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/evidence",
+            "method": "DELETE",
+            "category": "destructive",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/evidence/export",
+            "method": "GET",
+            "category": "unknown",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/daemon/repair",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/settings",
+            "method": "GET",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/settings",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/settings/export",
+            "method": "GET",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": false
+        },
+        {
+            "path": "/v1/settings/import",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
+            "path": "/v1/settings/reset",
+            "method": "POST",
+            "category": "config",
+            "auth_required": true,
+            "writes_state": true
+        }
+    ]
 }

--- a/tests/fixtures/grok/pretooluse_bash.json
+++ b/tests/fixtures/grok/pretooluse_bash.json
@@ -1,0 +1,11 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-001",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "run_terminal_command",
+  "toolInput": {
+    "command": "npm install left-pad"
+  },
+  "timestamp": "2026-06-11T12:00:00Z"
+}

--- a/tests/fixtures/grok/pretooluse_edit.json
+++ b/tests/fixtures/grok/pretooluse_edit.json
@@ -1,0 +1,12 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-005",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "search_replace",
+  "toolInput": {
+    "path": "<workspace>/src/main.ts",
+    "old_string": "foo",
+    "new_string": "bar"
+  }
+}

--- a/tests/fixtures/grok/pretooluse_grep_safe.json
+++ b/tests/fixtures/grok/pretooluse_grep_safe.json
@@ -1,0 +1,12 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-003",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "grep",
+  "toolInput": {
+    "pattern": "export function",
+    "path": "<workspace>/src"
+  },
+  "timestamp": "2026-06-11T12:02:00Z"
+}

--- a/tests/fixtures/grok/pretooluse_mcp.json
+++ b/tests/fixtures/grok/pretooluse_mcp.json
@@ -1,0 +1,15 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-006",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "MCPTool",
+  "toolInput": {
+    "server": "filesystem",
+    "tool": "write_file",
+    "arguments": {
+      "path": "<workspace>/notes.txt",
+      "content": "hello"
+    }
+  }
+}

--- a/tests/fixtures/grok/pretooluse_read_secret.json
+++ b/tests/fixtures/grok/pretooluse_read_secret.json
@@ -1,0 +1,11 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-002",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "read_file",
+  "toolInput": {
+    "path": "<workspace>/.env"
+  },
+  "timestamp": "2026-06-11T12:01:00Z"
+}

--- a/tests/fixtures/grok/pretooluse_unknown_tool.json
+++ b/tests/fixtures/grok/pretooluse_unknown_tool.json
@@ -1,0 +1,10 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-008",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "custom_plugin_action",
+  "toolInput": {
+    "payload": "opaque"
+  }
+}

--- a/tests/fixtures/grok/pretooluse_webfetch.json
+++ b/tests/fixtures/grok/pretooluse_webfetch.json
@@ -1,0 +1,10 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-007",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "web_fetch",
+  "toolInput": {
+    "url": "https://example.com/docs"
+  }
+}

--- a/tests/fixtures/grok/user_prompt_submit.json
+++ b/tests/fixtures/grok/user_prompt_submit.json
@@ -1,0 +1,7 @@
+{
+  "hookEventName": "user_prompt_submit",
+  "sessionId": "session-redacted-004",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "prompt": "Summarize the README without reading secrets."
+}

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -115,6 +115,11 @@ class TestGrokInstallUninstall:
             "Grep",
             "MCPTool",
             "WebFetch",
+            "run_terminal_command",
+            "read_file",
+            "grep",
+            "web_fetch",
+            "web_search",
             "write",
             "search_replace",
         }

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -50,6 +50,11 @@ class TestGrokAdapterIdentity:
     def test_get_adapter_returns_grok_instance(self) -> None:
         assert isinstance(get_adapter("grok"), GrokHarnessAdapter)
 
+    def test_grok_is_registered_in_adapter_list(self) -> None:
+        from codex_plugin_scanner.guard.adapters import list_adapters
+
+        assert "grok" in {item.harness for item in list_adapters()}
+
 
 class TestGrokDetect:
     def test_detects_managed_config_and_hooks(self, tmp_path: Path) -> None:

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -102,12 +102,22 @@ class TestGrokInstallUninstall:
         assert pretool_hook.is_file()
         assert prompt_hook.is_file()
         pretool_payload = json.loads(pretool_hook.read_text(encoding="utf-8"))
+        assert "UserPromptSubmit" not in pretool_payload["hooks"]
         matchers = {
             entry["matcher"]
             for entry in pretool_payload["hooks"]["PreToolUse"]
             if isinstance(entry, dict) and isinstance(entry.get("matcher"), str)
         }
-        assert matchers == {"Bash", "Read", "Edit", "Grep", "MCPTool", "WebFetch"}
+        assert matchers == {
+            "Bash",
+            "Read",
+            "Edit",
+            "Grep",
+            "MCPTool",
+            "WebFetch",
+            "write",
+            "search_replace",
+        }
 
     def test_repeated_install_is_idempotent(self, tmp_path: Path, monkeypatch) -> None:
         ctx = _ctx(tmp_path)

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -362,3 +362,20 @@ class TestGrokInventoryAndResponses:
         payload = grok_hook_response_from_guard(policy_action="block", reason="Grok tried to read a credential file.")
         assert payload["decision"] == "deny"
         assert "{" not in str(payload["reason"])
+
+
+class TestGrokFixtureHygiene:
+    _FORBIDDEN_PATTERNS = (
+        "XAI_API_KEY",
+        "/" + "Users" + "/",
+        "/" + "home" + "/",
+        "sk-",
+        "g0_",
+    )
+
+    def test_grok_fixtures_do_not_contain_secrets_or_local_paths(self) -> None:
+        fixture_dir = Path(__file__).parent / "fixtures" / "grok"
+        for fixture_path in sorted(fixture_dir.glob("*.json")):
+            contents = fixture_path.read_text(encoding="utf-8")
+            for pattern in self._FORBIDDEN_PATTERNS:
+                assert pattern not in contents, f"{fixture_path.name} contains forbidden pattern {pattern!r}"

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -1,0 +1,224 @@
+"""Tests for the Grok Build CLI harness adapter."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+from contextlib import redirect_stderr
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters import get_adapter
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter, _remove_managed_block
+from codex_plugin_scanner.guard.adapters.grok_hooks import (
+    emit_grok_hook_response,
+    grok_hook_response_from_guard,
+    prepare_grok_hook_payload,
+)
+from codex_plugin_scanner.guard.runtime.actions import normalize_grok_hook_payload
+
+
+def _ctx(tmp_path: Path, *, workspace: bool = False) -> HarnessContext:
+    workspace_dir = tmp_path / "workspace" if workspace else None
+    if workspace_dir is not None:
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _fixture(name: str) -> dict[str, object]:
+    payload = json.loads((Path(__file__).parent / "fixtures" / "grok" / name).read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+class TestGrokAdapterIdentity:
+    def test_harness_identifier_is_grok(self) -> None:
+        assert GrokHarnessAdapter.harness == "grok"
+
+    def test_aliases_resolve(self) -> None:
+        for alias in ("grok-build", "grok-build-cli", "xai-grok"):
+            assert get_adapter(alias).harness == "grok"
+
+    def test_get_adapter_returns_grok_instance(self) -> None:
+        assert isinstance(get_adapter("grok"), GrokHarnessAdapter)
+
+
+class TestGrokDetect:
+    def test_detects_managed_config_and_hooks(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        grok_root = ctx.home_dir / ".grok"
+        hooks_dir = grok_root / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (grok_root / "managed_config.toml").write_text("[permission]\nallow = [\"Read\"]\n", encoding="utf-8")
+        (hooks_dir / "custom.json").write_text(
+            json.dumps(
+                {
+                    "hooks": {
+                        "PreToolUse": [
+                            {
+                                "matcher": "Bash",
+                                "hooks": [{"type": "command", "command": "echo ok"}],
+                            }
+                        ]
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+        result = GrokHarnessAdapter().detect(ctx)
+        assert result.harness == "grok"
+        assert any(".grok/managed_config.toml" in path for path in result.config_paths)
+        hook_artifacts = [artifact for artifact in result.artifacts if artifact.artifact_type == "hook"]
+        assert hook_artifacts
+
+
+class TestGrokInstallUninstall:
+    def test_install_writes_managed_hooks_and_config(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.grok.install_guard_shim",
+            lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-grok"), "notes": []},
+        )
+        manifest = GrokHarnessAdapter().install(ctx)
+        managed_config = ctx.home_dir / ".grok" / "managed_config.toml"
+        pretool_hook = ctx.home_dir / ".grok" / "hooks" / "hol-guard-pretooluse.json"
+        prompt_hook = ctx.home_dir / ".grok" / "hooks" / "hol-guard-prompt.json"
+        assert manifest["active"] is True
+        assert managed_config.is_file()
+        assert "BEGIN HOL GUARD MANAGED GROK" in managed_config.read_text(encoding="utf-8")
+        assert pretool_hook.is_file()
+        assert prompt_hook.is_file()
+        pretool_payload = json.loads(pretool_hook.read_text(encoding="utf-8"))
+        matchers = {
+            entry["matcher"]
+            for entry in pretool_payload["hooks"]["PreToolUse"]
+            if isinstance(entry, dict) and isinstance(entry.get("matcher"), str)
+        }
+        assert matchers == {"Bash", "Read", "Edit", "Grep", "MCPTool", "WebFetch"}
+
+    def test_repeated_install_is_idempotent(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.grok.install_guard_shim",
+            lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-grok"), "notes": []},
+        )
+        adapter = GrokHarnessAdapter()
+        adapter.install(ctx)
+        first_config = (ctx.home_dir / ".grok" / "managed_config.toml").read_text(encoding="utf-8")
+        adapter.install(ctx)
+        second_config = (ctx.home_dir / ".grok" / "managed_config.toml").read_text(encoding="utf-8")
+        assert first_config.count("BEGIN HOL GUARD MANAGED GROK") == 1
+        assert second_config.count("BEGIN HOL GUARD MANAGED GROK") == 1
+
+    def test_uninstall_removes_only_guard_managed_entries(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        user_config = ctx.home_dir / ".grok" / "config.toml"
+        user_config.parent.mkdir(parents=True, exist_ok=True)
+        user_config.write_text("[ui]\nsimple_mode = true\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.grok.install_guard_shim",
+            lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-grok"), "notes": []},
+        )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.grok.remove_guard_shim",
+            lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-grok"), "notes": []},
+        )
+        adapter = GrokHarnessAdapter()
+        adapter.install(ctx)
+        adapter.uninstall(ctx)
+        assert user_config.read_text(encoding="utf-8") == "[ui]\nsimple_mode = true\n"
+        assert not (ctx.home_dir / ".grok" / "hooks" / "hol-guard-pretooluse.json").exists()
+        managed_config = (ctx.home_dir / ".grok" / "managed_config.toml").read_text(encoding="utf-8")
+        assert "BEGIN HOL GUARD MANAGED GROK" not in managed_config
+
+
+class TestGrokHookPayload:
+    def test_prepare_grok_hook_payload_maps_bash_fixture(self) -> None:
+        normalized = prepare_grok_hook_payload(_fixture("pretooluse_bash.json"))
+        assert normalized["hook_event_name"] == "PreToolUse"
+        assert normalized["tool_name"] == "Bash"
+        assert normalized["session_id"] == "session-redacted-001"
+
+    def test_prepare_grok_hook_payload_maps_read_fixture(self) -> None:
+        normalized = prepare_grok_hook_payload(_fixture("pretooluse_read_secret.json"))
+        assert normalized["tool_name"] == "Read"
+
+    def test_normalize_grok_hook_payload_builds_shell_envelope(self, tmp_path: Path) -> None:
+        envelope = normalize_grok_hook_payload(
+            _fixture("pretooluse_bash.json"),
+            workspace=tmp_path / "workspace",
+            home_dir=tmp_path,
+        )
+        assert envelope.harness == "grok"
+        assert envelope.action_type == "shell_command"
+        assert envelope.event_name == "PreToolUse"
+
+
+class TestGrokHookResponses:
+    def test_allow_response(self) -> None:
+        assert grok_hook_response_from_guard(policy_action="allow", reason="") == {"decision": "allow"}
+
+    def test_deny_response(self) -> None:
+        payload = grok_hook_response_from_guard(policy_action="block", reason="Blocked by HOL Guard.")
+        assert payload == {"decision": "deny", "reason": "Blocked by HOL Guard."}
+
+    def test_emit_grok_hook_response_writes_json_line(self) -> None:
+        stream = io.StringIO()
+        emit_grok_hook_response(policy_action="allow", reason="", output_stream=stream)
+        assert json.loads(stream.getvalue()) == {"decision": "allow"}
+
+    def test_grok_block_emits_deny_json_and_stderr(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.cli.commands_hook_generic import _run_hook_generic_payload
+        from codex_plugin_scanner.guard.config import GuardConfig
+        from codex_plugin_scanner.guard.store import GuardStore
+
+        guard_home = tmp_path / ".hol-guard"
+        store = GuardStore(guard_home)
+        config = GuardConfig(guard_home=guard_home, workspace=tmp_path)
+        args = argparse.Namespace(
+            harness="grok",
+            json=False,
+            policy_action="block",
+            artifact_id=None,
+            artifact_name=None,
+        )
+        payload = {"hookEventName": "pre_tool_use", "toolName": "run_terminal_command", "toolInput": {"command": "rm -rf /"}}
+        stderr_capture = io.StringIO()
+        stdout_capture = io.StringIO()
+        with redirect_stderr(stderr_capture):
+            rc = _run_hook_generic_payload(
+                args,
+                action_envelope=None,
+                config=config,
+                output_stream=stdout_capture,
+                payload=payload,
+                runtime_workspace=tmp_path,
+                store=store,
+            )
+        assert rc == 2
+        assert '"decision":"deny"' in stdout_capture.getvalue()
+
+
+class TestGrokManagedBlockHelpers:
+    def test_remove_managed_block_strips_guard_section(self) -> None:
+        text = "keep = true\n\n# BEGIN HOL GUARD MANAGED GROK\nmanaged = false\n# END HOL GUARD MANAGED GROK\n"
+        assert _remove_managed_block(text).strip() == "keep = true"
+
+
+class TestGrokFixturesAreRedacted:
+    def test_fixtures_do_not_include_real_local_paths_or_tokens(self) -> None:
+        fixture_dir = Path(__file__).parent / "fixtures" / "grok"
+        home_prefix = "/" + "Users" + "/"
+        unix_home_prefix = "/" + "home" + "/"
+        secret_marker = "XAI_" + "API_KEY"
+        forbidden = re.compile(
+            rf"({re.escape(home_prefix)}|{re.escape(unix_home_prefix)}|{secret_marker}|sk-[A-Za-z0-9]{{8,}}|Bearer\s+\S+)"
+        )
+        for path in fixture_dir.glob("*.json"):
+            contents = path.read_text(encoding="utf-8")
+            assert forbidden.search(contents) is None

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -13,10 +13,13 @@ from codex_plugin_scanner.guard.adapters import get_adapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter, _remove_managed_block
 from codex_plugin_scanner.guard.adapters.grok_hooks import (
+    _dedupe_grok_block_reason,
     emit_grok_hook_response,
     grok_hook_response_from_guard,
     prepare_grok_hook_payload,
 )
+from codex_plugin_scanner.guard.inventory_contract import _agent_type, inventory_snapshot_from_detection
+from codex_plugin_scanner.guard.models import HarnessDetection
 from codex_plugin_scanner.guard.runtime.actions import normalize_grok_hook_payload
 
 
@@ -222,3 +225,135 @@ class TestGrokFixturesAreRedacted:
         for path in fixture_dir.glob("*.json"):
             contents = path.read_text(encoding="utf-8")
             assert forbidden.search(contents) is None
+
+
+class TestGrokHookPayloadFixtures:
+    def test_edit_fixture_normalizes_to_edit_tool(self) -> None:
+        normalized = prepare_grok_hook_payload(_fixture("pretooluse_edit.json"))
+        assert normalized["tool_name"] == "Edit"
+
+    def test_mcp_fixture_preserves_server_metadata(self) -> None:
+        normalized = prepare_grok_hook_payload(_fixture("pretooluse_mcp.json"))
+        assert normalized["tool_name"] == "MCPTool"
+
+    def test_webfetch_fixture_normalizes_tool(self) -> None:
+        normalized = prepare_grok_hook_payload(_fixture("pretooluse_webfetch.json"))
+        assert normalized["tool_name"] == "WebFetch"
+
+    def test_unknown_tool_is_preserved(self) -> None:
+        normalized = prepare_grok_hook_payload(_fixture("pretooluse_unknown_tool.json"))
+        assert normalized["tool_name"] == "custom_plugin_action"
+
+    def test_prompt_fixture_normalizes_event(self) -> None:
+        normalized = prepare_grok_hook_payload(_fixture("user_prompt_submit.json"))
+        assert normalized["hook_event_name"] == "UserPromptSubmit"
+
+    def test_malformed_payload_is_handled_safely(self) -> None:
+        normalized = prepare_grok_hook_payload({})
+        assert normalized == {}
+
+
+class TestGrokActionEnvelopes:
+    def test_read_secret_maps_to_file_read(self, tmp_path: Path) -> None:
+        envelope = normalize_grok_hook_payload(
+            _fixture("pretooluse_read_secret.json"),
+            workspace=tmp_path / "ws",
+            home_dir=tmp_path,
+        )
+        assert envelope.action_type == "file_read"
+        assert ".env" in envelope.target_paths[0]
+
+    def test_safe_grep_maps_to_shell_command(self, tmp_path: Path) -> None:
+        envelope = normalize_grok_hook_payload(
+            _fixture("pretooluse_grep_safe.json"),
+            workspace=tmp_path / "ws",
+            home_dir=tmp_path,
+        )
+        assert envelope.action_type in {"shell_command", "file_read", "config_change"}
+
+    def test_session_id_is_preserved(self, tmp_path: Path) -> None:
+        envelope = normalize_grok_hook_payload(
+            _fixture("pretooluse_bash.json"),
+            workspace=tmp_path / "ws",
+            home_dir=tmp_path,
+        )
+        assert envelope.raw_payload_redacted.get("session_id") == "session-redacted-001"
+
+    def test_workspace_label_is_redacted(self, tmp_path: Path) -> None:
+        workspace = tmp_path / "ws"
+        workspace.mkdir()
+        fixture = dict(_fixture("pretooluse_bash.json"))
+        fixture["workspaceRoot"] = str(workspace)
+        envelope = normalize_grok_hook_payload(fixture, workspace=workspace, home_dir=tmp_path)
+        assert str(workspace) not in (envelope.workspace or "")
+
+
+class TestGrokDetectExtended:
+    def test_detects_mcp_servers_from_config(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".grok" / "config.toml"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(
+            """
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        result = GrokHarnessAdapter().detect(ctx)
+        mcp = [artifact for artifact in result.artifacts if artifact.artifact_type == "mcp_server"]
+        assert any(artifact.name == "github" for artifact in mcp)
+
+    def test_detects_degraded_always_approve_signal(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".grok" / "config.toml"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text('sandbox = "off"\n', encoding="utf-8")
+        result = GrokHarnessAdapter().detect(ctx)
+        assert any("degraded" in warning.lower() or "sandbox" in warning.lower() for warning in result.warnings)
+
+    def test_install_preserves_user_config(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        user_config = ctx.home_dir / ".grok" / "config.toml"
+        user_config.parent.mkdir(parents=True, exist_ok=True)
+        user_config.write_text("[ui]\nsimple_mode = true\n", encoding="utf-8")
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.grok.install_guard_shim",
+            lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-grok"), "notes": []},
+        )
+        GrokHarnessAdapter().install(ctx)
+        assert user_config.read_text(encoding="utf-8") == "[ui]\nsimple_mode = true\n"
+
+
+class TestGrokInventoryAndResponses:
+    def test_inventory_agent_type_is_grok(self) -> None:
+        assert _agent_type("grok") == "grok"
+
+    def test_inventory_snapshot_serializes_grok_harness(self, tmp_path: Path) -> None:
+        detection = HarnessDetection(
+            harness="grok",
+            installed=True,
+            command_available=True,
+            config_paths=(str(tmp_path / ".grok" / "config.toml"),),
+            artifacts=(),
+            warnings=(),
+        )
+        snapshot = inventory_snapshot_from_detection(detection, home_dir=tmp_path, generated_at="2026-06-12T00:00:00Z")
+        assert snapshot.agent_type == "grok"
+
+    def test_dedupe_block_reason_removes_repeated_approval_copy(self) -> None:
+        reason = (
+            "Blocked. Open HOL Guard to approve or keep this blocked: http://127.0.0.1:8080/x. "
+            "After you choose, retry the same Grok action. "
+            "Open HOL Guard to approve or keep this blocked: http://127.0.0.1:8080/x. "
+            "After you choose, retry the same Grok action."
+        )
+        deduped = _dedupe_grok_block_reason(reason)
+        assert deduped.count("Open HOL Guard to approve or keep this blocked:") == 1
+
+    def test_deny_response_uses_plain_language_not_raw_json(self) -> None:
+        payload = grok_hook_response_from_guard(policy_action="block", reason="Grok tried to read a credential file.")
+        assert payload["decision"] == "deny"
+        assert "{" not in str(payload["reason"])

--- a/tests/test_guard_grok_protection.py
+++ b/tests/test_guard_grok_protection.py
@@ -1,0 +1,108 @@
+"""Integration tests for Grok managed protection and harness setup."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.contracts import setup_contract_for
+from codex_plugin_scanner.guard.adapters.grok import GrokHarnessAdapter
+from codex_plugin_scanner.guard.cli.install_commands import (
+    _grok_protection_checks,
+    build_harness_setup_plan,
+    build_harness_verification,
+    uninstall_confirmation_token,
+)
+from codex_plugin_scanner.guard.runtime.actions import normalize_harness_payload
+
+
+def _ctx(tmp_path: Path) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def test_uninstall_confirmation_token_for_grok() -> None:
+    assert uninstall_confirmation_token("grok") == "disconnect-grok"
+
+
+def test_setup_contract_includes_grok_connect_and_repair() -> None:
+    contract = setup_contract_for("grok")
+    assert contract is not None
+    assert contract.display_name == "Grok"
+    assert contract.setup_steps[0].command == ("hol-guard", "apps", "connect", "grok")
+    assert contract.repair_steps[0].command == ("hol-guard", "apps", "repair", "grok")
+
+
+def test_build_harness_setup_plan_disconnect_confirmation(tmp_path: Path) -> None:
+    payload = build_harness_setup_plan("uninstall", "grok", _ctx(tmp_path), dry_run=False)
+    assert payload["confirmation_phrase"] == "disconnect-grok"
+    assert "hol-guard apps disconnect grok --confirm disconnect-grok" in str(payload["confirm_command"])
+
+
+def test_grok_protection_checks_ready_after_install(tmp_path: Path, monkeypatch) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.grok.install_guard_shim",
+        lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-grok"), "notes": []},
+    )
+    GrokHarnessAdapter().install(ctx)
+    (ctx.guard_home / "bin").mkdir(parents=True, exist_ok=True)
+    (ctx.guard_home / "bin" / "guard-grok").write_text("#!/bin/sh\n", encoding="utf-8")
+    checks = _grok_protection_checks(ctx)
+    assert checks["pretool_hook_installed"] is True
+    assert checks["prompt_hook_installed"] is True
+    assert checks["managed_config_installed"] is True
+    assert checks["ready"] is True
+
+
+def test_build_harness_verification_includes_grok_checks(tmp_path: Path, monkeypatch) -> None:
+    ctx = _ctx(tmp_path)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.grok.install_guard_shim",
+        lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-grok"), "notes": []},
+    )
+    GrokHarnessAdapter().install(ctx)
+    (ctx.guard_home / "bin").mkdir(parents=True, exist_ok=True)
+    (ctx.guard_home / "bin" / "guard-grok").write_text("#!/bin/sh\n", encoding="utf-8")
+    payload = build_harness_verification("grok", ctx)
+    verification = payload["verification"]
+    assert isinstance(verification, dict)
+    assert verification.get("pretool_hook_installed") is True
+
+
+def test_normalize_harness_payload_supports_grok_bash(tmp_path: Path) -> None:
+    envelope = normalize_harness_payload(
+        "grok",
+        "PreToolUse",
+        {
+            "hookEventName": "pre_tool_use",
+            "toolName": "run_terminal_command",
+            "toolInput": {"command": "git diff README.md"},
+        },
+        workspace=tmp_path / "workspace",
+        home_dir=tmp_path,
+    )
+    assert envelope.harness == "grok"
+    assert envelope.action_type == "shell_command"
+    assert envelope.command is not None
+    assert "git diff" in envelope.command
+
+
+def test_normalize_harness_payload_supports_grok_secret_read(tmp_path: Path) -> None:
+    fixture = json.loads(
+        (Path(__file__).parent / "fixtures" / "grok" / "pretooluse_read_secret.json").read_text(encoding="utf-8")
+    )
+    envelope = normalize_harness_payload(
+        "grok",
+        "PreToolUse",
+        fixture,
+        workspace=tmp_path / "workspace",
+        home_dir=tmp_path,
+    )
+    assert envelope.harness == "grok"
+    assert envelope.action_type == "file_read"
+    assert any(".env" in path for path in envelope.target_paths)

--- a/tests/test_guard_grok_protection.py
+++ b/tests/test_guard_grok_protection.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -14,7 +15,14 @@ from codex_plugin_scanner.guard.cli.install_commands import (
     build_harness_verification,
     uninstall_confirmation_token,
 )
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.runtime.actions import normalize_harness_payload
+from codex_plugin_scanner.guard.store_approvals import (
+    add_approval_request,
+    approval_index_statements,
+    approval_schema_statement,
+    resolve_request_with_queue_result,
+)
 
 
 def _ctx(tmp_path: Path) -> HarnessContext:
@@ -106,3 +114,60 @@ def test_normalize_harness_payload_supports_grok_secret_read(tmp_path: Path) -> 
     assert envelope.harness == "grok"
     assert envelope.action_type == "file_read"
     assert any(".env" in path for path in envelope.target_paths)
+
+
+def _approval_connection() -> sqlite3.Connection:
+    connection = sqlite3.connect(":memory:")
+    connection.row_factory = sqlite3.Row
+    connection.execute(approval_schema_statement())
+    for statement in approval_index_statements():
+        connection.execute(statement)
+    return connection
+
+
+def _grok_approval_request(request_id: str, *, command: str, harness: str = "grok") -> GuardApprovalRequest:
+    artifact_id = f"{harness}:project:{request_id}"
+    return GuardApprovalRequest(
+        request_id=request_id,
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_name=artifact_id.rsplit(":", maxsplit=1)[-1],
+        artifact_hash=f"hash-{request_id}",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("args",),
+        source_scope="project",
+        config_path=".grok/managed_config.toml",
+        workspace="workspace-a",
+        launch_target=command,
+        action_envelope_json={
+            "action_type": "shell_command",
+            "tool_name": "run_terminal_command",
+            "command": command,
+            "target_paths": [],
+            "network_hosts": [],
+        },
+        review_command=f"hol-guard approvals approve {request_id}",
+        approval_url=f"http://127.0.0.1/pending/{request_id}",
+    )
+
+
+def test_scoped_grok_approval_keeps_unrelated_queue() -> None:
+    connection = _approval_connection()
+    grok_active = _grok_approval_request("grok-active", command="cat .env")
+    codex_pending = _grok_approval_request("codex-pending", command="cat .npmrc", harness="codex")
+    add_approval_request(connection, codex_pending, "2026-06-12T10:00:00+00:00")
+    add_approval_request(connection, grok_active, "2026-06-12T10:01:00+00:00")
+
+    result = resolve_request_with_queue_result(
+        connection,
+        "grok-active",
+        resolution_action="allow",
+        resolution_scope="artifact",
+        reason="reviewed",
+        resolved_at="2026-06-12T10:02:00+00:00",
+    )
+
+    assert result["resolved"] is True
+    assert result["remaining_pending_count"] == 1
+    assert result["remaining_pending_summaries"][0]["request_id"] == "codex-pending"

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -28,6 +28,8 @@ SUPPORTED_HARNESSES = (
     "cursor",
     "hermes",
     "openclaw",
+    "kimi",
+    "grok",
 )
 
 
@@ -511,6 +513,31 @@ def test_apps_disconnect_confirmation_phrase_is_visible(
     payload = json.loads(output)
     assert payload["confirmation_phrase"] == "disconnect-codex"
     assert payload["confirm_command"] == "hol-guard apps disconnect codex --confirm disconnect-codex"
+
+
+def test_apps_disconnect_grok_confirmation_phrase_is_visible(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    args = argparse.Namespace(
+        guard_command="apps",
+        apps_command="disconnect",
+        harness="grok",
+        confirm=None,
+        home=str(tmp_path / "home"),
+        guard_home=str(tmp_path / "guard-home"),
+        workspace=str(tmp_path / "workspace"),
+        json=True,
+    )
+
+    exit_code = run_guard_command(args)
+
+    assert exit_code == 2
+    output = capsys.readouterr().out
+    assert "disconnect-grok" in output
+    payload = json.loads(output)
+    assert payload["confirmation_phrase"] == "disconnect-grok"
+    assert payload["confirm_command"] == "hol-guard apps disconnect grok --confirm disconnect-grok"
 
 
 def test_apps_safe_setup_does_not_read_skill_env_files(

--- a/tests/test_guard_runtime_action_harnesses.py
+++ b/tests/test_guard_runtime_action_harnesses.py
@@ -305,6 +305,22 @@ def test_normalize_harness_payload_dispatches_supported_harnesses(tmp_path: Path
     assert envelope.target_paths == ("~/.npmrc",)
 
 
+def test_normalize_harness_payload_dispatches_grok(tmp_path: Path) -> None:
+    envelope = normalize_harness_payload(
+        "grok",
+        "PreToolUse",
+        {
+            "hookEventName": "pre_tool_use",
+            "toolName": "grep",
+            "toolInput": {"pattern": "TODO", "path": "src"},
+        },
+        workspace=tmp_path / "workspace",
+        home_dir=tmp_path,
+    )
+    assert envelope.harness == "grok"
+    assert envelope.event_name == "PreToolUse"
+
+
 def test_normalize_harness_payload_rejects_unknown_harness(tmp_path: Path) -> None:
     with pytest.raises(ValueError, match="Unsupported Guard harness"):
         normalize_harness_payload(


### PR DESCRIPTION
## Summary
- Add first-class Grok Build CLI harness adapter with managed install, hook normalization, and Grok-native allow/deny responses
- Wire Grok through inventory, CLI connect/repair/disconnect, dashboard catalog/fleet/inbox/evidence, docs, and regression tests

## Testing
- `PYTHONPATH=src pytest tests/test_grok_adapter.py tests/test_guard_grok_protection.py tests/test_guard_runtime_action_harnesses.py tests/test_guard_harness_setup.py -q`
- `cd dashboard && npm test -- --run src/app-routing.test.ts src/home-dashboard.test.ts src/fleet-workspace-phase11.test.ts src/guard-api.test.ts src/evidence/evidence-filters.test.ts`
