### PR TITLE
feat(guard): add cloud command executors

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 from ._commands_shared import *
 from .commands_parser_helpers import *
+from ..runtime.command_queue import command_queue_status, repair_command_queue_state
 
 def _run_guard_exceptions_command(
     args: argparse.Namespace,
@@ -294,6 +295,10 @@ def _run_guard_doctor_command(
             package_shims_payload["repair"] = {"nothing_to_repair": True, "repaired": [], "repaired_count": 0}
     package_shims_payload["issues"] = package_shim_issues
     payload["package_shims"] = package_shims_payload
+    command_queue_payload = command_queue_status(store)
+    if getattr(args, "repair", False):
+        command_queue_payload["repair"] = repair_command_queue_state(store)
+    payload["command_queue"] = command_queue_payload
     payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())
     payload["aibom"] = build_aibom_status_payload(store, context, generated_at=_now())
     _emit("doctor", payload, getattr(args, "json", False))

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -1,0 +1,279 @@
+"""Typed executors for Guard Cloud command queue jobs."""
+
+from __future__ import annotations
+
+import tempfile
+from collections.abc import Callable
+from datetime import datetime, timezone
+from pathlib import Path
+
+from ..adapters import get_adapter
+from ..adapters.base import HarnessContext
+from ..cli.install_commands import (
+    apply_managed_install,
+    build_harness_verification,
+    list_harness_setup_items,
+)
+from ..config import load_guard_config
+from ..local_supply_chain import (
+    build_workspace_audit_payload,
+    managed_install_audit_workspace_dirs,
+    resolve_supply_chain_audit_workspace_dir,
+)
+from ..package_shim_status import record_package_shim_audit_result
+from ..runtime.runner import sync_supply_chain_bundle
+from ..shims import (
+    activate_package_shims,
+    package_shim_status,
+    package_shim_supported_managers,
+    probe_package_shim_intercepts,
+    uninstall_package_shims,
+)
+from ..store import GuardStore
+
+PACKAGE_SHIM_OPERATIONS: tuple[str, ...] = (
+    "guard.packageShims.status",
+    "guard.packageShims.repair",
+    "guard.packageShims.test",
+    "guard.packageShims.sync",
+    "guard.packageShims.install",
+    "guard.packageShims.remove",
+    "guard.packageShims.audit",
+)
+APP_OPERATIONS: tuple[str, ...] = (
+    "guard.app.status",
+    "guard.app.repair",
+    "guard.app.connect",
+    "guard.app.remove",
+)
+SUPPORTED_COMMAND_OPERATIONS: tuple[str, ...] = (*PACKAGE_SHIM_OPERATIONS, *APP_OPERATIONS)
+COMMAND_OPERATION_SCHEMA_VERSIONS: dict[str, int] = {operation: 1 for operation in SUPPORTED_COMMAND_OPERATIONS}
+
+
+def execute_guard_command_job(
+    job: dict[str, object],
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+    now: Callable[[], str] | None = None,
+) -> dict[str, object]:
+    operation = _job_operation(job)
+    generated_at = now() if now is not None else _now()
+    payload = _job_payload(job)
+    try:
+        if operation in PACKAGE_SHIM_OPERATIONS:
+            return _execute_package_shim_operation(
+                operation,
+                payload=payload,
+                context=context,
+                store=store,
+                generated_at=generated_at,
+            )
+        if operation in APP_OPERATIONS:
+            return _execute_app_operation(
+                operation,
+                payload=payload,
+                context=context,
+                store=store,
+                generated_at=generated_at,
+            )
+    except ValueError as error:
+        failure_code = str(error) or "invalid_payload"
+        return {
+            "failureCode": failure_code,
+            "failureMessage": failure_code.replace("_", " "),
+        }
+    return {
+        "failureCode": "unsupported_operation",
+        "failureMessage": f"Unsupported Guard command operation: {operation or 'unknown'}",
+    }
+
+
+def _execute_package_shim_operation(
+    operation: str,
+    *,
+    payload: dict[str, object],
+    context: HarnessContext,
+    store: GuardStore,
+    generated_at: str,
+) -> dict[str, object]:
+    managers = _package_shim_managers(payload)
+    command_context = _package_shim_context(payload, base_context=context, store=store)
+    if operation == "guard.packageShims.status":
+        return _result(package_shim_status(command_context), generated_at=generated_at)
+    if operation == "guard.packageShims.install":
+        return _result(activate_package_shims(command_context, managers=managers), generated_at=generated_at)
+    if operation == "guard.packageShims.repair":
+        return _result(
+            activate_package_shims(command_context, managers=managers, repair=True),
+            generated_at=generated_at,
+        )
+    if operation == "guard.packageShims.remove":
+        return _result(uninstall_package_shims(command_context, managers=managers), generated_at=generated_at)
+    if operation == "guard.packageShims.test":
+        return _result(
+            probe_package_shim_intercepts(
+                command_context,
+                managers=managers,
+                workspace_dir=command_context.workspace_dir,
+            ),
+            generated_at=generated_at,
+        )
+    if operation == "guard.packageShims.sync":
+        return _result(sync_supply_chain_bundle(store), generated_at=generated_at)
+    if operation == "guard.packageShims.audit":
+        if command_context.workspace_dir is None:
+            return {
+                "failureCode": "workspace_required",
+                "failureMessage": "Package shim audit requires a workspace path.",
+            }
+        audit_payload, exit_code = build_workspace_audit_payload(
+            command_name="audit",
+            config=load_guard_config(store.guard_home),
+            now=generated_at,
+            sbom_paths=(),
+            store=store,
+            workspace_dir=command_context.workspace_dir,
+        )
+        audit_payload["exit_code"] = exit_code
+        if exit_code == 0:
+            record_package_shim_audit_result(command_context, audited_at=generated_at)
+        return _result(audit_payload, generated_at=generated_at)
+    return {
+        "failureCode": "unsupported_operation",
+        "failureMessage": f"Unsupported package shim operation: {operation}",
+    }
+
+
+def _execute_app_operation(
+    operation: str,
+    *,
+    payload: dict[str, object],
+    context: HarnessContext,
+    store: GuardStore,
+    generated_at: str,
+) -> dict[str, object]:
+    harness = _optional_string(payload.get("harness"))
+    surface = _optional_surface(payload.get("surface"))
+    workspace = str(context.workspace_dir) if context.workspace_dir is not None else None
+    if operation == "guard.app.status":
+        if harness is None:
+            return _result({"items": list_harness_setup_items(context, store)}, generated_at=generated_at)
+        get_adapter(harness)
+        return _result(build_harness_verification(harness, context, store, surface=surface), generated_at=generated_at)
+    if harness is None:
+        return {"failureCode": "harness_required", "failureMessage": "App command requires a harness."}
+    get_adapter(harness)
+    if operation == "guard.app.connect":
+        return _result(
+            apply_managed_install("install", harness, False, context, store, workspace, generated_at, surface=surface),
+            generated_at=generated_at,
+        )
+    if operation == "guard.app.repair":
+        result = apply_managed_install(
+            "install",
+            harness,
+            False,
+            context,
+            store,
+            workspace,
+            generated_at,
+            surface=surface,
+        )
+        result["action"] = "repair"
+        return _result(result, generated_at=generated_at)
+    if operation == "guard.app.remove":
+        return _result(
+            apply_managed_install(
+                "uninstall",
+                harness,
+                False,
+                context,
+                store,
+                workspace,
+                generated_at,
+                surface=surface,
+            ),
+            generated_at=generated_at,
+        )
+    return {
+        "failureCode": "unsupported_operation",
+        "failureMessage": f"Unsupported app operation: {operation}",
+    }
+
+
+def _package_shim_context(
+    payload: dict[str, object],
+    *,
+    base_context: HarnessContext,
+    store: GuardStore,
+) -> HarnessContext:
+    if payload.get("workspace_dir") is None and payload.get("workspace") is None:
+        return base_context
+    allowed_roots = (
+        base_context.home_dir.resolve(),
+        Path.cwd().resolve(),
+        Path(tempfile.gettempdir()).resolve(),
+    )
+    workspace_dir = resolve_supply_chain_audit_workspace_dir(
+        workspace_dir_value=payload.get("workspace_dir"),
+        workspace_value=payload.get("workspace"),
+        allowed_roots=allowed_roots,
+        managed_workspace_dirs=managed_install_audit_workspace_dirs(store),
+    )
+    return HarnessContext(
+        home_dir=base_context.home_dir,
+        workspace_dir=workspace_dir or base_context.workspace_dir,
+        guard_home=base_context.guard_home,
+    )
+
+
+def _package_shim_managers(payload: dict[str, object]) -> tuple[str, ...] | None:
+    managers = payload.get("managers")
+    if managers is None:
+        return None
+    if not isinstance(managers, list) or not managers:
+        raise ValueError("invalid_managers")
+    normalized = tuple(manager.strip().lower() for manager in managers if isinstance(manager, str) and manager.strip())
+    if len(normalized) != len(managers):
+        raise ValueError("invalid_managers")
+    if len(normalized) != len(set(normalized)):
+        raise ValueError("duplicate_manager")
+    supported = set(package_shim_supported_managers())
+    if not set(normalized).issubset(supported):
+        raise ValueError("unsupported_manager")
+    return normalized
+
+
+def _job_operation(job: dict[str, object]) -> str:
+    operation = job.get("operation")
+    return operation if isinstance(operation, str) else ""
+
+
+def _job_payload(job: dict[str, object]) -> dict[str, object]:
+    payload = job.get("payload")
+    return dict(payload) if isinstance(payload, dict) else {}
+
+
+def _optional_string(value: object) -> str | None:
+    return value.strip() if isinstance(value, str) and value.strip() else None
+
+
+def _optional_surface(value: object) -> str | None:
+    surface = _optional_string(value)
+    if surface is None:
+        return None
+    if surface not in {"editor", "cli"}:
+        raise ValueError("unsupported_surface")
+    return surface
+
+
+def _result(data: dict[str, object], *, generated_at: str) -> dict[str, object]:
+    return {
+        "data": data,
+        "generatedAt": generated_at,
+    }
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -57,7 +57,7 @@ def execute_guard_command_job(
     store: GuardStore,
     now: Callable[[], str] | None = None,
 ) -> dict[str, object]:
-    operation = _job_operation(job)
+    operation = command_job_operation(job)
     generated_at = now() if now is not None else _now()
     payload = _job_payload(job)
     try:
@@ -97,20 +97,23 @@ def _execute_package_shim_operation(
     store: GuardStore,
     generated_at: str,
 ) -> dict[str, object]:
-    managers = _package_shim_managers(payload)
     command_context = _package_shim_context(payload, base_context=context, store=store)
     if operation == "guard.packageShims.status":
         return _result(package_shim_status(command_context), generated_at=generated_at)
     if operation == "guard.packageShims.install":
+        managers = _package_shim_managers(payload)
         return _result(activate_package_shims(command_context, managers=managers), generated_at=generated_at)
     if operation == "guard.packageShims.repair":
+        managers = _package_shim_managers(payload)
         return _result(
             activate_package_shims(command_context, managers=managers, repair=True),
             generated_at=generated_at,
         )
     if operation == "guard.packageShims.remove":
+        managers = _package_shim_managers(payload)
         return _result(uninstall_package_shims(command_context, managers=managers), generated_at=generated_at)
     if operation == "guard.packageShims.test":
+        managers = _package_shim_managers(payload)
         return _result(
             probe_package_shim_intercepts(
                 command_context,
@@ -245,7 +248,7 @@ def _package_shim_managers(payload: dict[str, object]) -> tuple[str, ...] | None
     return normalized
 
 
-def _job_operation(job: dict[str, object]) -> str:
+def command_job_operation(job: dict[str, object]) -> str:
     operation = job.get("operation")
     return operation if isinstance(operation, str) else ""
 

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -17,6 +17,7 @@ from ..store import GuardStore
 from .command_executors import (
     COMMAND_OPERATION_SCHEMA_VERSIONS,
     SUPPORTED_COMMAND_OPERATIONS,
+    command_job_operation,
     execute_guard_command_job,
 )
 from .runner import (
@@ -196,11 +197,6 @@ def _lease_payload(store: GuardStore) -> dict[str, object]:
     }
 
 
-def _job_operation(job: dict[str, object]) -> str:
-    operation = job.get("operation")
-    return operation if isinstance(operation, str) else ""
-
-
 def _job_id(job: dict[str, object]) -> str:
     job_id = job.get("id")
     if not isinstance(job_id, str) or not job_id:
@@ -338,7 +334,7 @@ def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[
         _save_state(store, state)
         raise
     try:
-        _LOGGER.info("Guard command leased: job_id=%s operation=%s", _job_id(item), _job_operation(item))
+        _LOGGER.info("Guard command leased: job_id=%s operation=%s", _job_id(item), command_job_operation(item))
         execution = _execute_job(item, context, store)
     except Exception as error:
         _LOGGER.warning("Guard command execution failed: job_id=%s error=%s", _job_id(item), _redacted_error(error))

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import os
 import urllib.error
 from datetime import datetime, timezone
@@ -12,8 +13,12 @@ from urllib.parse import urlparse, urlunparse
 
 from ...version import __version__
 from ..adapters.base import HarnessContext
-from ..shims import package_shim_status
 from ..store import GuardStore
+from .command_executors import (
+    COMMAND_OPERATION_SCHEMA_VERSIONS,
+    SUPPORTED_COMMAND_OPERATIONS,
+    execute_guard_command_job,
+)
 from .runner import (
     GuardSyncAuthorizationExpiredError,
     GuardSyncNotConfiguredError,
@@ -35,7 +40,7 @@ _DEFAULT_POLL_INTERVAL_SECONDS = 2.0
 _DEFAULT_ERROR_BACKOFF_SECONDS = 30.0
 _REQUEST_TIMEOUT_SECONDS = 35
 _RETRY_TIMEOUT_SECONDS = 60
-_SUPPORTED_OPERATIONS = ("guard.packageShims.status",)
+_LOGGER = logging.getLogger(__name__)
 
 
 def _now() -> str:
@@ -132,7 +137,34 @@ def command_queue_status(store: GuardStore) -> dict[str, object]:
         "last_poll_was_empty": bool(state.get("last_poll_was_empty")),
         "active_job": state.get("active_job"),
         "pending_result": state.get("pending_result"),
-        "supported_operations": list(_SUPPORTED_OPERATIONS),
+        "supported_operations": list(SUPPORTED_COMMAND_OPERATIONS),
+    }
+
+
+def repair_command_queue_state(store: GuardStore) -> dict[str, object]:
+    state = _load_state(store)
+    repaired: list[str] = []
+    active_job = state.get("active_job")
+    if active_job is not None and not isinstance(active_job, dict):
+        state.pop("active_job", None)
+        repaired.append("active_job")
+    pending_result = state.get("pending_result")
+    if pending_result is not None:
+        pending_valid = (
+            isinstance(pending_result, dict)
+            and isinstance(pending_result.get("job"), dict)
+            and isinstance(pending_result.get("payload"), dict)
+        )
+        if not pending_valid:
+            state.pop("pending_result", None)
+            repaired.append("pending_result")
+    if repaired:
+        state.update({"state": "idle", "last_error": None})
+        _save_state(store, state)
+    return {
+        "repaired": repaired,
+        "repaired_count": len(repaired),
+        "status": command_queue_status(store),
     }
 
 
@@ -156,8 +188,8 @@ def _lease_payload(store: GuardStore) -> dict[str, object]:
         "deviceId": machine_id,
         "daemonVersion": __version__,
         "capabilities": {
-            "operations": list(_SUPPORTED_OPERATIONS),
-            "schemaVersions": {"guard.packageShims.status": 1},
+            "operations": list(SUPPORTED_COMMAND_OPERATIONS),
+            "schemaVersions": dict(COMMAND_OPERATION_SCHEMA_VERSIONS),
         },
         "maxJobs": 1,
         "waitMs": _env_int(COMMAND_QUEUE_LEASE_WAIT_MS_ENV, _DEFAULT_LEASE_WAIT_MS),
@@ -183,17 +215,8 @@ def _lease_id(job: dict[str, object]) -> str:
     return lease_id
 
 
-def _execute_job(job: dict[str, object], context: HarnessContext) -> dict[str, object]:
-    operation = _job_operation(job)
-    if operation == "guard.packageShims.status":
-        return {
-            "data": package_shim_status(context),
-            "generatedAt": _now(),
-        }
-    return {
-        "failureCode": "unsupported_operation",
-        "failureMessage": f"Unsupported Guard command operation: {operation or 'unknown'}",
-    }
+def _execute_job(job: dict[str, object], context: HarnessContext, store: GuardStore) -> dict[str, object]:
+    return execute_guard_command_job(job, context=context, store=store, now=_now)
 
 
 def _heartbeat(auth_context: dict[str, object], job: dict[str, object]) -> None:
@@ -315,8 +338,10 @@ def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[
         _save_state(store, state)
         raise
     try:
-        execution = _execute_job(item, context)
+        _LOGGER.info("Guard command leased: job_id=%s operation=%s", _job_id(item), _job_operation(item))
+        execution = _execute_job(item, context, store)
     except Exception as error:
+        _LOGGER.warning("Guard command execution failed: job_id=%s error=%s", _job_id(item), _redacted_error(error))
         execution = {
             "failureCode": "execution_error",
             "failureMessage": _redacted_error(error),
@@ -326,6 +351,7 @@ def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[
         _heartbeat(auth_context, item)
         _post_result(auth_context, item, payload)
     except Exception:
+        _LOGGER.warning("Guard command result upload failed: job_id=%s", _job_id(item))
         state.update(
             {
                 "state": "result_pending",
@@ -338,6 +364,7 @@ def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[
     state.pop("pending_result", None)
     state.update({"state": "idle", "last_result_at": _now(), "last_poll_was_empty": False})
     _save_state(store, state)
+    _LOGGER.info("Guard command completed: job_id=%s status=%s", _job_id(item), payload.get("status"))
     return command_queue_status(store)
 
 

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -9,7 +9,7 @@ from codex_plugin_scanner.guard.daemon.command_queue_worker import (
     CommandQueueWorker,
     start_command_queue_worker,
 )
-from codex_plugin_scanner.guard.runtime import command_queue
+from codex_plugin_scanner.guard.runtime import command_executors, command_queue
 from codex_plugin_scanner.guard.store import GuardStore
 
 
@@ -79,7 +79,7 @@ def test_poll_once_leases_heartbeats_executes_and_posts_result(
     monkeypatch.setattr(command_queue, "_resolve_guard_sync_auth_context", fake_auth_context)
     monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
     monkeypatch.setattr(
-        command_queue,
+        command_executors,
         "package_shim_status",
         lambda context: {"active_managers": ["npm"]},
     )
@@ -95,8 +95,8 @@ def test_poll_once_leases_heartbeats_executes_and_posts_result(
             "deviceId": "machine-1",
             "daemonVersion": command_queue.__version__,
             "capabilities": {
-                "operations": ["guard.packageShims.status"],
-                "schemaVersions": {"guard.packageShims.status": 1},
+                "operations": list(command_executors.SUPPORTED_COMMAND_OPERATIONS),
+                "schemaVersions": dict(command_executors.COMMAND_OPERATION_SCHEMA_VERSIONS),
             },
             "maxJobs": 1,
             "waitMs": 25000,
@@ -124,7 +124,7 @@ def test_poll_once_persists_result_retry_when_result_upload_fails(
         "_resolve_guard_sync_auth_context",
         lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
     )
-    monkeypatch.setattr(command_queue, "package_shim_status", lambda context: {"active_managers": []})
+    monkeypatch.setattr(command_executors, "package_shim_status", lambda context: {"active_managers": []})
 
     def fake_json_request(
         auth_context: dict[str, object],
@@ -211,7 +211,7 @@ def test_poll_once_posts_failed_result_when_execution_raises(tmp_path: Path, mon
         lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
     )
     monkeypatch.setattr(
-        command_queue,
+        command_executors,
         "package_shim_status",
         lambda context: (_ for _ in ()).throw(RuntimeError("shim status failed")),
     )
@@ -445,4 +445,87 @@ def test_commands_status_outputs_command_queue_state(tmp_path: Path, capsys, mon
     payload = json.loads(capsys.readouterr().out)
     assert payload["state"] == "idle"
     assert payload["enabled"] is True
-    assert payload["supported_operations"] == ["guard.packageShims.status"]
+    assert payload["supported_operations"] == list(command_executors.SUPPORTED_COMMAND_OPERATIONS)
+
+
+def test_doctor_repair_clears_malformed_command_queue_state(tmp_path: Path, capsys) -> None:
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_sync_payload(
+        command_queue.COMMAND_QUEUE_STATE_KEY,
+        {"state": "result_pending", "active_job": "bad", "pending_result": {"job": "bad"}},
+        "2026-06-13T00:00:00+00:00",
+    )
+
+    rc = main(["guard", "doctor", "--guard-home", str(guard_home), "--repair", "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    repair = payload["command_queue"]["repair"]
+    assert repair["repaired_count"] == 2
+    assert sorted(repair["repaired"]) == ["active_job", "pending_result"]
+    state = store.get_sync_payload(command_queue.COMMAND_QUEUE_STATE_KEY)
+    assert isinstance(state, dict)
+    assert state["state"] == "idle"
+    assert "active_job" not in state
+    assert "pending_result" not in state
+
+
+def test_executor_rejects_duplicate_package_managers(tmp_path: Path) -> None:
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.packageShims.install",
+            "payload": {"managers": ["npm", "npm"]},
+        },
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["failureCode"] == "duplicate_manager"
+
+
+def test_executor_dispatches_app_connect(tmp_path: Path, monkeypatch) -> None:
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    def fake_apply_managed_install(
+        command: str,
+        requested_harness: str | None,
+        install_all: bool,
+        context: HarnessContext,
+        store: object,
+        workspace: str | None,
+        now: str,
+        *,
+        surface: str | None = None,
+    ) -> dict[str, object]:
+        assert install_all is False
+        calls.append((command, requested_harness, surface))
+        return {"managed_install": {"harness": requested_harness}, "surface": surface}
+
+    monkeypatch.setattr(command_executors, "apply_managed_install", fake_apply_managed_install)
+
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.app.connect",
+            "payload": {"harness": "codex", "surface": "cli"},
+        },
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert calls == [("install", "codex", "cli")]
+    assert result["generatedAt"] == "2026-06-13T00:00:00+00:00"
+    assert isinstance(result["data"], dict)
+
+
+def test_executor_rejects_approval_resolve_until_inbox_phase(tmp_path: Path) -> None:
+    result = command_executors.execute_guard_command_job(
+        {"operation": "guard.approval.resolve", "payload": {"requestId": "request-1", "action": "allow_once"}},
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["failureCode"] == "unsupported_operation"

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -485,6 +485,23 @@ def test_executor_rejects_duplicate_package_managers(tmp_path: Path) -> None:
     assert result["failureCode"] == "duplicate_manager"
 
 
+def test_executor_status_ignores_speculative_managers_field(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setattr(command_executors, "package_shim_status", lambda context: {"active_managers": []})
+
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.packageShims.status",
+            "payload": {"managers": ["not-a-manager"]},
+        },
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["generatedAt"] == "2026-06-13T00:00:00+00:00"
+    assert result["data"] == {"active_managers": []}
+
+
 def test_executor_dispatches_app_connect(tmp_path: Path, monkeypatch) -> None:
     calls: list[tuple[str, str | None, str | None]] = []
 


### PR DESCRIPTION
## Summary
- add typed Guard Cloud command executor registry for package shim and app operations
- advertise executor capabilities/schema versions through daemon lease payloads
- add command queue structured logs and doctor --repair cleanup for malformed stuck local state

## Phase Scope
- Phase 3 closeout: structured command logs and doctor command queue repair
- Phase 4: operation executors for package shims and app protection commands

## Tests
- /Users/michaelkantor/.cache/uv/binaries-v0/ruff/0.12.5/aarch64-apple-darwin/ruff check src/codex_plugin_scanner/guard/runtime/command_queue.py src/codex_plugin_scanner/guard/runtime/command_executors.py src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py tests/test_guard_command_queue.py
- python3 -m py_compile src/codex_plugin_scanner/guard/runtime/command_queue.py src/codex_plugin_scanner/guard/runtime/command_executors.py src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py tests/test_guard_command_queue.py
- pytest -q tests/test_guard_command_queue.py