### PR TITLE
fix(guard): use cloud cisco defaults for aibom sync

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -129,12 +129,19 @@ def _run_guard_aibom_command(
         _emit("aibom.status", payload, getattr(args, "json", False))
         return 0
     if aibom_command == "sync":
+        sync_options = AibomCliOptions(
+            include_symlinks=aibom_options.include_symlinks,
+            follow_unsafe_symlinks=aibom_options.follow_unsafe_symlinks,
+            cisco_skill_scan=getattr(args, "cisco_skill_scan", "auto"),
+            cisco_mcp_scan=getattr(args, "cisco_mcp_scan", "auto"),
+            cisco_timeout_seconds=getattr(args, "cisco_timeout_seconds", 30.0),
+        )
         try:
             payload = sync_aibom_snapshots(
                 store,
                 context,
                 generated_at=generated_at,
-                options=aibom_options,
+                options=sync_options,
             )
         except GuardSyncNotConfiguredError as error:
             message = _guard_sync_failure_message(error)

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+from ..aibom_cli import AibomCliOptions, _AIBOM_CLOUD_SYNC_OPTIONS
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -132,9 +133,21 @@ def _run_guard_aibom_command(
         sync_options = AibomCliOptions(
             include_symlinks=aibom_options.include_symlinks,
             follow_unsafe_symlinks=aibom_options.follow_unsafe_symlinks,
-            cisco_skill_scan=getattr(args, "cisco_skill_scan", "auto"),
-            cisco_mcp_scan=getattr(args, "cisco_mcp_scan", "auto"),
-            cisco_timeout_seconds=getattr(args, "cisco_timeout_seconds", 30.0),
+            cisco_skill_scan=getattr(
+                args,
+                "cisco_skill_scan",
+                _AIBOM_CLOUD_SYNC_OPTIONS.cisco_skill_scan,
+            ),
+            cisco_mcp_scan=getattr(
+                args,
+                "cisco_mcp_scan",
+                _AIBOM_CLOUD_SYNC_OPTIONS.cisco_mcp_scan,
+            ),
+            cisco_timeout_seconds=getattr(
+                args,
+                "cisco_timeout_seconds",
+                _AIBOM_CLOUD_SYNC_OPTIONS.cisco_timeout_seconds,
+            ),
         )
         try:
             payload = sync_aibom_snapshots(

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -108,7 +108,7 @@ def _scan_directory_with_timeout(
     os.close(file_descriptor)
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = os.pathsep.join(sys.path)
+    env["PYTHONPATH"] = os.pathsep.join(str(path) for path in sys.path)
     try:
         try:
             result = subprocess.run(

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import argparse
 import json
 from email.message import Message
 from pathlib import Path
@@ -7,6 +8,9 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import aibom_cli
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import commands_dispatch_records as dispatch
 from codex_plugin_scanner.guard.inventory_cisco import CiscoInventoryRun
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
@@ -466,6 +470,44 @@ def test_sync_aibom_snapshots_uses_cloud_sync_cisco_defaults(
     collect_kwargs = observed["collect_kwargs"]
     assert isinstance(collect_kwargs, dict)
     options = collect_kwargs["options"]
+    assert isinstance(options, aibom_cli.AibomCliOptions)
+    assert options.cisco_skill_scan == "auto"
+    assert options.cisco_mcp_scan == "auto"
+    assert options.cisco_timeout_seconds == 30.0
+
+
+def test_guard_aibom_sync_command_uses_cloud_sync_cisco_defaults(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard")
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard",
+    )
+    observed: dict[str, object] = {}
+
+    def fake_sync_aibom_snapshots(*args: object, **kwargs: object) -> dict[str, object]:
+        observed["kwargs"] = kwargs
+        return {"synced": True}
+
+    monkeypatch.setattr(dispatch, "sync_aibom_snapshots", fake_sync_aibom_snapshots)
+
+    exit_code = dispatch._run_guard_aibom_command(
+        argparse.Namespace(
+            aibom_command="sync",
+            include_symlinks=True,
+            follow_unsafe_symlinks=False,
+            json=True,
+        ),
+        context=context,
+        store=store,
+    )
+
+    assert exit_code == 0
+    kwargs = observed["kwargs"]
+    assert isinstance(kwargs, dict)
+    options = kwargs["options"]
     assert isinstance(options, aibom_cli.AibomCliOptions)
     assert options.cisco_skill_scan == "auto"
     assert options.cisco_mcp_scan == "auto"

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -512,6 +512,8 @@ def test_guard_aibom_sync_command_uses_cloud_sync_cisco_defaults(
     assert options.cisco_skill_scan == "auto"
     assert options.cisco_mcp_scan == "auto"
     assert options.cisco_timeout_seconds == 30.0
+    assert options.include_symlinks is True
+    assert options.follow_unsafe_symlinks is False
 
 
 def test_aibom_export_json_includes_redaction_report(tmp_path: Path, capsys) -> None:

--- a/tests/test_guard_cisco_evidence.py
+++ b/tests/test_guard_cisco_evidence.py
@@ -180,7 +180,7 @@ def test_skill_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, 
     assert "timed out" in summary.message
 
 
-def test_skill_scanner_timeout_path_drains_worker_result_before_terminating(monkeypatch, tmp_path: Path) -> None:
+def test_skill_scanner_subprocess_run_success(monkeypatch, tmp_path: Path) -> None:
     output_path = tmp_path / "scan-output.json"
 
     monkeypatch.setattr(cisco_skill_scanner.tempfile, "mkstemp", lambda prefix, suffix: (123, str(output_path)))


### PR DESCRIPTION
## Summary
## Summary
- force the `guard aibom sync` CLI dispatch path to use cloud-sync Cisco defaults instead of the local CLI `off` defaults
- add a direct CLI regression test so cloud AIBOM sync keeps running Cisco skill and MCP indexing during production uploads

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py tests/test_guard_aibom_cli.py`
- `pytest -q tests/test_guard_aibom_cli.py tests/test_guard_cisco_evidence.py tests/test_guard_inventory_cisco.py tests/test_skill_security.py`

## Notes
- the subprocess timeout-runner and per-skill-root scan fixes are already on `main`; this slice fixes the last-mile CLI dispatch path that was still overriding cloud sync back to Cisco `off`
