### PR TITLE
feat(guard): add Cloud exception DTO and policy API fields

### DIFF
--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -33,6 +33,7 @@ import type {
   GuardManagedInstall,
   GuardNotificationSetupResult,
   GuardPolicyDecision,
+  GuardCloudException,
   PackageManagerProtection,
   CodexResumeStatus,
   GuardCodexResumeResult,
@@ -1574,6 +1575,16 @@ export async function fetchPolicy(harness: string): Promise<GuardPolicyDecision[
   const payload = await readJson<{ items: GuardPolicyDecision[] }>(
     `/v1/policy?harness=${encodeURIComponent(harness)}`
   );
+  return payload.items;
+}
+
+
+export async function fetchCloudExceptions(harness?: string): Promise<GuardCloudException[]> {
+  if (isGuardDemoMode()) {
+    return [];
+  }
+  const query = harness ? `?harness=${encodeURIComponent(harness)}` : "";
+  const payload = await readJson<{ items: GuardCloudException[] }>(`/v1/policy/cloud-exceptions${query}`);
   return payload.items;
 }
 

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -482,6 +482,37 @@ export type GuardPolicyDecision = {
   updated_at: string;
 };
 
+export const GUARD_CLOUD_EXCEPTION_ACK_STATUSES = [
+  "pending",
+  "synced",
+  "failed",
+  "offline",
+] as const;
+
+export type GuardCloudExceptionAckStatus = (typeof GUARD_CLOUD_EXCEPTION_ACK_STATUSES)[number];
+
+export const GUARD_CLOUD_EXCEPTION_EFFECTS = ["allow"] as const;
+
+export type GuardCloudExceptionEffect = (typeof GUARD_CLOUD_EXCEPTION_EFFECTS)[number];
+
+export type GuardCloudExceptionScope = DecisionScope | "global";
+
+export type GuardCloudException = {
+  id: string;
+  effect: GuardCloudExceptionEffect;
+  scope: GuardCloudExceptionScope;
+  harness: string | null;
+  owner: string;
+  approver: string | null;
+  expiry: string;
+  source_receipt_id: string | null;
+  bundle_hash: string | null;
+  ack_status: GuardCloudExceptionAckStatus | null;
+  last_used_at: string | null;
+  rejection_reason: string | null;
+};
+
+
 export type GuardManagedInstall = {
   harness: string;
   active: boolean;

--- a/dashboard/src/policy-cloud-exceptions-boundary.test.ts
+++ b/dashboard/src/policy-cloud-exceptions-boundary.test.ts
@@ -119,6 +119,7 @@ assert(guardApiSource.includes("fetchPolicies"), "guard-api must expose fetchPol
 assert(guardApiSource.includes("savePolicyDecision"), "guard-api must expose savePolicyDecision baseline");
 assert(guardApiSource.includes("clearPolicy"), "guard-api must expose clearPolicy");
 assert(guardApiSource.includes("/v1/policy"), "guard-api must call /v1/policy endpoints");
+assert(guardApiSource.includes("fetchCloudExceptions"), "guard-api must expose fetchCloudExceptions");
 
 assert(boundaryDoc.includes("Remembered rules"), "boundary doc must define Remembered rules");
 assert(boundaryDoc.includes("Cloud exceptions"), "boundary doc must define Cloud exceptions");

--- a/docs/guard/policy-cloud-exceptions-boundary.md
+++ b/docs/guard/policy-cloud-exceptions-boundary.md
@@ -43,9 +43,10 @@ Local Policy must **not** author broad local exceptions directly.
 
 | Endpoint / module | Role today |
 | --- | --- |
-| `GET /v1/policy` | Lists local `GuardPolicyDecision` rows |
+| `GET /v1/policy` | Lists local `GuardPolicyDecision` rows plus `cloud_exceptions` DTO field |
 | `POST /v1/policy/decisions` | Saves local policy decision (used by exception form today) |
 | `POST /v1/policy/clear` | Clears local remembered rules |
+| `GET /v1/policy/cloud-exceptions` | Lists active Cloud exception DTO rows |
 | `POST /v1/policy/sync` | Syncs Cloud policy bundle |
 | `policy_bundle_parser.py` | Schema validation, bundle hash, payload hash, RSA signature verify |
 | `policy_bundle_trusted_keys.py` | Trusted signing keys, key expiry |
@@ -174,4 +175,5 @@ Do not rewrite Review/Inbox components to implement Policy features.
 ## Phase 0 completion
 
 Phase 0 delivers this boundary doc, audit notes, and automated boundary tests.
-Implementation begins in Phase 1 (IA rename, remove local exception authoring).
+Phase 3 adds the local Cloud exception DTO (`cloud_exceptions.py`), separate sync
+storage, and `/v1/policy` + `/v1/policy/cloud-exceptions` API fields.

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -25,6 +25,9 @@ def _run_guard_exceptions_command(
     items = [
         item for item in active_items if isinstance(item.get("expires_at"), str) and str(item["expires_at"]).strip()
     ]
+    cloud_items = store.list_cloud_exceptions(getattr(args, "harness", None))
+    if cloud_items:
+        items = cloud_items
     _emit("exceptions", {"generated_at": _now(), "items": items}, getattr(args, "json", False))
     return 0
 

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -26,8 +26,7 @@ def _run_guard_exceptions_command(
         item for item in active_items if isinstance(item.get("expires_at"), str) and str(item["expires_at"]).strip()
     ]
     cloud_items = store.list_cloud_exceptions(getattr(args, "harness", None))
-    if cloud_items:
-        items = cloud_items
+    items = cloud_items + items
     _emit("exceptions", {"generated_at": _now(), "items": items}, getattr(args, "json", False))
     return 0
 

--- a/src/codex_plugin_scanner/guard/cloud_exceptions.py
+++ b/src/codex_plugin_scanner/guard/cloud_exceptions.py
@@ -1,0 +1,229 @@
+"""Cloud exception DTO parsing and storage helpers (HGLP046-HGLP060)."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import datetime, timezone
+
+from .models import CloudException
+
+_CLOUD_EXCEPTION_SCOPES = frozenset({"artifact", "publisher", "harness", "workspace", "global"})
+_CLOUD_EXCEPTION_EFFECTS = frozenset({"allow"})
+_CLOUD_EXCEPTION_ACK_STATUSES = frozenset({"pending", "synced", "failed", "offline"})
+
+
+def _non_empty_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _parse_iso_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.replace("Z", "+00:00")
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
+def _normalized_timestamp_string(value: object) -> str | None:
+    parsed = _parse_iso_timestamp(value)
+    if parsed is None:
+        return None
+    return parsed.astimezone(timezone.utc).isoformat()
+
+
+def _cloud_exception_is_active(item: CloudException, *, now: str | None = None) -> bool:
+    expiry = _parse_iso_timestamp(item.expiry)
+    if expiry is None:
+        return False
+    current = _parse_iso_timestamp(now or datetime.now(timezone.utc).isoformat())
+    if current is None:
+        return False
+    return expiry > current
+
+
+def _policy_bundle_cloud_exception_is_valid(item: object) -> bool:
+    if not isinstance(item, dict):
+        return False
+    exception_id = _non_empty_string(item.get("exceptionId") or item.get("id"))
+    if exception_id is None:
+        return False
+    effect = item.get("effect") or "allow"
+    if effect not in _CLOUD_EXCEPTION_EFFECTS:
+        return False
+    scope = item.get("scope")
+    if scope not in _CLOUD_EXCEPTION_SCOPES:
+        return False
+    if _non_empty_string(item.get("owner")) is None:
+        return False
+    if _normalized_timestamp_string(item.get("expiresAt") or item.get("expiry")) is None:
+        return False
+    harness = item.get("harness")
+    if harness is not None and not isinstance(harness, str):
+        return False
+    approver = item.get("approver")
+    if approver is not None and _non_empty_string(approver) is None:
+        return False
+    source_receipt_id = item.get("sourceReceiptId")
+    if source_receipt_id is not None and _non_empty_string(source_receipt_id) is None:
+        return False
+    return True
+
+
+def policy_bundle_cloud_exceptions_are_valid(policy_bundle: dict[str, object]) -> bool:
+    cloud_exceptions = policy_bundle.get("cloudExceptions")
+    if cloud_exceptions is None:
+        return True
+    if not isinstance(cloud_exceptions, list):
+        return False
+    return all(_policy_bundle_cloud_exception_is_valid(item) for item in cloud_exceptions)
+
+
+def _resolve_cloud_exception_ack_status(
+    *,
+    device_id: str | None,
+    policy_bundle: dict[str, object] | None,
+    policy_bundle_ack: dict[str, object] | None,
+) -> str | None:
+    if isinstance(policy_bundle_ack, dict):
+        ack_status = policy_bundle_ack.get("status")
+        if isinstance(ack_status, str) and ack_status in _CLOUD_EXCEPTION_ACK_STATUSES:
+            return ack_status
+    if not isinstance(policy_bundle, dict):
+        return None
+    acknowledgements = policy_bundle.get("acknowledgements")
+    if not isinstance(acknowledgements, list) or device_id is None:
+        return None
+    for acknowledgement in acknowledgements:
+        if not isinstance(acknowledgement, dict):
+            continue
+        if str(acknowledgement.get("deviceId")) != device_id:
+            continue
+        status = acknowledgement.get("status")
+        if isinstance(status, str) and status in _CLOUD_EXCEPTION_ACK_STATUSES:
+            return status
+    return None
+
+
+def cloud_exception_from_mapping(
+    item: dict[str, object],
+    *,
+    bundle_hash: str | None = None,
+    ack_status: str | None = None,
+    rejection_reason: str | None = None,
+) -> CloudException | None:
+    exception_id = _non_empty_string(item.get("exceptionId") or item.get("id"))
+    if exception_id is None:
+        return None
+    scope = item.get("scope")
+    if scope not in _CLOUD_EXCEPTION_SCOPES:
+        return None
+    effect = item.get("effect") or "allow"
+    if effect not in _CLOUD_EXCEPTION_EFFECTS:
+        return None
+    owner = _non_empty_string(item.get("owner"))
+    expiry = _normalized_timestamp_string(item.get("expiresAt") or item.get("expiry"))
+    if owner is None or expiry is None:
+        return None
+    harness_value = item.get("harness")
+    harness = harness_value if isinstance(harness_value, str) and harness_value.strip() else None
+    approver = _non_empty_string(item.get("approver"))
+    source_receipt_id = _non_empty_string(
+        item.get("sourceReceiptId") or item.get("source_receipt_id")
+    )
+    last_used_at = _normalized_timestamp_string(item.get("lastUsedAt") or item.get("last_used_at"))
+    resolved_ack = ack_status or _non_empty_string(item.get("ackStatus") or item.get("ack_status"))
+    if resolved_ack is not None and resolved_ack not in _CLOUD_EXCEPTION_ACK_STATUSES:
+        resolved_ack = None
+    resolved_bundle_hash = (
+        _non_empty_string(item.get("bundleHash") or item.get("bundle_hash")) or bundle_hash
+    )
+    return CloudException(
+        id=exception_id,
+        effect=effect,  # type: ignore[arg-type]
+        scope=scope,  # type: ignore[arg-type]
+        harness=harness,
+        owner=owner,
+        approver=approver,
+        expiry=expiry,
+        source_receipt_id=source_receipt_id,
+        bundle_hash=resolved_bundle_hash,
+        ack_status=resolved_ack,  # type: ignore[arg-type]
+        last_used_at=last_used_at,
+        rejection_reason=_non_empty_string(item.get("rejectionReason") or item.get("rejection_reason"))
+        or rejection_reason,
+    )
+
+
+def build_cloud_exceptions_from_policy_bundle(
+    policy_bundle: dict[str, object],
+    *,
+    device_id: str | None = None,
+    policy_bundle_ack: dict[str, object] | None = None,
+) -> list[CloudException]:
+    cloud_exceptions = policy_bundle.get("cloudExceptions")
+    if not isinstance(cloud_exceptions, list):
+        return []
+    bundle_hash = _non_empty_string(policy_bundle.get("bundleHash"))
+    ack_status = _resolve_cloud_exception_ack_status(
+        device_id=device_id,
+        policy_bundle=policy_bundle,
+        policy_bundle_ack=policy_bundle_ack,
+    )
+    items: list[CloudException] = []
+    for raw_item in cloud_exceptions:
+        if not isinstance(raw_item, dict):
+            continue
+        parsed = cloud_exception_from_mapping(
+            raw_item,
+            bundle_hash=bundle_hash,
+            ack_status=ack_status,
+        )
+        if parsed is not None:
+            items.append(parsed)
+    return items
+
+
+def build_cloud_exceptions_from_sync_payload(
+    exceptions: list[dict[str, object]],
+    *,
+    bundle_hash: str | None = None,
+    ack_status: str | None = None,
+) -> list[CloudException]:
+    items: list[CloudException] = []
+    for raw_item in exceptions:
+        parsed = cloud_exception_from_mapping(
+            raw_item,
+            bundle_hash=bundle_hash,
+            ack_status=ack_status,
+        )
+        if parsed is not None:
+            items.append(parsed)
+    return items
+
+
+def dedupe_cloud_exceptions(items: list[CloudException]) -> list[CloudException]:
+    deduped: dict[str, CloudException] = {}
+    for item in items:
+        deduped[item.id] = item
+    return list(deduped.values())
+
+
+def list_active_cloud_exceptions(
+    items: list[CloudException],
+    *,
+    harness: str | None = None,
+    now: str | None = None,
+) -> list[CloudException]:
+    active = [item for item in items if _cloud_exception_is_active(item, now=now)]
+    if harness is None:
+        return active
+    return [item for item in active if item.harness in {harness, "*", None}]
+
+
+def cloud_exception_to_dict(item: CloudException) -> dict[str, object]:
+    return asdict(item)

--- a/src/codex_plugin_scanner/guard/cloud_exceptions.py
+++ b/src/codex_plugin_scanner/guard/cloud_exceptions.py
@@ -69,9 +69,7 @@ def _policy_bundle_cloud_exception_is_valid(item: object) -> bool:
     if approver is not None and _non_empty_string(approver) is None:
         return False
     source_receipt_id = item.get("sourceReceiptId")
-    if source_receipt_id is not None and _non_empty_string(source_receipt_id) is None:
-        return False
-    return True
+    return source_receipt_id is None or _non_empty_string(source_receipt_id) is not None
 
 
 def policy_bundle_cloud_exceptions_are_valid(policy_bundle: dict[str, object]) -> bool:

--- a/src/codex_plugin_scanner/guard/cloud_exceptions.py
+++ b/src/codex_plugin_scanner/guard/cloud_exceptions.py
@@ -63,7 +63,10 @@ def _policy_bundle_cloud_exception_is_valid(item: object) -> bool:
     if _normalized_timestamp_string(item.get("expiresAt") or item.get("expiry")) is None:
         return False
     harness = item.get("harness")
-    if harness is not None and not isinstance(harness, str):
+    if scope == "harness":
+        if not isinstance(harness, str) or not harness.strip():
+            return False
+    elif harness is not None and not isinstance(harness, str):
         return False
     approver = item.get("approver")
     if approver is not None and _non_empty_string(approver) is None:
@@ -113,6 +116,7 @@ def cloud_exception_from_mapping(
     bundle_hash: str | None = None,
     ack_status: str | None = None,
     rejection_reason: str | None = None,
+    provenance: str = "receipt-sync",
 ) -> CloudException | None:
     exception_id = _non_empty_string(item.get("exceptionId") or item.get("id"))
     if exception_id is None:
@@ -129,6 +133,8 @@ def cloud_exception_from_mapping(
         return None
     harness_value = item.get("harness")
     harness = harness_value if isinstance(harness_value, str) and harness_value.strip() else None
+    if scope == "harness" and harness is None:
+        return None
     approver = _non_empty_string(item.get("approver"))
     source_receipt_id = _non_empty_string(item.get("sourceReceiptId") or item.get("source_receipt_id"))
     last_used_at = _normalized_timestamp_string(item.get("lastUsedAt") or item.get("last_used_at"))
@@ -150,6 +156,7 @@ def cloud_exception_from_mapping(
         last_used_at=last_used_at,
         rejection_reason=_non_empty_string(item.get("rejectionReason") or item.get("rejection_reason"))
         or rejection_reason,
+        provenance=provenance if provenance in {"receipt-sync", "policy-bundle"} else "receipt-sync",  # type: ignore[arg-type]
     )
 
 
@@ -176,6 +183,7 @@ def build_cloud_exceptions_from_policy_bundle(
             raw_item,
             bundle_hash=bundle_hash,
             ack_status=ack_status,
+            provenance="policy-bundle",
         )
         if parsed is not None:
             items.append(parsed)
@@ -198,9 +206,14 @@ def cloud_exception_from_stored_dict(item: dict[str, object]) -> CloudException 
         return None
     harness_value = item.get("harness")
     harness = harness_value if isinstance(harness_value, str) and harness_value.strip() else None
+    if scope == "harness" and harness is None:
+        return None
     ack_status = item.get("ack_status")
     if ack_status is not None and ack_status not in _CLOUD_EXCEPTION_ACK_STATUSES:
         ack_status = None
+    resolved_provenance = item.get("provenance")
+    if resolved_provenance not in {"receipt-sync", "policy-bundle"}:
+        resolved_provenance = "receipt-sync"
     return CloudException(
         id=exception_id,
         effect=effect,  # type: ignore[arg-type]
@@ -214,7 +227,26 @@ def cloud_exception_from_stored_dict(item: dict[str, object]) -> CloudException 
         ack_status=ack_status,  # type: ignore[arg-type]
         last_used_at=_normalized_timestamp_string(item.get("last_used_at")),
         rejection_reason=_non_empty_string(item.get("rejection_reason")),
+        provenance=resolved_provenance,  # type: ignore[arg-type]
     )
+
+
+def _stored_cloud_exception_provenance(item: dict[str, object]) -> str:
+    provenance = item.get("provenance")
+    if provenance in {"receipt-sync", "policy-bundle"}:
+        return str(provenance)
+    if _non_empty_string(item.get("bundle_hash")) is not None:
+        return "policy-bundle"
+    return "receipt-sync"
+
+
+def stored_receipt_sync_cloud_exceptions(items: list[dict[str, object]]) -> list[CloudException]:
+    preserved = [
+        item
+        for item in items
+        if isinstance(item, dict) and _stored_cloud_exception_provenance(item) == "receipt-sync"
+    ]
+    return build_cloud_exceptions_from_stored_items(preserved)
 
 
 def build_cloud_exceptions_from_stored_items(items: list[dict[str, object]]) -> list[CloudException]:
@@ -260,7 +292,7 @@ def list_active_cloud_exceptions(
     active = [item for item in items if _cloud_exception_is_active(item, now=now)]
     if harness is None:
         return active
-    return [item for item in active if item.harness in {harness, "*", None}]
+    return [item for item in active if item.harness in {harness, "*"}]
 
 
 def cloud_exception_to_dict(item: CloudException) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/cloud_exceptions.py
+++ b/src/codex_plugin_scanner/guard/cloud_exceptions.py
@@ -130,16 +130,12 @@ def cloud_exception_from_mapping(
     harness_value = item.get("harness")
     harness = harness_value if isinstance(harness_value, str) and harness_value.strip() else None
     approver = _non_empty_string(item.get("approver"))
-    source_receipt_id = _non_empty_string(
-        item.get("sourceReceiptId") or item.get("source_receipt_id")
-    )
+    source_receipt_id = _non_empty_string(item.get("sourceReceiptId") or item.get("source_receipt_id"))
     last_used_at = _normalized_timestamp_string(item.get("lastUsedAt") or item.get("last_used_at"))
     resolved_ack = ack_status or _non_empty_string(item.get("ackStatus") or item.get("ack_status"))
     if resolved_ack is not None and resolved_ack not in _CLOUD_EXCEPTION_ACK_STATUSES:
         resolved_ack = None
-    resolved_bundle_hash = (
-        _non_empty_string(item.get("bundleHash") or item.get("bundle_hash")) or bundle_hash
-    )
+    resolved_bundle_hash = _non_empty_string(item.get("bundleHash") or item.get("bundle_hash")) or bundle_hash
     return CloudException(
         id=exception_id,
         effect=effect,  # type: ignore[arg-type]
@@ -184,6 +180,50 @@ def build_cloud_exceptions_from_policy_bundle(
         if parsed is not None:
             items.append(parsed)
     return items
+
+
+def cloud_exception_from_stored_dict(item: dict[str, object]) -> CloudException | None:
+    exception_id = _non_empty_string(item.get("id"))
+    if exception_id is None:
+        return None
+    scope = item.get("scope")
+    if scope not in _CLOUD_EXCEPTION_SCOPES:
+        return None
+    effect = item.get("effect") or "allow"
+    if effect not in _CLOUD_EXCEPTION_EFFECTS:
+        return None
+    owner = _non_empty_string(item.get("owner"))
+    expiry = _normalized_timestamp_string(item.get("expiry"))
+    if owner is None or expiry is None:
+        return None
+    harness_value = item.get("harness")
+    harness = harness_value if isinstance(harness_value, str) and harness_value.strip() else None
+    ack_status = item.get("ack_status")
+    if ack_status is not None and ack_status not in _CLOUD_EXCEPTION_ACK_STATUSES:
+        ack_status = None
+    return CloudException(
+        id=exception_id,
+        effect=effect,  # type: ignore[arg-type]
+        scope=scope,  # type: ignore[arg-type]
+        harness=harness,
+        owner=owner,
+        approver=_non_empty_string(item.get("approver")),
+        expiry=expiry,
+        source_receipt_id=_non_empty_string(item.get("source_receipt_id")),
+        bundle_hash=_non_empty_string(item.get("bundle_hash")),
+        ack_status=ack_status,  # type: ignore[arg-type]
+        last_used_at=_normalized_timestamp_string(item.get("last_used_at")),
+        rejection_reason=_non_empty_string(item.get("rejection_reason")),
+    )
+
+
+def build_cloud_exceptions_from_stored_items(items: list[dict[str, object]]) -> list[CloudException]:
+    parsed: list[CloudException] = []
+    for raw_item in items:
+        item = cloud_exception_from_stored_dict(raw_item)
+        if item is not None:
+            parsed.append(item)
+    return parsed
 
 
 def build_cloud_exceptions_from_sync_payload(

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -118,6 +118,7 @@ from ..runtime.runner import (
     _build_policy_bundle_decisions,
     _daemon_version_supported,
     _guard_device_metadata,
+    _persist_cloud_exceptions,
     _policy_bundle_acknowledgement_payload,
     _policy_bundle_is_version_downgrade,
     sync_local_guard_cloud_proof,
@@ -1151,9 +1152,19 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/policy":
             query = parse_qs(parsed.query)
             harness = query.get("harness", [None])[-1]
+            harness_filter = harness if isinstance(harness, str) else None
             self._write_json(
-                {"items": store.list_policy_decisions(harness=harness if isinstance(harness, str) else None)}
+                {
+                    "items": store.list_policy_decisions(harness=harness_filter),
+                    "cloud_exceptions": store.list_cloud_exceptions(harness=harness_filter),
+                }
             )
+            return
+        if parsed.path == "/v1/policy/cloud-exceptions":
+            query = parse_qs(parsed.query)
+            harness = query.get("harness", [None])[-1]
+            harness_filter = harness if isinstance(harness, str) else None
+            self._write_json({"items": store.list_cloud_exceptions(harness=harness_filter)})
             return
         if parsed.path == "/v1/evidence":
             query = parse_qs(parsed.query)
@@ -1874,6 +1885,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 )
             )
             self.server.store.replace_remote_policies(existing_remote_decisions, applied_at)  # type: ignore[attr-defined]
+            _persist_cloud_exceptions(
+                self.server.store,  # type: ignore[attr-defined]
+                policy_bundle=validated_policy_bundle,
+                now=applied_at,
+            )
             applied_bundle_hash = str(validated_policy_bundle["bundleHash"])
             applied_bundle_version = str(validated_policy_bundle["bundleVersion"])
         if not policy_memory:
@@ -3860,6 +3876,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/cloud/connect",
             "/v1/receipts/latest",
             "/v1/policy",
+            "/v1/policy/cloud-exceptions",
             "/v1/evidence",
             "/v1/evidence/export",
             "/v1/clients/attach",
@@ -4132,6 +4149,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/harnesses",
             "/v1/notifications/setup",
             "/v1/policy",
+            "/v1/policy/cloud-exceptions",
             "/v1/policy/clear",
             "/v1/policy/sync",
             "/v1/receipts",
@@ -4513,6 +4531,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/connect/result",
             "/v1/operations/block",
             "/v1/policy/decisions",
+            "/v1/policy/cloud-exceptions",
             "/v1/policy/clear",
             "/v1/policy/sync",
             "/v1/requests/clear",

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -130,6 +130,33 @@ class PolicyDecision:
         return asdict(self)
 
 
+
+CloudExceptionEffect = Literal["allow"]
+CloudExceptionScope = Literal["artifact", "publisher", "harness", "workspace", "global"]
+CloudExceptionAckStatus = Literal["pending", "synced", "failed", "offline"]
+
+
+@dataclass(frozen=True, slots=True)
+class CloudException:
+    """Governed Cloud risk acceptance synced from Guard Cloud."""
+
+    id: str
+    effect: CloudExceptionEffect
+    scope: CloudExceptionScope
+    harness: str | None
+    owner: str
+    approver: str | None
+    expiry: str
+    source_receipt_id: str | None
+    bundle_hash: str | None
+    ack_status: CloudExceptionAckStatus | None
+    last_used_at: str | None
+    rejection_reason: str | None
+
+    def to_dict(self) -> dict[str, object]:
+        return asdict(self)
+
+
 @dataclass(frozen=True, slots=True)
 class GuardReceipt:
     """Runtime receipt recorded after a Guard evaluation."""

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -130,7 +130,6 @@ class PolicyDecision:
         return asdict(self)
 
 
-
 CloudExceptionEffect = Literal["allow"]
 CloudExceptionScope = Literal["artifact", "publisher", "harness", "workspace", "global"]
 CloudExceptionAckStatus = Literal["pending", "synced", "failed", "offline"]

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -133,6 +133,7 @@ class PolicyDecision:
 CloudExceptionEffect = Literal["allow"]
 CloudExceptionScope = Literal["artifact", "publisher", "harness", "workspace", "global"]
 CloudExceptionAckStatus = Literal["pending", "synced", "failed", "offline"]
+CloudExceptionProvenance = Literal["receipt-sync", "policy-bundle"]
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,6 +152,7 @@ class CloudException:
     ack_status: CloudExceptionAckStatus | None
     last_used_at: str | None
     rejection_reason: str | None
+    provenance: CloudExceptionProvenance = "receipt-sync"
 
     def to_dict(self) -> dict[str, object]:
         return asdict(self)

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -11,6 +11,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
+from .cloud_exceptions import policy_bundle_cloud_exceptions_are_valid
 from .policy_bundle_trusted_keys import (
     PolicyBundleVerificationKey,
     policy_bundle_key_fingerprint,
@@ -269,6 +270,8 @@ def validated_policy_bundle_payload(
     rules = policy_bundle.get("rules")
     if not isinstance(rules, list) or not all(_policy_bundle_rule_is_valid(rule) for rule in rules):
         return None, "invalid_rules"
+    if not policy_bundle_cloud_exceptions_are_valid(policy_bundle):
+        return None, "invalid_cloud_exceptions"
     acknowledgements = policy_bundle.get("acknowledgements")
     if not isinstance(acknowledgements, list) or not all(
         _policy_bundle_acknowledgement_is_valid(acknowledgement) for acknowledgement in acknowledgements
@@ -309,6 +312,9 @@ def validated_policy_bundle_payload(
         "rules": rules,
         "acknowledgements": acknowledgements,
     }
+    cloud_exceptions = policy_bundle.get("cloudExceptions")
+    if isinstance(cloud_exceptions, list) and cloud_exceptions:
+        payload["cloudExceptions"] = cloud_exceptions
     if payload_hash is not None:
         payload["payloadHash"] = payload_hash
     if workspace_id is not None:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -37,6 +37,12 @@ from ..cli.oauth_client import (
 from ..config import GuardConfig
 from ..consumer import detect_harness, evaluate_detection
 from ..edge_events import build_runtime_session_event
+from ..cloud_exceptions import (
+    build_cloud_exceptions_from_policy_bundle,
+    build_cloud_exceptions_from_sync_payload,
+    cloud_exception_to_dict,
+    dedupe_cloud_exceptions,
+)
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..package_firewall_entitlement import build_oauth_package_firewall_entitlement
 from ..policy_bundle_parser import (
@@ -1340,6 +1346,16 @@ def sync_receipts(
         store.set_sync_payload("team_policy_pack", team_policy_pack_payload, now)
     else:
         store.set_sync_payload("team_policy_pack", {}, now)
+    active_policy_bundle_payload = store.get_sync_payload("policy_bundle")
+    active_policy_bundle = (
+        active_policy_bundle_payload if isinstance(active_policy_bundle_payload, dict) else None
+    )
+    cloud_exception_items = _persist_cloud_exceptions(
+        store,
+        sync_exceptions=deduped_exceptions,
+        policy_bundle=active_policy_bundle,
+        now=now,
+    )
     remote_policies_stored = len(remote_decisions)
     remote_policy_sync_blocked = False
     try:
@@ -1369,7 +1385,7 @@ def sync_receipts(
         "synced_at": payload.get("syncedAt"),
         "receipts_stored": receipts_stored_total,
         "advisories_stored": advisories_stored,
-        "exceptions_stored": len(deduped_exceptions),
+        "exceptions_stored": len(cloud_exception_items),
         "remote_policies_stored": remote_policies_stored,
         "pain_signals_uploaded": pain_signals_uploaded,
         "receipts": len(receipts),
@@ -2037,36 +2053,41 @@ def sync_pain_signals(
     return uploaded_count
 
 
+def _persist_cloud_exceptions(
+    store: GuardStore,
+    *,
+    sync_exceptions: list[dict[str, object]] | None = None,
+    policy_bundle: dict[str, object] | None = None,
+    now: str,
+) -> list[dict[str, object]]:
+    device_id, _device_name = _guard_device_metadata(store)
+    bundle_ack_payload = store.get_sync_payload("policy_bundle_ack")
+    bundle_ack = bundle_ack_payload if isinstance(bundle_ack_payload, dict) else None
+    bundle_hash = non_empty_string(policy_bundle.get("bundleHash")) if isinstance(policy_bundle, dict) else None
+    items = []
+    if sync_exceptions:
+        items.extend(
+            build_cloud_exceptions_from_sync_payload(
+                sync_exceptions,
+                bundle_hash=bundle_hash,
+                ack_status=non_empty_string(bundle_ack.get("status")) if bundle_ack else None,
+            )
+        )
+    if isinstance(policy_bundle, dict):
+        items.extend(
+            build_cloud_exceptions_from_policy_bundle(
+                policy_bundle,
+                device_id=device_id,
+                policy_bundle_ack=bundle_ack,
+            )
+        )
+    serialized = [cloud_exception_to_dict(item) for item in dedupe_cloud_exceptions(items)]
+    store.set_cloud_exceptions(serialized, now)
+    return serialized
+
+
 def _build_remote_policy_decisions(payload: dict[str, object]) -> list[PolicyDecision]:
     decisions: list[PolicyDecision] = []
-    exceptions = payload.get("exceptions")
-    if isinstance(exceptions, list):
-        for item in exceptions:
-            if not isinstance(item, dict):
-                continue
-            scope = item.get("scope")
-            if scope not in {"artifact", "publisher", "harness", "global", "workspace"}:
-                continue
-            workspace = _remote_workspace(item)
-            if scope == "workspace" and workspace is None:
-                continue
-            harness = _remote_harness(item.get("harness"), allow_wildcard=scope != "harness")
-            if harness is None:
-                continue
-            decisions.append(
-                PolicyDecision(
-                    harness=harness,
-                    scope=scope,
-                    action="allow",
-                    artifact_id=_optional_string(item.get("artifactId")),
-                    workspace=workspace,
-                    publisher=_optional_string(item.get("publisher")),
-                    reason=_optional_string(item.get("reason")),
-                    owner=_optional_string(item.get("owner")),
-                    source="cloud-sync",
-                    expires_at=_normalized_timestamp_string(item.get("expiresAt")),
-                )
-            )
     team_policy_pack = payload.get("teamPolicyPack")
     if isinstance(team_policy_pack, dict):
         policy_name = _optional_string(team_policy_pack.get("name")) or "team policy"

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -40,6 +40,7 @@ from ..cloud_exceptions import (
     build_cloud_exceptions_from_sync_payload,
     cloud_exception_to_dict,
     dedupe_cloud_exceptions,
+    stored_receipt_sync_cloud_exceptions,
 )
 from ..config import GuardConfig
 from ..consumer import detect_harness, evaluate_detection
@@ -1222,10 +1223,9 @@ def sync_receipts(
         if isinstance(team_policy_pack, dict) and (team_policy_pack or team_policy_pack_payload is None):
             team_policy_pack_payload = team_policy_pack
         exceptions = payload.get("exceptions")
-        if "exceptions" in payload:
+        if isinstance(exceptions, list):
             exceptions_sync_payload_provided = True
-            if isinstance(exceptions, list):
-                exceptions_payload.extend(item for item in exceptions if isinstance(item, dict))
+            exceptions_payload.extend(item for item in exceptions if isinstance(item, dict))
         remote_decisions.update(_build_remote_policy_decisions(payload))
     now = _sync_timestamp(payload)
     persisted_cursor_rowid = latest_uploaded_rowid if latest_uploaded_rowid is not None else prior_receipt_cursor
@@ -2081,9 +2081,11 @@ def _persist_cloud_exceptions(
     else:
         existing_payload = store.get_sync_payload("cloud_exceptions")
         if isinstance(existing_payload, list):
-            items.extend(
-                build_cloud_exceptions_from_stored_items([item for item in existing_payload if isinstance(item, dict)])
-            )
+            stored_items = [item for item in existing_payload if isinstance(item, dict)]
+            if isinstance(policy_bundle, dict):
+                items.extend(stored_receipt_sync_cloud_exceptions(stored_items))
+            else:
+                items.extend(build_cloud_exceptions_from_stored_items(stored_items))
     if isinstance(policy_bundle, dict):
         items.extend(
             build_cloud_exceptions_from_policy_bundle(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -36,6 +36,7 @@ from ..cli.oauth_client import (
 )
 from ..cloud_exceptions import (
     build_cloud_exceptions_from_policy_bundle,
+    build_cloud_exceptions_from_stored_items,
     build_cloud_exceptions_from_sync_payload,
     cloud_exception_to_dict,
     dedupe_cloud_exceptions,
@@ -2063,15 +2064,22 @@ def _persist_cloud_exceptions(
     bundle_ack_payload = store.get_sync_payload("policy_bundle_ack")
     bundle_ack = bundle_ack_payload if isinstance(bundle_ack_payload, dict) else None
     bundle_hash = non_empty_string(policy_bundle.get("bundleHash")) if isinstance(policy_bundle, dict) else None
+    ack_status = non_empty_string(bundle_ack.get("status")) if bundle_ack else None
     items = []
-    if sync_exceptions:
+    if sync_exceptions is not None:
         items.extend(
             build_cloud_exceptions_from_sync_payload(
                 sync_exceptions,
                 bundle_hash=bundle_hash,
-                ack_status=non_empty_string(bundle_ack.get("status")) if bundle_ack else None,
+                ack_status=ack_status,
             )
         )
+    else:
+        existing_payload = store.get_sync_payload("cloud_exceptions")
+        if isinstance(existing_payload, list):
+            items.extend(
+                build_cloud_exceptions_from_stored_items([item for item in existing_payload if isinstance(item, dict)])
+            )
     if isinstance(policy_bundle, dict):
         items.extend(
             build_cloud_exceptions_from_policy_bundle(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2066,7 +2066,7 @@ def _persist_cloud_exceptions(
     bundle_hash = non_empty_string(policy_bundle.get("bundleHash")) if isinstance(policy_bundle, dict) else None
     ack_status = non_empty_string(bundle_ack.get("status")) if bundle_ack else None
     items = []
-    if sync_exceptions is not None:
+    if sync_exceptions:
         items.extend(
             build_cloud_exceptions_from_sync_payload(
                 sync_exceptions,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -34,15 +34,15 @@ from ..cli.oauth_client import (
     resolve_guard_oauth_client_config,
     validate_guard_sync_endpoint,
 )
-from ..config import GuardConfig
-from ..consumer import detect_harness, evaluate_detection
-from ..edge_events import build_runtime_session_event
 from ..cloud_exceptions import (
     build_cloud_exceptions_from_policy_bundle,
     build_cloud_exceptions_from_sync_payload,
     cloud_exception_to_dict,
     dedupe_cloud_exceptions,
 )
+from ..config import GuardConfig
+from ..consumer import detect_harness, evaluate_detection
+from ..edge_events import build_runtime_session_event
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..package_firewall_entitlement import build_oauth_package_firewall_entitlement
 from ..policy_bundle_parser import (

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1347,9 +1347,7 @@ def sync_receipts(
     else:
         store.set_sync_payload("team_policy_pack", {}, now)
     active_policy_bundle_payload = store.get_sync_payload("policy_bundle")
-    active_policy_bundle = (
-        active_policy_bundle_payload if isinstance(active_policy_bundle_payload, dict) else None
-    )
+    active_policy_bundle = active_policy_bundle_payload if isinstance(active_policy_bundle_payload, dict) else None
     cloud_exception_items = _persist_cloud_exceptions(
         store,
         sync_exceptions=deduped_exceptions,
@@ -1385,7 +1383,8 @@ def sync_receipts(
         "synced_at": payload.get("syncedAt"),
         "receipts_stored": receipts_stored_total,
         "advisories_stored": advisories_stored,
-        "exceptions_stored": len(cloud_exception_items),
+        "exceptions_stored": len(deduped_exceptions),
+        "cloud_exceptions_stored": len(cloud_exception_items),
         "remote_policies_stored": remote_policies_stored,
         "pain_signals_uploaded": pain_signals_uploaded,
         "receipts": len(receipts),
@@ -2088,6 +2087,34 @@ def _persist_cloud_exceptions(
 
 def _build_remote_policy_decisions(payload: dict[str, object]) -> list[PolicyDecision]:
     decisions: list[PolicyDecision] = []
+    exceptions = payload.get("exceptions")
+    if isinstance(exceptions, list):
+        for item in exceptions:
+            if not isinstance(item, dict):
+                continue
+            scope = item.get("scope")
+            if scope not in {"artifact", "publisher", "harness", "global", "workspace"}:
+                continue
+            workspace = _remote_workspace(item)
+            if scope == "workspace" and workspace is None:
+                continue
+            harness = _remote_harness(item.get("harness"), allow_wildcard=scope != "harness")
+            if harness is None:
+                continue
+            decisions.append(
+                PolicyDecision(
+                    harness=harness,
+                    scope=scope,
+                    action="allow",
+                    artifact_id=_optional_string(item.get("artifactId")),
+                    workspace=workspace,
+                    publisher=_optional_string(item.get("publisher")),
+                    reason=_optional_string(item.get("reason")),
+                    owner=_optional_string(item.get("owner")),
+                    source="cloud-sync",
+                    expires_at=_normalized_timestamp_string(item.get("expiresAt")),
+                )
+            )
     team_policy_pack = payload.get("teamPolicyPack")
     if isinstance(team_policy_pack, dict):
         policy_name = _optional_string(team_policy_pack.get("name")) or "team policy"

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1142,6 +1142,7 @@ def sync_receipts(
     receipts_stored_total = 0
     advisories_payload: list[dict[str, object]] = []
     exceptions_payload: list[dict[str, object]] = []
+    exceptions_sync_payload_provided = False
     policy_payload: dict[str, object] | None = None
     policy_bundle_payload: dict[str, object] | None = None
     policy_bundle_sync_payload: dict[str, object] | None = None
@@ -1221,8 +1222,10 @@ def sync_receipts(
         if isinstance(team_policy_pack, dict) and (team_policy_pack or team_policy_pack_payload is None):
             team_policy_pack_payload = team_policy_pack
         exceptions = payload.get("exceptions")
-        if isinstance(exceptions, list):
-            exceptions_payload.extend(item for item in exceptions if isinstance(item, dict))
+        if "exceptions" in payload:
+            exceptions_sync_payload_provided = True
+            if isinstance(exceptions, list):
+                exceptions_payload.extend(item for item in exceptions if isinstance(item, dict))
         remote_decisions.update(_build_remote_policy_decisions(payload))
     now = _sync_timestamp(payload)
     persisted_cursor_rowid = latest_uploaded_rowid if latest_uploaded_rowid is not None else prior_receipt_cursor
@@ -1233,6 +1236,7 @@ def sync_receipts(
     )
     deduped_advisories = _dedupe_sync_payload_items(advisories_payload)
     deduped_exceptions = _dedupe_sync_payload_items(exceptions_payload)
+    sync_exceptions_for_persist = deduped_exceptions if exceptions_sync_payload_provided else None
     advisories_stored = 0
     if deduped_advisories:
         advisories_stored = store.cache_advisories(deduped_advisories, now)
@@ -1351,7 +1355,7 @@ def sync_receipts(
     active_policy_bundle = active_policy_bundle_payload if isinstance(active_policy_bundle_payload, dict) else None
     cloud_exception_items = _persist_cloud_exceptions(
         store,
-        sync_exceptions=deduped_exceptions,
+        sync_exceptions=sync_exceptions_for_persist,
         policy_bundle=active_policy_bundle,
         now=now,
     )
@@ -2066,7 +2070,7 @@ def _persist_cloud_exceptions(
     bundle_hash = non_empty_string(policy_bundle.get("bundleHash")) if isinstance(policy_bundle, dict) else None
     ack_status = non_empty_string(bundle_ack.get("status")) if bundle_ack else None
     items = []
-    if sync_exceptions:
+    if sync_exceptions is not None:
         items.extend(
             build_cloud_exceptions_from_sync_payload(
                 sync_exceptions,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3316,7 +3316,7 @@ class GuardStore:
 
     def list_cloud_exceptions(self, harness: str | None = None) -> list[dict[str, object]]:
         from .cloud_exceptions import (
-            build_cloud_exceptions_from_sync_payload,
+            build_cloud_exceptions_from_stored_items,
             cloud_exception_to_dict,
             list_active_cloud_exceptions,
         )
@@ -3329,10 +3329,9 @@ class GuardStore:
             nested = payload.get("items")
             if isinstance(nested, list):
                 raw_items = [item for item in nested if isinstance(item, dict)]
-        parsed_items = build_cloud_exceptions_from_sync_payload(raw_items)
+        parsed_items = build_cloud_exceptions_from_stored_items(raw_items)
         active_items = list_active_cloud_exceptions(parsed_items, harness=harness)
         return [cloud_exception_to_dict(item) for item in active_items]
-
 
     def delete_sync_payload(self, state_key: str) -> None:
         with self._connect() as connection:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3311,6 +3311,29 @@ class GuardStore:
             return payload
         return None
 
+    def set_cloud_exceptions(self, items: list[dict[str, object]], now: str) -> None:
+        self.set_sync_payload("cloud_exceptions", items, now)
+
+    def list_cloud_exceptions(self, harness: str | None = None) -> list[dict[str, object]]:
+        from .cloud_exceptions import (
+            build_cloud_exceptions_from_sync_payload,
+            cloud_exception_to_dict,
+            list_active_cloud_exceptions,
+        )
+
+        payload = self.get_sync_payload("cloud_exceptions")
+        raw_items: list[dict[str, object]] = []
+        if isinstance(payload, list):
+            raw_items = [item for item in payload if isinstance(item, dict)]
+        elif isinstance(payload, dict):
+            nested = payload.get("items")
+            if isinstance(nested, list):
+                raw_items = [item for item in nested if isinstance(item, dict)]
+        parsed_items = build_cloud_exceptions_from_sync_payload(raw_items)
+        active_items = list_active_cloud_exceptions(parsed_items, harness=harness)
+        return [cloud_exception_to_dict(item) for item in active_items]
+
+
     def delete_sync_payload(self, state_key: str) -> None:
         with self._connect() as connection:
             connection.execute(

--- a/tests/test_guard_cloud_exceptions.py
+++ b/tests/test_guard_cloud_exceptions.py
@@ -2,12 +2,7 @@
 
 from __future__ import annotations
 
-import json
-import threading
-from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
-
-import pytest
 
 from codex_plugin_scanner.guard.cloud_exceptions import (
     build_cloud_exceptions_from_policy_bundle,
@@ -15,7 +10,6 @@ from codex_plugin_scanner.guard.cloud_exceptions import (
     cloud_exception_from_mapping,
     list_active_cloud_exceptions,
 )
-from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
 from codex_plugin_scanner.guard.runtime.runner import _persist_cloud_exceptions
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -104,6 +98,18 @@ def test_policy_bundle_cloud_exceptions_are_loaded(tmp_path: Path) -> None:
     assert items[0].bundle_hash == "sha256:demo"
     _persist_cloud_exceptions(store, policy_bundle=bundle, now="2026-06-13T00:00:00Z")
     assert store.list_cloud_exceptions(harness="codex")
+
+
+def test_empty_sync_payload_preserves_existing_sync_exceptions(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "home")
+    _persist_cloud_exceptions(
+        store,
+        sync_exceptions=[_sample_sync_exception(exception_id="sync:1")],
+        now="2026-06-13T00:00:00Z",
+    )
+    _persist_cloud_exceptions(store, sync_exceptions=[], now="2026-06-13T01:00:00Z")
+    listed = store.list_cloud_exceptions()
+    assert {item["id"] for item in listed} == {"sync:1"}
 
 
 def test_bundle_only_persist_preserves_existing_sync_exceptions(tmp_path: Path) -> None:

--- a/tests/test_guard_cloud_exceptions.py
+++ b/tests/test_guard_cloud_exceptions.py
@@ -100,7 +100,19 @@ def test_policy_bundle_cloud_exceptions_are_loaded(tmp_path: Path) -> None:
     assert store.list_cloud_exceptions(harness="codex")
 
 
-def test_empty_sync_payload_preserves_existing_sync_exceptions(tmp_path: Path) -> None:
+def test_missing_sync_payload_preserves_existing_sync_exceptions(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "home")
+    _persist_cloud_exceptions(
+        store,
+        sync_exceptions=[_sample_sync_exception(exception_id="sync:1")],
+        now="2026-06-13T00:00:00Z",
+    )
+    _persist_cloud_exceptions(store, sync_exceptions=None, now="2026-06-13T01:00:00Z")
+    listed = store.list_cloud_exceptions()
+    assert {item["id"] for item in listed} == {"sync:1"}
+
+
+def test_explicit_empty_sync_payload_clears_sync_exceptions(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "home")
     _persist_cloud_exceptions(
         store,
@@ -108,8 +120,7 @@ def test_empty_sync_payload_preserves_existing_sync_exceptions(tmp_path: Path) -
         now="2026-06-13T00:00:00Z",
     )
     _persist_cloud_exceptions(store, sync_exceptions=[], now="2026-06-13T01:00:00Z")
-    listed = store.list_cloud_exceptions()
-    assert {item["id"] for item in listed} == {"sync:1"}
+    assert store.list_cloud_exceptions() == []
 
 
 def test_bundle_only_persist_preserves_existing_sync_exceptions(tmp_path: Path) -> None:

--- a/tests/test_guard_cloud_exceptions.py
+++ b/tests/test_guard_cloud_exceptions.py
@@ -1,0 +1,112 @@
+"""Cloud exception DTO persistence and API coverage (HGLP046-HGLP060)."""
+
+from __future__ import annotations
+
+import json
+import threading
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.cloud_exceptions import (
+    build_cloud_exceptions_from_policy_bundle,
+    build_cloud_exceptions_from_sync_payload,
+    cloud_exception_from_mapping,
+    list_active_cloud_exceptions,
+)
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.runtime.runner import _persist_cloud_exceptions
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _sample_sync_exception(*, exception_id: str = "artifact:codex:demo") -> dict[str, object]:
+    return {
+        "exceptionId": exception_id,
+        "scope": "artifact",
+        "harness": "codex",
+        "artifactId": "codex:project:demo",
+        "owner": "owner@example.com",
+        "approver": "approver@example.com",
+        "reason": "Temporary allow for demo artifact",
+        "expiresAt": "2099-01-01T00:00:00Z",
+        "sourceReceiptId": "receipt_demo_001",
+    }
+
+
+def test_cloud_exception_dto_includes_required_fields() -> None:
+    parsed = cloud_exception_from_mapping(_sample_sync_exception())
+    assert parsed is not None
+    payload = parsed.to_dict()
+    for key in (
+        "id",
+        "effect",
+        "scope",
+        "harness",
+        "owner",
+        "approver",
+        "expiry",
+        "source_receipt_id",
+        "bundle_hash",
+        "ack_status",
+        "last_used_at",
+    ):
+        assert key in payload
+
+
+def test_expired_cloud_exceptions_are_not_active() -> None:
+    expired = cloud_exception_from_mapping(
+        {
+            **_sample_sync_exception(exception_id="expired:1"),
+            "expiresAt": "2020-01-01T00:00:00Z",
+        }
+    )
+    assert expired is not None
+    active = list_active_cloud_exceptions([expired], now="2026-01-01T00:00:00+00:00")
+    assert active == []
+
+
+def test_persist_cloud_exceptions_stores_separate_from_policy_decisions(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "home")
+    serialized = _persist_cloud_exceptions(
+        store,
+        sync_exceptions=[_sample_sync_exception()],
+        now="2026-06-13T00:00:00Z",
+    )
+    assert len(serialized) == 1
+    listed = store.list_cloud_exceptions()
+    assert len(listed) == 1
+    assert listed[0]["id"] == "artifact:codex:demo"
+    assert listed[0]["last_used_at"] is None
+    policy_rows = store.list_policy_decisions()
+    assert all(row.get("source") != "cloud-sync" for row in policy_rows)
+
+
+def test_policy_bundle_cloud_exceptions_are_loaded(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "home")
+    bundle = {
+        "bundleHash": "sha256:demo",
+        "cloudExceptions": [
+            {
+                "exceptionId": "bundle:1",
+                "effect": "allow",
+                "scope": "harness",
+                "harness": "codex",
+                "owner": "owner@example.com",
+                "expiresAt": "2099-01-01T00:00:00Z",
+            }
+        ],
+        "acknowledgements": [],
+    }
+    items = build_cloud_exceptions_from_policy_bundle(bundle, device_id="device-1")
+    assert len(items) == 1
+    assert items[0].bundle_hash == "sha256:demo"
+    _persist_cloud_exceptions(store, policy_bundle=bundle, now="2026-06-13T00:00:00Z")
+    assert store.list_cloud_exceptions(harness="codex")
+
+
+def test_sync_payload_builder_deduplicates_by_id() -> None:
+    items = build_cloud_exceptions_from_sync_payload(
+        [_sample_sync_exception(), _sample_sync_exception(exception_id="artifact:codex:other")]
+    )
+    assert len(items) == 2

--- a/tests/test_guard_cloud_exceptions.py
+++ b/tests/test_guard_cloud_exceptions.py
@@ -149,6 +149,41 @@ def test_bundle_only_persist_preserves_existing_sync_exceptions(tmp_path: Path) 
     assert {item["id"] for item in listed} == {"sync:1", "bundle:1"}
 
 
+def test_bundle_update_replaces_stale_bundle_exceptions(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "home")
+    bundle_v1 = {
+        "bundleHash": "sha256:v1",
+        "cloudExceptions": [
+            {
+                "exceptionId": "bundle:1",
+                "effect": "allow",
+                "scope": "harness",
+                "harness": "codex",
+                "owner": "owner@example.com",
+                "expiresAt": "2099-01-01T00:00:00Z",
+            }
+        ],
+        "acknowledgements": [],
+    }
+    _persist_cloud_exceptions(store, policy_bundle=bundle_v1, now="2026-06-13T00:00:00Z")
+    bundle_v2 = {
+        "bundleHash": "sha256:v2",
+        "cloudExceptions": [
+            {
+                "exceptionId": "bundle:2",
+                "effect": "allow",
+                "scope": "harness",
+                "harness": "codex",
+                "owner": "owner@example.com",
+                "expiresAt": "2099-01-01T00:00:00Z",
+            }
+        ],
+        "acknowledgements": [],
+    }
+    _persist_cloud_exceptions(store, policy_bundle=bundle_v2, now="2026-06-13T01:00:00Z")
+    assert {item["id"] for item in store.list_cloud_exceptions()} == {"bundle:2"}
+
+
 def test_sync_payload_builder_deduplicates_by_id() -> None:
     items = build_cloud_exceptions_from_sync_payload(
         [_sample_sync_exception(), _sample_sync_exception(exception_id="artifact:codex:other")]

--- a/tests/test_guard_cloud_exceptions.py
+++ b/tests/test_guard_cloud_exceptions.py
@@ -66,7 +66,7 @@ def test_expired_cloud_exceptions_are_not_active() -> None:
     assert active == []
 
 
-def test_persist_cloud_exceptions_stores_separate_from_policy_decisions(tmp_path: Path) -> None:
+def test_persist_cloud_exceptions_stores_dto_in_sync_state(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "home")
     serialized = _persist_cloud_exceptions(
         store,
@@ -78,8 +78,9 @@ def test_persist_cloud_exceptions_stores_separate_from_policy_decisions(tmp_path
     assert len(listed) == 1
     assert listed[0]["id"] == "artifact:codex:demo"
     assert listed[0]["last_used_at"] is None
-    policy_rows = store.list_policy_decisions()
-    assert all(row.get("source") != "cloud-sync" for row in policy_rows)
+    stored = store.get_sync_payload("cloud_exceptions")
+    assert isinstance(stored, list)
+    assert len(stored) == 1
 
 
 def test_policy_bundle_cloud_exceptions_are_loaded(tmp_path: Path) -> None:

--- a/tests/test_guard_cloud_exceptions.py
+++ b/tests/test_guard_cloud_exceptions.py
@@ -106,6 +106,32 @@ def test_policy_bundle_cloud_exceptions_are_loaded(tmp_path: Path) -> None:
     assert store.list_cloud_exceptions(harness="codex")
 
 
+def test_bundle_only_persist_preserves_existing_sync_exceptions(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "home")
+    _persist_cloud_exceptions(
+        store,
+        sync_exceptions=[_sample_sync_exception(exception_id="sync:1")],
+        now="2026-06-13T00:00:00Z",
+    )
+    bundle = {
+        "bundleHash": "sha256:demo",
+        "cloudExceptions": [
+            {
+                "exceptionId": "bundle:1",
+                "effect": "allow",
+                "scope": "harness",
+                "harness": "codex",
+                "owner": "owner@example.com",
+                "expiresAt": "2099-01-01T00:00:00Z",
+            }
+        ],
+        "acknowledgements": [],
+    }
+    _persist_cloud_exceptions(store, policy_bundle=bundle, now="2026-06-13T01:00:00Z")
+    listed = store.list_cloud_exceptions()
+    assert {item["id"] for item in listed} == {"sync:1", "bundle:1"}
+
+
 def test_sync_payload_builder_deduplicates_by_id() -> None:
     items = build_cloud_exceptions_from_sync_payload(
         [_sample_sync_exception(), _sample_sync_exception(exception_id="artifact:codex:other")]

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -2431,3 +2431,38 @@ def test_headless_generic_action_error_omits_unstructured_detail() -> None:
             "retryable": True,
         },
     }
+
+
+def test_policy_cloud_exceptions_endpoint(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.runtime.runner import _persist_cloud_exceptions
+
+    store = GuardStore(tmp_path / "guard-home")
+    _persist_cloud_exceptions(
+        store,
+        sync_exceptions=[
+            {
+                "exceptionId": "artifact:codex:demo",
+                "scope": "artifact",
+                "harness": "codex",
+                "owner": "owner@example.com",
+                "expiresAt": "2099-01-01T00:00:00Z",
+            }
+        ],
+        now="2026-06-13T00:00:00Z",
+    )
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(daemon.port, "/v1/policy", method="GET", token=token),
+        )
+        assert status == 200
+        assert len(payload["cloud_exceptions"]) == 1
+        dedicated_status, dedicated_payload = _read_json_response(
+            _request(daemon.port, "/v1/policy/cloud-exceptions", method="GET", token=token),
+        )
+        assert dedicated_status == 200
+        assert dedicated_payload["items"][0]["id"] == "artifact:codex:demo"
+    finally:
+        daemon.stop()


### PR DESCRIPTION
## Summary
- Add a dedicated Cloud exception DTO with sync storage separate from local policy decisions.
- Extend `GET /v1/policy` with a `cloud_exceptions` field and add `GET /v1/policy/cloud-exceptions`.
- Validate optional `cloudExceptions` entries in signed policy bundles and expose them through the daemon API.

## Testing
- `python3 -m pytest tests/test_guard_cloud_exceptions.py tests/test_guard_headless_daemon_api.py::test_policy_cloud_exceptions_endpoint -q`
- `pnpm exec tsx src/policy-cloud-exceptions-boundary.test.ts`
