### PR TITLE
fix(dashboard): disable cloud exception request without controls URL

### DIFF
--- a/dashboard/src/policy-cloud-exceptions-ia.test.tsx
+++ b/dashboard/src/policy-cloud-exceptions-ia.test.tsx
@@ -23,6 +23,10 @@ const sidebarSource = readFileSync(join(here, "approval-center-primitives.tsx"),
 assert(!workspaceSource.includes("PolicyExceptionForm"), "policy workspace no longer mounts PolicyExceptionForm");
 assert(!workspaceSource.includes("New exception"), "policy workspace removes local New exception copy");
 assert(tabSource.includes("Request cloud exception"), "cloud exceptions tab exposes request CTA");
+assert(
+  workspaceSource.includes("cloudControlsUrl ? handleRequestCloudException : undefined"),
+  "request callback omitted when Cloud controls URL is unavailable",
+);
 assert(tabSource.includes("Open Guard Cloud"), "cloud exceptions tab exposes Open Guard Cloud CTA");
 assert(tabSource.includes("Guard Cloud is not connected"), "disconnected Cloud copy present");
 assert(!pageSource.includes("add custom exceptions"), "page header removes local exception authoring copy");

--- a/dashboard/src/policy-cloud-exceptions-tab.tsx
+++ b/dashboard/src/policy-cloud-exceptions-tab.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { HiMiniCloudArrowUp } from "react-icons/hi2";
 import { ActionButton, EmptyState, SectionLabel } from "./approval-center-primitives";
 import type { GuardRuntimeSnapshot } from "./guard-types";
@@ -21,10 +20,6 @@ export function PolicyCloudExceptionsTab({
   const cloudConnected = resolveCloudExceptionsConnected(snapshot);
   const connectUrl = snapshot.connect_url?.trim() || null;
 
-  const handleRequestCloudException = useCallback(() => {
-    onRequestCloudException?.();
-  }, [onRequestCloudException]);
-
   return (
     <div className="space-y-4">
       <div className="rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm">
@@ -42,7 +37,7 @@ export function PolicyCloudExceptionsTab({
       <div className="flex flex-wrap items-center gap-2">
         <ActionButton
           variant="primary"
-          onClick={handleRequestCloudException}
+          onClick={onRequestCloudException}
           disabled={!cloudConnected || onRequestCloudException === undefined}
         >
           Request cloud exception

--- a/dashboard/src/policy-workspace.tsx
+++ b/dashboard/src/policy-workspace.tsx
@@ -253,7 +253,7 @@ export function PolicyWorkspace({
       ) : null}
 
       {activeView === "exceptions" ? (
-        <PolicyCloudExceptionsTab snapshot={snapshot} onRequestCloudException={handleRequestCloudException} />
+        <PolicyCloudExceptionsTab snapshot={snapshot} onRequestCloudException={cloudControlsUrl ? handleRequestCloudException : undefined} />
       ) : null}
 
       {activeView === "strict" ? (

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
@@ -1,4 +1,4 @@
-import { b9 as policyActionLabel, h as harnessDisplayName, ba as scopeLabel, j as jsxRuntimeExports, r as reactExports, S as SectionLabel, A as ActionButton, b2 as HiMiniCloudArrowUp, b as EmptyState, ac as Tag, p as HiMiniChevronUp, q as HiMiniChevronDown, B as Badge, m as formatRelativeTime, b7 as guardAwareHref, ax as HiMiniTrash, ad as HiMiniMagnifyingGlass } from "../guard-dashboard.js";
+import { b9 as policyActionLabel, h as harnessDisplayName, ba as scopeLabel, j as jsxRuntimeExports, S as SectionLabel, A as ActionButton, b2 as HiMiniCloudArrowUp, b as EmptyState, r as reactExports, ac as Tag, p as HiMiniChevronUp, q as HiMiniChevronDown, B as Badge, m as formatRelativeTime, b7 as guardAwareHref, ax as HiMiniTrash, ad as HiMiniMagnifyingGlass } from "../guard-dashboard.js";
 const MATCHER_FAMILY_LABELS = {
   "package-request": "package install",
   "tool-action": "shell or tool command",
@@ -284,9 +284,6 @@ function PolicyCloudExceptionsTab({
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
   const cloudConnected = resolveCloudExceptionsConnected(snapshot);
   const connectUrl = snapshot.connect_url?.trim() || null;
-  const handleRequestCloudException = reactExports.useCallback(() => {
-    onRequestCloudException?.();
-  }, [onRequestCloudException]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Cloud risk acceptances" }),
@@ -298,7 +295,7 @@ function PolicyCloudExceptionsTab({
         ActionButton,
         {
           variant: "primary",
-          onClick: handleRequestCloudException,
+          onClick: onRequestCloudException,
           disabled: !cloudConnected || onRequestCloudException === void 0,
           children: "Request cloud exception"
         }
@@ -705,7 +702,7 @@ function PolicyWorkspace({
         }
       )
     ] }) : null,
-    activeView === "exceptions" ? /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyCloudExceptionsTab, { snapshot, onRequestCloudException: handleRequestCloudException }) : null,
+    activeView === "exceptions" ? /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyCloudExceptionsTab, { snapshot, onRequestCloudException: cloudControlsUrl ? handleRequestCloudException : void 0 }) : null,
     activeView === "strict" ? /* @__PURE__ */ jsxRuntimeExports.jsx(StrictModeView, { snapshot, onOpenSettings, onOpenInbox }) : null
   ] });
 }


### PR DESCRIPTION
## Summary
- Disable Request cloud exception when Guard Cloud controls URL is unavailable
- Remove redundant callback wrapper in Cloud exceptions tab

## Testing
- `pnpm exec tsx src/policy-cloud-exceptions-ia.test.tsx`
- `pnpm run build`
