### PR TITLE
fix(guard): emit foreign_shim_bypass in shim status bypasses

### DIFF
--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -577,11 +577,7 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         if exists and bool(path_status.get("shim_precedes_real")):
             protected_managers.append(manager)
         elif exists:
-            bypass_reason = (
-                "foreign_shim_bypass"
-                if bool(path_status.get("foreign_shim_bypass"))
-                else "path_inactive"
-            )
+            bypass_reason = "foreign_shim_bypass" if bool(path_status.get("foreign_shim_bypass")) else "path_inactive"
             bypasses.append(
                 {
                     "manager": manager,

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -577,10 +577,15 @@ def package_shim_status(context: HarnessContext) -> dict[str, object]:
         if exists and bool(path_status.get("shim_precedes_real")):
             protected_managers.append(manager)
         elif exists:
+            bypass_reason = (
+                "foreign_shim_bypass"
+                if bool(path_status.get("foreign_shim_bypass"))
+                else "path_inactive"
+            )
             bypasses.append(
                 {
                     "manager": manager,
-                    "reason": "path_inactive",
+                    "reason": bypass_reason,
                 }
             )
     profile_status = _package_shim_profile_status(context)

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -834,7 +834,7 @@ def test_guard_package_shim_status_reports_foreign_shim_bypass(
     assert status_payload["bypasses"] == [
         {
             "manager": "npm",
-            "reason": "path_inactive",
+            "reason": "foreign_shim_bypass",
         }
     ]
     npm_detail = next(


### PR DESCRIPTION
## Summary
- Emit `foreign_shim_bypass` in package shim status bypass telemetry for foreign PATH shims

## Testing
- `python3 -m pytest tests/test_guard_package_shims.py::test_guard_package_shim_status_reports_foreign_shim_bypass -q`
