### PR TITLE
fix(guard): enable cloud command polling by default

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -51,7 +51,10 @@ def _now() -> str:
 
 def command_queue_enabled(environ: dict[str, str] | None = None) -> bool:
     source = os.environ if environ is None else environ
-    return source.get(COMMAND_QUEUE_ENABLED_ENV, "").strip().lower() in {"1", "true", "yes", "on"}
+    value = source.get(COMMAND_QUEUE_ENABLED_ENV)
+    if value is None:
+        return True
+    return value.strip().lower() not in {"0", "false", "no", "off"}
 
 
 def _env_float(name: str, default: float) -> float:

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -54,7 +54,13 @@ def command_queue_enabled(environ: dict[str, str] | None = None) -> bool:
     value = source.get(COMMAND_QUEUE_ENABLED_ENV)
     if value is None:
         return True
-    return value.strip().lower() not in {"0", "false", "no", "off"}
+    normalized = value.strip().lower()
+    if normalized in {"1", "true", "yes", "on"}:
+        return True
+    if normalized in {"", "0", "false", "no", "off", "disabled"}:
+        return False
+    _LOGGER.warning("Ignoring unrecognized %s value; command queue disabled.", COMMAND_QUEUE_ENABLED_ENV)
+    return False
 
 
 def _env_float(name: str, default: float) -> float:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.daemon.command_queue_worker import (
@@ -65,11 +67,25 @@ def test_command_queue_enabled_defaults_on(monkeypatch) -> None:
     assert command_queue.command_queue_enabled() is True
 
 
-def test_command_queue_enabled_allows_explicit_opt_out(monkeypatch) -> None:
-    for value in ("0", "false", "no", "off"):
-        monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, value)
+@pytest.mark.parametrize("value", ["1", "true", "yes", "on"])
+def test_command_queue_enabled_allows_explicit_opt_in(value: str, monkeypatch) -> None:
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, value)
 
-        assert command_queue.command_queue_enabled() is False
+    assert command_queue.command_queue_enabled() is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "disabled"])
+def test_command_queue_enabled_allows_explicit_opt_out(value: str, monkeypatch) -> None:
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, value)
+
+    assert command_queue.command_queue_enabled() is False
+
+
+@pytest.mark.parametrize("value", ["garbage", "maybe"])
+def test_command_queue_enabled_disables_unrecognized_explicit_values(value: str, monkeypatch) -> None:
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, value)
+
+    assert command_queue.command_queue_enabled() is False
 
 
 def test_poll_once_leases_heartbeats_executes_and_posts_result(

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -59,6 +59,19 @@ def _context(tmp_path: Path) -> HarnessContext:
     )
 
 
+def test_command_queue_enabled_defaults_on(monkeypatch) -> None:
+    monkeypatch.delenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, raising=False)
+
+    assert command_queue.command_queue_enabled() is True
+
+
+def test_command_queue_enabled_allows_explicit_opt_out(monkeypatch) -> None:
+    for value in ("0", "false", "no", "off"):
+        monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, value)
+
+        assert command_queue.command_queue_enabled() is False
+
+
 def test_poll_once_leases_heartbeats_executes_and_posts_result(
     tmp_path: Path,
     monkeypatch,
@@ -456,7 +469,7 @@ def test_start_worker_replaces_stopped_alive_worker(tmp_path: Path, monkeypatch)
         created_threads.append(thread)
         return thread
 
-    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, "1")
+    monkeypatch.delenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, raising=False)
     monkeypatch.setattr("codex_plugin_scanner.guard.daemon.command_queue_worker.threading.Thread", fake_thread)
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.daemon.command_queue_worker.threading.Event",
@@ -468,6 +481,13 @@ def test_start_worker_replaces_stopped_alive_worker(tmp_path: Path, monkeypatch)
 
     assert worker is not existing
     assert created_threads[0].started is True
+
+
+def test_start_worker_respects_command_queue_opt_out(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, "0")
+
+    assert start_command_queue_worker(store, None) is None  # type: ignore[arg-type]
 
 
 def test_command_queue_loop_backs_off_after_errors(tmp_path: Path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- Enable Guard Cloud command queue polling by default while preserving explicit environment opt-out.
- Add regression coverage for default-on status, opt-out behavior, and daemon worker startup.

## Testing
- `python3 -m pytest tests/test_guard_command_queue.py -q`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/runtime/command_queue.py tests/test_guard_command_queue.py && python3 -m ruff check src/codex_plugin_scanner/guard/runtime/command_queue.py tests/test_guard_command_queue.py`
