### PR TITLE
feat(guard): index local skill security

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -13,6 +13,7 @@ from typing import Literal
 
 from .adapters.base import HarnessContext
 from .consumer import detect_all
+from .inventory_cisco import run_cisco_inventory_scans
 from .inventory_contract import (
     GuardAgentInventorySnapshot,
     extract_aibom_metadata_extensions,
@@ -29,6 +30,16 @@ AibomExportFormat = Literal["json", "markdown"]
 class AibomCliOptions:
     include_symlinks: bool = True
     follow_unsafe_symlinks: bool = False
+    cisco_skill_scan: str = "off"
+    cisco_mcp_scan: str = "off"
+    cisco_timeout_seconds: float | None = None
+
+
+_AIBOM_CLOUD_SYNC_OPTIONS = AibomCliOptions(
+    cisco_skill_scan="auto",
+    cisco_mcp_scan="auto",
+    cisco_timeout_seconds=30.0,
+)
 
 
 def collect_aibom_snapshots(
@@ -42,12 +53,21 @@ def collect_aibom_snapshots(
     for detection in detect_all(context):
         if not detection.installed and not detection.artifacts:
             continue
+        cisco_runs = run_cisco_inventory_scans(
+            harness=str(getattr(detection, "harness", "unknown")),
+            context=context,
+            detection=detection,
+            mcp_mode=resolved.cisco_mcp_scan,
+            skill_mode=resolved.cisco_skill_scan,
+            timeout_seconds=resolved.cisco_timeout_seconds,
+        )
         snapshots.append(
             inventory_snapshot_from_detection(
                 detection,
                 generated_at=generated_at,
                 home_dir=context.home_dir,
                 workspace_dir=context.workspace_dir,
+                cisco_runs=cisco_runs,
                 include_symlinks=resolved.include_symlinks,
                 follow_unsafe_symlinks=resolved.follow_unsafe_symlinks,
             )
@@ -279,7 +299,12 @@ def sync_aibom_snapshots(
     if workspace_id is None:
         raise GuardSyncNotConfiguredError("Guard Cloud workspace is not configured. Run `hol-guard connect` first.")
 
-    snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
+    resolved_options = options or _AIBOM_CLOUD_SYNC_OPTIONS
+    snapshots = collect_aibom_snapshots(
+        context,
+        generated_at=generated_at,
+        options=resolved_options,
+    )
     if not snapshots:
         synced_at = generated_at
         summary = {

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import Literal
 
 from ..checks.skill_security import resolve_skill_security_context
-from ..models import ScanOptions
+from ..models import ScanOptions, Severity
 from ..trust_instruction_scoring import build_instruction_domain
 from ..trust_mcp_scoring import build_mcp_domain, build_mcp_surface_domain
 from ..trust_models import TrustAdapterScore, TrustComponentScore, TrustDomainScore
@@ -116,9 +116,167 @@ def apply_local_trust_metadata(
         )
     )
 
+    local_security = _local_skill_security_for_artifact(
+        artifact,
+        item_kind=item_kind,
+        metadata=metadata,
+        captured_at=captured_at,
+        cisco_runs=cisco_runs,
+        workspace_dir=workspace_dir,
+    )
+    if local_security is not None:
+        enriched["localSecurity"] = local_security
+
     if trust_layers:
         enriched["trustLayers"] = _merge_trust_layers(metadata.get("trustLayers"), trust_layers)
     return enriched
+
+
+def _local_skill_security_for_artifact(
+    artifact: object,
+    *,
+    item_kind: InventoryItemKind,
+    metadata: dict[str, object],
+    captured_at: str,
+    cisco_runs: tuple[object, ...],
+    workspace_dir: Path | None,
+) -> dict[str, object] | None:
+    from .inventory_contract import _normalize_inventory_datetime
+
+    if item_kind != "skill" or metadata.get("artifactType") != "skill":
+        return None
+
+    trust_root = _trust_root_for_artifact(artifact, item_kind=item_kind, workspace_dir=workspace_dir)
+    if trust_root is None:
+        return None
+
+    run = next(
+        (
+            candidate
+            for candidate in cisco_runs
+            if getattr(candidate, "source", None) == "cisco-skill-scanner"
+            and _matches_skill_cisco_run(
+                artifact,
+                item_kind=item_kind,
+                run=candidate,
+                workspace_dir=workspace_dir,
+            )
+        ),
+        None,
+    )
+    if run is None:
+        return None
+
+    status = str(getattr(run, "status", "unknown"))
+    normalized_captured_at = _normalize_inventory_datetime(captured_at)
+    findings = _local_skill_security_findings(run, skill_root=trust_root)
+    severity_counts = _cisco_severity_counts(run)
+    score = _cisco_layer_score(severity_counts) if status == "enabled" else None
+    safety = None
+    if score is not None:
+        safety = {
+            "score": score,
+            "label": _local_skill_security_label(score),
+            "findingsTotal": len(findings),
+            "highFindings": sum(1 for finding in findings if finding["severity"] == "high"),
+            "scriptsTotal": _local_skill_scripts_total(run),
+            "permissionsMissing": [],
+        }
+
+    run_metadata = getattr(run, "metadata", None)
+    metadata_payload: dict[str, object] = {
+        "scannerSource": str(getattr(run, "source", "unknown")),
+        "message": str(getattr(run, "message", "")),
+        "findingsBySeverity": severity_counts,
+        "totalFindings": len(findings),
+    }
+    duration_ms = getattr(run, "duration_ms", None)
+    if isinstance(duration_ms, int):
+        metadata_payload["durationMs"] = duration_ms
+    if isinstance(run_metadata, dict):
+        for key in ("analyzersUsed", "policyName", "mode", "skillsScanned", "skillsSkipped"):
+            value = run_metadata.get(key)
+            if value is not None:
+                metadata_payload[key] = value
+
+    return {
+        "entityType": "skill",
+        "source": "local_indexed",
+        "provider": "cisco-skill-scanner",
+        "status": status,
+        "capturedAt": normalized_captured_at,
+        "safety": safety,
+        "findings": findings,
+        "metadata": metadata_payload,
+    }
+
+
+def _local_skill_security_findings(
+    run: object,
+    *,
+    skill_root: Path,
+) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    for finding in tuple(getattr(run, "findings", ()) or ()):
+        file_path = getattr(finding, "file_path", None)
+        if isinstance(file_path, str) and file_path.strip():
+            path = Path(file_path)
+            if not _paths_related(skill_root, path):
+                continue
+            try:
+                relative_file = str(path.resolve().relative_to(skill_root.resolve()))
+            except ValueError:
+                relative_file = path.name
+        else:
+            relative_file = "SKILL.md"
+
+        results.append(
+            {
+                "ruleId": str(getattr(finding, "rule_id", "unknown")),
+                "severity": _local_skill_security_severity(getattr(finding, "severity", None)),
+                "file": relative_file,
+                "message": _local_skill_security_message(finding),
+            }
+        )
+    return results
+
+
+def _local_skill_security_severity(value: object) -> str:
+    severity = value.value if isinstance(value, Severity) else str(value).lower()
+    if severity in {"critical", "high"}:
+        return "high"
+    if severity == "medium":
+        return "medium"
+    return "low"
+
+
+def _local_skill_security_message(finding: object) -> str:
+    description = getattr(finding, "description", None)
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+    title = getattr(finding, "title", None)
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return "Skill security finding"
+
+
+def _local_skill_security_label(score: int) -> str:
+    if score >= 90:
+        return "safe"
+    if score >= 70:
+        return "review"
+    if score >= 45:
+        return "caution"
+    return "unsafe"
+
+
+def _local_skill_scripts_total(run: object) -> int:
+    metadata = getattr(run, "metadata", None)
+    if isinstance(metadata, dict):
+        value = metadata.get("skillsScanned")
+        if isinstance(value, int):
+            return max(0, value)
+    return 0
 
 
 def _local_trust_domain_for_artifact(

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -147,6 +147,7 @@ _IGNORED_TREE_DIR_NAMES = {".git", ".hg", ".svn", "__pycache__", ".mypy_cache", 
 _MAX_FINGERPRINT_FILE_BYTES = 1024 * 1024
 _AIBOM_METADATA_KEYS = (
     "instructionRole",
+    "localSecurity",
     "registryIdentity",
     "sourceLinks",
     "sourceOfTruth",

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import json
+from email.message import Message
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.inventory_cisco import CiscoInventoryRun
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.store import GuardStore
@@ -316,7 +320,7 @@ def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(
             url="https://hol.test/api/v1/guard/events",
             code=404,
             msg="Not Found",
-            hdrs=None,
+            hdrs=Message(),
             fp=None,
         )
 
@@ -342,6 +346,130 @@ def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(
     assert guard_events_summary.get("events") == 12
     assert isinstance(aibom_backoff, dict)
     assert aibom_backoff.get("sync_reason") == "guard_events_endpoint_unavailable"
+
+
+def test_collect_aibom_snapshots_passes_cisco_runs(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    skill_path = workspace_dir / ".agents" / "skills" / "demo" / "SKILL.md"
+    _write_text(skill_path, "---\ndescription: demo\n---\n")
+
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(skill_path),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:global:skill:.agents/skills:demo",
+                name="demo",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_path),
+                metadata={"skill_root": ".agents/skills"},
+            ),
+        ),
+        warnings=(),
+    )
+    context = HarnessContext(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard",
+    )
+    observed: dict[str, object] = {}
+    cisco_runs = (
+        CiscoInventoryRun(
+            source="cisco-skill-scanner",
+            status="enabled",
+            message="ok",
+            findings=(),
+            duration_ms=12,
+            metadata={"skillsScanned": 1},
+        ),
+    )
+
+    monkeypatch.setattr(aibom_cli, "detect_all", lambda _context: [detection])
+
+    def fake_run_cisco_inventory_scans(**kwargs: object) -> tuple[object, ...]:
+        observed["cisco_kwargs"] = kwargs
+        return cisco_runs
+
+    def fake_inventory_snapshot_from_detection(*args: object, **kwargs: object) -> object:
+        observed["snapshot_kwargs"] = kwargs
+        return object()
+
+    monkeypatch.setattr(aibom_cli, "run_cisco_inventory_scans", fake_run_cisco_inventory_scans)
+    monkeypatch.setattr(
+        aibom_cli,
+        "inventory_snapshot_from_detection",
+        fake_inventory_snapshot_from_detection,
+    )
+
+    snapshots = aibom_cli.collect_aibom_snapshots(
+        context,
+        generated_at="2026-06-10T12:00:00+00:00",
+    )
+
+    assert len(snapshots) == 1
+    assert observed["cisco_kwargs"] == {
+        "harness": "codex",
+        "context": context,
+        "detection": detection,
+        "mcp_mode": "off",
+        "skill_mode": "off",
+        "timeout_seconds": None,
+    }
+    snapshot_kwargs = observed["snapshot_kwargs"]
+    assert isinstance(snapshot_kwargs, dict)
+    assert snapshot_kwargs["cisco_runs"] == cisco_runs
+
+
+def test_sync_aibom_snapshots_uses_cloud_sync_cisco_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard",
+    )
+    observed: dict[str, object] = {}
+
+    def fake_collect_aibom_snapshots(*args: object, **kwargs: object) -> tuple[object, ...]:
+        observed["collect_kwargs"] = kwargs
+        return ()
+
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", fake_collect_aibom_snapshots)
+
+    summary = sync_aibom_snapshots(
+        store,
+        context,
+        generated_at="2026-06-10T12:00:00+00:00",
+        auth_context={
+            "sync_url": "https://hol.test/api/v1/guard/events",
+            "token": "test-token",
+        },
+    )
+
+    assert summary["accepted"] == 0
+    collect_kwargs = observed["collect_kwargs"]
+    assert isinstance(collect_kwargs, dict)
+    options = collect_kwargs["options"]
+    assert isinstance(options, aibom_cli.AibomCliOptions)
+    assert options.cisco_skill_scan == "auto"
+    assert options.cisco_mcp_scan == "auto"
+    assert options.cisco_timeout_seconds == 30.0
 
 
 def test_aibom_export_json_includes_redaction_report(tmp_path: Path, capsys) -> None:

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -336,6 +336,7 @@ def test_inventory_snapshot_attaches_cisco_skill_trust_layer(tmp_path: Path) -> 
     )
     skill_item = next(item for item in snapshot.items if item.item_kind == "skill")
     trust_layers = skill_item.metadata.get("trustLayers")
+    local_security = skill_item.metadata.get("localSecurity")
     encoded = json.dumps(serialize_inventory_snapshot(snapshot), sort_keys=True)
 
     assert isinstance(trust_layers, list)
@@ -343,6 +344,17 @@ def test_inventory_snapshot_attaches_cisco_skill_trust_layer(tmp_path: Path) -> 
         layer for layer in trust_layers if isinstance(layer, dict) and layer.get("layerType") == "cisco_skill_scanner"
     )
     assert cisco_layer.get("trustScore") == 88
+    assert isinstance(local_security, dict)
+    assert local_security.get("entityType") == "skill"
+    assert local_security.get("provider") == "cisco-skill-scanner"
+    safety = local_security.get("safety")
+    assert isinstance(safety, dict)
+    assert safety.get("score") == 88
+    assert safety.get("label") == "review"
+    findings = local_security.get("findings")
+    assert isinstance(findings, list)
+    assert findings[0].get("severity") == "high"
+    assert findings[0].get("file") == "SKILL.md"
     assert str(skill_dir) not in encoded
 
 


### PR DESCRIPTION
## Summary
- run Cisco inventory scans on the cloud AIBOM sync path and carry the resulting scanner runs into snapshot construction
- emit top-level skill `localSecurity` metadata with registry-shaped safety summary and normalized findings for local indexed skills

## Testing
- `pytest -q tests/test_guard_aibom_cli.py tests/test_guard_inventory_contract.py tests/test_guard_aibom_trust_metadata.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/aibom_cli.py src/codex_plugin_scanner/guard/aibom_trust_metadata.py src/codex_plugin_scanner/guard/inventory_contract.py tests/test_guard_aibom_cli.py tests/test_guard_inventory_contract.py tests/test_guard_aibom_trust_metadata.py`

## Notes
- this keeps baseline trust scoring fast while enriching the cloud sync path with richer local skill security data for Guard Protect
