### PR TITLE
fix(guard): reject unsupported harness policy families

### DIFF
--- a/dashboard/src/policy-exception-form.tsx
+++ b/dashboard/src/policy-exception-form.tsx
@@ -9,10 +9,22 @@ import type { DecisionScope, GuardPolicyDecision } from "./guard-types";
 const ACTION_FAMILIES = [
   { id: "package-request", label: "Package installs", example: "npm, pip, pnpm installs" },
   { id: "tool-action", label: "Shell and tool commands", example: "terminal commands agents run" },
-  { id: "tool-output", label: "Command output", example: "reading prior command output" },
+  {
+    id: "tool-output",
+    label: "Command output",
+    example: "reading prior command output",
+    artifactScopeOnly: true as const,
+  },
   { id: "prompt", label: "Prompt submissions", example: "prompts sent to the model" },
   { id: "file-read", label: "File reads", example: "reading local files" },
 ] as const;
+
+type ActionFamilyId = (typeof ACTION_FAMILIES)[number]["id"];
+
+function familySupportsHarnessOrWorkspaceScope(familyId: ActionFamilyId): boolean {
+  const family = ACTION_FAMILIES.find((entry) => entry.id === familyId);
+  return family !== undefined && !("artifactScopeOnly" in family && family.artifactScopeOnly);
+}
 
 const RESPONSE_OPTIONS = [
   { id: "warn", label: "Warn me", description: "Show a warning but still allow unless I block it." },
@@ -52,6 +64,20 @@ export function PolicyExceptionForm({ policies, onSaved, onCancel }: PolicyExcep
     const defaults = ["codex", "cursor", "claude-code", "opencode", "copilot", "kimi"];
     return [...new Set([...fromPolicies, ...defaults])].sort();
   }, [policies]);
+
+  const scopeOptions = useMemo(() => {
+    if (familySupportsHarnessOrWorkspaceScope(family as ActionFamilyId)) {
+      return SCOPE_OPTIONS;
+    }
+    return SCOPE_OPTIONS.filter((option) => option.value === "artifact");
+  }, [family]);
+
+  const handleFamilySelect = useCallback((familyId: ActionFamilyId) => {
+    setFamily(familyId);
+    if (!familySupportsHarnessOrWorkspaceScope(familyId)) {
+      setScope("artifact");
+    }
+  }, []);
 
   const workspaceOptions = useMemo(() => {
     const fromPolicies = policies
@@ -207,7 +233,7 @@ export function PolicyExceptionForm({ policies, onSaved, onCancel }: PolicyExcep
               <button
                 key={option.id}
                 type="button"
-                onClick={() => setFamily(option.id)}
+                onClick={() => handleFamilySelect(option.id)}
                 aria-pressed={family === option.id}
                 className={`rounded-xl border px-3 py-3 text-left transition-colors ${
                   family === option.id
@@ -228,7 +254,7 @@ export function PolicyExceptionForm({ policies, onSaved, onCancel }: PolicyExcep
           <div className="space-y-2">
             <p className="text-sm font-medium text-brand-dark">How far should this reach?</p>
             <div className="grid gap-2">
-              {SCOPE_OPTIONS.map((option) => (
+              {scopeOptions.map((option) => (
                 <button
                   key={option.value}
                   type="button"

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -131,7 +131,7 @@ from ..shims import (
     uninstall_package_shims,
 )
 from ..stable_digest import stable_digest_hex
-from ..store import GuardStore
+from ..store import GuardStore, scoped_policy_artifact_target_is_valid
 from ..store_approvals import InvalidApprovalCursorError
 from ..store_evidence import (
     clear_evidence,
@@ -4310,6 +4310,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             payload["saved"] = False
             self._write_json(payload, status=error.status)
             return
+        except ValueError as error:
+            self._write_json({"saved": False, "error": str(error)}, status=400)
+            return
         self._write_json({"saved": True, "decision": record})
 
     @staticmethod
@@ -4454,7 +4457,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         publisher: str | None,
     ) -> bool:
         if scope in {"global", "harness"}:
-            return True
+            return scoped_policy_artifact_target_is_valid(scope, artifact_id)
         if scope == "artifact":
             return artifact_id is not None
         if scope == "workspace":

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -131,7 +131,7 @@ from ..shims import (
     uninstall_package_shims,
 )
 from ..stable_digest import stable_digest_hex
-from ..store import GuardStore, scoped_policy_artifact_target_is_valid
+from ..store import GuardStore
 from ..store_approvals import InvalidApprovalCursorError
 from ..store_evidence import (
     clear_evidence,
@@ -4457,7 +4457,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         publisher: str | None,
     ) -> bool:
         if scope in {"global", "harness"}:
-            return scoped_policy_artifact_target_is_valid(scope, artifact_id)
+            return True
         if scope == "artifact":
             return artifact_id is not None
         if scope == "workspace":

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
@@ -2,10 +2,19 @@ import { r as reactExports, b6 as savePolicyDecision, j as jsxRuntimeExports, S 
 const ACTION_FAMILIES = [
   { id: "package-request", label: "Package installs", example: "npm, pip, pnpm installs" },
   { id: "tool-action", label: "Shell and tool commands", example: "terminal commands agents run" },
-  { id: "tool-output", label: "Command output", example: "reading prior command output" },
+  {
+    id: "tool-output",
+    label: "Command output",
+    example: "reading prior command output",
+    artifactScopeOnly: true
+  },
   { id: "prompt", label: "Prompt submissions", example: "prompts sent to the model" },
   { id: "file-read", label: "File reads", example: "reading local files" }
 ];
+function familySupportsHarnessOrWorkspaceScope(familyId) {
+  const family = ACTION_FAMILIES.find((entry) => entry.id === familyId);
+  return family !== void 0 && !("artifactScopeOnly" in family && family.artifactScopeOnly);
+}
 const RESPONSE_OPTIONS = [
   { id: "warn", label: "Warn me", description: "Show a warning but still allow unless I block it." },
   { id: "require-reapproval", label: "Require review each time", description: "Never auto-allow; always ask in Inbox." },
@@ -33,6 +42,18 @@ function PolicyExceptionForm({ policies, onSaved, onCancel }) {
     const defaults = ["codex", "cursor", "claude-code", "opencode", "copilot", "kimi"];
     return [.../* @__PURE__ */ new Set([...fromPolicies, ...defaults])].sort();
   }, [policies]);
+  const scopeOptions = reactExports.useMemo(() => {
+    if (familySupportsHarnessOrWorkspaceScope(family)) {
+      return SCOPE_OPTIONS;
+    }
+    return SCOPE_OPTIONS.filter((option) => option.value === "artifact");
+  }, [family]);
+  const handleFamilySelect = reactExports.useCallback((familyId) => {
+    setFamily(familyId);
+    if (!familySupportsHarnessOrWorkspaceScope(familyId)) {
+      setScope("artifact");
+    }
+  }, []);
   const workspaceOptions = reactExports.useMemo(() => {
     const fromPolicies = policies.map((policy) => policy.workspace).filter((value) => Boolean(value?.trim()));
     return [...new Set(fromPolicies)].sort();
@@ -162,7 +183,7 @@ function PolicyExceptionForm({ policies, onSaved, onCancel }) {
         "button",
         {
           type: "button",
-          onClick: () => setFamily(option.id),
+          onClick: () => handleFamilySelect(option.id),
           "aria-pressed": family === option.id,
           className: `rounded-xl border px-3 py-3 text-left transition-colors ${family === option.id ? "border-brand-blue bg-brand-blue/[0.06]" : "border-slate-200 hover:border-slate-300"}`,
           children: [
@@ -176,7 +197,7 @@ function PolicyExceptionForm({ policies, onSaved, onCancel }) {
     step === "response" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "How far should this reach?" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2", children: SCOPE_OPTIONS.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2", children: scopeOptions.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "button",
           {
             type: "button",

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -5103,7 +5103,10 @@ def _validate_scoped_policy_artifact_target(scope: str, artifact_id: str | None)
         return
     if artifact_id is None or not artifact_id.strip():
         return
-    if _artifact_family_key(artifact_id) is None:
+    if not artifact_id.startswith("family:"):
+        return
+    family = artifact_id.removeprefix("family:").strip().lower()
+    if family not in _SCOPED_HARNESS_FAMILIES:
         msg = "unsupported_scoped_policy_family"
         raise ValueError(msg)
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1958,6 +1958,7 @@ class GuardStore:
             approval_gate_grant=approval_gate_grant,
             now=now,
         )
+        _validate_scoped_policy_artifact_target(decision.scope, decision.artifact_id)
         artifact_id, artifact_hash, workspace, publisher = self._normalized_policy_keys(decision)
         with self._connect() as connection:
             connection.execute(
@@ -2013,6 +2014,7 @@ class GuardStore:
                 "delete from policy_decisions where source in ('cloud-sync', 'team-policy', 'policy-bundle')"
             )
             for decision in decisions:
+                _validate_scoped_policy_artifact_target(decision.scope, decision.artifact_id)
                 artifact_id, artifact_hash, workspace, publisher = self._normalized_policy_keys(decision)
                 connection.execute(
                     """
@@ -5094,6 +5096,24 @@ def _stored_workspace_policy_key(workspace: str) -> str:
         msg = "Workspace policy key cannot be empty"
         raise ValueError(msg)
     return policy_key
+
+
+def _validate_scoped_policy_artifact_target(scope: str, artifact_id: str | None) -> None:
+    if scope not in {"harness", "global"}:
+        return
+    if artifact_id is None or not artifact_id.strip():
+        return
+    if _artifact_family_key(artifact_id) is None:
+        msg = "unsupported_scoped_policy_family"
+        raise ValueError(msg)
+
+
+def scoped_policy_artifact_target_is_valid(scope: str, artifact_id: str | None) -> bool:
+    try:
+        _validate_scoped_policy_artifact_target(scope, artifact_id)
+    except ValueError:
+        return False
+    return True
 
 
 def _artifact_family_key(artifact_id: str | None) -> str | None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -5108,14 +5108,6 @@ def _validate_scoped_policy_artifact_target(scope: str, artifact_id: str | None)
         raise ValueError(msg)
 
 
-def scoped_policy_artifact_target_is_valid(scope: str, artifact_id: str | None) -> bool:
-    try:
-        _validate_scoped_policy_artifact_target(scope, artifact_id)
-    except ValueError:
-        return False
-    return True
-
-
 def _artifact_family_key(artifact_id: str | None) -> str | None:
     if artifact_id is None or not artifact_id.strip():
         return None

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash as compute_artifact_hash
 from codex_plugin_scanner.guard.consumer import evaluate_detection
@@ -216,6 +218,26 @@ class TestPolicyScopePersistence:
         )
         result = store.resolve_policy("codex", "codex:project:any_tool", "hash-y")
         assert result == "allow"
+
+    def test_harness_unsupported_family_is_rejected_without_policy_row(self, tmp_path: Path) -> None:
+        store = _make_store(tmp_path)
+        with pytest.raises(ValueError, match="unsupported_scoped_policy_family"):
+            store.upsert_policy(
+                PolicyDecision(
+                    harness="codex",
+                    scope="harness",
+                    action="allow",
+                    artifact_id="family:tool-output",
+                ),
+                "2026-01-01T00:00:00+00:00",
+            )
+        assert store.list_policy_decisions("codex") == []
+        for artifact_id in (
+            "codex:project:tool-output:stdout",
+            "codex:project:tool-action:run-shell",
+            "codex:project:file-read:.npmrc",
+        ):
+            assert store.resolve_policy("codex", artifact_id, "hash") is None
 
     def test_global_scope_resolves_for_any_harness(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1741,6 +1741,39 @@ class TestGuardApprovals:
         assert status == 400
         assert payload["error"] == "missing_scope_target"
 
+    def test_guard_daemon_policy_upsert_rejects_unsupported_harness_family(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/policy/decisions",
+                data=json.dumps(
+                    {
+                        "harness": "codex",
+                        "scope": "harness",
+                        "action": "allow",
+                        "artifact_id": "family:tool-output",
+                        "reason": "allow command output review",
+                    }
+                ).encode("utf-8"),
+                headers=_guard_json_headers(daemon._server.auth_token),
+                method="POST",
+            )
+            try:
+                urllib.request.urlopen(request, timeout=5)
+            except urllib.error.HTTPError as error:
+                payload = json.loads(error.read().decode("utf-8"))
+                status = error.code
+            else:
+                raise AssertionError("expected HTTPError for unsupported harness family")
+        finally:
+            daemon.stop()
+
+        assert status == 400
+        assert payload["error"] == "missing_scope_target"
+
     def test_guard_daemon_policy_upsert_requires_auth_token(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -1772,7 +1772,7 @@ class TestGuardApprovals:
             daemon.stop()
 
         assert status == 400
-        assert payload["error"] == "missing_scope_target"
+        assert payload["error"] == "unsupported_scoped_policy_family"
 
     def test_guard_daemon_policy_upsert_requires_auth_token(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")


### PR DESCRIPTION
## Summary
- Reject unsupported harness/global policy family targets before upsert so values like `family:tool-output` cannot normalize to NULL and match every action in the harness.
- Restrict Command output exceptions in the dashboard to artifact scope only.

## Testing
- `python3 -m pytest tests/test_guard_approval_decisions.py::TestPolicyScopePersistence::test_harness_unsupported_family_is_rejected_without_policy_row tests/test_guard_approvals.py::TestGuardApprovals::test_guard_daemon_policy_upsert_rejects_unsupported_harness_family -q`
- `cd dashboard && npm run build`
