### PR TITLE
fix(guard): score standalone skills and mcp servers

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -10,7 +10,7 @@ from typing import Literal
 from ..checks.skill_security import resolve_skill_security_context
 from ..models import ScanOptions
 from ..trust_instruction_scoring import build_instruction_domain
-from ..trust_mcp_scoring import build_mcp_domain
+from ..trust_mcp_scoring import build_mcp_domain, build_mcp_surface_domain
 from ..trust_models import TrustAdapterScore, TrustComponentScore, TrustDomainScore
 from ..trust_plugin_scoring import build_plugin_domain
 from ..trust_skill_scoring import build_skill_domain
@@ -137,7 +137,12 @@ def _local_trust_domain_for_artifact(
         context = resolve_skill_security_context(trust_root, _INVENTORY_TRUST_SCAN_OPTIONS)
         return build_skill_domain(trust_root, context)
     if item_kind == "mcp_server":
-        return build_mcp_domain(trust_root, ())
+        return build_mcp_domain(trust_root, ()) or build_mcp_surface_domain(
+            name=getattr(artifact, "name", None),
+            command=getattr(artifact, "command", None),
+            url=getattr(artifact, "url", None),
+            transport=getattr(artifact, "transport", None),
+        )
     if item_kind in {"overlay", "policy", "prompt_pack"}:
         role = metadata.get("instructionRole")
         normalized_role = role if isinstance(role, str) and role else "unknown_instruction"

--- a/src/codex_plugin_scanner/trust_mcp_scoring.py
+++ b/src/codex_plugin_scanner/trust_mcp_scoring.py
@@ -45,11 +45,7 @@ def build_mcp_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]) -
             args_valid = args_value is None or (
                 isinstance(args_value, list) and all(isinstance(value, str) for value in args_value)
             )
-            if not (
-                isinstance(config.get("command"), str)
-                and bool(config.get("command"))
-                and args_valid
-            ):
+            if not (isinstance(config.get("command"), str) and bool(config.get("command")) and args_valid):
                 local_commands_valid = False
                 break
     config_shape = payload_state.parse_valid and (
@@ -182,17 +178,13 @@ def build_mcp_surface_domain(
             spec_by_id["verification.execution-safety"],
             component_scores={"score": round_trust_score(execution_score)} if execution_score > 0 else None,
             rationales={
-                "score": (
-                    "Execution safety was inferred from the MCP transport and local command/endpoint shape."
-                )
+                "score": ("Execution safety was inferred from the MCP transport and local command/endpoint shape.")
             },
         ),
         build_adapter_score(
             spec_by_id["verification.transport-security"],
             component_scores={"score": round_trust_score(transport_score)} if transport_score > 0 else None,
-            rationales={
-                "score": "Transport security was inferred from the MCP transport and endpoint protocol."
-            },
+            rationales={"score": "Transport security was inferred from the MCP transport and endpoint protocol."},
         ),
         build_adapter_score(
             spec_by_id["metadata.server-naming"],
@@ -221,8 +213,7 @@ def build_mcp_surface_domain(
             component_scores={"score": round_trust_score(config_shape_score)} if config_shape_score > 0 else None,
             rationales={
                 "score": (
-                    "The MCP server definition has enough structure to infer command, "
-                    "endpoint, and transport shape."
+                    "The MCP server definition has enough structure to infer command, endpoint, and transport shape."
                 )
             },
         ),

--- a/src/codex_plugin_scanner/trust_mcp_scoring.py
+++ b/src/codex_plugin_scanner/trust_mcp_scoring.py
@@ -12,6 +12,7 @@ from .trust_helpers import (
     check_percent,
     is_https_url,
     load_mcp_payload,
+    round_trust_score,
 )
 from .trust_models import TrustDomainScore
 from .trust_specs import MCP_TRUST_SPEC
@@ -34,22 +35,23 @@ def build_mcp_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]) -
         if remote_entries
         else True
     )
-    local_commands_valid = (
-        all(
-            isinstance(config, dict)
-            and isinstance(config.get("command"), str)
-            and bool(config.get("command"))
-            and (
-                "args" not in config
-                or (
-                    isinstance(config.get("args"), list) and all(isinstance(value, str) for value in config.get("args"))
-                )
+    local_commands_valid = True
+    if local_servers:
+        for config in local_servers.values():
+            if not isinstance(config, dict):
+                local_commands_valid = False
+                break
+            args_value = config.get("args")
+            args_valid = args_value is None or (
+                isinstance(args_value, list) and all(isinstance(value, str) for value in args_value)
             )
-            for config in local_servers.values()
-        )
-        if local_servers
-        else True
-    )
+            if not (
+                isinstance(config.get("command"), str)
+                and bool(config.get("command"))
+                and args_valid
+            ):
+                local_commands_valid = False
+                break
     config_shape = payload_state.parse_valid and (
         (remotes is None or isinstance(remotes, list)) and (servers is None or isinstance(servers, dict))
     )
@@ -109,6 +111,118 @@ def build_mcp_domain(plugin_dir: Path, categories: tuple[CategoryResult, ...]) -
                     "The top-level MCP config containers match the expected shape."
                     if config_shape
                     else "The MCP config containers do not match the expected shape."
+                )
+            },
+        ),
+    )
+    return build_domain_score(domain="mcp", spec=MCP_TRUST_SPEC, adapters=adapters)
+
+
+def build_mcp_surface_domain(
+    *,
+    name: str | None,
+    command: str | None,
+    url: str | None,
+    transport: str | None,
+) -> TrustDomainScore | None:
+    normalized_name = name.strip() if isinstance(name, str) else ""
+    normalized_command = command.strip() if isinstance(command, str) else ""
+    normalized_url = url.strip() if isinstance(url, str) else ""
+    normalized_transport = transport.strip().lower() if isinstance(transport, str) else ""
+
+    has_command = bool(normalized_command)
+    has_endpoint = bool(normalized_url)
+    has_surface = bool(normalized_name) or has_command or has_endpoint
+    if not has_surface:
+        return None
+
+    secure_endpoint = is_https_url(normalized_url)
+    stdio_like = normalized_transport == "stdio"
+    transport_declared = bool(normalized_transport)
+
+    if stdio_like and has_command:
+        execution_score = 90.0
+    elif secure_endpoint:
+        execution_score = 80.0
+    elif has_endpoint:
+        execution_score = 35.0
+    else:
+        execution_score = 45.0 if has_command else 0.0
+
+    if stdio_like:
+        transport_score = 100.0
+    elif secure_endpoint:
+        transport_score = 85.0
+    elif has_endpoint:
+        transport_score = 25.0
+    else:
+        transport_score = 40.0 if transport_declared else 0.0
+
+    if transport_declared and (has_command or has_endpoint):
+        config_shape_score = 100.0
+    elif has_command or has_endpoint:
+        config_shape_score = 60.0
+    else:
+        config_shape_score = 0.0
+
+    spec_by_id = {adapter.adapter_id: adapter for adapter in MCP_TRUST_SPEC.adapters}
+    adapters = (
+        build_adapter_score(
+            spec_by_id["verification.config-integrity"],
+            component_scores={"score": 100.0} if has_command or has_endpoint else None,
+            rationales={
+                "score": (
+                    "The MCP server definition declares a concrete command or endpoint in the agent config."
+                    if has_command or has_endpoint
+                    else "No command or endpoint could be recovered from the MCP server definition."
+                )
+            },
+        ),
+        build_adapter_score(
+            spec_by_id["verification.execution-safety"],
+            component_scores={"score": round_trust_score(execution_score)} if execution_score > 0 else None,
+            rationales={
+                "score": (
+                    "Execution safety was inferred from the MCP transport and local command/endpoint shape."
+                )
+            },
+        ),
+        build_adapter_score(
+            spec_by_id["verification.transport-security"],
+            component_scores={"score": round_trust_score(transport_score)} if transport_score > 0 else None,
+            rationales={
+                "score": "Transport security was inferred from the MCP transport and endpoint protocol."
+            },
+        ),
+        build_adapter_score(
+            spec_by_id["metadata.server-naming"],
+            component_scores={"score": 100.0} if normalized_name else None,
+            rationales={
+                "score": (
+                    "The MCP server definition provides an explicit server name."
+                    if normalized_name
+                    else "No MCP server name was available from the agent configuration."
+                )
+            },
+        ),
+        build_adapter_score(
+            spec_by_id["metadata.command-or-endpoint"],
+            component_scores={"score": 100.0} if has_command or has_endpoint else None,
+            rationales={
+                "score": (
+                    "The MCP server definition includes a concrete command or endpoint."
+                    if has_command or has_endpoint
+                    else "The MCP server definition is missing both command and endpoint details."
+                )
+            },
+        ),
+        build_adapter_score(
+            spec_by_id["metadata.config-shape"],
+            component_scores={"score": round_trust_score(config_shape_score)} if config_shape_score > 0 else None,
+            rationales={
+                "score": (
+                    "The MCP server definition has enough structure to infer command, "
+                    "endpoint, and transport shape."
                 )
             },
         ),

--- a/src/codex_plugin_scanner/trust_mcp_scoring.py
+++ b/src/codex_plugin_scanner/trust_mcp_scoring.py
@@ -136,15 +136,6 @@ def build_mcp_surface_domain(
     stdio_like = normalized_transport == "stdio"
     transport_declared = bool(normalized_transport)
 
-    if stdio_like and has_command:
-        execution_score = 90.0
-    elif secure_endpoint:
-        execution_score = 80.0
-    elif has_endpoint:
-        execution_score = 35.0
-    else:
-        execution_score = 45.0 if has_command else 0.0
-
     if stdio_like:
         transport_score = 100.0
     elif secure_endpoint:
@@ -165,20 +156,21 @@ def build_mcp_surface_domain(
     adapters = (
         build_adapter_score(
             spec_by_id["verification.config-integrity"],
-            component_scores={"score": 100.0} if has_command or has_endpoint else None,
+            component_scores=None,
             rationales={
                 "score": (
-                    "The MCP server definition declares a concrete command or endpoint in the agent config."
-                    if has_command or has_endpoint
-                    else "No command or endpoint could be recovered from the MCP server definition."
+                    "Config-defined MCP fallback does not claim config-integrity without a parseable .mcp.json payload."
                 )
             },
         ),
         build_adapter_score(
             spec_by_id["verification.execution-safety"],
-            component_scores={"score": round_trust_score(execution_score)} if execution_score > 0 else None,
+            component_scores=None,
             rationales={
-                "score": ("Execution safety was inferred from the MCP transport and local command/endpoint shape.")
+                "score": (
+                    "Config-defined MCP fallback does not infer execution-safety "
+                    "without scanner or payload-backed evidence."
+                )
             },
         ),
         build_adapter_score(

--- a/src/codex_plugin_scanner/trust_skill_scoring.py
+++ b/src/codex_plugin_scanner/trust_skill_scoring.py
@@ -22,16 +22,17 @@ from .trust_specs import SKILL_TRUST_SPEC
 
 
 def _skill_files(plugin_dir: Path, manifest: dict[str, object] | None) -> tuple[Path, ...]:
+    standalone_skill = plugin_dir / "SKILL.md"
     if manifest is None:
-        return ()
+        return (standalone_skill,) if standalone_skill.is_file() else ()
     skills_root = manifest.get("skills")
     if not isinstance(skills_root, str) or not skills_root.strip():
-        return ()
+        return (standalone_skill,) if standalone_skill.is_file() else ()
     if not is_safe_relative_path(plugin_dir, skills_root):
-        return ()
+        return (standalone_skill,) if standalone_skill.is_file() else ()
     skills_dir = plugin_dir / skills_root
     if not skills_dir.is_dir():
-        return ()
+        return (standalone_skill,) if standalone_skill.is_file() else ()
     return iter_safe_matching_files(plugin_dir, skills_dir, "**/SKILL.md")
 
 
@@ -124,6 +125,22 @@ def build_skill_domain(
 
     frontmatters = tuple(payload for payload in (parse_skill_frontmatter(path) for path in skill_files) if payload)
     normalized = _normalized_skill_metadata(manifest, frontmatters)
+    raw_descriptions = normalized.get("descriptions")
+    descriptions = (
+        tuple(description for description in raw_descriptions if isinstance(description, str))
+        if isinstance(raw_descriptions, tuple)
+        else ()
+    )
+    raw_tags = normalized.get("tags")
+    tags = tuple(tag for tag in raw_tags if isinstance(tag, str)) if isinstance(raw_tags, tuple) else ()
+    raw_languages = normalized.get("languages")
+    languages = (
+        tuple(language for language in raw_languages if isinstance(language, str))
+        if isinstance(raw_languages, tuple)
+        else ()
+    )
+    repository = str(normalized.get("repository") or "")
+    homepage = str(normalized.get("homepage") or "")
     has_author = (
         isinstance(manifest, dict)
         and isinstance(manifest.get("author"), dict)
@@ -133,15 +150,15 @@ def build_skill_domain(
     all_frontmatter_valid = len(frontmatters) == len(skill_files) and all(
         has_required_skill_frontmatter(payload) for payload in frontmatters
     )
-    repo_host = url_host(str(normalized["repository"]) or None)
-    home_host = url_host(str(normalized["homepage"]) or None)
+    repo_host = url_host(repository or None)
+    home_host = url_host(homepage or None)
     description_length = (
-        sum(len(description) for description in normalized["descriptions"]) / len(normalized["descriptions"])
-        if normalized["descriptions"]
+        sum(len(description) for description in descriptions) / len(descriptions)
+        if descriptions
         else 0
     )
-    tag_count = len(normalized["tags"])
-    language_count = len(normalized["languages"])
+    tag_count = len(tags)
+    language_count = len(languages)
 
     adapter_inputs: dict[str, tuple[dict[str, float] | None, dict[str, str], bool]] = {
         "verification.review-status": (

--- a/src/codex_plugin_scanner/trust_skill_scoring.py
+++ b/src/codex_plugin_scanner/trust_skill_scoring.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import TypedDict
 
 from .checks.manifest import load_manifest
 from .checks.skill_security import SkillSecurityContext
@@ -21,6 +22,15 @@ from .trust_models import TrustDomainScore
 from .trust_specs import SKILL_TRUST_SPEC
 
 
+class NormalizedSkillMetadata(TypedDict):
+    descriptions: tuple[str, ...]
+    repository: str
+    homepage: str
+    commit: str
+    tags: tuple[str, ...]
+    languages: tuple[str, ...]
+
+
 def _skill_files(plugin_dir: Path, manifest: dict[str, object] | None) -> tuple[Path, ...]:
     standalone_skill = plugin_dir / "SKILL.md"
     if manifest is None:
@@ -33,13 +43,13 @@ def _skill_files(plugin_dir: Path, manifest: dict[str, object] | None) -> tuple[
     skills_dir = plugin_dir / skills_root
     if not skills_dir.is_dir():
         return (standalone_skill,) if standalone_skill.is_file() else ()
-    return iter_safe_matching_files(plugin_dir, skills_dir, "**/SKILL.md")
+    return tuple(iter_safe_matching_files(plugin_dir, skills_dir, "**/SKILL.md"))
 
 
 def _normalized_skill_metadata(
     manifest: dict[str, object] | None,
     frontmatters: tuple[dict[str, object], ...],
-) -> dict[str, object]:
+) -> NormalizedSkillMetadata:
     descriptions = [
         str(payload.get("description", "")).strip() for payload in frontmatters if payload.get("description")
     ]
@@ -125,22 +135,11 @@ def build_skill_domain(
 
     frontmatters = tuple(payload for payload in (parse_skill_frontmatter(path) for path in skill_files) if payload)
     normalized = _normalized_skill_metadata(manifest, frontmatters)
-    raw_descriptions = normalized.get("descriptions")
-    descriptions = (
-        tuple(description for description in raw_descriptions if isinstance(description, str))
-        if isinstance(raw_descriptions, tuple)
-        else ()
-    )
-    raw_tags = normalized.get("tags")
-    tags = tuple(tag for tag in raw_tags if isinstance(tag, str)) if isinstance(raw_tags, tuple) else ()
-    raw_languages = normalized.get("languages")
-    languages = (
-        tuple(language for language in raw_languages if isinstance(language, str))
-        if isinstance(raw_languages, tuple)
-        else ()
-    )
-    repository = str(normalized.get("repository") or "")
-    homepage = str(normalized.get("homepage") or "")
+    descriptions = normalized["descriptions"]
+    tags = normalized["tags"]
+    languages = normalized["languages"]
+    repository = normalized["repository"]
+    homepage = normalized["homepage"]
     has_author = (
         isinstance(manifest, dict)
         and isinstance(manifest.get("author"), dict)
@@ -153,9 +152,7 @@ def build_skill_domain(
     repo_host = url_host(repository or None)
     home_host = url_host(homepage or None)
     description_length = (
-        sum(len(description) for description in descriptions) / len(descriptions)
-        if descriptions
-        else 0
+        sum(len(description) for description in descriptions) / len(descriptions) if descriptions else 0
     )
     tag_count = len(tags)
     language_count = len(languages)

--- a/src/codex_plugin_scanner/trust_skill_scoring.py
+++ b/src/codex_plugin_scanner/trust_skill_scoring.py
@@ -43,7 +43,10 @@ def _skill_files(plugin_dir: Path, manifest: dict[str, object] | None) -> tuple[
     skills_dir = plugin_dir / skills_root
     if not skills_dir.is_dir():
         return (standalone_skill,) if standalone_skill.is_file() else ()
-    return tuple(iter_safe_matching_files(plugin_dir, skills_dir, "**/SKILL.md"))
+    skill_files = tuple(iter_safe_matching_files(plugin_dir, skills_dir, "**/SKILL.md"))
+    if skill_files:
+        return skill_files
+    return (standalone_skill,) if standalone_skill.is_file() else ()
 
 
 def _normalized_skill_metadata(
@@ -140,6 +143,7 @@ def build_skill_domain(
     languages = normalized["languages"]
     repository = normalized["repository"]
     homepage = normalized["homepage"]
+    commit = normalized["commit"]
     has_author = (
         isinstance(manifest, dict)
         and isinstance(manifest.get("author"), dict)
@@ -184,11 +188,11 @@ def build_skill_domain(
             True,
         ),
         "verification.repo-commit-integrity": (
-            {"score": 100.0} if normalized["repository"] and normalized["commit"] else None,
+            {"score": 100.0} if repository and commit else None,
             {
                 "score": (
                     "The bundled skill metadata declares both a repository URL and an immutable commit reference."
-                    if normalized["repository"] and normalized["commit"]
+                    if repository and commit
                     else (
                         "Repo-commit integrity requires both a repository URL and "
                         "a commit reference in local bundled-skill metadata."

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -53,6 +54,44 @@ def _trust_layer_types(item_metadata: dict[str, object]) -> set[str]:
         for layer in layers
         if isinstance(layer, dict) and isinstance(layer.get("layerType"), str)
     }
+
+
+def _snapshot_for_artifact(
+    *,
+    artifact: GuardArtifact,
+    generated_at: str,
+    home_dir: Path,
+    workspace_dir: Path,
+) -> Any:
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(artifact.config_path),),
+        artifacts=(artifact,),
+    )
+    return inventory_snapshot_from_detection(
+        detection,
+        generated_at=generated_at,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    )
+
+
+def _assert_local_trust(
+    item_metadata: dict[str, object],
+    *,
+    trust_domain: str | None = None,
+) -> tuple[dict[str, object], dict[str, object]]:
+    trust = item_metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    assert trust.get("resolutionSource") == "local"
+    metadata = trust.get("metadata")
+    assert isinstance(metadata, dict)
+    if trust_domain is not None:
+        assert metadata.get("trustDomain") == trust_domain
+    assert "local_baseline" in _trust_layer_types(item_metadata)
+    return trust, metadata
 
 
 def _install_test_attestation_key(monkeypatch) -> GuardTrustAttestationVerificationKey:
@@ -106,47 +145,32 @@ def test_trust_resolution_captured_at_uses_utc_z_suffix() -> None:
 def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Path) -> None:
     plugin_dir = tmp_path
     _write_good_plugin(plugin_dir)
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(plugin_dir / ".codex-plugin" / "plugin.json"),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:project:plugin:trust-demo",
-                name="trust-demo",
-                harness="codex",
-                artifact_type="plugin",
-                source_scope="project",
-                config_path=str(plugin_dir),
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:plugin:trust-demo",
+            name="trust-demo",
+            harness="codex",
+            artifact_type="plugin",
+            source_scope="project",
+            config_path=str(plugin_dir),
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
     )
     plugin_item = next(item for item in snapshot.items if item.item_kind == "plugin")
-    trust = plugin_item.metadata.get("trustResolution")
-    assert isinstance(trust, dict)
-    assert trust.get("resolutionSource") == "local"
+    trust, metadata = _assert_local_trust(plugin_item.metadata, trust_domain="plugin")
     assert trust.get("status") == "local"
     assert trust.get("capturedAt") == "2026-06-10T12:00:00Z"
-    assert isinstance(trust.get("trustScore"), int)
-    assert trust.get("trustScore", 0) > 0
-    metadata = trust.get("metadata")
-    assert isinstance(metadata, dict)
-    assert metadata.get("trustDomain") == "plugin"
+    trust_score = trust.get("trustScore")
+    assert isinstance(trust_score, int)
+    assert trust_score > 0
     assert metadata.get("scorer") == "hol-guard-local"
     assert metadata.get("attestationStatus") == "unsigned"
     assert isinstance(metadata.get("evidenceHash"), str)
     components = trust.get("trustComponents")
     assert isinstance(components, list)
     assert components
-    assert "local_baseline" in _trust_layer_types(plugin_item.metadata)
 
 
 def test_inventory_skill_trust_enrichment_disables_cisco_scan(
@@ -199,35 +223,22 @@ def test_inventory_skill_trust_enrichment_disables_cisco_scan(
         _record_cisco_mode,
     )
 
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(skills_dir / "SKILL.md"),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:project:skill:demo-skill",
-                name="demo-skill",
-                harness="codex",
-                artifact_type="skill",
-                source_scope="project",
-                config_path=str(skills_dir / "SKILL.md"),
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:skill:demo-skill",
+            name="demo-skill",
+            harness="codex",
+            artifact_type="skill",
+            source_scope="project",
+            config_path=str(skills_dir / "SKILL.md"),
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
     )
     skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
-    trust = skill_item.metadata.get("trustResolution")
-    assert isinstance(trust, dict)
-    assert trust.get("resolutionSource") == "local"
+    _assert_local_trust(skill_item.metadata)
     assert cisco_modes == ["off"]
-    assert "local_baseline" in _trust_layer_types(skill_item.metadata)
 
 
 def test_inventory_snapshot_attaches_local_skill_trust_resolution(tmp_path: Path) -> None:
@@ -236,42 +247,27 @@ def test_inventory_snapshot_attaches_local_skill_trust_resolution(tmp_path: Path
     skills_dir = plugin_dir / "skills" / "demo-skill"
     skills_dir.mkdir(parents=True)
     (skills_dir / "SKILL.md").write_text("---\nname: demo-skill\ndescription: Demo\n---\n", encoding="utf-8")
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(skills_dir / "SKILL.md"),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:project:skill:demo-skill",
-                name="demo-skill",
-                harness="codex",
-                artifact_type="skill",
-                source_scope="project",
-                config_path=str(skills_dir / "SKILL.md"),
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:skill:demo-skill",
+            name="demo-skill",
+            harness="codex",
+            artifact_type="skill",
+            source_scope="project",
+            config_path=str(skills_dir / "SKILL.md"),
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
     )
     skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
-    trust = skill_item.metadata.get("trustResolution")
-    assert isinstance(trust, dict)
-    metadata = trust.get("metadata")
-    assert isinstance(metadata, dict)
-    assert metadata.get("trustDomain") == "skills"
+    trust, metadata = _assert_local_trust(skill_item.metadata, trust_domain="skills")
     assert metadata.get("attestationStatus") == "unsigned"
     assert isinstance(metadata.get("evidenceHash"), str)
     components = trust.get("trustComponents")
     assert isinstance(components, list)
     assert len(components) > 0
     assert all(isinstance(component.get("componentId"), str) for component in components)
-    assert "local_baseline" in _trust_layer_types(skill_item.metadata)
 
 
 def test_inventory_snapshot_attaches_local_standalone_skill_trust_resolution(tmp_path: Path) -> None:
@@ -281,38 +277,22 @@ def test_inventory_snapshot_attaches_local_standalone_skill_trust_resolution(tmp
         "---\nname: adapt\ndescription: Responsive helper\nrepo: https://github.com/hashgraph-online/test\n---\n",
         encoding="utf-8",
     )
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(skill_dir / "SKILL.md"),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:global:skill:.agents/skills:adapt",
-                name="adapt",
-                harness="codex",
-                artifact_type="skill",
-                source_scope="global",
-                config_path=str(skill_dir / "SKILL.md"),
-                metadata={"skill_root": ".agents/skills"},
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:global:skill:.agents/skills:adapt",
+            name="adapt",
+            harness="codex",
+            artifact_type="skill",
+            source_scope="global",
+            config_path=str(skill_dir / "SKILL.md"),
+            metadata={"skill_root": ".agents/skills"},
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=tmp_path,
     )
     skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
-    trust = skill_item.metadata.get("trustResolution")
-    assert isinstance(trust, dict)
-    assert trust.get("resolutionSource") == "local"
-    metadata = trust.get("metadata")
-    assert isinstance(metadata, dict)
-    assert metadata.get("trustDomain") == "skills"
-    assert "local_baseline" in _trust_layer_types(skill_item.metadata)
+    _assert_local_trust(skill_item.metadata, trust_domain="skills")
 
 
 def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) -> None:
@@ -331,38 +311,22 @@ def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) 
         ),
         encoding="utf-8",
     )
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(plugin_dir / ".mcp.json"),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:project:mcp:local-demo",
-                name="local-demo",
-                harness="codex",
-                artifact_type="mcp_server",
-                source_scope="project",
-                config_path=str(plugin_dir / ".mcp.json"),
-                transport="stdio",
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:mcp:local-demo",
+            name="local-demo",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="project",
+            config_path=str(plugin_dir / ".mcp.json"),
+            transport="stdio",
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
     )
     mcp_item = next(item for item in snapshot.items if item.item_kind == "mcp_server")
-    trust = mcp_item.metadata.get("trustResolution")
-    assert isinstance(trust, dict)
-    assert trust.get("resolutionSource") == "local"
-    metadata = trust.get("metadata")
-    assert isinstance(metadata, dict)
-    assert metadata.get("trustDomain") == "mcp"
-    assert "local_baseline" in _trust_layer_types(mcp_item.metadata)
+    _assert_local_trust(mcp_item.metadata, trust_domain="mcp")
 
 
 def test_inventory_snapshot_attaches_local_config_defined_mcp_trust_resolution(tmp_path: Path) -> None:
@@ -371,65 +335,39 @@ def test_inventory_snapshot_attaches_local_config_defined_mcp_trust_resolution(t
         '[mcp_servers.demo]\ncommand = "node"\nargs = ["server.js"]\n',
         encoding="utf-8",
     )
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(config_path),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:global:mcp:demo",
-                name="demo",
-                harness="codex",
-                artifact_type="mcp_server",
-                source_scope="global",
-                config_path=str(config_path),
-                command="node",
-                args=("server.js",),
-                transport="stdio",
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:global:mcp:demo",
+            name="demo",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="global",
+            config_path=str(config_path),
+            command="node",
+            args=("server.js",),
+            transport="stdio",
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=tmp_path,
     )
     mcp_item = next(item for item in snapshot.items if item.item_kind == "mcp_server")
-    trust = mcp_item.metadata.get("trustResolution")
-    assert isinstance(trust, dict)
-    assert trust.get("resolutionSource") == "local"
-    metadata = trust.get("metadata")
-    assert isinstance(metadata, dict)
-    assert metadata.get("trustDomain") == "mcp"
-    assert "local_baseline" in _trust_layer_types(mcp_item.metadata)
+    _assert_local_trust(mcp_item.metadata, trust_domain="mcp")
 
 
 def test_inventory_snapshot_signs_local_trust_metadata_when_configured(monkeypatch, tmp_path: Path) -> None:
     verification_key = _install_test_attestation_key(monkeypatch)
     plugin_dir = tmp_path
     _write_good_plugin(plugin_dir)
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(plugin_dir / ".codex-plugin" / "plugin.json"),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:project:plugin:trust-demo",
-                name="trust-demo",
-                harness="codex",
-                artifact_type="plugin",
-                source_scope="project",
-                config_path=str(plugin_dir),
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:plugin:trust-demo",
+            name="trust-demo",
+            harness="codex",
+            artifact_type="plugin",
+            source_scope="project",
+            config_path=str(plugin_dir),
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
@@ -458,9 +396,7 @@ def test_inventory_snapshot_signs_local_trust_metadata_when_configured(monkeypat
     trust_layers = plugin_item.metadata.get("trustLayers")
     assert isinstance(trust_layers, list)
     local_layer = next(
-        layer
-        for layer in trust_layers
-        if isinstance(layer, dict) and layer.get("layerType") == "local_baseline"
+        layer for layer in trust_layers if isinstance(layer, dict) and layer.get("layerType") == "local_baseline"
     )
     layer_metadata = local_layer.get("metadata")
     assert isinstance(layer_metadata, dict)
@@ -491,43 +427,30 @@ def test_registry_identified_skill_still_gets_local_baseline(tmp_path: Path) -> 
     skills_dir.mkdir(parents=True)
     (skills_dir / "SKILL.md").write_text("---\nname: registry-skill\ndescription: Demo\n---\n", encoding="utf-8")
 
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(skills_dir / "SKILL.md"),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:project:skill:registry-skill",
-                name="registry-skill",
-                harness="codex",
-                artifact_type="skill",
-                source_scope="project",
-                config_path=str(skills_dir / "SKILL.md"),
-                metadata={
-                    "registryIdentity": {
-                        "entityId": "hol-skill-registry-skill",
-                        "entityType": "skill",
-                        "name": "registry-skill",
-                        "version": "1.0.0",
-                    }
-                },
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:skill:registry-skill",
+            name="registry-skill",
+            harness="codex",
+            artifact_type="skill",
+            source_scope="project",
+            config_path=str(skills_dir / "SKILL.md"),
+            metadata={
+                "registryIdentity": {
+                    "entityId": "hol-skill-registry-skill",
+                    "entityType": "skill",
+                    "name": "registry-skill",
+                    "version": "1.0.0",
+                }
+            },
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
     )
     skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
-
-    trust_resolution = skill_item.metadata.get("trustResolution")
-    assert isinstance(trust_resolution, dict)
+    trust_resolution, _ = _assert_local_trust(skill_item.metadata)
     assert trust_resolution.get("resolutionSource") == "local"
-    assert "local_baseline" in _trust_layer_types(skill_item.metadata)
 
 
 def test_inventory_snapshot_attaches_instruction_trust_resolution(tmp_path: Path) -> None:
@@ -539,36 +462,20 @@ def test_inventory_snapshot_attaches_instruction_trust_resolution(tmp_path: Path
         encoding="utf-8",
     )
 
-    detection = HarnessDetection(
-        harness="codex",
-        installed=True,
-        command_available=True,
-        config_paths=(str(design_doc),),
-        artifacts=(
-            GuardArtifact(
-                artifact_id="codex:project:instruction:design",
-                name="DESIGN.md",
-                harness="codex",
-                artifact_type="instruction",
-                source_scope="project",
-                config_path=str(design_doc),
-            ),
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:instruction:design",
+            name="DESIGN.md",
+            harness="codex",
+            artifact_type="instruction",
+            source_scope="project",
+            config_path=str(design_doc),
         ),
-    )
-
-    snapshot = inventory_snapshot_from_detection(
-        detection,
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=workspace,
     )
     overlay_item = next(item for item in snapshot.items if item.item_kind == "overlay")
-    trust = overlay_item.metadata.get("trustResolution")
 
     assert overlay_item.metadata.get("instructionRole") == "design_md"
-    assert isinstance(trust, dict)
-    assert trust.get("resolutionSource") == "local"
-    trust_metadata = trust.get("metadata")
-    assert isinstance(trust_metadata, dict)
-    assert trust_metadata.get("trustDomain") == "instructions"
-    assert "local_baseline" in _trust_layer_types(overlay_item.metadata)
+    _assert_local_trust(overlay_item.metadata, trust_domain="instructions")

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -274,6 +274,47 @@ def test_inventory_snapshot_attaches_local_skill_trust_resolution(tmp_path: Path
     assert "local_baseline" in _trust_layer_types(skill_item.metadata)
 
 
+def test_inventory_snapshot_attaches_local_standalone_skill_trust_resolution(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".agents" / "skills" / "adapt"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: adapt\ndescription: Responsive helper\nrepo: https://github.com/hashgraph-online/test\n---\n",
+        encoding="utf-8",
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(skill_dir / "SKILL.md"),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:global:skill:.agents/skills:adapt",
+                name="adapt",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_dir / "SKILL.md"),
+                metadata={"skill_root": ".agents/skills"},
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=tmp_path,
+    )
+    skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
+    trust = skill_item.metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    assert trust.get("resolutionSource") == "local"
+    metadata = trust.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("trustDomain") == "skills"
+    assert "local_baseline" in _trust_layer_types(skill_item.metadata)
+
+
 def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) -> None:
     plugin_dir = tmp_path
     _write_good_plugin(plugin_dir)
@@ -313,6 +354,48 @@ def test_inventory_snapshot_attaches_local_mcp_trust_resolution(tmp_path: Path) 
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
+    )
+    mcp_item = next(item for item in snapshot.items if item.item_kind == "mcp_server")
+    trust = mcp_item.metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    assert trust.get("resolutionSource") == "local"
+    metadata = trust.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("trustDomain") == "mcp"
+    assert "local_baseline" in _trust_layer_types(mcp_item.metadata)
+
+
+def test_inventory_snapshot_attaches_local_config_defined_mcp_trust_resolution(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.toml"
+    config_path.write_text(
+        '[mcp_servers.demo]\ncommand = "node"\nargs = ["server.js"]\n',
+        encoding="utf-8",
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(config_path),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:global:mcp:demo",
+                name="demo",
+                harness="codex",
+                artifact_type="mcp_server",
+                source_scope="global",
+                config_path=str(config_path),
+                command="node",
+                args=("server.js",),
+                transport="stdio",
+            ),
+        ),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=tmp_path,
     )
     mcp_item = next(item for item in snapshot.items if item.item_kind == "mcp_server")
     trust = mcp_item.metadata.get("trustResolution")


### PR DESCRIPTION
## Summary
- score standalone `SKILL.md` artifacts so skills outside plugin manifests emit local baseline trust metadata
- score config-defined MCP servers from command, endpoint, and transport fields when no `.mcp.json` payload exists

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/trust_skill_scoring.py src/codex_plugin_scanner/trust_mcp_scoring.py src/codex_plugin_scanner/guard/aibom_trust_metadata.py tests/test_guard_aibom_trust_metadata.py`
- `pytest -q tests/test_guard_aibom_trust_metadata.py tests/test_guard_aibom_detection.py tests/test_guard_inventory_contract.py`

## Notes
- this fixes the live gap where skills and MCP servers in synced workspace snapshots were missing both `trustResolution` and `trustLayers` while plugins and prompt packs already had trust metadata
