### PR TITLE
fix(guard): clear stale package-shim PATH false positives after repair

### DIFF
--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2307,17 +2307,18 @@ function normalizePackageShimEntry(
   const pathBroken =
     pathStatus !== "restart_required" &&
     (coverage.pathBroken || detail?.path_broken === true);
-  const activation_state = !installed
-    ? "uninstalled"
-    : integrity === "tampered"
-    ? "repair_required"
-    : active
-    ? "protected"
-    : pathStatus === "restart_required"
-    ? "restart_required"
-    : pathBroken
-    ? "repair_required"
-    : "repair_required";
+  let activation_state: PackageShimEntry["activation_state"];
+  if (!installed) {
+    activation_state = "uninstalled";
+  } else if (integrity === "tampered") {
+    activation_state = "repair_required";
+  } else if (active) {
+    activation_state = "protected";
+  } else if (pathStatus === "restart_required") {
+    activation_state = "restart_required";
+  } else {
+    activation_state = "repair_required";
+  }
   return {
     active,
     activation_state,

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2258,8 +2258,11 @@ function buildPackageShimPathSummary(detail: Record<string, unknown> | null): st
   }
   const shimPath = stringValue(detail.shim_path);
   const realBinaryPath = stringValue(detail.real_binary_path);
+  const pathActive = booleanValue(detail.path_active);
   if (shimPath !== null && realBinaryPath !== null) {
-    return `${shimPath} precedes ${realBinaryPath}`;
+    return pathActive
+      ? `${shimPath} precedes ${realBinaryPath}`
+      : `${realBinaryPath} precedes ${shimPath}`;
   }
   if (shimPath !== null) {
     return shimPath;
@@ -2301,15 +2304,19 @@ function normalizePackageShimEntry(
   const integrity = stringValue(detail?.integrity) ?? "uninstalled";
   const installed = detail !== null && integrity !== "missing";
   const active = booleanValue(detail?.path_active);
-  const pathBroken = coverage.pathBroken || detail?.path_broken === true;
+  const pathBroken =
+    pathStatus !== "restart_required" &&
+    (coverage.pathBroken || detail?.path_broken === true);
   const activation_state = !installed
     ? "uninstalled"
-    : integrity === "tampered" || pathBroken
+    : integrity === "tampered"
     ? "repair_required"
     : active
     ? "protected"
     : pathStatus === "restart_required"
     ? "restart_required"
+    : pathBroken
+    ? "repair_required"
     : "repair_required";
   return {
     active,

--- a/dashboard/src/scsr-phase09-package-firewall-status.test.ts
+++ b/dashboard/src/scsr-phase09-package-firewall-status.test.ts
@@ -90,8 +90,37 @@ assert(
   "SCSR151: restart_required path status maps to restart activation state",
 );
 assert(
+  nestedNpm?.path_broken === false,
+  "SCSR151: restart_required clears path broken after profile repair",
+);
+assert(
   nestedNpm?.last_intercept_proof_at === "2026-06-07T10:00:00Z",
   "SCSR151: snake_case intercept proof map is read",
+);
+
+const pathBrokenSummaryPayload = normalizePackageFirewallStatus({
+  supported_managers: ["npm"],
+  package_shims: {
+    detected_managers: ["npm"],
+    installed_managers: ["npm"],
+    tested_managers: [],
+    path_broken_managers: ["npm"],
+    path_status: "missing_from_path",
+    manager_details: [
+      {
+        manager: "npm",
+        integrity: "ok",
+        path_active: false,
+        shim_path: "/guard-home/package-shims/bin/npm",
+        real_binary_path: "/usr/local/bin/npm",
+      },
+    ],
+  },
+});
+const brokenNpm = pathBrokenSummaryPayload.package_shims.find((entry) => entry.manager === "npm");
+assert(
+  brokenNpm?.path_summary === "/usr/local/bin/npm precedes /guard-home/package-shims/bin/npm",
+  "SCSR151: path summary reflects real binary preceding shim when inactive",
 );
 
 const hiddenManagerPayload = normalizePackageFirewallStatus({

--- a/dashboard/src/supply-chain-firewall-manager-row.tsx
+++ b/dashboard/src/supply-chain-firewall-manager-row.tsx
@@ -28,14 +28,14 @@ export function resolveShimStatus(shim: PackageShimEntry | undefined): {
   if (!shim.installed) {
     return { label: "Unprotected", tone: "attention", icon: "warning" };
   }
-  if (shim.path_broken) {
-    return { label: "PATH broken", tone: "attention", icon: "warning" };
-  }
   if (shim.activation_state === "protected") {
     return { label: "Protected", tone: "green", icon: "check" };
   }
   if (shim.activation_state === "restart_required") {
     return { label: "Restart required", tone: "blue", icon: "restart" };
+  }
+  if (shim.path_broken) {
+    return { label: "PATH broken", tone: "attention", icon: "warning" };
   }
   if (shim.activation_state === "repair_required") {
     return { label: "Needs PATH repair", tone: "attention", icon: "warning" };
@@ -231,7 +231,7 @@ export function ManagerRow({
         </div>
       )}
 
-      {shim?.activation_state === "repair_required" && (
+      {shim?.activation_state === "repair_required" && !shim.path_broken && (
         <div className={cardLayout ? "mt-2" : "px-4 pb-2"}>
           <p className="text-xs text-slate-500">
             Guard can add the shim directory to your shell profile automatically, then this manager will be ready after a restart.

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -435,14 +435,14 @@ function resolveShimStatus(shim) {
   if (!shim.installed) {
     return { label: "Unprotected", tone: "attention", icon: "warning" };
   }
-  if (shim.path_broken) {
-    return { label: "PATH broken", tone: "attention", icon: "warning" };
-  }
   if (shim.activation_state === "protected") {
     return { label: "Protected", tone: "green", icon: "check" };
   }
   if (shim.activation_state === "restart_required") {
     return { label: "Restart required", tone: "blue", icon: "restart" };
+  }
+  if (shim.path_broken) {
+    return { label: "PATH broken", tone: "attention", icon: "warning" };
   }
   if (shim.activation_state === "repair_required") {
     return { label: "Needs PATH repair", tone: "attention", icon: "warning" };
@@ -594,7 +594,7 @@ function ManagerRow({
       ] })
     ] }),
     shim?.activation_state === "restart_required" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: cardLayout ? "mt-2" : "px-4 pb-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Guard updated your shell profile. Open a new shell or restart AI apps to activate this shim." }) }),
-    shim?.activation_state === "repair_required" && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: cardLayout ? "mt-2" : "px-4 pb-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Guard can add the shim directory to your shell profile automatically, then this manager will be ready after a restart." }) }),
+    shim?.activation_state === "repair_required" && !shim.path_broken && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: cardLayout ? "mt-2" : "px-4 pb-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Guard can add the shim directory to your shell profile automatically, then this manager will be ready after a restart." }) }),
     shim?.path_broken && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: cardLayout ? "mt-2" : "px-4 pb-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-brand-attention", children: "Restart your shell after repair so PATH exports reload." }) })
   ] });
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15702,7 +15702,18 @@ function normalizePackageShimEntry(manager, detail, pathStatus, coverage) {
   const installed = detail !== null && integrity !== "missing";
   const active = booleanValue(detail?.path_active);
   const pathBroken = pathStatus !== "restart_required" && (coverage.pathBroken || detail?.path_broken === true);
-  const activation_state = !installed ? "uninstalled" : integrity === "tampered" ? "repair_required" : active ? "protected" : pathStatus === "restart_required" ? "restart_required" : pathBroken ? "repair_required" : "repair_required";
+  let activation_state;
+  if (!installed) {
+    activation_state = "uninstalled";
+  } else if (integrity === "tampered") {
+    activation_state = "repair_required";
+  } else if (active) {
+    activation_state = "protected";
+  } else if (pathStatus === "restart_required") {
+    activation_state = "restart_required";
+  } else {
+    activation_state = "repair_required";
+  }
   return {
     active,
     activation_state,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15669,8 +15669,9 @@ function buildPackageShimPathSummary(detail) {
   }
   const shimPath = stringValue(detail.shim_path);
   const realBinaryPath = stringValue(detail.real_binary_path);
+  const pathActive = booleanValue(detail.path_active);
   if (shimPath !== null && realBinaryPath !== null) {
-    return `${shimPath} precedes ${realBinaryPath}`;
+    return pathActive ? `${shimPath} precedes ${realBinaryPath}` : `${realBinaryPath} precedes ${shimPath}`;
   }
   if (shimPath !== null) {
     return shimPath;
@@ -15700,8 +15701,8 @@ function normalizePackageShimEntry(manager, detail, pathStatus, coverage) {
   const integrity = stringValue(detail?.integrity) ?? "uninstalled";
   const installed = detail !== null && integrity !== "missing";
   const active = booleanValue(detail?.path_active);
-  const pathBroken = coverage.pathBroken || detail?.path_broken === true;
-  const activation_state = !installed ? "uninstalled" : integrity === "tampered" || pathBroken ? "repair_required" : active ? "protected" : pathStatus === "restart_required" ? "restart_required" : "repair_required";
+  const pathBroken = pathStatus !== "restart_required" && (coverage.pathBroken || detail?.path_broken === true);
+  const activation_state = !installed ? "uninstalled" : integrity === "tampered" ? "repair_required" : active ? "protected" : pathStatus === "restart_required" ? "restart_required" : pathBroken ? "repair_required" : "repair_required";
   return {
     active,
     activation_state,

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -298,14 +298,14 @@ def get_path_order_status(
     command = _PACKAGE_SHIM_COMMANDS.get(manager)
     if not command:
         return {"shim_precedes_real": False, "real_binary_found": False, "path_broken": True, "shim_dir": None}
-    shim_dir = (context.guard_home / "package-shims" / "bin").expanduser()
+    shim_dir = (context.guard_home / "package-shims" / "bin").expanduser().resolve()
     shim_path = shim_dir / command
     path_dirs = (path_env or os.environ.get("PATH", "")).split(os.pathsep)
     shim_dir_index: int | None = None
     real_dir_index: int | None = None
     real_binary_path: str | None = None
     for idx, dir_entry in enumerate(path_dirs):
-        d = Path(dir_entry).expanduser()
+        d = Path(dir_entry).expanduser().resolve()
         if d == shim_dir and shim_dir_index is None:
             shim_dir_index = idx
             continue

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -280,6 +280,14 @@ def get_real_binary_info(
     }
 
 
+def _is_package_shim_binary(candidate: Path) -> bool:
+    """Return True when candidate lives under any Guard package-shims/bin directory."""
+
+    parent = candidate.parent
+    grandparent = parent.parent
+    return parent.name == "bin" and grandparent.name == "package-shims"
+
+
 def get_path_order_status(
     context: HarnessContext,
     *,
@@ -290,21 +298,27 @@ def get_path_order_status(
     command = _PACKAGE_SHIM_COMMANDS.get(manager)
     if not command:
         return {"shim_precedes_real": False, "real_binary_found": False, "path_broken": True, "shim_dir": None}
-    shim_dir = context.guard_home / "package-shims" / "bin"
+    shim_dir = (context.guard_home / "package-shims" / "bin").expanduser()
     shim_path = shim_dir / command
     path_dirs = (path_env or os.environ.get("PATH", "")).split(os.pathsep)
     shim_dir_index: int | None = None
     real_dir_index: int | None = None
     real_binary_path: str | None = None
     for idx, dir_entry in enumerate(path_dirs):
-        d = Path(dir_entry)
+        d = Path(dir_entry).expanduser()
         if d == shim_dir and shim_dir_index is None:
             shim_dir_index = idx
-        else:
-            candidate = d / command
-            if candidate.exists() and candidate.is_file() and candidate != shim_path and real_dir_index is None:
-                real_dir_index = idx
-                real_binary_path = str(candidate)
+            continue
+        candidate = d / command
+        if (
+            candidate.exists()
+            and candidate.is_file()
+            and candidate != shim_path
+            and not _is_package_shim_binary(candidate)
+            and real_dir_index is None
+        ):
+            real_dir_index = idx
+            real_binary_path = str(candidate)
     if shim_dir_index is None:
         return {
             "shim_precedes_real": False,

--- a/tests/test_guard_shim_truth.py
+++ b/tests/test_guard_shim_truth.py
@@ -91,6 +91,43 @@ class TestScrg265PathOrderVerification:
         result = get_path_order_status(ctx, manager="npm", path_env=shim_dir)
         assert result["real_binary_found"] is False
 
+    def test_stale_package_shim_dirs_are_ignored_on_path(self, tmp_path: Path) -> None:
+        ctx = _make_context(tmp_path)
+        install_package_shims(ctx, managers=("npm",))
+        shim_dir = str(ctx.guard_home / "package-shims" / "bin")
+        stale_home = tmp_path / "pytest-guard-home"
+        stale_shim_dir = stale_home / "package-shims" / "bin"
+        stale_shim_dir.mkdir(parents=True)
+        stale_shim = stale_shim_dir / "npm"
+        stale_shim.write_text("#!/bin/sh\nstale shim", encoding="utf-8")
+        stale_shim.chmod(0o755)
+        real_dir = str(tmp_path / "usr" / "bin")
+        Path(real_dir).mkdir(parents=True, exist_ok=True)
+        real_binary = Path(real_dir) / "npm"
+        real_binary.write_text("#!/bin/sh\nnpm $@", encoding="utf-8")
+        real_binary.chmod(0o755)
+        fake_path = f"{shim_dir}:{stale_shim_dir}:{real_dir}"
+        result = get_path_order_status(ctx, manager="npm", path_env=fake_path)
+        assert result["shim_precedes_real"] is True
+        assert result["path_broken"] is False
+        assert result["real_binary_path"] == str(real_binary)
+
+    def test_only_stale_package_shim_before_canonical_is_not_path_broken(self, tmp_path: Path) -> None:
+        ctx = _make_context(tmp_path)
+        install_package_shims(ctx, managers=("npm",))
+        shim_dir = str(ctx.guard_home / "package-shims" / "bin")
+        stale_home = tmp_path / "pytest-guard-home"
+        stale_shim_dir = stale_home / "package-shims" / "bin"
+        stale_shim_dir.mkdir(parents=True)
+        stale_shim = stale_shim_dir / "npm"
+        stale_shim.write_text("#!/bin/sh\nstale shim", encoding="utf-8")
+        stale_shim.chmod(0o755)
+        fake_path = f"{stale_shim_dir}:{shim_dir}"
+        result = get_path_order_status(ctx, manager="npm", path_env=fake_path)
+        assert result["shim_precedes_real"] is True
+        assert result["path_broken"] is False
+        assert result["real_binary_found"] is False
+
 
 class TestScrg268RealBinaryInfo:
     """SCRG268: real binary info recorded safely (hash, mtime), no private path in Cloud."""


### PR DESCRIPTION
## Summary
- Ignore stale `package-shims/bin` directories when evaluating PATH order so pytest temp shims are not treated as real npm/pnpm binaries.
- After Fix PATH configures the shell profile, show restart-required on the manager card instead of leaving PATH broken visible.
- Correct shell-path summary copy to reflect which binary actually precedes the other.

## Testing
- `python3 -m pytest tests/test_guard_shim_truth.py::TestScrg265PathOrderVerification -q`
- `cd dashboard && ./node_modules/.bin/tsx src/scsr-phase09-package-firewall-status.test.ts`
- `cd dashboard && npm run build`
