### PR TITLE
feat(guard): add cloud command poller

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ._commands_shared import *
 from .commands_parser_helpers import *
+from ..runtime.command_queue import command_queue_status
 
 def _run_guard_login_command(
     args: argparse.Namespace,
@@ -428,9 +429,28 @@ def _run_guard_daemon_command(
     _emit("doctor", {"daemon_url": f"http://127.0.0.1:{daemon.port}"}, getattr(args, "json", False))
     return 0
 
+def _run_guard_commands_command(
+    args: argparse.Namespace,
+    *,
+    guard_home: Path | None = None,
+    workspace: Path | None = None,
+    context: HarnessContext | None = None,
+    store: GuardStore | None = None,
+    config: GuardConfig | None = None,
+    input_text: str | None = None,
+    output_stream: TextIO | None = None,
+) -> int:
+    commands_command = getattr(args, "commands_command", None)
+    if commands_command == "status":
+        _emit("commands", command_queue_status(store), getattr(args, "json", False))
+        return 0
+    print("commands subcommand is required", file=sys.stderr)
+    return 2
+
 __all__ = [
     "_run_guard_bridge_command",
     "_run_guard_cloud_command",
+    "_run_guard_commands_command",
     "_run_guard_connect_command",
     "_run_guard_daemon_command",
     "_run_guard_device_command",

--- a/src/codex_plugin_scanner/guard/cli/commands_parser.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser.py
@@ -50,7 +50,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
             "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
             "receipts,inventory,abom,aibom,approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,"
             "remote-pair,disconnect,"
-            "login,sync,device,bridge}"
+            "login,sync,device,commands,bridge}"
         ),
     )
     _configure_guard_local_parsers(guard_subparsers)

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
@@ -104,6 +104,23 @@ def _configure_guard_cloud_parsers(
     sync_parser.add_argument("--guard-home")
     sync_parser.add_argument("--json", action="store_true")
 
+    commands_parser = guard_subparsers.add_parser(
+        "commands",
+        help="Inspect Guard Cloud command queue state",
+    )
+    _add_guard_common_args(commands_parser)
+    commands_subparsers = commands_parser.add_subparsers(
+        dest="commands_command",
+        required=True,
+        parser_class=FriendlyArgumentParser,
+    )
+    commands_status_parser = commands_subparsers.add_parser(
+        "status",
+        help="Show local Guard Cloud command queue status",
+    )
+    _add_guard_common_args(commands_status_parser)
+    commands_status_parser.add_argument("--json", action="store_true")
+
     cloud_parser = guard_subparsers.add_parser(
         "cloud",
         help="Sync Guard Cloud supply-chain intelligence and diagnostics",

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -62,6 +62,7 @@ _COMMON_HANDLERS = {
     "supply-chain": "_run_guard_supply_chain_command",
     "service": "_run_guard_service_command",
     "device": "_run_guard_device_command",
+    "commands": "_run_guard_commands_command",
     "daemon": "_run_guard_daemon_command",
     "hook": "_run_guard_hook_command",
 }

--- a/src/codex_plugin_scanner/guard/daemon/command_queue_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/command_queue_worker.py
@@ -1,0 +1,47 @@
+"""Daemon lifecycle helpers for the Guard Cloud command queue poller."""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass
+
+from ..runtime.command_queue import command_queue_enabled, command_queue_loop, default_command_context
+from ..store import GuardStore
+
+_COMMAND_QUEUE_THREAD_JOIN_TIMEOUT_SECONDS = 100
+
+
+@dataclass
+class CommandQueueWorker:
+    thread: threading.Thread
+    stop_event: threading.Event
+
+
+def start_command_queue_worker(
+    store: GuardStore,
+    existing: CommandQueueWorker | None = None,
+) -> CommandQueueWorker | None:
+    if not command_queue_enabled():
+        return existing if existing is not None and existing.thread.is_alive() else None
+    if existing is not None and existing.thread.is_alive() and not existing.stop_event.is_set():
+        return existing
+    stop_event = threading.Event()
+    thread = threading.Thread(
+        target=command_queue_loop,
+        kwargs={
+            "store": store,
+            "context": default_command_context(store),
+            "stop_event": stop_event,
+        },
+        daemon=True,
+    )
+    thread.start()
+    return CommandQueueWorker(thread=thread, stop_event=stop_event)
+
+
+def stop_command_queue_worker(worker: CommandQueueWorker | None) -> CommandQueueWorker | None:
+    if worker is None:
+        return None
+    worker.stop_event.set()
+    worker.thread.join(timeout=_COMMAND_QUEUE_THREAD_JOIN_TIMEOUT_SECONDS)
+    return worker if worker.thread.is_alive() else None

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -142,6 +142,7 @@ from ..store_evidence import (
     export_evidence_json,
     list_evidence,
 )
+from .command_queue_worker import CommandQueueWorker, start_command_queue_worker, stop_command_queue_worker
 from .dashboard_update import merge_dashboard_update_progress, schedule_guard_dashboard_update
 from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
@@ -4714,6 +4715,7 @@ class GuardDaemonServer:
         self._bundle_refresh_backoff_seconds = bundle_refresh_backoff_seconds
         self._bundle_refresh_interval_seconds = bundle_refresh_interval_seconds
         self._bundle_refresh_thread: threading.Thread | None = None
+        self._command_queue_worker: CommandQueueWorker | None = None
         self._thread: threading.Thread | None = None
         self._watchdog_thread: threading.Thread | None = None
         self._shutdown_started = threading.Event()
@@ -4743,6 +4745,7 @@ class GuardDaemonServer:
         if self._bundle_refresh_thread is not None:
             self._bundle_refresh_thread.join(timeout=5)
             self._bundle_refresh_thread = None
+        self._command_queue_worker = stop_command_queue_worker(self._command_queue_worker)
 
     def _begin_service(self) -> None:
         self._shutdown_started.clear()
@@ -4757,6 +4760,7 @@ class GuardDaemonServer:
         )
         self._start_watchdog()
         self._start_supply_chain_bundle_refresh()
+        self._command_queue_worker = start_command_queue_worker(self._server.store, self._command_queue_worker)
 
     def _serve_forever(self) -> None:
         try:

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -1,0 +1,412 @@
+"""Guard Cloud command queue client for local daemon workers."""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.error
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+from ...version import __version__
+from ..adapters.base import HarnessContext
+from ..shims import package_shim_status
+from ..store import GuardStore
+from .runner import (
+    GuardSyncAuthorizationExpiredError,
+    GuardSyncNotConfiguredError,
+    _guard_sync_request,
+    _resolve_guard_sync_auth_context,
+    _sync_http_error_message,
+    _sync_url_error_message,
+    _urlopen_json_with_timeout_retry,
+)
+
+COMMAND_QUEUE_STATE_KEY = "guard_command_queue_state"
+COMMAND_QUEUE_ENABLED_ENV = "GUARD_CLOUD_COMMAND_QUEUE_ENABLED"
+COMMAND_QUEUE_LEASE_WAIT_MS_ENV = "GUARD_CLOUD_COMMAND_QUEUE_LEASE_WAIT_MS"
+COMMAND_QUEUE_POLL_INTERVAL_ENV = "GUARD_CLOUD_COMMAND_QUEUE_POLL_INTERVAL_SECONDS"
+COMMAND_QUEUE_ERROR_BACKOFF_ENV = "GUARD_CLOUD_COMMAND_QUEUE_ERROR_BACKOFF_SECONDS"
+
+_DEFAULT_LEASE_WAIT_MS = 25_000
+_DEFAULT_POLL_INTERVAL_SECONDS = 2.0
+_DEFAULT_ERROR_BACKOFF_SECONDS = 30.0
+_REQUEST_TIMEOUT_SECONDS = 35
+_RETRY_TIMEOUT_SECONDS = 60
+_SUPPORTED_OPERATIONS = ("guard.packageShims.status",)
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def command_queue_enabled(environ: dict[str, str] | None = None) -> bool:
+    source = os.environ if environ is None else environ
+    return source.get(COMMAND_QUEUE_ENABLED_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_float(name: str, default: float) -> float:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name, "").strip()
+    if not value:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed >= 0 else default
+
+
+def _command_api_url(sync_url: object, path: str) -> str:
+    parsed = urlparse(str(sync_url))
+    base_path = "/api/guard/commands"
+    normalized_path = path if path.startswith("/") else f"/{path}"
+    return urlunparse((parsed.scheme, parsed.netloc, f"{base_path}{normalized_path}", "", "", ""))
+
+
+def _redacted_error(error: BaseException) -> str:
+    if isinstance(error, urllib.error.HTTPError):
+        try:
+            return _sync_http_error_message(error)
+        except Exception:
+            return f"HTTP Error {error.code}: {error.reason}"
+    if isinstance(error, OSError):
+        return _sync_url_error_message(error)
+    return str(error)
+
+
+def _json_request(
+    auth_context: dict[str, object],
+    *,
+    method: str,
+    path: str,
+    payload: dict[str, object],
+) -> dict[str, object]:
+    request_url = _command_api_url(auth_context["sync_url"], path)
+    request = _guard_sync_request(
+        auth_context,
+        request_url=request_url,
+        method=method,
+        data=json.dumps(payload, separators=(",", ":")).encode("utf-8"),
+    )
+    return _urlopen_json_with_timeout_retry(
+        request=request,
+        timeout_seconds=_REQUEST_TIMEOUT_SECONDS,
+        retry_timeout_seconds=_RETRY_TIMEOUT_SECONDS,
+    )
+
+
+def _load_state(store: GuardStore) -> dict[str, object]:
+    payload = store.get_sync_payload(COMMAND_QUEUE_STATE_KEY)
+    return dict(payload) if isinstance(payload, dict) else {}
+
+
+def _save_state(store: GuardStore, payload: dict[str, object]) -> None:
+    store.set_sync_payload(COMMAND_QUEUE_STATE_KEY, payload, _now())
+
+
+def command_queue_status(store: GuardStore) -> dict[str, object]:
+    state = _load_state(store)
+    profile = store.get_cloud_sync_profile()
+    return {
+        "enabled": command_queue_enabled(),
+        "configured": profile is not None,
+        "state": state.get("state", "idle"),
+        "last_poll_at": state.get("last_poll_at"),
+        "last_lease_at": state.get("last_lease_at"),
+        "last_empty_poll_at": state.get("last_empty_poll_at"),
+        "last_result_at": state.get("last_result_at"),
+        "last_error": state.get("last_error"),
+        "last_poll_was_empty": bool(state.get("last_poll_was_empty")),
+        "active_job": state.get("active_job"),
+        "pending_result": state.get("pending_result"),
+        "supported_operations": list(_SUPPORTED_OPERATIONS),
+    }
+
+
+def _oauth_metadata(store: GuardStore) -> tuple[str, str]:
+    credentials = store.get_oauth_local_credentials(allow_primary=False)
+    if not isinstance(credentials, dict):
+        raise GuardSyncNotConfiguredError("Guard command queue requires OAuth credentials.")
+    machine_id = credentials.get("machine_id")
+    workspace_id = credentials.get("workspace_id")
+    if not isinstance(machine_id, str) or not machine_id:
+        raise GuardSyncNotConfiguredError("Guard command queue requires a machine-bound OAuth grant.")
+    if not isinstance(workspace_id, str) or not workspace_id:
+        raise GuardSyncNotConfiguredError("Guard command queue requires a workspace-bound OAuth grant.")
+    return machine_id, workspace_id
+
+
+def _lease_payload(store: GuardStore) -> dict[str, object]:
+    machine_id, workspace_id = _oauth_metadata(store)
+    return {
+        "workspaceId": workspace_id,
+        "deviceId": machine_id,
+        "daemonVersion": __version__,
+        "capabilities": {
+            "operations": list(_SUPPORTED_OPERATIONS),
+            "schemaVersions": {"guard.packageShims.status": 1},
+        },
+        "maxJobs": 1,
+        "waitMs": _env_int(COMMAND_QUEUE_LEASE_WAIT_MS_ENV, _DEFAULT_LEASE_WAIT_MS),
+    }
+
+
+def _job_operation(job: dict[str, object]) -> str:
+    operation = job.get("operation")
+    return operation if isinstance(operation, str) else ""
+
+
+def _job_id(job: dict[str, object]) -> str:
+    job_id = job.get("id")
+    if not isinstance(job_id, str) or not job_id:
+        raise RuntimeError("Guard command job is missing an id.")
+    return job_id
+
+
+def _lease_id(job: dict[str, object]) -> str:
+    lease_id = job.get("leaseId")
+    if not isinstance(lease_id, str) or not lease_id:
+        raise RuntimeError("Guard command job is missing a lease id.")
+    return lease_id
+
+
+def _execute_job(job: dict[str, object], context: HarnessContext) -> dict[str, object]:
+    operation = _job_operation(job)
+    if operation == "guard.packageShims.status":
+        return {
+            "data": package_shim_status(context),
+            "generatedAt": _now(),
+        }
+    return {
+        "failureCode": "unsupported_operation",
+        "failureMessage": f"Unsupported Guard command operation: {operation or 'unknown'}",
+    }
+
+
+def _heartbeat(auth_context: dict[str, object], job: dict[str, object]) -> None:
+    _json_request(
+        auth_context,
+        method="POST",
+        path=f"/{_job_id(job)}/heartbeat",
+        payload={"leaseId": _lease_id(job)},
+    )
+
+
+def _result_payload(job: dict[str, object], execution: dict[str, object]) -> dict[str, object]:
+    failure_code = execution.get("failureCode")
+    if isinstance(failure_code, str) and failure_code:
+        payload: dict[str, object] = {
+            "leaseId": _lease_id(job),
+            "idempotencyKey": f"{_job_id(job)}:{_lease_id(job)}:failed",
+            "status": "failed",
+            "failureCode": failure_code,
+            "failureMessage": str(execution.get("failureMessage") or failure_code),
+        }
+        return payload
+    return {
+        "leaseId": _lease_id(job),
+        "idempotencyKey": f"{_job_id(job)}:{_lease_id(job)}:succeeded",
+        "status": "succeeded",
+        "result": execution,
+    }
+
+
+def _post_result(auth_context: dict[str, object], job: dict[str, object], payload: dict[str, object]) -> None:
+    _json_request(
+        auth_context,
+        method="POST",
+        path=f"/{_job_id(job)}/result",
+        payload=payload,
+    )
+
+
+def _retry_pending_result(
+    store: GuardStore,
+    auth_context: dict[str, object],
+    state: dict[str, object],
+) -> bool:
+    pending = state.get("pending_result")
+    if not isinstance(pending, dict):
+        return False
+    job = pending.get("job")
+    payload = pending.get("payload")
+    if not isinstance(job, dict) or not isinstance(payload, dict):
+        state.pop("pending_result", None)
+        state.pop("active_job", None)
+        _save_state(store, state)
+        return False
+    _post_result(auth_context, job, payload)
+    state.pop("pending_result", None)
+    state.pop("active_job", None)
+    state.update(
+        {
+            "state": "idle",
+            "last_result_at": _now(),
+            "last_error": None,
+            "last_poll_was_empty": False,
+        }
+    )
+    _save_state(store, state)
+    return True
+
+
+def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[str, object]:
+    auth_context = _resolve_guard_sync_auth_context(store)
+    state = _load_state(store)
+    state.update(
+        {
+            "state": "polling",
+            "last_poll_at": _now(),
+            "last_error": None,
+            "last_poll_was_empty": False,
+        }
+    )
+    _save_state(store, state)
+    if _retry_pending_result(store, auth_context, state):
+        return command_queue_status(store)
+
+    lease_response = _json_request(
+        auth_context,
+        method="POST",
+        path="/lease",
+        payload=_lease_payload(store),
+    )
+    item = lease_response.get("item")
+    if not isinstance(item, dict):
+        empty_at = _now()
+        state.update(
+            {
+                "state": "idle",
+                "last_empty_poll_at": empty_at,
+                "last_poll_at": empty_at,
+                "last_poll_was_empty": True,
+            }
+        )
+        _save_state(store, state)
+        return command_queue_status(store)
+
+    state.update(
+        {
+            "state": "leased",
+            "last_lease_at": _now(),
+            "active_job": item,
+            "last_poll_was_empty": False,
+        }
+    )
+    _save_state(store, state)
+    try:
+        _heartbeat(auth_context, item)
+    except Exception:
+        state.pop("active_job", None)
+        state.update({"state": "error", "last_error": "Guard command heartbeat failed."})
+        _save_state(store, state)
+        raise
+    try:
+        execution = _execute_job(item, context)
+    except Exception as error:
+        execution = {
+            "failureCode": "execution_error",
+            "failureMessage": _redacted_error(error),
+        }
+    payload = _result_payload(item, execution)
+    try:
+        _heartbeat(auth_context, item)
+        _post_result(auth_context, item, payload)
+    except Exception:
+        state.update(
+            {
+                "state": "result_pending",
+                "pending_result": {"job": item, "payload": payload, "recorded_at": _now()},
+            }
+        )
+        _save_state(store, state)
+        raise
+    state.pop("active_job", None)
+    state.pop("pending_result", None)
+    state.update({"state": "idle", "last_result_at": _now(), "last_poll_was_empty": False})
+    _save_state(store, state)
+    return command_queue_status(store)
+
+
+def command_queue_loop(
+    store: GuardStore,
+    context: HarnessContext,
+    *,
+    stop_event: Any,
+) -> None:
+    if not command_queue_enabled():
+        return
+    poll_interval = _env_float(COMMAND_QUEUE_POLL_INTERVAL_ENV, _DEFAULT_POLL_INTERVAL_SECONDS)
+    error_backoff = _env_float(COMMAND_QUEUE_ERROR_BACKOFF_ENV, _DEFAULT_ERROR_BACKOFF_SECONDS)
+    empty_streak = 0
+    error_streak = 0
+    while not stop_event.is_set():
+        wait_seconds = poll_interval
+        try:
+            status = poll_command_queue_once(store, context)
+            error_streak = 0
+            if status.get("last_poll_was_empty") is True:
+                empty_streak += 1
+                wait_seconds = min(error_backoff, poll_interval * (2 ** max(0, empty_streak - 1)))
+            else:
+                empty_streak = 0
+        except GuardSyncAuthorizationExpiredError as error:
+            _save_state(
+                store,
+                {
+                    **_load_state(store),
+                    "state": "auth_expired",
+                    "last_error": _redacted_error(error),
+                    "last_poll_at": _now(),
+                },
+            )
+            return
+        except GuardSyncNotConfiguredError as error:
+            empty_streak = 0
+            error_streak += 1
+            _save_state(
+                store,
+                {
+                    **_load_state(store),
+                    "state": "not_configured",
+                    "last_error": _redacted_error(error),
+                    "last_poll_at": _now(),
+                },
+            )
+            wait_seconds = min(error_backoff, poll_interval * (2 ** max(0, error_streak - 1)))
+        except Exception as error:
+            empty_streak = 0
+            error_streak += 1
+            _save_state(
+                store,
+                {
+                    **_load_state(store),
+                    "state": "error",
+                    "last_error": _redacted_error(error),
+                    "last_poll_at": _now(),
+                },
+            )
+            wait_seconds = min(error_backoff, poll_interval * (2 ** max(0, error_streak - 1)))
+        if stop_event.wait(wait_seconds):
+            return
+
+
+def default_command_context(store: GuardStore) -> HarnessContext:
+    return HarnessContext(
+        home_dir=Path.home().resolve(),
+        workspace_dir=None,
+        guard_home=store.guard_home,
+    )

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1,0 +1,448 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.daemon.command_queue_worker import (
+    CommandQueueWorker,
+    start_command_queue_worker,
+)
+from codex_plugin_scanner.guard.runtime import command_queue
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+class FakeStore:
+    def __init__(self, guard_home: Path) -> None:
+        self.guard_home = guard_home
+        self.payloads: dict[str, dict[str, object] | list[object]] = {}
+
+    def get_sync_payload(self, key: str) -> dict[str, object] | list[object] | None:
+        return self.payloads.get(key)
+
+    def set_sync_payload(self, key: str, payload: dict[str, object] | list[object], now: str) -> None:
+        self.payloads[key] = payload
+
+    def get_cloud_sync_profile(self) -> dict[str, str]:
+        return {
+            "auth_mode": "oauth",
+            "sync_url": "https://hol.test/api/guard/receipts/sync",
+            "workspace_id": "workspace-1",
+        }
+
+    def get_oauth_local_credentials(self, *, allow_primary: bool = False) -> dict[str, object]:
+        return {
+            "grant_id": "grant-1",
+            "machine_id": "machine-1",
+            "workspace_id": "workspace-1",
+        }
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path,
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def test_poll_once_leases_heartbeats_executes_and_posts_result(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    calls: list[tuple[str, str, dict[str, object]]] = []
+
+    def fake_auth_context(current_store: object) -> dict[str, object]:
+        assert current_store is store
+        return {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"}
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append((method, path, payload))
+        if path == "/lease":
+            return {
+                "item": {
+                    "id": "job-1",
+                    "leaseId": "lease-1",
+                    "operation": "guard.packageShims.status",
+                }
+            }
+        return {"ok": True}
+
+    monkeypatch.setattr(command_queue, "_resolve_guard_sync_auth_context", fake_auth_context)
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+    monkeypatch.setattr(
+        command_queue,
+        "package_shim_status",
+        lambda context: {"active_managers": ["npm"]},
+    )
+
+    status = command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    assert status["state"] == "idle"
+    assert calls[0] == (
+        "POST",
+        "/lease",
+        {
+            "workspaceId": "workspace-1",
+            "deviceId": "machine-1",
+            "daemonVersion": command_queue.__version__,
+            "capabilities": {
+                "operations": ["guard.packageShims.status"],
+                "schemaVersions": {"guard.packageShims.status": 1},
+            },
+            "maxJobs": 1,
+            "waitMs": 25000,
+        },
+    )
+    assert calls[1] == ("POST", "/job-1/heartbeat", {"leaseId": "lease-1"})
+    assert calls[2] == ("POST", "/job-1/heartbeat", {"leaseId": "lease-1"})
+    assert calls[3][0:2] == ("POST", "/job-1/result")
+    assert calls[3][2]["status"] == "succeeded"
+    assert calls[3][2]["leaseId"] == "lease-1"
+    assert "machineInstallationId" not in calls[0][2]
+    assert "machineInstallationId" not in calls[1][2]
+    assert "machineInstallationId" not in calls[2][2]
+    assert "machineInstallationId" not in calls[3][2]
+
+
+def test_poll_once_persists_result_retry_when_result_upload_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
+    )
+    monkeypatch.setattr(command_queue, "package_shim_status", lambda context: {"active_managers": []})
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        if path == "/lease":
+            return {
+                "item": {
+                    "id": "job-2",
+                    "leaseId": "lease-2",
+                    "operation": "guard.packageShims.status",
+                }
+            }
+        if path.endswith("/result"):
+            raise OSError("upload failed")
+        return {"ok": True}
+
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+
+    try:
+        command_queue.poll_command_queue_once(store, _context(tmp_path))
+    except OSError:
+        pass
+    else:
+        raise AssertionError("result upload should fail")
+
+    state = store.get_sync_payload(command_queue.COMMAND_QUEUE_STATE_KEY)
+    assert isinstance(state, dict)
+    assert state["state"] == "result_pending"
+    assert isinstance(state["pending_result"], dict)
+
+
+def test_poll_once_clears_active_job_when_heartbeat_fails(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
+    )
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        if path == "/lease":
+            return {
+                "item": {
+                    "id": "job-2",
+                    "leaseId": "lease-2",
+                    "operation": "guard.packageShims.status",
+                }
+            }
+        if path.endswith("/heartbeat"):
+            raise OSError("heartbeat failed")
+        return {"ok": True}
+
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+
+    try:
+        command_queue.poll_command_queue_once(store, _context(tmp_path))
+    except OSError:
+        pass
+    else:
+        raise AssertionError("heartbeat should fail")
+
+    state = store.get_sync_payload(command_queue.COMMAND_QUEUE_STATE_KEY)
+    assert isinstance(state, dict)
+    assert state["state"] == "error"
+    assert "active_job" not in state
+
+
+def test_poll_once_posts_failed_result_when_execution_raises(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    result_payloads: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
+    )
+    monkeypatch.setattr(
+        command_queue,
+        "package_shim_status",
+        lambda context: (_ for _ in ()).throw(RuntimeError("shim status failed")),
+    )
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        if path == "/lease":
+            return {
+                "item": {
+                    "id": "job-5",
+                    "leaseId": "lease-5",
+                    "operation": "guard.packageShims.status",
+                }
+            }
+        if path.endswith("/result"):
+            result_payloads.append(payload)
+        return {"ok": True}
+
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+
+    status = command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    assert status["state"] == "idle"
+    assert result_payloads[0]["status"] == "failed"
+    assert result_payloads[0]["failureCode"] == "execution_error"
+    assert "shim status failed" in str(result_payloads[0]["failureMessage"])
+
+
+def test_poll_once_retries_pending_result_before_leasing(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        command_queue.COMMAND_QUEUE_STATE_KEY,
+        {
+            "state": "result_pending",
+            "pending_result": {
+                "job": {"id": "job-3", "leaseId": "lease-3"},
+                "payload": {
+                    "leaseId": "lease-3",
+                    "idempotencyKey": "job-3:lease-3:succeeded",
+                    "status": "succeeded",
+                    "result": {"data": {}},
+                },
+            },
+        },
+        "2026-06-13T00:00:00+00:00",
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
+    )
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append(path)
+        return {"ok": True}
+
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+
+    status = command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    assert status["state"] == "idle"
+    assert calls == ["/job-3/result"]
+    assert status["pending_result"] is None
+
+
+def test_poll_once_clears_active_job_for_malformed_pending_result(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        command_queue.COMMAND_QUEUE_STATE_KEY,
+        {
+            "state": "result_pending",
+            "active_job": {"id": "job-4", "leaseId": "lease-4"},
+            "pending_result": {"job": "bad", "payload": {}},
+        },
+        "2026-06-13T00:00:00+00:00",
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
+    )
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append(path)
+        return {"item": None}
+
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+
+    command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    state = store.get_sync_payload(command_queue.COMMAND_QUEUE_STATE_KEY)
+    assert isinstance(state, dict)
+    assert "active_job" not in state
+    assert "pending_result" not in state
+    assert calls == ["/lease"]
+
+
+def test_command_queue_loop_backs_off_after_empty_polls(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    waits: list[float] = []
+
+    class StopAfterThreeWaits:
+        def is_set(self) -> bool:
+            return False
+
+        def wait(self, seconds: float) -> bool:
+            waits.append(seconds)
+            return len(waits) >= 3
+
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, "1")
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_POLL_INTERVAL_ENV, "1")
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ERROR_BACKOFF_ENV, "8")
+
+    def fake_poll_once(current_store: object, context: HarnessContext) -> dict[str, object]:
+        return {"last_poll_was_empty": True}
+
+    monkeypatch.setattr(command_queue, "poll_command_queue_once", fake_poll_once)
+
+    command_queue.command_queue_loop(
+        store,
+        _context(tmp_path),
+        stop_event=StopAfterThreeWaits(),
+    )
+
+    assert waits == [1, 2, 4]
+
+
+def test_start_worker_replaces_stopped_alive_worker(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+
+    class FakeThread:
+        def __init__(self) -> None:
+            self.started = False
+
+        def is_alive(self) -> bool:
+            return True
+
+        def start(self) -> None:
+            self.started = True
+
+    class FakeEvent:
+        def __init__(self, stopped: bool = False) -> None:
+            self.stopped = stopped
+
+        def is_set(self) -> bool:
+            return self.stopped
+
+    created_threads: list[FakeThread] = []
+
+    def fake_thread(*args: object, **kwargs: object) -> FakeThread:
+        thread = FakeThread()
+        created_threads.append(thread)
+        return thread
+
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, "1")
+    monkeypatch.setattr("codex_plugin_scanner.guard.daemon.command_queue_worker.threading.Thread", fake_thread)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.command_queue_worker.threading.Event",
+        lambda: FakeEvent(False),
+    )
+    existing = CommandQueueWorker(thread=FakeThread(), stop_event=FakeEvent(True))  # type: ignore[arg-type]
+
+    worker = start_command_queue_worker(store, existing)  # type: ignore[arg-type]
+
+    assert worker is not existing
+    assert created_threads[0].started is True
+
+
+def test_command_queue_loop_backs_off_after_errors(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    waits: list[float] = []
+
+    class StopAfterThreeWaits:
+        def is_set(self) -> bool:
+            return False
+
+        def wait(self, seconds: float) -> bool:
+            waits.append(seconds)
+            return len(waits) >= 3
+
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, "1")
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_POLL_INTERVAL_ENV, "1")
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ERROR_BACKOFF_ENV, "8")
+    monkeypatch.setattr(
+        command_queue,
+        "poll_command_queue_once",
+        lambda current_store, context: (_ for _ in ()).throw(OSError("network down")),
+    )
+
+    command_queue.command_queue_loop(
+        store,
+        _context(tmp_path),
+        stop_event=StopAfterThreeWaits(),
+    )
+
+    assert waits == [1, 2, 4]
+
+
+def test_commands_status_outputs_command_queue_state(tmp_path: Path, capsys, monkeypatch) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_sync_payload(
+        command_queue.COMMAND_QUEUE_STATE_KEY,
+        {"state": "idle", "last_poll_at": "2026-06-13T00:00:00+00:00"},
+        "2026-06-13T00:00:00+00:00",
+    )
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, "1")
+
+    rc = main(["guard", "commands", "status", "--guard-home", str(guard_home), "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["state"] == "idle"
+    assert payload["enabled"] is True
+    assert payload["supported_operations"] == ["guard.packageShims.status"]


### PR DESCRIPTION
## Summary
- Add a default-off Guard Cloud command queue poller for local daemon workers.
- Lease and execute `guard.packageShims.status` jobs with heartbeat, result upload, and persisted retry state.
- Add `hol-guard commands status --json` for command queue diagnostics.

## Testing
- `python3 -m py_compile src/codex_plugin_scanner/guard/runtime/command_queue.py src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py src/codex_plugin_scanner/guard/cli/commands_router.py src/codex_plugin_scanner/guard/cli/commands_parser.py`
- `pytest -q tests/test_guard_command_queue.py`

## Notes
- `python3 -m ruff ...` could not run because `ruff` is not installed in this environment.
