### PR TITLE
fix(guard): isolate cisco skill scan subprocess

### DIFF
--- a/src/codex_plugin_scanner/guard/inventory_cisco.py
+++ b/src/codex_plugin_scanner/guard/inventory_cisco.py
@@ -221,6 +221,8 @@ def _skill_dirs_under(root: Path) -> tuple[Path, ...]:
         return ()
     skill_dirs = sorted({path.parent.resolve() for path in root.rglob("SKILL.md") if path.is_file()})
     return tuple(skill_dirs)
+
+
 def _nearest_skill_dir(path: Path) -> Path | None:
     if path.name == "SKILL.md":
         return path.parent

--- a/src/codex_plugin_scanner/guard/inventory_cisco.py
+++ b/src/codex_plugin_scanner/guard/inventory_cisco.py
@@ -87,100 +87,6 @@ def _run_mcp_inventory_scan(
     )
 
 
-def _run_skill_inventory_scan(
-    *,
-    harness: str,
-    context: HarnessContext,
-    detection: object,
-    mode: str,
-    timeout_seconds: float | None,
-) -> CiscoInventoryRun:
-    roots = _skill_scan_roots(harness=harness, context=context, detection=detection)
-    if not roots:
-        return CiscoInventoryRun(
-            source="cisco-skill-scanner",
-            status="skipped",
-            message="No skill directory found; Cisco skill inventory scan skipped.",
-            findings=(),
-            duration_ms=0,
-            metadata={"target": "missing", "skillsScanned": 0, "mode": mode},
-        )
-    if len(roots) == 1:
-        return _run_single_skill_inventory_scan(root=roots[0], mode=mode, timeout_seconds=timeout_seconds)
-
-    findings: list[Finding] = []
-    severity_counts = {"critical": 0, "high": 0, "medium": 0, "low": 0, "info": 0}
-    analyzers_used: list[str] = []
-    skills_scanned = 0
-    skills_skipped: list[str] = []
-    duration_ms = 0
-    failure_message: str | None = None
-
-    for root in roots:
-        run = _run_single_skill_inventory_scan(root=root, mode=mode, timeout_seconds=timeout_seconds)
-        duration_ms += run.duration_ms
-        metadata = run.metadata if isinstance(run.metadata, dict) else {}
-        for finding in run.findings:
-            findings.append(finding)
-        raw_counts = metadata.get("findingsBySeverity")
-        if isinstance(raw_counts, dict):
-            for key in severity_counts:
-                value = raw_counts.get(key)
-                if isinstance(value, int):
-                    severity_counts[key] += value
-        raw_analyzers = metadata.get("analyzersUsed")
-        if isinstance(raw_analyzers, list):
-            for analyzer in raw_analyzers:
-                if isinstance(analyzer, str) and analyzer and analyzer not in analyzers_used:
-                    analyzers_used.append(analyzer)
-        raw_scanned = metadata.get("skillsScanned")
-        if isinstance(raw_scanned, int):
-            skills_scanned += raw_scanned
-        raw_skipped = metadata.get("skillsSkipped")
-        if isinstance(raw_skipped, list):
-            for entry in raw_skipped:
-                if isinstance(entry, str) and entry:
-                    skills_skipped.append(entry)
-        if run.status in {"failed", "timed_out", "unavailable"}:
-            failure_message = run.message
-            return CiscoInventoryRun(
-                source="cisco-skill-scanner",
-                status=run.status,
-                message=failure_message,
-                findings=tuple(findings),
-                duration_ms=duration_ms,
-                metadata={
-                    "target": str(roots[0].parent),
-                    "skillsScanned": skills_scanned,
-                    "skillsSkipped": tuple(skills_skipped),
-                    "totalFindings": len(findings),
-                    "findingsBySeverity": severity_counts,
-                    "analyzersUsed": tuple(analyzers_used),
-                    "policyName": metadata.get("policyName", "balanced"),
-                    "mode": mode,
-                },
-            )
-
-    return CiscoInventoryRun(
-        source="cisco-skill-scanner",
-        status="enabled",
-        message="Cisco skill scan completed.",
-        findings=tuple(findings),
-        duration_ms=duration_ms,
-        metadata={
-            "target": str(roots[0].parent),
-            "skillsScanned": skills_scanned,
-            "skillsSkipped": tuple(skills_skipped),
-            "totalFindings": len(findings),
-            "findingsBySeverity": severity_counts,
-            "analyzersUsed": tuple(analyzers_used),
-            "policyName": "balanced",
-            "mode": mode,
-            "skillTargets": [str(root) for root in roots],
-        },
-    )
-
-
 def _run_skill_inventory_scans(
     *,
     harness: str,
@@ -283,8 +189,12 @@ def _artifact_skill_root(artifact: object, *, context: HarnessContext) -> Path |
                 if base_dir is None:
                     continue
                 candidate = (base_dir / skill_root).resolve()
-                if candidate.is_dir() and (candidate / "SKILL.md").is_file():
-                    return candidate
+                if candidate.is_dir():
+                    nested_skill_dirs = _skill_dirs_under(candidate)
+                    if len(nested_skill_dirs) == 1:
+                        return nested_skill_dirs[0]
+                    if (candidate / "SKILL.md").is_file():
+                        return candidate
     config_path = getattr(artifact, "config_path", None)
     if not isinstance(config_path, str):
         return None
@@ -311,15 +221,6 @@ def _skill_dirs_under(root: Path) -> tuple[Path, ...]:
         return ()
     skill_dirs = sorted({path.parent.resolve() for path in root.rglob("SKILL.md") if path.is_file()})
     return tuple(skill_dirs)
-
-
-def _nearest_skills_root(path: Path) -> Path | None:
-    for parent in path.parents:
-        if parent.name == "skills":
-            return parent
-    return None
-
-
 def _nearest_skill_dir(path: Path) -> Path | None:
     if path.name == "SKILL.md":
         return path.parent

--- a/tests/test_guard_inventory_cisco.py
+++ b/tests/test_guard_inventory_cisco.py
@@ -236,6 +236,62 @@ def test_cisco_inventory_scans_use_detected_nonstandard_skill_roots(tmp_path: Pa
     assert calls == [skill_path.parent]
 
 
+def test_cisco_inventory_scans_resolve_skill_root_collection_directories(tmp_path: Path, monkeypatch) -> None:
+    context = _ctx(tmp_path)
+    home_dir = context.home_dir
+    assert home_dir is not None
+    collection_root = home_dir / "shared-openclaw-skills"
+    skill_path = collection_root / "reviewer" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("---\nname: reviewer\n---\nReview local files.\n")
+    detection = HarnessDetection(
+        harness="openclaw",
+        installed=True,
+        command_available=False,
+        config_paths=(),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="openclaw:skill:extra:reviewer",
+                name="reviewer",
+                harness="openclaw",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(collection_root),
+                metadata={"skill_root": str(collection_root)},
+            ),
+        ),
+    )
+    calls: list[Path] = []
+
+    def fake_skill_scan(skills_dir: Path, mode: str, timeout_seconds: float | None = None) -> _SkillSummary:
+        del mode, timeout_seconds
+        calls.append(skills_dir)
+        return _SkillSummary(
+            status=CiscoIntegrationStatus.ENABLED,
+            message="Skill scanner completed.",
+            findings=(),
+            skills_scanned=1,
+            skills_skipped=(),
+            analyzers_used=("prompt-injection",),
+            policy_name="balanced",
+            total_findings=0,
+            findings_by_severity={severity.value: 0 for severity in Severity},
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.inventory_cisco.run_cisco_skill_scan", fake_skill_scan)
+
+    runs = run_cisco_inventory_scans(
+        harness="openclaw",
+        context=context,
+        detection=detection,
+        skill_mode="auto",
+    )
+
+    assert [run.source for run in runs] == ["cisco-skill-scanner"]
+    assert calls == [skill_path.parent]
+    assert [run.metadata["target"] for run in runs] == [str(skill_path.parent)]
+
+
 def test_cisco_inventory_scans_runs_each_detected_skill_root(tmp_path: Path, monkeypatch) -> None:
     context = _ctx(tmp_path)
     home_dir = context.home_dir


### PR DESCRIPTION
## Summary
- replace the Cisco skill scanner timeout path with a subprocess-based runner so per-skill cloud AIBOM scans work under Python 3.14/macOS
- keep the existing scanner summary contract intact while preserving timeout/error handling for Guard inventory and AIBOM indexing

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/integrations/cisco_skill_scanner.py tests/test_guard_cisco_evidence.py tests/test_guard_inventory_cisco.py tests/test_skill_security.py`
- `pytest -q tests/test_guard_cisco_evidence.py tests/test_guard_inventory_cisco.py tests/test_skill_security.py`

## Notes
- this unblocks the live production path where `cisco-skill-scanner` was failing on every per-skill root with the Python 3.14 multiprocessing bootstrap error, preventing `metadata.localSecurity` from being emitted for top-level skills
