### PR TITLE
fix(guard): treat successful pipx repairs as updates

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -134,33 +134,19 @@ def run_guard_update(
         post_version_check,
         resulting_version,
     )
+    nonzero_success_note: str | None = None
     if result.returncode != 0:
         if _version_changed(current_version, resulting_version):
-            payload["status"] = _success_status(payload)
-            payload["changed"] = True
-            stale_retry_command = _stale_retry_command(payload)
-            if stale_retry_command:
-                payload["retry_command"] = stale_retry_command
-            payload["message"] = _success_message(
-                status=str(payload["status"]),
-                current_version=current_version,
-                resulting_version=resulting_version,
-                version_check=payload.get("version_check"),
-                retry_command=stale_retry_command,
-            )
-            notes = _success_notes(payload)
-            payload_notes = [*notes]
-            payload_notes.append(
+            nonzero_success_note = (
                 "Installer exited with code "
                 f"{result.returncode} after version changed. "
                 "Review stderr for any follow-up action."
             )
-            payload["notes"] = payload_notes
-            return payload, 0
         payload["status"] = "failed"
         payload["changed"] = False
         payload["message"] = "HOL Guard update failed."
-        return payload, 1
+        if nonzero_success_note is None:
+            return payload, 1
     payload["status"] = _success_status(payload)
     payload["changed"] = _version_changed(current_version, resulting_version) or payload["status"] == "updated"
     stale_retry_command = _stale_retry_command(payload)
@@ -174,6 +160,8 @@ def run_guard_update(
         retry_command=stale_retry_command,
     )
     notes = _success_notes(payload)
+    if nonzero_success_note is not None:
+        notes = [*notes, nonzero_success_note]
     if notes:
         payload["notes"] = notes
     repaired_installs, repair_notes = _repair_supported_harnesses(

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -35,6 +35,13 @@ _PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
 _PYPI_TIMEOUT_SECONDS = 3.0
 
 
+def _read_direct_url_dir_info(direct_url: dict[str, object] | None) -> dict[str, object]:
+    if direct_url is None:
+        return {}
+    dir_info = direct_url.get("dir_info")
+    return dir_info if isinstance(dir_info, dict) else {}
+
+
 def run_guard_update(
     *,
     dry_run: bool,
@@ -55,7 +62,7 @@ def run_guard_update(
     }
     if direct_url is not None:
         payload["direct_url"] = direct_url
-        is_editable = bool(direct_url.get("dir_info", {}).get("editable"))
+        is_editable = bool(_read_direct_url_dir_info(direct_url).get("editable"))
         payload["editable_install"] = is_editable
         if local_source_install is not None:
             payload["source_install"] = local_source_install
@@ -118,11 +125,6 @@ def run_guard_update(
     payload["return_code"] = result.returncode
     importlib.invalidate_caches()
     payload["resulting_version"] = _current_version_from_subprocess()
-    if result.returncode != 0:
-        payload["status"] = "failed"
-        payload["changed"] = False
-        payload["message"] = "HOL Guard update failed."
-        return payload, 1
     initial_version_check = payload.get("version_check")
     resulting_version = str(payload.get("resulting_version") or current_version)
     post_version_check = _version_check_payload(resulting_version)
@@ -132,6 +134,33 @@ def run_guard_update(
         post_version_check,
         resulting_version,
     )
+    if result.returncode != 0:
+        if _version_changed(current_version, resulting_version):
+            payload["status"] = _success_status(payload)
+            payload["changed"] = True
+            stale_retry_command = _stale_retry_command(payload)
+            if stale_retry_command:
+                payload["retry_command"] = stale_retry_command
+            payload["message"] = _success_message(
+                status=str(payload["status"]),
+                current_version=current_version,
+                resulting_version=resulting_version,
+                version_check=payload.get("version_check"),
+                retry_command=stale_retry_command,
+            )
+            notes = _success_notes(payload)
+            payload_notes = [*notes]
+            payload_notes.append(
+                "Installer exited with code "
+                f"{result.returncode} after version changed. "
+                "Review stderr for any follow-up action."
+            )
+            payload["notes"] = payload_notes
+            return payload, 0
+        payload["status"] = "failed"
+        payload["changed"] = False
+        payload["message"] = "HOL Guard update failed."
+        return payload, 1
     payload["status"] = _success_status(payload)
     payload["changed"] = _version_changed(current_version, resulting_version) or payload["status"] == "updated"
     stale_retry_command = _stale_retry_command(payload)
@@ -166,9 +195,10 @@ def run_guard_update(
         if dashboard_sync:
             payload["dashboard_sync"] = dashboard_sync
             sync_notes = dashboard_sync.get("notes")
-            if sync_notes:
-                existing = payload.get("notes") or []
-                payload["notes"] = [*existing, *sync_notes]
+            if isinstance(sync_notes, list) and sync_notes:
+                existing = payload.get("notes")
+                existing_notes = existing if isinstance(existing, list) else []
+                payload["notes"] = [*existing_notes, *sync_notes]
     return payload, 0
 
 
@@ -670,7 +700,7 @@ def build_guard_update_status_payload() -> dict[str, object]:
     blocked_reason: str | None = None
 
     if isinstance(direct_url, dict):
-        if bool(direct_url.get("dir_info", {}).get("editable")):
+        if bool(_read_direct_url_dir_info(direct_url).get("editable")):
             auto_updatable = False
             blocked_reason = (
                 "This install was set up from local source code. Re-run your usual local install command instead."

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -192,6 +192,52 @@ def test_update_repairs_missing_pipx_local_source_install(monkeypatch: pytest.Mo
     assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.489."
 
 
+def test_update_treats_nonzero_pipx_repair_as_updated_when_version_changed(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    missing_dir = tmp_path / "missing-src-install"
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.345")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.628")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.628")
+    monkeypatch.setattr(
+        update_commands,
+        "_direct_url_payload",
+        lambda: {"dir_info": {}, "url": missing_dir.as_uri()},
+    )
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["pipx", "install", "--force", "hol-guard"]
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            "hol-guard 2.0.628 installed",
+            "TypeError: expected string or bytes-like object, got 'NoneType'",
+        )
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert payload["status"] == "updated"
+    assert payload["changed"] is True
+    assert payload["resulting_version"] == "2.0.628"
+    assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.628."
+    notes = payload.get("notes")
+    assert isinstance(notes, list)
+    assert any(
+        "Installer exited with code 1 after version changed." in str(note)
+        for note in notes
+    )
+
+
 def test_update_repairs_missing_pip_local_source_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     missing_dir = tmp_path / "missing-src-install"
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.489")

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -213,6 +213,7 @@ def test_update_treats_nonzero_pipx_repair_as_updated_when_version_changed(
         "which",
         lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
     )
+    monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: {"notes": ["synced dashboard"]})
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         assert command == ["pipx", "install", "--force", "hol-guard"]

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -123,6 +123,8 @@ def test_update_binary_diagnostics_treats_pipx_shim_as_healthy(monkeypatch: pyte
         "which",
         lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
     )
+    monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: {"notes": ["synced dashboard"]})
+    monkeypatch.setattr(update_commands, "_repair_supported_harnesses", lambda **_: ([], ["repaired codex hooks"]))
 
     payload, exit_code = update_commands.run_guard_update(dry_run=True)
 
@@ -230,6 +232,7 @@ def test_update_treats_nonzero_pipx_repair_as_updated_when_version_changed(
     assert payload["changed"] is True
     assert payload["resulting_version"] == "2.0.628"
     assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.628."
+    assert "dashboard_sync" in payload
     notes = payload.get("notes")
     assert isinstance(notes, list)
     assert any(


### PR DESCRIPTION
## Summary
- treat `hol-guard guard update` as successful when pipx reports a nonzero exit but the installed version actually changed
- preserve stderr diagnostics as notes so follow-up action is still visible without false-negative status

## Testing
- `pytest -q tests/test_guard_phase03_local_install.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_phase03_local_install.py`

## Notes
- this addresses the real pipx/local-source repair path where the package upgrades but pipx emits a metadata-inspection error afterward
