### PR TITLE
fix(dashboard): deduplicate supply chain home UI

### DIFF
--- a/dashboard/src/supply-chain-audit-findings-summary.tsx
+++ b/dashboard/src/supply-chain-audit-findings-summary.tsx
@@ -1,13 +1,12 @@
 import { useMemo } from "react";
 import { HiMiniBugAnt, HiMiniExclamationTriangle } from "react-icons/hi2";
-import { SectionLabel, Tag, EmptyState, ActionButton } from "./approval-center-primitives";
+import { SectionLabel, Tag, EmptyState } from "./approval-center-primitives";
 import { formatRelativeTime } from "./approval-center-utils";
 import type { SupplyChainAuditFinding, SupplyChainAuditSnapshot } from "./guard-types";
 
 type SupplyChainAuditFindingsSummaryProps = {
   auditSnapshot: SupplyChainAuditSnapshot | null;
   auditRunning: boolean;
-  onRunAudit?: () => void;
 };
 
 const decisionPriority: Record<string, number> = {
@@ -102,7 +101,6 @@ function FindingSummaryRow({ finding }: FindingSummaryRowProps) {
 export function SupplyChainAuditFindingsSummary({
   auditSnapshot,
   auditRunning,
-  onRunAudit,
 }: SupplyChainAuditFindingsSummaryProps) {
   const topFindings = useMemo(() => {
     if (auditSnapshot === null) {
@@ -147,13 +145,6 @@ export function SupplyChainAuditFindingsSummary({
                 : "Run an audit from the firewall panel to see package risks here."
             }
             tone="teach"
-            action={
-              auditRunning || onRunAudit === undefined ? undefined : (
-                <ActionButton variant="primary" onClick={onRunAudit}>
-                  Run audit
-                </ActionButton>
-              )
-            }
           />
         </div>
       ) : topFindings.length === 0 ? (

--- a/dashboard/src/supply-chain-firewall-controls.tsx
+++ b/dashboard/src/supply-chain-firewall-controls.tsx
@@ -16,7 +16,6 @@ import {
 } from "./supply-chain-firewall-views";
 import { resolvePackageFirewallNextAction } from "./supply-chain-firewall-next-action";
 import { ManagerRow, resolveShimStatus } from "./supply-chain-firewall-manager-row";
-import { SupplyChainManagerCards } from "./supply-chain-manager-cards";
 
 export type FirewallOpKey = PackageFirewallActionType | "audit" | "sync";
 
@@ -219,13 +218,6 @@ export function FirewallControlsView({
         onOpenShell={onOpenShell}
         onRefreshStatus={onRefreshStatus}
         protection={data.protection}
-      />
-
-      <SupplyChainManagerCards
-        managers={
-          data.supported_managers.length > 0 ? data.supported_managers : data.detected_managers
-        }
-        shims={data.package_shims}
       />
 
       {lastFailed !== null && <FailureBanner failed={lastFailed} />}

--- a/dashboard/src/supply-chain-issue-focus.tsx
+++ b/dashboard/src/supply-chain-issue-focus.tsx
@@ -16,6 +16,7 @@ type SupplyChainIssueFocusProps = {
   issues: SupplyChainIssue[];
   onIssueAction: (action: SupplyChainIssueAction) => void;
   actionPending?: boolean;
+  tagline?: React.ReactNode;
 };
 
 function issueSurfaceClass(tone: SupplyChainIssue["tone"]): string {
@@ -58,6 +59,7 @@ export function SupplyChainIssueFocus({
   issues,
   onIssueAction,
   actionPending = false,
+  tagline,
 }: SupplyChainIssueFocusProps) {
   const [activeIndex, setActiveIndex] = useState(0);
 
@@ -115,6 +117,12 @@ export function SupplyChainIssueFocus({
           </div>
         ) : null}
       </div>
+
+      {tagline ? (
+        <div className="border-b border-black/[0.04] px-4 py-2.5 sm:px-5 bg-white/60">
+          {tagline}
+        </div>
+      ) : null}
 
       <div className="px-4 py-5 sm:px-6 sm:py-6">
         <div className="flex items-start gap-3">

--- a/dashboard/src/supply-chain-workspace.tsx
+++ b/dashboard/src/supply-chain-workspace.tsx
@@ -18,7 +18,6 @@ import type {
 } from "./guard-types";
 import { derivePackageWorkbenchFromReceipts, fetchReceipts, normalizeSupplyChainAuditSnapshot } from "./guard-api";
 import { PackageFirewallPanel, type PackageFirewallPanelHandle } from "./supply-chain-firewall-panel";
-import { PackageWorkbenchPanel } from "./package-workbench-panel";
 import { SupplyChainBundlePanel } from "./supply-chain-bundle-panel";
 import {
   deriveSupplyChainEvidenceRail,
@@ -215,10 +214,6 @@ export function SupplyChainWorkspace({
     setAuditRunning(running);
   }, []);
 
-  const handleRunAudit = useCallback(() => {
-    runAuditRef.current?.();
-  }, []);
-
   return (
     <div className={SUPPLY_CHAIN_WORKSPACE_SHELL_CLASS} data-testid="supply-chain-workspace">
       <div className="flex flex-wrap items-start justify-end gap-3">
@@ -227,7 +222,9 @@ export function SupplyChainWorkspace({
         </ActionButton>
       </div>
 
-      <SupplyChainWorkspaceHero hero={workspaceHero} compact={supplyChainIssues.length > 0} />
+      {supplyChainIssues.length === 0 ? (
+        <SupplyChainWorkspaceHero hero={workspaceHero} />
+      ) : null}
 
       <SupplyChainIssueFocus
         issues={supplyChainIssues}
@@ -235,6 +232,18 @@ export function SupplyChainWorkspace({
           void handleIssueAction(action);
         }}
         actionPending={issueActionPending}
+        tagline={
+          <div className="flex flex-wrap items-center gap-2">
+            <Tag tone={(() => {
+              if (workspaceHero.cloudMode === "paired_active") return "green" as const;
+              if (workspaceHero.cloudMode === "paired_waiting") return "blue" as const;
+              return "attention" as const;
+            })()}>
+              {workspaceHero.cloudLabel}
+            </Tag>
+            <span className="text-xs text-slate-500">{workspaceHero.statLine}</span>
+          </div>
+        }
       />
 
       {supplyChainIssues.length === 0 ? (
@@ -246,7 +255,6 @@ export function SupplyChainWorkspace({
       <SupplyChainAuditFindingsSummary
         auditSnapshot={auditSnapshot}
         auditRunning={auditRunning}
-        onRunAudit={handleRunAudit}
       />
 
       <SupplyChainBundlePanel />
@@ -258,12 +266,6 @@ export function SupplyChainWorkspace({
         onAuditCompleted={handleAuditCompleted}
         onAuditRunningChange={handleAuditRunningChange}
         runAuditRef={runAuditRef}
-      />
-
-      <PackageWorkbenchPanel
-        auditSnapshot={auditSnapshot}
-        onRunAudit={handleRunAudit}
-        auditRunning={auditRunning}
       />
 
       <div className="rounded-2xl border border-slate-100 bg-white shadow-sm">


### PR DESCRIPTION
## Summary
- Combine hero tagline + next-step cards into single `SupplyChainIssueFocus` card via new `tagline` prop; hero now only renders when no issues exist
- Remove duplicate `SupplyChainManagerCards` grid from `FirewallControlsView` (per-manager cards duplicate `ManagerRow` table already present in same panel)
- Remove duplicate "Run audit" CTA from `SupplyChainAuditFindingsSummary` empty state (audit panel retains its primary CTA)
- Remove unused `handleRunAudit` callback and `runAuditRef` wiring from workspace

## Testing
- `npm run build` (from `dashboard/`)
- `npx tsc --noEmit` (from `dashboard/`)

## Notes
- Existing pre-existing type errors in `audit-workspace.tsx` and `guard-api.ts` unchanged
- Static build assets were generated during local build and reset before commit