### PR TITLE
feat(dashboard): polish Policy remembered rules layout

### DIFF
--- a/dashboard/src/policy-cloud-exceptions-boundary.test.ts
+++ b/dashboard/src/policy-cloud-exceptions-boundary.test.ts
@@ -33,6 +33,10 @@ const POLICY_SOURCE_FILES = [
   "policy-workspace-views.tsx",
   "policy-workspace-helpers.ts",
   "policy-exception-form.tsx",
+  "policy-remembered-local-rules.tsx",
+  "policy-remembered-cloud-rules.tsx",
+  "policy-remembered-rules-tab.tsx",
+  "policy-remembered-rules-right-rail.tsx",
 ];
 
 const FORBIDDEN_FIXTURE_PATTERNS = [

--- a/dashboard/src/policy-cloud-exceptions-tab.tsx
+++ b/dashboard/src/policy-cloud-exceptions-tab.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { HiMiniCloudArrowUp } from "react-icons/hi2";
 import { ActionButton, EmptyState, SectionLabel } from "./approval-center-primitives";
 import type { GuardRuntimeSnapshot } from "./guard-types";
@@ -21,10 +20,6 @@ export function PolicyCloudExceptionsTab({
   const cloudConnected = resolveCloudExceptionsConnected(snapshot);
   const connectUrl = snapshot.connect_url?.trim() || null;
 
-  const handleRequestCloudException = useCallback(() => {
-    onRequestCloudException?.();
-  }, [onRequestCloudException]);
-
   return (
     <div className="space-y-4">
       <div className="rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm">
@@ -42,7 +37,7 @@ export function PolicyCloudExceptionsTab({
       <div className="flex flex-wrap items-center gap-2">
         <ActionButton
           variant="primary"
-          onClick={handleRequestCloudException}
+          onClick={onRequestCloudException}
           disabled={!cloudConnected || onRequestCloudException === undefined}
         >
           Request cloud exception
@@ -77,15 +72,3 @@ export function PolicyCloudExceptionsTab({
   );
 }
 
-export function PolicyRememberedRulesHelper() {
-  return (
-    <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600">
-      <p className="font-medium text-brand-dark">Remembered approvals vs Cloud exceptions</p>
-      <ul className="mt-2 list-disc space-y-1 pl-5">
-        <li>Review and Inbox keep fast allow/block decisions for the work in front of you.</li>
-        <li>Remembered rules on this tab explain what Guard will do next time for matching actions.</li>
-        <li>Cloud exceptions are separate governed risk acceptances managed in Guard Cloud.</li>
-      </ul>
-    </div>
-  );
-}

--- a/dashboard/src/policy-remembered-cloud-rules.tsx
+++ b/dashboard/src/policy-remembered-cloud-rules.tsx
@@ -1,0 +1,24 @@
+import type { GuardPolicyDecision } from "./guard-types";
+import { GroupedPolicySection } from "./policy-workspace-views";
+
+type PolicyRememberedCloudRulesProps = {
+  policies: GuardPolicyDecision[];
+  cloudControlsUrl: string | null;
+};
+
+export function PolicyRememberedCloudRules({
+  policies,
+  cloudControlsUrl,
+}: PolicyRememberedCloudRulesProps) {
+  return (
+    <GroupedPolicySection
+      title="From Guard Cloud"
+      description="Synced team rules are read-only here. Edit them in Guard Cloud Controls."
+      policies={policies}
+      cloudControlsUrl={cloudControlsUrl}
+      emptyTitle="No Guard Cloud rules synced"
+      emptyBody="Connect Guard Cloud to sync shared policy bundles."
+      defaultOpen={policies.length > 0}
+    />
+  );
+}

--- a/dashboard/src/policy-remembered-local-rules.tsx
+++ b/dashboard/src/policy-remembered-local-rules.tsx
@@ -1,0 +1,27 @@
+import type { GuardPolicyDecision } from "./guard-types";
+import { GroupedPolicySection } from "./policy-workspace-views";
+
+type PolicyRememberedLocalRulesProps = {
+  policies: GuardPolicyDecision[];
+  cloudControlsUrl: string | null;
+  onClearPolicy?: (policy: GuardPolicyDecision) => void;
+};
+
+export function PolicyRememberedLocalRules({
+  policies,
+  cloudControlsUrl,
+  onClearPolicy,
+}: PolicyRememberedLocalRulesProps) {
+  return (
+    <GroupedPolicySection
+      title="Remembered on this device"
+      description="Choices you saved from Inbox. Each card explains what Guard will do next time."
+      policies={policies}
+      cloudControlsUrl={cloudControlsUrl}
+      onClearPolicy={onClearPolicy}
+      emptyTitle="No local remembered rules yet"
+      emptyBody="Approve or block in Inbox and Guard remembers the decision here in plain language."
+      defaultOpen
+    />
+  );
+}

--- a/dashboard/src/policy-remembered-rules-right-rail.tsx
+++ b/dashboard/src/policy-remembered-rules-right-rail.tsx
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { scopeLabel } from "./approval-center-utils";
 
 const REVIEW_SCOPE_LADDER = [
@@ -16,10 +15,6 @@ type PolicyRememberedRulesRightRailProps = {
 export function PolicyRememberedRulesRightRail({
   onOpenCloudExceptions,
 }: PolicyRememberedRulesRightRailProps) {
-  const handleOpenCloudExceptions = useCallback(() => {
-    onOpenCloudExceptions();
-  }, [onOpenCloudExceptions]);
-
   return (
     <aside className="space-y-4 lg:sticky lg:top-4">
       <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600">
@@ -31,7 +26,7 @@ export function PolicyRememberedRulesRightRail({
         </ul>
         <button
           type="button"
-          onClick={handleOpenCloudExceptions}
+          onClick={onOpenCloudExceptions}
           className="mt-3 text-sm font-medium text-brand-blue hover:underline"
         >
           Open Cloud exceptions tab

--- a/dashboard/src/policy-remembered-rules-right-rail.tsx
+++ b/dashboard/src/policy-remembered-rules-right-rail.tsx
@@ -1,0 +1,63 @@
+import { useCallback } from "react";
+import { scopeLabel } from "./approval-center-utils";
+
+const REVIEW_SCOPE_LADDER = [
+  { scope: "artifact", detail: "Guard remembers only the next matching retry." },
+  { scope: "workspace", detail: "Guard remembers the same action in this project folder." },
+  { scope: "publisher", detail: "Guard remembers actions from the same source in this app." },
+  { scope: "harness", detail: "Guard remembers the action across this app." },
+  { scope: "global", detail: "Guard remembers the action on every project on this device." },
+] as const;
+
+type PolicyRememberedRulesRightRailProps = {
+  onOpenCloudExceptions: () => void;
+};
+
+export function PolicyRememberedRulesRightRail({
+  onOpenCloudExceptions,
+}: PolicyRememberedRulesRightRailProps) {
+  const handleOpenCloudExceptions = useCallback(() => {
+    onOpenCloudExceptions();
+  }, [onOpenCloudExceptions]);
+
+  return (
+    <aside className="space-y-4 lg:sticky lg:top-4">
+      <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600">
+        <p className="font-medium text-brand-dark">Remembered rules vs Cloud exceptions</p>
+        <ul className="mt-2 list-disc space-y-1 pl-5">
+          <li>Review and Inbox keep fast allow/block decisions for the work in front of you.</li>
+          <li>Remembered rules on this tab explain what Guard will do next time for matching actions.</li>
+          <li>Cloud exceptions are separate governed risk acceptances managed in Guard Cloud.</li>
+        </ul>
+        <button
+          type="button"
+          onClick={handleOpenCloudExceptions}
+          className="mt-3 text-sm font-medium text-brand-blue hover:underline"
+        >
+          Open Cloud exceptions tab
+        </button>
+      </div>
+
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
+        <p className="font-medium text-brand-dark">Review scope ladder</p>
+        <p className="mt-1 text-xs leading-relaxed text-slate-500">
+          When you approve in Inbox, you pick how broadly Guard should remember the decision. Wider
+          scopes apply to more future actions.
+        </p>
+        <ol className="mt-3 space-y-2.5">
+          {REVIEW_SCOPE_LADDER.map((step, index) => (
+            <li key={step.scope} className="flex gap-2.5">
+              <span className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-blue/10 text-[11px] font-semibold text-brand-blue">
+                {index + 1}
+              </span>
+              <div>
+                <p className="text-sm font-medium text-brand-dark">{scopeLabel(step.scope)}</p>
+                <p className="text-xs leading-relaxed text-slate-500">{step.detail}</p>
+              </div>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </aside>
+  );
+}

--- a/dashboard/src/policy-remembered-rules-tab.tsx
+++ b/dashboard/src/policy-remembered-rules-tab.tsx
@@ -1,0 +1,155 @@
+import { useCallback, useMemo, useState } from "react";
+import type { ChangeEvent } from "react";
+import { HiMiniMagnifyingGlass } from "react-icons/hi2";
+import { harnessDisplayName, policyActionLabel } from "./approval-center-utils";
+import type { GuardPolicyDecision } from "./guard-types";
+import {
+  isCloudManagedPolicy,
+  resolvePolicyDisplay,
+  resolvePolicyMatcherFamily,
+} from "./policy-workspace-helpers";
+import {
+  groupPoliciesByFamily,
+  resolveFamilyFilterLabel,
+} from "./policy-workspace-views";
+import { PolicyRememberedCloudRules } from "./policy-remembered-cloud-rules";
+import { PolicyRememberedLocalRules } from "./policy-remembered-local-rules";
+import { PolicyRememberedRulesRightRail } from "./policy-remembered-rules-right-rail";
+
+type PolicyRememberedRulesTabProps = {
+  policies: GuardPolicyDecision[];
+  cloudControlsUrl: string | null;
+  onClearPolicy?: (policy: GuardPolicyDecision) => void;
+  onOpenCloudExceptions: () => void;
+};
+
+export function PolicyRememberedRulesTab({
+  policies,
+  cloudControlsUrl,
+  onClearPolicy,
+  onOpenCloudExceptions,
+}: PolicyRememberedRulesTabProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [appFilter, setAppFilter] = useState("");
+  const [familyFilter, setFamilyFilter] = useState("");
+
+  const handleSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setSearchQuery(event.target.value);
+  }, []);
+
+  const filteredPolicies = useMemo(() => {
+    const query = searchQuery.trim().toLowerCase();
+    return policies.filter((policy) => {
+      if (appFilter && policy.harness !== appFilter) {
+        return false;
+      }
+      if (familyFilter) {
+        const family = resolvePolicyMatcherFamily(policy) ?? "other";
+        if (family !== familyFilter) {
+          return false;
+        }
+      }
+      if (!query) {
+        return true;
+      }
+      const display = resolvePolicyDisplay(policy);
+      const displayHaystack = [
+        policy.harness,
+        policy.artifact_id,
+        policy.workspace,
+        policy.publisher,
+        policy.scope,
+        policy.action,
+        policy.reason,
+        display.headline,
+        display.subtitle,
+        harnessDisplayName(policy.harness),
+        policyActionLabel(policy.action),
+      ]
+        .filter(Boolean)
+        .join(" ")
+        .toLowerCase();
+      return displayHaystack.includes(query);
+    });
+  }, [policies, searchQuery, appFilter, familyFilter]);
+
+  const rememberedRules = useMemo(
+    () =>
+      filteredPolicies
+        .filter((policy) => policy.action === "allow" || policy.action === "block")
+        .sort((a, b) => new Date(b.updated_at || 0).getTime() - new Date(a.updated_at || 0).getTime()),
+    [filteredPolicies],
+  );
+
+  const localRules = useMemo(
+    () => rememberedRules.filter((policy) => !isCloudManagedPolicy(policy.source)),
+    [rememberedRules],
+  );
+  const cloudRules = useMemo(
+    () => rememberedRules.filter((policy) => isCloudManagedPolicy(policy.source)),
+    [rememberedRules],
+  );
+
+  const appOptions = useMemo(
+    () => [...new Set(policies.map((policy) => policy.harness).filter(Boolean))].sort(),
+    [policies],
+  );
+  const familyCounts = useMemo(() => groupPoliciesByFamily(rememberedRules), [rememberedRules]);
+
+  return (
+    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start">
+      <div className="space-y-4">
+        <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+          <div className="flex flex-1 items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2">
+            <HiMiniMagnifyingGlass className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
+            <input
+              type="search"
+              placeholder="Search by app, action, or reason…"
+              value={searchQuery}
+              onChange={handleSearchChange}
+              aria-label="Search policies"
+              className="w-full bg-transparent text-sm text-brand-dark placeholder:text-slate-400 focus:outline-none"
+            />
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <select
+              value={appFilter}
+              onChange={(event) => setAppFilter(event.target.value)}
+              aria-label="Filter by app"
+              className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark"
+            >
+              <option value="">All apps</option>
+              {appOptions.map((app) => (
+                <option key={app} value={app}>
+                  {harnessDisplayName(app)}
+                </option>
+              ))}
+            </select>
+            <select
+              value={familyFilter}
+              onChange={(event) => setFamilyFilter(event.target.value)}
+              aria-label="Filter by action type"
+              className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark"
+            >
+              <option value="">All action types</option>
+              {[...familyCounts.entries()].map(([family, count]) => (
+                <option key={family} value={family}>
+                  {resolveFamilyFilterLabel(family)} ({count})
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <PolicyRememberedLocalRules
+          policies={localRules}
+          cloudControlsUrl={cloudControlsUrl}
+          onClearPolicy={onClearPolicy}
+        />
+        <PolicyRememberedCloudRules policies={cloudRules} cloudControlsUrl={cloudControlsUrl} />
+      </div>
+
+      <PolicyRememberedRulesRightRail onOpenCloudExceptions={onOpenCloudExceptions} />
+    </div>
+  );
+}

--- a/dashboard/src/policy-remembered-rules.test.tsx
+++ b/dashboard/src/policy-remembered-rules.test.tsx
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { PolicyRememberedCloudRules } from "./policy-remembered-cloud-rules";
+import { PolicyRememberedLocalRules } from "./policy-remembered-local-rules";
+import { PolicyRememberedRulesRightRail } from "./policy-remembered-rules-right-rail";
+import { PolicyRememberedRulesTab } from "./policy-remembered-rules-tab";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+
+assert(typeof PolicyRememberedLocalRules === "function", "exports PolicyRememberedLocalRules");
+assert(typeof PolicyRememberedCloudRules === "function", "exports PolicyRememberedCloudRules");
+assert(typeof PolicyRememberedRulesTab === "function", "exports PolicyRememberedRulesTab");
+assert(typeof PolicyRememberedRulesRightRail === "function", "exports PolicyRememberedRulesRightRail");
+
+const localSource = readFileSync(join(here, "policy-remembered-local-rules.tsx"), "utf8");
+const cloudSource = readFileSync(join(here, "policy-remembered-cloud-rules.tsx"), "utf8");
+const tabSource = readFileSync(join(here, "policy-remembered-rules-tab.tsx"), "utf8");
+const railSource = readFileSync(join(here, "policy-remembered-rules-right-rail.tsx"), "utf8");
+const workspaceSource = readFileSync(join(here, "policy-workspace.tsx"), "utf8");
+const viewsSource = readFileSync(join(here, "policy-workspace-views.tsx"), "utf8");
+
+assert(localSource.includes("No local remembered rules yet"), "local rules empty state title");
+assert(localSource.includes("Approve or block in Inbox"), "local rules empty state body");
+assert(localSource.includes("onClearPolicy"), "local rules support remove action");
+
+assert(cloudSource.includes("No Guard Cloud rules synced"), "cloud rules empty state title");
+assert(cloudSource.includes("Connect Guard Cloud"), "cloud rules empty state body");
+assert(!cloudSource.includes("onClearPolicy"), "cloud rules are read-only without remove");
+
+assert(tabSource.includes('placeholder="Search by app, action, or reason…"'), "tab preserves search");
+assert(tabSource.includes('aria-label="Filter by app"'), "tab preserves app filter");
+assert(tabSource.includes('aria-label="Filter by action type"'), "tab preserves family filter");
+assert(tabSource.includes("PolicyRememberedLocalRules"), "tab mounts local rules section");
+assert(tabSource.includes("PolicyRememberedCloudRules"), "tab mounts cloud rules section");
+assert(tabSource.includes("PolicyRememberedRulesRightRail"), "tab mounts right rail helper");
+
+assert(railSource.includes("Review scope ladder"), "right rail explains review scope ladder");
+assert(railSource.includes('scope: "artifact"'), "scope ladder includes narrowest scope");
+assert(railSource.includes('scope: "global"'), "scope ladder includes widest scope");
+assert(railSource.includes("scopeLabel(step.scope)"), "scope ladder renders human scope labels");
+assert(railSource.includes("Open Cloud exceptions tab"), "right rail links to Cloud exceptions tab");
+assert(railSource.includes("Remembered rules vs Cloud exceptions"), "right rail explains remembered vs cloud");
+
+assert(workspaceSource.includes("PolicyRememberedRulesTab"), "workspace uses remembered rules tab");
+assert(!workspaceSource.includes("PolicyRememberedRulesHelper"), "workspace no longer uses inline helper");
+assert(!workspaceSource.includes("GroupedPolicySection"), "workspace no longer mounts grouped sections directly");
+
+assert(viewsSource.includes("scopeLabel(policy.scope)"), "rule cards show explicit scope tag");
+assert(viewsSource.includes("See approval record"), "local cards link to approval record");
+assert(viewsSource.includes("View on cloud"), "cloud cards link to Guard Cloud");
+assert(viewsSource.includes("Remove rule"), "local cards expose remove action");
+assert(viewsSource.includes("!cloudManaged"), "remove action gated to non-cloud rules");
+assert(viewsSource.includes("cloudManaged && cloudControlsUrl"), "cloud link gated to cloud-managed rules");
+
+console.log("policy-remembered-rules.test.tsx: all assertions passed");

--- a/dashboard/src/policy-workspace-views.tsx
+++ b/dashboard/src/policy-workspace-views.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useMemo, useState } from "react";
 import { HiMiniTrash, HiMiniCloudArrowUp, HiMiniChevronDown, HiMiniChevronUp } from "react-icons/hi2";
 import { Badge, Tag, EmptyState } from "./approval-center-primitives";
-import { harnessDisplayName, formatRelativeTime, policyActionLabel } from "./approval-center-utils";
+import { harnessDisplayName, formatRelativeTime, policyActionLabel, scopeLabel } from "./approval-center-utils";
 import { guardAwareHref } from "./guard-api";
 import type { GuardPolicyDecision } from "./guard-types";
 import {
@@ -49,6 +49,7 @@ export function PolicyRuleCard({ policy, cloudControlsUrl, onClear }: PolicyRule
           <div className="flex flex-wrap items-center gap-2">
             <Badge tone={resolveActionTone(policy.action)}>{policyActionLabel(policy.action)}</Badge>
             <Tag tone={cloudManaged ? "blue" : "green"}>{resolvePolicySourceLabel(policy.source)}</Tag>
+            <Tag tone="slate">{scopeLabel(policy.scope)}</Tag>
             <span className="text-xs text-slate-400">{harnessDisplayName(policy.harness)}</span>
           </div>
           <h3 className="text-base font-semibold leading-snug text-brand-dark">{display.headline}</h3>

--- a/dashboard/src/policy-workspace.tsx
+++ b/dashboard/src/policy-workspace.tsx
@@ -1,27 +1,14 @@
 import { useCallback, useMemo, useState } from "react";
-import type { ChangeEvent } from "react";
-import { HiMiniMagnifyingGlass } from "react-icons/hi2";
 import { SectionLabel, Tag, ActionButton } from "./approval-center-primitives";
-import { harnessDisplayName, policyActionLabel } from "./approval-center-utils";
 import type { GuardPolicyDecision, GuardRuntimeSnapshot } from "./guard-types";
+import { PolicyCloudExceptionsTab } from "./policy-cloud-exceptions-tab";
+import { PolicyRememberedRulesTab } from "./policy-remembered-rules-tab";
 import {
-  PolicyCloudExceptionsTab,
-  PolicyRememberedRulesHelper,
-} from "./policy-cloud-exceptions-tab";
-import {
-  isCloudManagedPolicy,
   resolveCloudBundleSurfaceClass,
   resolveCloudPolicyBundleCopy,
   resolveCloudPolicyControlsUrl,
-  resolvePolicyDisplay,
-  resolvePolicyMatcherFamily,
   resolveSecurityModeCopy,
 } from "./policy-workspace-helpers";
-import {
-  GroupedPolicySection,
-  resolveFamilyFilterLabel,
-  groupPoliciesByFamily,
-} from "./policy-workspace-views";
 
 export type PolicyPageView = "rules" | "exceptions" | "strict";
 
@@ -58,16 +45,13 @@ export function PolicyWorkspace({
   onOpenInbox,
 }: PolicyWorkspaceProps) {
   const [activeView, setActiveView] = useState<PolicyPageView>("rules");
-  const [searchQuery, setSearchQuery] = useState("");
-  const [appFilter, setAppFilter] = useState("");
-  const [familyFilter, setFamilyFilter] = useState("");
-
-  const handleSearchChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setSearchQuery(event.target.value);
-  }, []);
 
   const handleViewChange = useCallback((view: PolicyPageView) => {
     setActiveView(view);
+  }, []);
+
+  const handleOpenCloudExceptions = useCallback(() => {
+    setActiveView("exceptions");
   }, []);
 
   const cloudControlsUrl = useMemo(() => resolveCloudPolicyControlsUrl(snapshot), [snapshot]);
@@ -80,65 +64,6 @@ export function PolicyWorkspace({
 
   const modeCopy = useMemo(() => resolveSecurityModeCopy(snapshot.security_level), [snapshot.security_level]);
   const cloudBundleCopy = useMemo(() => resolveCloudPolicyBundleCopy(snapshot), [snapshot]);
-
-  const filteredPolicies = useMemo(() => {
-    const query = searchQuery.trim().toLowerCase();
-    return policies.filter((policy) => {
-      if (appFilter && policy.harness !== appFilter) {
-        return false;
-      }
-      if (familyFilter) {
-        const family = resolvePolicyMatcherFamily(policy) ?? "other";
-        if (family !== familyFilter) {
-          return false;
-        }
-      }
-      if (!query) {
-        return true;
-      }
-      const display = resolvePolicyDisplay(policy);
-      const displayHaystack = [
-        policy.harness,
-        policy.artifact_id,
-        policy.workspace,
-        policy.publisher,
-        policy.scope,
-        policy.action,
-        policy.reason,
-        display.headline,
-        display.subtitle,
-        harnessDisplayName(policy.harness),
-        policyActionLabel(policy.action),
-      ]
-        .filter(Boolean)
-        .join(" ")
-        .toLowerCase();
-      return displayHaystack.includes(query);
-    });
-  }, [policies, searchQuery, appFilter, familyFilter]);
-
-  const rememberedRules = useMemo(
-    () =>
-      filteredPolicies
-        .filter((policy) => policy.action === "allow" || policy.action === "block")
-        .sort((a, b) => new Date(b.updated_at || 0).getTime() - new Date(a.updated_at || 0).getTime()),
-    [filteredPolicies],
-  );
-
-  const localRules = useMemo(
-    () => rememberedRules.filter((policy) => !isCloudManagedPolicy(policy.source)),
-    [rememberedRules],
-  );
-  const cloudRules = useMemo(
-    () => rememberedRules.filter((policy) => isCloudManagedPolicy(policy.source)),
-    [rememberedRules],
-  );
-
-  const appOptions = useMemo(
-    () => [...new Set(policies.map((policy) => policy.harness).filter(Boolean))].sort(),
-    [policies],
-  );
-  const familyCounts = useMemo(() => groupPoliciesByFamily(rememberedRules), [rememberedRules]);
 
   return (
     <div className="space-y-6">
@@ -186,74 +111,16 @@ export function PolicyWorkspace({
       </div>
 
       {activeView === "rules" ? (
-        <div className="space-y-4">
-          <PolicyRememberedRulesHelper />
-          <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-            <div className="flex flex-1 items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2">
-              <HiMiniMagnifyingGlass className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
-              <input
-                type="search"
-                placeholder="Search by app, action, or reason…"
-                value={searchQuery}
-                onChange={handleSearchChange}
-                aria-label="Search policies"
-                className="w-full bg-transparent text-sm text-brand-dark placeholder:text-slate-400 focus:outline-none"
-              />
-            </div>
-            <div className="flex flex-wrap gap-2">
-              <select
-                value={appFilter}
-                onChange={(event) => setAppFilter(event.target.value)}
-                aria-label="Filter by app"
-                className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark"
-              >
-                <option value="">All apps</option>
-                {appOptions.map((app) => (
-                  <option key={app} value={app}>
-                    {harnessDisplayName(app)}
-                  </option>
-                ))}
-              </select>
-              <select
-                value={familyFilter}
-                onChange={(event) => setFamilyFilter(event.target.value)}
-                aria-label="Filter by action type"
-                className="rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark"
-              >
-                <option value="">All action types</option>
-                {[...familyCounts.entries()].map(([family, count]) => (
-                  <option key={family} value={family}>
-                    {resolveFamilyFilterLabel(family)} ({count})
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          <GroupedPolicySection
-            title="Remembered on this device"
-            description="Choices you saved from Inbox. Each card explains what Guard will do next time."
-            policies={localRules}
-            cloudControlsUrl={cloudControlsUrl}
-            onClearPolicy={onClearPolicy}
-            emptyTitle="No local remembered rules yet"
-            emptyBody="Approve or block in Inbox and Guard remembers the decision here in plain language."
-            defaultOpen
-          />
-          <GroupedPolicySection
-            title="From Guard Cloud"
-            description="Synced team rules are read-only here. Edit them in Guard Cloud Controls."
-            policies={cloudRules}
-            cloudControlsUrl={cloudControlsUrl}
-            emptyTitle="No Guard Cloud rules synced"
-            emptyBody="Connect Guard Cloud to sync shared policy bundles."
-            defaultOpen={cloudRules.length > 0}
-          />
-        </div>
+        <PolicyRememberedRulesTab
+          policies={policies}
+          cloudControlsUrl={cloudControlsUrl}
+          onClearPolicy={onClearPolicy}
+          onOpenCloudExceptions={handleOpenCloudExceptions}
+        />
       ) : null}
 
       {activeView === "exceptions" ? (
-        <PolicyCloudExceptionsTab snapshot={snapshot} onRequestCloudException={handleRequestCloudException} />
+        <PolicyCloudExceptionsTab snapshot={snapshot} onRequestCloudException={cloudControlsUrl ? handleRequestCloudException : undefined} />
       ) : null}
 
       {activeView === "strict" ? (

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
@@ -552,9 +552,6 @@ const REVIEW_SCOPE_LADDER = [
 function PolicyRememberedRulesRightRail({
   onOpenCloudExceptions
 }) {
-  const handleOpenCloudExceptions = reactExports.useCallback(() => {
-    onOpenCloudExceptions();
-  }, [onOpenCloudExceptions]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "space-y-4 lg:sticky lg:top-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Remembered rules vs Cloud exceptions" }),
@@ -567,7 +564,7 @@ function PolicyRememberedRulesRightRail({
         "button",
         {
           type: "button",
-          onClick: handleOpenCloudExceptions,
+          onClick: onOpenCloudExceptions,
           className: "mt-3 text-sm font-medium text-brand-blue hover:underline",
           children: "Open Cloud exceptions tab"
         }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
@@ -1,4 +1,4 @@
-import { bd as policyActionLabel, h as harnessDisplayName, be as scopeLabel, j as jsxRuntimeExports, r as reactExports, S as SectionLabel, A as ActionButton, b6 as HiMiniCloudArrowUp, b as EmptyState, ac as Tag, p as HiMiniChevronUp, q as HiMiniChevronDown, B as Badge, m as formatRelativeTime, bb as guardAwareHref, ax as HiMiniTrash, ad as HiMiniMagnifyingGlass } from "../guard-dashboard.js";
+import { bd as policyActionLabel, h as harnessDisplayName, be as scopeLabel, j as jsxRuntimeExports, S as SectionLabel, A as ActionButton, b6 as HiMiniCloudArrowUp, b as EmptyState, r as reactExports, ac as Tag, p as HiMiniChevronUp, q as HiMiniChevronDown, B as Badge, m as formatRelativeTime, bb as guardAwareHref, ax as HiMiniTrash, ad as HiMiniMagnifyingGlass } from "../guard-dashboard.js";
 const MATCHER_FAMILY_LABELS = {
   "package-request": "package install",
   "tool-action": "shell or tool command",
@@ -284,9 +284,6 @@ function PolicyCloudExceptionsTab({
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
   const cloudConnected = resolveCloudExceptionsConnected(snapshot);
   const connectUrl = snapshot.connect_url?.trim() || null;
-  const handleRequestCloudException = reactExports.useCallback(() => {
-    onRequestCloudException?.();
-  }, [onRequestCloudException]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Cloud risk acceptances" }),
@@ -298,7 +295,7 @@ function PolicyCloudExceptionsTab({
         ActionButton,
         {
           variant: "primary",
-          onClick: handleRequestCloudException,
+          onClick: onRequestCloudException,
           disabled: !cloudConnected || onRequestCloudException === void 0,
           children: "Request cloud exception"
         }
@@ -326,16 +323,6 @@ function PolicyCloudExceptionsTab({
     )
   ] });
 }
-function PolicyRememberedRulesHelper() {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Remembered approvals vs Cloud exceptions" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("ul", { className: "mt-2 list-disc space-y-1 pl-5", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: "Review and Inbox keep fast allow/block decisions for the work in front of you." }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: "Remembered rules on this tab explain what Guard will do next time for matching actions." }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: "Cloud exceptions are separate governed risk acceptances managed in Guard Cloud." })
-    ] })
-  ] });
-}
 const PAGE_SIZE = 30;
 function resolveActionTone(action) {
   if (action === "allow") {
@@ -359,6 +346,7 @@ function PolicyRuleCard({ policy, cloudControlsUrl, onClear }) {
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: resolveActionTone(policy.action), children: policyActionLabel(policy.action) }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudManaged ? "blue" : "green", children: resolvePolicySourceLabel(policy.source) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: scopeLabel(policy.scope) }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400", children: harnessDisplayName(policy.harness) })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-base font-semibold leading-snug text-brand-dark", children: display.headline }),
@@ -518,40 +506,98 @@ function groupPoliciesByFamily(policies) {
   }
   return counts;
 }
-function resolvePolicyViewLabel(view) {
-  if (view === "rules") {
-    return "Remembered rules";
-  }
-  if (view === "exceptions") {
-    return "Cloud exceptions";
-  }
-  return "Strict config";
-}
-function PolicyWorkspace({
+function PolicyRememberedCloudRules({
   policies,
-  snapshot,
-  onClearPolicy,
-  onOpenSettings,
-  onOpenInbox
+  cloudControlsUrl
 }) {
-  const [activeView, setActiveView] = reactExports.useState("rules");
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    GroupedPolicySection,
+    {
+      title: "From Guard Cloud",
+      description: "Synced team rules are read-only here. Edit them in Guard Cloud Controls.",
+      policies,
+      cloudControlsUrl,
+      emptyTitle: "No Guard Cloud rules synced",
+      emptyBody: "Connect Guard Cloud to sync shared policy bundles.",
+      defaultOpen: policies.length > 0
+    }
+  );
+}
+function PolicyRememberedLocalRules({
+  policies,
+  cloudControlsUrl,
+  onClearPolicy
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    GroupedPolicySection,
+    {
+      title: "Remembered on this device",
+      description: "Choices you saved from Inbox. Each card explains what Guard will do next time.",
+      policies,
+      cloudControlsUrl,
+      onClearPolicy,
+      emptyTitle: "No local remembered rules yet",
+      emptyBody: "Approve or block in Inbox and Guard remembers the decision here in plain language.",
+      defaultOpen: true
+    }
+  );
+}
+const REVIEW_SCOPE_LADDER = [
+  { scope: "artifact", detail: "Guard remembers only the next matching retry." },
+  { scope: "workspace", detail: "Guard remembers the same action in this project folder." },
+  { scope: "publisher", detail: "Guard remembers actions from the same source in this app." },
+  { scope: "harness", detail: "Guard remembers the action across this app." },
+  { scope: "global", detail: "Guard remembers the action on every project on this device." }
+];
+function PolicyRememberedRulesRightRail({
+  onOpenCloudExceptions
+}) {
+  const handleOpenCloudExceptions = reactExports.useCallback(() => {
+    onOpenCloudExceptions();
+  }, [onOpenCloudExceptions]);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "space-y-4 lg:sticky lg:top-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Remembered rules vs Cloud exceptions" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("ul", { className: "mt-2 list-disc space-y-1 pl-5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: "Review and Inbox keep fast allow/block decisions for the work in front of you." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: "Remembered rules on this tab explain what Guard will do next time for matching actions." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: "Cloud exceptions are separate governed risk acceptances managed in Guard Cloud." })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "button",
+        {
+          type: "button",
+          onClick: handleOpenCloudExceptions,
+          className: "mt-3 text-sm font-medium text-brand-blue hover:underline",
+          children: "Open Cloud exceptions tab"
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Review scope ladder" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-500", children: "When you approve in Inbox, you pick how broadly Guard should remember the decision. Wider scopes apply to more future actions." }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("ol", { className: "mt-3 space-y-2.5", children: REVIEW_SCOPE_LADDER.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex gap-2.5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-5 w-5 shrink-0 items-center justify-center rounded-full bg-brand-blue/10 text-[11px] font-semibold text-brand-blue", children: index + 1 }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: scopeLabel(step.scope) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-slate-500", children: step.detail })
+        ] })
+      ] }, step.scope)) })
+    ] })
+  ] });
+}
+function PolicyRememberedRulesTab({
+  policies,
+  cloudControlsUrl,
+  onClearPolicy,
+  onOpenCloudExceptions
+}) {
   const [searchQuery, setSearchQuery] = reactExports.useState("");
   const [appFilter, setAppFilter] = reactExports.useState("");
   const [familyFilter, setFamilyFilter] = reactExports.useState("");
   const handleSearchChange = reactExports.useCallback((event) => {
     setSearchQuery(event.target.value);
   }, []);
-  const handleViewChange = reactExports.useCallback((view) => {
-    setActiveView(view);
-  }, []);
-  const cloudControlsUrl = reactExports.useMemo(() => resolveCloudPolicyControlsUrl(snapshot), [snapshot]);
-  const handleRequestCloudException = reactExports.useCallback(() => {
-    if (cloudControlsUrl) {
-      window.open(cloudControlsUrl, "_blank", "noopener,noreferrer");
-    }
-  }, [cloudControlsUrl]);
-  const modeCopy = reactExports.useMemo(() => resolveSecurityModeCopy(snapshot.security_level), [snapshot.security_level]);
-  const cloudBundleCopy = reactExports.useMemo(() => resolveCloudPolicyBundleCopy(snapshot), [snapshot]);
   const filteredPolicies = reactExports.useMemo(() => {
     const query = searchQuery.trim().toLowerCase();
     return policies.filter((policy) => {
@@ -601,35 +647,8 @@ function PolicyWorkspace({
     [policies]
   );
   const familyCounts = reactExports.useMemo(() => groupPoliciesByFamily(rememberedRules), [rememberedRules]);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    cloudBundleCopy ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: resolveCloudBundleSurfaceClass(cloudBundleCopy.tone), children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudBundleCopy.tone, children: cloudBundleCopy.label })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: cloudBundleCopy.detail })
-    ] }) : null,
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Active mode" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: modeCopy.tone, children: modeCopy.label })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: modeCopy.description }),
-      onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Open security settings" }) }) : null
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap gap-2 border-b border-slate-100 pb-3", children: ["rules", "exceptions", "strict"].map((view) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "button",
-      {
-        type: "button",
-        onClick: () => handleViewChange(view),
-        "aria-pressed": activeView === view,
-        className: `rounded-full px-4 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-brand-blue/30 ${activeView === view ? "bg-brand-blue text-white" : "border border-slate-200 bg-white text-slate-600 hover:bg-slate-50"}`,
-        children: resolvePolicyViewLabel(view)
-      },
-      view
-    )) }),
-    activeView === "rules" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyRememberedRulesHelper, {}),
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1fr)_260px] lg:items-start", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-1 items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMagnifyingGlass, { className: "h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }),
@@ -680,32 +699,86 @@ function PolicyWorkspace({
         ] })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(
-        GroupedPolicySection,
+        PolicyRememberedLocalRules,
         {
-          title: "Remembered on this device",
-          description: "Choices you saved from Inbox. Each card explains what Guard will do next time.",
           policies: localRules,
           cloudControlsUrl,
-          onClearPolicy,
-          emptyTitle: "No local remembered rules yet",
-          emptyBody: "Approve or block in Inbox and Guard remembers the decision here in plain language.",
-          defaultOpen: true
+          onClearPolicy
         }
       ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        GroupedPolicySection,
-        {
-          title: "From Guard Cloud",
-          description: "Synced team rules are read-only here. Edit them in Guard Cloud Controls.",
-          policies: cloudRules,
-          cloudControlsUrl,
-          emptyTitle: "No Guard Cloud rules synced",
-          emptyBody: "Connect Guard Cloud to sync shared policy bundles.",
-          defaultOpen: cloudRules.length > 0
-        }
-      )
+      /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyRememberedCloudRules, { policies: cloudRules, cloudControlsUrl })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyRememberedRulesRightRail, { onOpenCloudExceptions })
+  ] });
+}
+function resolvePolicyViewLabel(view) {
+  if (view === "rules") {
+    return "Remembered rules";
+  }
+  if (view === "exceptions") {
+    return "Cloud exceptions";
+  }
+  return "Strict config";
+}
+function PolicyWorkspace({
+  policies,
+  snapshot,
+  onClearPolicy,
+  onOpenSettings,
+  onOpenInbox
+}) {
+  const [activeView, setActiveView] = reactExports.useState("rules");
+  const handleViewChange = reactExports.useCallback((view) => {
+    setActiveView(view);
+  }, []);
+  const handleOpenCloudExceptions = reactExports.useCallback(() => {
+    setActiveView("exceptions");
+  }, []);
+  const cloudControlsUrl = reactExports.useMemo(() => resolveCloudPolicyControlsUrl(snapshot), [snapshot]);
+  const handleRequestCloudException = reactExports.useCallback(() => {
+    if (cloudControlsUrl) {
+      window.open(cloudControlsUrl, "_blank", "noopener,noreferrer");
+    }
+  }, [cloudControlsUrl]);
+  const modeCopy = reactExports.useMemo(() => resolveSecurityModeCopy(snapshot.security_level), [snapshot.security_level]);
+  const cloudBundleCopy = reactExports.useMemo(() => resolveCloudPolicyBundleCopy(snapshot), [snapshot]);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
+    cloudBundleCopy ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: resolveCloudBundleSurfaceClass(cloudBundleCopy.tone), children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudBundleCopy.tone, children: cloudBundleCopy.label })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: cloudBundleCopy.detail })
     ] }) : null,
-    activeView === "exceptions" ? /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyCloudExceptionsTab, { snapshot, onRequestCloudException: handleRequestCloudException }) : null,
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Active mode" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: modeCopy.tone, children: modeCopy.label })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: modeCopy.description }),
+      onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Open security settings" }) }) : null
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap gap-2 border-b border-slate-100 pb-3", children: ["rules", "exceptions", "strict"].map((view) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        onClick: () => handleViewChange(view),
+        "aria-pressed": activeView === view,
+        className: `rounded-full px-4 py-1.5 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-brand-blue/30 ${activeView === view ? "bg-brand-blue text-white" : "border border-slate-200 bg-white text-slate-600 hover:bg-slate-50"}`,
+        children: resolvePolicyViewLabel(view)
+      },
+      view
+    )) }),
+    activeView === "rules" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+      PolicyRememberedRulesTab,
+      {
+        policies,
+        cloudControlsUrl,
+        onClearPolicy,
+        onOpenCloudExceptions: handleOpenCloudExceptions
+      }
+    ) : null,
+    activeView === "exceptions" ? /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyCloudExceptionsTab, { snapshot, onRequestCloudException: cloudControlsUrl ? handleRequestCloudException : void 0 }) : null,
     activeView === "strict" ? /* @__PURE__ */ jsxRuntimeExports.jsx(StrictModeView, { snapshot, onOpenSettings, onOpenInbox }) : null
   ] });
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -5452,6 +5452,10 @@
       position: sticky;
     }
 
+    .lg\:top-4 {
+      top: calc(var(--spacing) * 4);
+    }
+
     .lg\:top-6 {
       top: calc(var(--spacing) * 6);
     }


### PR DESCRIPTION
## Summary
- Extract remembered local and Cloud-managed rules into dedicated components
- Add remembered-rules tab layout with right-rail helper and scope ladder copy
- Disable cloud exception request when Guard Cloud controls URL is unavailable

## Testing
- `pnpm exec tsx src/policy-remembered-rules.test.tsx`
- `pnpm exec tsx src/policy-cloud-exceptions-boundary.test.ts`
- `pnpm exec tsx src/policy-cloud-exceptions-ia.test.tsx`
- `pnpm run build`
