### PR TITLE
fix(dashboard): restore supply chain hero import on workspace route

### DIFF
--- a/dashboard/src/supply-chain-ux-consolidation.test.ts
+++ b/dashboard/src/supply-chain-ux-consolidation.test.ts
@@ -32,7 +32,7 @@ assert(
   "workspace keeps single audit findings workbench",
 );
 assert(
-  workspaceSource.includes('from "./supply-chain-workspace-hero-state"'),
+  workspaceSource.includes("supply-chain-workspace-hero-state"),
   "workspace imports supply chain hero state helpers",
 );
 assert(

--- a/dashboard/src/supply-chain-ux-consolidation.test.ts
+++ b/dashboard/src/supply-chain-ux-consolidation.test.ts
@@ -32,6 +32,14 @@ assert(
   "workspace keeps single audit findings workbench",
 );
 assert(
+  workspaceSource.includes('from "./supply-chain-workspace-hero-state"'),
+  "workspace imports supply chain hero state helpers",
+);
+assert(
+  workspaceSource.includes("resolveSupplyChainWorkspaceHero"),
+  "workspace resolves hero state for status header",
+);
+assert(
   !controlsSource.includes("NextActionHero"),
   "firewall controls drop duplicate next-step hero",
 );

--- a/dashboard/src/supply-chain-workspace.tsx
+++ b/dashboard/src/supply-chain-workspace.tsx
@@ -32,6 +32,7 @@ import { SupplyChainCloudCapabilitiesPanel } from "./supply-chain-cloud-capabili
 import { PackageWorkbenchPanel } from "./package-workbench-panel";
 import { resolveSupplyChainIssues, type SupplyChainIssueAction } from "./supply-chain-issues";
 import { resolveSupplyChainAuditWorkspaceDir } from "./supply-chain-audit-workspace";
+import { resolveSupplyChainWorkspaceHero } from "./supply-chain-workspace-hero-state";
 import { SupplyChainStatusHeader } from "./supply-chain-status-header";
 import { SUPPLY_CHAIN_WORKSPACE_SHELL_CLASS } from "./supply-chain-workspace-layout";
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -2473,6 +2473,85 @@ function resolveSupplyChainIssues(snapshot) {
   }
   return issues;
 }
+function protectionTitle(status) {
+  if (status === "protected") {
+    return "Package installs are protected on this device";
+  }
+  if (status === "partial") {
+    return "Protection is only partly set up";
+  }
+  if (status === "staged") {
+    return "Finish setup in a new terminal";
+  }
+  if (status === "unprotected") {
+    return "Package installs are not protected yet";
+  }
+  return "Checking package protection on this device";
+}
+function protectionDetail(snapshot, status) {
+  const protection = snapshot.supply_chain?.package_manager_protection;
+  if (status === "protected" && protection) {
+    return `${protection.protected_managers.length} package tool${protection.protected_managers.length === 1 ? "" : "s"} active. Guard can block risky installs before they run.`;
+  }
+  if (status === "partial" && protection) {
+    return `${protection.unprotected_managers.length} tool${protection.unprotected_managers.length === 1 ? "" : "s"} still open: ${protection.unprotected_managers.join(", ")}.`;
+  }
+  if (status === "staged") {
+    return "Guard updated your shell profile. Open a new terminal, then run a protection test.";
+  }
+  if (status === "unprotected") {
+    return "Turn on protection for npm, pip, and other tools in the firewall panel below.";
+  }
+  return "Refresh status after installing package tools on this machine.";
+}
+function protectionTone(status) {
+  if (status === "protected") {
+    return "green";
+  }
+  if (status === "staged") {
+    return "blue";
+  }
+  if (status === "partial" || status === "unprotected") {
+    return "attention";
+  }
+  return "slate";
+}
+function cloudLabel(snapshot) {
+  const label = snapshot.cloud_state_label ?? "";
+  if (snapshot.cloud_state === "paired_active") {
+    return label.trim().length > 0 ? label : "Guard Cloud connected";
+  }
+  if (snapshot.cloud_state === "paired_waiting") {
+    return label.trim().length > 0 ? label : "Pairing in progress";
+  }
+  return label.trim().length > 0 ? label : "On this device only";
+}
+function resolveSupplyChainWorkspaceHero(snapshot, options) {
+  const protectionStatus = resolveHomeProtectionStatus(snapshot);
+  const stats = buildSupplyChainStats(snapshot);
+  const preventedLabel = stats.preventedInstalls > 0 ? `${stats.preventedInstalls} blocked install${stats.preventedInstalls === 1 ? "" : "s"}` : "No blocked installs yet";
+  const openIssueCount = options?.openIssueCount ?? 0;
+  if (openIssueCount > 0) {
+    return {
+      cloudMode: snapshot.cloud_state,
+      cloudLabel: cloudLabel(snapshot),
+      protectionStatus,
+      title: "Work through the steps below",
+      detail: `${openIssueCount} setup step${openIssueCount === 1 ? "" : "s"} need attention on this device.`,
+      tone: protectionTone(protectionStatus),
+      statLine: `${stats.protectedManagers} protected · ${stats.unprotectedManagers} open · ${preventedLabel}`
+    };
+  }
+  return {
+    cloudMode: snapshot.cloud_state,
+    cloudLabel: cloudLabel(snapshot),
+    protectionStatus,
+    title: protectionTitle(protectionStatus),
+    detail: protectionDetail(snapshot, protectionStatus),
+    tone: protectionTone(protectionStatus),
+    statLine: `${stats.protectedManagers} protected · ${stats.unprotectedManagers} open · ${preventedLabel}`
+  };
+}
 function supplyChainCloudTagTone(mode) {
   if (mode === "paired_active") {
     return "green";


### PR DESCRIPTION
## Summary
- Restore missing `resolveSupplyChainWorkspaceHero` import that broke `/supply-chain` at runtime after #813
- Add static regression guard so the hero-state import cannot be dropped again

## Testing
- `cd dashboard && ./node_modules/.bin/tsx src/supply-chain-ux-consolidation.test.ts`
- `cd dashboard && npm run build`
