### PR TITLE
fix(guard): anchor policy bundle signatures to trusted keys

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -106,6 +106,10 @@ from ..package_firewall_entitlement import (
 from ..package_firewall_receipts import package_firewall_receipt_metadata
 from ..package_shim_status import record_package_shim_audit_result
 from ..receipts.manager import build_receipt
+from ..policy_bundle_trusted_keys import (
+    policy_bundle_keyring_payload,
+    validate_synced_policy_bundle,
+)
 from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
     GuardSyncNotAvailableError,
@@ -115,7 +119,6 @@ from ..runtime.runner import (
     _guard_device_metadata,
     _policy_bundle_acknowledgement_payload,
     _policy_bundle_is_version_downgrade,
-    _validated_policy_bundle_payload,
     sync_local_guard_cloud_proof,
     sync_supply_chain_bundle,
 )
@@ -1803,7 +1806,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "missing_policy_memory"}, status=400)
             return
         if policy_bundle:
-            validated_policy_bundle, rejection_reason = _validated_policy_bundle_payload(policy_bundle)
+            validated_policy_bundle, rejection_reason, trusted_policy_bundle_keys = validate_synced_policy_bundle(
+                policy_bundle,
+                stored_keyring=self.server.store.get_sync_payload("policy_bundle_keyring"),  # type: ignore[attr-defined]
+                sync_payload=payload if isinstance(payload, dict) else None,
+            )
             existing_policy_bundle_payload = self.server.store.get_sync_payload("policy_bundle")  # type: ignore[attr-defined]
             existing_policy_bundle = (
                 existing_policy_bundle_payload if isinstance(existing_policy_bundle_payload, dict) else None
@@ -1820,6 +1827,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             applied_at = _now()
             self.server.store.set_sync_payload("policy_bundle", validated_policy_bundle, applied_at)  # type: ignore[attr-defined]
             self.server.store.set_sync_payload("policy_bundle_last_good", validated_policy_bundle, applied_at)  # type: ignore[attr-defined]
+            self.server.store.set_sync_payload(  # type: ignore[attr-defined]
+                "policy_bundle_keyring",
+                policy_bundle_keyring_payload(
+                    trusted_policy_bundle_keys,
+                    workspace_id=self.server.store.get_cloud_workspace_id(),  # type: ignore[attr-defined]
+                ),
+                applied_at,
+            )
             device_id, device_name = _guard_device_metadata(self.server.store)  # type: ignore[attr-defined]
             self.server.store.set_sync_payload(  # type: ignore[attr-defined]
                 "policy_bundle_ack",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -105,11 +105,11 @@ from ..package_firewall_entitlement import (
 )
 from ..package_firewall_receipts import package_firewall_receipt_metadata
 from ..package_shim_status import record_package_shim_audit_result
-from ..receipts.manager import build_receipt
 from ..policy_bundle_trusted_keys import (
     policy_bundle_keyring_payload,
     validate_synced_policy_bundle,
 )
+from ..receipts.manager import build_receipt
 from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
     GuardSyncNotAvailableError,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1810,6 +1810,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 policy_bundle,
                 stored_keyring=self.server.store.get_sync_payload("policy_bundle_keyring"),  # type: ignore[attr-defined]
                 sync_payload=payload if isinstance(payload, dict) else None,
+                supply_chain_keyring=self.server.store.get_sync_payload("supply_chain_bundle_keyring"),  # type: ignore[attr-defined]
             )
             existing_policy_bundle_payload = self.server.store.get_sync_payload("policy_bundle")  # type: ignore[attr-defined]
             existing_policy_bundle = (

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -15,6 +15,7 @@ from .policy_bundle_trusted_keys import (
     PolicyBundleVerificationKey,
     policy_bundle_key_fingerprint,
     resolve_policy_bundle_signing_key,
+    signing_key_is_current,
     signing_key_is_trusted,
 )
 
@@ -189,7 +190,7 @@ def _verify_policy_bundle_signature(
         bundled_fingerprint = policy_bundle_key_fingerprint(bundled_public_key_pem)
         if bundled_fingerprint != signing_key.fingerprint_sha256:
             return "untrusted_signing_key"
-    if signing_key.state == "revoked":
+    if not signing_key_is_current(signing_key):
         return "untrusted_signing_key"
     try:
         public_key = serialization.load_pem_public_key(signing_key.public_key_pem.encode("utf-8"))

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -11,6 +11,13 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
+from .policy_bundle_trusted_keys import (
+    PolicyBundleVerificationKey,
+    policy_bundle_key_fingerprint,
+    resolve_policy_bundle_signing_key,
+    signing_key_is_trusted,
+)
+
 _POLICY_BUNDLE_CORE_KEYS = (
     "contractVersion",
     "bundleVersion",
@@ -156,6 +163,9 @@ def payload_hash_for_policy_bundle(policy_bundle: dict[str, object]) -> str:
 def _verify_policy_bundle_signature(
     policy_bundle: dict[str, object],
     canonical_payload: bytes,
+    *,
+    trusted_verification_keys: tuple[PolicyBundleVerificationKey, ...],
+    anchored_verification_keys: tuple[PolicyBundleVerificationKey, ...],
 ) -> str | None:
     verifier = policy_bundle.get("verifier")
     if not isinstance(verifier, dict):
@@ -165,12 +175,24 @@ def _verify_policy_bundle_signature(
         return None
     if algorithm != "rsa-pss-sha256":
         return "invalid_verifier"
-    public_key_pem = _non_empty_string(verifier.get("publicKeyPem"))
+    key_id = _non_empty_string(verifier.get("keyId"))
     signature = _non_empty_string(verifier.get("signature"))
-    if public_key_pem is None or signature is None:
+    if key_id is None or signature is None:
         return "invalid_verifier"
+    signing_key = resolve_policy_bundle_signing_key(key_id, trusted_verification_keys)
+    if signing_key is None:
+        return "untrusted_signing_key"
+    if not signing_key_is_trusted(signing_key, anchored_verification_keys):
+        return "untrusted_signing_key"
+    bundled_public_key_pem = _non_empty_string(verifier.get("publicKeyPem"))
+    if bundled_public_key_pem is not None:
+        bundled_fingerprint = policy_bundle_key_fingerprint(bundled_public_key_pem)
+        if bundled_fingerprint != signing_key.fingerprint_sha256:
+            return "untrusted_signing_key"
+    if signing_key.state == "revoked":
+        return "untrusted_signing_key"
     try:
-        public_key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
+        public_key = serialization.load_pem_public_key(signing_key.public_key_pem.encode("utf-8"))
     except (UnsupportedAlgorithm, ValueError, TypeError):
         return "invalid_verifier"
     if not isinstance(public_key, RSAPublicKey):
@@ -193,6 +215,9 @@ def _verify_policy_bundle_signature(
 
 def validated_policy_bundle_payload(
     policy_bundle: dict[str, object],
+    *,
+    trusted_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
+    anchored_verification_keys: tuple[PolicyBundleVerificationKey, ...] = (),
 ) -> tuple[dict[str, object] | None, str | None]:
     required_top_level = (*_POLICY_BUNDLE_CORE_KEYS, "bundleHash", "acknowledgements")
     if any(key not in policy_bundle for key in required_top_level):
@@ -258,7 +283,12 @@ def validated_policy_bundle_payload(
     computed_hash = computed_policy_bundle_hash(policy_bundle)
     if bundle_hash != computed_hash:
         return None, "bundle_hash_mismatch"
-    signature_error = _verify_policy_bundle_signature(policy_bundle, canonical_payload)
+    signature_error = _verify_policy_bundle_signature(
+        policy_bundle,
+        canonical_payload,
+        trusted_verification_keys=trusted_verification_keys,
+        anchored_verification_keys=anchored_verification_keys,
+    )
     if signature_error is not None:
         return None, signature_error
     payload = {

--- a/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import hashlib
+import time
 from dataclasses import dataclass
+
+from .runtime.supply_chain_bundle_base import _parse_iso_timestamp
 
 _VERIFICATION_KEY_STATES = frozenset({"active", "grace", "revoked"})
 
@@ -89,6 +92,32 @@ def load_policy_bundle_verification_keys(raw: object) -> tuple[PolicyBundleVerif
     return tuple(parsed)
 
 
+def safe_load_policy_bundle_verification_keys(raw: object) -> tuple[PolicyBundleVerificationKey, ...]:
+    try:
+        return load_policy_bundle_verification_keys(raw)
+    except ValueError:
+        return ()
+
+
+def policy_bundle_keys_from_supply_chain_keyring(raw: object) -> tuple[PolicyBundleVerificationKey, ...]:
+    from .runtime.supply_chain_bundle_runtime import load_supply_chain_verification_keys
+
+    try:
+        supply_chain_keys = load_supply_chain_verification_keys(raw)
+    except Exception:
+        return ()
+    return tuple(
+        PolicyBundleVerificationKey(
+            key_id=item.key_id,
+            public_key_pem=item.public_key_pem,
+            fingerprint_sha256=item.fingerprint_sha256,
+            state=item.state,
+            valid_until=item.valid_until,
+        )
+        for item in supply_chain_keys
+    )
+
+
 def builtin_policy_bundle_verification_keys() -> tuple[PolicyBundleVerificationKey, ...]:
     return ()
 
@@ -118,16 +147,33 @@ def signing_key_is_trusted(
     anchored_keys: tuple[PolicyBundleVerificationKey, ...],
 ) -> bool:
     if not anchored_keys:
-        return True
+        return False
     trusted_fingerprints = {item.fingerprint_sha256 for item in anchored_keys}
     return signing_key.fingerprint_sha256 in trusted_fingerprints
+
+
+def signing_key_is_current(
+    signing_key: PolicyBundleVerificationKey,
+    *,
+    now: float | None = None,
+) -> bool:
+    if signing_key.state == "revoked":
+        return False
+    if signing_key.valid_until is None:
+        return True
+    current_time = now if now is not None else time.time()
+    try:
+        expiry = _parse_iso_timestamp(signing_key.valid_until, field_name="validUntil")
+    except ValueError:
+        return False
+    return current_time <= expiry
 
 
 def load_policy_bundle_verification_keys_from_sync(payload: dict[str, object]) -> tuple[PolicyBundleVerificationKey, ...]:
     verification_keys = payload.get("policyBundleVerificationKeys")
     if verification_keys is None:
         return ()
-    return load_policy_bundle_verification_keys(verification_keys)
+    return safe_load_policy_bundle_verification_keys(verification_keys)
 
 
 def policy_bundle_keyring_payload(
@@ -147,12 +193,14 @@ def policy_bundle_verification_context(
     *,
     stored_keyring: object,
     sync_payload: dict[str, object] | None = None,
+    supply_chain_keyring: object = None,
 ) -> tuple[tuple[PolicyBundleVerificationKey, ...], tuple[PolicyBundleVerificationKey, ...]]:
     builtin_keys = builtin_policy_bundle_verification_keys()
-    stored_keys = load_policy_bundle_verification_keys(stored_keyring)
+    stored_keys = safe_load_policy_bundle_verification_keys(stored_keyring)
+    supply_chain_keys = policy_bundle_keys_from_supply_chain_keyring(supply_chain_keyring)
     sync_keys = load_policy_bundle_verification_keys_from_sync(sync_payload or {})
-    trusted_keys = merge_policy_bundle_trusted_keys(builtin_keys, stored_keys, sync_keys)
-    anchored_keys = merge_policy_bundle_trusted_keys(builtin_keys, stored_keys)
+    trusted_keys = merge_policy_bundle_trusted_keys(builtin_keys, stored_keys, supply_chain_keys, sync_keys)
+    anchored_keys = merge_policy_bundle_trusted_keys(builtin_keys, stored_keys, supply_chain_keys)
     return trusted_keys, anchored_keys
 
 
@@ -161,10 +209,12 @@ def validate_synced_policy_bundle(
     *,
     stored_keyring: object,
     sync_payload: dict[str, object] | None = None,
+    supply_chain_keyring: object = None,
 ) -> tuple[dict[str, object] | None, str | None, tuple[PolicyBundleVerificationKey, ...]]:
     trusted_keys, anchored_keys = policy_bundle_verification_context(
         stored_keyring=stored_keyring,
         sync_payload=sync_payload,
+        supply_chain_keyring=supply_chain_keyring,
     )
     from .policy_bundle_parser import validated_policy_bundle_payload
 

--- a/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
@@ -1,0 +1,201 @@
+"""Trusted verification keys for Guard Cloud policy bundle signatures."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+
+_VERIFICATION_KEY_STATES = frozenset({"active", "grace", "revoked"})
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyBundleVerificationKey:
+    key_id: str
+    public_key_pem: str
+    fingerprint_sha256: str
+    state: str = "active"
+    valid_until: str | None = None
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "fingerprintSha256": self.fingerprint_sha256,
+            "keyId": self.key_id,
+            "publicKeyPem": self.public_key_pem,
+            "state": self.state,
+            "validUntil": self.valid_until,
+        }
+
+    @staticmethod
+    def from_dict(data: dict[str, object]) -> PolicyBundleVerificationKey:
+        key_id = data.get("keyId")
+        public_key_pem = data.get("publicKeyPem")
+        fingerprint = data.get("fingerprintSha256")
+        if not isinstance(key_id, str) or not key_id.strip():
+            raise ValueError("invalid_policy_bundle_verification_key:keyId")
+        if not isinstance(public_key_pem, str) or not public_key_pem.strip():
+            raise ValueError("invalid_policy_bundle_verification_key:publicKeyPem")
+        if not isinstance(fingerprint, str) or not fingerprint.strip():
+            raise ValueError("invalid_policy_bundle_verification_key:fingerprintSha256")
+        state = data.get("state")
+        normalized_state = state if isinstance(state, str) and state in _VERIFICATION_KEY_STATES else "active"
+        valid_until = data.get("validUntil")
+        normalized_valid_until = valid_until if isinstance(valid_until, str) and valid_until.strip() else None
+        normalized_pem = public_key_pem.replace("\r\n", "\n").strip()
+        computed_fingerprint = policy_bundle_key_fingerprint(normalized_pem)
+        if fingerprint.strip() != computed_fingerprint:
+            raise ValueError("invalid_policy_bundle_verification_key:fingerprint_mismatch")
+        return PolicyBundleVerificationKey(
+            key_id=key_id.strip(),
+            public_key_pem=normalized_pem,
+            fingerprint_sha256=computed_fingerprint,
+            state=normalized_state,
+            valid_until=normalized_valid_until,
+        )
+
+
+def policy_bundle_key_fingerprint(public_key_pem: str) -> str:
+    normalized_pem = public_key_pem.replace("\r\n", "\n").strip()
+    return hashlib.sha256(normalized_pem.encode("utf-8")).hexdigest()
+
+
+def policy_bundle_verification_key_from_public_key(
+    *,
+    key_id: str,
+    public_key_pem: str,
+    state: str = "active",
+    valid_until: str | None = None,
+) -> PolicyBundleVerificationKey:
+    normalized_pem = public_key_pem.replace("\r\n", "\n").strip()
+    return PolicyBundleVerificationKey(
+        key_id=key_id.strip(),
+        public_key_pem=normalized_pem,
+        fingerprint_sha256=policy_bundle_key_fingerprint(normalized_pem),
+        state=state,
+        valid_until=valid_until,
+    )
+
+
+def load_policy_bundle_verification_keys(raw: object) -> tuple[PolicyBundleVerificationKey, ...]:
+    raw_keys = raw
+    if isinstance(raw, dict):
+        raw_keys = raw.get("keys")
+    if not isinstance(raw_keys, list):
+        return ()
+    parsed: list[PolicyBundleVerificationKey] = []
+    for item in raw_keys:
+        if not isinstance(item, dict):
+            raise ValueError("invalid_policy_bundle_verification_keys")
+        parsed.append(PolicyBundleVerificationKey.from_dict(item))
+    return tuple(parsed)
+
+
+def builtin_policy_bundle_verification_keys() -> tuple[PolicyBundleVerificationKey, ...]:
+    return ()
+
+
+def merge_policy_bundle_trusted_keys(
+    *sources: tuple[PolicyBundleVerificationKey, ...],
+) -> tuple[PolicyBundleVerificationKey, ...]:
+    merged: dict[str, PolicyBundleVerificationKey] = {}
+    for source in sources:
+        for key in source:
+            merged[key.key_id] = key
+    return tuple(merged[key_id] for key_id in sorted(merged))
+
+
+def resolve_policy_bundle_signing_key(
+    key_id: str,
+    trusted_keys: tuple[PolicyBundleVerificationKey, ...],
+) -> PolicyBundleVerificationKey | None:
+    for key in trusted_keys:
+        if key.key_id == key_id:
+            return key
+    return None
+
+
+def signing_key_is_trusted(
+    signing_key: PolicyBundleVerificationKey,
+    anchored_keys: tuple[PolicyBundleVerificationKey, ...],
+) -> bool:
+    if not anchored_keys:
+        return True
+    trusted_fingerprints = {item.fingerprint_sha256 for item in anchored_keys}
+    return signing_key.fingerprint_sha256 in trusted_fingerprints
+
+
+def load_policy_bundle_verification_keys_from_sync(payload: dict[str, object]) -> tuple[PolicyBundleVerificationKey, ...]:
+    verification_keys = payload.get("policyBundleVerificationKeys")
+    if verification_keys is None:
+        return ()
+    return load_policy_bundle_verification_keys(verification_keys)
+
+
+def policy_bundle_keyring_payload(
+    keys: tuple[PolicyBundleVerificationKey, ...],
+    *,
+    workspace_id: str | None,
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "keys": [item.to_dict() for item in keys],
+    }
+    if workspace_id is not None:
+        payload["workspace_id"] = workspace_id
+    return payload
+
+
+def policy_bundle_verification_context(
+    *,
+    stored_keyring: object,
+    sync_payload: dict[str, object] | None = None,
+) -> tuple[tuple[PolicyBundleVerificationKey, ...], tuple[PolicyBundleVerificationKey, ...]]:
+    builtin_keys = builtin_policy_bundle_verification_keys()
+    stored_keys = load_policy_bundle_verification_keys(stored_keyring)
+    sync_keys = load_policy_bundle_verification_keys_from_sync(sync_payload or {})
+    trusted_keys = merge_policy_bundle_trusted_keys(builtin_keys, stored_keys, sync_keys)
+    anchored_keys = merge_policy_bundle_trusted_keys(builtin_keys, stored_keys)
+    return trusted_keys, anchored_keys
+
+
+def validate_synced_policy_bundle(
+    policy_bundle: dict[str, object],
+    *,
+    stored_keyring: object,
+    sync_payload: dict[str, object] | None = None,
+) -> tuple[dict[str, object] | None, str | None, tuple[PolicyBundleVerificationKey, ...]]:
+    trusted_keys, anchored_keys = policy_bundle_verification_context(
+        stored_keyring=stored_keyring,
+        sync_payload=sync_payload,
+    )
+    from .policy_bundle_parser import validated_policy_bundle_payload
+
+    validated_bundle, rejection_reason = validated_policy_bundle_payload(
+        policy_bundle,
+        trusted_verification_keys=trusted_keys,
+        anchored_verification_keys=anchored_keys,
+    )
+    if validated_bundle is None:
+        return None, rejection_reason, trusted_keys
+    updated_keys = persistable_policy_bundle_keyring(
+        trusted_keys=trusted_keys,
+        policy_bundle=validated_bundle,
+    )
+    return validated_bundle, None, updated_keys
+
+
+def persistable_policy_bundle_keyring(
+    *,
+    trusted_keys: tuple[PolicyBundleVerificationKey, ...],
+    policy_bundle: dict[str, object],
+) -> tuple[PolicyBundleVerificationKey, ...]:
+    verifier = policy_bundle.get("verifier")
+    if not isinstance(verifier, dict):
+        return trusted_keys
+    if verifier.get("algorithm") != "rsa-pss-sha256":
+        return trusted_keys
+    key_id = verifier.get("keyId")
+    if not isinstance(key_id, str) or not key_id.strip():
+        return trusted_keys
+    signing_key = resolve_policy_bundle_signing_key(key_id.strip(), trusted_keys)
+    if signing_key is None:
+        return trusted_keys
+    return merge_policy_bundle_trusted_keys(trusted_keys, (signing_key,))

--- a/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_trusted_keys.py
@@ -169,7 +169,9 @@ def signing_key_is_current(
     return current_time <= expiry
 
 
-def load_policy_bundle_verification_keys_from_sync(payload: dict[str, object]) -> tuple[PolicyBundleVerificationKey, ...]:
+def load_policy_bundle_verification_keys_from_sync(
+    payload: dict[str, object],
+) -> tuple[PolicyBundleVerificationKey, ...]:
     verification_keys = payload.get("policyBundleVerificationKeys")
     if verification_keys is None:
         return ()

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -46,9 +46,6 @@ from ..policy_bundle_parser import (
     computed_policy_bundle_hash,
     non_empty_string,
 )
-from ..policy_bundle_parser import (
-    validated_policy_bundle_payload as _validated_policy_bundle_payload,
-)
 from ..policy_bundle_trusted_keys import (
     policy_bundle_keyring_payload,
     validate_synced_policy_bundle,
@@ -1242,6 +1239,7 @@ def sync_receipts(
                 policy_bundle_payload,
                 stored_keyring=store.get_sync_payload("policy_bundle_keyring"),
                 sync_payload=policy_bundle_sync_payload,
+                supply_chain_keyring=store.get_sync_payload("supply_chain_bundle_keyring"),
             )
         )
         existing_policy_bundle_payload = store.get_sync_payload("policy_bundle")

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -49,6 +49,10 @@ from ..policy_bundle_parser import (
 from ..policy_bundle_parser import (
     validated_policy_bundle_payload as _validated_policy_bundle_payload,
 )
+from ..policy_bundle_trusted_keys import (
+    policy_bundle_keyring_payload,
+    validate_synced_policy_bundle,
+)
 from ..redaction import redact_sensitive_text
 from ..shims import package_shim_cloud_coverage
 from ..store import GuardStore
@@ -1136,6 +1140,7 @@ def sync_receipts(
     exceptions_payload: list[dict[str, object]] = []
     policy_payload: dict[str, object] | None = None
     policy_bundle_payload: dict[str, object] | None = None
+    policy_bundle_sync_payload: dict[str, object] | None = None
     alert_preferences_payload: dict[str, object] | None = None
     team_policy_pack_payload: dict[str, object] | None = None
     remote_decisions: set[PolicyDecision] = set()
@@ -1204,6 +1209,7 @@ def sync_receipts(
         policy_bundle = payload.get("policyBundle")
         if isinstance(policy_bundle, dict) and (policy_bundle or policy_bundle_payload is None):
             policy_bundle_payload = policy_bundle
+            policy_bundle_sync_payload = payload
         alert_preferences = payload.get("alertPreferences")
         if isinstance(alert_preferences, dict) and (alert_preferences or alert_preferences_payload is None):
             alert_preferences_payload = alert_preferences
@@ -1231,8 +1237,12 @@ def sync_receipts(
     else:
         store.set_sync_payload("policy", {}, now)
     if policy_bundle_payload is not None:
-        validated_policy_bundle, policy_bundle_rejection_reason = _validated_policy_bundle_payload(
-            policy_bundle_payload
+        validated_policy_bundle, policy_bundle_rejection_reason, trusted_policy_bundle_keys = (
+            validate_synced_policy_bundle(
+                policy_bundle_payload,
+                stored_keyring=store.get_sync_payload("policy_bundle_keyring"),
+                sync_payload=policy_bundle_sync_payload,
+            )
         )
         existing_policy_bundle_payload = store.get_sync_payload("policy_bundle")
         existing_policy_bundle = (
@@ -1261,6 +1271,14 @@ def sync_receipts(
         if validated_policy_bundle is not None:
             store.set_sync_payload("policy_bundle", validated_policy_bundle, now)
             store.set_sync_payload("policy_bundle_last_good", validated_policy_bundle, now)
+            store.set_sync_payload(
+                "policy_bundle_keyring",
+                policy_bundle_keyring_payload(
+                    trusted_policy_bundle_keys,
+                    workspace_id=store.get_cloud_workspace_id(),
+                ),
+                now,
+            )
             store.set_sync_payload(
                 "policy_bundle_ack",
                 _policy_bundle_acknowledgement_payload(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -42,6 +42,7 @@ from codex_plugin_scanner.guard.models import (
     PolicyDecision,
 )
 from codex_plugin_scanner.guard.policy import decide_action, decide_action_with_v2
+from codex_plugin_scanner.guard.policy_bundle_parser import validated_policy_bundle_payload
 from codex_plugin_scanner.guard.proxy import RemoteGuardProxy, StdioGuardProxy
 from codex_plugin_scanner.guard.proxy import stdio as stdio_proxy_module
 from codex_plugin_scanner.guard.receipts import build_receipt
@@ -16808,7 +16809,7 @@ def test_policy_bundle_validation_rejects_tampered_hash():
         "acknowledgements": [],
     }
 
-    validated_bundle, reason = guard_runner_module._validated_policy_bundle_payload(bundle)
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
 
     assert validated_bundle is None
     assert reason == "bundle_hash_mismatch"
@@ -16870,7 +16871,7 @@ def test_policy_bundle_validation_rejects_missing_rules_field():
         "acknowledgements": [],
     }
 
-    validated_bundle, reason = guard_runner_module._validated_policy_bundle_payload(bundle)
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
 
     assert validated_bundle is None
     assert reason == "missing_required_field"

--- a/tests/test_policy_bundle_parser.py
+++ b/tests/test_policy_bundle_parser.py
@@ -16,6 +16,7 @@ from codex_plugin_scanner.guard.policy_bundle_parser import (
 )
 from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
     policy_bundle_verification_key_from_public_key,
+    validate_synced_policy_bundle,
 )
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -124,6 +125,7 @@ def test_hgc071_signed_policy_bundle_parses() -> None:
     validated_bundle, reason = validated_policy_bundle_payload(
         bundle,
         trusted_verification_keys=trusted_keys,
+        anchored_verification_keys=trusted_keys,
     )
 
     assert reason is None
@@ -144,6 +146,7 @@ def test_hgc073_signed_policy_bundle_rejects_invalid_signature() -> None:
     validated_bundle, reason = validated_policy_bundle_payload(
         bundle,
         trusted_verification_keys=trusted_keys,
+        anchored_verification_keys=trusted_keys,
     )
 
     assert validated_bundle is None
@@ -304,10 +307,64 @@ def test_signed_policy_bundle_accepts_trusted_sync_verification_keys() -> None:
     validated_bundle, reason = validated_policy_bundle_payload(
         bundle,
         trusted_verification_keys=trusted_keys,
+        anchored_verification_keys=trusted_keys,
     )
 
     assert reason is None
     assert validated_bundle is not None
+
+
+def test_signed_policy_bundle_rejects_sync_only_keys_without_anchor() -> None:
+    bundle, trusted_keys = _signed_policy_bundle()
+    sync_payload = {
+        "policyBundleVerificationKeys": [trusted_keys[0].to_dict()],
+    }
+
+    validated_bundle, reason, _ = validate_synced_policy_bundle(
+        bundle,
+        stored_keyring=None,
+        sync_payload=sync_payload,
+    )
+
+    assert validated_bundle is None
+    assert reason == "untrusted_signing_key"
+
+
+def test_validate_synced_policy_bundle_ignores_malformed_sync_keyring() -> None:
+    bundle, trusted_keys = _signed_policy_bundle()
+    stored_keyring = {
+        "keys": [trusted_keys[0].to_dict()],
+    }
+    sync_payload = {
+        "policyBundleVerificationKeys": ["not-a-key-object"],
+    }
+
+    validated_bundle, reason, _ = validate_synced_policy_bundle(
+        bundle,
+        stored_keyring=stored_keyring,
+        sync_payload=sync_payload,
+    )
+
+    assert reason is None
+    assert validated_bundle is not None
+
+
+def test_signed_policy_bundle_rejects_expired_signing_key() -> None:
+    bundle, trusted_keys = _signed_policy_bundle()
+    expired_key = policy_bundle_verification_key_from_public_key(
+        key_id=trusted_keys[0].key_id,
+        public_key_pem=trusted_keys[0].public_key_pem,
+        valid_until="2020-01-01T00:00:00Z",
+    )
+
+    validated_bundle, reason = validated_policy_bundle_payload(
+        bundle,
+        trusted_verification_keys=(expired_key,),
+        anchored_verification_keys=(expired_key,),
+    )
+
+    assert validated_bundle is None
+    assert reason == "untrusted_signing_key"
 
 
 def test_hgc075_updates_last_known_good_on_valid_replacement(tmp_path: Path) -> None:

--- a/tests/test_policy_bundle_parser.py
+++ b/tests/test_policy_bundle_parser.py
@@ -14,6 +14,9 @@ from codex_plugin_scanner.guard.policy_bundle_parser import (
     payload_hash_for_policy_bundle,
     validated_policy_bundle_payload,
 )
+from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
+    policy_bundle_verification_key_from_public_key,
+)
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -69,17 +72,24 @@ def _sample_policy_bundle(*, bundle_hash: str | None = None) -> dict[str, object
     return bundle
 
 
-def _signed_policy_bundle() -> dict[str, object]:
+def _signed_policy_bundle(
+    *,
+    key_id: str = "guard-policy-bundle-test-key",
+) -> tuple[dict[str, object], tuple[object, ...]]:
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     public_key_pem = private_key.public_key().public_bytes(
         encoding=serialization.Encoding.PEM,
         format=serialization.PublicFormat.SubjectPublicKeyInfo,
     ).decode('utf-8')
+    trusted_key = policy_bundle_verification_key_from_public_key(
+        key_id=key_id,
+        public_key_pem=public_key_pem,
+    )
     bundle = _sample_policy_bundle()
     bundle['workspaceId'] = 'workspace-1'
     verifier = dict(bundle['verifier']) if isinstance(bundle['verifier'], dict) else {}
     verifier['algorithm'] = 'rsa-pss-sha256'
-    verifier['keyId'] = 'guard-policy-bundle-test-key'
+    verifier['keyId'] = key_id
     verifier['publicKeyPem'] = public_key_pem
     verifier['signature'] = None
     bundle['verifier'] = verifier
@@ -93,7 +103,7 @@ def _signed_policy_bundle() -> dict[str, object]:
         )
     ).decode('utf-8')
     bundle['verifier'] = verifier
-    return bundle
+    return bundle, (trusted_key,)
 
 
 def test_hgc071_valid_policy_bundle_parses() -> None:
@@ -109,9 +119,12 @@ def test_hgc071_valid_policy_bundle_parses() -> None:
 
 
 def test_hgc071_signed_policy_bundle_parses() -> None:
-    bundle = _signed_policy_bundle()
+    bundle, trusted_keys = _signed_policy_bundle()
 
-    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+    validated_bundle, reason = validated_policy_bundle_payload(
+        bundle,
+        trusted_verification_keys=trusted_keys,
+    )
 
     assert reason is None
     assert validated_bundle is not None
@@ -123,20 +136,23 @@ def test_hgc071_signed_policy_bundle_parses() -> None:
 
 
 def test_hgc073_signed_policy_bundle_rejects_invalid_signature() -> None:
-    bundle = _signed_policy_bundle()
+    bundle, trusted_keys = _signed_policy_bundle()
     verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}
     verifier["signature"] = base64.b64encode(b"tampered-signature").decode('utf-8')
     bundle["verifier"] = verifier
 
-    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+    validated_bundle, reason = validated_policy_bundle_payload(
+        bundle,
+        trusted_verification_keys=trusted_keys,
+    )
 
     assert validated_bundle is None
     assert reason == "bundle_signature_invalid"
 
 
 def test_hgc073_bundle_hash_ignores_public_key_rotation() -> None:
-    first_bundle = _signed_policy_bundle()
-    second_bundle = _signed_policy_bundle()
+    first_bundle, _ = _signed_policy_bundle()
+    second_bundle, _ = _signed_policy_bundle()
     first_verifier = first_bundle["verifier"]
     second_verifier = second_bundle["verifier"]
 
@@ -249,6 +265,49 @@ def test_hgc075_preserves_last_known_good_policy_on_invalid_update(tmp_path: Pat
     assert store.get_sync_payload("policy_bundle_last_error") == {
         "reason": "missing_required_field",
     }
+
+
+def test_signed_policy_bundle_rejects_attacker_self_signed_key() -> None:
+    attacker_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    attacker_public_key_pem = attacker_private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("utf-8")
+    bundle = _sample_policy_bundle()
+    bundle["workspaceId"] = "workspace-1"
+    verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}
+    verifier["algorithm"] = "rsa-pss-sha256"
+    verifier["keyId"] = "guard-policy-bundle-v1"
+    verifier["publicKeyPem"] = attacker_public_key_pem
+    verifier["signature"] = None
+    bundle["verifier"] = verifier
+    bundle["bundleHash"] = computed_policy_bundle_hash(bundle)
+    bundle["payloadHash"] = payload_hash_for_policy_bundle(bundle)
+    verifier["signature"] = base64.b64encode(
+        attacker_private_key.sign(
+            canonical_policy_bundle_payload(bundle),
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+    ).decode("utf-8")
+    bundle["verifier"] = verifier
+
+    validated_bundle, reason = validated_policy_bundle_payload(bundle)
+
+    assert validated_bundle is None
+    assert reason == "untrusted_signing_key"
+
+
+def test_signed_policy_bundle_accepts_trusted_sync_verification_keys() -> None:
+    bundle, trusted_keys = _signed_policy_bundle()
+
+    validated_bundle, reason = validated_policy_bundle_payload(
+        bundle,
+        trusted_verification_keys=trusted_keys,
+    )
+
+    assert reason is None
+    assert validated_bundle is not None
 
 
 def test_hgc075_updates_last_known_good_on_valid_replacement(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Anchor RSA policy bundle verification to trusted keyIds from built-in, stored, and sync keyrings instead of bundle-embedded publicKeyPem
- Reject attacker self-signed bundles with `untrusted_signing_key` while preserving sha256 legacy integrity checks
- Persist verified policy bundle signing keys to `policy_bundle_keyring` after successful cloud/daemon sync

## Testing
- `python3 -m pytest tests/test_policy_bundle_parser.py -q`
- `python3 -m pytest tests/test_guard_runtime.py::test_policy_bundle_validation_rejects_missing_rules_field tests/test_guard_runtime.py::test_sync_receipts_preserves_last_known_good_policy_bundle_on_invalid_update -q`

## Notes
- Cloud sync can bootstrap RSA verification via optional `policyBundleVerificationKeys` in the sync response; hol-points-portal follow-up may be needed to emit that field in production.
