### PR TITLE
fix(dashboard): redesign connect fallback as progressive step rail

### DIFF
--- a/dashboard/src/package-firewall-connect.test.tsx
+++ b/dashboard/src/package-firewall-connect.test.tsx
@@ -257,8 +257,91 @@ assert(
   "PF5: raw HTTP errors should not appear in the connect card",
 );
 assert(
+  !failedConnectMarkup.includes("What still works locally"),
+  "PF5: omitted localRecoveryHint should not render an empty disclosure",
+);
+assert(
   failedConnectMarkup.includes("Connect progress"),
   "PF5: failed connect card should keep the progressive step rail",
+);
+
+const authExpiredMarkup = renderToStaticMarkup(
+  <ConnectFlowCard
+    compact
+    connectError="HTTP Error 401: Unauthorized"
+    connectStarting={false}
+    connectFlow={{
+      state: "failed",
+      title: "Guard Cloud sign-in needs attention",
+      detail: "Reconnect HOL Guard Cloud to restore package firewall access.",
+      action_label: "Repair Guard Cloud access",
+      connect_url: "https://hol.org/guard/connect",
+      authorize_url: null,
+      browser_opened: null,
+      request_id: null,
+      poll_after_ms: null,
+    }}
+    mode="repair"
+    onStartConnect={() => undefined}
+  />,
+);
+assert(
+  authExpiredMarkup.includes("Guard Cloud authorization expired"),
+  "PF6: 401 connect errors should map to reconnect guidance",
+);
+
+const networkMarkup = renderToStaticMarkup(
+  <ConnectFlowCard
+    compact
+    connectError="Failed to fetch"
+    connectStarting={false}
+    connectFlow={{
+      state: "failed",
+      title: "Guard Cloud sign-in needs attention",
+      detail: "Reconnect HOL Guard Cloud to restore package firewall access.",
+      action_label: "Repair Guard Cloud access",
+      connect_url: "https://hol.org/guard/connect",
+      authorize_url: null,
+      browser_opened: null,
+      request_id: null,
+      poll_after_ms: null,
+    }}
+    mode="repair"
+    onStartConnect={() => undefined}
+  />,
+);
+assert(
+  networkMarkup.includes("Guard lost contact with the local daemon"),
+  "PF6: network connect errors should map to daemon guidance",
+);
+
+const unknownMarkup = renderToStaticMarkup(
+  <ConnectFlowCard
+    compact
+    connectError="traceback at /tmp/guard-connect.log line 42"
+    connectStarting={false}
+    connectFlow={{
+      state: "failed",
+      title: "Guard Cloud sign-in needs attention",
+      detail: "Reconnect HOL Guard Cloud to restore package firewall access.",
+      action_label: "Repair Guard Cloud access",
+      connect_url: "https://hol.org/guard/connect",
+      authorize_url: null,
+      browser_opened: null,
+      request_id: null,
+      poll_after_ms: null,
+    }}
+    mode="repair"
+    onStartConnect={() => undefined}
+  />,
+);
+assert(
+  unknownMarkup.includes("Guard could not connect right now"),
+  "PF6: unknown connect errors should fall back to generic guidance",
+);
+assert(
+  !unknownMarkup.includes("/tmp/guard-connect.log"),
+  "PF6: unknown connect errors should not leak raw diagnostics",
 );
 
 console.log("package-firewall-connect.test.tsx: all assertions passed");

--- a/dashboard/src/package-firewall-connect.test.tsx
+++ b/dashboard/src/package-firewall-connect.test.tsx
@@ -150,6 +150,14 @@ assert(
   "PF2: staged local recovery view should stay compact instead of nesting extra helper cards",
 );
 assert(
+  freeViewMarkup.includes("What still works locally"),
+  "PF2: local recovery hint should live in progressive disclosure",
+);
+assert(
+  freeViewMarkup.includes("Connect progress"),
+  "PF2: compact connect view should render the progressive step rail",
+);
+assert(
   !freeViewMarkup.includes("SECURITY"),
   "PF2: staged local recovery view should not render the large nested security card",
 );
@@ -218,3 +226,39 @@ assert(
   reconnectLikeMarkup.includes("Repair required"),
   "PF4: broken post-connect local auth should render repair guidance instead of a first-connect badge",
 );
+
+const failedConnectMarkup = renderToStaticMarkup(
+  <ConnectFlowCard
+    compact
+    connectError="HTTP Error 500: Internal Server Error"
+    connectStarting={false}
+    connectFlow={{
+      state: "failed",
+      title: "Guard Cloud sign-in needs attention",
+      detail: "Reconnect HOL Guard Cloud to restore package firewall access.",
+      action_label: "Repair Guard Cloud access",
+      connect_url: "https://hol.org/guard/connect",
+      authorize_url: "https://hol.org/mock-authorize",
+      browser_opened: false,
+      request_id: "guard-connect-2",
+      poll_after_ms: 1500,
+    }}
+    mode="repair"
+    onStartConnect={() => undefined}
+  />,
+);
+
+assert(
+  failedConnectMarkup.includes("Cloud sign-in is temporarily unavailable"),
+  "PF5: connect errors should surface human guidance instead of raw HTTP text",
+);
+assert(
+  !failedConnectMarkup.includes("HTTP Error 500"),
+  "PF5: raw HTTP errors should not appear in the connect card",
+);
+assert(
+  failedConnectMarkup.includes("Connect progress"),
+  "PF5: failed connect card should keep the progressive step rail",
+);
+
+console.log("package-firewall-connect.test.tsx: all assertions passed");

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -105,7 +105,7 @@ function humanizeConnectError(error: string): { detail: string; title: string } 
   }
   return {
     title: "Guard could not start local connect",
-    detail: trimmed,
+    detail: "Guard could not connect right now. Check that the local daemon is running, then try again.",
   };
 }
 
@@ -118,18 +118,24 @@ function ConnectStep({
   title,
 }: ConnectStepProps) {
   const prominent = emphasis === "prominent";
-  const toneClass = done
-    ? "border-brand-green/25 bg-brand-green/[0.05]"
-    : current
-      ? prominent
-        ? "border-brand-blue/30 bg-gradient-to-br from-brand-blue/[0.08] to-white shadow-sm"
-        : "border-brand-blue/25 bg-brand-blue/[0.05]"
-      : "border-slate-200/90 bg-white/90";
-  const badgeClass = done
-    ? "bg-brand-green/12 text-brand-green"
-    : current
-      ? "bg-brand-blue/12 text-brand-blue"
-      : "bg-slate-100 text-slate-500";
+  let toneClass: string;
+  if (done) {
+    toneClass = "border-brand-green/25 bg-brand-green/[0.05]";
+  } else if (current && prominent) {
+    toneClass = "border-brand-blue/30 bg-gradient-to-br from-brand-blue/[0.08] to-white shadow-sm";
+  } else if (current) {
+    toneClass = "border-brand-blue/25 bg-brand-blue/[0.05]";
+  } else {
+    toneClass = "border-slate-200/90 bg-white/90";
+  }
+  let badgeClass: string;
+  if (done) {
+    badgeClass = "bg-brand-green/12 text-brand-green";
+  } else if (current) {
+    badgeClass = "bg-brand-blue/12 text-brand-blue";
+  } else {
+    badgeClass = "bg-slate-100 text-slate-500";
+  }
   const titleClass = prominent
     ? "text-base font-semibold tracking-[-0.02em] text-brand-dark"
     : "text-sm font-semibold text-brand-dark";
@@ -163,7 +169,7 @@ function ConnectProgressRail({
   return (
     <div className="space-y-2.5" role="list" aria-label="Connect progress">
       {steps.map((step, index) => (
-        <div key={step.title} role="listitem">
+        <div key={`${index}-${step.title}`} role="listitem">
           <ConnectStep
             index={index + 1}
             title={step.title}
@@ -404,7 +410,7 @@ export function ConnectFlowCard({
           ) : null}
         </div>
 
-        {localRecoveryHint !== null ? (
+        {localRecoveryHint != null ? (
           <details className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3">
             <summary className="cursor-pointer list-none text-sm font-medium text-brand-dark">
               What still works locally

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -78,30 +78,121 @@ type ConnectStepProps = {
   body: string;
   current: boolean;
   done: boolean;
+  emphasis?: "default" | "prominent";
   index: number;
   title: string;
 };
 
-function ConnectStep({ body, current, done, index, title }: ConnectStepProps) {
+function humanizeConnectError(error: string): { detail: string; title: string } {
+  const trimmed = error.trim();
+  if (/HTTP Error 500|internal server error/i.test(trimmed)) {
+    return {
+      title: "Cloud sign-in is temporarily unavailable",
+      detail: "Guard could not finish the repair flow. Wait a moment, then try connect again.",
+    };
+  }
+  if (/HTTP Error 401|unauthorized/i.test(trimmed)) {
+    return {
+      title: "Guard Cloud authorization expired",
+      detail: "Run connect again to refresh signed access on this machine.",
+    };
+  }
+  if (/failed to fetch|networkerror|load failed/i.test(trimmed)) {
+    return {
+      title: "Guard lost contact with the local daemon",
+      detail: "Confirm the local daemon is still running, then try connect again.",
+    };
+  }
+  return {
+    title: "Guard could not start local connect",
+    detail: trimmed,
+  };
+}
+
+function ConnectStep({
+  body,
+  current,
+  done,
+  emphasis = "default",
+  index,
+  title,
+}: ConnectStepProps) {
+  const prominent = emphasis === "prominent";
   const toneClass = done
-    ? "border-brand-green/20 bg-brand-green/[0.04]"
+    ? "border-brand-green/25 bg-brand-green/[0.05]"
     : current
-    ? "border-brand-blue/20 bg-brand-blue/[0.04]"
-    : "border-slate-200 bg-white/85";
+      ? prominent
+        ? "border-brand-blue/30 bg-gradient-to-br from-brand-blue/[0.08] to-white shadow-sm"
+        : "border-brand-blue/25 bg-brand-blue/[0.05]"
+      : "border-slate-200/90 bg-white/90";
   const badgeClass = done
-    ? "bg-brand-green/10 text-brand-green"
+    ? "bg-brand-green/12 text-brand-green"
     : current
-    ? "bg-brand-blue/10 text-brand-blue"
-    : "bg-slate-100 text-slate-500";
+      ? "bg-brand-blue/12 text-brand-blue"
+      : "bg-slate-100 text-slate-500";
+  const titleClass = prominent
+    ? "text-base font-semibold tracking-[-0.02em] text-brand-dark"
+    : "text-sm font-semibold text-brand-dark";
+  const bodyClass = prominent
+    ? "mt-1.5 text-sm leading-relaxed text-slate-600"
+    : "mt-1 text-sm leading-relaxed text-slate-500";
   return (
-    <div className={`rounded-[18px] border px-3.5 py-3 ${toneClass}`}>
+    <div className={`rounded-2xl border px-4 py-3.5 ${toneClass}`}>
       <div className="flex items-start gap-3">
-        <span className={`inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold ${badgeClass}`}>
-          {done ? <HiMiniCheckCircle className="h-3.5 w-3.5" aria-hidden="true" /> : index}
+        <span
+          className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${badgeClass}`}
+        >
+          {done ? <HiMiniCheckCircle className="h-4 w-4" aria-hidden="true" /> : index}
         </span>
         <div className="min-w-0">
-          <p className="text-sm font-semibold text-brand-dark">{title}</p>
-          <p className="mt-1 text-xs leading-relaxed text-slate-500">{body}</p>
+          <p className={titleClass}>{title}</p>
+          <p className={bodyClass}>{body}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function ConnectProgressRail({
+  steps,
+}: {
+  steps: Array<{ body: string; current: boolean; done: boolean; title: string }>;
+}) {
+  const activeIndex = steps.findIndex((step) => step.current);
+  const focusIndex = activeIndex >= 0 ? activeIndex : steps.findIndex((step) => !step.done);
+  return (
+    <div className="space-y-2.5" role="list" aria-label="Connect progress">
+      {steps.map((step, index) => (
+        <div key={step.title} role="listitem">
+          <ConnectStep
+            index={index + 1}
+            title={step.title}
+            body={step.body}
+            current={step.current}
+            done={step.done}
+            emphasis={index === focusIndex ? "prominent" : "default"}
+          />
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function ConnectErrorBanner({ connectError }: { connectError: string }) {
+  const copy = humanizeConnectError(connectError);
+  return (
+    <div
+      className="rounded-2xl border border-brand-attention/30 bg-brand-attention/[0.06] px-4 py-3.5"
+      role="alert"
+    >
+      <div className="flex items-start gap-3">
+        <HiMiniExclamationTriangle
+          className="mt-0.5 h-5 w-5 shrink-0 text-brand-attention"
+          aria-hidden="true"
+        />
+        <div className="min-w-0">
+          <p className="text-sm font-semibold text-brand-dark">{copy.title}</p>
+          <p className="mt-1 text-sm leading-relaxed text-slate-600">{copy.detail}</p>
         </div>
       </div>
     </div>
@@ -255,9 +346,7 @@ export function ConnectFlowCard({
         </div>
         <p className="text-sm leading-relaxed text-slate-600">{helperText}</p>
         {connectError !== null ? (
-          <p className="text-sm text-brand-attention" role="alert">
-            {connectError}
-          </p>
+          <ConnectErrorBanner connectError={connectError} />
         ) : null}
         <div className="flex flex-wrap items-center gap-2">
           <ActionButton variant="primary" onClick={onStartConnect} disabled={primaryBusy}>
@@ -280,60 +369,53 @@ export function ConnectFlowCard({
   }
   if (compact) {
     return (
-      <div className="space-y-3">
-        <div className="space-y-2">
+      <div className="space-y-5">
+        <div className="space-y-3">
           <div className="flex flex-wrap items-center gap-2">
-            <p className="text-[10px] font-semibold uppercase tracking-[0.18em] text-brand-blue">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-blue">
               HOL Guard Cloud
             </p>
             <Tag tone={statusTone}>{statusLabel}</Tag>
           </div>
-          <div className="space-y-1">
-            <p className="text-base font-semibold tracking-[-0.02em] text-brand-dark">
-              {titleCopy}
-            </p>
-            <p className="max-w-3xl text-sm leading-relaxed text-slate-500">
-              {detailCopy}
-            </p>
+          <div className="space-y-2">
+            <p className="text-lg font-semibold tracking-[-0.02em] text-brand-dark">{titleCopy}</p>
+            <p className="max-w-2xl text-sm leading-relaxed text-slate-600">{detailCopy}</p>
           </div>
         </div>
 
-        <div className="grid gap-2 text-xs leading-relaxed text-slate-500 md:grid-cols-3">
-          {steps.map((step, index) => (
-            <div key={step.title} className="min-w-0">
-              <p className="font-semibold text-brand-dark">
-                {index + 1}. {step.title}
-              </p>
-              <p className="mt-0.5">{step.body}</p>
-            </div>
-          ))}
-        </div>
+        <ConnectProgressRail steps={steps} />
 
-        <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs leading-relaxed text-slate-500">
-          {localRecoveryHint !== null && <span>{localRecoveryHint}</span>}
-          <span>Guard changes routing only after this machine receives signed cloud access.</span>
-        </div>
+        {connectError !== null ? <ConnectErrorBanner connectError={connectError} /> : null}
 
-        {connectError !== null && (
-          <p className="text-xs leading-relaxed text-brand-attention">{connectError}</p>
-        )}
-
-        <div className="flex flex-wrap items-center gap-2">
+        <div className="flex flex-wrap items-center gap-2.5">
           <ActionButton variant="primary" onClick={onStartConnect} disabled={primaryBusy}>
             {primaryBusy ? (
-              <HiMiniArrowPath className="mr-1.5 h-3.5 w-3.5 animate-spin" aria-hidden="true" />
+              <HiMiniArrowPath className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
             ) : (
-              <HiMiniShieldCheck className="mr-1.5 h-3.5 w-3.5" aria-hidden="true" />
+              <HiMiniShieldCheck className="mr-1.5 h-4 w-4" aria-hidden="true" />
             )}
             {primaryLabel}
           </ActionButton>
-          {showManualLink && (
+          {showManualLink ? (
             <ActionButton href={manualHref} variant="outline">
               Open sign-in page
-              <HiMiniArrowTopRightOnSquare className="ml-1.5 h-3.5 w-3.5" aria-hidden="true" />
+              <HiMiniArrowTopRightOnSquare className="ml-1.5 h-4 w-4" aria-hidden="true" />
             </ActionButton>
-          )}
+          ) : null}
         </div>
+
+        {localRecoveryHint !== null ? (
+          <details className="rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3">
+            <summary className="cursor-pointer list-none text-sm font-medium text-brand-dark">
+              What still works locally
+            </summary>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">{localRecoveryHint}</p>
+          </details>
+        ) : null}
+
+        <p className="text-sm leading-relaxed text-slate-500">
+          Guard changes routing only after this machine receives signed cloud access.
+        </p>
       </div>
     );
   }
@@ -367,34 +449,18 @@ export function ConnectFlowCard({
           </div>
         </div>
 
-        <div className="grid gap-2.5 md:grid-cols-3">
-          {steps.map((step, index) => (
-            <ConnectStep
-              key={step.title}
-              index={index + 1}
-              title={step.title}
-              body={step.body}
-              current={step.current}
-              done={step.done}
-            />
-          ))}
-        </div>
+        <ConnectProgressRail steps={steps} />
 
         {localRecoveryHint != null && (
-          <div className="rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3">
-            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-slate-400">
-              Available now
-            </p>
-            <p className="mt-1 text-xs leading-relaxed text-slate-600">{localRecoveryHint}</p>
-          </div>
+          <details className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3">
+            <summary className="cursor-pointer list-none text-sm font-medium text-brand-dark">
+              What still works locally
+            </summary>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">{localRecoveryHint}</p>
+          </details>
         )}
 
-        {connectError !== null && (
-          <div className="rounded-[18px] border border-brand-attention/25 bg-brand-attention/[0.05] px-3.5 py-3">
-            <p className="text-sm font-medium text-brand-dark">Guard could not start local connect</p>
-            <p className="mt-1 text-xs leading-relaxed text-slate-600">{connectError}</p>
-          </div>
-        )}
+        {connectError !== null ? <ConnectErrorBanner connectError={connectError} /> : null}
 
         <div className="flex flex-wrap items-center gap-2">
           <ActionButton variant="primary" onClick={onStartConnect} disabled={primaryBusy}>
@@ -424,17 +490,17 @@ type CliFallbackProps = {
 export function CliFallback({ commands }: CliFallbackProps) {
   const items = Object.entries(commands);
   return (
-    <details className="rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3">
-      <summary className="cursor-pointer list-none text-xs font-semibold uppercase tracking-[0.18em] text-slate-400">
-        CLI fallback
+    <details className="rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3.5">
+      <summary className="cursor-pointer list-none text-sm font-medium text-slate-600">
+        Advanced: run connect from the terminal
       </summary>
-      <div className="mt-3 space-y-1.5">
+      <div className="mt-3 space-y-2">
         {items.map(([label, command]) => (
           <div key={label} className="min-w-0">
-            <span className="mr-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400">
+            <span className="mr-2 text-xs font-semibold uppercase tracking-wide text-slate-400">
               {label}
             </span>
-            <code className="break-all font-mono text-xs text-brand-dark">{command}</code>
+            <code className="break-all font-mono text-sm text-brand-dark">{command}</code>
           </div>
         ))}
       </div>
@@ -478,7 +544,7 @@ export function EntitlementNotice({
     data.package_shims.some((shim) => shim.installed) ||
     data.protection?.path_status === "restart_required";
   return (
-    <div className="space-y-4 px-4 py-4">
+    <div className="space-y-5 px-4 py-5 sm:px-5 sm:py-6">
       {connectRequired && data.connect_flow !== null ? (
         <ConnectFlowCard
           compact={compactConnectNotice}

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19178,16 +19178,97 @@ function UpgradeCta({ entitlement }) {
     ] })
   ] });
 }
-function ConnectStep({ body, current, done, index, title }) {
-  const toneClass = done ? "border-brand-green/20 bg-brand-green/[0.04]" : current ? "border-brand-blue/20 bg-brand-blue/[0.04]" : "border-slate-200 bg-white/85";
-  const badgeClass = done ? "bg-brand-green/10 text-brand-green" : current ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-100 text-slate-500";
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `rounded-[18px] border px-3.5 py-3 ${toneClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-semibold ${badgeClass}`, children: done ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) : index }),
+function humanizeConnectError(error) {
+  const trimmed = error.trim();
+  if (/HTTP Error 500|internal server error/i.test(trimmed)) {
+    return {
+      title: "Cloud sign-in is temporarily unavailable",
+      detail: "Guard could not finish the repair flow. Wait a moment, then try connect again."
+    };
+  }
+  if (/HTTP Error 401|unauthorized/i.test(trimmed)) {
+    return {
+      title: "Guard Cloud authorization expired",
+      detail: "Run connect again to refresh signed access on this machine."
+    };
+  }
+  if (/failed to fetch|networkerror|load failed/i.test(trimmed)) {
+    return {
+      title: "Guard lost contact with the local daemon",
+      detail: "Confirm the local daemon is still running, then try connect again."
+    };
+  }
+  return {
+    title: "Guard could not start local connect",
+    detail: trimmed
+  };
+}
+function ConnectStep({
+  body,
+  current,
+  done,
+  emphasis = "default",
+  index,
+  title
+}) {
+  const prominent = emphasis === "prominent";
+  const toneClass = done ? "border-brand-green/25 bg-brand-green/[0.05]" : current ? prominent ? "border-brand-blue/30 bg-gradient-to-br from-brand-blue/[0.08] to-white shadow-sm" : "border-brand-blue/25 bg-brand-blue/[0.05]" : "border-slate-200/90 bg-white/90";
+  const badgeClass = done ? "bg-brand-green/12 text-brand-green" : current ? "bg-brand-blue/12 text-brand-blue" : "bg-slate-100 text-slate-500";
+  const titleClass = prominent ? "text-base font-semibold tracking-[-0.02em] text-brand-dark" : "text-sm font-semibold text-brand-dark";
+  const bodyClass = prominent ? "mt-1.5 text-sm leading-relaxed text-slate-600" : "mt-1 text-sm leading-relaxed text-slate-500";
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `rounded-2xl border px-4 py-3.5 ${toneClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "span",
+      {
+        className: `inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-xs font-semibold ${badgeClass}`,
+        children: done ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4", "aria-hidden": "true" }) : index
+      }
+    ),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: title }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-500", children: body })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: titleClass, children: title }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: bodyClass, children: body })
     ] })
   ] }) });
+}
+function ConnectProgressRail({
+  steps
+}) {
+  const activeIndex = steps.findIndex((step) => step.current);
+  const focusIndex = activeIndex >= 0 ? activeIndex : steps.findIndex((step) => !step.done);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-2.5", role: "list", "aria-label": "Connect progress", children: steps.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "listitem", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+    ConnectStep,
+    {
+      index: index + 1,
+      title: step.title,
+      body: step.body,
+      current: step.current,
+      done: step.done,
+      emphasis: index === focusIndex ? "prominent" : "default"
+    }
+  ) }, step.title)) });
+}
+function ConnectErrorBanner({ connectError }) {
+  const copy = humanizeConnectError(connectError);
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    "div",
+    {
+      className: "rounded-2xl border border-brand-attention/30 bg-brand-attention/[0.06] px-4 py-3.5",
+      role: "alert",
+      children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          HiMiniExclamationTriangle,
+          {
+            className: "mt-0.5 h-5 w-5 shrink-0 text-brand-attention",
+            "aria-hidden": "true"
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: copy.title }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: copy.detail })
+        ] })
+      ] })
+    }
+  );
 }
 function resolveConnectUnlockCopy(purpose) {
   if (purpose === "insights_share") {
@@ -19307,7 +19388,7 @@ function ConnectFlowCard({
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-5 py-5", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap items-center gap-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: statusTone, children: statusLabel }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm leading-relaxed text-slate-600", children: helperText }),
-      connectError !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-attention", role: "alert", children: connectError }) : null,
+      connectError !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(ConnectErrorBanner, { connectError }) : null,
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "primary", onClick: onStartConnect, disabled: primaryBusy, children: [
           primaryBusy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mr-1.5 h-3.5 w-3.5 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mr-1.5 h-3.5 w-3.5", "aria-hidden": "true" }),
@@ -19321,40 +19402,34 @@ function ConnectFlowCard({
     ] });
   }
   if (compact) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-brand-blue", children: "HOL Guard Cloud" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[11px] font-semibold uppercase tracking-[0.16em] text-brand-blue", children: "HOL Guard Cloud" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: statusTone, children: statusLabel })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-base font-semibold tracking-[-0.02em] text-brand-dark", children: titleCopy }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "max-w-3xl text-sm leading-relaxed text-slate-500", children: detailCopy })
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-lg font-semibold tracking-[-0.02em] text-brand-dark", children: titleCopy }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "max-w-2xl text-sm leading-relaxed text-slate-600", children: detailCopy })
         ] })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2 text-xs leading-relaxed text-slate-500 md:grid-cols-3", children: steps.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "font-semibold text-brand-dark", children: [
-          index + 1,
-          ". ",
-          step.title
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5", children: step.body })
-      ] }, step.title)) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-x-4 gap-y-1 text-xs leading-relaxed text-slate-500", children: [
-        localRecoveryHint !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: localRecoveryHint }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Guard changes routing only after this machine receives signed cloud access." })
-      ] }),
-      connectError !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-brand-attention", children: connectError }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(ConnectProgressRail, { steps }),
+      connectError !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(ConnectErrorBanner, { connectError }) : null,
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2.5", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "primary", onClick: onStartConnect, disabled: primaryBusy, children: [
-          primaryBusy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mr-1.5 h-3.5 w-3.5 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mr-1.5 h-3.5 w-3.5", "aria-hidden": "true" }),
+          primaryBusy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mr-1.5 h-4 w-4 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
           primaryLabel
         ] }),
-        showManualLink && /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: manualHref, variant: "outline", children: [
+        showManualLink ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: manualHref, variant: "outline", children: [
           "Open sign-in page",
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "ml-1.5 h-3.5 w-3.5", "aria-hidden": "true" })
-        ] })
-      ] })
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "ml-1.5 h-4 w-4", "aria-hidden": "true" })
+        ] }) : null
+      ] }),
+      localRecoveryHint !== null ? /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer list-none text-sm font-medium text-brand-dark", children: "What still works locally" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-slate-600", children: localRecoveryHint })
+      ] }) : null,
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm leading-relaxed text-slate-500", children: "Guard changes routing only after this machine receives signed cloud access." })
     ] });
   }
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4", children: [
@@ -19374,25 +19449,12 @@ function ConnectFlowCard({
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: "Guard does not change package-manager routing until this machine receives signed cloud access." })
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "grid gap-2.5 md:grid-cols-3", children: steps.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-      ConnectStep,
-      {
-        index: index + 1,
-        title: step.title,
-        body: step.body,
-        current: step.current,
-        done: step.done
-      },
-      step.title
-    )) }),
-    localRecoveryHint != null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 px-3.5 py-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-[0.14em] text-slate-400", children: "Available now" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: localRecoveryHint })
+    /* @__PURE__ */ jsxRuntimeExports.jsx(ConnectProgressRail, { steps }),
+    localRecoveryHint != null && /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer list-none text-sm font-medium text-brand-dark", children: "What still works locally" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-slate-600", children: localRecoveryHint })
     ] }),
-    connectError !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-[18px] border border-brand-attention/25 bg-brand-attention/[0.05] px-3.5 py-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: "Guard could not start local connect" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: connectError })
-    ] }),
+    connectError !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(ConnectErrorBanner, { connectError }) : null,
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "primary", onClick: onStartConnect, disabled: primaryBusy, children: [
         primaryBusy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mr-1.5 h-3.5 w-3.5 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mr-1.5 h-3.5 w-3.5", "aria-hidden": "true" }),
@@ -19407,11 +19469,11 @@ function ConnectFlowCard({
 }
 function CliFallback({ commands }) {
   const items = Object.entries(commands);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "rounded-xl border border-slate-200 bg-slate-50/80 px-4 py-3", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer list-none text-xs font-semibold uppercase tracking-[0.18em] text-slate-400", children: "CLI fallback" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 space-y-1.5", children: items.map(([label, command]) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mr-2 text-[10px] font-semibold uppercase tracking-wide text-slate-400", children: label }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "break-all font-mono text-xs text-brand-dark", children: command })
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 px-4 py-3.5", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer list-none text-sm font-medium text-slate-600", children: "Advanced: run connect from the terminal" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 space-y-2", children: items.map(([label, command]) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mr-2 text-xs font-semibold uppercase tracking-wide text-slate-400", children: label }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("code", { className: "break-all font-mono text-sm text-brand-dark", children: command })
     ] }, label)) })
   ] });
 }
@@ -19429,7 +19491,7 @@ function EntitlementNotice({
   const connectMode = reconnectLikeState ? "repair" : "connect";
   const localRecoveryHint = data.package_shims.some((shim) => shim.installed) ? connectRequired ? "Existing shims on this machine can still be fixed or removed locally. Connect is only needed for new installs and cloud-gated verification." : null : null;
   const compactConnectNotice = data.package_shims.some((shim) => shim.installed) || data.protection?.path_status === "restart_required";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-4 py-4", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-5 px-4 py-5 sm:px-5 sm:py-6", children: [
     connectRequired && data.connect_flow !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       ConnectFlowCard,
       {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -19200,7 +19200,7 @@ function humanizeConnectError(error) {
   }
   return {
     title: "Guard could not start local connect",
-    detail: trimmed
+    detail: "Guard could not connect right now. Check that the local daemon is running, then try again."
   };
 }
 function ConnectStep({
@@ -19212,8 +19212,24 @@ function ConnectStep({
   title
 }) {
   const prominent = emphasis === "prominent";
-  const toneClass = done ? "border-brand-green/25 bg-brand-green/[0.05]" : current ? prominent ? "border-brand-blue/30 bg-gradient-to-br from-brand-blue/[0.08] to-white shadow-sm" : "border-brand-blue/25 bg-brand-blue/[0.05]" : "border-slate-200/90 bg-white/90";
-  const badgeClass = done ? "bg-brand-green/12 text-brand-green" : current ? "bg-brand-blue/12 text-brand-blue" : "bg-slate-100 text-slate-500";
+  let toneClass;
+  if (done) {
+    toneClass = "border-brand-green/25 bg-brand-green/[0.05]";
+  } else if (current && prominent) {
+    toneClass = "border-brand-blue/30 bg-gradient-to-br from-brand-blue/[0.08] to-white shadow-sm";
+  } else if (current) {
+    toneClass = "border-brand-blue/25 bg-brand-blue/[0.05]";
+  } else {
+    toneClass = "border-slate-200/90 bg-white/90";
+  }
+  let badgeClass;
+  if (done) {
+    badgeClass = "bg-brand-green/12 text-brand-green";
+  } else if (current) {
+    badgeClass = "bg-brand-blue/12 text-brand-blue";
+  } else {
+    badgeClass = "bg-slate-100 text-slate-500";
+  }
   const titleClass = prominent ? "text-base font-semibold tracking-[-0.02em] text-brand-dark" : "text-sm font-semibold text-brand-dark";
   const bodyClass = prominent ? "mt-1.5 text-sm leading-relaxed text-slate-600" : "mt-1 text-sm leading-relaxed text-slate-500";
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `rounded-2xl border px-4 py-3.5 ${toneClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
@@ -19245,7 +19261,7 @@ function ConnectProgressRail({
       done: step.done,
       emphasis: index === focusIndex ? "prominent" : "default"
     }
-  ) }, step.title)) });
+  ) }, `${index}-${step.title}`)) });
 }
 function ConnectErrorBanner({ connectError }) {
   const copy = humanizeConnectError(connectError);
@@ -19425,7 +19441,7 @@ function ConnectFlowCard({
           /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "ml-1.5 h-4 w-4", "aria-hidden": "true" })
         ] }) : null
       ] }),
-      localRecoveryHint !== null ? /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3", children: [
+      localRecoveryHint != null ? /* @__PURE__ */ jsxRuntimeExports.jsxs("details", { className: "rounded-2xl border border-slate-200 bg-slate-50/70 px-4 py-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("summary", { className: "cursor-pointer list-none text-sm font-medium text-brand-dark", children: "What still works locally" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-slate-600", children: localRecoveryHint })
       ] }) : null,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1713,10 +1713,6 @@
     border-radius: 3px;
   }
 
-  .rounded-\[18px\] {
-    border-radius: 18px;
-  }
-
   .rounded-full {
     border-radius: 3.40282e38px;
   }
@@ -2179,6 +2175,16 @@
     }
   }
 
+  .border-slate-200\/90 {
+    border-color: #e2e8f0e6;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-slate-200\/90 {
+      border-color: color-mix(in oklab, var(--color-slate-200) 90%, transparent);
+    }
+  }
+
   .border-slate-300 {
     border-color: var(--color-slate-300);
   }
@@ -2441,13 +2447,13 @@
     }
   }
 
-  .bg-brand-attention\/\[0\.05\] {
+  .bg-brand-attention\/\[0\.06\] {
     background-color: var(--brand-attention);
   }
 
   @supports (color: color-mix(in lab, red, red)) {
-    .bg-brand-attention\/\[0\.05\] {
-      background-color: color-mix(in oklab, var(--brand-attention) 5%, transparent);
+    .bg-brand-attention\/\[0\.06\] {
+      background-color: color-mix(in oklab, var(--brand-attention) 6%, transparent);
     }
   }
 
@@ -2458,6 +2464,16 @@
   @supports (color: color-mix(in lab, red, red)) {
     .bg-brand-blue\/10 {
       background-color: color-mix(in oklab, var(--brand-blue) 10%, transparent);
+    }
+  }
+
+  .bg-brand-blue\/12 {
+    background-color: var(--brand-blue);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-brand-blue\/12 {
+      background-color: color-mix(in oklab, var(--brand-blue) 12%, transparent);
     }
   }
 
@@ -2605,6 +2621,16 @@
     }
   }
 
+  .bg-brand-green\/12 {
+    background-color: var(--brand-green);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-brand-green\/12 {
+      background-color: color-mix(in oklab, var(--brand-green) 12%, transparent);
+    }
+  }
+
   .bg-brand-green\/20 {
     background-color: var(--brand-green);
   }
@@ -2632,6 +2658,16 @@
   @supports (color: color-mix(in lab, red, red)) {
     .bg-brand-green\/\[0\.04\] {
       background-color: color-mix(in oklab, var(--brand-green) 4%, transparent);
+    }
+  }
+
+  .bg-brand-green\/\[0\.05\] {
+    background-color: var(--brand-green);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-brand-green\/\[0\.05\] {
+      background-color: color-mix(in oklab, var(--brand-green) 5%, transparent);
     }
   }
 
@@ -3044,16 +3080,6 @@
   @supports (color: color-mix(in lab, red, red)) {
     .bg-white\/80 {
       background-color: color-mix(in oklab, var(--color-white) 80%, transparent);
-    }
-  }
-
-  .bg-white\/85 {
-    background-color: #ffffffd9;
-  }
-
-  @supports (color: color-mix(in lab, red, red)) {
-    .bg-white\/85 {
-      background-color: color-mix(in oklab, var(--color-white) 85%, transparent);
     }
   }
 


### PR DESCRIPTION
## Summary
- Replace the compact connect gate's three-column text wall with a vertical progressive step rail
- Increase readable type scale and elevate the active connect step
- Humanize connect errors (including HTTP 500) into actionable banners
- Move local recovery and CLI guidance into progressive disclosure

## Testing
- `cd dashboard && pnpm exec tsx src/package-firewall-connect.test.tsx`
- `cd dashboard && pnpm run build`
