### PR TITLE
fix(guard): scan each skill root individually

### DIFF
--- a/src/codex_plugin_scanner/guard/inventory_cisco.py
+++ b/src/codex_plugin_scanner/guard/inventory_cisco.py
@@ -38,8 +38,8 @@ def run_cisco_inventory_scans(
     if mcp_mode != "off":
         runs.append(_run_mcp_inventory_scan(context=context, mode=mcp_mode, timeout_seconds=timeout_seconds))
     if skill_mode != "off":
-        runs.append(
-            _run_skill_inventory_scan(
+        runs.extend(
+            _run_skill_inventory_scans(
                 harness=harness,
                 context=context,
                 detection=detection,
@@ -95,8 +95,8 @@ def _run_skill_inventory_scan(
     mode: str,
     timeout_seconds: float | None,
 ) -> CiscoInventoryRun:
-    root = _skill_scan_root(harness=harness, context=context, detection=detection)
-    if root is None:
+    roots = _skill_scan_roots(harness=harness, context=context, detection=detection)
+    if not roots:
         return CiscoInventoryRun(
             source="cisco-skill-scanner",
             status="skipped",
@@ -105,6 +105,118 @@ def _run_skill_inventory_scan(
             duration_ms=0,
             metadata={"target": "missing", "skillsScanned": 0, "mode": mode},
         )
+    if len(roots) == 1:
+        return _run_single_skill_inventory_scan(root=roots[0], mode=mode, timeout_seconds=timeout_seconds)
+
+    findings: list[Finding] = []
+    severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
+    analyzers_used: list[str] = []
+    skills_scanned = 0
+    skills_skipped: list[str] = []
+    duration_ms = 0
+    failure_message: str | None = None
+
+    for root in roots:
+        run = _run_single_skill_inventory_scan(root=root, mode=mode, timeout_seconds=timeout_seconds)
+        duration_ms += run.duration_ms
+        metadata = run.metadata if isinstance(run.metadata, dict) else {}
+        for finding in run.findings:
+            findings.append(finding)
+        raw_counts = metadata.get("findingsBySeverity")
+        if isinstance(raw_counts, dict):
+            for key in severity_counts:
+                value = raw_counts.get(key)
+                if isinstance(value, int):
+                    severity_counts[key] += value
+        raw_analyzers = metadata.get("analyzersUsed")
+        if isinstance(raw_analyzers, list):
+            for analyzer in raw_analyzers:
+                if isinstance(analyzer, str) and analyzer and analyzer not in analyzers_used:
+                    analyzers_used.append(analyzer)
+        raw_scanned = metadata.get("skillsScanned")
+        if isinstance(raw_scanned, int):
+            skills_scanned += raw_scanned
+        raw_skipped = metadata.get("skillsSkipped")
+        if isinstance(raw_skipped, list):
+            for entry in raw_skipped:
+                if isinstance(entry, str) and entry:
+                    skills_skipped.append(entry)
+        if run.status in {"failed", "timed_out", "unavailable"}:
+            failure_message = run.message
+            return CiscoInventoryRun(
+                source="cisco-skill-scanner",
+                status=run.status,
+                message=failure_message,
+                findings=tuple(findings),
+                duration_ms=duration_ms,
+                metadata={
+                    "target": str(roots[0].parent),
+                    "skillsScanned": skills_scanned,
+                    "skillsSkipped": tuple(skills_skipped),
+                    "totalFindings": len(findings),
+                    "findingsBySeverity": severity_counts,
+                    "analyzersUsed": tuple(analyzers_used),
+                    "policyName": metadata.get("policyName", "balanced"),
+                    "mode": mode,
+                },
+            )
+
+    return CiscoInventoryRun(
+        source="cisco-skill-scanner",
+        status="enabled",
+        message="Cisco skill scan completed.",
+        findings=tuple(findings),
+        duration_ms=duration_ms,
+        metadata={
+            "target": str(roots[0].parent),
+            "skillsScanned": skills_scanned,
+            "skillsSkipped": tuple(skills_skipped),
+            "totalFindings": len(findings),
+            "findingsBySeverity": severity_counts,
+            "analyzersUsed": tuple(analyzers_used),
+            "policyName": "balanced",
+            "mode": mode,
+            "skillTargets": [str(root) for root in roots],
+        },
+    )
+
+
+def _run_skill_inventory_scans(
+    *,
+    harness: str,
+    context: HarnessContext,
+    detection: object,
+    mode: str,
+    timeout_seconds: float | None,
+) -> tuple[CiscoInventoryRun, ...]:
+    roots = _skill_scan_roots(harness=harness, context=context, detection=detection)
+    if not roots:
+        return (
+            CiscoInventoryRun(
+                source="cisco-skill-scanner",
+                status="skipped",
+                message="No skill directory found; Cisco skill inventory scan skipped.",
+                findings=(),
+                duration_ms=0,
+                metadata={"target": "missing", "skillsScanned": 0, "mode": mode},
+            ),
+        )
+    return tuple(
+        _run_single_skill_inventory_scan(
+            root=root,
+            mode=mode,
+            timeout_seconds=timeout_seconds,
+        )
+        for root in roots
+    )
+
+
+def _run_single_skill_inventory_scan(
+    *,
+    root: Path,
+    mode: str,
+    timeout_seconds: float | None,
+) -> CiscoInventoryRun:
     started = time.perf_counter()
     summary = run_cisco_skill_scan(root, mode=mode, timeout_seconds=timeout_seconds)
     duration_ms = int((time.perf_counter() - started) * 1000)
@@ -115,7 +227,7 @@ def _run_skill_inventory_scan(
         findings=summary.findings,
         duration_ms=duration_ms,
         metadata={
-            "target": root.name,
+            "target": str(root),
             "skillsScanned": summary.skills_scanned,
             "skillsSkipped": summary.skills_skipped,
             "totalFindings": summary.total_findings,
@@ -138,34 +250,67 @@ def _mcp_scan_root(context: HarnessContext) -> Path | None:
     return None
 
 
-def _skill_scan_root(*, harness: str, context: HarnessContext, detection: object) -> Path | None:
+def _skill_scan_roots(*, harness: str, context: HarnessContext, detection: object) -> tuple[Path, ...]:
+    roots: list[Path] = []
+    seen: set[str] = set()
+
     if harness == "hermes":
         hermes_skills = context.home_dir / ".hermes" / "skills"
-        if hermes_skills.is_dir():
-            return hermes_skills
+        _extend_unique_skill_roots(roots, seen, _skill_dirs_under(hermes_skills))
+        if roots:
+            return tuple(roots)
+
     artifacts = tuple(getattr(detection, "artifacts", ()))
     for artifact in artifacts:
         artifact_type = str(getattr(artifact, "artifact_type", ""))
         if artifact_type not in {"skill", "skill_file"}:
             continue
-        metadata = getattr(artifact, "metadata", {})
-        if isinstance(metadata, dict):
-            skill_root = metadata.get("skill_root")
-            if isinstance(skill_root, str):
-                root = Path(skill_root)
-                if root.is_dir():
-                    return root
-        config_path = getattr(artifact, "config_path", None)
-        if not isinstance(config_path, str):
-            continue
-        skill_path = Path(config_path)
-        root = _nearest_skills_root(skill_path)
-        if root is not None and root.is_dir():
-            return root
-        root = _nearest_skill_dir(skill_path)
-        if root is not None and root.is_dir():
-            return root
+        root = _artifact_skill_root(artifact, context=context)
+        if root is not None:
+            resolved = str(root.resolve())
+            if resolved not in seen:
+                seen.add(resolved)
+                roots.append(root)
+    return tuple(roots)
+
+
+def _artifact_skill_root(artifact: object, *, context: HarnessContext) -> Path | None:
+    metadata = getattr(artifact, "metadata", {})
+    if isinstance(metadata, dict):
+        skill_root = metadata.get("skill_root")
+        if isinstance(skill_root, str):
+            for base_dir in (context.workspace_dir, context.home_dir):
+                if base_dir is None:
+                    continue
+                candidate = (base_dir / skill_root).resolve()
+                if candidate.is_dir() and (candidate / "SKILL.md").is_file():
+                    return candidate
+    config_path = getattr(artifact, "config_path", None)
+    if not isinstance(config_path, str):
+        return None
+    skill_path = Path(config_path)
+    root = _nearest_skill_dir(skill_path)
+    if root is not None and root.is_dir():
+        return root
+    if skill_path.is_dir() and (skill_path / "SKILL.md").is_file():
+        return skill_path
     return None
+
+
+def _extend_unique_skill_roots(roots: list[Path], seen: set[str], candidates: tuple[Path, ...]) -> None:
+    for candidate in candidates:
+        resolved = str(candidate.resolve())
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        roots.append(candidate)
+
+
+def _skill_dirs_under(root: Path) -> tuple[Path, ...]:
+    if not root.is_dir():
+        return ()
+    skill_dirs = sorted({path.parent.resolve() for path in root.rglob("SKILL.md") if path.is_file()})
+    return tuple(skill_dirs)
 
 
 def _nearest_skills_root(path: Path) -> Path | None:

--- a/tests/test_guard_inventory_cisco.py
+++ b/tests/test_guard_inventory_cisco.py
@@ -71,8 +71,12 @@ def test_cisco_inventory_scans_report_missing_targets_without_running_dependenci
 
 def test_cisco_inventory_scans_run_mcp_and_skill_scanners_with_required_mode(tmp_path: Path, monkeypatch) -> None:
     context = _ctx(tmp_path)
-    (context.workspace_dir / ".mcp.json").write_text('{"mcpServers": {}}\n')
-    skill_path = context.home_dir / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md"
+    workspace_dir = context.workspace_dir
+    home_dir = context.home_dir
+    assert workspace_dir is not None
+    assert home_dir is not None
+    (workspace_dir / ".mcp.json").write_text('{"mcpServers": {}}\n')
+    skill_path = home_dir / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md"
     skill_path.parent.mkdir(parents=True)
     skill_path.write_text("---\nname: reviewer\n---\nReview local files.\n")
     detection = HarnessDetection(
@@ -132,15 +136,17 @@ def test_cisco_inventory_scans_run_mcp_and_skill_scanners_with_required_mode(tmp
     )
 
     assert [call[0] for call in calls] == ["mcp", "skill"]
-    assert calls[0][1] == context.workspace_dir
-    assert calls[1][1] == context.home_dir / ".hermes" / "skills"
+    assert calls[0][1] == workspace_dir
+    assert calls[1][1] == skill_path.parent
     assert all(call[2] == "on" and call[3] == 3.5 for call in calls)
     assert all(run.status == "enabled" for run in runs)
 
 
 def test_cisco_inventory_scans_preserve_timeout_status(tmp_path: Path, monkeypatch) -> None:
     context = _ctx(tmp_path)
-    (context.workspace_dir / ".mcp.json").write_text('{"mcpServers": {}}\n')
+    workspace_dir = context.workspace_dir
+    assert workspace_dir is not None
+    (workspace_dir / ".mcp.json").write_text('{"mcpServers": {}}\n')
     detection = HarnessDetection(
         harness="openclaw",
         installed=True,
@@ -178,7 +184,9 @@ def test_cisco_inventory_scans_preserve_timeout_status(tmp_path: Path, monkeypat
 
 def test_cisco_inventory_scans_use_detected_nonstandard_skill_roots(tmp_path: Path, monkeypatch) -> None:
     context = _ctx(tmp_path)
-    extra_root = context.home_dir / "shared-openclaw-skills"
+    home_dir = context.home_dir
+    assert home_dir is not None
+    extra_root = home_dir / "shared-openclaw-skills"
     skill_path = extra_root / "reviewer" / "SKILL.md"
     skill_path.parent.mkdir(parents=True)
     skill_path.write_text("---\nname: reviewer\n---\nReview local files.\n")
@@ -225,4 +233,69 @@ def test_cisco_inventory_scans_use_detected_nonstandard_skill_roots(tmp_path: Pa
         skill_mode="on",
     )
 
-    assert calls == [extra_root]
+    assert calls == [skill_path.parent]
+
+
+def test_cisco_inventory_scans_runs_each_detected_skill_root(tmp_path: Path, monkeypatch) -> None:
+    context = _ctx(tmp_path)
+    home_dir = context.home_dir
+    assert home_dir is not None
+    skill_a = home_dir / ".agents" / "skills" / "adapt" / "SKILL.md"
+    skill_b = home_dir / ".agents" / "skills" / "audit" / "SKILL.md"
+    skill_a.parent.mkdir(parents=True)
+    skill_b.parent.mkdir(parents=True)
+    skill_a.write_text("---\nname: adapt\n---\nAdapt layouts.\n")
+    skill_b.write_text("---\nname: audit\n---\nAudit interfaces.\n")
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_a), str(skill_b)),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:skill:adapt",
+                name="adapt",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_a),
+            ),
+            GuardArtifact(
+                artifact_id="codex:skill:audit",
+                name="audit",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_b),
+            ),
+        ),
+    )
+    calls: list[Path] = []
+
+    def fake_skill_scan(skills_dir: Path, mode: str, timeout_seconds: float | None = None) -> _SkillSummary:
+        del mode, timeout_seconds
+        calls.append(skills_dir)
+        return _SkillSummary(
+            status=CiscoIntegrationStatus.ENABLED,
+            message="Skill scanner completed.",
+            findings=(),
+            skills_scanned=1,
+            skills_skipped=(),
+            analyzers_used=("prompt-injection",),
+            policy_name="balanced",
+            total_findings=0,
+            findings_by_severity={severity.value: 0 for severity in Severity},
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.inventory_cisco.run_cisco_skill_scan", fake_skill_scan)
+
+    runs = run_cisco_inventory_scans(
+        harness="codex",
+        context=context,
+        detection=detection,
+        skill_mode="auto",
+    )
+
+    assert [run.source for run in runs] == ["cisco-skill-scanner", "cisco-skill-scanner"]
+    assert calls == [skill_a.parent, skill_b.parent]
+    assert [run.metadata["target"] for run in runs] == [str(skill_a.parent), str(skill_b.parent)]


### PR DESCRIPTION
## Summary
- run Cisco skill inventory scans per actual skill root instead of the parent `skills` container so standalone home/workspace skills can be scanned successfully during cloud AIBOM sync
- preserve the richer local skill security/trust indexing path by recording full root targets for matching while keeping serialized scanner metadata redaction-safe

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/inventory_cisco.py tests/test_guard_inventory_cisco.py`
- `pytest -q tests/test_guard_inventory_cisco.py tests/test_guard_inventory_contract.py tests/test_guard_aibom_trust_metadata.py`

## Notes
- this targets the live production blocker where `cisco-skill-scanner` was failing on `~/.agents/skills` / `.hermes/skills` container roots, leaving top-level skills without `metadata.localSecurity`
