### PR TITLE
feat(guard): sign local trust attestations

### DIFF
--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -575,6 +575,13 @@ def _item_from_artifact(
         }
     )
     content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
+    safe_metadata = _apply_trust_attestation_metadata(
+        safe_metadata,
+        agent_id=f"{harness}:local",
+        item_id=artifact_id,
+        item_kind=item_kind,
+        content_hash=content_hash,
+    )
     return GuardAgentInventoryItem(
         item_id=artifact_id,
         item_kind=item_kind,
@@ -641,7 +648,12 @@ def _mcp_tool_items_from_artifact(
                     {
                         **layer,
                         "metadata": {
-                            **layer_metadata,
+                            **{
+                                key: value
+                                for key, value in layer_metadata.items()
+                                if key != "attestation"
+                            },
+                            "attestationStatus": "unsigned",
                             "inheritedFromServerItemId": server_item.item_id,
                         },
                     }
@@ -678,6 +690,98 @@ def _mcp_tool_items_from_artifact(
 
 def _string_value(value: object) -> str | None:
     return value if isinstance(value, str) else None
+
+
+def _apply_trust_attestation_metadata(
+    metadata: dict[str, object],
+    *,
+    agent_id: str,
+    item_id: str,
+    item_kind: InventoryItemKind,
+    content_hash: str,
+) -> dict[str, object]:
+    from .runtime.trust_attestation import (
+        build_trust_attestation_payload,
+        resolve_trust_attestation_signing_config,
+        sign_trust_attestation,
+    )
+
+    config = resolve_trust_attestation_signing_config()
+    if config is None:
+        return metadata
+
+    enriched = dict(metadata)
+
+    raw_trust_resolution = enriched.get("trustResolution")
+    if isinstance(raw_trust_resolution, dict):
+        trust_resolution = dict(raw_trust_resolution)
+        raw_resolution_metadata = trust_resolution.get("metadata")
+        resolution_metadata = dict(raw_resolution_metadata) if isinstance(raw_resolution_metadata, dict) else {}
+        evidence_hash = resolution_metadata.get("evidenceHash")
+        captured_at = trust_resolution.get("capturedAt")
+        if isinstance(evidence_hash, str) and evidence_hash and isinstance(captured_at, str) and captured_at:
+            resolution_metadata["attestation"] = sign_trust_attestation(
+                payload=build_trust_attestation_payload(
+                    agent_id=agent_id,
+                    item_id=item_id,
+                    item_kind=item_kind,
+                    content_hash=content_hash,
+                    captured_at=captured_at,
+                    evidence_hash=evidence_hash,
+                    scope="trust_resolution",
+                ),
+                config=config,
+                signed_at=captured_at,
+            )
+            resolution_metadata["attestationStatus"] = "signed"
+            trust_resolution["metadata"] = resolution_metadata
+            enriched["trustResolution"] = trust_resolution
+
+    raw_trust_layers = enriched.get("trustLayers")
+    if isinstance(raw_trust_layers, list):
+        signed_layers: list[object] = []
+        for raw_layer in raw_trust_layers:
+            if not isinstance(raw_layer, dict):
+                signed_layers.append(raw_layer)
+                continue
+            layer = dict(raw_layer)
+            raw_layer_metadata = layer.get("metadata")
+            layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
+            evidence_hash = layer_metadata.get("evidenceHash")
+            captured_at = layer.get("capturedAt")
+            layer_id = layer.get("layerId")
+            layer_type = layer.get("layerType")
+            if (
+                isinstance(evidence_hash, str)
+                and evidence_hash
+                and isinstance(captured_at, str)
+                and captured_at
+                and isinstance(layer_id, str)
+                and layer_id
+                and isinstance(layer_type, str)
+                and layer_type
+            ):
+                layer_metadata["attestation"] = sign_trust_attestation(
+                    payload=build_trust_attestation_payload(
+                        agent_id=agent_id,
+                        item_id=item_id,
+                        item_kind=item_kind,
+                        content_hash=content_hash,
+                        captured_at=captured_at,
+                        evidence_hash=evidence_hash,
+                        scope="trust_layer",
+                        layer_id=layer_id,
+                        layer_type=layer_type,
+                    ),
+                    config=config,
+                    signed_at=captured_at,
+                )
+                layer_metadata["attestationStatus"] = "signed"
+                layer["metadata"] = layer_metadata
+            signed_layers.append(layer)
+        enriched["trustLayers"] = signed_layers
+
+    return enriched
 
 
 def _first_present_value(mapping: dict[str, object], *keys: str) -> object | None:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -575,7 +575,9 @@ def _item_from_artifact(
         }
     )
     content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
-    safe_metadata = _apply_trust_attestation_metadata(
+    from .runtime.trust_attestation import apply_trust_attestation_metadata
+
+    safe_metadata = apply_trust_attestation_metadata(
         safe_metadata,
         agent_id=f"{harness}:local",
         item_id=artifact_id,
@@ -690,98 +692,6 @@ def _mcp_tool_items_from_artifact(
 
 def _string_value(value: object) -> str | None:
     return value if isinstance(value, str) else None
-
-
-def _apply_trust_attestation_metadata(
-    metadata: dict[str, object],
-    *,
-    agent_id: str,
-    item_id: str,
-    item_kind: InventoryItemKind,
-    content_hash: str,
-) -> dict[str, object]:
-    from .runtime.trust_attestation import (
-        build_trust_attestation_payload,
-        resolve_trust_attestation_signing_config,
-        sign_trust_attestation,
-    )
-
-    config = resolve_trust_attestation_signing_config()
-    if config is None:
-        return metadata
-
-    enriched = dict(metadata)
-
-    raw_trust_resolution = enriched.get("trustResolution")
-    if isinstance(raw_trust_resolution, dict):
-        trust_resolution = dict(raw_trust_resolution)
-        raw_resolution_metadata = trust_resolution.get("metadata")
-        resolution_metadata = dict(raw_resolution_metadata) if isinstance(raw_resolution_metadata, dict) else {}
-        evidence_hash = resolution_metadata.get("evidenceHash")
-        captured_at = trust_resolution.get("capturedAt")
-        if isinstance(evidence_hash, str) and evidence_hash and isinstance(captured_at, str) and captured_at:
-            resolution_metadata["attestation"] = sign_trust_attestation(
-                payload=build_trust_attestation_payload(
-                    agent_id=agent_id,
-                    item_id=item_id,
-                    item_kind=item_kind,
-                    content_hash=content_hash,
-                    captured_at=captured_at,
-                    evidence_hash=evidence_hash,
-                    scope="trust_resolution",
-                ),
-                config=config,
-                signed_at=captured_at,
-            )
-            resolution_metadata["attestationStatus"] = "signed"
-            trust_resolution["metadata"] = resolution_metadata
-            enriched["trustResolution"] = trust_resolution
-
-    raw_trust_layers = enriched.get("trustLayers")
-    if isinstance(raw_trust_layers, list):
-        signed_layers: list[object] = []
-        for raw_layer in raw_trust_layers:
-            if not isinstance(raw_layer, dict):
-                signed_layers.append(raw_layer)
-                continue
-            layer = dict(raw_layer)
-            raw_layer_metadata = layer.get("metadata")
-            layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
-            evidence_hash = layer_metadata.get("evidenceHash")
-            captured_at = layer.get("capturedAt")
-            layer_id = layer.get("layerId")
-            layer_type = layer.get("layerType")
-            if (
-                isinstance(evidence_hash, str)
-                and evidence_hash
-                and isinstance(captured_at, str)
-                and captured_at
-                and isinstance(layer_id, str)
-                and layer_id
-                and isinstance(layer_type, str)
-                and layer_type
-            ):
-                layer_metadata["attestation"] = sign_trust_attestation(
-                    payload=build_trust_attestation_payload(
-                        agent_id=agent_id,
-                        item_id=item_id,
-                        item_kind=item_kind,
-                        content_hash=content_hash,
-                        captured_at=captured_at,
-                        evidence_hash=evidence_hash,
-                        scope="trust_layer",
-                        layer_id=layer_id,
-                        layer_type=layer_type,
-                    ),
-                    config=config,
-                    signed_at=captured_at,
-                )
-                layer_metadata["attestationStatus"] = "signed"
-                layer["metadata"] = layer_metadata
-            signed_layers.append(layer)
-        enriched["trustLayers"] = signed_layers
-
-    return enriched
 
 
 def _first_present_value(mapping: dict[str, object], *keys: str) -> object | None:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -650,11 +650,7 @@ def _mcp_tool_items_from_artifact(
                     {
                         **layer,
                         "metadata": {
-                            **{
-                                key: value
-                                for key, value in layer_metadata.items()
-                                if key != "attestation"
-                            },
+                            **{key: value for key, value in layer_metadata.items() if key != "attestation"},
                             "attestationStatus": "unsigned",
                             "inheritedFromServerItemId": server_item.item_id,
                         },

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -102,6 +102,92 @@ def build_trust_attestation_payload(
     return payload
 
 
+def apply_trust_attestation_metadata(
+    metadata: dict[str, object],
+    *,
+    agent_id: str,
+    item_id: str,
+    item_kind: str,
+    content_hash: str,
+) -> dict[str, object]:
+    config = resolve_trust_attestation_signing_config()
+    if config is None:
+        return metadata
+
+    enriched = dict(metadata)
+
+    raw_trust_resolution = enriched.get("trustResolution")
+    if isinstance(raw_trust_resolution, dict):
+        trust_resolution = dict(raw_trust_resolution)
+        raw_resolution_metadata = trust_resolution.get("metadata")
+        resolution_metadata = dict(raw_resolution_metadata) if isinstance(raw_resolution_metadata, dict) else {}
+        evidence_hash = resolution_metadata.get("evidenceHash")
+        captured_at = trust_resolution.get("capturedAt")
+        if isinstance(evidence_hash, str) and evidence_hash and isinstance(captured_at, str) and captured_at:
+            resolution_metadata["attestation"] = sign_trust_attestation(
+                payload=build_trust_attestation_payload(
+                    agent_id=agent_id,
+                    item_id=item_id,
+                    item_kind=item_kind,
+                    content_hash=content_hash,
+                    captured_at=captured_at,
+                    evidence_hash=evidence_hash,
+                    scope="trust_resolution",
+                ),
+                config=config,
+                signed_at=captured_at,
+            )
+            resolution_metadata["attestationStatus"] = "signed"
+            trust_resolution["metadata"] = resolution_metadata
+            enriched["trustResolution"] = trust_resolution
+
+    raw_trust_layers = enriched.get("trustLayers")
+    if isinstance(raw_trust_layers, list):
+        signed_layers: list[object] = []
+        for raw_layer in raw_trust_layers:
+            if not isinstance(raw_layer, dict):
+                signed_layers.append(raw_layer)
+                continue
+            layer = dict(raw_layer)
+            raw_layer_metadata = layer.get("metadata")
+            layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
+            evidence_hash = layer_metadata.get("evidenceHash")
+            captured_at = layer.get("capturedAt")
+            layer_id = layer.get("layerId")
+            layer_type = layer.get("layerType")
+            if (
+                isinstance(evidence_hash, str)
+                and evidence_hash
+                and isinstance(captured_at, str)
+                and captured_at
+                and isinstance(layer_id, str)
+                and layer_id
+                and isinstance(layer_type, str)
+                and layer_type
+            ):
+                layer_metadata["attestation"] = sign_trust_attestation(
+                    payload=build_trust_attestation_payload(
+                        agent_id=agent_id,
+                        item_id=item_id,
+                        item_kind=item_kind,
+                        content_hash=content_hash,
+                        captured_at=captured_at,
+                        evidence_hash=evidence_hash,
+                        scope="trust_layer",
+                        layer_id=layer_id,
+                        layer_type=layer_type,
+                    ),
+                    config=config,
+                    signed_at=captured_at,
+                )
+                layer_metadata["attestationStatus"] = "signed"
+                layer["metadata"] = layer_metadata
+            signed_layers.append(layer)
+        enriched["trustLayers"] = signed_layers
+
+    return enriched
+
+
 def sign_trust_attestation(
     *,
     payload: Mapping[str, object],
@@ -109,13 +195,18 @@ def sign_trust_attestation(
     signed_at: str,
 ) -> dict[str, object]:
     private_key = _load_private_key(config.private_key_pem)
-    canonical_payload = canonical_trust_attestation_payload(payload)
+    canonical_payload = canonical_trust_attestation_payload(
+        _payload_with_signed_at(payload, signed_at)
+    )
     signature = private_key.sign(
         canonical_payload,
         padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
         hashes.SHA256(),
     )
-    verification_key = build_trust_attestation_verification_key(config)
+    verification_key = _verification_key_from_private_key(
+        private_key,
+        key_id=config.active_key_id,
+    )
     return {
         "payloadVersion": GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION,
         "payloadHash": hashlib.sha256(canonical_payload).hexdigest(),
@@ -160,7 +251,9 @@ def verify_trust_attestation(
     signature: str = raw_signature
     if signature_algorithm != GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM:
         raise ValueError("Unsupported trust attestation signature algorithm")
-    canonical_payload = canonical_trust_attestation_payload(payload)
+    canonical_payload = canonical_trust_attestation_payload(
+        _payload_with_signed_at(payload, envelope.get("signedAt"))
+    )
     if hashlib.sha256(canonical_payload).hexdigest() != payload_hash:
         raise ValueError("Trust attestation payload hash mismatch")
     if _public_key_fingerprint(public_key_pem) != fingerprint_sha256:
@@ -191,6 +284,37 @@ def _load_private_key(private_key_pem: str) -> RSAPrivateKey:
     if not isinstance(private_key, RSAPrivateKey):
         raise ValueError("Trust attestation private key must be RSA")
     return private_key
+
+
+def _verification_key_from_private_key(
+    private_key: RSAPrivateKey,
+    *,
+    key_id: str,
+) -> GuardTrustAttestationVerificationKey:
+    public_key_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    return GuardTrustAttestationVerificationKey(
+        key_id=key_id,
+        public_key_pem=public_key_pem,
+        fingerprint_sha256=_public_key_fingerprint(public_key_pem),
+    )
+
+
+def _payload_with_signed_at(
+    payload: Mapping[str, object],
+    signed_at: object,
+) -> dict[str, object]:
+    enriched = dict(payload)
+    if isinstance(signed_at, str) and signed_at:
+        enriched["signedAt"] = signed_at
+    return enriched
 
 
 def _public_key_fingerprint(public_key_pem: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -42,9 +42,7 @@ def resolve_trust_attestation_signing_config(
 ) -> GuardTrustAttestationSigningConfig | None:
     env = environ or os.environ
     active_key_id = _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID")) or "guard-aibom-trust-key-default"
-    private_key_pem = _normalize_pem(
-        _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY"))
-    )
+    private_key_pem = _normalize_pem(_sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY")))
     if not private_key_pem:
         return None
     return GuardTrustAttestationSigningConfig(
@@ -195,9 +193,7 @@ def sign_trust_attestation(
     signed_at: str,
 ) -> dict[str, object]:
     private_key = _load_private_key(config.private_key_pem)
-    canonical_payload = canonical_trust_attestation_payload(
-        _payload_with_signed_at(payload, signed_at)
-    )
+    canonical_payload = canonical_trust_attestation_payload(_payload_with_signed_at(payload, signed_at))
     signature = private_key.sign(
         canonical_payload,
         padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
@@ -251,9 +247,7 @@ def verify_trust_attestation(
     signature: str = raw_signature
     if signature_algorithm != GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM:
         raise ValueError("Unsupported trust attestation signature algorithm")
-    canonical_payload = canonical_trust_attestation_payload(
-        _payload_with_signed_at(payload, envelope.get("signedAt"))
-    )
+    canonical_payload = canonical_trust_attestation_payload(_payload_with_signed_at(payload, envelope.get("signedAt")))
     if hashlib.sha256(canonical_payload).hexdigest() != payload_hash:
         raise ValueError("Trust attestation payload hash mismatch")
     if _public_key_fingerprint(public_key_pem) != fingerprint_sha256:
@@ -323,7 +317,7 @@ def _public_key_fingerprint(public_key_pem: str) -> str:
 
 
 def _sanitize_env(value: str | None) -> str:
-    return value.replace('\\n', '\n').replace("\r\n", "\n").strip().strip("'\"") if isinstance(value, str) else ""
+    return value.replace("\\n", "\n").replace("\r\n", "\n").strip().strip("'\"") if isinstance(value, str) else ""
 
 
 def _normalize_pem(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -1,0 +1,206 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
+
+GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION = "guard-aibom-trust-attestation.v1"
+GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
+
+
+@dataclass(frozen=True, slots=True)
+class GuardTrustAttestationSigningConfig:
+    active_key_id: str
+    private_key_pem: str
+
+
+@dataclass(frozen=True, slots=True)
+class GuardTrustAttestationVerificationKey:
+    key_id: str
+    public_key_pem: str
+    fingerprint_sha256: str
+
+
+def canonical_trust_attestation_payload(payload: Mapping[str, object]) -> bytes:
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def payload_hash_for_trust_attestation(payload: Mapping[str, object]) -> str:
+    return hashlib.sha256(canonical_trust_attestation_payload(payload)).hexdigest()
+
+
+def resolve_trust_attestation_signing_config(
+    environ: Mapping[str, str] | None = None,
+) -> GuardTrustAttestationSigningConfig | None:
+    env = environ or os.environ
+    active_key_id = _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID")) or "guard-aibom-trust-key-default"
+    private_key_pem = _normalize_pem(
+        _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY"))
+    )
+    if not private_key_pem:
+        return None
+    return GuardTrustAttestationSigningConfig(
+        active_key_id=active_key_id,
+        private_key_pem=private_key_pem,
+    )
+
+
+def build_trust_attestation_verification_key(
+    config: GuardTrustAttestationSigningConfig,
+) -> GuardTrustAttestationVerificationKey:
+    private_key = _load_private_key(config.private_key_pem)
+    public_key_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    return GuardTrustAttestationVerificationKey(
+        key_id=config.active_key_id,
+        public_key_pem=public_key_pem,
+        fingerprint_sha256=_public_key_fingerprint(public_key_pem),
+    )
+
+
+def build_trust_attestation_payload(
+    *,
+    agent_id: str,
+    item_id: str,
+    item_kind: str,
+    content_hash: str,
+    captured_at: str,
+    evidence_hash: str,
+    scope: str,
+    layer_id: str | None = None,
+    layer_type: str | None = None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "payloadVersion": GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION,
+        "agentId": agent_id,
+        "itemId": item_id,
+        "itemKind": item_kind,
+        "contentHash": content_hash,
+        "capturedAt": captured_at,
+        "evidenceHash": evidence_hash,
+        "scope": scope,
+    }
+    if layer_id is not None:
+        payload["layerId"] = layer_id
+    if layer_type is not None:
+        payload["layerType"] = layer_type
+    return payload
+
+
+def sign_trust_attestation(
+    *,
+    payload: Mapping[str, object],
+    config: GuardTrustAttestationSigningConfig,
+    signed_at: str,
+) -> dict[str, object]:
+    private_key = _load_private_key(config.private_key_pem)
+    canonical_payload = canonical_trust_attestation_payload(payload)
+    signature = private_key.sign(
+        canonical_payload,
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+        hashes.SHA256(),
+    )
+    verification_key = build_trust_attestation_verification_key(config)
+    return {
+        "payloadVersion": GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION,
+        "payloadHash": hashlib.sha256(canonical_payload).hexdigest(),
+        "signature": base64.b64encode(signature).decode("ascii"),
+        "signatureAlgorithm": GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM,
+        "signedAt": signed_at,
+        "keyId": verification_key.key_id,
+        "publicKeyPem": verification_key.public_key_pem,
+        "fingerprintSha256": verification_key.fingerprint_sha256,
+    }
+
+
+def verify_trust_attestation(
+    *,
+    payload: Mapping[str, object],
+    envelope: Mapping[str, object],
+    trusted_keys: tuple[GuardTrustAttestationVerificationKey, ...] | None = None,
+) -> None:
+    raw_payload_hash = envelope.get("payloadHash")
+    raw_signature_algorithm = envelope.get("signatureAlgorithm")
+    raw_key_id = envelope.get("keyId")
+    raw_public_key_pem = envelope.get("publicKeyPem")
+    raw_fingerprint_sha256 = envelope.get("fingerprintSha256")
+    raw_signature = envelope.get("signature")
+    if not isinstance(raw_payload_hash, str) or not raw_payload_hash:
+        raise ValueError("Trust attestation envelope is incomplete")
+    if not isinstance(raw_signature_algorithm, str) or not raw_signature_algorithm:
+        raise ValueError("Trust attestation envelope is incomplete")
+    if not isinstance(raw_key_id, str) or not raw_key_id:
+        raise ValueError("Trust attestation envelope is incomplete")
+    if not isinstance(raw_public_key_pem, str) or not raw_public_key_pem:
+        raise ValueError("Trust attestation envelope is incomplete")
+    if not isinstance(raw_fingerprint_sha256, str) or not raw_fingerprint_sha256:
+        raise ValueError("Trust attestation envelope is incomplete")
+    if not isinstance(raw_signature, str) or not raw_signature:
+        raise ValueError("Trust attestation envelope is incomplete")
+    payload_hash: str = raw_payload_hash
+    signature_algorithm: str = raw_signature_algorithm
+    key_id: str = raw_key_id
+    public_key_pem: str = raw_public_key_pem
+    fingerprint_sha256: str = raw_fingerprint_sha256
+    signature: str = raw_signature
+    if signature_algorithm != GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM:
+        raise ValueError("Unsupported trust attestation signature algorithm")
+    canonical_payload = canonical_trust_attestation_payload(payload)
+    if hashlib.sha256(canonical_payload).hexdigest() != payload_hash:
+        raise ValueError("Trust attestation payload hash mismatch")
+    if _public_key_fingerprint(public_key_pem) != fingerprint_sha256:
+        raise ValueError("Trust attestation public key fingerprint mismatch")
+    if trusted_keys is not None and not any(
+        trusted_key.key_id == key_id
+        and trusted_key.fingerprint_sha256 == fingerprint_sha256
+        and _normalize_pem(trusted_key.public_key_pem) == _normalize_pem(public_key_pem)
+        for trusted_key in trusted_keys
+    ):
+        raise ValueError("Trust attestation key is not trusted")
+    public_key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+    if not isinstance(public_key, RSAPublicKey):
+        raise ValueError("Trust attestation public key must be RSA")
+    try:
+        public_key.verify(
+            base64.b64decode(signature),
+            canonical_payload,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+    except InvalidSignature as exc:
+        raise ValueError("Trust attestation signature verification failed") from exc
+
+
+def _load_private_key(private_key_pem: str) -> RSAPrivateKey:
+    private_key = serialization.load_pem_private_key(private_key_pem.encode("utf-8"), password=None)
+    if not isinstance(private_key, RSAPrivateKey):
+        raise ValueError("Trust attestation private key must be RSA")
+    return private_key
+
+
+def _public_key_fingerprint(public_key_pem: str) -> str:
+    normalized_pem = _normalize_pem(public_key_pem)
+    return hashlib.sha256(normalized_pem.encode("utf-8")).hexdigest()
+
+
+def _sanitize_env(value: str | None) -> str:
+    return value.replace('\\n', '\n').replace("\r\n", "\n").strip().strip("'\"") if isinstance(value, str) else ""
+
+
+def _normalize_pem(value: str) -> str:
+    return value.replace("\r\n", "\n").strip()

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import builtins
+import hashlib
 import json
 from collections.abc import Mapping
 from pathlib import Path
@@ -70,7 +71,7 @@ def _install_test_attestation_key(monkeypatch) -> GuardTrustAttestationVerificat
         .decode("utf-8")
         .strip()
     )
-    fingerprint = __import__("hashlib").sha256(public_key_pem.encode("utf-8")).hexdigest()
+    fingerprint = hashlib.sha256(public_key_pem.encode("utf-8")).hexdigest()
     monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID", "guard-test-key-1")
     monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", private_key_pem)
     return GuardTrustAttestationVerificationKey(

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -4,12 +4,20 @@ from __future__ import annotations
 
 import builtins
 import json
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Mapping
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
 
 from codex_plugin_scanner.guard.aibom_trust_metadata import trust_resolution_from_domain
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.runtime.trust_attestation import (
+    GuardTrustAttestationVerificationKey,
+    build_trust_attestation_payload,
+    verify_trust_attestation,
+)
 from codex_plugin_scanner.trust_models import TrustDomainScore
 
 
@@ -44,6 +52,32 @@ def _trust_layer_types(item_metadata: dict[str, object]) -> set[str]:
         for layer in layers
         if isinstance(layer, dict) and isinstance(layer.get("layerType"), str)
     }
+
+
+def _install_test_attestation_key(monkeypatch) -> GuardTrustAttestationVerificationKey:
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    public_key_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    fingerprint = __import__("hashlib").sha256(public_key_pem.encode("utf-8")).hexdigest()
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID", "guard-test-key-1")
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", private_key_pem)
+    return GuardTrustAttestationVerificationKey(
+        key_id="guard-test-key-1",
+        public_key_pem=public_key_pem,
+        fingerprint_sha256=fingerprint,
+    )
 
 
 def test_trust_resolution_captured_at_uses_utc_z_suffix() -> None:
@@ -128,14 +162,14 @@ def test_inventory_skill_trust_enrichment_disables_cisco_scan(
 
     def _guard_import(
         name: str,
-        globals: Mapping[str, object] | None = None,
-        locals: Mapping[str, object] | None = None,
+        global_vars: Mapping[str, object] | None = None,
+        local_vars: Mapping[str, object] | None = None,
         fromlist: tuple[str, ...] = (),
         level: int = 0,
     ) -> object:
         if name == "skill_scanner" or name.startswith("skill_scanner."):
             raise AssertionError("inventory trust enrichment must not import skill_scanner")
-        return original_import(name, globals, locals, fromlist, level)
+        return original_import(name, global_vars, local_vars, fromlist, level)
 
     def _record_cisco_mode(**kwargs: object) -> object:
         from codex_plugin_scanner.integrations.cisco_skill_scanner import (
@@ -287,6 +321,83 @@ def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) 
     assert isinstance(metadata, dict)
     assert metadata.get("trustDomain") == "mcp"
     assert "local_baseline" in _trust_layer_types(mcp_item.metadata)
+
+
+def test_inventory_snapshot_signs_local_trust_metadata_when_configured(monkeypatch, tmp_path: Path) -> None:
+    verification_key = _install_test_attestation_key(monkeypatch)
+    plugin_dir = tmp_path
+    _write_good_plugin(plugin_dir)
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(plugin_dir / ".codex-plugin" / "plugin.json"),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:plugin:trust-demo",
+                name="trust-demo",
+                harness="codex",
+                artifact_type="plugin",
+                source_scope="project",
+                config_path=str(plugin_dir),
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+    plugin_item = next(item for item in snapshot.items if item.item_kind == "plugin")
+    trust = plugin_item.metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    metadata = trust.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("attestationStatus") == "signed"
+    attestation = metadata.get("attestation")
+    assert isinstance(attestation, dict)
+    verify_trust_attestation(
+        payload=build_trust_attestation_payload(
+            agent_id=snapshot.agent_id,
+            item_id=plugin_item.item_id,
+            item_kind=plugin_item.item_kind,
+            content_hash=plugin_item.content_hash,
+            captured_at=str(trust.get("capturedAt")),
+            evidence_hash=str(metadata.get("evidenceHash")),
+            scope="trust_resolution",
+        ),
+        envelope=attestation,
+        trusted_keys=(verification_key,),
+    )
+    trust_layers = plugin_item.metadata.get("trustLayers")
+    assert isinstance(trust_layers, list)
+    local_layer = next(
+        layer
+        for layer in trust_layers
+        if isinstance(layer, dict) and layer.get("layerType") == "local_baseline"
+    )
+    layer_metadata = local_layer.get("metadata")
+    assert isinstance(layer_metadata, dict)
+    assert layer_metadata.get("attestationStatus") == "signed"
+    layer_attestation = layer_metadata.get("attestation")
+    assert isinstance(layer_attestation, dict)
+    verify_trust_attestation(
+        payload=build_trust_attestation_payload(
+            agent_id=snapshot.agent_id,
+            item_id=plugin_item.item_id,
+            item_kind=plugin_item.item_kind,
+            content_hash=plugin_item.content_hash,
+            captured_at=str(local_layer.get("capturedAt")),
+            evidence_hash=str(layer_metadata.get("evidenceHash")),
+            scope="trust_layer",
+            layer_id=str(local_layer.get("layerId")),
+            layer_type=str(local_layer.get("layerType")),
+        ),
+        envelope=layer_attestation,
+        trusted_keys=(verification_key,),
+    )
 
 
 def test_registry_identified_skill_still_gets_local_baseline(tmp_path: Path) -> None:

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import Any, cast
 
 from codex_plugin_scanner.guard.inventory_cisco import CiscoInventoryRun
 from codex_plugin_scanner.guard.inventory_contract import (
@@ -71,7 +72,7 @@ def test_inventory_snapshot_serialization_redacts_raw_secrets(tmp_path: Path) ->
         redaction_report={"raw_secret_values": False, "redacted_fields": ("headers.authorization", "url.token")},
     )
 
-    payload = serialize_inventory_snapshot(snapshot)
+    payload = cast(dict[str, Any], serialize_inventory_snapshot(snapshot))
     encoded = json.dumps(payload, sort_keys=True)
 
     assert payload["agentId"] == "agent-hermes"
@@ -106,7 +107,7 @@ def test_inventory_snapshot_omits_null_optional_finding_summary() -> None:
         ),
     )
 
-    payload = serialize_inventory_snapshot(snapshot)
+    payload = cast(dict[str, Any], serialize_inventory_snapshot(snapshot))
 
     assert "summary" not in payload["findings"][0]
 
@@ -137,7 +138,7 @@ def test_inventory_snapshot_serialization_preserves_free_form_metadata_keys() ->
         ),
     )
 
-    payload = serialize_inventory_snapshot(snapshot)
+    payload = cast(dict[str, Any], serialize_inventory_snapshot(snapshot))
     schema = payload["items"][0]["metadata"]["tool_schemas"][0]["input_schema"]
 
     assert schema["properties"]["file_path"]["type"] == "string"
@@ -442,6 +443,8 @@ def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tm
         isinstance(layer, dict)
         and layer.get("layerType") == "cisco_mcp_scanner"
         and isinstance(layer.get("metadata"), dict)
+        and layer["metadata"].get("attestationStatus") == "unsigned"
+        and layer["metadata"].get("attestation") is None
         and layer["metadata"].get("inheritedFromServerItemId") == server_item.item_id
         for layer in tool_layers
     )
@@ -691,7 +694,7 @@ def test_inventory_snapshot_maps_cisco_findings_to_redacted_inventory_evidence(t
         home_dir=tmp_path,
         cisco_runs=(cisco_run,),
     )
-    payload = serialize_inventory_snapshot(snapshot)
+    payload = cast(dict[str, Any], serialize_inventory_snapshot(snapshot))
     encoded = json.dumps(payload, sort_keys=True)
 
     assert len(payload["findings"]) == 1


### PR DESCRIPTION
## Summary
- add optional signed AIBOM trust attestations on top of existing unsigned `evidenceHash` metadata
- bind trust attestations to `agentId`, `itemId`, `itemKind`, `contentHash`, and per-layer evidence so portal verification can anchor them later

## Testing
- `pytest tests/test_guard_aibom_trust_metadata.py tests/test_guard_aibom_detection.py tests/test_guard_inventory_contract.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/aibom_trust_metadata.py src/codex_plugin_scanner/guard/inventory_contract.py src/codex_plugin_scanner/guard/runtime/trust_attestation.py src/codex_plugin_scanner/trust_instruction_scoring.py tests/test_guard_aibom_trust_metadata.py tests/test_guard_inventory_contract.py`

## Notes
- unsigned behavior remains the default when no attestation private key is configured
- inherited MCP tool scanner layers intentionally drop signed attestation envelopes because the server signature cannot be safely replayed onto the derived tool item identity
