### PR TITLE
fix(guard): isolate cisco skill scan subprocess

### DIFF
--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -107,25 +107,28 @@ def _scan_directory_with_timeout(
     # Explicit close avoids leaking the temp file descriptor into the child.
     os.close(file_descriptor)
 
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(sys.path)
     try:
-        result = subprocess.run(
-            [
-                sys.executable,
-                "-c",
-                _SUBPROCESS_SCAN_SNIPPET,
-                str(skills_dir),
-                policy_name,
-                str(output_path),
-            ],
-            capture_output=True,
-            check=False,
-            text=True,
-            timeout=timeout_seconds,
-        )
-    except subprocess.TimeoutExpired as exc:
-        raise TimeoutError("Cisco skill scanner timed out") from exc
+        try:
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    _SUBPROCESS_SCAN_SNIPPET,
+                    str(skills_dir),
+                    policy_name,
+                    str(output_path),
+                ],
+                capture_output=True,
+                check=False,
+                text=True,
+                timeout=timeout_seconds,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise TimeoutError("Cisco skill scanner timed out") from exc
 
-    try:
         if result.returncode != 0:
             error_output = result.stderr.strip() or result.stdout.strip()
             if not error_output:

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+import json
+import os
+import subprocess
+import sys
+import tempfile
 from dataclasses import dataclass
 from enum import Enum
-from multiprocessing import get_context
-from multiprocessing.process import BaseProcess
 from pathlib import Path
-from queue import Empty
 
 from ..models import Finding, Severity, severity_from_value
 
@@ -83,20 +85,15 @@ def _scan_directory_payload(skills_dir: Path, policy_name: str) -> dict[str, obj
     return payload if isinstance(payload, dict) else {}
 
 
-def _scan_directory_worker(skills_dir: str, policy_name: str, result_queue: object) -> None:
-    try:
-        payload = _scan_directory_payload(Path(skills_dir), policy_name)
-        result_queue.put(("ok", payload))
-    except BaseException as exc:
-        result_queue.put(("error", type(exc).__name__, str(exc)))
+_SUBPROCESS_SCAN_SNIPPET = """
+from pathlib import Path
+import json
+import sys
+from codex_plugin_scanner.integrations.cisco_skill_scanner import _scan_directory_payload
 
-
-def _terminate_scan_process(process: BaseProcess) -> None:
-    process.terminate()
-    process.join(1)
-    if process.is_alive():
-        process.kill()
-        process.join()
+payload = _scan_directory_payload(Path(sys.argv[1]), sys.argv[2])
+Path(sys.argv[3]).write_text(json.dumps(payload), encoding='utf-8')
+""".strip()
 
 
 def _scan_directory_with_timeout(
@@ -105,35 +102,47 @@ def _scan_directory_with_timeout(
     if timeout_seconds is None:
         return _scan_directory_payload(skills_dir, policy_name)
 
-    context = get_context("spawn")
-    result_queue = context.Queue(maxsize=1)
-    process = context.Process(
-        target=_scan_directory_worker,
-        args=(str(skills_dir), policy_name, result_queue),
-    )
-    process.start()
+    file_descriptor, output_name = tempfile.mkstemp(prefix="cisco-skill-scan-", suffix=".json")
+    output_path = Path(output_name)
+    # Explicit close avoids leaking the temp file descriptor into the child.
+    os.close(file_descriptor)
 
     try:
-        status, payload, *details = result_queue.get(timeout=timeout_seconds)
-    except Empty as exc:
-        process.join(0)
-        if process.is_alive():
-            _terminate_scan_process(process)
-            raise TimeoutError("Cisco skill scanner timed out") from exc
-        try:
-            status, payload, *details = result_queue.get(timeout=1)
-        except Empty as empty_exc:
-            raise RuntimeError(f"Cisco skill scanner exited with code {process.exitcode}") from empty_exc
-    else:
-        process.join(1)
-        if process.is_alive():
-            _terminate_scan_process(process)
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                _SUBPROCESS_SCAN_SNIPPET,
+                str(skills_dir),
+                policy_name,
+                str(output_path),
+            ],
+            capture_output=True,
+            check=False,
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError("Cisco skill scanner timed out") from exc
 
-    if status == "error":
-        error_type = str(payload)
-        error_message = str(details[0]) if details else "unknown error"
-        raise RuntimeError(f"{error_type}: {error_message}")
-    return payload if isinstance(payload, dict) else {}
+    try:
+        if result.returncode != 0:
+            error_output = result.stderr.strip() or result.stdout.strip()
+            if not error_output:
+                error_output = f"Cisco skill scanner exited with code {result.returncode}"
+            raise RuntimeError(error_output)
+
+        if not output_path.is_file():
+            raise RuntimeError("Cisco skill scanner did not produce a result payload")
+
+        try:
+            payload = json.loads(output_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError as exc:
+            raise RuntimeError("Cisco skill scanner produced invalid JSON output") from exc
+
+        return payload if isinstance(payload, dict) else {}
+    finally:
+        output_path.unlink(missing_ok=True)
 
 
 def _to_local_finding(plugin_dir: Path, skill_result: dict[str, object], finding: dict[str, object]) -> Finding:
@@ -241,6 +250,8 @@ def run_cisco_skill_scan(
 
     findings: list[Finding] = []
     results = payload.get("results", [])
+    if not isinstance(results, list):
+        results = []
     for result in results:
         if not isinstance(result, dict):
             continue
@@ -252,6 +263,8 @@ def run_cisco_skill_scan(
                 findings.append(_to_local_finding(skills_dir.parent, result, finding))
 
     summary = payload.get("summary", {})
+    if not isinstance(summary, dict):
+        summary = {}
     counts = _empty_counts()
     findings_by_severity = summary.get("findings_by_severity", {})
     if isinstance(findings_by_severity, dict):

--- a/tests/test_guard_cisco_evidence.py
+++ b/tests/test_guard_cisco_evidence.py
@@ -9,6 +9,8 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from typing import Any, cast
 
+import pytest
+
 from codex_plugin_scanner.guard.runtime.cisco_evidence import (
     cisco_finding_to_risk_signal,
     scanner_cache_key,
@@ -196,6 +198,24 @@ def test_skill_scanner_timeout_path_drains_worker_result_before_terminating(monk
     payload = cisco_skill_scanner._scan_directory_with_timeout(tmp_path, "balanced", 0.1)
 
     assert payload == {"summary": {"total_skills_scanned": 0}, "results": []}
+    assert output_path.exists() is False
+
+
+def test_skill_scanner_timeout_path_cleans_temp_file_on_timeout(monkeypatch, tmp_path: Path) -> None:
+    output_path = tmp_path / "scan-timeout.json"
+
+    monkeypatch.setattr(cisco_skill_scanner.tempfile, "mkstemp", lambda prefix, suffix: (123, str(output_path)))
+    monkeypatch.setattr(cisco_skill_scanner.os, "close", lambda fd: None)
+
+    def fake_run(*args: object, **kwargs: object) -> object:
+        output_path.write_text("{}", encoding="utf-8")
+        raise cisco_skill_scanner.subprocess.TimeoutExpired(cmd="skill-scanner", timeout=0.1)
+
+    monkeypatch.setattr(cisco_skill_scanner.subprocess, "run", fake_run)
+
+    with pytest.raises(TimeoutError, match="timed out"):
+        cisco_skill_scanner._scan_directory_with_timeout(tmp_path, "balanced", 0.1)
+
     assert output_path.exists() is False
 
 

--- a/tests/test_guard_cisco_evidence.py
+++ b/tests/test_guard_cisco_evidence.py
@@ -7,6 +7,7 @@ import sqlite3
 import time
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
+from typing import Any, cast
 
 from codex_plugin_scanner.guard.runtime.cisco_evidence import (
     cisco_finding_to_risk_signal,
@@ -91,7 +92,7 @@ def test_scanner_cache_key_changes_with_content_hash_or_version() -> None:
 
 def test_guard_store_invalidates_scanner_cache_when_hash_or_version_changes(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    payload = {"signals": [{"signal_id": "signal-1"}]}
+    payload = cast(dict[str, object], {"signals": [{"signal_id": "signal-1"}]})
 
     store.save_scanner_cache(
         scanner_name="cisco-mcp-scanner",
@@ -158,9 +159,9 @@ def test_skill_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, 
         def __init__(self, preset_base: str) -> None:
             self.preset_base = preset_base
 
-    skill_scanner_module = ModuleType("skill_scanner")
+    skill_scanner_module = cast(Any, ModuleType("skill_scanner"))
     skill_scanner_module.SkillScanner = SlowScanner
-    scan_policy_module = ModuleType("skill_scanner.core.scan_policy")
+    scan_policy_module = cast(Any, ModuleType("skill_scanner.core.scan_policy"))
     scan_policy_module.ScanPolicy = ScanPolicy
     monkeypatch.setitem(__import__("sys").modules, "skill_scanner", skill_scanner_module)
     monkeypatch.setitem(__import__("sys").modules, "skill_scanner.core", ModuleType("skill_scanner.core"))
@@ -178,51 +179,24 @@ def test_skill_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, 
 
 
 def test_skill_scanner_timeout_path_drains_worker_result_before_terminating(monkeypatch, tmp_path: Path) -> None:
-    class FakeQueue:
-        def __init__(self) -> None:
-            self.process: FakeProcess | None = None
+    output_path = tmp_path / "scan-output.json"
 
-        def get(self, timeout: float) -> tuple[str, dict[str, object]]:
-            if self.process is not None:
-                self.process.alive = False
-            return ("ok", {"summary": {"total_skills_scanned": 0}, "results": []})
+    monkeypatch.setattr(cisco_skill_scanner.tempfile, "mkstemp", lambda prefix, suffix: (123, str(output_path)))
+    monkeypatch.setattr(cisco_skill_scanner.os, "close", lambda fd: None)
 
-    class FakeProcess:
-        def __init__(self, queue: FakeQueue) -> None:
-            self.queue = queue
-            self.alive = True
-            self.exitcode = 0
-            self.terminated = False
-            self.killed = False
+    def fake_run(*args: object, **kwargs: object) -> object:
+        output_path.write_text(
+            json.dumps({"summary": {"total_skills_scanned": 0}, "results": []}),
+            encoding="utf-8",
+        )
+        return SimpleNamespace(returncode=0, stderr="", stdout="")
 
-        def start(self) -> None:
-            self.queue.process = self
-
-        def join(self, timeout: float | None = None) -> None:
-            return None
-
-        def is_alive(self) -> bool:
-            return self.alive
-
-        def terminate(self) -> None:
-            self.terminated = True
-
-        def kill(self) -> None:
-            self.killed = True
-
-    queue = FakeQueue()
-    process = FakeProcess(queue)
-    context = SimpleNamespace(
-        Queue=lambda maxsize: queue,
-        Process=lambda target, args: process,
-    )
-    monkeypatch.setattr(cisco_skill_scanner, "get_context", lambda method: context)
+    monkeypatch.setattr(cisco_skill_scanner.subprocess, "run", fake_run)
 
     payload = cisco_skill_scanner._scan_directory_with_timeout(tmp_path, "balanced", 0.1)
 
     assert payload == {"summary": {"total_skills_scanned": 0}, "results": []}
-    assert process.terminated is False
-    assert process.killed is False
+    assert output_path.exists() is False
 
 
 def test_mcp_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
## Summary
- replace the Cisco skill scanner timeout path with a subprocess-based runner so per-skill cloud AIBOM scans work under Python 3.14/macOS
- keep the existing scanner summary contract intact while preserving timeout/error handling for Guard inventory and AIBOM indexing

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/integrations/cisco_skill_scanner.py tests/test_guard_cisco_evidence.py tests/test_guard_inventory_cisco.py tests/test_skill_security.py`
- `pytest -q tests/test_guard_cisco_evidence.py tests/test_guard_inventory_cisco.py tests/test_skill_security.py`

## Notes
- this unblocks the live production path where `cisco-skill-scanner` was failing on every per-skill root with the Python 3.14 multiprocessing bootstrap error, preventing `metadata.localSecurity` from being emitted for top-level skills
