### PR TITLE
fix(guard): surface incomplete workspace audits instead of false clean state

### DIFF
--- a/dashboard/src/scsr-phase09c-evidence-rail.test.ts
+++ b/dashboard/src/scsr-phase09c-evidence-rail.test.ts
@@ -174,4 +174,27 @@ assert(
   "SCSR154-G: blocked audit receipts still surface in audit slot",
 );
 
+const incompleteAuditReceipt: GuardReceipt = {
+  ...auditReceipt,
+  receipt_id: "receipt-audit-incomplete-1",
+  policy_decision: "ask",
+  capabilities_summary: "Sync Guard supply-chain intel on this device before auditing workspace packages.",
+  timestamp: "2026-06-09T16:00:00.000Z",
+  scanner_evidence: [
+    {
+      operation: "audit",
+      audit_status: "incomplete",
+      audit_decision: "monitor",
+      blocked_package_count: 0,
+      total_packages: 0,
+    },
+  ] as unknown as GuardReceipt["scanner_evidence"],
+};
+const incompleteRail = deriveSupplyChainEvidenceRail([incompleteAuditReceipt]);
+assert(
+  incompleteRail.audit.title === "Workspace audit did not complete",
+  "SCSR154-H: incomplete audit receipts surface warning copy on evidence rail",
+);
+assert(incompleteRail.audit.tone === "attention", "SCSR154-I: incomplete audit receipts use attention tone");
+
 console.log("scsr-phase09c-evidence-rail.test.ts: all assertions passed");

--- a/dashboard/src/scsr-phase10-package-workbench.test.ts
+++ b/dashboard/src/scsr-phase10-package-workbench.test.ts
@@ -4,6 +4,7 @@ import {
   normalizeSupplyChainAuditSnapshot,
   sortPackageWorkbenchFindings,
 } from "./supply-chain-audit-normalize";
+import { isSupplyChainAuditIncomplete } from "./supply-chain-audit-result";
 import type { GuardReceipt } from "./guard-types";
 
 function assert(condition: boolean, message: string): void {
@@ -147,9 +148,16 @@ assert(
     generated_at: "2026-06-09T12:00:00.000Z",
     lockfile_paths: ["package-lock.json"],
     audit_status: "incomplete",
-    exit_code: 1,
   }) === null,
   "SCSR175-C: incomplete lockfile-only audit does not masquerade as clean findings",
+);
+assert(
+  isSupplyChainAuditIncomplete({
+    generated_at: "2026-06-09T12:00:00.000Z",
+    exit_code: 2,
+    evaluation: { decision: "block", packages: [{ name: "risky-lib", decision: "block" }] },
+  }) === false,
+  "SCSR175-D: blocked completed audits are not treated as incomplete",
 );
 
 console.log("scsr-phase10-package-workbench.test.ts: all assertions passed");

--- a/dashboard/src/scsr-phase10-package-workbench.test.ts
+++ b/dashboard/src/scsr-phase10-package-workbench.test.ts
@@ -142,5 +142,14 @@ assert(
   normalizeSupplyChainAuditSnapshot({ generated_at: "2026-06-09T12:00:00.000Z" }) === null,
   "SCSR175-B: empty audit payload returns null snapshot",
 );
+assert(
+  normalizeSupplyChainAuditSnapshot({
+    generated_at: "2026-06-09T12:00:00.000Z",
+    lockfile_paths: ["package-lock.json"],
+    audit_status: "incomplete",
+    exit_code: 1,
+  }) === null,
+  "SCSR175-C: incomplete lockfile-only audit does not masquerade as clean findings",
+);
 
 console.log("scsr-phase10-package-workbench.test.ts: all assertions passed");

--- a/dashboard/src/supply-chain-audit-connect.ts
+++ b/dashboard/src/supply-chain-audit-connect.ts
@@ -1,5 +1,8 @@
 import { GuardHarnessActionError } from "./guard-api";
 import type { PackageFirewallStatusResponse } from "./guard-types";
+import { isSupplyChainAuditIncomplete, resolveSupplyChainAuditFailure } from "./supply-chain-audit-result";
+
+export { isSupplyChainAuditIncomplete, resolveSupplyChainAuditFailure };
 
 export const SUPPLY_CHAIN_AUDIT_CONNECT_ERROR_CODES = [
   "guard_cloud_connect_required",

--- a/dashboard/src/supply-chain-audit-normalize.ts
+++ b/dashboard/src/supply-chain-audit-normalize.ts
@@ -9,6 +9,7 @@ import type {
   SupplyChainAuditSeverity,
   SupplyChainAuditSnapshot,
 } from "./guard-types";
+import { isSupplyChainAuditIncomplete } from "./supply-chain-audit-result";
 
 const SEVERITY_RANK: Record<SupplyChainAuditSeverity, number> = {
   critical: 4,
@@ -264,6 +265,9 @@ export function normalizeSupplyChainAuditSnapshot(
   if (!isRecord(raw)) {
     return null;
   }
+  if (isSupplyChainAuditIncomplete(raw)) {
+    return null;
+  }
   const evaluation = isRecord(raw.evaluation) ? raw.evaluation : null;
   const findingsFromEvidence = normalizePackageFindings(raw.package_findings);
   const findings =
@@ -277,8 +281,6 @@ export function normalizeSupplyChainAuditSnapshot(
   const hasAuditContext =
     findings.length > 0 ||
     inventory.totalPackages > 0 ||
-    manifestPaths.length > 0 ||
-    lockfilePaths.length > 0 ||
     evaluation !== null;
   if (!hasAuditContext) {
     return null;
@@ -310,6 +312,8 @@ export function derivePackageWorkbenchFromReceipts(receipts: GuardReceipt[]): Su
     const snapshot = normalizeSupplyChainAuditSnapshot(
       {
         generated_at: receipt.timestamp,
+        audit_status: evidenceRaw.audit_status,
+        exit_code: evidenceRaw.audit_status === "incomplete" ? 1 : 0,
         evaluation: {
           decision: evidenceRaw.audit_decision,
           packages: evidenceRaw.package_findings,

--- a/dashboard/src/supply-chain-audit-normalize.ts
+++ b/dashboard/src/supply-chain-audit-normalize.ts
@@ -313,7 +313,6 @@ export function derivePackageWorkbenchFromReceipts(receipts: GuardReceipt[]): Su
       {
         generated_at: receipt.timestamp,
         audit_status: evidenceRaw.audit_status,
-        exit_code: evidenceRaw.audit_status === "incomplete" ? 1 : 0,
         evaluation: {
           decision: evidenceRaw.audit_decision,
           packages: evidenceRaw.package_findings,

--- a/dashboard/src/supply-chain-audit-result.test.ts
+++ b/dashboard/src/supply-chain-audit-result.test.ts
@@ -1,0 +1,49 @@
+import {
+  isSupplyChainAuditIncomplete,
+  resolveSupplyChainAuditFailure,
+} from "./supply-chain-audit-result";
+import { normalizeSupplyChainAuditSnapshot } from "./supply-chain-audit-normalize";
+import { parsePackageFirewallActionResult } from "./supply-chain-firewall-action-result";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const incompletePayload = {
+  generated_at: "2026-06-13T18:22:54.785483+00:00",
+  mode: "audit",
+  manifest_paths: [],
+  lockfile_paths: ["package-lock.json"],
+  audit_outcome: "sync_required",
+  audit_status: "incomplete",
+  exit_code: 1,
+  message: "Sync Guard supply-chain intel on this device before auditing workspace packages.",
+  supply_chain: {
+    status: "sync_required",
+    detail: "Run `hol-guard supply-chain sync` to fetch the latest signed bundle.",
+  },
+};
+
+assert(
+  isSupplyChainAuditIncomplete(incompletePayload),
+  "incomplete audit payload is detected",
+);
+assert(
+  resolveSupplyChainAuditFailure(incompletePayload)?.includes("Sync Guard supply-chain intel"),
+  "sync_required audit returns actionable failure copy",
+);
+assert(
+  normalizeSupplyChainAuditSnapshot(incompletePayload) === null,
+  "incomplete audit does not hydrate a clean findings snapshot",
+);
+
+const parsed = parsePackageFirewallActionResult("audit", { result: incompletePayload });
+assert(parsed?.tone === "warning", "incomplete audit action result uses warning tone");
+assert(
+  parsed?.summary === "Workspace audit did not complete.",
+  "incomplete audit action result summary is explicit",
+);
+
+console.log("supply-chain-audit-result.test.ts: all assertions passed");

--- a/dashboard/src/supply-chain-audit-result.test.ts
+++ b/dashboard/src/supply-chain-audit-result.test.ts
@@ -3,7 +3,6 @@ import {
   resolveSupplyChainAuditFailure,
 } from "./supply-chain-audit-result";
 import { normalizeSupplyChainAuditSnapshot } from "./supply-chain-audit-normalize";
-import { parsePackageFirewallActionResult } from "./supply-chain-firewall-action-result";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -18,7 +17,6 @@ const incompletePayload = {
   lockfile_paths: ["package-lock.json"],
   audit_outcome: "sync_required",
   audit_status: "incomplete",
-  exit_code: 1,
   message: "Sync Guard supply-chain intel on this device before auditing workspace packages.",
   supply_chain: {
     status: "sync_required",
@@ -39,11 +37,12 @@ assert(
   "incomplete audit does not hydrate a clean findings snapshot",
 );
 
-const parsed = parsePackageFirewallActionResult("audit", { result: incompletePayload });
-assert(parsed?.tone === "warning", "incomplete audit action result uses warning tone");
 assert(
-  parsed?.summary === "Workspace audit did not complete.",
-  "incomplete audit action result summary is explicit",
+  isSupplyChainAuditIncomplete({
+    exit_code: 2,
+    evaluation: { decision: "block" },
+  }) === false,
+  "blocked completed audits with non-zero exit code stay complete",
 );
 
 console.log("supply-chain-audit-result.test.ts: all assertions passed");

--- a/dashboard/src/supply-chain-audit-result.ts
+++ b/dashboard/src/supply-chain-audit-result.ts
@@ -10,20 +10,15 @@ function readString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-export function isSupplyChainAuditIncomplete(detail: Record<string, unknown>): boolean {
-  const auditStatus = readString(detail.audit_status);
-  if (auditStatus === "incomplete") {
-    return true;
+export function isSupplyChainAuditIncomplete(detail: unknown): boolean {
+  if (!isRecord(detail)) {
+    return false;
   }
-  const exitCode = typeof detail.exit_code === "number" ? detail.exit_code : null;
-  if (exitCode !== null && exitCode !== 0) {
-    return true;
-  }
-  return false;
+  return readString(detail.audit_status) === "incomplete";
 }
 
-export function resolveSupplyChainAuditFailure(detail: Record<string, unknown>): string | null {
-  if (!isSupplyChainAuditIncomplete(detail)) {
+export function resolveSupplyChainAuditFailure(detail: unknown): string | null {
+  if (!isRecord(detail) || !isSupplyChainAuditIncomplete(detail)) {
     return null;
   }
   const outcome = readString(detail.audit_outcome);

--- a/dashboard/src/supply-chain-audit-result.ts
+++ b/dashboard/src/supply-chain-audit-result.ts
@@ -1,0 +1,55 @@
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+export function isSupplyChainAuditIncomplete(detail: Record<string, unknown>): boolean {
+  const auditStatus = readString(detail.audit_status);
+  if (auditStatus === "incomplete") {
+    return true;
+  }
+  const exitCode = typeof detail.exit_code === "number" ? detail.exit_code : null;
+  if (exitCode !== null && exitCode !== 0) {
+    return true;
+  }
+  return false;
+}
+
+export function resolveSupplyChainAuditFailure(detail: Record<string, unknown>): string | null {
+  if (!isSupplyChainAuditIncomplete(detail)) {
+    return null;
+  }
+  const outcome = readString(detail.audit_outcome);
+  const message = readString(detail.message);
+  const supplyChain = isRecord(detail.supply_chain) ? detail.supply_chain : null;
+  const supplyStatus = readString(supplyChain?.status);
+  if (outcome === "sync_required" || supplyStatus === "sync_required") {
+    return (
+      message ??
+      "Guard supply-chain intel is not synced on this device. Run Sync, then audit again."
+    );
+  }
+  if (outcome === "inventory_empty") {
+    return (
+      message ??
+      "Guard found project files but could not index any packages for audit."
+    );
+  }
+  if (outcome === "no_project_files") {
+    return (
+      message ??
+      "No supported manifests or lockfiles were found in the audit workspace."
+    );
+  }
+  if (message !== null) {
+    return message;
+  }
+  return "Workspace audit did not complete. Review supply-chain status and try again.";
+}

--- a/dashboard/src/supply-chain-evidence-rail.ts
+++ b/dashboard/src/supply-chain-evidence-rail.ts
@@ -115,6 +115,24 @@ function auditRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
   const evidence = (receipt.scanner_evidence ?? []).find(
     (entry) => readOperation(entry) === "audit",
   );
+  const auditStatus =
+    isRecord(evidence) && typeof evidence.audit_status === "string"
+      ? evidence.audit_status
+      : null;
+  if (auditStatus === "incomplete") {
+    return {
+      kind: "audit",
+      timestamp: receipt.timestamp,
+      title: "Workspace audit did not complete",
+      detail:
+        receipt.capabilities_summary.trim().length > 0
+          ? receipt.capabilities_summary
+          : "Guard could not index workspace packages for audit.",
+      receiptId: receipt.receipt_id,
+      harness: receipt.harness,
+      tone: "attention",
+    };
+  }
   const decision =
     isRecord(evidence) && typeof evidence.audit_decision === "string"
       ? evidence.audit_decision

--- a/dashboard/src/supply-chain-firewall-action-result.ts
+++ b/dashboard/src/supply-chain-firewall-action-result.ts
@@ -1,3 +1,8 @@
+import {
+  isSupplyChainAuditIncomplete,
+  resolveSupplyChainAuditFailure,
+} from "./supply-chain-audit-result";
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -27,6 +32,28 @@ export type PackageFirewallActionResultDetail = {
 };
 
 function parseAuditActionResult(result: Record<string, unknown>): PackageFirewallActionResultDetail {
+  if (isSupplyChainAuditIncomplete(result)) {
+    const failureMessage = resolveSupplyChainAuditFailure(result);
+    const manifestPaths = readStringArray(result.manifest_paths);
+    const lockfilePaths = readStringArray(result.lockfile_paths);
+    const lines: string[] = [];
+    if (manifestPaths.length > 0) {
+      lines.push(`Manifests found: ${manifestPaths.join(", ")}.`);
+    }
+    if (lockfilePaths.length > 0) {
+      lines.push(`Lockfiles found: ${lockfilePaths.join(", ")}.`);
+    }
+    if (failureMessage !== null) {
+      lines.push(failureMessage);
+    }
+    return {
+      emptyState: false,
+      lines,
+      summary: "Workspace audit did not complete.",
+      tone: "warning",
+    };
+  }
+
   const evaluation = isRecord(result.evaluation) ? result.evaluation : null;
   const decision = readString(evaluation?.decision) ?? readString(result.decision) ?? "monitor";
   const manifestPaths = readStringArray(result.manifest_paths);

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -23,6 +23,7 @@ import {
   isSupplyChainAuditConnectError,
   packageAuditNeedsCloudConnect,
   resolveSupplyChainAuditConnectGate,
+  resolveSupplyChainAuditFailure,
   supplyChainAuditUserMessage,
   type SupplyChainAuditConnectGate,
 } from "./supply-chain-audit-connect";
@@ -251,6 +252,16 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
       });
       try {
         const response = await runPackageAudit({ workspaceDir });
+        const failureMessage = resolveSupplyChainAuditFailure(response.result_detail);
+        if (failureMessage !== null) {
+          setLastFailed({ op: "audit", manager: null, message: failureMessage });
+          setLastCompleted(null);
+          onAuditErrorChange?.(failureMessage);
+          clearAuditConnectGate();
+          await refreshAfterOp();
+          await onStateChanged?.();
+          return;
+        }
         setLastCompleted({ op: "audit", manager: null, response });
         onAuditCompleted?.(response.result_detail);
         clearAuditConnectGate();

--- a/dashboard/src/supply-chain-workspace.tsx
+++ b/dashboard/src/supply-chain-workspace.tsx
@@ -17,6 +17,7 @@ import type {
   SupplyChainAuditSnapshot,
 } from "./guard-types";
 import { derivePackageWorkbenchFromReceipts, fetchReceipts, normalizeSupplyChainAuditSnapshot } from "./guard-api";
+import { resolveSupplyChainAuditFailure } from "./supply-chain-audit-connect";
 import { PackageFirewallPanel, type PackageFirewallPanelHandle } from "./supply-chain-firewall-panel";
 import type { AuditConnectGateViewState } from "./supply-chain-firewall-panel";
 import { SupplyChainBundlePanel } from "./supply-chain-bundle-panel";
@@ -213,6 +214,12 @@ export function SupplyChainWorkspace({
   }, [snapshot.generated_at, snapshot.receipt_count]);
 
   const handleAuditCompleted = useCallback((resultDetail: Record<string, unknown>) => {
+    const failureMessage = resolveSupplyChainAuditFailure(resultDetail);
+    if (failureMessage !== null) {
+      setAuditSnapshot(null);
+      setAuditError(failureMessage);
+      return;
+    }
     const normalized = normalizeSupplyChainAuditSnapshot(resultDetail);
     setAuditSnapshot(normalized);
     setAuditError(null);

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2252,8 +2252,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         )
         response_status = "completed"
         if operation == "audit":
-            exit_code = result.get("exit_code")
-            if isinstance(exit_code, int) and exit_code != 0:
+            audit_status = result.get("audit_status")
+            if audit_status == "incomplete":
                 response_status = "incomplete"
         response_payload: dict[str, object] = {
             "entitlement": entitlement,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2250,12 +2250,17 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 else None
             ),
         )
+        response_status = "completed"
+        if operation == "audit":
+            exit_code = result.get("exit_code")
+            if isinstance(exit_code, int) and exit_code != 0:
+                response_status = "incomplete"
         response_payload: dict[str, object] = {
             "entitlement": entitlement,
             "operation": operation,
             "receipt": receipt,
             "result": result,
-            "status": "completed",
+            "status": response_status,
         }
         if operation == "audit":
             cloud_sync = _queue_headless_cloud_sync(store=self.server.store)  # type: ignore[attr-defined]

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -261,7 +261,6 @@ function derivePackageWorkbenchFromReceipts(receipts) {
       {
         generated_at: receipt.timestamp,
         audit_status: evidenceRaw.audit_status,
-        exit_code: evidenceRaw.audit_status === "incomplete" ? 1 : 0,
         evaluation: {
           decision: evidenceRaw.audit_decision,
           packages: evidenceRaw.package_findings

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,4 +1,4 @@
-import { au as GuardHarnessActionError, r as reactExports, j as jsxRuntimeExports, d as HiMiniCheckCircle, aw as HiMiniArrowPath, w as HiMiniExclamationTriangle, ac as Tag, m as formatRelativeTime, aG as HiMiniClock, aH as IconActionButton, I as HiMiniXCircle, ax as HiMiniTrash, l as HiMiniShieldCheck, F as HiMiniWrenchScrewdriver, aI as HiMiniBeaker, aJ as ActivationSummary, aK as ActionResultPanel, ad as HiMiniMagnifyingGlass, b as EmptyState, A as ActionButton, aL as HiMiniBugAnt, o as HiMiniXMark, aM as fetchPackageFirewallStatus, aN as runPackageAudit, aO as startPackageFirewallConnect, aP as runPackageFirewallAction, aQ as parseInterceptProofSnapshot, aR as runPackageSync, aS as openPackageFirewallShell, S as SectionLabel, aT as EntitlementNotice, aU as fetchSupplyChainBundle, aE as HiMiniArrowTopRightOnSquare, B as Badge, aV as HiMiniDocumentMagnifyingGlass, aW as HiMiniShieldExclamation, aX as HiMiniComputerDesktop, t as HiMiniCloud, aY as ConnectFlowCard, aZ as HiMiniArrowDown, a_ as HiMiniArrowUp, ah as HiMiniArrowLeft, a$ as HiMiniArrowRight, b0 as HiMiniCloudArrowUp, b1 as HiMiniInformationCircle, b2 as fetchReceipts, h as harnessDisplayName, p as HiMiniChevronUp, q as HiMiniChevronDown } from "../guard-dashboard.js";
+import { aG as isSupplyChainAuditIncomplete, au as GuardHarnessActionError, r as reactExports, j as jsxRuntimeExports, d as HiMiniCheckCircle, aw as HiMiniArrowPath, w as HiMiniExclamationTriangle, ac as Tag, m as formatRelativeTime, aH as HiMiniClock, aI as IconActionButton, I as HiMiniXCircle, ax as HiMiniTrash, l as HiMiniShieldCheck, F as HiMiniWrenchScrewdriver, aJ as HiMiniBeaker, aK as ActivationSummary, aL as ActionResultPanel, ad as HiMiniMagnifyingGlass, b as EmptyState, A as ActionButton, aM as HiMiniBugAnt, o as HiMiniXMark, aN as fetchPackageFirewallStatus, aO as runPackageAudit, aP as resolveSupplyChainAuditFailure, aQ as startPackageFirewallConnect, aR as runPackageFirewallAction, aS as parseInterceptProofSnapshot, aT as runPackageSync, aU as openPackageFirewallShell, S as SectionLabel, aV as EntitlementNotice, aW as fetchSupplyChainBundle, aE as HiMiniArrowTopRightOnSquare, B as Badge, aX as HiMiniDocumentMagnifyingGlass, aY as HiMiniShieldExclamation, aZ as HiMiniComputerDesktop, t as HiMiniCloud, a_ as ConnectFlowCard, a$ as HiMiniArrowDown, b0 as HiMiniArrowUp, ah as HiMiniArrowLeft, b1 as HiMiniArrowRight, b2 as HiMiniCloudArrowUp, b3 as HiMiniInformationCircle, b4 as fetchReceipts, h as harnessDisplayName, p as HiMiniChevronUp, q as HiMiniChevronDown } from "../guard-dashboard.js";
 import { u as useResolvedApprovalGate, A as ApprovalProofModal, b as buildSupplyChainStats } from "./supply-chain-protection-stats.js";
 import { resolveFeedStaleness } from "./feed-health-workspace.js";
 import { r as resolveHomeProtectionStatus } from "./home-protection-module.js";
@@ -222,6 +222,9 @@ function normalizeSupplyChainAuditSnapshot(raw, receiptId = null) {
   if (!isRecord$1(raw)) {
     return null;
   }
+  if (isSupplyChainAuditIncomplete(raw)) {
+    return null;
+  }
   const evaluation = isRecord$1(raw.evaluation) ? raw.evaluation : null;
   const findingsFromEvidence = normalizePackageFindings(raw.package_findings);
   const findings = findingsFromEvidence.length > 0 ? findingsFromEvidence : packageRecordsFromEvaluation(evaluation);
@@ -230,7 +233,7 @@ function normalizeSupplyChainAuditSnapshot(raw, receiptId = null) {
   const decision = normalizeDecision(evaluation?.decision ?? raw.audit_decision);
   const manifestPaths = readStringArray(raw.manifest_paths);
   const lockfilePaths = readStringArray(raw.lockfile_paths);
-  const hasAuditContext = findings.length > 0 || inventory.totalPackages > 0 || manifestPaths.length > 0 || lockfilePaths.length > 0 || evaluation !== null;
+  const hasAuditContext = findings.length > 0 || inventory.totalPackages > 0 || evaluation !== null;
   if (!hasAuditContext) {
     return null;
   }
@@ -257,6 +260,8 @@ function derivePackageWorkbenchFromReceipts(receipts) {
     const snapshot = normalizeSupplyChainAuditSnapshot(
       {
         generated_at: receipt.timestamp,
+        audit_status: evidenceRaw.audit_status,
+        exit_code: evidenceRaw.audit_status === "incomplete" ? 1 : 0,
         evaluation: {
           decision: evidenceRaw.audit_decision,
           packages: evidenceRaw.package_findings
@@ -1152,6 +1157,16 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
       });
       try {
         const response = await runPackageAudit({ workspaceDir });
+        const failureMessage = resolveSupplyChainAuditFailure(response.result_detail);
+        if (failureMessage !== null) {
+          setLastFailed({ op: "audit", manager: null, message: failureMessage });
+          setLastCompleted(null);
+          onAuditErrorChange?.(failureMessage);
+          clearAuditConnectGate();
+          await refreshAfterOp();
+          await onStateChanged?.();
+          return;
+        }
         setLastCompleted({ op: "audit", manager: null, response });
         onAuditCompleted?.(response.result_detail);
         clearAuditConnectGate();
@@ -1744,6 +1759,18 @@ function auditRailItem(receipt) {
   const evidence = (receipt.scanner_evidence ?? []).find(
     (entry) => readOperation(entry) === "audit"
   );
+  const auditStatus = isRecord(evidence) && typeof evidence.audit_status === "string" ? evidence.audit_status : null;
+  if (auditStatus === "incomplete") {
+    return {
+      kind: "audit",
+      timestamp: receipt.timestamp,
+      title: "Workspace audit did not complete",
+      detail: receipt.capabilities_summary.trim().length > 0 ? receipt.capabilities_summary : "Guard could not index workspace packages for audit.",
+      receiptId: receipt.receipt_id,
+      harness: receipt.harness,
+      tone: "attention"
+    };
+  }
   const decision = isRecord(evidence) && typeof evidence.audit_decision === "string" ? evidence.audit_decision : receipt.policy_decision;
   const blockedCount = isRecord(evidence) && typeof evidence.blocked_package_count === "number" ? evidence.blocked_package_count : 0;
   const totalPackages = isRecord(evidence) && typeof evidence.total_packages === "number" ? evidence.total_packages : blockedCount;
@@ -2924,6 +2951,12 @@ function SupplyChainWorkspace({
     };
   }, [snapshot.generated_at, snapshot.receipt_count]);
   const handleAuditCompleted = reactExports.useCallback((resultDetail) => {
+    const failureMessage = resolveSupplyChainAuditFailure(resultDetail);
+    if (failureMessage !== null) {
+      setAuditSnapshot(null);
+      setAuditError(failureMessage);
+      return;
+    }
     const normalized = normalizeSupplyChainAuditSnapshot(resultDetail);
     setAuditSnapshot(normalized);
     setAuditError(null);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -494,7 +494,7 @@ function requireReact_production() {
   react_production.useTransition = function() {
     return ReactSharedInternals.H.useTransition();
   };
-  react_production.version = "19.2.5";
+  react_production.version = "19.2.7";
   return react_production;
 }
 var hasRequiredReact;
@@ -516,7 +516,7 @@ var hasRequiredScheduler_production;
 function requireScheduler_production() {
   if (hasRequiredScheduler_production) return scheduler_production;
   hasRequiredScheduler_production = 1;
-  (function(exports$1) {
+  (function(exports) {
     function push(heap, node) {
       var index = heap.length;
       heap.push(node);
@@ -550,15 +550,15 @@ function requireScheduler_production() {
       var diff = a.sortIndex - b.sortIndex;
       return 0 !== diff ? diff : a.id - b.id;
     }
-    exports$1.unstable_now = void 0;
+    exports.unstable_now = void 0;
     if ("object" === typeof performance && "function" === typeof performance.now) {
       var localPerformance = performance;
-      exports$1.unstable_now = function() {
+      exports.unstable_now = function() {
         return localPerformance.now();
       };
     } else {
       var localDate = Date, initialTime = localDate.now();
-      exports$1.unstable_now = function() {
+      exports.unstable_now = function() {
         return localDate.now() - initialTime;
       };
     }
@@ -585,12 +585,12 @@ function requireScheduler_production() {
     }
     var isMessageLoopRunning = false, taskTimeoutID = -1, frameInterval = 5, startTime = -1;
     function shouldYieldToHost() {
-      return needsPaint ? true : exports$1.unstable_now() - startTime < frameInterval ? false : true;
+      return needsPaint ? true : exports.unstable_now() - startTime < frameInterval ? false : true;
     }
     function performWorkUntilDeadline() {
       needsPaint = false;
       if (isMessageLoopRunning) {
-        var currentTime = exports$1.unstable_now();
+        var currentTime = exports.unstable_now();
         startTime = currentTime;
         var hasMoreWork = true;
         try {
@@ -610,7 +610,7 @@ function requireScheduler_production() {
                     var continuationCallback = callback(
                       currentTask.expirationTime <= currentTime
                     );
-                    currentTime = exports$1.unstable_now();
+                    currentTime = exports.unstable_now();
                     if ("function" === typeof continuationCallback) {
                       currentTask.callback = continuationCallback;
                       advanceTimers(currentTime);
@@ -660,27 +660,27 @@ function requireScheduler_production() {
       };
     function requestHostTimeout(callback, ms) {
       taskTimeoutID = localSetTimeout(function() {
-        callback(exports$1.unstable_now());
+        callback(exports.unstable_now());
       }, ms);
     }
-    exports$1.unstable_IdlePriority = 5;
-    exports$1.unstable_ImmediatePriority = 1;
-    exports$1.unstable_LowPriority = 4;
-    exports$1.unstable_NormalPriority = 3;
-    exports$1.unstable_Profiling = null;
-    exports$1.unstable_UserBlockingPriority = 2;
-    exports$1.unstable_cancelCallback = function(task) {
+    exports.unstable_IdlePriority = 5;
+    exports.unstable_ImmediatePriority = 1;
+    exports.unstable_LowPriority = 4;
+    exports.unstable_NormalPriority = 3;
+    exports.unstable_Profiling = null;
+    exports.unstable_UserBlockingPriority = 2;
+    exports.unstable_cancelCallback = function(task) {
       task.callback = null;
     };
-    exports$1.unstable_forceFrameRate = function(fps) {
+    exports.unstable_forceFrameRate = function(fps) {
       0 > fps || 125 < fps ? console.error(
         "forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"
       ) : frameInterval = 0 < fps ? Math.floor(1e3 / fps) : 5;
     };
-    exports$1.unstable_getCurrentPriorityLevel = function() {
+    exports.unstable_getCurrentPriorityLevel = function() {
       return currentPriorityLevel;
     };
-    exports$1.unstable_next = function(eventHandler) {
+    exports.unstable_next = function(eventHandler) {
       switch (currentPriorityLevel) {
         case 1:
         case 2:
@@ -698,10 +698,10 @@ function requireScheduler_production() {
         currentPriorityLevel = previousPriorityLevel;
       }
     };
-    exports$1.unstable_requestPaint = function() {
+    exports.unstable_requestPaint = function() {
       needsPaint = true;
     };
-    exports$1.unstable_runWithPriority = function(priorityLevel, eventHandler) {
+    exports.unstable_runWithPriority = function(priorityLevel, eventHandler) {
       switch (priorityLevel) {
         case 1:
         case 2:
@@ -720,8 +720,8 @@ function requireScheduler_production() {
         currentPriorityLevel = previousPriorityLevel;
       }
     };
-    exports$1.unstable_scheduleCallback = function(priorityLevel, callback, options) {
-      var currentTime = exports$1.unstable_now();
+    exports.unstable_scheduleCallback = function(priorityLevel, callback, options) {
+      var currentTime = exports.unstable_now();
       "object" === typeof options && null !== options ? (options = options.delay, options = "number" === typeof options && 0 < options ? currentTime + options : currentTime) : options = currentTime;
       switch (priorityLevel) {
         case 1:
@@ -751,8 +751,8 @@ function requireScheduler_production() {
       options > currentTime ? (priorityLevel.sortIndex = options, push(timerQueue, priorityLevel), null === peek(taskQueue) && priorityLevel === peek(timerQueue) && (isHostTimeoutScheduled ? (localClearTimeout(taskTimeoutID), taskTimeoutID = -1) : isHostTimeoutScheduled = true, requestHostTimeout(handleTimeout, options - currentTime))) : (priorityLevel.sortIndex = timeout, push(taskQueue, priorityLevel), isHostCallbackScheduled || isPerformingWork || (isHostCallbackScheduled = true, isMessageLoopRunning || (isMessageLoopRunning = true, schedulePerformWorkUntilDeadline())));
       return priorityLevel;
     };
-    exports$1.unstable_shouldYield = shouldYieldToHost;
-    exports$1.unstable_wrapCallback = function(callback) {
+    exports.unstable_shouldYield = shouldYieldToHost;
+    exports.unstable_wrapCallback = function(callback) {
       var parentPriorityLevel = currentPriorityLevel;
       return function() {
         var previousPriorityLevel = currentPriorityLevel;
@@ -922,7 +922,7 @@ function requireReactDom_production() {
   reactDom_production.useFormStatus = function() {
     return ReactSharedInternals.H.useHostTransitionStatus();
   };
-  reactDom_production.version = "19.2.5";
+  reactDom_production.version = "19.2.7";
   return reactDom_production;
 }
 var hasRequiredReactDom;
@@ -12366,12 +12366,12 @@ function requireReactDomClient_production() {
     }
   };
   var isomorphicReactPackageVersion$jscomp$inline_1840 = React2.version;
-  if ("19.2.5" !== isomorphicReactPackageVersion$jscomp$inline_1840)
+  if ("19.2.7" !== isomorphicReactPackageVersion$jscomp$inline_1840)
     throw Error(
       formatProdErrorMessage(
         527,
         isomorphicReactPackageVersion$jscomp$inline_1840,
-        "19.2.5"
+        "19.2.7"
       )
     );
   ReactDOMSharedInternals.findDOMNode = function(componentOrElement) {
@@ -12389,10 +12389,10 @@ function requireReactDomClient_production() {
   };
   var internals$jscomp$inline_2347 = {
     bundleType: 0,
-    version: "19.2.5",
+    version: "19.2.7",
     rendererPackageName: "react-dom",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.5"
+    reconcilerVersion: "19.2.7"
   };
   if ("undefined" !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__) {
     var hook$jscomp$inline_2348 = __REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -12459,7 +12459,7 @@ function requireReactDomClient_production() {
     listenToAllSupportedEvents(container2);
     return new ReactDOMHydrationRoot(initialChildren);
   };
-  reactDomClient_production.version = "19.2.5";
+  reactDomClient_production.version = "19.2.7";
   return reactDomClient_production;
 }
 var hasRequiredClient;
@@ -13966,6 +13966,49 @@ function getDemoDiff(artifactId, harness) {
     return null;
   }
   return demoDiff;
+}
+function isRecord$2(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function readString$1(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+function isSupplyChainAuditIncomplete(detail) {
+  const auditStatus = readString$1(detail.audit_status);
+  if (auditStatus === "incomplete") {
+    return true;
+  }
+  const exitCode = typeof detail.exit_code === "number" ? detail.exit_code : null;
+  if (exitCode !== null && exitCode !== 0) {
+    return true;
+  }
+  return false;
+}
+function resolveSupplyChainAuditFailure(detail) {
+  if (!isSupplyChainAuditIncomplete(detail)) {
+    return null;
+  }
+  const outcome = readString$1(detail.audit_outcome);
+  const message = readString$1(detail.message);
+  const supplyChain = isRecord$2(detail.supply_chain) ? detail.supply_chain : null;
+  const supplyStatus = readString$1(supplyChain?.status);
+  if (outcome === "sync_required" || supplyStatus === "sync_required") {
+    return message ?? "Guard supply-chain intel is not synced on this device. Run Sync, then audit again.";
+  }
+  if (outcome === "inventory_empty") {
+    return message ?? "Guard found project files but could not index any packages for audit.";
+  }
+  if (outcome === "no_project_files") {
+    return message ?? "No supported manifests or lockfiles were found in the audit workspace.";
+  }
+  if (message !== null) {
+    return message;
+  }
+  return "Workspace audit did not complete. Review supply-chain status and try again.";
 }
 const GUARD_TOKEN_PARAM = "guard-token";
 const GUARD_DAEMON_PARAM = "guardDaemon";
@@ -18784,6 +18827,27 @@ function readStringArray(value) {
   return value.filter((entry) => typeof entry === "string" && entry.trim().length > 0).map((entry) => entry.trim());
 }
 function parseAuditActionResult(result) {
+  if (isSupplyChainAuditIncomplete(result)) {
+    const failureMessage = resolveSupplyChainAuditFailure(result);
+    const manifestPaths2 = readStringArray(result.manifest_paths);
+    const lockfilePaths2 = readStringArray(result.lockfile_paths);
+    const lines2 = [];
+    if (manifestPaths2.length > 0) {
+      lines2.push(`Manifests found: ${manifestPaths2.join(", ")}.`);
+    }
+    if (lockfilePaths2.length > 0) {
+      lines2.push(`Lockfiles found: ${lockfilePaths2.join(", ")}.`);
+    }
+    if (failureMessage !== null) {
+      lines2.push(failureMessage);
+    }
+    return {
+      emptyState: false,
+      lines: lines2,
+      summary: "Workspace audit did not complete.",
+      tone: "warning"
+    };
+  }
   const evaluation = isRecord(result.evaluation) ? result.evaluation : null;
   const decision = readString(evaluation?.decision) ?? readString(result.decision) ?? "monitor";
   const manifestPaths = readStringArray(result.manifest_paths);
@@ -26385,12 +26449,12 @@ export {
   HiMiniExclamationCircle as J,
   HiMiniClipboardDocumentCheck as K,
   HiMiniClipboard as L,
-  requireReact as M,
-  getDefaultExportFromCjs as N,
-  HiMiniKey as O,
+  getDefaultExportFromCjs as M,
+  HiMiniKey as N,
+  HiMiniLockClosed as O,
   ProofStrip as P,
-  HiMiniLockClosed as Q,
-  HiMiniBellAlert as R,
+  HiMiniBellAlert as Q,
+  React as R,
   SectionLabel as S,
   HiMiniAdjustmentsHorizontal as T,
   HiMiniCog6Tooth as U,
@@ -26401,7 +26465,7 @@ export {
   fetchRuntimeSnapshot as Z,
   updateSettings as _,
   EvidenceActivityHeatmapMini as a,
-  HiMiniArrowRight as a$,
+  HiMiniArrowDown as a$,
   clearReviewQueue as a0,
   revokeApprovalGateCooldown as a1,
   disableApprovalGateTotp as a2,
@@ -26418,27 +26482,27 @@ export {
   Surface as aD,
   HiMiniArrowTopRightOnSquare as aE,
   HiMiniCheckBadge as aF,
-  HiMiniClock as aG,
-  IconActionButton as aH,
-  HiMiniBeaker as aI,
-  ActivationSummary as aJ,
-  ActionResultPanel as aK,
-  HiMiniBugAnt as aL,
-  fetchPackageFirewallStatus as aM,
-  runPackageAudit as aN,
-  startPackageFirewallConnect as aO,
-  runPackageFirewallAction as aP,
-  parseInterceptProofSnapshot as aQ,
-  runPackageSync as aR,
-  openPackageFirewallShell as aS,
-  EntitlementNotice as aT,
-  fetchSupplyChainBundle as aU,
-  HiMiniDocumentMagnifyingGlass as aV,
-  HiMiniShieldExclamation as aW,
-  HiMiniComputerDesktop as aX,
-  ConnectFlowCard as aY,
-  HiMiniArrowDown as aZ,
-  HiMiniArrowUp as a_,
+  isSupplyChainAuditIncomplete as aG,
+  HiMiniClock as aH,
+  IconActionButton as aI,
+  HiMiniBeaker as aJ,
+  ActivationSummary as aK,
+  ActionResultPanel as aL,
+  HiMiniBugAnt as aM,
+  fetchPackageFirewallStatus as aN,
+  runPackageAudit as aO,
+  resolveSupplyChainAuditFailure as aP,
+  startPackageFirewallConnect as aQ,
+  runPackageFirewallAction as aR,
+  parseInterceptProofSnapshot as aS,
+  runPackageSync as aT,
+  openPackageFirewallShell as aU,
+  EntitlementNotice as aV,
+  fetchSupplyChainBundle as aW,
+  HiMiniDocumentMagnifyingGlass as aX,
+  HiMiniShieldExclamation as aY,
+  HiMiniComputerDesktop as aZ,
+  ConnectFlowCard as a_,
   resetSettings as aa,
   setupDesktopNotifications as ab,
   Tag as ac,
@@ -26466,18 +26530,20 @@ export {
   clearLabelForScope as ay,
   formatHarnessCommand as az,
   EmptyState as b,
-  HiMiniCloudArrowUp as b0,
-  HiMiniInformationCircle as b1,
-  fetchReceipts as b2,
-  runAuditRemediation as b3,
-  HiMiniDocumentText as b4,
-  guardAwareHref as b5,
-  HiMiniSignal as b6,
-  savePolicyDecision as b7,
-  HiMiniChevronLeft as b8,
-  policyActionLabel as b9,
-  scopeLabel as ba,
-  HiMiniPlus as bb,
+  HiMiniArrowUp as b0,
+  HiMiniArrowRight as b1,
+  HiMiniCloudArrowUp as b2,
+  HiMiniInformationCircle as b3,
+  fetchReceipts as b4,
+  runAuditRemediation as b5,
+  HiMiniDocumentText as b6,
+  guardAwareHref as b7,
+  HiMiniSignal as b8,
+  savePolicyDecision as b9,
+  HiMiniChevronLeft as ba,
+  policyActionLabel as bb,
+  scopeLabel as bc,
+  HiMiniPlus as bd,
   EvidenceInsightsShareModal as c,
   HiMiniCheckCircle as d,
   GuardHero as e,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -13978,18 +13978,13 @@ function readString$1(value) {
   return trimmed.length > 0 ? trimmed : null;
 }
 function isSupplyChainAuditIncomplete(detail) {
-  const auditStatus = readString$1(detail.audit_status);
-  if (auditStatus === "incomplete") {
-    return true;
+  if (!isRecord$2(detail)) {
+    return false;
   }
-  const exitCode = typeof detail.exit_code === "number" ? detail.exit_code : null;
-  if (exitCode !== null && exitCode !== 0) {
-    return true;
-  }
-  return false;
+  return readString$1(detail.audit_status) === "incomplete";
 }
 function resolveSupplyChainAuditFailure(detail) {
-  if (!isSupplyChainAuditIncomplete(detail)) {
+  if (!isRecord$2(detail) || !isSupplyChainAuditIncomplete(detail)) {
     return null;
   }
   const outcome = readString$1(detail.audit_outcome);

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -523,6 +523,63 @@ def workspace_audit_path_hashes(
     }
 
 
+def _resolve_empty_audit_outcome(
+    *,
+    manifest_paths: Sequence[str],
+    lockfile_paths: Sequence[str],
+    posture: dict[str, object],
+) -> tuple[str, str]:
+    supply_status = str(posture.get("status") or "")
+    supply_detail = str(posture.get("detail") or _posture_detail(supply_status))
+    if supply_status == "sync_required":
+        return (
+            "sync_required",
+            "Sync Guard supply-chain intel on this device before auditing workspace packages.",
+        )
+    if supply_status in {"not_connected", "workspace_required", "expired", "degraded"}:
+        return (supply_status, supply_detail)
+    if lockfile_paths or manifest_paths:
+        return (
+            "inventory_empty",
+            "Guard found project files but could not index any packages for audit.",
+        )
+    return (
+        "no_project_files",
+        "No supported manifests or lockfiles found in this workspace.",
+    )
+
+
+def _incomplete_audit_receipt_metadata(
+    result: dict[str, object],
+    *,
+    workspace_dir: Path | None = None,
+) -> dict[str, object]:
+    message = str(result.get("message") or "Workspace audit did not complete.")
+    outcome = str(result.get("audit_outcome") or "incomplete")
+    manifest_paths = [str(path) for path in result.get("manifest_paths") or () if isinstance(path, str)]
+    lockfile_paths = [str(path) for path in result.get("lockfile_paths") or () if isinstance(path, str)]
+    path_hashes = workspace_audit_path_hashes(workspace_dir, manifest_paths, lockfile_paths)
+    policy_decision = "ask" if outcome in {"sync_required", "inventory_empty", "no_project_files"} else "monitor"
+    return {
+        "policy_decision": policy_decision,
+        "capabilities_summary": message,
+        "artifact_name": "Workspace supply-chain audit",
+        "scanner_evidence": {
+            "operation": "audit",
+            "audit_status": "incomplete",
+            "audit_outcome": outcome,
+            "audit_decision": "monitor",
+            "blocked_package_count": 0,
+            "total_packages": 0,
+            "manifest_paths": manifest_paths,
+            "lockfile_paths": lockfile_paths,
+            "manifest_hashes": path_hashes["manifest_hashes"],
+            "lockfile_hashes": path_hashes["lockfile_hashes"],
+            "package_findings": [],
+        },
+    }
+
+
 def audit_receipt_metadata(
     result: dict[str, object],
     *,
@@ -530,7 +587,7 @@ def audit_receipt_metadata(
 ) -> dict[str, object]:
     evaluation = result.get("evaluation")
     if not isinstance(evaluation, dict):
-        return {}
+        return _incomplete_audit_receipt_metadata(result, workspace_dir=workspace_dir)
     decision = str(evaluation.get("decision") or "monitor")
     packages = evaluation.get("packages")
     package_items = [item for item in packages if isinstance(item, dict)] if isinstance(packages, list) else []
@@ -612,6 +669,11 @@ def build_workspace_audit_payload(
             sbom_paths=sbom_paths,
         )
     if not inventory:
+        audit_outcome, message = _resolve_empty_audit_outcome(
+            manifest_paths=manifest_paths,
+            lockfile_paths=lockfile_paths,
+            posture=posture,
+        )
         return (
             {
                 "generated_at": now,
@@ -619,7 +681,9 @@ def build_workspace_audit_payload(
                 "manifest_paths": list(manifest_paths),
                 "lockfile_paths": list(lockfile_paths),
                 "sbom_paths": list(resolved_sbom_paths),
-                "message": "No supported manifests or lockfiles found in this workspace.",
+                "audit_outcome": audit_outcome,
+                "audit_status": "incomplete",
+                "message": message,
                 "supply_chain": posture,
             },
             1,

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -558,15 +558,11 @@ def _incomplete_audit_receipt_metadata(
     outcome = str(result.get("audit_outcome") or "incomplete")
     manifest_raw = result.get("manifest_paths")
     manifest_paths = (
-        [str(path) for path in manifest_raw if isinstance(path, str)]
-        if isinstance(manifest_raw, (list, tuple))
-        else []
+        [str(path) for path in manifest_raw if isinstance(path, str)] if isinstance(manifest_raw, (list, tuple)) else []
     )
     lockfile_raw = result.get("lockfile_paths")
     lockfile_paths = (
-        [str(path) for path in lockfile_raw if isinstance(path, str)]
-        if isinstance(lockfile_raw, (list, tuple))
-        else []
+        [str(path) for path in lockfile_raw if isinstance(path, str)] if isinstance(lockfile_raw, (list, tuple)) else []
     )
     path_hashes = workspace_audit_path_hashes(workspace_dir, manifest_paths, lockfile_paths)
     policy_decision = "ask" if outcome in {"sync_required", "inventory_empty", "no_project_files"} else "monitor"

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -556,8 +556,18 @@ def _incomplete_audit_receipt_metadata(
 ) -> dict[str, object]:
     message = str(result.get("message") or "Workspace audit did not complete.")
     outcome = str(result.get("audit_outcome") or "incomplete")
-    manifest_paths = [str(path) for path in result.get("manifest_paths") or () if isinstance(path, str)]
-    lockfile_paths = [str(path) for path in result.get("lockfile_paths") or () if isinstance(path, str)]
+    manifest_raw = result.get("manifest_paths")
+    manifest_paths = (
+        [str(path) for path in manifest_raw if isinstance(path, str)]
+        if isinstance(manifest_raw, (list, tuple))
+        else []
+    )
+    lockfile_raw = result.get("lockfile_paths")
+    lockfile_paths = (
+        [str(path) for path in lockfile_raw if isinstance(path, str)]
+        if isinstance(lockfile_raw, (list, tuple))
+        else []
+    )
     path_hashes = workspace_audit_path_hashes(workspace_dir, manifest_paths, lockfile_paths)
     policy_decision = "ask" if outcome in {"sync_required", "inventory_empty", "no_project_files"} else "monitor"
     return {

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -29,6 +29,7 @@ from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_guard_supply_chain_evaluator import WORKSPACE_ID, _bundle_response, _package
 
 
 def _read_json_response_details(
@@ -921,21 +922,60 @@ def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(
 def test_supply_chain_audit_scans_workspace_manifests(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
+    audit_now = "2026-05-27T16:00:00.000Z"
     (workspace_dir / "package.json").write_text(
-        json.dumps({"name": "demo", "version": "1.0.0"}),
+        json.dumps({"name": "demo", "version": "1.0.0", "dependencies": {"minimist": "^1.2.0"}}),
+        encoding="utf-8",
+    )
+    (workspace_dir / "package-lock.json").write_text(
+        json.dumps(
+            {
+                "packages": {
+                    "": {"dependencies": {"minimist": "^1.2.0"}},
+                    "node_modules/minimist": {"version": "1.2.8"},
+                }
+            }
+        ),
         encoding="utf-8",
     )
     store = GuardStore(tmp_path / "guard-home")
     store.set_sync_credentials(
         "https://hol.org/api/guard/receipts/sync",
         "cloud-token",
-        "2026-05-27T16:00:00.000Z",
-        workspace_id="workspace-1",
+        audit_now,
+        workspace_id=WORKSPACE_ID,
+    )
+    bundle_response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="minimist",
+                version="1.2.8",
+                default_action="block",
+                recommended_fix_version="1.2.9",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, bundle_response, audit_now)
+    store.set_sync_payload(
+        "supply_chain_bundle_summary",
+        {
+            "advisory_count": 1,
+            "bundle_version": "1747612800000-deadbeef",
+            "feed_snapshot_hash": "feed-snapshot-1",
+            "package_count": 1,
+            "policy_hash": "policy-hash-1",
+            "status": "synced",
+            "synced_at": audit_now,
+            "tier": "premium",
+            "workspace_id": WORKSPACE_ID,
+        },
+        audit_now,
     )
     store.set_sync_payload(
         "supply_chain_bundle_entitlement",
-        {"tier": "premium", "workspace_id": "workspace-1"},
-        "2026-05-27T16:00:00.000Z",
+        {"tier": "premium", "workspace_id": WORKSPACE_ID},
+        audit_now,
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -522,6 +522,8 @@ def test_guard_supply_chain_scan_without_supported_manifests_returns_nonzero(tmp
     assert rc == 1
     assert output["manifest_paths"] == []
     assert output["lockfile_paths"] == []
+    assert output["audit_status"] == "incomplete"
+    assert output["audit_outcome"] == "no_project_files"
     assert output["message"] == "No supported manifests or lockfiles found in this workspace."
 
 

--- a/tests/test_guard_phase06_workspace_audit.py
+++ b/tests/test_guard_phase06_workspace_audit.py
@@ -289,6 +289,31 @@ def test_workspace_audit_returns_evaluation_not_posture_only(
     assert payload["inventory"]["total_packages"] >= 1
 
 
+def test_workspace_audit_block_exit_code_does_not_mark_incomplete(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = _audit_payload_for_workspace(
+        tmp_path,
+        files={
+            "package.json": '{"dependencies":{"minimist":"^1.2.0"}}',
+            "package-lock.json": json.dumps(
+                {
+                    "packages": {
+                        "": {"dependencies": {"minimist": "^1.2.0"}},
+                        "node_modules/minimist": {"version": "1.2.8"},
+                    }
+                }
+            ),
+        },
+        monkeypatch=monkeypatch,
+    )
+    assert payload.get("audit_status") != "incomplete"
+    evaluation = payload["evaluation"]
+    assert isinstance(evaluation, dict)
+    assert evaluation.get("decision") == "block"
+
+
 def test_workspace_audit_inference_uses_current_directory_with_markers(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_phase06_workspace_audit.py
+++ b/tests/test_guard_phase06_workspace_audit.py
@@ -631,3 +631,62 @@ def test_audit_receipt_metadata_includes_prioritized_package_findings() -> None:
     assert isinstance(findings, list)
     assert len(findings) == 1
     assert findings[0]["name"] == "risky-lib"
+
+
+def test_workspace_audit_without_inventory_marks_incomplete_and_sync_required(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package-lock.json", "{}")
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_premium_entitlement(store)
+    config = load_guard_config(store.guard_home)
+    payload, exit_code = build_workspace_audit_payload(
+        command_name="audit",
+        config=config,
+        now=WORKSPACE_AUDIT_NOW,
+        sbom_paths=(),
+        store=store,
+        workspace_dir=workspace_dir,
+    )
+    assert exit_code == 1
+    assert payload["audit_status"] == "incomplete"
+    assert payload["audit_outcome"] == "sync_required"
+    assert payload["lockfile_paths"] == ["package-lock.json"]
+    metadata = audit_receipt_metadata(payload, workspace_dir=workspace_dir)
+    evidence = metadata["scanner_evidence"]
+    assert isinstance(evidence, dict)
+    assert evidence["audit_status"] == "incomplete"
+    assert evidence["total_packages"] == 0
+
+
+def test_workspace_audit_daemon_reports_incomplete_status_for_empty_inventory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(workspace_dir / "package-lock.json", "{}")
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_premium_entitlement(store)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/audit",
+                token=token,
+                payload={"workspace_dir": str(workspace_dir)},
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["status"] == "incomplete"
+    assert payload["result"]["audit_status"] == "incomplete"
+    assert payload["result"]["exit_code"] == 1


### PR DESCRIPTION
## Summary
- Mark zero-inventory workspace audits as incomplete with structured outcomes (`sync_required`, `inventory_empty`, `no_project_files`) instead of returning a misleading success payload.
- Return `status: incomplete` from the audit API when `exit_code` is non-zero and surface warning copy in the supply-chain dashboard, evidence rail, and action result panel.
- Stop hydrating a clean findings snapshot when an audit did not index any packages.

## Testing
- `python3 -m pytest tests/test_guard_phase06_workspace_audit.py::test_workspace_audit_without_inventory_marks_incomplete_and_sync_required tests/test_guard_phase06_workspace_audit.py::test_workspace_audit_daemon_reports_incomplete_status_for_empty_inventory tests/test_guard_local_supply_chain_phase15.py::test_guard_supply_chain_scan_without_supported_manifests_returns_nonzero -q`
- `cd dashboard && ./node_modules/.bin/tsx src/supply-chain-audit-result.test.ts`
- `cd dashboard && ./node_modules/.bin/tsx src/scsr-phase10-package-workbench.test.ts`
- `cd dashboard && ./node_modules/.bin/tsx src/scsr-phase09c-evidence-rail.test.ts`
- `cd dashboard && npm run build`
