### PR TITLE
fix(hol-guard): resolve audit workspace and surface supply chain audit errors

### DIFF
--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2423,6 +2423,7 @@ export function normalizePackageFirewallStatus(value: unknown): PackageFirewallS
   const protectedSet = new Set(protectedManagers);
   const lastAuditProofAt =
     stringValue(readPackageShimField(shimStatus, "last_audit_proof_at", "lastAuditProofAt")) ?? null;
+  const auditWorkspaceDir = stringValue(record.audit_workspace_dir) ?? null;
   const shellProfilePath = readPackageShimField(shimStatus, "shell_profile_path", "shellProfilePath");
   const protection: PackageManagerProtection = {
     path_status: rawPathStatus,
@@ -2443,6 +2444,7 @@ export function normalizePackageFirewallStatus(value: unknown): PackageFirewallS
   };
   return {
     actions: normalizePackageFirewallActions(record.actions),
+    audit_workspace_dir: auditWorkspaceDir,
     cli_fallback: normalizePackageFirewallCliFallback(record.cli_fallback),
     connect_flow: normalizePackageFirewallConnectFlow(record.connect_flow),
     detected_managers: detectedManagers,
@@ -2595,14 +2597,21 @@ export async function runAuditRemediation(input: AuditRemediationInput): Promise
   return normalizePackageFirewallAction(payload);
 }
 
-export async function runPackageAudit(): Promise<PackageFirewallActionResponse> {
+export async function runPackageAudit(input?: {
+  workspaceDir?: string | null;
+}): Promise<PackageFirewallActionResponse> {
+  const workspaceDir = input?.workspaceDir?.trim() ?? null;
+  const body: Record<string, string> = {};
+  if (workspaceDir) {
+    body.workspace_dir = workspaceDir;
+  }
   const response = await fetchGuardApi("/v1/supply-chain/audit", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       ...guardAuthHeaders(),
     },
-    body: JSON.stringify({}),
+    body: JSON.stringify(body),
   });
   const payloadBody = (await response.json().catch(() => null)) as unknown;
   if (!response.ok) {

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -708,6 +708,7 @@ export type PackageFirewallStatusResponse = {
   supported_managers: string[];
   detected_managers: string[];
   last_audit_proof_at: string | null;
+  audit_workspace_dir?: string | null;
   protection: PackageManagerProtection | null;
   package_shims: PackageShimEntry[];
   entitlement: PackageFirewallEntitlement;

--- a/dashboard/src/package-workbench-panel.tsx
+++ b/dashboard/src/package-workbench-panel.tsx
@@ -4,6 +4,7 @@ import {
   HiMiniArrowDown,
   HiMiniArrowUp,
   HiMiniBugAnt,
+  HiMiniExclamationTriangle,
   HiMiniMagnifyingGlass,
 } from "react-icons/hi2";
 import { SectionLabel, Tag, ActionButton, EmptyState } from "./approval-center-primitives";
@@ -26,6 +27,7 @@ import type { AuditConnectGateViewState } from "./supply-chain-firewall-panel";
 
 type PackageWorkbenchPanelProps = {
   auditConnectGate?: AuditConnectGateViewState | null;
+  auditError?: string | null;
   auditSnapshot: SupplyChainAuditSnapshot | null;
   onRunAudit?: () => void;
   auditRunning?: boolean;
@@ -333,11 +335,29 @@ function EcosystemChip({ ecosystem, active, onSelect }: EcosystemChipProps) {
 
 type WorkbenchEmptyStateProps = {
   auditConnectGate?: AuditConnectGateViewState | null;
+  auditError?: string | null;
   onRunAudit?: () => void;
   auditRunning?: boolean;
 };
 
-function WorkbenchEmptyState({ auditConnectGate, onRunAudit, auditRunning }: WorkbenchEmptyStateProps) {
+function WorkbenchAuditErrorBanner({ message }: { message: string }) {
+  return (
+    <div
+      className="mb-4 flex items-start gap-2 rounded-xl border border-brand-attention/30 bg-brand-attention/[0.04] px-3 py-2.5"
+      role="alert"
+      aria-live="assertive"
+      data-testid="workbench-audit-error"
+    >
+      <HiMiniExclamationTriangle className="mt-0.5 h-4 w-4 shrink-0 text-brand-attention" aria-hidden="true" />
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-brand-dark">Workspace audit could not start</p>
+        <p className="mt-0.5 text-xs leading-relaxed text-slate-600">{message}</p>
+      </div>
+    </div>
+  );
+}
+
+function WorkbenchEmptyState({ auditConnectGate, auditError, onRunAudit, auditRunning }: WorkbenchEmptyStateProps) {
   if (auditConnectGate !== null && auditConnectGate !== undefined) {
     return (
       <ConnectFlowCard
@@ -355,24 +375,28 @@ function WorkbenchEmptyState({ auditConnectGate, onRunAudit, auditRunning }: Wor
   }
 
   return (
-    <EmptyState
-      title="No workspace audit yet"
-      body="Run a package audit to index dependencies and surface flagged packages here."
-      tone="teach"
-      action={
-        onRunAudit !== undefined ? (
-          <ActionButton variant="outline" onClick={onRunAudit} disabled={auditRunning} aria-busy={auditRunning}>
-            <HiMiniBugAnt className="mr-1.5 h-4 w-4" aria-hidden="true" />
-            Run audit
-          </ActionButton>
-        ) : undefined
-      }
-    />
+    <>
+      {auditError ? <WorkbenchAuditErrorBanner message={auditError} /> : null}
+      <EmptyState
+        title="No workspace audit yet"
+        body="Run a package audit to index dependencies and surface flagged packages here."
+        tone="teach"
+        action={
+          onRunAudit !== undefined ? (
+            <ActionButton variant="outline" onClick={onRunAudit} disabled={auditRunning} aria-busy={auditRunning}>
+              <HiMiniBugAnt className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              Run audit
+            </ActionButton>
+          ) : undefined
+        }
+      />
+    </>
   );
 }
 
 export function PackageWorkbenchPanel({
   auditConnectGate = null,
+  auditError = null,
   auditSnapshot,
   onRunAudit,
   auditRunning = false,
@@ -462,6 +486,7 @@ export function PackageWorkbenchPanel({
         <div className="px-4 py-6">
           <WorkbenchEmptyState
             auditConnectGate={auditConnectGate}
+            auditError={auditError}
             onRunAudit={onRunAudit}
             auditRunning={auditRunning}
           />

--- a/dashboard/src/supply-chain-audit-connect.test.tsx
+++ b/dashboard/src/supply-chain-audit-connect.test.tsx
@@ -6,6 +6,7 @@ import {
   packageAuditNeedsCloudConnect,
   resolveSupplyChainAuditConnectGate,
   supplyChainAuditConnectUserMessage,
+  supplyChainAuditUserMessage,
 } from "./supply-chain-audit-connect";
 import type { PackageFirewallStatusResponse } from "./guard-types";
 
@@ -75,6 +76,21 @@ assert(isSupplyChainAuditConnectError(connectError), "structured audit connect e
 assert(
   supplyChainAuditConnectUserMessage(connectError)?.includes("Sign in"),
   "audit connect user message should guide sign-in before retry",
+);
+
+const workspaceError = new GuardHarnessActionError(400, {
+  error: "workspace_dir_required",
+  message:
+    "Guard needs a project folder with package manifests before it can run the workspace audit.",
+  operation: "audit",
+});
+assert(
+  supplyChainAuditUserMessage(workspaceError)?.includes("project folder"),
+  "workspace audit errors should surface actionable copy instead of raw codes",
+);
+assert(
+  !isSupplyChainAuditConnectError(workspaceError),
+  "workspace_dir_required should not be treated as a cloud connect gate",
 );
 
 const auditConnectMarkup = renderToStaticMarkup(

--- a/dashboard/src/supply-chain-audit-connect.ts
+++ b/dashboard/src/supply-chain-audit-connect.ts
@@ -81,3 +81,19 @@ export function supplyChainAuditConnectUserMessage(error: unknown): string | nul
   }
   return "Sign in to HOL Guard Cloud on this machine, then run the workspace audit.";
 }
+
+export function supplyChainAuditUserMessage(error: unknown): string | null {
+  if (error instanceof GuardHarnessActionError) {
+    if (error.payload?.error === "workspace_dir_required") {
+      return (
+        error.payload.message ??
+        "Guard needs a connected app project folder with package manifests before it can run the workspace audit."
+      );
+    }
+    return supplyChainAuditConnectUserMessage(error);
+  }
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return null;
+}

--- a/dashboard/src/supply-chain-audit-workspace.test.ts
+++ b/dashboard/src/supply-chain-audit-workspace.test.ts
@@ -1,0 +1,51 @@
+import {
+  resolveSupplyChainAuditWorkspaceDir,
+  resolveSupplyChainAuditWorkspaceTarget,
+} from "./supply-chain-audit-workspace";
+import type { GuardManagedInstall } from "./guard-types";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const installs: GuardManagedInstall[] = [
+  {
+    harness: "codex",
+    active: false,
+    workspace: "workspace/inactive",
+    manifest: {},
+    updated_at: "2026-06-08T10:00:00.000Z",
+  },
+  {
+    harness: "cursor",
+    active: true,
+    workspace: "workspace/active-project",
+    manifest: {},
+    updated_at: "2026-06-08T11:00:00.000Z",
+  },
+];
+
+assert(
+  resolveSupplyChainAuditWorkspaceDir(installs) === "workspace/active-project",
+  "audit workspace resolver should prefer active managed installs",
+);
+
+assert(
+  resolveSupplyChainAuditWorkspaceTarget({
+    managedWorkspaceDir: "workspace/managed",
+    statusWorkspaceDir: "workspace/status",
+  }) === "workspace/managed",
+  "audit workspace target should prefer managed install workspace",
+);
+
+assert(
+  resolveSupplyChainAuditWorkspaceTarget({
+    managedWorkspaceDir: null,
+    statusWorkspaceDir: "workspace/status",
+  }) === "workspace/status",
+  "audit workspace target should fall back to daemon status workspace",
+);
+
+console.log("supply-chain-audit-workspace.test.ts passed");

--- a/dashboard/src/supply-chain-audit-workspace.test.ts
+++ b/dashboard/src/supply-chain-audit-workspace.test.ts
@@ -16,14 +16,14 @@ const installs: GuardManagedInstall[] = [
     active: false,
     workspace: "workspace/inactive",
     manifest: {},
-    updated_at: "2026-06-08T10:00:00.000Z",
+    updated_at: "2026-06-08T11:00:00.000Z",
   },
   {
     harness: "cursor",
     active: true,
     workspace: "workspace/active-project",
     manifest: {},
-    updated_at: "2026-06-08T11:00:00.000Z",
+    updated_at: "2026-06-08T10:00:00.000Z",
   },
 ];
 

--- a/dashboard/src/supply-chain-audit-workspace.ts
+++ b/dashboard/src/supply-chain-audit-workspace.ts
@@ -1,0 +1,34 @@
+import type { GuardManagedInstall } from "./guard-types";
+
+export function resolveSupplyChainAuditWorkspaceDir(
+  managedInstalls: readonly GuardManagedInstall[],
+): string | null {
+  const ordered = [...managedInstalls].sort((left, right) => {
+    if (left.active !== right.active) {
+      return left.active ? -1 : 1;
+    }
+    return right.updated_at.localeCompare(left.updated_at);
+  });
+  for (const install of ordered) {
+    const workspace = install.workspace?.trim();
+    if (workspace) {
+      return workspace;
+    }
+  }
+  return null;
+}
+
+export function resolveSupplyChainAuditWorkspaceTarget(input: {
+  managedWorkspaceDir?: string | null;
+  statusWorkspaceDir?: string | null;
+}): string | null {
+  const managed = input.managedWorkspaceDir?.trim();
+  if (managed) {
+    return managed;
+  }
+  const status = input.statusWorkspaceDir?.trim();
+  if (status) {
+    return status;
+  }
+  return null;
+}

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -23,8 +23,10 @@ import {
   isSupplyChainAuditConnectError,
   packageAuditNeedsCloudConnect,
   resolveSupplyChainAuditConnectGate,
+  supplyChainAuditUserMessage,
   type SupplyChainAuditConnectGate,
 } from "./supply-chain-audit-connect";
+import { resolveSupplyChainAuditWorkspaceTarget } from "./supply-chain-audit-workspace";
 import {
   FirewallControlsView,
   type FirewallFailedOp,
@@ -141,7 +143,9 @@ export type AuditConnectGateViewState = {
 export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
   props: {
   approvalGate: GuardApprovalGatePublicConfig | null;
+  auditWorkspaceDir?: string | null;
   onAuditConnectGateChange?: (state: AuditConnectGateViewState | null) => void;
+  onAuditErrorChange?: (message: string | null) => void;
   onStateChanged?: () => Promise<void> | void;
   onAuditCompleted?: (resultDetail: Record<string, unknown>) => void;
   onAuditRunningChange?: (running: boolean) => void;
@@ -151,7 +155,9 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
 ) {
   const {
     approvalGate,
+    auditWorkspaceDir,
     onAuditConnectGateChange,
+    onAuditErrorChange,
     onStateChanged,
     onAuditCompleted,
     onAuditRunningChange,
@@ -235,12 +241,20 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
       setLastFailed(null);
       setConnectError(null);
       setActivationAssistError(null);
+      onAuditErrorChange?.(null);
       onAuditRunningChange?.(true);
+      const statusWorkspaceDir =
+        panelLoad.phase === "loaded" ? panelLoad.data.audit_workspace_dir ?? null : null;
+      const workspaceDir = resolveSupplyChainAuditWorkspaceTarget({
+        managedWorkspaceDir: auditWorkspaceDir,
+        statusWorkspaceDir,
+      });
       try {
-        const response = await runPackageAudit();
+        const response = await runPackageAudit({ workspaceDir });
         setLastCompleted({ op: "audit", manager: null, response });
         onAuditCompleted?.(response.result_detail);
         clearAuditConnectGate();
+        onAuditErrorChange?.(null);
         await refreshAfterOp();
         await onStateChanged?.();
       } catch (err) {
@@ -248,19 +262,23 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
           openAuditConnectGate(true);
           return;
         }
-        const message = err instanceof Error ? err.message : "Operation failed.";
+        const message = supplyChainAuditUserMessage(err) ?? "Operation failed.";
         setLastFailed({ op: "audit", manager: null, message });
+        onAuditErrorChange?.(message);
       } finally {
         onAuditRunningChange?.(false);
         setPendingOp(null);
       }
     },
     [
+      auditWorkspaceDir,
       clearAuditConnectGate,
       onAuditCompleted,
+      onAuditErrorChange,
       onAuditRunningChange,
       onStateChanged,
       openAuditConnectGate,
+      panelLoad,
       refreshAfterOp,
     ],
   );

--- a/dashboard/src/supply-chain-workspace.tsx
+++ b/dashboard/src/supply-chain-workspace.tsx
@@ -31,7 +31,7 @@ import { resolveSupplyChainCloudCapabilities } from "./supply-chain-cloud-capabi
 import { SupplyChainCloudCapabilitiesPanel } from "./supply-chain-cloud-capabilities-panel";
 import { PackageWorkbenchPanel } from "./package-workbench-panel";
 import { resolveSupplyChainIssues, type SupplyChainIssueAction } from "./supply-chain-issues";
-import { resolveSupplyChainWorkspaceHero } from "./supply-chain-workspace-hero-state";
+import { resolveSupplyChainAuditWorkspaceDir } from "./supply-chain-audit-workspace";
 import { SupplyChainStatusHeader } from "./supply-chain-status-header";
 import { SUPPLY_CHAIN_WORKSPACE_SHELL_CLASS } from "./supply-chain-workspace-layout";
 
@@ -128,6 +128,7 @@ export function SupplyChainWorkspace({
   const [auditSnapshot, setAuditSnapshot] = useState<SupplyChainAuditSnapshot | null>(null);
   const [evidenceRail, setEvidenceRail] = useState<SupplyChainEvidenceRailSnapshot | null>(null);
   const [auditRunning, setAuditRunning] = useState(false);
+  const [auditError, setAuditError] = useState<string | null>(null);
   const [auditConnectGate, setAuditConnectGate] = useState<AuditConnectGateViewState | null>(null);
   const runAuditRef = useRef<(() => void) | null>(null);
   const firewallPanelRef = useRef<PackageFirewallPanelHandle>(null);
@@ -173,6 +174,10 @@ export function SupplyChainWorkspace({
   );
 
 
+  const auditWorkspaceDir = useMemo(
+    () => resolveSupplyChainAuditWorkspaceDir(managedInstalls),
+    [managedInstalls],
+  );
   const supplyChainIssues = useMemo(() => resolveSupplyChainIssues(snapshot), [snapshot]);
   const workspaceHero = useMemo(
     () => resolveSupplyChainWorkspaceHero(snapshot, { openIssueCount: supplyChainIssues.length }),
@@ -209,6 +214,11 @@ export function SupplyChainWorkspace({
   const handleAuditCompleted = useCallback((resultDetail: Record<string, unknown>) => {
     const normalized = normalizeSupplyChainAuditSnapshot(resultDetail);
     setAuditSnapshot(normalized);
+    setAuditError(null);
+  }, []);
+
+  const handleAuditErrorChange = useCallback((message: string | null) => {
+    setAuditError(message);
   }, []);
 
   const handleAuditRunningChange = useCallback((running: boolean) => {
@@ -244,6 +254,7 @@ export function SupplyChainWorkspace({
 
       <PackageWorkbenchPanel
         auditConnectGate={auditConnectGate}
+        auditError={auditError}
         auditSnapshot={auditSnapshot}
         auditRunning={auditRunning}
         onRunAudit={handleRunAudit}
@@ -254,7 +265,9 @@ export function SupplyChainWorkspace({
       <PackageFirewallPanel
         ref={firewallPanelRef}
         approvalGate={approvalGate}
+        auditWorkspaceDir={auditWorkspaceDir}
         onAuditConnectGateChange={setAuditConnectGate}
+        onAuditErrorChange={handleAuditErrorChange}
         onStateChanged={onRuntimeRefresh}
         onAuditCompleted={handleAuditCompleted}
         onAuditRunningChange={handleAuditRunningChange}

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -93,6 +93,7 @@ from ..local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE, build_lo
 from ..local_supply_chain import (
     build_workspace_audit_payload,
     resolve_package_firewall_entitlement_with_refresh,
+    managed_install_audit_workspace_dirs,
     resolve_supply_chain_audit_workspace_dir,
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision
@@ -2144,11 +2145,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def _handle_supply_chain_package_firewall_status(self) -> None:
         entitlement = self._supply_chain_entitlement()
         status = package_shim_status(self._harness_context({}))
+        audit_workspace_dir = self._resolve_supply_chain_workspace_dir({})
         self._write_json(
             {
                 "actions": package_firewall_action_states(
                     entitlement,
                     has_installed_managers=bool(status.get("installed_managers")),
+                ),
+                "audit_workspace_dir": (
+                    str(audit_workspace_dir) if audit_workspace_dir is not None else None
                 ),
                 "cli_fallback": {
                     "connect": "hol-guard connect",
@@ -2215,7 +2220,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_approval_gate_error(error)
             return
         except ValueError as error:
-            self._write_json({"error": str(error), "operation": operation}, status=400)
+            error_code = str(error)
+            error_payload: dict[str, object] = {"error": error_code, "operation": operation}
+            if error_code == "workspace_dir_required":
+                error_payload["message"] = (
+                    "Guard needs a project folder with package manifests before it can run "
+                    "the workspace audit. Open Guard from a connected app workspace or pass "
+                    "workspace_dir in the audit request."
+                )
+            self._write_json(error_payload, status=400)
             return
         receipt_overrides = package_firewall_receipt_metadata(
             operation=operation,
@@ -2292,17 +2305,18 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return sync_supply_chain_bundle(self.server.store)  # type: ignore[attr-defined]
         raise ValueError("unsupported_supply_chain_operation")
 
-    @staticmethod
-    def _resolve_supply_chain_workspace_dir(payload: dict[str, object]) -> Path | None:
+    def _resolve_supply_chain_workspace_dir(self, payload: dict[str, object]) -> Path | None:
         allowed_roots = (
             Path.home().resolve(),
             Path.cwd().resolve(),
             Path(tempfile.gettempdir()).resolve(),
         )
+        managed_workspace_dirs = managed_install_audit_workspace_dirs(self.server.store)  # type: ignore[attr-defined]
         return resolve_supply_chain_audit_workspace_dir(
             workspace_dir_value=payload.get("workspace_dir"),
             workspace_value=payload.get("workspace"),
             allowed_roots=allowed_roots,
+            managed_workspace_dirs=managed_workspace_dirs,
         )
 
     def _supply_chain_context(self, payload: dict[str, object]) -> HarnessContext:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -92,8 +92,8 @@ from ..insights_share import publish_insights_share
 from ..local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE, build_local_dashboard_session_token
 from ..local_supply_chain import (
     build_workspace_audit_payload,
-    resolve_package_firewall_entitlement_with_refresh,
     managed_install_audit_workspace_dirs,
+    resolve_package_firewall_entitlement_with_refresh,
     resolve_supply_chain_audit_workspace_dir,
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, PolicyDecision

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2152,9 +2152,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     entitlement,
                     has_installed_managers=bool(status.get("installed_managers")),
                 ),
-                "audit_workspace_dir": (
-                    str(audit_workspace_dir) if audit_workspace_dir is not None else None
-                ),
+                "audit_workspace_dir": (str(audit_workspace_dir) if audit_workspace_dir is not None else None),
                 "cli_fallback": {
                     "connect": "hol-guard connect",
                     "install": "hol-guard package-shims install --json",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -377,6 +377,54 @@ function resolveSupplyChainAuditConnectGate(data, options) {
     resumeAfterConnect: options?.resumeAfterConnect ?? false
   };
 }
+function supplyChainAuditConnectUserMessage(error) {
+  if (!isSupplyChainAuditConnectError(error)) {
+    return null;
+  }
+  const code = error.payload?.error;
+  if (code === "guard_cloud_reconnect_required") {
+    return "Reconnect HOL Guard Cloud, then run the workspace audit again.";
+  }
+  return "Sign in to HOL Guard Cloud on this machine, then run the workspace audit.";
+}
+function supplyChainAuditUserMessage(error) {
+  if (error instanceof GuardHarnessActionError) {
+    if (error.payload?.error === "workspace_dir_required") {
+      return error.payload.message ?? "Guard needs a connected app project folder with package manifests before it can run the workspace audit.";
+    }
+    return supplyChainAuditConnectUserMessage(error);
+  }
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return null;
+}
+function resolveSupplyChainAuditWorkspaceDir(managedInstalls) {
+  const ordered = [...managedInstalls].sort((left, right) => {
+    if (left.active !== right.active) {
+      return left.active ? -1 : 1;
+    }
+    return right.updated_at.localeCompare(left.updated_at);
+  });
+  for (const install of ordered) {
+    const workspace = install.workspace?.trim();
+    if (workspace) {
+      return workspace;
+    }
+  }
+  return null;
+}
+function resolveSupplyChainAuditWorkspaceTarget(input) {
+  const managed = input.managedWorkspaceDir?.trim();
+  if (managed) {
+    return managed;
+  }
+  const status = input.statusWorkspaceDir?.trim();
+  if (status) {
+    return status;
+  }
+  return null;
+}
 function resolveShimStatus(shim) {
   if (!shim) {
     return { label: "Unprotected", tone: "attention", icon: "warning" };
@@ -1018,7 +1066,9 @@ function RefreshButton({ disabled, spinning, onRefresh }) {
 const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPanel2(props, ref) {
   const {
     approvalGate,
+    auditWorkspaceDir,
     onAuditConnectGateChange,
+    onAuditErrorChange,
     onStateChanged,
     onAuditCompleted,
     onAuditRunningChange,
@@ -1093,12 +1143,19 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
       setLastFailed(null);
       setConnectError(null);
       setActivationAssistError(null);
+      onAuditErrorChange?.(null);
       onAuditRunningChange?.(true);
+      const statusWorkspaceDir = panelLoad.phase === "loaded" ? panelLoad.data.audit_workspace_dir ?? null : null;
+      const workspaceDir = resolveSupplyChainAuditWorkspaceTarget({
+        managedWorkspaceDir: auditWorkspaceDir,
+        statusWorkspaceDir
+      });
       try {
-        const response = await runPackageAudit();
+        const response = await runPackageAudit({ workspaceDir });
         setLastCompleted({ op: "audit", manager: null, response });
         onAuditCompleted?.(response.result_detail);
         clearAuditConnectGate();
+        onAuditErrorChange?.(null);
         await refreshAfterOp();
         await onStateChanged?.();
       } catch (err) {
@@ -1106,19 +1163,23 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
           openAuditConnectGate(true);
           return;
         }
-        const message = err instanceof Error ? err.message : "Operation failed.";
+        const message = supplyChainAuditUserMessage(err) ?? "Operation failed.";
         setLastFailed({ op: "audit", manager: null, message });
+        onAuditErrorChange?.(message);
       } finally {
         onAuditRunningChange?.(false);
         setPendingOp(null);
       }
     },
     [
+      auditWorkspaceDir,
       clearAuditConnectGate,
       onAuditCompleted,
+      onAuditErrorChange,
       onAuditRunningChange,
       onStateChanged,
       openAuditConnectGate,
+      panelLoad,
       refreshAfterOp
     ]
   );
@@ -2152,7 +2213,25 @@ function EcosystemChip({ ecosystem, active, onSelect }) {
   }, [ecosystem, onSelect]);
   return /* @__PURE__ */ jsxRuntimeExports.jsx(FilterChip, { label: ecosystem, active, onSelect: handleSelect });
 }
-function WorkbenchEmptyState({ auditConnectGate, onRunAudit, auditRunning }) {
+function WorkbenchAuditErrorBanner({ message }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    "div",
+    {
+      className: "mb-4 flex items-start gap-2 rounded-xl border border-brand-attention/30 bg-brand-attention/[0.04] px-3 py-2.5",
+      role: "alert",
+      "aria-live": "assertive",
+      "data-testid": "workbench-audit-error",
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniExclamationTriangle, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-attention", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Workspace audit could not start" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs leading-relaxed text-slate-600", children: message })
+        ] })
+      ]
+    }
+  );
+}
+function WorkbenchEmptyState({ auditConnectGate, auditError, onRunAudit, auditRunning }) {
   if (auditConnectGate !== null && auditConnectGate !== void 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(
       ConnectFlowCard,
@@ -2169,21 +2248,25 @@ function WorkbenchEmptyState({ auditConnectGate, onRunAudit, auditRunning }) {
       }
     );
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(
-    EmptyState,
-    {
-      title: "No workspace audit yet",
-      body: "Run a package audit to index dependencies and surface flagged packages here.",
-      tone: "teach",
-      action: onRunAudit !== void 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "outline", onClick: onRunAudit, disabled: auditRunning, "aria-busy": auditRunning, children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBugAnt, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
-        "Run audit"
-      ] }) : void 0
-    }
-  );
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+    auditError ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchAuditErrorBanner, { message: auditError }) : null,
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      EmptyState,
+      {
+        title: "No workspace audit yet",
+        body: "Run a package audit to index dependencies and surface flagged packages here.",
+        tone: "teach",
+        action: onRunAudit !== void 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "outline", onClick: onRunAudit, disabled: auditRunning, "aria-busy": auditRunning, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBugAnt, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+          "Run audit"
+        ] }) : void 0
+      }
+    )
+  ] });
 }
 function PackageWorkbenchPanel({
   auditConnectGate = null,
+  auditError = null,
   auditSnapshot,
   onRunAudit,
   auditRunning = false
@@ -2254,6 +2337,7 @@ function PackageWorkbenchPanel({
       WorkbenchEmptyState,
       {
         auditConnectGate,
+        auditError,
         onRunAudit,
         auditRunning
       }
@@ -2388,85 +2472,6 @@ function resolveSupplyChainIssues(snapshot) {
     }
   }
   return issues;
-}
-function protectionTitle(status) {
-  if (status === "protected") {
-    return "Package installs are protected on this device";
-  }
-  if (status === "partial") {
-    return "Protection is only partly set up";
-  }
-  if (status === "staged") {
-    return "Finish setup in a new terminal";
-  }
-  if (status === "unprotected") {
-    return "Package installs are not protected yet";
-  }
-  return "Checking package protection on this device";
-}
-function protectionDetail(snapshot, status) {
-  const protection = snapshot.supply_chain?.package_manager_protection;
-  if (status === "protected" && protection) {
-    return `${protection.protected_managers.length} package tool${protection.protected_managers.length === 1 ? "" : "s"} active. Guard can block risky installs before they run.`;
-  }
-  if (status === "partial" && protection) {
-    return `${protection.unprotected_managers.length} tool${protection.unprotected_managers.length === 1 ? "" : "s"} still open: ${protection.unprotected_managers.join(", ")}.`;
-  }
-  if (status === "staged") {
-    return "Guard updated your shell profile. Open a new terminal, then run a protection test.";
-  }
-  if (status === "unprotected") {
-    return "Turn on protection for npm, pip, and other tools in the firewall panel below.";
-  }
-  return "Refresh status after installing package tools on this machine.";
-}
-function protectionTone(status) {
-  if (status === "protected") {
-    return "green";
-  }
-  if (status === "staged") {
-    return "blue";
-  }
-  if (status === "partial" || status === "unprotected") {
-    return "attention";
-  }
-  return "slate";
-}
-function cloudLabel(snapshot) {
-  const label = snapshot.cloud_state_label ?? "";
-  if (snapshot.cloud_state === "paired_active") {
-    return label.trim().length > 0 ? label : "Guard Cloud connected";
-  }
-  if (snapshot.cloud_state === "paired_waiting") {
-    return label.trim().length > 0 ? label : "Pairing in progress";
-  }
-  return label.trim().length > 0 ? label : "On this device only";
-}
-function resolveSupplyChainWorkspaceHero(snapshot, options) {
-  const protectionStatus = resolveHomeProtectionStatus(snapshot);
-  const stats = buildSupplyChainStats(snapshot);
-  const preventedLabel = stats.preventedInstalls > 0 ? `${stats.preventedInstalls} blocked install${stats.preventedInstalls === 1 ? "" : "s"}` : "No blocked installs yet";
-  const openIssueCount = options?.openIssueCount ?? 0;
-  if (openIssueCount > 0) {
-    return {
-      cloudMode: snapshot.cloud_state,
-      cloudLabel: cloudLabel(snapshot),
-      protectionStatus,
-      title: "Work through the steps below",
-      detail: `${openIssueCount} setup step${openIssueCount === 1 ? "" : "s"} need attention on this device.`,
-      tone: protectionTone(protectionStatus),
-      statLine: `${stats.protectedManagers} protected · ${stats.unprotectedManagers} open · ${preventedLabel}`
-    };
-  }
-  return {
-    cloudMode: snapshot.cloud_state,
-    cloudLabel: cloudLabel(snapshot),
-    protectionStatus,
-    title: protectionTitle(protectionStatus),
-    detail: protectionDetail(snapshot, protectionStatus),
-    tone: protectionTone(protectionStatus),
-    statLine: `${stats.protectedManagers} protected · ${stats.unprotectedManagers} open · ${preventedLabel}`
-  };
 }
 function supplyChainCloudTagTone(mode) {
   if (mode === "paired_active") {
@@ -2762,6 +2767,7 @@ function SupplyChainWorkspace({
   const [auditSnapshot, setAuditSnapshot] = reactExports.useState(null);
   const [evidenceRail, setEvidenceRail] = reactExports.useState(null);
   const [auditRunning, setAuditRunning] = reactExports.useState(false);
+  const [auditError, setAuditError] = reactExports.useState(null);
   const [auditConnectGate, setAuditConnectGate] = reactExports.useState(null);
   const runAuditRef = reactExports.useRef(null);
   const firewallPanelRef = reactExports.useRef(null);
@@ -2803,6 +2809,10 @@ function SupplyChainWorkspace({
     },
     [onRuntimeRefresh]
   );
+  const auditWorkspaceDir = reactExports.useMemo(
+    () => resolveSupplyChainAuditWorkspaceDir(managedInstalls),
+    [managedInstalls]
+  );
   const supplyChainIssues = reactExports.useMemo(() => resolveSupplyChainIssues(snapshot), [snapshot]);
   const workspaceHero = reactExports.useMemo(
     () => resolveSupplyChainWorkspaceHero(snapshot, { openIssueCount: supplyChainIssues.length }),
@@ -2837,6 +2847,10 @@ function SupplyChainWorkspace({
   const handleAuditCompleted = reactExports.useCallback((resultDetail) => {
     const normalized = normalizeSupplyChainAuditSnapshot(resultDetail);
     setAuditSnapshot(normalized);
+    setAuditError(null);
+  }, []);
+  const handleAuditErrorChange = reactExports.useCallback((message) => {
+    setAuditError(message);
   }, []);
   const handleAuditRunningChange = reactExports.useCallback((running) => {
     setAuditRunning(running);
@@ -2863,6 +2877,7 @@ function SupplyChainWorkspace({
       PackageWorkbenchPanel,
       {
         auditConnectGate,
+        auditError,
         auditSnapshot,
         auditRunning,
         onRunAudit: handleRunAudit
@@ -2874,7 +2889,9 @@ function SupplyChainWorkspace({
       {
         ref: firewallPanelRef,
         approvalGate,
+        auditWorkspaceDir,
         onAuditConnectGateChange: setAuditConnectGate,
+        onAuditErrorChange: handleAuditErrorChange,
         onStateChanged: onRuntimeRefresh,
         onAuditCompleted: handleAuditCompleted,
         onAuditRunningChange: handleAuditRunningChange,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15796,6 +15796,7 @@ function normalizePackageFirewallStatus(value) {
   const protectedManagers = packageShims.filter((shim) => shim.activation_state === "protected").map((shim) => shim.manager);
   const protectedSet = new Set(protectedManagers);
   const lastAuditProofAt = stringValue(readPackageShimField(shimStatus, "last_audit_proof_at", "lastAuditProofAt")) ?? null;
+  const auditWorkspaceDir = stringValue(record.audit_workspace_dir) ?? null;
   const shellProfilePath = readPackageShimField(shimStatus, "shell_profile_path", "shellProfilePath");
   const protection = {
     path_status: rawPathStatus,
@@ -15813,6 +15814,7 @@ function normalizePackageFirewallStatus(value) {
   };
   return {
     actions: normalizePackageFirewallActions(record.actions),
+    audit_workspace_dir: auditWorkspaceDir,
     cli_fallback: normalizePackageFirewallCliFallback(record.cli_fallback),
     connect_flow: normalizePackageFirewallConnectFlow(record.connect_flow),
     detected_managers: detectedManagers,
@@ -15940,14 +15942,19 @@ async function runAuditRemediation(input) {
   }
   return normalizePackageFirewallAction(payload);
 }
-async function runPackageAudit() {
+async function runPackageAudit(input) {
+  const workspaceDir = input?.workspaceDir?.trim() ?? null;
+  const body = {};
+  if (workspaceDir) {
+    body.workspace_dir = workspaceDir;
+  }
   const response = await fetchGuardApi("/v1/supply-chain/audit", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       ...guardAuthHeaders()
     },
-    body: JSON.stringify({})
+    body: JSON.stringify(body)
   });
   const payloadBody = await response.json().catch(() => null);
   if (!response.ok) {

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -378,11 +378,36 @@ def _workspace_has_project_markers(workspace_dir: Path) -> bool:
     return any((resolved / marker).exists() for marker in _MANIFEST_CANDIDATES)
 
 
+def managed_install_audit_workspace_dirs(store: GuardStore) -> tuple[str, ...]:
+    installs = store.list_managed_installs()
+    ordered = sorted(
+        installs,
+        key=lambda item: (
+            0 if bool(item.get("active")) else 1,
+            str(item.get("updated_at") or ""),
+        ),
+        reverse=True,
+    )
+    candidates: list[str] = []
+    seen: set[str] = set()
+    for install in ordered:
+        workspace = install.get("workspace")
+        if not isinstance(workspace, str):
+            continue
+        normalized = workspace.strip()
+        if not normalized or normalized in seen:
+            continue
+        seen.add(normalized)
+        candidates.append(normalized)
+    return tuple(candidates)
+
+
 def resolve_supply_chain_audit_workspace_dir(
     *,
     workspace_dir_value: object,
     workspace_value: object,
     allowed_roots: tuple[Path, ...],
+    managed_workspace_dirs: Sequence[str] | None = None,
 ) -> Path | None:
     for candidate in (workspace_dir_value, workspace_value):
         if isinstance(candidate, str):
@@ -405,12 +430,19 @@ def resolve_supply_chain_audit_workspace_dir(
     try:
         cwd = Path.cwd().resolve()
     except OSError:
-        return None
-    if not _workspace_has_project_markers(cwd):
-        return None
-    for root in allowed_roots:
-        if resolves_within_root(root, cwd, require_exists=True):
-            return cwd
+        cwd = None
+    if cwd is not None and _workspace_has_project_markers(cwd):
+        for root in allowed_roots:
+            if resolves_within_root(root, cwd, require_exists=True):
+                return cwd
+    for managed_workspace in managed_workspace_dirs or ():
+        resolved = resolve_path_within_allowed_roots(
+            managed_workspace,
+            allowed_roots,
+            require_exists=True,
+        )
+        if resolved is not None and _workspace_has_project_markers(resolved):
+            return resolved
     return None
 
 

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -383,7 +383,7 @@ def managed_install_audit_workspace_dirs(store: GuardStore) -> tuple[str, ...]:
     ordered = sorted(
         installs,
         key=lambda item: (
-            0 if bool(item.get("active")) else 1,
+            1 if bool(item.get("active")) else 0,
             str(item.get("updated_at") or ""),
         ),
         reverse=True,

--- a/tests/test_guard_phase06_workspace_audit.py
+++ b/tests/test_guard_phase06_workspace_audit.py
@@ -14,6 +14,7 @@ from codex_plugin_scanner.guard.daemon import server as daemon_server
 from codex_plugin_scanner.guard.local_supply_chain import (
     audit_receipt_metadata,
     build_workspace_audit_payload,
+    managed_install_audit_workspace_dirs,
     resolve_supply_chain_audit_workspace_dir,
 )
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
@@ -318,6 +319,68 @@ def test_workspace_audit_inference_accepts_workspace_alias(
         allowed_roots=allowed_roots,
     )
     assert resolved == workspace_dir.resolve()
+
+
+def test_workspace_audit_inference_uses_active_managed_install_workspace(
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}')
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_managed_install("codex", True, str(workspace_dir), {}, WORKSPACE_AUDIT_NOW)
+    allowed_roots = (tmp_path.resolve(),)
+    resolved = resolve_supply_chain_audit_workspace_dir(
+        workspace_dir_value=None,
+        workspace_value=None,
+        allowed_roots=allowed_roots,
+        managed_workspace_dirs=managed_install_audit_workspace_dirs(store),
+    )
+    assert resolved == workspace_dir.resolve()
+
+
+def test_daemon_workspace_audit_uses_managed_install_workspace_when_cwd_is_not_a_project(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package.json", '{"name":"demo","dependencies":{"minimist":"^1.2.0"}}')
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "packages": {
+                    "": {"dependencies": {"minimist": "^1.2.0"}},
+                    "node_modules/minimist": {"version": "1.2.8"},
+                }
+            }
+        ),
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_managed_install("codex", True, str(workspace_dir), {}, WORKSPACE_AUDIT_NOW)
+    _seed_premium_entitlement(store)
+    monkeypatch.chdir(empty_dir)
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/audit",
+                token=token,
+                payload={},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["operation"] == "audit"
 
 
 def test_workspace_audit_never_reads_env_files(

--- a/tests/test_guard_phase06_workspace_audit.py
+++ b/tests/test_guard_phase06_workspace_audit.py
@@ -324,11 +324,17 @@ def test_workspace_audit_inference_accepts_workspace_alias(
 def test_workspace_audit_inference_uses_active_managed_install_workspace(
     tmp_path: Path,
 ) -> None:
-    workspace_dir = tmp_path / "workspace"
-    workspace_dir.mkdir()
-    _write_text(workspace_dir / "package.json", '{"name":"demo"}')
+    active_dir = tmp_path / "active-workspace"
+    active_dir.mkdir()
+    _write_text(active_dir / "package.json", '{"name":"active"}')
+
+    inactive_dir = tmp_path / "inactive-workspace"
+    inactive_dir.mkdir()
+    _write_text(inactive_dir / "package.json", '{"name":"inactive"}')
+
     store = GuardStore(tmp_path / "guard-home")
-    store.set_managed_install("codex", True, str(workspace_dir), {}, WORKSPACE_AUDIT_NOW)
+    store.set_managed_install("cursor", False, str(inactive_dir), {}, "2026-06-08T13:00:00.000Z")
+    store.set_managed_install("codex", True, str(active_dir), {}, "2026-06-08T12:00:00.000Z")
     allowed_roots = (tmp_path.resolve(),)
     resolved = resolve_supply_chain_audit_workspace_dir(
         workspace_dir_value=None,
@@ -336,7 +342,7 @@ def test_workspace_audit_inference_uses_active_managed_install_workspace(
         allowed_roots=allowed_roots,
         managed_workspace_dirs=managed_install_audit_workspace_dirs(store),
     )
-    assert resolved == workspace_dir.resolve()
+    assert resolved == active_dir.resolve()
 
 
 def test_daemon_workspace_audit_uses_managed_install_workspace_when_cwd_is_not_a_project(


### PR DESCRIPTION
## Summary
- Infer supply-chain audit workspace from active managed installs when the daemon has no project root
- Pass `workspace_dir` from the dashboard and expose `audit_workspace_dir` on package-shims status
- Surface workspace audit failures in the Audit findings workbench with actionable copy

## Testing
- `python3 -m pytest tests/test_guard_phase06_workspace_audit.py -q -k managed_install`
- `cd dashboard && ./node_modules/.bin/tsx src/supply-chain-audit-workspace.test.ts && ./node_modules/.bin/tsx src/supply-chain-audit-connect.test.tsx`
- `cd dashboard && npm run build`
