### PR TITLE
fix(dashboard): clarify remembered rules command and evidence links

### DIFF
--- a/dashboard/src/evidence/evidence-filters.test.ts
+++ b/dashboard/src/evidence/evidence-filters.test.ts
@@ -89,6 +89,19 @@ assert(byArtifactId.length >= 1 && byArtifactId[0].receipt_id === "r5", "search:
 const byHashPrefix = filterBySearch(ALL, "abcdef78");
 assert(byHashPrefix.length >= 1 && byHashPrefix[0].receipt_id === "r5", "search: artifact_hash prefix");
 
+const bySha256HashPrefix = filterBySearch(
+  [
+    makeReceipt("sha-r1", {
+      artifact_hash: "sha256:2dd8986742cb4f850ae2bb52a9aaa2820c6d9be809592ec0c4b3d207b83f9b6",
+    }),
+  ],
+  "2dd8986742cb",
+);
+assert(bySha256HashPrefix.length === 1 && bySha256HashPrefix[0].receipt_id === "sha-r1", "search: sha256 hash prefix");
+
+const byReceiptId = filterBySearch(ALL, "r3");
+assert(byReceiptId.length === 1 && byReceiptId[0].receipt_id === "r3", "search: receipt id");
+
 const noMatch = filterBySearch(ALL, "zzznomatch999");
 assert(noMatch.length === 0, "search: no match returns empty");
 

--- a/dashboard/src/evidence/evidence-filters.ts
+++ b/dashboard/src/evidence/evidence-filters.ts
@@ -89,7 +89,6 @@ export function filterBySearch(
       provenance.includes(q) ||
       scope.includes(q) ||
       decision.includes(q) ||
-      hashNormalized.startsWith(q) ||
       hashRaw.startsWith(q) ||
       hashNormalized.includes(q)
     );

--- a/dashboard/src/evidence/evidence-filters.ts
+++ b/dashboard/src/evidence/evidence-filters.ts
@@ -70,23 +70,28 @@ export function filterBySearch(
   return receipts.filter((r) => {
     const name = (r.artifact_name ?? r.artifact_id ?? "").toLowerCase();
     const id = r.artifact_id.toLowerCase();
+    const receiptId = r.receipt_id.toLowerCase();
     const harness = r.harness.toLowerCase();
     const caps = (r.capabilities_summary ?? "").toLowerCase();
     const changed = (r.changed_capabilities ?? []).join(" ").toLowerCase();
     const provenance = (r.provenance_summary ?? "").toLowerCase();
     const scope = (r.source_scope ?? "").toLowerCase();
     const decision = (r.policy_decision ?? "").toLowerCase();
-    const hashPrefix = (r.artifact_hash ?? "").toLowerCase().slice(0, 12);
+    const hashRaw = (r.artifact_hash ?? "").toLowerCase();
+    const hashNormalized = hashRaw.replace(/^sha256:/, "");
     return (
       name.includes(q) ||
       id.includes(q) ||
+      receiptId.includes(q) ||
       harness.includes(q) ||
       caps.includes(q) ||
       changed.includes(q) ||
       provenance.includes(q) ||
       scope.includes(q) ||
       decision.includes(q) ||
-      hashPrefix.startsWith(q)
+      hashNormalized.startsWith(q) ||
+      hashRaw.startsWith(q) ||
+      hashNormalized.includes(q)
     );
   });
 }

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -470,6 +470,7 @@ export type GuardArtifactDiff = {
 };
 
 export type GuardPolicyDecision = {
+  decision_id?: number;
   harness: string;
   scope: DecisionScope;
   artifact_id: string | null;

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -480,6 +480,10 @@ export type GuardPolicyDecision = {
   reason: string | null;
   source: string;
   updated_at: string;
+  source_receipt_id?: string | null;
+  remembered_command?: string | null;
+  remembered_context?: string | null;
+  workspace_label?: string | null;
 };
 
 export const GUARD_CLOUD_EXCEPTION_ACK_STATUSES = [

--- a/dashboard/src/policy-remembered-local-rules.tsx
+++ b/dashboard/src/policy-remembered-local-rules.tsx
@@ -15,7 +15,7 @@ export function PolicyRememberedLocalRules({
   return (
     <GroupedPolicySection
       title="Remembered on this device"
-      description="Choices you saved from Inbox. Each card explains what Guard will do next time."
+      description="Choices you saved from Inbox. Each row shows the exact command or action Guard will remember, and where it applies."
       policies={policies}
       cloudControlsUrl={cloudControlsUrl}
       onClearPolicy={onClearPolicy}

--- a/dashboard/src/policy-remembered-rules.test.tsx
+++ b/dashboard/src/policy-remembered-rules.test.tsx
@@ -52,10 +52,11 @@ assert(workspaceSource.includes("PolicyRememberedRulesTab"), "workspace uses rem
 assert(!workspaceSource.includes("PolicyRememberedRulesHelper"), "workspace no longer uses inline helper");
 assert(!workspaceSource.includes("GroupedPolicySection"), "workspace no longer mounts grouped sections directly");
 
-assert(viewsSource.includes("scopeLabel(policy.scope)"), "rule cards show explicit scope tag");
-assert(viewsSource.includes("See approval record"), "local cards link to approval record");
-assert(viewsSource.includes("View on cloud"), "cloud cards link to Guard Cloud");
-assert(viewsSource.includes("Remove rule"), "local cards expose remove action");
+assert(viewsSource.includes("Remembered action"), "rules table uses mockup-style columns");
+assert(viewsSource.includes("resolvePolicyApprovalRecordLabel"), "rules table links approval record by receipt id");
+assert(viewsSource.includes("display.rememberSentence"), "rules table explains remembered behavior");
+assert(viewsSource.includes("View on cloud"), "cloud rules link to Guard Cloud");
+assert(viewsSource.includes("Remove rule"), "local rules expose remove action");
 assert(viewsSource.includes("!cloudManaged"), "remove action gated to non-cloud rules");
 assert(viewsSource.includes("cloudManaged && cloudControlsUrl"), "cloud link gated to cloud-managed rules");
 

--- a/dashboard/src/policy-workspace-helpers.test.ts
+++ b/dashboard/src/policy-workspace-helpers.test.ts
@@ -1,5 +1,6 @@
 import type { GuardPolicyDecision } from "./guard-types";
 import {
+  resolvePolicyApprovalRecordLabel,
   resolvePolicyDisplay,
   resolvePolicyEvidenceHref,
   resolvePolicyMatcherFamily,
@@ -25,82 +26,61 @@ const basePolicy = (overrides: Partial<GuardPolicyDecision>): GuardPolicyDecisio
   ...overrides,
 });
 
+const enrichedPackageRule = basePolicy({
+  remembered_command: "pnpm install",
+  remembered_context: "Package install via pnpm",
+  workspace_label: "hol-points-portal",
+  source_receipt_id: "receipt-abc123",
+  artifact_hash: "sha256:62de981049ed20f850ae2bb52a9aaa2820c6d9be809592ec0c4b3d207b83f9b6",
+});
+
+const enrichedDisplay = resolvePolicyDisplay(enrichedPackageRule);
+
+assert(enrichedDisplay.headline === "pnpm install", "POL-H1: enriched command becomes headline");
+assert(
+  enrichedDisplay.subtitle.includes("Package install via pnpm"),
+  "POL-H2: enriched context appears in subtitle",
+);
+assert(
+  enrichedDisplay.rememberSentence.includes("hol-points-portal"),
+  "POL-H3: remember sentence names project folder",
+);
+assert(
+  enrichedDisplay.rememberSentence.includes("pnpm install"),
+  "POL-H4: remember sentence repeats exact command",
+);
+
 const workspacePackageRule = basePolicy({});
 const display = resolvePolicyDisplay(workspacePackageRule);
 
-assert(
-  !display.headline.includes("62de9810"),
-  "POL-H1: headline must not expose artifact hash ids",
-);
-assert(
-  !display.headline.includes("workspace:c188"),
-  "POL-H2: headline must not expose workspace hash ids",
-);
-assert(
-  display.headline.toLowerCase().includes("package install"),
-  "POL-H3: workspace package rule headline names the action family",
-);
-assert(
-  display.subtitle.includes("this project"),
-  "POL-H4: workspace scope subtitle uses plain project language",
-);
+assert(!display.headline.includes("62de9810"), "POL-H5: headline must not expose artifact hash ids");
+assert(display.headline.toLowerCase().includes("package install"), "POL-H6: fallback names action family");
 
-const familyHarnessRule = resolvePolicyDisplay(
+const evidenceHref = resolvePolicyEvidenceHref(enrichedPackageRule);
+assert(evidenceHref.includes("selected=receipt-abc123"), "POL-H7: evidence link selects source receipt");
+assert(evidenceHref.includes("search=receipt-abc123"), "POL-H8: evidence link searches receipt id");
+
+const hashOnlyHref = resolvePolicyEvidenceHref(
   basePolicy({
-    scope: "harness",
-    artifact_id: "family:package-request",
-    workspace: null,
-    harness: "opencode",
+    artifact_hash: "sha256:62de981049ed20f850ae2bb52a9aaa2820c6d9be809592ec0c4b3d207b83f9b6",
   }),
 );
-assert(
-  familyHarnessRule.headline.toLowerCase().includes("all package install"),
-  "POL-H5: harness family rule explains breadth in plain language",
-);
+assert(hashOnlyHref.includes("search=62de981049ed"), "POL-H9: hash fallback strips sha256 prefix");
 
-const meaningfulReason = resolvePolicyDisplay(
-  basePolicy({
-    reason: "Install locked portal dependencies in isolated worktree for Guard connect-flow validation.",
-    scope: "artifact",
-  }),
-);
 assert(
-  meaningfulReason.headline.includes("Install locked portal dependencies"),
-  "POL-H6: meaningful approval reason becomes the headline",
-);
-
-const runtimeRule = resolvePolicyDisplay(
-  basePolicy({
-    scope: "artifact",
-    artifact_id: "opencode:runtime:global:chrome-devtools:navigate_page",
-    reason: "approved in review",
-  }),
-);
-assert(
-  runtimeRule.headline.toLowerCase().includes("chrome devtools"),
-  "POL-H7: runtime actions get readable tool labels",
+  resolvePolicyApprovalRecordLabel(enrichedPackageRule) === "receipt-abc123.json",
+  "POL-H10: approval record label uses receipt filename",
 );
 
 assert(
   resolveWorkspaceLabel("workspace:c188b6362f81cac126242642b9d7baaa7026c681d5c5ea9e4cc92df615049faf") ===
     "this project",
-  "POL-H8: workspace hash labels collapse to this project",
+  "POL-H11: workspace hash labels collapse to this project",
 );
 
 assert(
   resolvePolicyMatcherFamily(basePolicy({ artifact_id: "family:tool-action" })) === "tool-action",
-  "POL-H9: family matcher ids parse correctly",
+  "POL-H12: family matcher ids parse correctly",
 );
-
-const evidenceHref = resolvePolicyEvidenceHref(
-  basePolicy({
-    artifact_hash: "sha256:62de981049ed20f850ae2bb52a9aaa2820c6d9be809592ec0c4b3d207b83f9b6",
-  }),
-);
-assert(
-  evidenceHref.includes("search=62de981049ed"),
-  "POL-H10: evidence link uses short hash prefix search",
-);
-assert(!evidenceHref.includes("harness="), "POL-H11: evidence link does not over-filter by harness");
 
 console.log("policy-workspace-helpers.test.ts: all assertions passed");

--- a/dashboard/src/policy-workspace-helpers.ts
+++ b/dashboard/src/policy-workspace-helpers.ts
@@ -2,13 +2,13 @@ import type { GuardPolicyDecision } from "./guard-types";
 import { harnessDisplayName, policyActionLabel, scopeLabel } from "./approval-center-utils";
 
 const MATCHER_FAMILY_LABELS: Record<string, string> = {
-  "package-request": "package install",
-  "tool-action": "shell or tool command",
-  "tool-output": "command output review",
-  prompt: "prompt submission",
-  "prompt-env-read": "environment variable read",
+  "package-request": "Package install",
+  "tool-action": "Shell or tool command",
+  "tool-output": "Command output review",
+  prompt: "Prompt submission",
+  "prompt-env-read": "Environment variable read",
   mcp: "MCP server call",
-  "file-read": "file read",
+  "file-read": "File read",
 };
 
 const GENERIC_REASONS = [
@@ -21,6 +21,7 @@ const GENERIC_REASONS = [
 export type PolicyDisplay = {
   headline: string;
   subtitle: string;
+  rememberSentence: string;
   technicalId: string | null;
 };
 
@@ -33,7 +34,7 @@ export function resolvePolicySourceLabel(source: string): string {
     return "Guard Cloud";
   }
   if (source === "manual" || source === "local") {
-    return "This device";
+    return "Local";
   }
   return source.replace(/_/g, " ");
 }
@@ -82,7 +83,7 @@ function resolvePromptSubtypeLabel(artifactId: string): string | null {
   const parts = artifactId.split(":");
   const promptIndex = parts.indexOf("prompt");
   if (promptIndex < 0) {
-    return null;
+    return "prompt review";
   }
   const subtype = parts[promptIndex + 1];
   if (!subtype) {
@@ -99,7 +100,7 @@ export function resolveWorkspaceLabel(workspace: string | null | undefined): str
   if (value.startsWith("workspace:")) {
     return "this project";
   }
-  if (value.startsWith("/")) {
+  if (value.startsWith("/") || value.startsWith("~")) {
     const segments = value.split("/").filter(Boolean);
     return segments[segments.length - 1] ?? "this project";
   }
@@ -119,23 +120,48 @@ function resolveActionVerb(action: string): string {
   return policyActionLabel(action);
 }
 
-function resolveScopeSubtitle(policy: GuardPolicyDecision): string {
+function resolveRememberSentence(policy: GuardPolicyDecision, commandLabel: string): string {
   const app = harnessDisplayName(policy.harness);
+  const folder = policy.workspace_label?.trim() || resolveWorkspaceLabel(policy.workspace);
+  const verb = policy.action === "block" ? "block" : "allow";
+
   if (policy.scope === "artifact") {
-    return `Applies once in ${app}`;
+    return `Guard will ${verb} "${commandLabel}" the next time ${app} retries this exact action.`;
   }
   if (policy.scope === "workspace") {
-    return `Applies every time in ${resolveWorkspaceLabel(policy.workspace)} (${app})`;
+    return `Guard will ${verb} "${commandLabel}" every time ${app} runs it in ${folder}.`;
   }
   if (policy.scope === "harness") {
-    return `Applies every time in ${app}`;
+    return `Guard will ${verb} "${commandLabel}" every time ${app} runs a matching action.`;
   }
   if (policy.scope === "publisher") {
     const publisher = policy.publisher?.trim() || "this publisher";
-    return `Applies to ${publisher} in ${app}`;
+    return `Guard will ${verb} actions from ${publisher} in ${app}.`;
   }
   if (policy.scope === "global") {
-    return "Applies on every project on this device";
+    return `Guard will ${verb} matching actions on every project on this device.`;
+  }
+  return `Guard will ${verb} matching actions when ${scopeLabel(policy.scope).toLowerCase()} rules apply.`;
+}
+
+function resolveScopeSubtitle(policy: GuardPolicyDecision): string {
+  const app = harnessDisplayName(policy.harness);
+  if (policy.scope === "artifact") {
+    return `Once in ${app}`;
+  }
+  if (policy.scope === "workspace") {
+    const folder = policy.workspace_label?.trim() || resolveWorkspaceLabel(policy.workspace);
+    return `This project · ${folder}`;
+  }
+  if (policy.scope === "harness") {
+    return `Every time in ${app}`;
+  }
+  if (policy.scope === "publisher") {
+    const publisher = policy.publisher?.trim() || "this publisher";
+    return `${publisher} in ${app}`;
+  }
+  if (policy.scope === "global") {
+    return "Every project on this device";
   }
   return scopeLabel(policy.scope);
 }
@@ -158,13 +184,13 @@ function resolveWhatPhrase(policy: GuardPolicyDecision): string {
 
   if (familyPhrase) {
     if (artifactId.startsWith("family:") || policy.scope === "harness") {
-      return `all ${familyPhrase}s`;
+      return `all ${familyPhrase.toLowerCase()}s`;
     }
     if (family === "prompt") {
       const subtype = resolvePromptSubtypeLabel(artifactId);
       return subtype ? `${familyPhrase} (${subtype})` : familyPhrase;
     }
-    return familyPhrase;
+    return familyPhrase.toLowerCase();
   }
 
   if (publisher) {
@@ -174,31 +200,61 @@ function resolveWhatPhrase(policy: GuardPolicyDecision): string {
   return "matching guarded actions";
 }
 
+function resolveContextLine(policy: GuardPolicyDecision): string | null {
+  const remembered = policy.remembered_context?.trim();
+  if (remembered) {
+    return remembered;
+  }
+  const family = policy.artifact_id ? extractMatcherFamily(policy.artifact_id) : null;
+  if (family && MATCHER_FAMILY_LABELS[family]) {
+    return MATCHER_FAMILY_LABELS[family];
+  }
+  return null;
+}
+
 export function resolvePolicyDisplay(policy: GuardPolicyDecision): PolicyDisplay {
   const reason = policy.reason?.trim() ?? null;
+  const rememberedCommand = policy.remembered_command?.trim();
+  const contextLine = resolveContextLine(policy);
+
+  if (rememberedCommand) {
+    return {
+      headline: rememberedCommand,
+      subtitle: [contextLine, resolveScopeSubtitle(policy)].filter(Boolean).join(" · "),
+      rememberSentence: resolveRememberSentence(policy, rememberedCommand),
+      technicalId: policy.artifact_id,
+    };
+  }
+
   const actionVerb = resolveActionVerb(policy.action);
 
   if (reason && !isGenericReason(reason)) {
     return {
-      headline: `${actionVerb}: ${reason}`,
-      subtitle: resolveScopeSubtitle(policy),
+      headline: reason,
+      subtitle: [contextLine, resolveScopeSubtitle(policy)].filter(Boolean).join(" · "),
+      rememberSentence: resolveRememberSentence(policy, reason),
       technicalId: policy.artifact_id,
     };
   }
 
   const what = resolveWhatPhrase(policy);
+  const headline = `${actionVerb} ${what}`;
   return {
-    headline: `${actionVerb} ${what}`,
-    subtitle: resolveScopeSubtitle(policy),
+    headline,
+    subtitle: [contextLine, resolveScopeSubtitle(policy)].filter(Boolean).join(" · "),
+    rememberSentence: resolveRememberSentence(policy, what),
     technicalId: policy.artifact_id,
   };
 }
 
 export function resolvePolicyEvidenceSearchTerm(policy: GuardPolicyDecision): string | null {
+  const receiptId = policy.source_receipt_id?.trim();
+  if (receiptId) {
+    return receiptId;
+  }
   const hash = policy.artifact_hash?.trim();
   if (hash) {
-    const normalized = hash.replace(/^sha256:/i, "");
-    return normalized.slice(0, 12);
+    return hash.replace(/^sha256:/i, "").slice(0, 12);
   }
   const target = policyTargetLabel(policy);
   if (!target || target === "Global") {
@@ -217,12 +273,30 @@ export function resolvePolicyEvidenceSearchTerm(policy: GuardPolicyDecision): st
 
 export function resolvePolicyEvidenceHref(policy: GuardPolicyDecision): string {
   const params = new URLSearchParams();
+  const receiptId = policy.source_receipt_id?.trim();
+  if (receiptId) {
+    params.set("selected", receiptId);
+    params.set("search", receiptId);
+    return `/evidence?${params.toString()}`;
+  }
   const searchTerm = resolvePolicyEvidenceSearchTerm(policy);
   if (searchTerm) {
     params.set("search", searchTerm);
   }
   const query = params.toString();
   return query ? `/evidence?${query}` : "/evidence";
+}
+
+export function resolvePolicyApprovalRecordLabel(policy: GuardPolicyDecision): string {
+  const receiptId = policy.source_receipt_id?.trim();
+  if (receiptId) {
+    return `${receiptId}.json`;
+  }
+  const hash = policy.artifact_hash?.replace(/^sha256:/i, "").slice(0, 8);
+  if (hash) {
+    return `receipt_${hash}.json`;
+  }
+  return "View in Evidence";
 }
 
 export function resolveCloudPolicyControlsUrl(snapshot: {
@@ -272,9 +346,9 @@ export function resolveSecurityModeCopy(
 ): { label: string; description: string; tone: "green" | "attention" | "slate" } {
   if (level === "strict") {
     return {
-      label: "Strict mode",
+      label: "Protect",
       description:
-        "Guard asks before most actions including new network connections and file writes. Higher noise, maximum protection.",
+        "Guard asks before risky actions that are not already allowed by policy, remembered rules, or Cloud exceptions.",
       tone: "attention",
     };
   }
@@ -304,9 +378,12 @@ export function resolveCloudPolicyBundleCopy(snapshot: {
   cloud_policy_bundle_version?: string | null;
   cloud_policy_rollout_state?: string | null;
   cloud_policy_sync_error?: string | null;
+  cloud_policy_bundle_hash?: string | null;
+  cloud_policy_last_ack_at?: string | null;
 }): {
   label: string;
   detail: string;
+  hash: string | null;
   tone: "green" | "attention" | "slate";
 } | null {
   const bundleVersion = snapshot.cloud_policy_bundle_version?.trim();
@@ -315,16 +392,19 @@ export function resolveCloudPolicyBundleCopy(snapshot: {
   }
   const rollout = snapshot.cloud_policy_rollout_state?.trim() || "unknown";
   const syncError = snapshot.cloud_policy_sync_error?.trim();
+  const hash = snapshot.cloud_policy_bundle_hash?.trim() || null;
   if (syncError) {
     return {
-      label: `Cloud bundle ${bundleVersion}`,
-      detail: `Guard Cloud Controls owns rollout and authoring. Latest sync issue: ${syncError}.`,
+      label: "Needs attention",
+      detail: `Bundle ${bundleVersion} is connected, but the latest sync reported: ${syncError}`,
+      hash,
       tone: "attention",
     };
   }
   return {
-    label: `Cloud bundle ${bundleVersion}`,
-    detail: `Guard Cloud Controls owns authoring and rollout. This local workspace reflects rollout state ${rollout}.`,
+    label: "Synced",
+    detail: `Bundle ${bundleVersion} is active on this device (${rollout}).`,
+    hash,
     tone: "green",
   };
 }

--- a/dashboard/src/policy-workspace-views.tsx
+++ b/dashboard/src/policy-workspace-views.tsx
@@ -1,11 +1,22 @@
 import { useCallback, useMemo, useState } from "react";
-import { HiMiniTrash, HiMiniCloudArrowUp, HiMiniChevronDown, HiMiniChevronUp } from "react-icons/hi2";
+import {
+  HiMiniTrash,
+  HiMiniCloudArrowUp,
+  HiMiniChevronDown,
+  HiMiniChevronUp,
+  HiMiniCommandLine,
+  HiMiniCube,
+  HiMiniDocumentText,
+  HiMiniGlobeAlt,
+  HiMiniShieldCheck,
+} from "react-icons/hi2";
 import { Badge, Tag, EmptyState } from "./approval-center-primitives";
 import { harnessDisplayName, formatRelativeTime, policyActionLabel, scopeLabel } from "./approval-center-utils";
 import { guardAwareHref } from "./guard-api";
 import type { GuardPolicyDecision } from "./guard-types";
 import {
   isCloudManagedPolicy,
+  resolvePolicyApprovalRecordLabel,
   resolvePolicyDisplay,
   resolvePolicyEvidenceHref,
   resolvePolicyMatcherFamily,
@@ -30,47 +41,69 @@ function resolveActionTone(action: string): "success" | "destructive" | "warning
   return "default";
 }
 
-type PolicyRuleCardProps = {
+function resolveFamilyIcon(family: string | null) {
+  if (family === "package-request") {
+    return HiMiniCube;
+  }
+  if (family === "tool-action" || family === "tool-output") {
+    return HiMiniCommandLine;
+  }
+  if (family === "prompt" || family === "prompt-env-read") {
+    return HiMiniDocumentText;
+  }
+  if (family === "mcp") {
+    return HiMiniGlobeAlt;
+  }
+  return HiMiniShieldCheck;
+}
+
+type PolicyRuleRowProps = {
   policy: GuardPolicyDecision;
   cloudControlsUrl: string | null;
   onClear?: (policy: GuardPolicyDecision) => void;
 };
 
-export function PolicyRuleCard({ policy, cloudControlsUrl, onClear }: PolicyRuleCardProps) {
+function PolicyRuleRow({ policy, cloudControlsUrl, onClear }: PolicyRuleRowProps) {
   const handleClear = useCallback(() => onClear?.(policy), [onClear, policy]);
   const cloudManaged = isCloudManagedPolicy(policy.source);
   const display = resolvePolicyDisplay(policy);
   const canClear = onClear !== undefined && !cloudManaged;
+  const family = resolvePolicyMatcherFamily(policy);
+  const Icon = resolveFamilyIcon(family);
 
   return (
-    <article className="rounded-2xl border border-slate-100 bg-white px-4 py-3.5 shadow-sm">
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 flex-1 space-y-1.5">
-          <div className="flex flex-wrap items-center gap-2">
-            <Badge tone={resolveActionTone(policy.action)}>{policyActionLabel(policy.action)}</Badge>
-            <Tag tone={cloudManaged ? "blue" : "green"}>{resolvePolicySourceLabel(policy.source)}</Tag>
-            <Tag tone="slate">{scopeLabel(policy.scope)}</Tag>
-            <span className="text-xs text-slate-400">{harnessDisplayName(policy.harness)}</span>
-          </div>
-          <h3 className="text-base font-semibold leading-snug text-brand-dark">{display.headline}</h3>
-          <p className="text-sm text-slate-600">{display.subtitle}</p>
-          {display.technicalId ? (
-            <details className="text-xs text-slate-500">
-              <summary className="cursor-pointer text-brand-blue hover:underline">Technical id</summary>
-              <p className="mt-1 break-all font-mono text-[11px] text-slate-600">{display.technicalId}</p>
-            </details>
-          ) : null}
-        </div>
-        <div className="flex shrink-0 flex-col items-end gap-2 text-right">
-          <span className="text-xs text-slate-400">
-            {policy.updated_at ? formatRelativeTime(policy.updated_at) : null}
+    <tr className="border-b border-slate-100 last:border-0 hover:bg-slate-50/80">
+      <td className="px-3 py-3 align-top">
+        <div className="flex items-start gap-2">
+          <span className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500">
+            <Icon className="h-4 w-4" aria-hidden="true" />
           </span>
+          <div className="min-w-0 space-y-1">
+            <Badge tone={resolveActionTone(policy.action)}>{policyActionLabel(policy.action)}</Badge>
+            <p className="text-sm font-semibold leading-snug text-brand-dark">{display.headline}</p>
+            {display.subtitle ? <p className="text-xs text-slate-500">{display.subtitle}</p> : null}
+            <p className="text-xs leading-relaxed text-slate-600">{display.rememberSentence}</p>
+          </div>
+        </div>
+      </td>
+      <td className="hidden px-3 py-3 align-top text-sm text-slate-600 md:table-cell">
+        <Tag tone={cloudManaged ? "blue" : "green"}>{resolvePolicySourceLabel(policy.source)}</Tag>
+      </td>
+      <td className="hidden px-3 py-3 align-top text-sm text-slate-600 lg:table-cell">{scopeLabel(policy.scope)}</td>
+      <td className="hidden px-3 py-3 align-top text-sm text-slate-600 xl:table-cell">
+        {harnessDisplayName(policy.harness)}
+      </td>
+      <td className="hidden px-3 py-3 align-top text-xs text-slate-500 sm:table-cell">
+        {policy.updated_at ? formatRelativeTime(policy.updated_at) : "—"}
+      </td>
+      <td className="px-3 py-3 align-top text-right">
+        <div className="flex flex-col items-end gap-2">
           {!cloudManaged ? (
             <a
               href={guardAwareHref(resolvePolicyEvidenceHref(policy))}
               className="text-sm font-medium text-brand-blue hover:underline"
             >
-              See approval record
+              {resolvePolicyApprovalRecordLabel(policy)}
             </a>
           ) : null}
           {cloudManaged && cloudControlsUrl ? (
@@ -95,12 +128,12 @@ export function PolicyRuleCard({ policy, cloudControlsUrl, onClear }: PolicyRule
             </button>
           ) : null}
         </div>
-      </div>
-    </article>
+      </td>
+    </tr>
   );
 }
 
-type PolicyRuleListProps = {
+type PolicyRuleTableProps = {
   policies: GuardPolicyDecision[];
   cloudControlsUrl: string | null;
   onClearPolicy?: (policy: GuardPolicyDecision) => void;
@@ -108,7 +141,13 @@ type PolicyRuleListProps = {
   emptyBody: string;
 };
 
-export function PolicyRuleList({ policies, cloudControlsUrl, onClearPolicy, emptyTitle, emptyBody }: PolicyRuleListProps) {
+export function PolicyRuleTable({
+  policies,
+  cloudControlsUrl,
+  onClearPolicy,
+  emptyTitle,
+  emptyBody,
+}: PolicyRuleTableProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
   const visiblePolicies = useMemo(() => policies.slice(0, visibleCount), [policies, visibleCount]);
@@ -124,14 +163,30 @@ export function PolicyRuleList({ policies, cloudControlsUrl, onClearPolicy, empt
 
   return (
     <div className="space-y-3">
-      {visiblePolicies.map((policy) => (
-        <PolicyRuleCard
-          key={`${policy.harness}-${policy.scope}-${policy.artifact_id ?? policy.publisher ?? "global"}-${policy.updated_at ?? ""}-${policy.source}`}
-          policy={policy}
-          cloudControlsUrl={cloudControlsUrl}
-          onClear={onClearPolicy}
-        />
-      ))}
+      <div className="overflow-x-auto rounded-2xl border border-slate-100 bg-white shadow-sm">
+        <table className="min-w-full border-collapse text-left">
+          <thead className="border-b border-slate-100 bg-slate-50/80 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <tr>
+              <th className="px-3 py-3">Remembered action</th>
+              <th className="hidden px-3 py-3 md:table-cell">Source</th>
+              <th className="hidden px-3 py-3 lg:table-cell">Scope</th>
+              <th className="hidden px-3 py-3 xl:table-cell">Harness</th>
+              <th className="hidden px-3 py-3 sm:table-cell">Last updated</th>
+              <th className="px-3 py-3 text-right">Record</th>
+            </tr>
+          </thead>
+          <tbody>
+            {visiblePolicies.map((policy) => (
+              <PolicyRuleRow
+                key={`${policy.harness}-${policy.scope}-${policy.artifact_id ?? policy.publisher ?? "global"}-${policy.updated_at ?? ""}-${policy.source}`}
+                policy={policy}
+                cloudControlsUrl={cloudControlsUrl}
+                onClear={onClearPolicy}
+              />
+            ))}
+          </tbody>
+        </table>
+      </div>
       {hasMore ? (
         <div className="flex justify-center pt-1">
           <button
@@ -205,7 +260,7 @@ export function GroupedPolicySection({
         </div>
       </button>
       {open ? (
-        <PolicyRuleList
+        <PolicyRuleTable
           policies={policies}
           cloudControlsUrl={cloudControlsUrl}
           onClearPolicy={onClearPolicy}

--- a/dashboard/src/policy-workspace.tsx
+++ b/dashboard/src/policy-workspace.tsx
@@ -83,29 +83,39 @@ export function PolicyWorkspace({
 
   return (
     <div className="space-y-6">
-      {cloudBundleCopy ? (
-        <div className={resolveCloudBundleSurfaceClass(cloudBundleCopy.tone)}>
-          <div className="mb-2 flex flex-wrap items-center gap-2">
+      <div className="grid gap-4 lg:grid-cols-2">
+        {cloudBundleCopy ? (
+          <div className={resolveCloudBundleSurfaceClass(cloudBundleCopy.tone)}>
+            <div className="mb-2 flex flex-wrap items-center gap-2">
+              <SectionLabel>Guard Cloud bundle</SectionLabel>
+              <Tag tone={cloudBundleCopy.tone}>{cloudBundleCopy.label}</Tag>
+            </div>
+            <p className="text-sm text-brand-dark/75">{cloudBundleCopy.detail}</p>
+            {cloudBundleCopy.hash ? (
+              <p className="mt-2 break-all font-mono text-[11px] text-slate-500">{cloudBundleCopy.hash.slice(0, 8)}</p>
+            ) : null}
+          </div>
+        ) : (
+          <div className="rounded-2xl border border-slate-200/70 bg-slate-50/70 p-4 shadow-sm">
             <SectionLabel>Guard Cloud bundle</SectionLabel>
-            <Tag tone={cloudBundleCopy.tone}>{cloudBundleCopy.label}</Tag>
+            <p className="mt-2 text-sm text-brand-dark/75">Not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle.</p>
           </div>
-          <p className="text-sm text-brand-dark/75">{cloudBundleCopy.detail}</p>
-        </div>
-      ) : null}
+        )}
 
-      <div className="rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm">
-        <div className="mb-2 flex flex-wrap items-center gap-2">
-          <SectionLabel>Active mode</SectionLabel>
-          <Tag tone={modeCopy.tone}>{modeCopy.label}</Tag>
-        </div>
-        <p className="text-sm text-brand-dark/75">{modeCopy.description}</p>
-        {onOpenSettings ? (
-          <div className="mt-3">
-            <ActionButton variant="secondary" onClick={onOpenSettings}>
-              Open security settings
-            </ActionButton>
+        <div className="rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm">
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <SectionLabel>Active mode</SectionLabel>
+            <Tag tone={modeCopy.tone}>{modeCopy.label}</Tag>
           </div>
-        ) : null}
+          <p className="text-sm text-brand-dark/75">{modeCopy.description}</p>
+          {onOpenSettings ? (
+            <div className="mt-3">
+              <ActionButton variant="secondary" onClick={onOpenSettings}>
+                Open security settings
+              </ActionButton>
+            </div>
+          ) : null}
+        </div>
       </div>
 
       <div

--- a/dashboard/src/scrg159-170.test.ts
+++ b/dashboard/src/scrg159-170.test.ts
@@ -338,7 +338,7 @@ assert(grouped.get("cursor")?.length === 1, "SCRG164-B: 1 cursor policy");
 
 const strictCopy = resolveSecurityModeCopy("strict");
 assert(strictCopy.tone === "attention", "SCRG164-C: strict mode is attention tone");
-assert(strictCopy.label.toLowerCase().includes("strict"), "SCRG164-D: strict label includes strict");
+assert(strictCopy.label.toLowerCase().includes("protect"), "SCRG164-D: strict mode shows Protect label");
 
 const balancedCopy = resolveSecurityModeCopy("balanced");
 assert(balancedCopy.tone === "green", "SCRG164-E: balanced is green tone");

--- a/dashboard/src/scrg171-172.test.ts
+++ b/dashboard/src/scrg171-172.test.ts
@@ -266,8 +266,8 @@ assert(
 
 const cloudBundleCopy = resolveCloudPolicyBundleCopy(pairedPolicySnapshot);
 assert(cloudBundleCopy !== null, "SCRG171-K: paired cloud bundle should expose policy workspace copy");
-assert(cloudBundleCopy!.label.includes("policy-2026-06-05.1"), "SCRG171-L: cloud bundle label includes version");
-assert(cloudBundleCopy!.detail.includes("Guard Cloud Controls"), "SCRG171-M: cloud bundle detail preserves cloud ownership");
+assert(cloudBundleCopy!.label === "Synced", "SCRG171-L: cloud bundle label shows sync status");
+assert(cloudBundleCopy!.detail.includes("policy-2026-06-05.1"), "SCRG171-M: cloud bundle detail includes version");
 
 assert(
   typeof loadAuditPage === "function",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, S as SectionLabel, o as HiMiniXMark, B as Badge, bd as scopeLabel, m as formatRelativeTime, b6 as HiMiniCloudArrowUp, r as reactExports, be as createCloudExceptionRequest, A as ActionButton, h as harnessDisplayName, b as EmptyState, p as HiMiniChevronUp, q as HiMiniChevronDown, ac as Tag, bf as policyActionLabel, bg as fetchCloudExceptions, bh as fetchCloudExceptionRequests, bb as guardAwareHref, ax as HiMiniTrash, ad as HiMiniMagnifyingGlass, Y as fetchSettings, _ as updateSettings } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, S as SectionLabel, o as HiMiniXMark, B as Badge, bd as scopeLabel, m as formatRelativeTime, b6 as HiMiniCloudArrowUp, r as reactExports, be as createCloudExceptionRequest, A as ActionButton, h as harnessDisplayName, b as EmptyState, p as HiMiniChevronUp, q as HiMiniChevronDown, ac as Tag, bf as policyActionLabel, bg as fetchCloudExceptions, bh as fetchCloudExceptionRequests, bb as guardAwareHref, ax as HiMiniTrash, bi as HiMiniCube, aA as HiMiniCommandLine, ba as HiMiniDocumentText, bj as HiMiniGlobeAlt, l as HiMiniShieldCheck, ad as HiMiniMagnifyingGlass, Y as fetchSettings, _ as updateSettings } from "../guard-dashboard.js";
 const CLOUD_EXCEPTION_EXPIRING_SOON_DAYS = 7;
 function parseCloudExceptionTimestamp(value) {
   if (!value || !value.trim()) {
@@ -797,13 +797,13 @@ function PolicyCloudExceptionsSummary({
   );
 }
 const MATCHER_FAMILY_LABELS = {
-  "package-request": "package install",
-  "tool-action": "shell or tool command",
-  "tool-output": "command output review",
-  prompt: "prompt submission",
-  "prompt-env-read": "environment variable read",
+  "package-request": "Package install",
+  "tool-action": "Shell or tool command",
+  "tool-output": "Command output review",
+  prompt: "Prompt submission",
+  "prompt-env-read": "Environment variable read",
   mcp: "MCP server call",
-  "file-read": "file read"
+  "file-read": "File read"
 };
 const GENERIC_REASONS = [
   "approved in review",
@@ -819,7 +819,7 @@ function resolvePolicySourceLabel(source) {
     return "Guard Cloud";
   }
   if (source === "manual" || source === "local") {
-    return "This device";
+    return "Local";
   }
   return source.replace(/_/g, " ");
 }
@@ -863,7 +863,7 @@ function resolvePromptSubtypeLabel(artifactId) {
   const parts = artifactId.split(":");
   const promptIndex = parts.indexOf("prompt");
   if (promptIndex < 0) {
-    return null;
+    return "prompt review";
   }
   const subtype = parts[promptIndex + 1];
   if (!subtype) {
@@ -879,7 +879,7 @@ function resolveWorkspaceLabel(workspace) {
   if (value.startsWith("workspace:")) {
     return "this project";
   }
-  if (value.startsWith("/")) {
+  if (value.startsWith("/") || value.startsWith("~")) {
     const segments = value.split("/").filter(Boolean);
     return segments[segments.length - 1] ?? "this project";
   }
@@ -897,23 +897,46 @@ function resolveActionVerb(action) {
   }
   return policyActionLabel(action);
 }
-function resolveScopeSubtitle(policy) {
+function resolveRememberSentence(policy, commandLabel) {
   const app = harnessDisplayName(policy.harness);
+  const folder = policy.workspace_label?.trim() || resolveWorkspaceLabel(policy.workspace);
+  const verb = policy.action === "block" ? "block" : "allow";
   if (policy.scope === "artifact") {
-    return `Applies once in ${app}`;
+    return `Guard will ${verb} "${commandLabel}" the next time ${app} retries this exact action.`;
   }
   if (policy.scope === "workspace") {
-    return `Applies every time in ${resolveWorkspaceLabel(policy.workspace)} (${app})`;
+    return `Guard will ${verb} "${commandLabel}" every time ${app} runs it in ${folder}.`;
   }
   if (policy.scope === "harness") {
-    return `Applies every time in ${app}`;
+    return `Guard will ${verb} "${commandLabel}" every time ${app} runs a matching action.`;
   }
   if (policy.scope === "publisher") {
     const publisher = policy.publisher?.trim() || "this publisher";
-    return `Applies to ${publisher} in ${app}`;
+    return `Guard will ${verb} actions from ${publisher} in ${app}.`;
   }
   if (policy.scope === "global") {
-    return "Applies on every project on this device";
+    return `Guard will ${verb} matching actions on every project on this device.`;
+  }
+  return `Guard will ${verb} matching actions when ${scopeLabel(policy.scope).toLowerCase()} rules apply.`;
+}
+function resolveScopeSubtitle(policy) {
+  const app = harnessDisplayName(policy.harness);
+  if (policy.scope === "artifact") {
+    return `Once in ${app}`;
+  }
+  if (policy.scope === "workspace") {
+    const folder = policy.workspace_label?.trim() || resolveWorkspaceLabel(policy.workspace);
+    return `This project · ${folder}`;
+  }
+  if (policy.scope === "harness") {
+    return `Every time in ${app}`;
+  }
+  if (policy.scope === "publisher") {
+    const publisher = policy.publisher?.trim() || "this publisher";
+    return `${publisher} in ${app}`;
+  }
+  if (policy.scope === "global") {
+    return "Every project on this device";
   }
   return scopeLabel(policy.scope);
 }
@@ -931,41 +954,68 @@ function resolveWhatPhrase(policy) {
   const familyPhrase = family ? MATCHER_FAMILY_LABELS[family] ?? family.replace(/-/g, " ") : null;
   if (familyPhrase) {
     if (artifactId.startsWith("family:") || policy.scope === "harness") {
-      return `all ${familyPhrase}s`;
+      return `all ${familyPhrase.toLowerCase()}s`;
     }
     if (family === "prompt") {
       const subtype = resolvePromptSubtypeLabel(artifactId);
       return subtype ? `${familyPhrase} (${subtype})` : familyPhrase;
     }
-    return familyPhrase;
+    return familyPhrase.toLowerCase();
   }
   if (publisher) {
     return `actions from ${publisher}`;
   }
   return "matching guarded actions";
 }
+function resolveContextLine(policy) {
+  const remembered = policy.remembered_context?.trim();
+  if (remembered) {
+    return remembered;
+  }
+  const family = policy.artifact_id ? extractMatcherFamily(policy.artifact_id) : null;
+  if (family && MATCHER_FAMILY_LABELS[family]) {
+    return MATCHER_FAMILY_LABELS[family];
+  }
+  return null;
+}
 function resolvePolicyDisplay(policy) {
   const reason = policy.reason?.trim() ?? null;
+  const rememberedCommand = policy.remembered_command?.trim();
+  const contextLine = resolveContextLine(policy);
+  if (rememberedCommand) {
+    return {
+      headline: rememberedCommand,
+      subtitle: [contextLine, resolveScopeSubtitle(policy)].filter(Boolean).join(" · "),
+      rememberSentence: resolveRememberSentence(policy, rememberedCommand),
+      technicalId: policy.artifact_id
+    };
+  }
   const actionVerb = resolveActionVerb(policy.action);
   if (reason && !isGenericReason(reason)) {
     return {
-      headline: `${actionVerb}: ${reason}`,
-      subtitle: resolveScopeSubtitle(policy),
+      headline: reason,
+      subtitle: [contextLine, resolveScopeSubtitle(policy)].filter(Boolean).join(" · "),
+      rememberSentence: resolveRememberSentence(policy, reason),
       technicalId: policy.artifact_id
     };
   }
   const what = resolveWhatPhrase(policy);
+  const headline = `${actionVerb} ${what}`;
   return {
-    headline: `${actionVerb} ${what}`,
-    subtitle: resolveScopeSubtitle(policy),
+    headline,
+    subtitle: [contextLine, resolveScopeSubtitle(policy)].filter(Boolean).join(" · "),
+    rememberSentence: resolveRememberSentence(policy, what),
     technicalId: policy.artifact_id
   };
 }
 function resolvePolicyEvidenceSearchTerm(policy) {
+  const receiptId = policy.source_receipt_id?.trim();
+  if (receiptId) {
+    return receiptId;
+  }
   const hash = policy.artifact_hash?.trim();
   if (hash) {
-    const normalized = hash.replace(/^sha256:/i, "");
-    return normalized.slice(0, 12);
+    return hash.replace(/^sha256:/i, "").slice(0, 12);
   }
   const target = policyTargetLabel(policy);
   if (!target || target === "Global") {
@@ -983,12 +1033,29 @@ function resolvePolicyEvidenceSearchTerm(policy) {
 }
 function resolvePolicyEvidenceHref(policy) {
   const params = new URLSearchParams();
+  const receiptId = policy.source_receipt_id?.trim();
+  if (receiptId) {
+    params.set("selected", receiptId);
+    params.set("search", receiptId);
+    return `/evidence?${params.toString()}`;
+  }
   const searchTerm = resolvePolicyEvidenceSearchTerm(policy);
   if (searchTerm) {
     params.set("search", searchTerm);
   }
   const query = params.toString();
   return query ? `/evidence?${query}` : "/evidence";
+}
+function resolvePolicyApprovalRecordLabel(policy) {
+  const receiptId = policy.source_receipt_id?.trim();
+  if (receiptId) {
+    return `${receiptId}.json`;
+  }
+  const hash = policy.artifact_hash?.replace(/^sha256:/i, "").slice(0, 8);
+  if (hash) {
+    return `receipt_${hash}.json`;
+  }
+  return "View in Evidence";
 }
 function resolveCloudPolicyControlsUrl(snapshot) {
   const dashboardUrl = snapshot.dashboard_url?.trim();
@@ -1026,8 +1093,8 @@ function groupPoliciesByHarness(policies) {
 function resolveSecurityModeCopy(level) {
   if (level === "strict") {
     return {
-      label: "Strict mode",
-      description: "Guard asks before most actions including new network connections and file writes. Higher noise, maximum protection.",
+      label: "Protect",
+      description: "Guard asks before risky actions that are not already allowed by policy, remembered rules, or Cloud exceptions.",
       tone: "attention"
     };
   }
@@ -1058,16 +1125,19 @@ function resolveCloudPolicyBundleCopy(snapshot) {
   }
   const rollout = snapshot.cloud_policy_rollout_state?.trim() || "unknown";
   const syncError = snapshot.cloud_policy_sync_error?.trim();
+  const hash = snapshot.cloud_policy_bundle_hash?.trim() || null;
   if (syncError) {
     return {
-      label: `Cloud bundle ${bundleVersion}`,
-      detail: `Guard Cloud Controls owns rollout and authoring. Latest sync issue: ${syncError}.`,
+      label: "Needs attention",
+      detail: `Bundle ${bundleVersion} is connected, but the latest sync reported: ${syncError}`,
+      hash,
       tone: "attention"
     };
   }
   return {
-    label: `Cloud bundle ${bundleVersion}`,
-    detail: `Guard Cloud Controls owns authoring and rollout. This local workspace reflects rollout state ${rollout}.`,
+    label: "Synced",
+    detail: `Bundle ${bundleVersion} is active on this device (${rollout}).`,
+    hash,
     tone: "green"
   };
 }
@@ -1238,34 +1308,49 @@ function resolveActionTone(action) {
   }
   return "default";
 }
-function PolicyRuleCard({ policy, cloudControlsUrl, onClear }) {
+function resolveFamilyIcon(family) {
+  if (family === "package-request") {
+    return HiMiniCube;
+  }
+  if (family === "tool-action" || family === "tool-output") {
+    return HiMiniCommandLine;
+  }
+  if (family === "prompt" || family === "prompt-env-read") {
+    return HiMiniDocumentText;
+  }
+  if (family === "mcp") {
+    return HiMiniGlobeAlt;
+  }
+  return HiMiniShieldCheck;
+}
+function PolicyRuleRow({ policy, cloudControlsUrl, onClear }) {
   const handleClear = reactExports.useCallback(() => onClear?.(policy), [onClear, policy]);
   const cloudManaged = isCloudManagedPolicy(policy.source);
   const display = resolvePolicyDisplay(policy);
   const canClear = onClear !== void 0 && !cloudManaged;
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("article", { className: "rounded-2xl border border-slate-100 bg-white px-4 py-3.5 shadow-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1 space-y-1.5", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+  const family = resolvePolicyMatcherFamily(policy);
+  const Icon = resolveFamilyIcon(family);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { className: "border-b border-slate-100 last:border-0 hover:bg-slate-50/80", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-3 align-top", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4", "aria-hidden": "true" }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 space-y-1", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: resolveActionTone(policy.action), children: policyActionLabel(policy.action) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudManaged ? "blue" : "green", children: resolvePolicySourceLabel(policy.source) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: scopeLabel(policy.scope) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400", children: harnessDisplayName(policy.harness) })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-base font-semibold leading-snug text-brand-dark", children: display.headline }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-600", children: display.subtitle }),
-      display.technicalId ? /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "text-xs text-slate-500", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer text-brand-blue hover:underline", children: "Technical id" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 break-all font-mono text-[11px] text-slate-600", children: display.technicalId })
-      ] }) : null
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex shrink-0 flex-col items-end gap-2 text-right", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs text-slate-400", children: policy.updated_at ? formatRelativeTime(policy.updated_at) : null }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold leading-snug text-brand-dark", children: display.headline }),
+        display.subtitle ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: display.subtitle }) : null,
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-slate-600", children: display.rememberSentence })
+      ] })
+    ] }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "hidden px-3 py-3 align-top text-sm text-slate-600 md:table-cell", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudManaged ? "blue" : "green", children: resolvePolicySourceLabel(policy.source) }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "hidden px-3 py-3 align-top text-sm text-slate-600 lg:table-cell", children: scopeLabel(policy.scope) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "hidden px-3 py-3 align-top text-sm text-slate-600 xl:table-cell", children: harnessDisplayName(policy.harness) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "hidden px-3 py-3 align-top text-xs text-slate-500 sm:table-cell", children: policy.updated_at ? formatRelativeTime(policy.updated_at) : "—" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("td", { className: "px-3 py-3 align-top text-right", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col items-end gap-2", children: [
       !cloudManaged ? /* @__PURE__ */ jsxRuntimeExports.jsx(
         "a",
         {
           href: guardAwareHref(resolvePolicyEvidenceHref(policy)),
           className: "text-sm font-medium text-brand-blue hover:underline",
-          children: "See approval record"
+          children: resolvePolicyApprovalRecordLabel(policy)
         }
       ) : null,
       cloudManaged && cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
@@ -1293,10 +1378,16 @@ function PolicyRuleCard({ policy, cloudControlsUrl, onClear }) {
           ]
         }
       ) : null
-    ] })
-  ] }) });
+    ] }) })
+  ] });
 }
-function PolicyRuleList({ policies, cloudControlsUrl, onClearPolicy, emptyTitle, emptyBody }) {
+function PolicyRuleTable({
+  policies,
+  cloudControlsUrl,
+  onClearPolicy,
+  emptyTitle,
+  emptyBody
+}) {
   const [visibleCount, setVisibleCount] = reactExports.useState(PAGE_SIZE);
   const visiblePolicies = reactExports.useMemo(() => policies.slice(0, visibleCount), [policies, visibleCount]);
   const hasMore = policies.length > visibleCount;
@@ -1307,15 +1398,25 @@ function PolicyRuleList({ policies, cloudControlsUrl, onClearPolicy, emptyTitle,
     return /* @__PURE__ */ jsxRuntimeExports.jsx(EmptyState, { title: emptyTitle, body: emptyBody, tone: "teach" });
   }
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
-    visiblePolicies.map((policy) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-      PolicyRuleCard,
-      {
-        policy,
-        cloudControlsUrl,
-        onClear: onClearPolicy
-      },
-      `${policy.harness}-${policy.scope}-${policy.artifact_id ?? policy.publisher ?? "global"}-${policy.updated_at ?? ""}-${policy.source}`
-    )),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "overflow-x-auto rounded-2xl border border-slate-100 bg-white shadow-sm", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("table", { className: "min-w-full border-collapse text-left", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("thead", { className: "border-b border-slate-100 bg-slate-50/80 text-xs font-semibold uppercase tracking-wide text-slate-500", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("tr", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "px-3 py-3", children: "Remembered action" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "hidden px-3 py-3 md:table-cell", children: "Source" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "hidden px-3 py-3 lg:table-cell", children: "Scope" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "hidden px-3 py-3 xl:table-cell", children: "Harness" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "hidden px-3 py-3 sm:table-cell", children: "Last updated" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("th", { className: "px-3 py-3 text-right", children: "Record" })
+      ] }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("tbody", { children: visiblePolicies.map((policy) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        PolicyRuleRow,
+        {
+          policy,
+          cloudControlsUrl,
+          onClear: onClearPolicy
+        },
+        `${policy.harness}-${policy.scope}-${policy.artifact_id ?? policy.publisher ?? "global"}-${policy.updated_at ?? ""}-${policy.source}`
+      )) })
+    ] }) }),
     hasMore ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex justify-center pt-1", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {
@@ -1375,7 +1476,7 @@ function GroupedPolicySection({
       }
     ),
     open ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-      PolicyRuleList,
+      PolicyRuleTable,
       {
         policies,
         cloudControlsUrl,
@@ -1434,7 +1535,7 @@ function PolicyRememberedLocalRules({
     GroupedPolicySection,
     {
       title: "Remembered on this device",
-      description: "Choices you saved from Inbox. Each card explains what Guard will do next time.",
+      description: "Choices you saved from Inbox. Each row shows the exact command or action Guard will remember, and where it applies.",
       policies,
       cloudControlsUrl,
       onClearPolicy,
@@ -2050,20 +2151,26 @@ function PolicyWorkspace({
   const modeCopy = reactExports.useMemo(() => resolveSecurityModeCopy(snapshot.security_level), [snapshot.security_level]);
   const cloudBundleCopy = reactExports.useMemo(() => resolveCloudPolicyBundleCopy(snapshot), [snapshot]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    cloudBundleCopy ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: resolveCloudBundleSurfaceClass(cloudBundleCopy.tone), children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-2", children: [
+      cloudBundleCopy ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: resolveCloudBundleSurfaceClass(cloudBundleCopy.tone), children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudBundleCopy.tone, children: cloudBundleCopy.label })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: cloudBundleCopy.detail }),
+        cloudBundleCopy.hash ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 break-all font-mono text-[11px] text-slate-500", children: cloudBundleCopy.hash.slice(0, 8) }) : null
+      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200/70 bg-slate-50/70 p-4 shadow-sm", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudBundleCopy.tone, children: cloudBundleCopy.label })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark/75", children: "Not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle." })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: cloudBundleCopy.detail })
-    ] }) : null,
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Active mode" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: modeCopy.tone, children: modeCopy.label })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: modeCopy.description }),
-      onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Open security settings" }) }) : null
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-5 shadow-sm", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Active mode" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: modeCopy.tone, children: modeCopy.label })
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: modeCopy.description }),
+        onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Open security settings" }) }) : null
+      ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       "div",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16892,7 +16892,7 @@ function filterBySearch(receipts, search) {
     const decision = (r.policy_decision ?? "").toLowerCase();
     const hashRaw = (r.artifact_hash ?? "").toLowerCase();
     const hashNormalized = hashRaw.replace(/^sha256:/, "");
-    return name.includes(q) || id.includes(q) || receiptId.includes(q) || harness.includes(q) || caps.includes(q) || changed.includes(q) || provenance.includes(q) || scope.includes(q) || decision.includes(q) || hashNormalized.startsWith(q) || hashRaw.startsWith(q) || hashNormalized.includes(q);
+    return name.includes(q) || id.includes(q) || receiptId.includes(q) || harness.includes(q) || caps.includes(q) || changed.includes(q) || provenance.includes(q) || scope.includes(q) || decision.includes(q) || hashRaw.startsWith(q) || hashNormalized.includes(q);
   });
 }
 function filterBySourceScope(receipts, sourceScope) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -494,7 +494,7 @@ function requireReact_production() {
   react_production.useTransition = function() {
     return ReactSharedInternals.H.useTransition();
   };
-  react_production.version = "19.2.5";
+  react_production.version = "19.2.7";
   return react_production;
 }
 var hasRequiredReact;
@@ -516,7 +516,7 @@ var hasRequiredScheduler_production;
 function requireScheduler_production() {
   if (hasRequiredScheduler_production) return scheduler_production;
   hasRequiredScheduler_production = 1;
-  (function(exports$1) {
+  (function(exports) {
     function push(heap, node) {
       var index = heap.length;
       heap.push(node);
@@ -550,15 +550,15 @@ function requireScheduler_production() {
       var diff = a.sortIndex - b.sortIndex;
       return 0 !== diff ? diff : a.id - b.id;
     }
-    exports$1.unstable_now = void 0;
+    exports.unstable_now = void 0;
     if ("object" === typeof performance && "function" === typeof performance.now) {
       var localPerformance = performance;
-      exports$1.unstable_now = function() {
+      exports.unstable_now = function() {
         return localPerformance.now();
       };
     } else {
       var localDate = Date, initialTime = localDate.now();
-      exports$1.unstable_now = function() {
+      exports.unstable_now = function() {
         return localDate.now() - initialTime;
       };
     }
@@ -585,12 +585,12 @@ function requireScheduler_production() {
     }
     var isMessageLoopRunning = false, taskTimeoutID = -1, frameInterval = 5, startTime = -1;
     function shouldYieldToHost() {
-      return needsPaint ? true : exports$1.unstable_now() - startTime < frameInterval ? false : true;
+      return needsPaint ? true : exports.unstable_now() - startTime < frameInterval ? false : true;
     }
     function performWorkUntilDeadline() {
       needsPaint = false;
       if (isMessageLoopRunning) {
-        var currentTime = exports$1.unstable_now();
+        var currentTime = exports.unstable_now();
         startTime = currentTime;
         var hasMoreWork = true;
         try {
@@ -610,7 +610,7 @@ function requireScheduler_production() {
                     var continuationCallback = callback(
                       currentTask.expirationTime <= currentTime
                     );
-                    currentTime = exports$1.unstable_now();
+                    currentTime = exports.unstable_now();
                     if ("function" === typeof continuationCallback) {
                       currentTask.callback = continuationCallback;
                       advanceTimers(currentTime);
@@ -660,27 +660,27 @@ function requireScheduler_production() {
       };
     function requestHostTimeout(callback, ms) {
       taskTimeoutID = localSetTimeout(function() {
-        callback(exports$1.unstable_now());
+        callback(exports.unstable_now());
       }, ms);
     }
-    exports$1.unstable_IdlePriority = 5;
-    exports$1.unstable_ImmediatePriority = 1;
-    exports$1.unstable_LowPriority = 4;
-    exports$1.unstable_NormalPriority = 3;
-    exports$1.unstable_Profiling = null;
-    exports$1.unstable_UserBlockingPriority = 2;
-    exports$1.unstable_cancelCallback = function(task) {
+    exports.unstable_IdlePriority = 5;
+    exports.unstable_ImmediatePriority = 1;
+    exports.unstable_LowPriority = 4;
+    exports.unstable_NormalPriority = 3;
+    exports.unstable_Profiling = null;
+    exports.unstable_UserBlockingPriority = 2;
+    exports.unstable_cancelCallback = function(task) {
       task.callback = null;
     };
-    exports$1.unstable_forceFrameRate = function(fps) {
+    exports.unstable_forceFrameRate = function(fps) {
       0 > fps || 125 < fps ? console.error(
         "forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"
       ) : frameInterval = 0 < fps ? Math.floor(1e3 / fps) : 5;
     };
-    exports$1.unstable_getCurrentPriorityLevel = function() {
+    exports.unstable_getCurrentPriorityLevel = function() {
       return currentPriorityLevel;
     };
-    exports$1.unstable_next = function(eventHandler) {
+    exports.unstable_next = function(eventHandler) {
       switch (currentPriorityLevel) {
         case 1:
         case 2:
@@ -698,10 +698,10 @@ function requireScheduler_production() {
         currentPriorityLevel = previousPriorityLevel;
       }
     };
-    exports$1.unstable_requestPaint = function() {
+    exports.unstable_requestPaint = function() {
       needsPaint = true;
     };
-    exports$1.unstable_runWithPriority = function(priorityLevel, eventHandler) {
+    exports.unstable_runWithPriority = function(priorityLevel, eventHandler) {
       switch (priorityLevel) {
         case 1:
         case 2:
@@ -720,8 +720,8 @@ function requireScheduler_production() {
         currentPriorityLevel = previousPriorityLevel;
       }
     };
-    exports$1.unstable_scheduleCallback = function(priorityLevel, callback, options) {
-      var currentTime = exports$1.unstable_now();
+    exports.unstable_scheduleCallback = function(priorityLevel, callback, options) {
+      var currentTime = exports.unstable_now();
       "object" === typeof options && null !== options ? (options = options.delay, options = "number" === typeof options && 0 < options ? currentTime + options : currentTime) : options = currentTime;
       switch (priorityLevel) {
         case 1:
@@ -751,8 +751,8 @@ function requireScheduler_production() {
       options > currentTime ? (priorityLevel.sortIndex = options, push(timerQueue, priorityLevel), null === peek(taskQueue) && priorityLevel === peek(timerQueue) && (isHostTimeoutScheduled ? (localClearTimeout(taskTimeoutID), taskTimeoutID = -1) : isHostTimeoutScheduled = true, requestHostTimeout(handleTimeout, options - currentTime))) : (priorityLevel.sortIndex = timeout, push(taskQueue, priorityLevel), isHostCallbackScheduled || isPerformingWork || (isHostCallbackScheduled = true, isMessageLoopRunning || (isMessageLoopRunning = true, schedulePerformWorkUntilDeadline())));
       return priorityLevel;
     };
-    exports$1.unstable_shouldYield = shouldYieldToHost;
-    exports$1.unstable_wrapCallback = function(callback) {
+    exports.unstable_shouldYield = shouldYieldToHost;
+    exports.unstable_wrapCallback = function(callback) {
       var parentPriorityLevel = currentPriorityLevel;
       return function() {
         var previousPriorityLevel = currentPriorityLevel;
@@ -922,7 +922,7 @@ function requireReactDom_production() {
   reactDom_production.useFormStatus = function() {
     return ReactSharedInternals.H.useHostTransitionStatus();
   };
-  reactDom_production.version = "19.2.5";
+  reactDom_production.version = "19.2.7";
   return reactDom_production;
 }
 var hasRequiredReactDom;
@@ -12366,12 +12366,12 @@ function requireReactDomClient_production() {
     }
   };
   var isomorphicReactPackageVersion$jscomp$inline_1840 = React2.version;
-  if ("19.2.5" !== isomorphicReactPackageVersion$jscomp$inline_1840)
+  if ("19.2.7" !== isomorphicReactPackageVersion$jscomp$inline_1840)
     throw Error(
       formatProdErrorMessage(
         527,
         isomorphicReactPackageVersion$jscomp$inline_1840,
-        "19.2.5"
+        "19.2.7"
       )
     );
   ReactDOMSharedInternals.findDOMNode = function(componentOrElement) {
@@ -12389,10 +12389,10 @@ function requireReactDomClient_production() {
   };
   var internals$jscomp$inline_2347 = {
     bundleType: 0,
-    version: "19.2.5",
+    version: "19.2.7",
     rendererPackageName: "react-dom",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.5"
+    reconcilerVersion: "19.2.7"
   };
   if ("undefined" !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__) {
     var hook$jscomp$inline_2348 = __REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -12459,7 +12459,7 @@ function requireReactDomClient_production() {
     listenToAllSupportedEvents(container2);
     return new ReactDOMHydrationRoot(initialChildren);
   };
-  reactDomClient_production.version = "19.2.5";
+  reactDomClient_production.version = "19.2.7";
   return reactDomClient_production;
 }
 var hasRequiredClient;
@@ -16883,14 +16883,16 @@ function filterBySearch(receipts, search) {
   return receipts.filter((r) => {
     const name = (r.artifact_name ?? r.artifact_id ?? "").toLowerCase();
     const id = r.artifact_id.toLowerCase();
+    const receiptId = r.receipt_id.toLowerCase();
     const harness = r.harness.toLowerCase();
     const caps = (r.capabilities_summary ?? "").toLowerCase();
     const changed = (r.changed_capabilities ?? []).join(" ").toLowerCase();
     const provenance = (r.provenance_summary ?? "").toLowerCase();
     const scope = (r.source_scope ?? "").toLowerCase();
     const decision = (r.policy_decision ?? "").toLowerCase();
-    const hashPrefix = (r.artifact_hash ?? "").toLowerCase().slice(0, 12);
-    return name.includes(q) || id.includes(q) || harness.includes(q) || caps.includes(q) || changed.includes(q) || provenance.includes(q) || scope.includes(q) || decision.includes(q) || hashPrefix.startsWith(q);
+    const hashRaw = (r.artifact_hash ?? "").toLowerCase();
+    const hashNormalized = hashRaw.replace(/^sha256:/, "");
+    return name.includes(q) || id.includes(q) || receiptId.includes(q) || harness.includes(q) || caps.includes(q) || changed.includes(q) || provenance.includes(q) || scope.includes(q) || decision.includes(q) || hashNormalized.startsWith(q) || hashRaw.startsWith(q) || hashNormalized.includes(q);
   });
 }
 function filterBySourceScope(receipts, sourceScope) {
@@ -26474,12 +26476,12 @@ export {
   HiMiniExclamationCircle as J,
   HiMiniClipboardDocumentCheck as K,
   HiMiniClipboard as L,
-  requireReact as M,
-  getDefaultExportFromCjs as N,
-  HiMiniKey as O,
+  getDefaultExportFromCjs as M,
+  HiMiniKey as N,
+  HiMiniLockClosed as O,
   ProofStrip as P,
-  HiMiniLockClosed as Q,
-  HiMiniBellAlert as R,
+  HiMiniBellAlert as Q,
+  React as R,
   SectionLabel as S,
   HiMiniAdjustmentsHorizontal as T,
   HiMiniCog6Tooth as U,
@@ -26573,6 +26575,8 @@ export {
   policyActionLabel as bf,
   fetchCloudExceptions as bg,
   fetchCloudExceptionRequests as bh,
+  HiMiniCube as bi,
+  HiMiniGlobeAlt as bj,
   EvidenceInsightsShareModal as c,
   HiMiniCheckCircle as d,
   GuardHero as e,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.3.1 | MIT License | https://tailwindcss.com */
 @layer properties {
   @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
     *, :before, :after, ::backdrop {
@@ -496,11 +496,11 @@
   }
 
   .inset-0 {
-    inset: calc(var(--spacing) * 0);
+    inset: 0;
   }
 
   .inset-x-0 {
-    inset-inline: calc(var(--spacing) * 0);
+    inset-inline: 0;
   }
 
   .inset-x-2 {
@@ -508,15 +508,7 @@
   }
 
   .inset-y-0 {
-    inset-block: calc(var(--spacing) * 0);
-  }
-
-  .start {
-    inset-inline-start: var(--spacing);
-  }
-
-  .end {
-    inset-inline-end: var(--spacing);
+    inset-block: 0;
   }
 
   .-top-6 {
@@ -524,7 +516,7 @@
   }
 
   .top-0 {
-    top: calc(var(--spacing) * 0);
+    top: 0;
   }
 
   .top-0\.5 {
@@ -560,7 +552,7 @@
   }
 
   .right-0 {
-    right: calc(var(--spacing) * 0);
+    right: 0;
   }
 
   .right-2 {
@@ -580,7 +572,7 @@
   }
 
   .bottom-0 {
-    bottom: calc(var(--spacing) * 0);
+    bottom: 0;
   }
 
   .bottom-4 {
@@ -600,7 +592,7 @@
   }
 
   .left-0 {
-    left: calc(var(--spacing) * 0);
+    left: 0;
   }
 
   .left-0\.5 {
@@ -694,7 +686,7 @@
   }
 
   .mx-1 {
-    margin-inline: calc(var(--spacing) * 1);
+    margin-inline: var(--spacing);
   }
 
   .mx-1\.5 {
@@ -722,7 +714,7 @@
   }
 
   .mt-1 {
-    margin-top: calc(var(--spacing) * 1);
+    margin-top: var(--spacing);
   }
 
   .mt-1\.5 {
@@ -770,7 +762,7 @@
   }
 
   .mr-1 {
-    margin-right: calc(var(--spacing) * 1);
+    margin-right: var(--spacing);
   }
 
   .mr-1\.5 {
@@ -782,7 +774,7 @@
   }
 
   .mb-1 {
-    margin-bottom: calc(var(--spacing) * 1);
+    margin-bottom: var(--spacing);
   }
 
   .mb-1\.5 {
@@ -818,11 +810,11 @@
   }
 
   .ml-0 {
-    margin-left: calc(var(--spacing) * 0);
+    margin-left: 0;
   }
 
   .ml-1 {
-    margin-left: calc(var(--spacing) * 1);
+    margin-left: var(--spacing);
   }
 
   .ml-1\.5 {
@@ -905,7 +897,7 @@
   }
 
   .h-1 {
-    height: calc(var(--spacing) * 1);
+    height: var(--spacing);
   }
 
   .h-1\.5 {
@@ -1041,7 +1033,7 @@
   }
 
   .min-h-0 {
-    min-height: calc(var(--spacing) * 0);
+    min-height: 0;
   }
 
   .min-h-7 {
@@ -1113,7 +1105,7 @@
   }
 
   .w-1 {
-    width: calc(var(--spacing) * 1);
+    width: var(--spacing);
   }
 
   .w-1\.5 {
@@ -1297,7 +1289,7 @@
   }
 
   .min-w-0 {
-    min-width: calc(var(--spacing) * 0);
+    min-width: 0;
   }
 
   .min-w-5 {
@@ -1324,6 +1316,10 @@
     min-width: 180px;
   }
 
+  .min-w-full {
+    min-width: 100%;
+  }
+
   .flex-1 {
     flex: 1;
   }
@@ -1340,6 +1336,10 @@
     flex-shrink: 0;
   }
 
+  .border-collapse {
+    border-collapse: collapse;
+  }
+
   .origin-left {
     transform-origin: 0;
   }
@@ -1350,7 +1350,7 @@
   }
 
   .translate-x-0 {
-    --tw-translate-x: calc(var(--spacing) * 0);
+    --tw-translate-x: 0;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
 
@@ -1365,7 +1365,7 @@
   }
 
   .translate-y-0 {
-    --tw-translate-y: calc(var(--spacing) * 0);
+    --tw-translate-y: 0;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
 
@@ -1407,6 +1407,10 @@
 
   .resize {
     resize: both;
+  }
+
+  .\[scrollbar-gutter\:stable\] {
+    scrollbar-gutter: stable;
   }
 
   .list-disc {
@@ -1490,7 +1494,7 @@
   }
 
   .gap-0 {
-    gap: calc(var(--spacing) * 0);
+    gap: 0;
   }
 
   .gap-0\.5 {
@@ -1498,7 +1502,7 @@
   }
 
   .gap-1 {
-    gap: calc(var(--spacing) * 1);
+    gap: var(--spacing);
   }
 
   .gap-1\.5 {
@@ -1539,8 +1543,7 @@
 
   :where(.space-y-0 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
+    margin-block: 0;
   }
 
   :where(.space-y-0\.5 > :not(:last-child)) {
@@ -1551,8 +1554,8 @@
 
   :where(.space-y-1 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+    margin-block-start: calc(var(--spacing) * var(--tw-space-y-reverse));
+    margin-block-end: calc(var(--spacing) * calc(1 - var(--tw-space-y-reverse)));
   }
 
   :where(.space-y-1\.5 > :not(:last-child)) {
@@ -1626,7 +1629,7 @@
   }
 
   .gap-y-1 {
-    row-gap: calc(var(--spacing) * 1);
+    row-gap: var(--spacing);
   }
 
   .gap-y-2 {
@@ -3392,7 +3395,7 @@
   }
 
   .p-0 {
-    padding: calc(var(--spacing) * 0);
+    padding: 0;
   }
 
   .p-0\.5 {
@@ -3400,7 +3403,7 @@
   }
 
   .p-1 {
-    padding: calc(var(--spacing) * 1);
+    padding: var(--spacing);
   }
 
   .p-1\.5 {
@@ -3432,7 +3435,7 @@
   }
 
   .px-1 {
-    padding-inline: calc(var(--spacing) * 1);
+    padding-inline: var(--spacing);
   }
 
   .px-1\.5 {
@@ -3472,7 +3475,7 @@
   }
 
   .py-1 {
-    padding-block: calc(var(--spacing) * 1);
+    padding-block: var(--spacing);
   }
 
   .py-1\.5 {
@@ -3524,7 +3527,7 @@
   }
 
   .pt-1 {
-    padding-top: calc(var(--spacing) * 1);
+    padding-top: var(--spacing);
   }
 
   .pt-2 {
@@ -3560,7 +3563,7 @@
   }
 
   .pb-1 {
-    padding-bottom: calc(var(--spacing) * 1);
+    padding-bottom: var(--spacing);
   }
 
   .pb-2 {
@@ -3625,6 +3628,10 @@
 
   .text-right {
     text-align: right;
+  }
+
+  .align-top {
+    vertical-align: top;
   }
 
   .font-mono {
@@ -4534,10 +4541,6 @@
     user-select: none;
   }
 
-  .\[scrollbar-gutter\:stable\] {
-    scrollbar-gutter: stable;
-  }
-
   .group-open\:rotate-90:is(:where(.group):is([open], :popover-open, :open) *) {
     rotate: 90deg;
   }
@@ -4567,7 +4570,7 @@
   }
 
   .last\:mb-0:last-child {
-    margin-bottom: calc(var(--spacing) * 0);
+    margin-bottom: 0;
   }
 
   .last\:border-0:last-child {
@@ -4795,6 +4798,16 @@
     @supports (color: color-mix(in lab, red, red)) {
       .hover\:bg-slate-50\/70:hover {
         background-color: color-mix(in oklab, var(--color-slate-50) 70%, transparent);
+      }
+    }
+
+    .hover\:bg-slate-50\/80:hover {
+      background-color: #f8fafccc;
+    }
+
+    @supports (color: color-mix(in lab, red, red)) {
+      .hover\:bg-slate-50\/80:hover {
+        background-color: color-mix(in oklab, var(--color-slate-50) 80%, transparent);
       }
     }
 
@@ -5248,7 +5261,7 @@
     }
 
     .sm\:mt-0 {
-      margin-top: calc(var(--spacing) * 0);
+      margin-top: 0;
     }
 
     .sm\:flex {
@@ -5397,7 +5410,7 @@
     }
 
     .sm\:py-0 {
-      padding-block: calc(var(--spacing) * 0);
+      padding-block: 0;
     }
 
     .sm\:py-2 {
@@ -5429,11 +5442,11 @@
     }
 
     .sm\:pb-0 {
-      padding-bottom: calc(var(--spacing) * 0);
+      padding-bottom: 0;
     }
 
     .sm\:pl-0 {
-      padding-left: calc(var(--spacing) * 0);
+      padding-left: 0;
     }
 
     .sm\:pl-6 {
@@ -5691,6 +5704,10 @@
 
     .xl\:top-6 {
       top: calc(var(--spacing) * 6);
+    }
+
+    .xl\:table-cell {
+      display: table-cell;
     }
 
     .xl\:grid-cols-1 {

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3014,23 +3014,43 @@ class GuardStore:
         query += " order by updated_at desc"
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
-        return [
-            {
-                "harness": str(row["harness"]),
-                "scope": str(row["scope"]),
-                "artifact_id": row["artifact_id"],
-                "artifact_hash": row["artifact_hash"],
-                "workspace": row["workspace"],
-                "publisher": row["publisher"],
-                "action": str(row["action"]),
-                "reason": row["reason"],
-                "owner": row["owner"],
-                "source": str(row["source"]),
-                "expires_at": row["expires_at"],
-                "updated_at": str(row["updated_at"]),
-            }
-            for row in rows
-        ]
+            return [
+                self._policy_decision_dict_from_row(connection, row)
+                for row in rows
+            ]
+
+    @staticmethod
+    def _policy_decision_dict_from_row(connection: sqlite3.Connection, row: sqlite3.Row) -> dict[str, object]:
+        harness = str(row["harness"])
+        artifact_id = row["artifact_id"]
+        artifact_hash = row["artifact_hash"]
+        workspace = row["workspace"]
+        source_context = _find_policy_source_context(
+            connection,
+            harness=harness,
+            scope=str(row["scope"]),
+            artifact_id=str(artifact_id) if artifact_id is not None else None,
+            artifact_hash=str(artifact_hash) if artifact_hash is not None else None,
+            workspace=str(workspace) if workspace is not None else None,
+            reason=str(row["reason"]) if row["reason"] is not None else None,
+        )
+        payload: dict[str, object] = {
+            "harness": harness,
+            "scope": str(row["scope"]),
+            "artifact_id": artifact_id,
+            "artifact_hash": artifact_hash,
+            "workspace": workspace,
+            "publisher": row["publisher"],
+            "action": str(row["action"]),
+            "reason": row["reason"],
+            "owner": row["owner"],
+            "source": str(row["source"]),
+            "expires_at": row["expires_at"],
+            "updated_at": str(row["updated_at"]),
+        }
+        if source_context is not None:
+            payload.update(source_context)
+        return payload
 
     def clear_policy_decisions(
         self,
@@ -5187,6 +5207,241 @@ def _family_key_value(family_key: str) -> str:
     if family_key.startswith("family:"):
         return family_key.removeprefix("family:")
     return family_key
+
+
+_GENERIC_POLICY_REASONS = (
+    "approved in review",
+    "approved in local approval center",
+    "local auto-resume proof",
+    "local e2e approval proof",
+)
+
+
+def _is_generic_policy_reason(reason: str | None) -> bool:
+    if reason is None or not reason.strip():
+        return True
+    normalized = reason.strip().lower()
+    return any(phrase in normalized for phrase in _GENERIC_POLICY_REASONS)
+
+
+def _is_human_policy_label(value: str | None) -> bool:
+    if value is None or not value.strip():
+        return False
+    normalized = value.strip()
+    lowered = normalized.lower()
+    if lowered.startswith("family:"):
+        return False
+    if len(normalized) >= 32 and all(ch in "0123456789abcdef" for ch in lowered):
+        return False
+    if ":" in normalized:
+        tail = normalized.split(":")[-1]
+        if len(tail) >= 16 and all(ch in "0123456789abcdef" for ch in tail):
+            return False
+    return True
+
+
+def _normalize_hash_for_match(value: str) -> str:
+    return value.strip().lower().removeprefix("sha256:")
+
+
+def _workspace_display_label(source_scope: str | None, workspace: str | None) -> str | None:
+    if source_scope and source_scope.strip() and not source_scope.strip().startswith("workspace:"):
+        path = source_scope.strip()
+        if path.startswith("/") or path.startswith("~"):
+            segments = [segment for segment in path.rstrip("/").split("/") if segment]
+            if segments:
+                return segments[-1]
+    if workspace and workspace.strip() and not workspace.strip().startswith("workspace:"):
+        path = workspace.strip()
+        if path.startswith("/") or path.startswith("~"):
+            segments = [segment for segment in path.rstrip("/").split("/") if segment]
+            if segments:
+                return segments[-1]
+        return path
+    return None
+
+
+def _find_policy_source_receipt_row(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_id: str | None,
+    artifact_hash: str | None,
+) -> sqlite3.Row | None:
+    conditions: list[str] = []
+    params: list[object] = []
+    if harness != "*":
+        conditions.append("harness = ?")
+        params.append(harness)
+    if artifact_hash:
+        normalized = _normalize_hash_for_match(artifact_hash)
+        conditions.append(
+            "(artifact_hash = ? OR artifact_hash = ? OR lower(replace(artifact_hash, 'sha256:', '')) = ?)"
+        )
+        params.extend([artifact_hash, f"sha256:{normalized}", normalized])
+    elif artifact_id:
+        conditions.append("artifact_id = ?")
+        params.append(artifact_id)
+    if not conditions:
+        return None
+    return connection.execute(
+        f"""
+        select receipt_id, artifact_name, capabilities_summary, provenance_summary, source_scope
+        from runtime_receipts
+        where {' and '.join(conditions)}
+        order by timestamp desc
+        limit 1
+        """,
+        tuple(params),
+    ).fetchone()
+
+
+def _find_policy_inventory_row(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_id: str | None,
+) -> sqlite3.Row | None:
+    if artifact_id is None or not artifact_id.strip():
+        return None
+    return connection.execute(
+        """
+        select artifact_name, launch_command, source_scope
+        from artifact_inventory
+        where harness = ? and artifact_id = ?
+        limit 1
+        """,
+        (harness, artifact_id),
+    ).fetchone()
+
+
+def _find_policy_approval_row(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_id: str | None,
+    artifact_hash: str | None,
+) -> sqlite3.Row | None:
+    conditions = ["status = 'resolved'"]
+    params: list[object] = []
+    if harness != "*":
+        conditions.append("harness = ?")
+        params.append(harness)
+    if artifact_id:
+        conditions.append("artifact_id = ?")
+        params.append(artifact_id)
+    if artifact_hash:
+        normalized = _normalize_hash_for_match(artifact_hash)
+        conditions.append(
+            "(artifact_hash = ? OR artifact_hash = ? OR lower(replace(artifact_hash, 'sha256:', '')) = ?)"
+        )
+        params.extend([artifact_hash, f"sha256:{normalized}", normalized])
+    if len(conditions) <= 1:
+        return None
+    return connection.execute(
+        f"""
+        select request_id, artifact_name, launch_summary, launch_target, workspace, resolved_at
+        from approval_requests
+        where {' and '.join(conditions)}
+        order by resolved_at desc
+        limit 1
+        """,
+        tuple(params),
+    ).fetchone()
+
+
+def _find_policy_source_context(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    scope: str,
+    artifact_id: str | None,
+    artifact_hash: str | None,
+    workspace: str | None,
+    reason: str | None,
+) -> dict[str, str] | None:
+    receipt_row = _find_policy_source_receipt_row(
+        connection,
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+    )
+    inventory_row = _find_policy_inventory_row(connection, harness=harness, artifact_id=artifact_id)
+    approval_row = _find_policy_approval_row(
+        connection,
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+    )
+
+    remembered_command: str | None = None
+    remembered_context: str | None = None
+    workspace_label: str | None = None
+    source_receipt_id: str | None = None
+
+    if receipt_row is not None:
+        source_receipt_id = str(receipt_row["receipt_id"])
+        receipt_name = receipt_row["artifact_name"]
+        if _is_human_policy_label(str(receipt_name) if receipt_name is not None else None):
+            remembered_command = str(receipt_name).strip()
+        caps = receipt_row["capabilities_summary"]
+        if caps is not None and str(caps).strip():
+            remembered_context = str(caps).strip()
+        workspace_label = _workspace_display_label(
+            str(receipt_row["source_scope"]) if receipt_row["source_scope"] is not None else None,
+            workspace,
+        )
+
+    if inventory_row is not None:
+        launch_command = inventory_row["launch_command"]
+        if remembered_command is None and _is_human_policy_label(
+            str(launch_command) if launch_command is not None else None
+        ):
+            remembered_command = str(launch_command).strip()
+        inventory_name = inventory_row["artifact_name"]
+        if remembered_context is None and _is_human_policy_label(
+            str(inventory_name) if inventory_name is not None else None
+        ):
+            remembered_context = str(inventory_name).strip()
+        if workspace_label is None:
+            workspace_label = _workspace_display_label(
+                str(inventory_row["source_scope"]) if inventory_row["source_scope"] is not None else None,
+                workspace,
+            )
+
+    if approval_row is not None:
+        approval_name = approval_row["artifact_name"]
+        launch_target = approval_row["launch_target"]
+        launch_summary = approval_row["launch_summary"]
+        if remembered_command is None and _is_human_policy_label(
+            str(launch_target) if launch_target is not None else None
+        ):
+            remembered_command = str(launch_target).strip()
+        if remembered_command is None and _is_human_policy_label(str(approval_name)):
+            remembered_command = str(approval_name).strip()
+        if remembered_context is None and _is_human_policy_label(
+            str(launch_summary) if launch_summary is not None else None
+        ):
+            remembered_context = str(launch_summary).strip()
+        if workspace_label is None and approval_row["workspace"] is not None:
+            workspace_label = _workspace_display_label(str(approval_row["workspace"]), workspace)
+
+    if remembered_command is None and not _is_generic_policy_reason(reason):
+        remembered_command = reason.strip() if reason is not None else None
+
+    if source_receipt_id is None and remembered_command is None and remembered_context is None:
+        return None
+
+    payload: dict[str, str] = {}
+    if source_receipt_id is not None:
+        payload["source_receipt_id"] = source_receipt_id
+    if remembered_command is not None:
+        payload["remembered_command"] = remembered_command
+    if remembered_context is not None:
+        payload["remembered_context"] = remembered_context
+    if workspace_label is not None:
+        payload["workspace_label"] = workspace_label
+    return payload or None
 
 
 def _chunks(values: list[str], size: int) -> Iterator[list[str]]:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3003,7 +3003,7 @@ class GuardStore:
 
     def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]:
         query = """
-            select harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
+            select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
                    expires_at, updated_at
             from policy_decisions
         """
@@ -3014,10 +3014,7 @@ class GuardStore:
         query += " order by updated_at desc"
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
-            return [
-                self._policy_decision_dict_from_row(connection, row)
-                for row in rows
-            ]
+            return [self._policy_decision_dict_from_row(connection, row) for row in rows]
 
     @staticmethod
     def _policy_decision_dict_from_row(connection: sqlite3.Connection, row: sqlite3.Row) -> dict[str, object]:
@@ -3035,6 +3032,7 @@ class GuardStore:
             reason=str(row["reason"]) if row["reason"] is not None else None,
         )
         payload: dict[str, object] = {
+            "decision_id": int(row["decision_id"]),
             "harness": harness,
             "scope": str(row["scope"]),
             "artifact_id": artifact_id,
@@ -5244,20 +5242,39 @@ def _normalize_hash_for_match(value: str) -> str:
     return value.strip().lower().removeprefix("sha256:")
 
 
+def _artifact_hash_match_variants(artifact_hash: str) -> tuple[str, ...]:
+    normalized = _normalize_hash_for_match(artifact_hash)
+    variants = {artifact_hash, f"sha256:{normalized}", normalized}
+    return tuple(variant for variant in variants if variant)
+
+
+def _artifact_hash_in_clause(artifact_hash: str) -> tuple[str, tuple[object, ...]]:
+    variants = _artifact_hash_match_variants(artifact_hash)
+    placeholders = ", ".join("?" for _ in variants)
+    return f"artifact_hash in ({placeholders})", variants
+
+
+def _path_basename_label(path: str) -> str | None:
+    normalized = path.strip().replace("\\", "/").rstrip("/")
+    if not normalized or normalized.startswith("workspace:"):
+        return None
+    if normalized.startswith("/") or normalized.startswith("~") or ":" in normalized:
+        segments = [segment for segment in normalized.split("/") if segment]
+        if segments:
+            return segments[-1]
+    return None
+
+
 def _workspace_display_label(source_scope: str | None, workspace: str | None) -> str | None:
-    if source_scope and source_scope.strip() and not source_scope.strip().startswith("workspace:"):
-        path = source_scope.strip()
-        if path.startswith("/") or path.startswith("~"):
-            segments = [segment for segment in path.rstrip("/").split("/") if segment]
-            if segments:
-                return segments[-1]
+    if source_scope and source_scope.strip():
+        label = _path_basename_label(source_scope)
+        if label is not None:
+            return label
     if workspace and workspace.strip() and not workspace.strip().startswith("workspace:"):
-        path = workspace.strip()
-        if path.startswith("/") or path.startswith("~"):
-            segments = [segment for segment in path.rstrip("/").split("/") if segment]
-            if segments:
-                return segments[-1]
-        return path
+        label = _path_basename_label(workspace)
+        if label is not None:
+            return label
+        return workspace.strip()
     return None
 
 
@@ -5274,11 +5291,9 @@ def _find_policy_source_receipt_row(
         conditions.append("harness = ?")
         params.append(harness)
     if artifact_hash:
-        normalized = _normalize_hash_for_match(artifact_hash)
-        conditions.append(
-            "(artifact_hash = ? OR artifact_hash = ? OR lower(replace(artifact_hash, 'sha256:', '')) = ?)"
-        )
-        params.extend([artifact_hash, f"sha256:{normalized}", normalized])
+        hash_clause, hash_params = _artifact_hash_in_clause(artifact_hash)
+        conditions.append(hash_clause)
+        params.extend(hash_params)
     elif artifact_id:
         conditions.append("artifact_id = ?")
         params.append(artifact_id)
@@ -5288,7 +5303,7 @@ def _find_policy_source_receipt_row(
         f"""
         select receipt_id, artifact_name, capabilities_summary, provenance_summary, source_scope
         from runtime_receipts
-        where {' and '.join(conditions)}
+        where {" and ".join(conditions)}
         order by timestamp desc
         limit 1
         """,
@@ -5331,18 +5346,16 @@ def _find_policy_approval_row(
         conditions.append("artifact_id = ?")
         params.append(artifact_id)
     if artifact_hash:
-        normalized = _normalize_hash_for_match(artifact_hash)
-        conditions.append(
-            "(artifact_hash = ? OR artifact_hash = ? OR lower(replace(artifact_hash, 'sha256:', '')) = ?)"
-        )
-        params.extend([artifact_hash, f"sha256:{normalized}", normalized])
+        hash_clause, hash_params = _artifact_hash_in_clause(artifact_hash)
+        conditions.append(hash_clause)
+        params.extend(hash_params)
     if len(conditions) <= 1:
         return None
     return connection.execute(
         f"""
         select request_id, artifact_name, launch_summary, launch_target, workspace, resolved_at
         from approval_requests
-        where {' and '.join(conditions)}
+        where {" and ".join(conditions)}
         order by resolved_at desc
         limit 1
         """,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3003,8 +3003,8 @@ class GuardStore:
 
     def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]:
         query = """
-            select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
-                   expires_at, updated_at
+            select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher,
+                   action, reason, owner, source, expires_at, updated_at
             from policy_decisions
         """
         params: tuple[object, ...] = ()
@@ -3025,7 +3025,6 @@ class GuardStore:
         source_context = _find_policy_source_context(
             connection,
             harness=harness,
-            scope=str(row["scope"]),
             artifact_id=str(artifact_id) if artifact_id is not None else None,
             artifact_hash=str(artifact_hash) if artifact_hash is not None else None,
             workspace=str(workspace) if workspace is not None else None,
@@ -5258,7 +5257,7 @@ def _path_basename_label(path: str) -> str | None:
     normalized = path.strip().replace("\\", "/").rstrip("/")
     if not normalized or normalized.startswith("workspace:"):
         return None
-    if normalized.startswith("/") or normalized.startswith("~") or ":" in normalized:
+    if normalized.startswith("/") or normalized.startswith("~") or (len(normalized) >= 2 and normalized[1] == ":"):
         segments = [segment for segment in normalized.split("/") if segment]
         if segments:
             return segments[-1]
@@ -5367,7 +5366,6 @@ def _find_policy_source_context(
     connection: sqlite3.Connection,
     *,
     harness: str,
-    scope: str,
     artifact_id: str | None,
     artifact_hash: str | None,
     workspace: str | None,

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -1,0 +1,93 @@
+import pytest
+
+from codex_plugin_scanner.guard.models import GuardReceipt, PolicyDecision
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _store(tmp_path) -> GuardStore:
+    return GuardStore(tmp_path / "guard-home")
+
+
+def test_list_policy_decisions_enriches_source_receipt_and_command(tmp_path) -> None:
+    store = _store(tmp_path)
+    receipt = GuardReceipt(
+        receipt_id="receipt-policy-ux-1",
+        timestamp="2026-06-14T12:00:00+00:00",
+        harness="codex",
+        artifact_id="codex:project:package-request:abc123",
+        artifact_hash="2dd8986742cb4f850ae2bb52a9aaa2820c6d9be809592ec0c4b3d207b83f9b6",
+        policy_decision="allow",
+        capabilities_summary="Package install via pnpm",
+        changed_capabilities=("package-request",),
+        provenance_summary="hook event for package install",
+        artifact_name="pnpm install",
+        source_scope="~/projects/hol-points-portal",
+    )
+    store.add_receipt(receipt)
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="workspace",
+            action="allow",
+            artifact_id="codex:project:package-request:abc123",
+            artifact_hash="sha256:2dd8986742cb4f850ae2bb52a9aaa2820c6d9be809592ec0c4b3d207b83f9b6",
+            workspace="workspace:testhash",
+            reason="approved in review",
+            source="local",
+        ),
+        "2026-06-14T12:01:00+00:00",
+    )
+
+    items = store.list_policy_decisions()
+    assert len(items) == 1
+    item = items[0]
+    assert item["source_receipt_id"] == "receipt-policy-ux-1"
+    assert item["remembered_command"] == "pnpm install"
+    assert item["remembered_context"] == "Package install via pnpm"
+    assert item["workspace_label"] == "hol-points-portal"
+
+
+def test_list_policy_decisions_falls_back_to_inventory_launch_command(tmp_path) -> None:
+    store = _store(tmp_path)
+    with store._connect() as connection:
+        connection.execute(
+            """
+            insert into artifact_inventory (
+              artifact_id, harness, artifact_name, artifact_type, source_scope, config_path,
+              first_seen_at, last_seen_at, last_policy_action, artifact_hash
+            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "codex:project:package-request:inv1",
+                "codex",
+                "pnpm",
+                "package_request",
+                "~/projects/hol-guard",
+                "config.json",
+                "2026-06-14T12:00:00+00:00",
+                "2026-06-14T12:00:00+00:00",
+                "allow",
+                "hash-inv1",
+            ),
+        )
+        connection.execute(
+            "update artifact_inventory set launch_command = ? where artifact_id = ? and harness = ?",
+            ("pnpm install --frozen-lockfile", "codex:project:package-request:inv1", "codex"),
+        )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="workspace",
+            action="allow",
+            artifact_id="codex:project:package-request:inv1",
+            artifact_hash="hash-inv1",
+            workspace="workspace:inv",
+            reason="approved in review",
+            source="local",
+        ),
+        "2026-06-14T12:01:00+00:00",
+    )
+
+    item = store.list_policy_decisions()[0]
+    assert item["remembered_command"] == "pnpm install --frozen-lockfile"
+    assert item["workspace_label"] == "hol-guard"

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -1,5 +1,3 @@
-import pytest
-
 from codex_plugin_scanner.guard.models import GuardReceipt, PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -41,6 +39,7 @@ def test_list_policy_decisions_enriches_source_receipt_and_command(tmp_path) -> 
     items = store.list_policy_decisions()
     assert len(items) == 1
     item = items[0]
+    assert isinstance(item["decision_id"], int)
     assert item["source_receipt_id"] == "receipt-policy-ux-1"
     assert item["remembered_command"] == "pnpm install"
     assert item["remembered_context"] == "Package install via pnpm"


### PR DESCRIPTION
## Summary
- Enrich local policy decisions from SQLite receipts, inventory, and resolved approvals so Remembered rules shows the exact command and a plain-language remember sentence
- Link approval records to Evidence by receipt id and fix hash-prefix search for sha256-prefixed artifact hashes
- Restructure Remembered rules into a mockup-aligned table with Guard Cloud bundle and Active mode status cards

## Testing
- `python3 -m pytest tests/test_policy_decision_source_context.py -q`
- `cd dashboard && npx tsx src/policy-workspace-helpers.test.ts`
- `cd dashboard && npx tsx src/policy-remembered-rules.test.tsx`
- `cd dashboard && npx tsx src/evidence/evidence-filters.test.ts`
- `cd dashboard && npm run build`
