### PR TITLE
fix(dashboard): inline approval step for supply-chain audit recovery sync

### DIFF
--- a/dashboard/src/approval-proof-inline.tsx
+++ b/dashboard/src/approval-proof-inline.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef } from "react";
+import type { ChangeEvent, KeyboardEvent } from "react";
+import { HiMiniKey } from "react-icons/hi2";
+import { ActionButton } from "./approval-center-primitives";
+import type { GuardApprovalGatePublicConfig } from "./guard-types";
+
+type ApprovalProofInlineProps = {
+  approvalGate: GuardApprovalGatePublicConfig | null;
+  approvalPassword: string;
+  approvalTotpCode: string;
+  error: string | null;
+  submitLabel: string;
+  submitBusy: boolean;
+  onApprovalPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onApprovalTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onSubmit: () => void;
+  onBack: () => void;
+};
+
+export function ApprovalProofInline(props: ApprovalProofInlineProps) {
+  const passwordRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      passwordRef.current?.focus();
+    }, 50);
+    return () => window.clearTimeout(timer);
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        props.onSubmit();
+      }
+    },
+    [props.onSubmit],
+  );
+
+  const submitDisabled =
+    props.submitBusy ||
+    props.approvalPassword.trim() === "" ||
+    (props.approvalGate?.totp_enabled === true && props.approvalTotpCode.trim() === "");
+
+  return (
+    <div className="space-y-5" onKeyDown={handleKeyDown}>
+      <div className="rounded-xl border border-brand-blue/20 bg-brand-blue/[0.04] px-4 py-4">
+        <div className="flex items-start gap-3">
+          <span className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-brand-blue/10">
+            <HiMiniKey className="h-5 w-5 text-brand-blue" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <h3 className="text-sm font-semibold text-brand-dark">Approval proof required</h3>
+            <p className="mt-1 text-sm leading-relaxed text-slate-600">
+              Enter your local approval password before Guard syncs supply-chain intel on this device.
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="space-y-3">
+        <label className="block">
+          <span className="text-sm font-semibold text-brand-dark">Approval password</span>
+          <input
+            ref={passwordRef}
+            type="password"
+            autoComplete="current-password"
+            value={props.approvalPassword}
+            onChange={props.onApprovalPasswordChange}
+            className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          />
+        </label>
+        {props.approvalGate?.totp_enabled === true ? (
+          <label className="block">
+            <span className="text-sm font-semibold text-brand-dark">Authenticator code</span>
+            <input
+              type="text"
+              inputMode="numeric"
+              pattern="[0-9]*"
+              autoComplete="one-time-code"
+              value={props.approvalTotpCode}
+              onChange={props.onApprovalTotpCodeChange}
+              className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+            />
+          </label>
+        ) : null}
+      </div>
+
+      {props.error !== null ? (
+        <p className="text-sm text-brand-attention" role="alert">
+          {props.error}
+        </p>
+      ) : null}
+
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
+        <ActionButton variant="primary" onClick={props.onSubmit} disabled={submitDisabled}>
+          {props.submitLabel}
+        </ActionButton>
+        <ActionButton variant="outline" onClick={props.onBack} disabled={props.submitBusy}>
+          Go back
+        </ActionButton>
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/approval-proof-inline.tsx
+++ b/dashboard/src/approval-proof-inline.tsx
@@ -1,8 +1,49 @@
 import { useCallback, useEffect, useRef } from "react";
-import type { ChangeEvent, KeyboardEvent } from "react";
+import type { ChangeEvent, KeyboardEvent, RefObject } from "react";
 import { HiMiniKey } from "react-icons/hi2";
 import { ActionButton } from "./approval-center-primitives";
 import type { GuardApprovalGatePublicConfig } from "./guard-types";
+
+type ApprovalProofFieldInputsProps = {
+  approvalGate: GuardApprovalGatePublicConfig | null;
+  approvalPassword: string;
+  approvalTotpCode: string;
+  passwordRef?: RefObject<HTMLInputElement | null>;
+  onApprovalPasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
+  onApprovalTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
+};
+
+export function ApprovalProofFieldInputs(props: ApprovalProofFieldInputsProps) {
+  return (
+    <div className="space-y-3">
+      <label className="block">
+        <span className="text-sm font-semibold text-brand-dark">Approval password</span>
+        <input
+          ref={props.passwordRef}
+          type="password"
+          autoComplete="current-password"
+          value={props.approvalPassword}
+          onChange={props.onApprovalPasswordChange}
+          className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+        />
+      </label>
+      {props.approvalGate?.totp_enabled === true ? (
+        <label className="block">
+          <span className="text-sm font-semibold text-brand-dark">Authenticator code</span>
+          <input
+            type="text"
+            inputMode="numeric"
+            pattern="[0-9]*"
+            autoComplete="one-time-code"
+            value={props.approvalTotpCode}
+            onChange={props.onApprovalTotpCodeChange}
+            className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+          />
+        </label>
+      ) : null}
+    </div>
+  );
+}
 
 type ApprovalProofInlineProps = {
   approvalGate: GuardApprovalGatePublicConfig | null;
@@ -58,33 +99,14 @@ export function ApprovalProofInline(props: ApprovalProofInlineProps) {
         </div>
       </div>
 
-      <div className="space-y-3">
-        <label className="block">
-          <span className="text-sm font-semibold text-brand-dark">Approval password</span>
-          <input
-            ref={passwordRef}
-            type="password"
-            autoComplete="current-password"
-            value={props.approvalPassword}
-            onChange={props.onApprovalPasswordChange}
-            className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-          />
-        </label>
-        {props.approvalGate?.totp_enabled === true ? (
-          <label className="block">
-            <span className="text-sm font-semibold text-brand-dark">Authenticator code</span>
-            <input
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              autoComplete="one-time-code"
-              value={props.approvalTotpCode}
-              onChange={props.onApprovalTotpCodeChange}
-              className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-            />
-          </label>
-        ) : null}
-      </div>
+      <ApprovalProofFieldInputs
+        approvalGate={props.approvalGate}
+        approvalPassword={props.approvalPassword}
+        approvalTotpCode={props.approvalTotpCode}
+        passwordRef={passwordRef}
+        onApprovalPasswordChange={props.onApprovalPasswordChange}
+        onApprovalTotpCodeChange={props.onApprovalTotpCodeChange}
+      />
 
       {props.error !== null ? (
         <p className="text-sm text-brand-attention" role="alert">

--- a/dashboard/src/approval-proof-inline.tsx
+++ b/dashboard/src/approval-proof-inline.tsx
@@ -27,20 +27,20 @@ export function ApprovalProofInline(props: ApprovalProofInlineProps) {
     return () => window.clearTimeout(timer);
   }, []);
 
-  const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
-      if (event.key === "Enter") {
-        event.preventDefault();
-        props.onSubmit();
-      }
-    },
-    [props.onSubmit],
-  );
-
   const submitDisabled =
     props.submitBusy ||
     props.approvalPassword.trim() === "" ||
     (props.approvalGate?.totp_enabled === true && props.approvalTotpCode.trim() === "");
+
+  const handleKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "Enter" && !submitDisabled) {
+        event.preventDefault();
+        props.onSubmit();
+      }
+    },
+    [props.onSubmit, submitDisabled],
+  );
 
   return (
     <div className="space-y-5" onKeyDown={handleKeyDown}>

--- a/dashboard/src/approval-proof-modal.tsx
+++ b/dashboard/src/approval-proof-modal.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 import type { ChangeEvent } from "react";
 import { ActionButton, SectionLabel } from "./approval-center-primitives";
+import { ApprovalProofFieldInputs } from "./approval-proof-inline";
 import type { GuardApprovalGatePublicConfig } from "./guard-types";
 
 type ApprovalProofModalProps = {
@@ -41,33 +42,15 @@ export function ApprovalProofModal(props: ApprovalProofModalProps) {
         <SectionLabel>Approval required</SectionLabel>
         <h2 className="mt-2 text-base font-semibold text-brand-dark">{title}</h2>
         <p className="mt-1 text-sm text-slate-500">{detail}</p>
-        <label className="mt-4 block">
-          <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
-            Approval password
-          </span>
-          <input
-            type="password"
-            value={password}
-            onChange={handlePasswordChange}
-            autoComplete="current-password"
-            className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+        <div className="mt-4">
+          <ApprovalProofFieldInputs
+            approvalGate={approvalGate}
+            approvalPassword={password}
+            approvalTotpCode={totpCode}
+            onApprovalPasswordChange={handlePasswordChange}
+            onApprovalTotpCodeChange={handleTotpChange}
           />
-        </label>
-        {approvalGate?.totp_enabled === true && (
-          <label className="mt-3 block">
-            <span className="text-xs font-semibold uppercase tracking-[0.15em] text-slate-500">
-              Authenticator code
-            </span>
-            <input
-              type="text"
-              inputMode="numeric"
-              pattern="[0-9]*"
-              value={totpCode}
-              onChange={handleTotpChange}
-              className="mt-1 min-h-10 w-full rounded-lg border border-slate-200 bg-white px-3 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-            />
-          </label>
-        )}
+        </div>
         <div className="mt-5 flex justify-end gap-2">
           <ActionButton variant="outline" onClick={onCancel}>
             Cancel

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -13,7 +13,8 @@ import {
   parseDecisionV2,
   readGuardToken,
   runPackageFirewallAction,
-	  startPackageFirewallConnect,
+  runPackageSync,
+  startPackageFirewallConnect,
 	  runAuditRemediation,
 	  resolveRequestWithQueueResult,
 	  retryResume,
@@ -972,6 +973,60 @@ assert(firewallError instanceof GuardHarnessActionError, "L079db: runPackageFire
 assert(
   firewallError instanceof GuardHarnessActionError && firewallError.payload?.error === "approval_gate_required",
   "L079db: runPackageFirewallAction preserves daemon error code for approval modal fallback"
+);
+
+installGuardWindow("?guard-token=token-sync&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+const syncCalls = installFetchStub({
+  "/v1/supply-chain/sync": {
+    entitlement: { allowed: true },
+    operation: "sync",
+    receipt: null,
+    result: { synced: true },
+    status: "completed",
+  },
+});
+const syncAction = await runPackageSync({
+  approval_password: "local-password",
+  approval_totp_code: "654321",
+});
+const syncBody = JSON.parse(String(syncCalls[0].init?.body)) as Record<string, unknown>;
+assert(
+  syncCalls[0].url === "http://127.0.0.1:4781/v1/supply-chain/sync",
+  "L079dc: runPackageSync posts to the sync route",
+);
+assert(
+  headerValue(syncCalls[0].init, "X-Guard-Dashboard-Session") === "token-sync",
+  "L079dc: runPackageSync sends dashboard session token",
+);
+assert(syncBody["approval_password"] === "local-password", "L079dc: runPackageSync sends approval password");
+assert(syncBody["approval_totp_code"] === "654321", "L079dc: runPackageSync sends approval TOTP code");
+assert(syncAction.operation === "sync", "L079dc: runPackageSync normalizes response");
+
+installGuardWindow("?guard-token=token-sync&guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");
+globalThis.fetch = async (input: RequestInfo | URL): Promise<Response> => {
+  const url = input instanceof Request ? input.url : String(input);
+  const parsed = new URL(url, "http://127.0.0.1:4174");
+  if (parsed.pathname === "/v1/supply-chain/sync") {
+    return new Response(
+      JSON.stringify({
+        error: "approval_gate_required",
+        message: "Approval password is required.",
+      }),
+      { status: 403, headers: { "Content-Type": "application/json" } },
+    );
+  }
+  return new Response(JSON.stringify({ error: "not_found" }), { status: 404 });
+};
+let syncError: unknown = null;
+try {
+  await runPackageSync();
+} catch (error) {
+  syncError = error;
+}
+assert(syncError instanceof GuardHarnessActionError, "L079dd: runPackageSync throws GuardHarnessActionError on structured failures");
+assert(
+  syncError instanceof GuardHarnessActionError && syncError.payload?.error === "approval_gate_required",
+  "L079dd: runPackageSync preserves daemon error code for inline approval fallback",
 );
 
 installGuardWindow("?guardDaemon=http%3A%2F%2F127.0.0.1%3A4781");

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2642,14 +2642,24 @@ export async function runPackageAudit(input?: {
   return normalizePackageFirewallAction(payloadBody);
 }
 
-export async function runPackageSync(): Promise<PackageFirewallActionResponse> {
+export async function runPackageSync(credentials?: {
+  approval_password?: string;
+  approval_totp_code?: string;
+}): Promise<PackageFirewallActionResponse> {
   const response = await fetchGuardApi("/v1/supply-chain/sync", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       ...guardAuthHeaders(),
     },
-    body: JSON.stringify({}),
+    body: JSON.stringify({
+      ...(credentials?.approval_password !== undefined
+        ? { approval_password: credentials.approval_password }
+        : {}),
+      ...(credentials?.approval_totp_code !== undefined
+        ? { approval_totp_code: credentials.approval_totp_code }
+        : {}),
+    }),
   });
   const payloadBody = (await response.json().catch(() => null)) as unknown;
   if (!response.ok) {

--- a/dashboard/src/supply-chain-audit-recovery-modal.tsx
+++ b/dashboard/src/supply-chain-audit-recovery-modal.tsx
@@ -1,4 +1,5 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
+import type { ChangeEvent } from "react";
 import {
   HiMiniArrowPath,
   HiMiniArrowTopRightOnSquare,
@@ -6,9 +7,10 @@ import {
   HiMiniCloudArrowDown,
   HiMiniShieldCheck,
 } from "react-icons/hi2";
+import { ApprovalProofInline } from "./approval-proof-inline";
 import { ActionButton, Tag } from "./approval-center-primitives";
 import { GuardModalLayer } from "./guard-modal-layer";
-import type { PackageFirewallStatusResponse } from "./guard-types";
+import type { GuardApprovalGatePublicConfig, PackageFirewallStatusResponse } from "./guard-types";
 import { ConnectFlowCard } from "./supply-chain-firewall-views";
 import type { SupplyChainAuditRecoveryGate } from "./supply-chain-audit-recovery";
 
@@ -17,6 +19,7 @@ export type AuditRecoveryModalPhase =
   | "syncing"
   | "connecting"
   | "auditing"
+  | "approval"
   | "failed";
 
 type AuditRecoveryModalProps = {
@@ -26,9 +29,15 @@ type AuditRecoveryModalProps = {
   connectError: string | null;
   connectStarting: boolean;
   connectFlow: PackageFirewallStatusResponse["connect_flow"];
+  approvalGate: GuardApprovalGatePublicConfig | null;
   onClose: () => void;
   onPrimaryAction: () => void;
   onStartConnect: () => void;
+  onApprovalSubmit: (credentials: {
+    approval_password?: string;
+    approval_totp_code?: string;
+  }) => void;
+  onApprovalBack: () => void;
 };
 
 function resolvePhaseLabel(phase: AuditRecoveryModalPhase): string {
@@ -40,6 +49,9 @@ function resolvePhaseLabel(phase: AuditRecoveryModalPhase): string {
   }
   if (phase === "auditing") {
     return "Running audit";
+  }
+  if (phase === "approval") {
+    return "Approval required";
   }
   if (phase === "failed") {
     return "Needs attention";
@@ -96,7 +108,7 @@ function resolveActiveStepIndex(
   if (phase === "auditing") {
     return gate.steps.length;
   }
-  if (phase === "syncing") {
+  if (phase === "syncing" || phase === "approval") {
     return gate.obstacle === "cloud_auth" ? 2 : 1;
   }
   if (phase === "connecting") {
@@ -112,15 +124,29 @@ export function AuditRecoveryModal({
   connectError,
   connectStarting,
   connectFlow,
+  approvalGate,
   onClose,
   onPrimaryAction,
   onStartConnect,
+  onApprovalSubmit,
+  onApprovalBack,
 }: AuditRecoveryModalProps) {
+  const [approvalPassword, setApprovalPassword] = useState("");
+  const [approvalTotpCode, setApprovalTotpCode] = useState("");
+
+  useEffect(() => {
+    if (phase !== "approval") {
+      setApprovalPassword("");
+      setApprovalTotpCode("");
+    }
+  }, [phase]);
+
   const activeStep = resolveActiveStepIndex(gate, phase);
   const primaryBusy = phase === "syncing" || phase === "connecting" || phase === "auditing";
   const PrimaryIcon = resolvePrimaryIcon(gate, phase);
   const showConnectFlow =
     gate.primaryAction === "connect" && connectFlow !== null && phase !== "auditing";
+  const showApprovalStep = phase === "approval";
 
   const handlePrimaryClick = useCallback(() => {
     if (primaryBusy) {
@@ -128,6 +154,21 @@ export function AuditRecoveryModal({
     }
     onPrimaryAction();
   }, [onPrimaryAction, primaryBusy]);
+
+  const handleApprovalPasswordChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setApprovalPassword(event.target.value);
+  }, []);
+
+  const handleApprovalTotpCodeChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setApprovalTotpCode(event.target.value);
+  }, []);
+
+  const handleApprovalSubmit = useCallback(() => {
+    onApprovalSubmit({
+      approval_password: approvalPassword,
+      ...(approvalGate?.totp_enabled === true ? { approval_totp_code: approvalTotpCode } : {}),
+    });
+  }, [approvalGate, approvalPassword, approvalTotpCode, onApprovalSubmit]);
 
   return (
     <GuardModalLayer ariaLabel="Finish workspace audit setup" onClose={onClose}>
@@ -168,6 +209,21 @@ export function AuditRecoveryModal({
             detail={gate.detail}
             onStartConnect={onStartConnect}
           />
+        ) : showApprovalStep ? (
+          <div className="px-5 py-5">
+            <ApprovalProofInline
+              approvalGate={approvalGate}
+              approvalPassword={approvalPassword}
+              approvalTotpCode={approvalTotpCode}
+              error={error}
+              submitLabel="Sync supply-chain intel"
+              submitBusy={false}
+              onApprovalPasswordChange={handleApprovalPasswordChange}
+              onApprovalTotpCodeChange={handleApprovalTotpCodeChange}
+              onSubmit={handleApprovalSubmit}
+              onBack={onApprovalBack}
+            />
+          </div>
         ) : (
           <div className="space-y-5 px-5 py-5">
             <ol className="grid gap-3 sm:grid-cols-2">

--- a/dashboard/src/supply-chain-audit-recovery-modal.tsx
+++ b/dashboard/src/supply-chain-audit-recovery-modal.tsx
@@ -136,11 +136,16 @@ export function AuditRecoveryModal({
   const [approvalSubmitting, setApprovalSubmitting] = useState(false);
 
   useEffect(() => {
-    if (phase !== "approval") {
-      setApprovalPassword("");
-      setApprovalTotpCode("");
-      setApprovalSubmitting(false);
+    if (phase === "syncing" || phase === "connecting" || phase === "auditing") {
+      return;
     }
+    if (phase === "approval") {
+      setApprovalSubmitting(false);
+      return;
+    }
+    setApprovalPassword("");
+    setApprovalTotpCode("");
+    setApprovalSubmitting(false);
   }, [phase]);
 
   const activeStep = resolveActiveStepIndex(gate, phase);

--- a/dashboard/src/supply-chain-audit-recovery-modal.tsx
+++ b/dashboard/src/supply-chain-audit-recovery-modal.tsx
@@ -133,11 +133,13 @@ export function AuditRecoveryModal({
 }: AuditRecoveryModalProps) {
   const [approvalPassword, setApprovalPassword] = useState("");
   const [approvalTotpCode, setApprovalTotpCode] = useState("");
+  const [approvalSubmitting, setApprovalSubmitting] = useState(false);
 
   useEffect(() => {
     if (phase !== "approval") {
       setApprovalPassword("");
       setApprovalTotpCode("");
+      setApprovalSubmitting(false);
     }
   }, [phase]);
 
@@ -164,6 +166,7 @@ export function AuditRecoveryModal({
   }, []);
 
   const handleApprovalSubmit = useCallback(() => {
+    setApprovalSubmitting(true);
     onApprovalSubmit({
       approval_password: approvalPassword,
       ...(approvalGate?.totp_enabled === true ? { approval_totp_code: approvalTotpCode } : {}),
@@ -217,7 +220,7 @@ export function AuditRecoveryModal({
               approvalTotpCode={approvalTotpCode}
               error={error}
               submitLabel="Sync supply-chain intel"
-              submitBusy={false}
+              submitBusy={approvalSubmitting}
               onApprovalPasswordChange={handleApprovalPasswordChange}
               onApprovalTotpCodeChange={handleApprovalTotpCodeChange}
               onSubmit={handleApprovalSubmit}

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -337,38 +337,69 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
     setAuditRecoveryPhase((currentPhase) => (currentPhase === "failed" ? "failed" : "ready"));
   }, [runAuditOperation]);
 
-  const runRecoverySync = useCallback(async () => {
-    setAuditRecoveryPhase("syncing");
-    setAuditRecoveryError(null);
-    try {
-      const response = await runPackageSync();
-      setLastCompleted({ op: "sync", manager: null, response });
-      await refreshAfterOp();
-      await onStateChanged?.();
-      if (auditRecoveryGate?.autoRetryAuditAfterPrimary) {
-        await continueAuditAfterRecovery();
-        return;
-      }
-      setAuditRecoveryPhase("ready");
-    } catch (err) {
-      if (isSupplyChainAuditConnectError(err)) {
-        const connectGate = resolveSupplyChainAuditRecoveryGate({
-          audit_status: "incomplete",
-          audit_outcome: "not_connected",
-        });
-        if (connectGate !== null) {
-          setAuditRecoveryGate(connectGate);
+  const runRecoverySync = useCallback(
+    async (credentials?: { approval_password?: string; approval_totp_code?: string }) => {
+      setAuditRecoveryPhase("syncing");
+      setAuditRecoveryError(null);
+      try {
+        const response = await runPackageSync(credentials);
+        setLastCompleted({ op: "sync", manager: null, response });
+        await refreshAfterOp();
+        await onStateChanged?.();
+        if (auditRecoveryGate?.autoRetryAuditAfterPrimary) {
+          await continueAuditAfterRecovery();
+          return;
         }
         setAuditRecoveryPhase("ready");
-        setAuditRecoveryError(null);
-        return;
+      } catch (err) {
+        if (isSupplyChainAuditConnectError(err)) {
+          const connectGate = resolveSupplyChainAuditRecoveryGate({
+            audit_status: "incomplete",
+            audit_outcome: "not_connected",
+          });
+          if (connectGate !== null) {
+            setAuditRecoveryGate(connectGate);
+          }
+          setAuditRecoveryPhase("ready");
+          setAuditRecoveryError(null);
+          return;
+        }
+        if (
+          credentials === undefined &&
+          err instanceof GuardHarnessActionError &&
+          err.payload?.error === "approval_gate_required"
+        ) {
+          await resolveApprovalGate();
+          setAuditRecoveryPhase("approval");
+          setAuditRecoveryError(null);
+          return;
+        }
+        const message = err instanceof Error ? err.message : "Sync failed.";
+        setAuditRecoveryError(message);
+        setAuditRecoveryPhase(credentials === undefined ? "failed" : "approval");
+        setLastFailed({ op: "sync", manager: null, message });
       }
-      const message = err instanceof Error ? err.message : "Sync failed.";
-      setAuditRecoveryError(message);
-      setAuditRecoveryPhase("failed");
-      setLastFailed({ op: "sync", manager: null, message });
-    }
-  }, [auditRecoveryGate, continueAuditAfterRecovery, onStateChanged, refreshAfterOp]);
+    },
+    [
+      auditRecoveryGate,
+      continueAuditAfterRecovery,
+      onStateChanged,
+      refreshAfterOp,
+      resolveApprovalGate,
+    ],
+  );
+
+  const handleRecoveryApprovalBack = useCallback(() => {
+    setAuditRecoveryPhase("ready");
+    setAuditRecoveryError(null);
+  }, []);
+
+  const handleRecoveryApprovalSubmit = useCallback(
+    (credentials: { approval_password?: string; approval_totp_code?: string }) => {
+      void runRecoverySync(credentials);
+    },
+    [runRecoverySync],
+  );
 
   const handleStartConnect = useCallback(async () => {
     setStartingConnect(true);
@@ -774,12 +805,15 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
           connectError={connectError}
           connectStarting={startingConnect}
           connectFlow={panelLoad.phase === "loaded" ? panelLoad.data.connect_flow : null}
+          approvalGate={resolvedApprovalGate}
           onClose={closeAuditRecovery}
           onPrimaryAction={handleRecoveryPrimary}
           onStartConnect={() => {
             setAuditRecoveryPhase("connecting");
             void handleStartConnect();
           }}
+          onApprovalSubmit={handleRecoveryApprovalSubmit}
+          onApprovalBack={handleRecoveryApprovalBack}
         />
       ) : null}
     </div>


### PR DESCRIPTION
## Summary
- Add progressive in-modal approval proof step when supply-chain sync returns `approval_gate_required` during workspace audit recovery
- Reuse inline password and MFA fields in the audit recovery modal, then retry sync and auto-chain the audit

## Testing
- `cd dashboard && pnpm install && pnpm exec tsx src/guard-api.test.ts`
- `cd dashboard && pnpm exec tsx src/supply-chain-audit-recovery.test.ts`
- `cd dashboard && pnpm run build`
