### PR TITLE
feat: sync approval queue through cloud commands

### DIFF
--- a/src/codex_plugin_scanner/guard/cloud_exceptions.py
+++ b/src/codex_plugin_scanner/guard/cloud_exceptions.py
@@ -154,9 +154,13 @@ def cloud_exception_from_mapping(
         bundle_hash=resolved_bundle_hash,
         ack_status=resolved_ack,  # type: ignore[arg-type]
         last_used_at=last_used_at,
-        rejection_reason=_non_empty_string(item.get("rejectionReason") or item.get("rejection_reason"))
-        or rejection_reason,
-        provenance=provenance if provenance in {"receipt-sync", "policy-bundle"} else "receipt-sync",  # type: ignore[arg-type]
+        rejection_reason=(
+            _non_empty_string(item.get("rejectionReason") or item.get("rejection_reason"))
+            or rejection_reason
+        ),
+        provenance=(
+            provenance if provenance in {"receipt-sync", "policy-bundle"} else "receipt-sync"
+        ),  # type: ignore[arg-type]
     )
 
 

--- a/src/codex_plugin_scanner/guard/cloud_exceptions.py
+++ b/src/codex_plugin_scanner/guard/cloud_exceptions.py
@@ -155,12 +155,9 @@ def cloud_exception_from_mapping(
         ack_status=resolved_ack,  # type: ignore[arg-type]
         last_used_at=last_used_at,
         rejection_reason=(
-            _non_empty_string(item.get("rejectionReason") or item.get("rejection_reason"))
-            or rejection_reason
+            _non_empty_string(item.get("rejectionReason") or item.get("rejection_reason")) or rejection_reason
         ),
-        provenance=(
-            provenance if provenance in {"receipt-sync", "policy-bundle"} else "receipt-sync"
-        ),  # type: ignore[arg-type]
+        provenance=(provenance if provenance in {"receipt-sync", "policy-bundle"} else "receipt-sync"),  # type: ignore[arg-type]
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -232,7 +232,9 @@ def _execute_approval_operation(
             "failureMessage": f"Unsupported approval operation: {operation}",
         }
     action = _optional_string(payload.get("action"))
-    local_request_id = _optional_string(payload.get("localRequestId")) or _optional_string(payload.get("local_request_id"))
+    local_request_id = _optional_string(payload.get("localRequestId")) or _optional_string(
+        payload.get("local_request_id")
+    )
     if action not in {"allow_once", "block", "policy_sync"} or local_request_id is None:
         raise ValueError("invalid_approval_payload")
     if action == "policy_sync":
@@ -268,7 +270,9 @@ def _execute_policy_sync(
     target = policy_memory.get("target")
     target_payload = target if isinstance(target, dict) else {}
     harness = _optional_string(payload.get("harness")) or _optional_string(target_payload.get("harness"))
-    artifact_id = _optional_string(target_payload.get("artifactId")) or _optional_string(target_payload.get("artifact_id"))
+    artifact_id = _optional_string(target_payload.get("artifactId")) or _optional_string(
+        target_payload.get("artifact_id")
+    )
     if harness is None or artifact_id is None:
         raise ValueError("missing_policy_target")
     scope = _local_policy_scope(_optional_string(policy_memory.get("scope")))

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -20,6 +20,7 @@ from ..local_supply_chain import (
     managed_install_audit_workspace_dirs,
     resolve_supply_chain_audit_workspace_dir,
 )
+from ..models import PolicyDecision
 from ..package_shim_status import record_package_shim_audit_result
 from ..runtime.runner import sync_supply_chain_bundle
 from ..shims import (
@@ -46,7 +47,11 @@ APP_OPERATIONS: tuple[str, ...] = (
     "guard.app.connect",
     "guard.app.remove",
 )
-SUPPORTED_COMMAND_OPERATIONS: tuple[str, ...] = (*PACKAGE_SHIM_OPERATIONS, *APP_OPERATIONS)
+APPROVAL_OPERATIONS: tuple[str, ...] = (
+    "guard.approval.resolve",
+    "guard.localRequests.snapshot",
+)
+SUPPORTED_COMMAND_OPERATIONS: tuple[str, ...] = (*PACKAGE_SHIM_OPERATIONS, *APP_OPERATIONS, *APPROVAL_OPERATIONS)
 COMMAND_OPERATION_SCHEMA_VERSIONS: dict[str, int] = {operation: 1 for operation in SUPPORTED_COMMAND_OPERATIONS}
 
 
@@ -74,6 +79,13 @@ def execute_guard_command_job(
                 operation,
                 payload=payload,
                 context=context,
+                store=store,
+                generated_at=generated_at,
+            )
+        if operation in APPROVAL_OPERATIONS:
+            return _execute_approval_operation(
+                operation,
+                payload=payload,
                 store=store,
                 generated_at=generated_at,
             )
@@ -203,6 +215,117 @@ def _execute_app_operation(
         "failureCode": "unsupported_operation",
         "failureMessage": f"Unsupported app operation: {operation}",
     }
+
+
+def _execute_approval_operation(
+    operation: str,
+    *,
+    payload: dict[str, object],
+    store: GuardStore,
+    generated_at: str,
+) -> dict[str, object]:
+    if operation == "guard.localRequests.snapshot":
+        return _result({"requests": _local_request_snapshot_items(store)}, generated_at=generated_at)
+    if operation != "guard.approval.resolve":
+        return {
+            "failureCode": "unsupported_operation",
+            "failureMessage": f"Unsupported approval operation: {operation}",
+        }
+    action = _optional_string(payload.get("action"))
+    local_request_id = _optional_string(payload.get("localRequestId")) or _optional_string(payload.get("local_request_id"))
+    if action not in {"allow_once", "block", "policy_sync"} or local_request_id is None:
+        raise ValueError("invalid_approval_payload")
+    if action == "policy_sync":
+        return _execute_policy_sync(payload, store=store, generated_at=generated_at)
+    resolution_action = "allow" if action == "allow_once" else "block"
+    result = store.resolve_request_with_queue_result(
+        local_request_id,
+        resolution_action=resolution_action,
+        resolution_scope=_optional_string(payload.get("scope")) or "artifact",
+        reason=_optional_string(payload.get("reason")) or "Guard Cloud approval command",
+        resolved_at=generated_at,
+    )
+    return _result(
+        {
+            "action": action,
+            "localRequestId": local_request_id,
+            "resolution": result,
+            "status": "completed" if result.get("resolved") is True else "not_resolved",
+        },
+        generated_at=generated_at,
+    )
+
+
+def _execute_policy_sync(
+    payload: dict[str, object],
+    *,
+    store: GuardStore,
+    generated_at: str,
+) -> dict[str, object]:
+    policy_memory = payload.get("policyMemory") or payload.get("policy_memory")
+    if not isinstance(policy_memory, dict):
+        raise ValueError("missing_policy_memory")
+    target = policy_memory.get("target")
+    target_payload = target if isinstance(target, dict) else {}
+    harness = _optional_string(payload.get("harness")) or _optional_string(target_payload.get("harness"))
+    artifact_id = _optional_string(target_payload.get("artifactId")) or _optional_string(target_payload.get("artifact_id"))
+    if harness is None or artifact_id is None:
+        raise ValueError("missing_policy_target")
+    scope = _local_policy_scope(_optional_string(policy_memory.get("scope")))
+    decision = PolicyDecision(
+        harness=harness,
+        scope=scope,
+        action="allow",
+        artifact_id=artifact_id,
+        artifact_hash=None,
+        workspace=_optional_string(target_payload.get("workspaceId")) if scope == "workspace" else None,
+        publisher=None,
+        reason=_optional_string(policy_memory.get("reason")) or "Guard Cloud policy memory sync",
+        source="cloud-sync",
+        expires_at=_optional_string(policy_memory.get("expiry")),
+    )
+    store.upsert_policy(decision, generated_at)
+    return _result(
+        {
+            "action": "policy_sync",
+            "decision": decision.to_dict(),
+            "localRequestId": _optional_string(payload.get("localRequestId")),
+            "status": "completed",
+        },
+        generated_at=generated_at,
+    )
+
+
+def _local_policy_scope(scope: str | None) -> str:
+    if scope in {"workspace", "team", "policy", "machine", "project"}:
+        return "workspace"
+    if scope == "item":
+        return "artifact"
+    return scope or "artifact"
+
+
+def _local_request_snapshot_items(store: GuardStore) -> list[dict[str, object]]:
+    items: list[dict[str, object]] = []
+    for status in ("pending", "resolved"):
+        for item in store.list_approval_requests(status=status, limit=100):
+            request_id = item.get("request_id")
+            if not isinstance(request_id, str) or not request_id:
+                continue
+            created_at = str(item.get("created_at") or _now())
+            last_seen_at = str(item.get("last_seen_at") or created_at)
+            resolved_at = item.get("resolved_at")
+            items.append(
+                {
+                    "localRequestId": request_id,
+                    "requestKind": str(item.get("harness") or "guard-review"),
+                    "requestPayload": dict(item),
+                    "localStatus": str(item.get("status") or status),
+                    "firstSeenAt": created_at,
+                    "lastSeenAt": last_seen_at,
+                    "resolvedAt": str(resolved_at) if isinstance(resolved_at, str) and resolved_at else None,
+                }
+            )
+    return items[:200]
 
 
 def _package_shim_context(

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -235,10 +235,12 @@ def _execute_approval_operation(
     local_request_id = _optional_string(payload.get("localRequestId")) or _optional_string(
         payload.get("local_request_id")
     )
-    if action not in {"allow_once", "block", "policy_sync"} or local_request_id is None:
+    if action not in {"allow_once", "block", "policy_sync"}:
         raise ValueError("invalid_approval_payload")
     if action == "policy_sync":
         return _execute_policy_sync(payload, store=store, generated_at=generated_at)
+    if local_request_id is None:
+        raise ValueError("invalid_approval_payload")
     resolution_action = "allow" if action == "allow_once" else "block"
     result = store.resolve_request_with_queue_result(
         local_request_id,
@@ -301,6 +303,7 @@ def _execute_policy_sync(
 
 
 def _local_policy_scope(scope: str | None) -> str:
+    """Map Cloud policy scopes onto the narrower local policy model."""
     if scope in {"workspace", "team", "policy", "machine", "project"}:
         return "workspace"
     if scope == "item":

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -308,7 +308,7 @@ def _local_policy_scope(scope: str | None) -> str:
         return "workspace"
     if scope == "item":
         return "artifact"
-    return scope or "artifact"
+    return "artifact"
 
 
 def _local_request_snapshot_items(store: GuardStore) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -17,9 +17,9 @@ from ..store import GuardStore
 from .command_executors import (
     COMMAND_OPERATION_SCHEMA_VERSIONS,
     SUPPORTED_COMMAND_OPERATIONS,
+    _local_request_snapshot_items,
     command_job_operation,
     execute_guard_command_job,
-    _local_request_snapshot_items,
 )
 from .runner import (
     GuardSyncAuthorizationExpiredError,

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -192,9 +192,34 @@ def _lease_payload(store: GuardStore) -> dict[str, object]:
             "operations": list(SUPPORTED_COMMAND_OPERATIONS),
             "schemaVersions": dict(COMMAND_OPERATION_SCHEMA_VERSIONS),
         },
+        "localRequestsSnapshot": _local_requests_snapshot(store),
         "maxJobs": 1,
         "waitMs": _env_int(COMMAND_QUEUE_LEASE_WAIT_MS_ENV, _DEFAULT_LEASE_WAIT_MS),
     }
+
+
+def _local_requests_snapshot(store: GuardStore) -> dict[str, object]:
+    requests: list[dict[str, object]] = []
+    for status in ("pending", "resolved"):
+        for item in store.list_approval_requests(status=status, limit=100):
+            request_id = item.get("request_id")
+            if not isinstance(request_id, str) or not request_id:
+                continue
+            created_at = str(item.get("created_at") or _now())
+            last_seen_at = str(item.get("last_seen_at") or created_at)
+            resolved_at = item.get("resolved_at")
+            requests.append(
+                {
+                    "localRequestId": request_id,
+                    "requestKind": str(item.get("harness") or "guard-review"),
+                    "requestPayload": dict(item),
+                    "localStatus": str(item.get("status") or status),
+                    "firstSeenAt": created_at,
+                    "lastSeenAt": last_seen_at,
+                    "resolvedAt": str(resolved_at) if isinstance(resolved_at, str) and resolved_at else None,
+                }
+            )
+    return {"requests": requests[:200]}
 
 
 def _job_id(job: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -193,10 +193,18 @@ def _lease_payload(store: GuardStore) -> dict[str, object]:
             "operations": list(SUPPORTED_COMMAND_OPERATIONS),
             "schemaVersions": dict(COMMAND_OPERATION_SCHEMA_VERSIONS),
         },
-        "localRequestsSnapshot": {"requests": _local_request_snapshot_items(store)},
+        "localRequestsSnapshot": _local_requests_snapshot(store),
         "maxJobs": 1,
         "waitMs": _env_int(COMMAND_QUEUE_LEASE_WAIT_MS_ENV, _DEFAULT_LEASE_WAIT_MS),
     }
+
+
+def _local_requests_snapshot(store: GuardStore) -> dict[str, object]:
+    try:
+        return {"requests": _local_request_snapshot_items(store)}
+    except Exception as exc:
+        _LOGGER.warning("Guard command local request snapshot failed: %s", _redacted_error(exc))
+        return {"requests": []}
 
 
 def _job_id(job: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -19,6 +19,7 @@ from .command_executors import (
     SUPPORTED_COMMAND_OPERATIONS,
     command_job_operation,
     execute_guard_command_job,
+    _local_request_snapshot_items,
 )
 from .runner import (
     GuardSyncAuthorizationExpiredError,
@@ -192,34 +193,10 @@ def _lease_payload(store: GuardStore) -> dict[str, object]:
             "operations": list(SUPPORTED_COMMAND_OPERATIONS),
             "schemaVersions": dict(COMMAND_OPERATION_SCHEMA_VERSIONS),
         },
-        "localRequestsSnapshot": _local_requests_snapshot(store),
+        "localRequestsSnapshot": {"requests": _local_request_snapshot_items(store)},
         "maxJobs": 1,
         "waitMs": _env_int(COMMAND_QUEUE_LEASE_WAIT_MS_ENV, _DEFAULT_LEASE_WAIT_MS),
     }
-
-
-def _local_requests_snapshot(store: GuardStore) -> dict[str, object]:
-    requests: list[dict[str, object]] = []
-    for status in ("pending", "resolved"):
-        for item in store.list_approval_requests(status=status, limit=100):
-            request_id = item.get("request_id")
-            if not isinstance(request_id, str) or not request_id:
-                continue
-            created_at = str(item.get("created_at") or _now())
-            last_seen_at = str(item.get("last_seen_at") or created_at)
-            resolved_at = item.get("resolved_at")
-            requests.append(
-                {
-                    "localRequestId": request_id,
-                    "requestKind": str(item.get("harness") or "guard-review"),
-                    "requestPayload": dict(item),
-                    "localStatus": str(item.get("status") or status),
-                    "firstSeenAt": created_at,
-                    "lastSeenAt": last_seen_at,
-                    "resolvedAt": str(resolved_at) if isinstance(resolved_at, str) and resolved_at else None,
-                }
-            )
-    return {"requests": requests[:200]}
 
 
 def _job_id(job: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1355,10 +1355,10 @@ def sync_receipts(
     active_policy_bundle = active_policy_bundle_payload if isinstance(active_policy_bundle_payload, dict) else None
     cloud_exception_items = _persist_cloud_exceptions(
         store,
+        device_id=device_id,
         sync_exceptions=sync_exceptions_for_persist,
         policy_bundle=active_policy_bundle,
         now=now,
-        device_id=device_id,
     )
     remote_policies_stored = len(remote_decisions)
     remote_policy_sync_blocked = False
@@ -2061,10 +2061,10 @@ def sync_pain_signals(
 def _persist_cloud_exceptions(
     store: GuardStore,
     *,
+    device_id: str | None = None,
     sync_exceptions: list[dict[str, object]] | None = None,
     policy_bundle: dict[str, object] | None = None,
     now: str,
-    device_id: str | None = None,
 ) -> list[dict[str, object]]:
     resolved_device_id = device_id
     if resolved_device_id is None:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -126,6 +126,64 @@ def test_poll_once_leases_heartbeats_executes_and_posts_result(
     assert "machineInstallationId" not in calls[3][2]
 
 
+def test_poll_once_continues_when_local_request_snapshot_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    class BrokenSnapshotStore(FakeStore):
+        def list_approval_requests(
+            self,
+            *,
+            status: str | None = "pending",
+            harness: str | None = None,
+            limit: int | None = 50,
+            cursor: str | None = None,
+            search: str | None = None,
+        ) -> list[dict[str, object]]:
+            del status, harness, limit, cursor, search
+            raise OSError("approval store locked")
+
+    store = BrokenSnapshotStore(tmp_path / "guard-home")
+    calls: list[tuple[str, str, dict[str, object]]] = []
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
+    )
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        calls.append((method, path, payload))
+        if path == "/lease":
+            return {
+                "item": {
+                    "id": "job-1",
+                    "leaseId": "lease-1",
+                    "operation": "guard.packageShims.status",
+                }
+            }
+        return {"ok": True}
+
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+    monkeypatch.setattr(
+        command_executors,
+        "package_shim_status",
+        lambda context: {"active_managers": []},
+    )
+
+    status = command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    assert status["state"] == "idle"
+    assert calls[0][0:2] == ("POST", "/lease")
+    assert calls[0][2]["localRequestsSnapshot"] == {"requests": []}
+    assert calls[-1][0:2] == ("POST", "/job-1/result")
+
+
 def test_poll_once_persists_result_retry_when_result_upload_fails(
     tmp_path: Path,
     monkeypatch,

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -651,3 +651,36 @@ def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
             "2026-06-13T00:00:00+00:00",
         )
     ]
+
+
+def test_executor_maps_unknown_cloud_policy_scope_to_artifact(tmp_path: Path) -> None:
+    class PolicyStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.upserts: list[dict[str, object]] = []
+
+        def upsert_policy(self, decision: object, generated_at: str) -> None:
+            del generated_at
+            self.upserts.append(decision.to_dict())
+
+    store = PolicyStore(tmp_path / "guard-home")
+    command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.approval.resolve",
+            "payload": {
+                "action": "policy_sync",
+                "policyMemory": {
+                    "scope": "global",
+                    "target": {
+                        "artifactId": "pkg:npm/react",
+                        "harness": "package-install",
+                    },
+                },
+            },
+        },
+        context=_context(tmp_path),
+        store=store,  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert store.upserts[0]["scope"] == "artifact"

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -598,3 +598,56 @@ def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:
             "resolved_at": "2026-06-13T00:00:00+00:00",
         }
     ]
+
+
+def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
+    class PolicyStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.upserts: list[tuple[dict[str, object], str]] = []
+
+        def upsert_policy(self, decision: object, generated_at: str) -> None:
+            self.upserts.append((decision.to_dict(), generated_at))
+
+    store = PolicyStore(tmp_path / "guard-home")
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.approval.resolve",
+            "payload": {
+                "action": "policy_sync",
+                "policyMemory": {
+                    "scope": "workspace",
+                    "reason": "approved in cloud",
+                    "target": {
+                        "artifactId": "pkg:npm/react",
+                        "harness": "package-install",
+                        "workspaceId": "workspace-1",
+                    },
+                },
+            },
+        },
+        context=_context(tmp_path),
+        store=store,  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["data"]["status"] == "completed"
+    assert result["data"]["localRequestId"] is None
+    assert store.upserts == [
+        (
+            {
+                "harness": "package-install",
+                "scope": "workspace",
+                "action": "allow",
+                "artifact_id": "pkg:npm/react",
+                "artifact_hash": None,
+                "workspace": "workspace-1",
+                "publisher": None,
+                "reason": "approved in cloud",
+                "owner": None,
+                "source": "cloud-sync",
+                "expires_at": None,
+            },
+            "2026-06-13T00:00:00+00:00",
+        )
+    ]

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -38,6 +38,18 @@ class FakeStore:
             "workspace_id": "workspace-1",
         }
 
+    def list_approval_requests(
+        self,
+        *,
+        status: str | None = "pending",
+        harness: str | None = None,
+        limit: int | None = 50,
+        cursor: str | None = None,
+        search: str | None = None,
+    ) -> list[dict[str, object]]:
+        del status, harness, limit, cursor, search
+        return []
+
 
 def _context(tmp_path: Path) -> HarnessContext:
     return HarnessContext(
@@ -98,6 +110,7 @@ def test_poll_once_leases_heartbeats_executes_and_posts_result(
                 "operations": list(command_executors.SUPPORTED_COMMAND_OPERATIONS),
                 "schemaVersions": dict(command_executors.COMMAND_OPERATION_SCHEMA_VERSIONS),
             },
+            "localRequestsSnapshot": {"requests": []},
             "maxJobs": 1,
             "waitMs": 25000,
         },
@@ -537,12 +550,51 @@ def test_executor_dispatches_app_connect(tmp_path: Path, monkeypatch) -> None:
     assert isinstance(result["data"], dict)
 
 
-def test_executor_rejects_approval_resolve_until_inbox_phase(tmp_path: Path) -> None:
+def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:
+    class ApprovalStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.resolved: list[dict[str, object]] = []
+
+        def resolve_request_with_queue_result(
+            self,
+            request_id: str,
+            *,
+            resolution_action: str,
+            resolution_scope: str,
+            reason: str | None,
+            resolved_at: str,
+        ) -> dict[str, object]:
+            self.resolved.append(
+                {
+                    "request_id": request_id,
+                    "resolution_action": resolution_action,
+                    "resolution_scope": resolution_scope,
+                    "reason": reason,
+                    "resolved_at": resolved_at,
+                }
+            )
+            return {"resolved": True, "resolved_request": {"request_id": request_id}}
+
+    store = ApprovalStore(tmp_path / "guard-home")
     result = command_executors.execute_guard_command_job(
-        {"operation": "guard.approval.resolve", "payload": {"requestId": "request-1", "action": "allow_once"}},
+        {
+            "operation": "guard.approval.resolve",
+            "payload": {"localRequestId": "request-1", "action": "allow_once", "scope": "artifact"},
+        },
         context=_context(tmp_path),
-        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        store=store,  # type: ignore[arg-type]
         now=lambda: "2026-06-13T00:00:00+00:00",
     )
 
-    assert result["failureCode"] == "unsupported_operation"
+    assert result["generatedAt"] == "2026-06-13T00:00:00+00:00"
+    assert result["data"]["status"] == "completed"
+    assert store.resolved == [
+        {
+            "request_id": "request-1",
+            "resolution_action": "allow",
+            "resolution_scope": "artifact",
+            "reason": "Guard Cloud approval command",
+            "resolved_at": "2026-06-13T00:00:00+00:00",
+        }
+    ]


### PR DESCRIPTION
## Summary

include local pending/resolved approval snapshots in command queue lease polling\n- advertise and execute guard.approval.resolve and guard.localRequests.snapshot operations\n- resolve local approval queue requests from Cloud command jobs and cover the flow in command queue tests

## Validation
-python3 -m pytest tests/test_guard_command_queue.py -q - python3 -m py_compile src/codex_plugin_scanner/guard/runtime/command_executors.py src/codex_plugin_scanner/guard/runtime/command_queue.py