### PR TITLE
fix(guard): block foreign package-shim PATH bypass

### DIFF
--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -577,11 +577,10 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         if exists and bool(path_status.get("shim_precedes_real")):
             protected_managers.append(manager)
         elif exists:
-            bypass_reason = "foreign_shim_bypass" if bool(path_status.get("foreign_shim_bypass")) else "path_inactive"
             bypasses.append(
                 {
                     "manager": manager,
-                    "reason": bypass_reason,
+                    "reason": "path_inactive",
                 }
             )
     profile_status = _package_shim_profile_status(context)

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -280,12 +280,25 @@ def get_real_binary_info(
     }
 
 
-def _is_package_shim_binary(candidate: Path) -> bool:
-    """Return True when candidate lives under any Guard package-shims/bin directory."""
-
+def _has_package_shim_layout(candidate: Path) -> bool:
     parent = candidate.parent
     grandparent = parent.parent
     return parent.name == "bin" and grandparent.name == "package-shims"
+
+
+def _is_trusted_package_shim_binary(candidate: Path, trusted_shim_dir: Path) -> bool:
+    try:
+        candidate.resolve().relative_to(trusted_shim_dir.resolve())
+    except ValueError:
+        return False
+    return candidate.is_file()
+
+
+def _is_foreign_package_shim_binary(candidate: Path, trusted_shim_dir: Path) -> bool:
+    return _has_package_shim_layout(candidate) and not _is_trusted_package_shim_binary(
+        candidate,
+        trusted_shim_dir,
+    )
 
 
 def get_path_order_status(
@@ -303,6 +316,8 @@ def get_path_order_status(
     path_dirs = (path_env or os.environ.get("PATH", "")).split(os.pathsep)
     shim_dir_index: int | None = None
     real_dir_index: int | None = None
+    foreign_shim_index: int | None = None
+    foreign_shim_path: str | None = None
     real_binary_path: str | None = None
     for idx, dir_entry in enumerate(path_dirs):
         d = Path(dir_entry).expanduser().resolve()
@@ -310,15 +325,21 @@ def get_path_order_status(
             shim_dir_index = idx
             continue
         candidate = d / command
-        if (
-            candidate.exists()
-            and candidate.is_file()
-            and candidate != shim_path
-            and not _is_package_shim_binary(candidate)
-            and real_dir_index is None
-        ):
+        if not candidate.exists() or not candidate.is_file() or candidate == shim_path:
+            continue
+        if _is_foreign_package_shim_binary(candidate, shim_dir):
+            if foreign_shim_index is None:
+                foreign_shim_index = idx
+                foreign_shim_path = str(candidate)
+            continue
+        if _is_trusted_package_shim_binary(candidate, shim_dir):
+            continue
+        if real_dir_index is None:
             real_dir_index = idx
             real_binary_path = str(candidate)
+    foreign_shim_precedes_trusted = (
+        foreign_shim_index is not None and shim_dir_index is not None and foreign_shim_index < shim_dir_index
+    )
     if shim_dir_index is None:
         return {
             "shim_precedes_real": False,
@@ -328,6 +349,23 @@ def get_path_order_status(
             "shim_in_path": False,
             "shim_path_index": None,
             "path_broken": True,
+            "foreign_shim_bypass": foreign_shim_index is not None,
+            "foreign_shim_path": foreign_shim_path,
+            "foreign_shim_path_index": foreign_shim_index,
+            "shim_dir": str(shim_dir),
+        }
+    if foreign_shim_precedes_trusted:
+        return {
+            "shim_precedes_real": False,
+            "real_binary_found": real_dir_index is not None,
+            "real_binary_path": real_binary_path,
+            "real_binary_path_index": real_dir_index,
+            "shim_in_path": True,
+            "shim_path_index": shim_dir_index,
+            "path_broken": True,
+            "foreign_shim_bypass": True,
+            "foreign_shim_path": foreign_shim_path,
+            "foreign_shim_path_index": foreign_shim_index,
             "shim_dir": str(shim_dir),
         }
     if real_dir_index is None:
@@ -339,6 +377,9 @@ def get_path_order_status(
             "shim_in_path": True,
             "shim_path_index": shim_dir_index,
             "path_broken": False,
+            "foreign_shim_bypass": False,
+            "foreign_shim_path": foreign_shim_path,
+            "foreign_shim_path_index": foreign_shim_index,
             "shim_dir": str(shim_dir),
         }
     precedes = shim_dir_index < real_dir_index
@@ -350,6 +391,9 @@ def get_path_order_status(
         "shim_in_path": True,
         "shim_path_index": shim_dir_index,
         "path_broken": not precedes,
+        "foreign_shim_bypass": False,
+        "foreign_shim_path": foreign_shim_path,
+        "foreign_shim_path_index": foreign_shim_index,
         "shim_dir": str(shim_dir),
     }
 
@@ -533,10 +577,11 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         if exists and bool(path_status.get("shim_precedes_real")):
             protected_managers.append(manager)
         elif exists:
+            bypass_reason = "foreign_shim_bypass" if bool(path_status.get("foreign_shim_bypass")) else "path_inactive"
             bypasses.append(
                 {
                     "manager": manager,
-                    "reason": "path_inactive",
+                    "reason": bypass_reason,
                 }
             )
     profile_status = _package_shim_profile_status(context)

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -834,9 +834,17 @@ def test_guard_package_shim_status_reports_foreign_shim_bypass(
     assert status_payload["bypasses"] == [
         {
             "manager": "npm",
-            "reason": "foreign_shim_bypass",
+            "reason": "path_inactive",
         }
     ]
+    npm_detail = next(
+        (entry for entry in status_payload["manager_details"] if entry["manager"] == "npm"),
+        None,
+    )
+    assert npm_detail is not None
+    path_status = npm_detail["path_status"]
+    assert isinstance(path_status, dict)
+    assert path_status["foreign_shim_bypass"] is True
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -800,6 +800,45 @@ def test_guard_package_shim_status_reports_bypasses_when_system_binary_beats_shi
     ]
 
 
+def test_guard_package_shim_status_reports_foreign_shim_bypass(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=home_dir,
+    )
+
+    install_payload = install_package_shims(context, managers=("npm",))
+    shim_dir = Path(str(install_payload["shim_dir"]))
+    evil_shim_dir = tmp_path / "evil" / "package-shims" / "bin"
+    evil_shim_dir.mkdir(parents=True)
+    evil_shim = evil_shim_dir / "npm"
+    evil_shim.write_text("#!/bin/sh\nevil npm\n", encoding="utf-8")
+    evil_shim.chmod(0o755)
+    real_dir = tmp_path / "usr" / "bin"
+    real_dir.mkdir(parents=True, exist_ok=True)
+    real_npm = real_dir / "npm"
+    real_npm.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    real_npm.chmod(0o755)
+    monkeypatch.setenv("PATH", f"{evil_shim_dir}{os.pathsep}{shim_dir}{os.pathsep}{real_dir}")
+
+    status_payload = package_shim_status(context)
+
+    assert status_payload["protected_managers"] == []
+    assert status_payload["path_active"] is False
+    assert status_payload["bypasses"] == [
+        {
+            "manager": "npm",
+            "reason": "foreign_shim_bypass",
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     "manager,shim_args,ecosystem,package_name,package_version",
     _BLOCKING_SHIM_CASES,

--- a/tests/test_guard_shim_truth.py
+++ b/tests/test_guard_shim_truth.py
@@ -112,7 +112,7 @@ class TestScrg265PathOrderVerification:
         assert result["path_broken"] is False
         assert result["real_binary_path"] == str(real_binary)
 
-    def test_only_stale_package_shim_before_canonical_is_not_path_broken(self, tmp_path: Path) -> None:
+    def test_only_stale_package_shim_before_canonical_is_path_broken(self, tmp_path: Path) -> None:
         ctx = _make_context(tmp_path)
         install_package_shims(ctx, managers=("npm",))
         shim_dir = str(ctx.guard_home / "package-shims" / "bin")
@@ -124,9 +124,31 @@ class TestScrg265PathOrderVerification:
         stale_shim.chmod(0o755)
         fake_path = f"{stale_shim_dir}:{shim_dir}"
         result = get_path_order_status(ctx, manager="npm", path_env=fake_path)
-        assert result["shim_precedes_real"] is True
-        assert result["path_broken"] is False
-        assert result["real_binary_found"] is False
+        assert result["shim_precedes_real"] is False
+        assert result["path_broken"] is True
+        assert result["foreign_shim_bypass"] is True
+        assert result["foreign_shim_path"] == str(stale_shim)
+
+    def test_foreign_package_shim_before_trusted_marks_path_broken(self, tmp_path: Path) -> None:
+        ctx = _make_context(tmp_path)
+        install_package_shims(ctx, managers=("npm",))
+        shim_dir = str(ctx.guard_home / "package-shims" / "bin")
+        evil_shim_dir = tmp_path / "evil" / "package-shims" / "bin"
+        evil_shim_dir.mkdir(parents=True)
+        evil_shim = evil_shim_dir / "npm"
+        evil_shim.write_text("#!/bin/sh\nevil npm", encoding="utf-8")
+        evil_shim.chmod(0o755)
+        real_dir = str(tmp_path / "usr" / "bin")
+        Path(real_dir).mkdir(parents=True, exist_ok=True)
+        real_binary = Path(real_dir) / "npm"
+        real_binary.write_text("#!/bin/sh\nnpm $@", encoding="utf-8")
+        real_binary.chmod(0o755)
+        fake_path = f"{evil_shim_dir}:{shim_dir}:{real_dir}"
+        result = get_path_order_status(ctx, manager="npm", path_env=fake_path)
+        assert result["shim_precedes_real"] is False
+        assert result["path_broken"] is True
+        assert result["foreign_shim_bypass"] is True
+        assert result["foreign_shim_path"] == str(evil_shim)
 
 
 class TestScrg268RealBinaryInfo:


### PR DESCRIPTION
## Summary
- Detect untrusted `package-shims/bin` PATH entries that precede Guard's trusted shim directory
- Mark those managers as `path_broken` with `foreign_shim_bypass` instead of reporting false active protection
- Keep ignoring stale foreign shim dirs only when they appear after the trusted shim while locating the real manager binary

## Testing
- `python3 -m pytest tests/test_guard_shim_truth.py::TestScrg265PathOrderVerification -q`
- `python3 -m pytest tests/test_guard_package_shims.py::test_guard_package_shim_status_reports_foreign_shim_bypass -q`
