### PR TITLE
feat(guard): mention insights share referral CTA in share sheet

### DIFF
--- a/dashboard/src/evidence/evidence-insights-share-sheet.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-sheet.tsx
@@ -64,7 +64,7 @@ export function EvidenceInsightsShareSheet({ publicUrl, onClose }: EvidenceInsig
           <p className="mt-1 text-xs text-slate-500">
             Visitors who sign up through it get 20% off HOL Guard Pro or Team for 12 months. Track referrals and payouts in the{" "}
             <a
-              href="https://hol.org/guard/affiliate"
+              href="https://hol.org/guard/affiliates"
               target="_blank"
               rel="noopener noreferrer"
               className="font-medium text-brand-blue hover:underline"

--- a/dashboard/src/evidence/evidence-insights-share-sheet.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-sheet.tsx
@@ -59,6 +59,22 @@ export function EvidenceInsightsShareSheet({ publicUrl, onClose }: EvidenceInsig
           {publicUrl}
         </div>
 
+        <div className="mt-4 rounded-xl border border-brand-blue/10 bg-gradient-to-br from-white to-[#f0f6ff] px-4 py-3">
+          <p className="text-sm font-medium text-brand-dark">A referral link is shown on your public stats page.</p>
+          <p className="mt-1 text-xs text-slate-500">
+            Visitors who sign up through it get 20% off HOL Guard Pro or Team for 12 months. Track referrals and payouts in the{" "}
+            <a
+              href="https://hol.org/guard/affiliate"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-brand-blue hover:underline"
+            >
+              affiliate dashboard
+            </a>
+            .
+          </p>
+        </div>
+
         <div className="mt-4 flex flex-wrap gap-2">
           <button
             type="button"


### PR DESCRIPTION
## Summary
- Add a note in the insights share sheet informing the owner that their public stats page now displays a referral link.
- Link to the affiliate dashboard so owners can track referrals and payouts.

## Testing
- `cd dashboard && node ./node_modules/vite/bin/vite.js build`
