### PR TITLE
fix(guard): include Grok MCP env metadata for reapproval

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/grok_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_config.py
@@ -215,6 +215,7 @@ def append_mcp_artifacts(
         transport = "http" if isinstance(url, str) else "stdio"
         metadata = enrich_mcp_server_metadata(
             {
+                "name": server_name,
                 "env_keys": _mcp_env_keys(server_config),
                 "headers_keys": _mcp_headers_keys(server_config),
             },

--- a/src/codex_plugin_scanner/guard/adapters/grok_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok_config.py
@@ -6,6 +6,7 @@ import json
 import re
 from pathlib import Path
 
+from ..aibom_detection import enrich_mcp_server_metadata
 from ..models import GuardArtifact
 from .base import _json_payload
 
@@ -169,6 +170,22 @@ def append_permission_artifacts(
             )
 
 
+def _mcp_env_keys(server_config: dict[str, object]) -> list[str]:
+    keys: set[str] = set()
+    for field in ("env", "environment"):
+        value = server_config.get(field)
+        if isinstance(value, dict):
+            keys.update(key for key in value if isinstance(key, str))
+    return sorted(keys)
+
+
+def _mcp_headers_keys(server_config: dict[str, object]) -> list[str]:
+    headers = server_config.get("headers")
+    if not isinstance(headers, dict):
+        return []
+    return sorted(key for key in headers if isinstance(key, str))
+
+
 def append_mcp_artifacts(
     *,
     harness: str,
@@ -195,6 +212,17 @@ def append_mcp_artifacts(
             continue
         raw_args = server_config.get("args")
         args = tuple(str(item) for item in raw_args) if isinstance(raw_args, list) else ()
+        transport = "http" if isinstance(url, str) else "stdio"
+        metadata = enrich_mcp_server_metadata(
+            {
+                "env_keys": _mcp_env_keys(server_config),
+                "headers_keys": _mcp_headers_keys(server_config),
+            },
+            command=command if isinstance(command, str) else None,
+            args=args,
+            url=url if isinstance(url, str) else None,
+            transport=transport,
+        )
         artifacts.append(
             GuardArtifact(
                 artifact_id=f"{harness}:{scope}:mcp:{server_name}",
@@ -206,7 +234,8 @@ def append_mcp_artifacts(
                 command=command if isinstance(command, str) else None,
                 args=args,
                 url=url if isinstance(url, str) else None,
-                transport="http" if isinstance(url, str) else "stdio",
+                transport=transport,
+                metadata=metadata,
             )
         )
 

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -106,6 +106,7 @@ def mcp_server_content_hash(
     url: str | None,
     transport: str | None,
     env_keys: tuple[str, ...] = (),
+    headers_keys: tuple[str, ...] = (),
 ) -> str:
     return fingerprint_mapping(
         {
@@ -114,6 +115,7 @@ def mcp_server_content_hash(
             "url": url,
             "transport": transport,
             "env_keys": sorted(env_keys),
+            "headers_keys": sorted(headers_keys),
         }
     )
 
@@ -631,12 +633,17 @@ def enrich_mcp_server_metadata(
     normalized_env_keys: tuple[str, ...] = ()
     if isinstance(env_keys, list):
         normalized_env_keys = tuple(str(key) for key in env_keys if isinstance(key, str))
+    headers_keys = metadata.get("headers_keys")
+    normalized_headers_keys: tuple[str, ...] = ()
+    if isinstance(headers_keys, list):
+        normalized_headers_keys = tuple(str(key) for key in headers_keys if isinstance(key, str))
     content_hash = mcp_server_content_hash(
         command=command,
         args=args,
         url=url,
         transport=transport,
         env_keys=normalized_env_keys,
+        headers_keys=normalized_headers_keys,
     )
     enriched = dict(metadata)
     enriched["content_hash"] = content_hash

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -326,6 +326,90 @@ args = ["-y", "@modelcontextprotocol/server-github"]
         mcp = [artifact for artifact in result.artifacts if artifact.artifact_type == "mcp_server"]
         assert any(artifact.name == "github" for artifact in mcp)
 
+    def test_mcp_env_keys_and_headers_in_metadata(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".grok" / "config.toml"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(
+            """
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp_servers.github.env]
+GITHUB_TOKEN = "redacted"
+
+[mcp_servers.remote]
+url = "https://mcp.example.com/mcp"
+
+[mcp_servers.remote.headers]
+Authorization = "Bearer redacted"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        result = GrokHarnessAdapter().detect(ctx)
+        github = next(artifact for artifact in result.artifacts if artifact.name == "github")
+        remote = next(artifact for artifact in result.artifacts if artifact.name == "remote")
+        assert github.metadata["env_keys"] == ["GITHUB_TOKEN"]
+        assert remote.metadata["headers_keys"] == ["Authorization"]
+
+    def test_mcp_env_change_changes_artifact_hash(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.consumer import artifact_hash
+
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".grok" / "config.toml"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(
+            """
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        adapter = GrokHarnessAdapter()
+        baseline = next(artifact for artifact in adapter.detect(ctx).artifacts if artifact.name == "github")
+        config.write_text(
+            """
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp_servers.github.env]
+GITHUB_TOKEN = "redacted"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        changed = next(artifact for artifact in adapter.detect(ctx).artifacts if artifact.name == "github")
+        assert artifact_hash(baseline) != artifact_hash(changed)
+        assert changed.metadata["env_keys"] == ["GITHUB_TOKEN"]
+
+    def test_mcp_credential_env_emits_secret_risk_signals(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.risk import artifact_risk_signals_typed
+
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".grok" / "config.toml"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(
+            """
+[mcp_servers.github]
+command = "npx"
+args = ["-y", "@modelcontextprotocol/server-github"]
+
+[mcp_servers.github.env]
+GITHUB_TOKEN = "redacted"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        artifact = next(artifact for artifact in GrokHarnessAdapter().detect(ctx).artifacts if artifact.name == "github")
+        signal_ids = {signal.signal_id for signal in artifact_risk_signals_typed(artifact)}
+        assert "secret:env-keys" in signal_ids
+        assert "secret:env-semantic" in signal_ids
+
     def test_detects_degraded_always_approve_signal(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
         config = ctx.home_dir / ".grok" / "config.toml"

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -353,6 +353,8 @@ Authorization = "Bearer redacted"
         remote = next(artifact for artifact in result.artifacts if artifact.name == "remote")
         assert github.metadata["env_keys"] == ["GITHUB_TOKEN"]
         assert remote.metadata["headers_keys"] == ["Authorization"]
+        assert github.metadata["versionInfo"]["versionLabel"] == "github"
+        assert remote.metadata["versionInfo"]["versionLabel"] == "remote"
 
     def test_mcp_env_change_changes_artifact_hash(self, tmp_path: Path) -> None:
         from codex_plugin_scanner.guard.consumer import artifact_hash
@@ -386,6 +388,38 @@ GITHUB_TOKEN = "redacted"
         changed = next(artifact for artifact in adapter.detect(ctx).artifacts if artifact.name == "github")
         assert artifact_hash(baseline) != artifact_hash(changed)
         assert changed.metadata["env_keys"] == ["GITHUB_TOKEN"]
+
+    def test_mcp_headers_change_changes_artifact_hash(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.consumer import artifact_hash
+
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".grok" / "config.toml"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(
+            """
+[mcp_servers.remote]
+url = "https://mcp.example.com/mcp"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        adapter = GrokHarnessAdapter()
+        baseline = next(artifact for artifact in adapter.detect(ctx).artifacts if artifact.name == "remote")
+        config.write_text(
+            """
+[mcp_servers.remote]
+url = "https://mcp.example.com/mcp"
+
+[mcp_servers.remote.headers]
+Authorization = "Bearer redacted"
+""".strip()
+            + "\n",
+            encoding="utf-8",
+        )
+        changed = next(artifact for artifact in adapter.detect(ctx).artifacts if artifact.name == "remote")
+        assert artifact_hash(baseline) != artifact_hash(changed)
+        assert changed.metadata["headers_keys"] == ["Authorization"]
+        assert baseline.metadata["versionInfo"]["contentHash"] != changed.metadata["versionInfo"]["contentHash"]
 
     def test_mcp_credential_env_emits_secret_risk_signals(self, tmp_path: Path) -> None:
         from codex_plugin_scanner.guard.risk import artifact_risk_signals_typed


### PR DESCRIPTION
## Summary
- Include MCP `env_keys` and `headers_keys` in Grok adapter artifacts via `enrich_mcp_server_metadata`, so env/header changes trigger reapproval.
- Add regression tests covering metadata enrichment, artifact hash changes on env updates, and secret risk signals for credential env vars.

## Testing
```bash
PYTHONPATH=src pytest tests/test_grok_adapter.py::TestGrokDetectExtended::test_mcp_env_keys_and_headers_in_metadata tests/test_grok_adapter.py::TestGrokDetectExtended::test_mcp_env_change_changes_artifact_hash tests/test_grok_adapter.py::TestGrokDetectExtended::test_mcp_credential_env_emits_secret_risk_signals -q --tb=short
PYTHONPATH=src pytest tests/test_grok_adapter.py tests/test_guard_grok_protection.py -q --tb=no
```
