### PR TITLE
fix(guard): prevent MCP servers from colliding with CLAUDE.md artifact IDs

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -224,6 +224,10 @@ def _claude_digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def _claude_mcp_artifact_id(scope: str, server_name: str) -> str:
+    return f"claude-code:{scope}:mcp:{server_name}"
+
+
 def _metadata_with_digest(path: Path) -> dict[str, object]:
     try:
         digest = _claude_digest(path)
@@ -318,7 +322,7 @@ class ClaudeCodeHarnessAdapter(HarnessAdapter):
                     url = server_config.get("url")
                     artifacts.append(
                         GuardArtifact(
-                            artifact_id=f"claude-code:{scope}:{name}",
+                            artifact_id=_claude_mcp_artifact_id(scope, name),
                             name=name,
                             harness=self.harness,
                             artifact_type="mcp_server",

--- a/src/codex_plugin_scanner/guard/adapters/claude_code.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_code.py
@@ -228,6 +228,40 @@ def _claude_mcp_artifact_id(scope: str, server_name: str) -> str:
     return f"claude-code:{scope}:mcp:{server_name}"
 
 
+_CLAUDE_BUILTIN_HOOK_TOOL_NAMES = frozenset(
+    {
+        "bash",
+        "shell",
+        "sh",
+        "zsh",
+        "terminal",
+        "run_command",
+        "run_terminal_command",
+        "read",
+        "read_file",
+        "open_file",
+        "view",
+        "view_file",
+        "cat_file",
+        "write",
+        "edit",
+        "multiedit",
+        "write_file",
+        "edit_file",
+        "webfetch",
+        "websearch",
+        "askuserquestion",
+    }
+)
+
+
+def claude_hook_fallback_artifact_id(scope: str, tool_name: str) -> str:
+    normalized_tool = tool_name.strip()
+    if normalized_tool.lower() in _CLAUDE_BUILTIN_HOOK_TOOL_NAMES:
+        return f"claude-code:{scope}:{normalized_tool}"
+    return _claude_mcp_artifact_id(scope, normalized_tool)
+
+
 def _metadata_with_digest(path: Path) -> dict[str, object]:
     try:
         digest = _claude_digest(path)

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -476,6 +476,10 @@ def _is_claude_rules_instruction_replacement_target(
     existing: GuardArtifact,
     workspace_dir: Path,
 ) -> bool:
+    # Defense-in-depth: only Claude rules markdown may be replaced by workspace-root
+    # CLAUDE.md when IDs collide. MCP servers are namespaced under mcp:, and current
+    # rule discovery uses rules-{stem}, but legacy inventories may still carry the
+    # pre-prefix rules ID at the CLAUDE.md legacy artifact_id.
     if existing.artifact_type != "instruction" or existing.harness != "claude-code":
         return False
     config_path = getattr(existing, "config_path", None)

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -472,6 +472,23 @@ def extend_codex_runtime_inventory(
     )
 
 
+def _is_claude_rules_instruction_replacement_target(
+    existing: GuardArtifact,
+    workspace_dir: Path,
+) -> bool:
+    if existing.artifact_type != "instruction" or existing.harness != "claude-code":
+        return False
+    config_path = getattr(existing, "config_path", None)
+    if not isinstance(config_path, str):
+        return False
+    try:
+        resolved = Path(config_path).resolve()
+        rules_dir = (workspace_dir / ".claude" / "rules").resolve()
+        return resolved.is_relative_to(rules_dir)
+    except (OSError, ValueError):
+        return False
+
+
 def _is_workspace_root_claude_md(artifact: GuardArtifact, workspace_dir: Path) -> bool:
     metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
     if metadata.get("instructionRole") != "claude_md":
@@ -507,10 +524,13 @@ def extend_detection_with_workspace_aibom(
     for artifact in extra:
         if artifact.artifact_id in existing_ids:
             if _is_workspace_root_claude_md(artifact, workspace_dir):
-                merged[artifact_index_by_id[artifact.artifact_id]] = artifact
-                config_path = getattr(artifact, "config_path", None)
-                if isinstance(config_path, str):
-                    found_paths.append(config_path)
+                existing_index = artifact_index_by_id[artifact.artifact_id]
+                existing = merged[existing_index]
+                if _is_claude_rules_instruction_replacement_target(existing, workspace_dir):
+                    merged[existing_index] = artifact
+                    config_path = getattr(artifact, "config_path", None)
+                    if isinstance(config_path, str):
+                        found_paths.append(config_path)
             continue
         merged.append(artifact)
         existing_ids.add(artifact.artifact_id)

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -32,7 +32,12 @@ def _artifact_id_from_event(harness: str, payload: dict[str, object]) -> str:
     source_scope = _coalesce_string(payload.get("source_scope"), "project")
     tool_name = payload.get("tool_name")
     if isinstance(tool_name, str) and tool_name.strip():
-        return f"{harness}:{source_scope}:{tool_name.strip()}"
+        normalized_tool = tool_name.strip()
+        if _canonical_harness_name(harness) == "claude-code":
+            from ..adapters.claude_code import claude_hook_fallback_artifact_id
+
+            return claude_hook_fallback_artifact_id(source_scope, normalized_tool)
+        return f"{harness}:{source_scope}:{normalized_tool}"
     event_name = _hook_event_name(payload)
     if isinstance(event_name, str) and event_name.strip():
         return f"{harness}:{source_scope}:{event_name.strip().lower()}"

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -18,7 +18,7 @@ from codex_plugin_scanner.guard.aibom_detection import (
 )
 from codex_plugin_scanner.guard.consumer.service import artifact_hash, diff_artifact
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
-from codex_plugin_scanner.guard.models import HarnessDetection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 
 
 def test_inventory_item_kinds_align_with_portal_contract() -> None:
@@ -311,6 +311,43 @@ def test_marketplace_escape_path_does_not_read_outside_workspace(tmp_path: Path)
 
     assert len(evil_plugins) == 1
     assert "content_hash" not in evil_plugins[0].metadata
+
+
+def test_extend_detection_replaces_legacy_rules_collision_with_workspace_claude_md(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    root_claude_md = workspace / "CLAUDE.md"
+    root_claude_md.write_text("# root instructions\n", encoding="utf-8")
+    legacy_rule = workspace / ".claude" / "rules" / "claude-md.md"
+    legacy_rule.parent.mkdir(parents=True)
+    legacy_rule.write_text("# legacy rule id\n", encoding="utf-8")
+
+    base = HarnessDetection(
+        harness="claude-code",
+        installed=True,
+        command_available=True,
+        config_paths=(str(legacy_rule),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="claude-code:project:instruction:claude-md",
+                name="claude-md",
+                harness="claude-code",
+                artifact_type="instruction",
+                source_scope="project",
+                config_path=str(legacy_rule),
+                metadata={"instructionRole": "cursor_rules"},
+            ),
+        ),
+    )
+    extended = extend_detection_with_workspace_aibom(
+        base,
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    artifacts = {artifact.artifact_id: artifact for artifact in extended.artifacts}
+
+    assert artifacts["claude-code:project:instruction:claude-md"].config_path == str(root_claude_md)
+    assert artifacts["claude-code:project:instruction:claude-md"].metadata.get("instructionRole") == "claude_md"
 
 
 def test_extend_detection_does_not_replace_colliding_mcp_server_with_claude_md(tmp_path: Path) -> None:

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -313,6 +313,33 @@ def test_marketplace_escape_path_does_not_read_outside_workspace(tmp_path: Path)
     assert "content_hash" not in evil_plugins[0].metadata
 
 
+def test_extend_detection_does_not_replace_colliding_mcp_server_with_claude_md(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "CLAUDE.md").write_text("# root instructions\n", encoding="utf-8")
+    mcp_config = workspace / ".mcp.json"
+    mcp_config.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "instruction:claude-md": {
+                        "command": "python3",
+                        "args": ["-m", "http.server", "9000"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    context = HarnessContext(home_dir=tmp_path, workspace_dir=workspace, guard_home=tmp_path / ".hol-guard")
+    detection = ClaudeCodeHarnessAdapter().detect(context)
+    artifacts = {artifact.artifact_id: artifact for artifact in detection.artifacts}
+
+    assert artifacts["claude-code:project:mcp:instruction:claude-md"].artifact_type == "mcp_server"
+    assert artifacts["claude-code:project:instruction:claude-md"].artifact_type == "instruction"
+
+
 def test_extend_detection_prefers_workspace_root_claude_md_on_legacy_id_collision(tmp_path: Path) -> None:
     workspace = tmp_path / "repo"
     workspace.mkdir()

--- a/tests/test_guard_claude_adapter.py
+++ b/tests/test_guard_claude_adapter.py
@@ -632,10 +632,10 @@ def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path
     detection = adapter.detect(context)
     artifacts = {artifact.artifact_id: artifact for artifact in detection.artifacts}
 
-    assert "claude-code:global:global-tools" in artifacts
-    assert artifacts["claude-code:global:global-tools"].metadata["env_keys"] == ["MODE", "OPENROUTER_API_KEY"]
-    assert "claude-code:project:workspace-tools" in artifacts
-    assert artifacts["claude-code:project:workspace-tools"].metadata["headers_keys"] == ["Authorization"]
+    assert "claude-code:global:mcp:global-tools" in artifacts
+    assert artifacts["claude-code:global:mcp:global-tools"].metadata["env_keys"] == ["MODE", "OPENROUTER_API_KEY"]
+    assert "claude-code:project:mcp:workspace-tools" in artifacts
+    assert artifacts["claude-code:project:mcp:workspace-tools"].metadata["headers_keys"] == ["Authorization"]
     assert "claude-code:project:pretooluse:0:0" in artifacts
     assert "claude-code:project:userpromptsubmit:0:0" in artifacts
     assert "claude-code:project:skill:review" in artifacts
@@ -644,6 +644,34 @@ def test_claude_detect_discovers_nested_hooks_skills_commands_and_rules(tmp_path
     claude_instruction = artifacts.get("claude-code:project:instruction:claude-md")
     assert claude_instruction is not None
     assert claude_instruction.metadata.get("instructionRole") == "claude_md"
+
+
+def test_claude_detect_keeps_mcp_server_when_name_collides_with_claude_md_id(tmp_path):
+    context = _build_context(tmp_path)
+    adapter = ClaudeCodeHarnessAdapter()
+    (context.workspace_dir / "CLAUDE.md").write_text("# workspace instructions\n", encoding="utf-8")
+    _write_json(
+        context.workspace_dir / ".mcp.json",
+        {
+            "mcpServers": {
+                "instruction:claude-md": {
+                    "command": "python3",
+                    "args": ["-m", "http.server", "9000"],
+                }
+            }
+        },
+    )
+
+    detection = adapter.detect(context)
+    artifacts = {artifact.artifact_id: artifact for artifact in detection.artifacts}
+
+    mcp_artifact = artifacts.get("claude-code:project:mcp:instruction:claude-md")
+    assert mcp_artifact is not None
+    assert mcp_artifact.artifact_type == "mcp_server"
+    root_instruction = artifacts.get("claude-code:project:instruction:claude-md")
+    assert root_instruction is not None
+    assert root_instruction.artifact_type == "instruction"
+    assert root_instruction.config_path == str(context.workspace_dir / "CLAUDE.md")
 
 
 def test_claude_detect_keeps_root_claude_md_when_rules_stem_collides(tmp_path):

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -829,7 +829,7 @@ args = ["workspace-skill.js"]
         artifact_ids = [item["artifact_id"] for item in output["harnesses"][0]["artifacts"]]
 
         assert rc == 0
-        assert artifact_ids == ["claude-code:global:shared-tools", "claude-code:project:shared-tools"]
+        assert artifact_ids == ["claude-code:global:mcp:shared-tools", "claude-code:project:mcp:shared-tools"]
 
     def test_guard_detect_scopes_claude_hook_artifact_ids(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -4264,7 +4264,7 @@ clearer UX and an implementation plan with technical references.
         event = {
             "event": "PreToolUse",
             "tool_name": "workspace-tools",
-            "artifact_id": "claude-code:project:workspace-tools",
+            "artifact_id": "claude-code:project:mcp:workspace-tools",
             "artifact_name": "workspace-tools",
             "policy_action": "require-reapproval",
             "changed_capabilities": ["tool_name"],
@@ -4298,7 +4298,7 @@ clearer UX and an implementation plan with technical references.
         message = "HOL Guard blocked this launch because the action matched a sensitive local secret path."
         event = {
             "event": "PreToolUse",
-            "artifact_id": "claude-code:project:workspace-tools",
+            "artifact_id": "claude-code:project:mcp:workspace-tools",
             "artifact_name": "workspace-tools",
             "policy_action": "block",
             "decision_v2_json": {
@@ -4401,7 +4401,7 @@ clearer UX and an implementation plan with technical references.
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 0
-        assert output["artifact_id"] == "claude-code:project:workspace-tools"
+        assert output["artifact_id"] == "claude-code:project:mcp:workspace-tools"
 
     def test_guard_hook_uses_copilot_repo_hook_runtime_path(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
@@ -11898,7 +11898,7 @@ def test_guard_run_headless_redetects_before_persisted_resume(tmp_path, monkeypa
 
     store = GuardStore(home_dir)
     baseline = GuardArtifact(
-        artifact_id="claude-code:project:workspace-tools",
+        artifact_id="claude-code:project:mcp:workspace-tools",
         name="workspace-tools",
         harness="claude-code",
         artifact_type="mcp_server",
@@ -12020,7 +12020,7 @@ def test_guard_headless_blocked_run_persists_receipts_and_diffs(tmp_path, monkey
     _build_guard_fixture(home_dir, workspace_dir)
     store = GuardStore(home_dir)
     baseline = GuardArtifact(
-        artifact_id="claude-code:project:workspace-tools",
+        artifact_id="claude-code:project:mcp:workspace-tools",
         name="workspace-tools",
         harness="claude-code",
         artifact_type="mcp_server",
@@ -12176,7 +12176,7 @@ def test_guard_hook_invalid_policy_action_falls_back_to_reapproval(tmp_path, cap
     event = {
         "event": "PreToolUse",
         "tool_name": "workspace-tools",
-        "artifact_id": "claude-code:project:workspace-tools",
+        "artifact_id": "claude-code:project:mcp:workspace-tools",
         "policy_action": "require_reapproval",
         "source_scope": "project",
     }


### PR DESCRIPTION
## Summary
- Namespace Claude MCP server artifact IDs as `claude-code:{scope}:mcp:{name}` so attacker-controlled server names cannot collide with legacy root CLAUDE.md IDs
- Restrict CLAUDE.md merge replacement to colliding Claude rules instructions under the rules directory, never MCP servers or other artifact types

## Testing
- `python3 -m pytest tests/test_guard_claude_adapter.py::test_claude_detect_keeps_mcp_server_when_name_collides_with_claude_md_id tests/test_guard_claude_adapter.py::test_claude_detect_keeps_root_claude_md_when_rules_stem_collides tests/test_guard_aibom_detection.py::test_extend_detection_does_not_replace_colliding_mcp_server_with_claude_md tests/test_guard_aibom_detection.py::test_extend_detection_prefers_workspace_root_claude_md_on_legacy_id_collision -q`
- `python3 -m pytest tests/test_guard_cli.py::TestGuardCli::test_guard_detect_scopes_claude_artifact_ids -q`
- `ruff check src/codex_plugin_scanner/guard/aibom_detection.py src/codex_plugin_scanner/guard/adapters/claude_code.py`
