### PR TITLE
fix(guard): require review for manifest-only install dependencies

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -114,11 +114,13 @@ from ..harness_usage import record_harness_usage_events
 from ..incident import build_incident_context
 from ..local_dashboard_session import build_local_dashboard_session_token
 from ..local_supply_chain import (
+    _apply_stored_package_policy_override,
     build_local_supply_chain_posture,
     build_supply_chain_explain_payload,
     build_supply_chain_status_payload,
     build_workspace_audit_payload,
     build_workspace_scan_payload,
+    package_request_policy_hash,
     resolve_package_firewall_entitlement_with_refresh,
 )
 from ..mcp_tool_calls import (

--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -114,7 +114,7 @@ from ..harness_usage import record_harness_usage_events
 from ..incident import build_incident_context
 from ..local_dashboard_session import build_local_dashboard_session_token
 from ..local_supply_chain import (
-    _apply_stored_package_policy_override,
+    apply_stored_package_policy_override,
     build_local_supply_chain_posture,
     build_supply_chain_explain_payload,
     build_supply_chain_status_payload,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -24,7 +24,21 @@ def _evaluate_runtime_artifact_hook(
     store: GuardStore,
 ) -> int | RuntimeArtifactHookState:
     event_name = _hook_event_name(payload) or "PreToolUse"
-    runtime_artifact_hash = artifact_hash(runtime_artifact)
+    package_evaluation = None
+    if runtime_artifact.artifact_type == "package_request" and runtime_workspace is not None:
+        package_evaluation = evaluate_package_request_artifact(
+            artifact=runtime_artifact,
+            store=store,
+            workspace_dir=runtime_workspace,
+        )
+        runtime_artifact_hash = package_request_policy_hash(
+            artifact=runtime_artifact,
+            store=store,
+            workspace_dir=runtime_workspace,
+            evaluation=package_evaluation,
+        )
+    else:
+        runtime_artifact_hash = artifact_hash(runtime_artifact)
     artifact_id = runtime_artifact.artifact_id
     artifact_name = runtime_artifact.name
     policy_harness = _canonical_harness_name(args.harness)
@@ -125,23 +139,23 @@ def _evaluate_runtime_artifact_hook(
             policy_action="allow" if saved else "require-reapproval",
         )
         return 0
+    if package_evaluation is not None and runtime_workspace is not None:
+        package_evaluation = _apply_stored_package_policy_override(
+            package_evaluation,
+            store=store,
+            artifact=runtime_artifact,
+            artifact_hash=runtime_artifact_hash,
+            workspace_dir=runtime_workspace,
+            now=_now(),
+        )
     changed_capabilities = [runtime_artifact.artifact_type]
-    package_evaluation = None
     scanner_evidence = (
         scan_action_for_cisco_evidence(action_envelope, workspace=runtime_workspace)
         if action_envelope is not None
         else ()
     )
     scanner_evidence_payload = [signal.to_dict() for signal in scanner_evidence]
-    if (
-        runtime_artifact.artifact_type == "package_request"
-        and requested_policy_action not in VALID_GUARD_ACTIONS
-    ):
-        package_evaluation = evaluate_package_request_artifact(
-            artifact=runtime_artifact,
-            store=store,
-            workspace_dir=runtime_workspace,
-        )
+    if package_evaluation is not None:
         if guard_action_severity(package_evaluation.policy_action) > guard_action_severity(policy_action):
             policy_action = package_evaluation.policy_action
     if data_flow_signals:

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -155,9 +155,11 @@ def _evaluate_runtime_artifact_hook(
         else ()
     )
     scanner_evidence_payload = [signal.to_dict() for signal in scanner_evidence]
-    if package_evaluation is not None:
-        if guard_action_severity(package_evaluation.policy_action) > guard_action_severity(policy_action):
-            policy_action = package_evaluation.policy_action
+    if (
+        package_evaluation is not None
+        and guard_action_severity(package_evaluation.policy_action) > guard_action_severity(policy_action)
+    ):
+        policy_action = package_evaluation.policy_action
     if data_flow_signals:
         data_flow_action = resolve_risk_action(
             config,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -25,18 +25,21 @@ def _evaluate_runtime_artifact_hook(
 ) -> int | RuntimeArtifactHookState:
     event_name = _hook_event_name(payload) or "PreToolUse"
     package_evaluation = None
-    if runtime_artifact.artifact_type == "package_request" and runtime_workspace is not None:
+    if runtime_artifact.artifact_type == "package_request":
         package_evaluation = evaluate_package_request_artifact(
             artifact=runtime_artifact,
             store=store,
             workspace_dir=runtime_workspace,
         )
-        runtime_artifact_hash = package_request_policy_hash(
-            artifact=runtime_artifact,
-            store=store,
-            workspace_dir=runtime_workspace,
-            evaluation=package_evaluation,
-        )
+        if runtime_workspace is not None:
+            runtime_artifact_hash = package_request_policy_hash(
+                artifact=runtime_artifact,
+                store=store,
+                workspace_dir=runtime_workspace,
+                evaluation=package_evaluation,
+            )
+        else:
+            runtime_artifact_hash = artifact_hash(runtime_artifact)
     else:
         runtime_artifact_hash = artifact_hash(runtime_artifact)
     artifact_id = runtime_artifact.artifact_id

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -140,7 +140,7 @@ def _evaluate_runtime_artifact_hook(
         )
         return 0
     if package_evaluation is not None and runtime_workspace is not None:
-        package_evaluation = _apply_stored_package_policy_override(
+        package_evaluation = apply_stored_package_policy_override(
             package_evaluation,
             store=store,
             artifact=runtime_artifact,

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -1239,6 +1239,23 @@ def _package_request_artifact_hash(
     )
 
 
+def package_request_policy_hash(
+    *,
+    artifact: GuardArtifact,
+    store: GuardStore,
+    workspace_dir: Path,
+    evaluation: PackageRequestEvaluation,
+) -> str:
+    """Hash a package request using manifest and lockfile contents."""
+
+    return _package_request_artifact_hash(
+        artifact,
+        workspace_dir=workspace_dir,
+        store=store,
+        evaluation=evaluation,
+    )
+
+
 def _evaluation_uses_saved_package_approval(evaluation: PackageRequestEvaluation) -> bool:
     return any(reason.get("code") == "saved_package_approval" for reason in evaluation.reasons)
 

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -1045,6 +1045,27 @@ def build_package_protect_payload(
     return (payload, int(execution.returncode))
 
 
+def apply_stored_package_policy_override(
+    evaluation: PackageRequestEvaluation,
+    *,
+    store: GuardStore,
+    artifact: GuardArtifact,
+    artifact_hash: str,
+    workspace_dir: Path,
+    now: str,
+) -> PackageRequestEvaluation:
+    """Apply a saved package approval when the content hash still matches."""
+
+    return _apply_stored_package_policy_override(
+        evaluation,
+        store=store,
+        artifact=artifact,
+        artifact_hash=artifact_hash,
+        workspace_dir=workspace_dir,
+        now=now,
+    )
+
+
 def _apply_stored_package_policy_override(
     evaluation: PackageRequestEvaluation,
     *,

--- a/src/codex_plugin_scanner/guard/runtime/manifest_dependency_targets.py
+++ b/src/codex_plugin_scanner/guard/runtime/manifest_dependency_targets.py
@@ -1,0 +1,125 @@
+"""Manifest and lockfile target derivation for package install evaluation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..models import GuardArtifact
+from .package_manifest_diff import parse_manifest_dependencies
+
+_MANIFEST_ECOSYSTEMS = {
+    "package.json": "npm",
+    "pyproject.toml": "pypi",
+    "requirements.txt": "pypi",
+    "pipfile": "pypi",
+    "cargo.toml": "cargo",
+    "go.mod": "go",
+    "composer.json": "packagist",
+    "gemfile": "rubygems",
+}
+
+
+def _manifest_ecosystem_for_path(path: str) -> str | None:
+    manifest_name = Path(path).name.lower()
+    return _MANIFEST_ECOSYSTEMS.get(manifest_name)
+
+
+def evaluation_targets(
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+    *,
+    explicit_targets: tuple[dict[str, object], ...],
+) -> tuple[dict[str, object], ...]:
+    if explicit_targets:
+        return explicit_targets
+    from .supply_chain_package_eval import _optional_string
+
+    intent_kind = _optional_string(artifact.metadata.get("intent_kind"))
+    if intent_kind not in {None, "install", "sync"}:
+        return ()
+    return unsynced_manifest_dependency_targets(artifact, workspace_dir)
+
+
+def unsynced_manifest_dependency_targets(
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+) -> tuple[dict[str, object], ...]:
+    if workspace_dir is None:
+        return ()
+    from .supply_chain_package_eval import (
+        _artifact_manifest_dependency_map,
+        _lockfile_ecosystem,
+        _manifest_exact_version,
+        _normalize_package_name,
+        _optional_string,
+        _source_url_from_specifier,
+        _split_namespace_name,
+    )
+
+    manifest_paths = artifact.metadata.get("manifest_paths")
+    if not isinstance(manifest_paths, list) or not manifest_paths:
+        return ()
+    package_manager = str(artifact.metadata.get("package_manager") or "npm")
+    redacted_command = _optional_string(artifact.metadata.get("redacted_command"))
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    lockfile_names: set[str] = set()
+    if isinstance(lockfile_paths, list):
+        for relative_path in lockfile_paths:
+            if not isinstance(relative_path, str) or not relative_path:
+                continue
+            lockfile_path = workspace_dir / relative_path
+            if not lockfile_path.exists():
+                continue
+            try:
+                lockfile_text = lockfile_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name) or "npm"
+            for package_name in parse_manifest_dependencies(path=relative_path, text=lockfile_text):
+                lockfile_names.add(_normalize_package_name(lockfile_ecosystem, package_name))
+    unsynced_targets: list[dict[str, object]] = []
+    for relative_path in manifest_paths:
+        if not isinstance(relative_path, str) or not relative_path:
+            continue
+        ecosystem = _manifest_ecosystem_for_path(relative_path)
+        if ecosystem is None:
+            continue
+        manifest_path = workspace_dir / relative_path
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest_text = manifest_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        dependency_map = _artifact_manifest_dependency_map(
+            package_manager=package_manager,
+            relative_path=relative_path,
+            manifest_text=manifest_text,
+        )
+        for package_name, specifier in dependency_map.items():
+            normalized_name = _normalize_package_name(ecosystem, package_name)
+            if normalized_name in lockfile_names:
+                continue
+            namespace, name = _split_namespace_name(package_name)
+            exact_version = _manifest_exact_version(ecosystem, specifier)
+            unsynced_targets.append(
+                {
+                    "ecosystem": ecosystem,
+                    "package_name": package_name,
+                    "normalized_name": normalized_name,
+                    "namespace": namespace,
+                    "name": name,
+                    "raw_spec": package_name if exact_version is None else f"{package_name}@{exact_version}",
+                    "version": exact_version,
+                    "range": specifier if exact_version is None else None,
+                    "source_url": _source_url_from_specifier(specifier),
+                    "alias": None,
+                    "dependency_group": None,
+                    "extras": (),
+                    "editable": False,
+                    "package_manager": package_manager,
+                    "redacted_command": redacted_command,
+                    "manifest_unsynced": True,
+                }
+            )
+    return tuple(unsynced_targets)

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -150,7 +150,7 @@ def _parse_npm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
 def _parse_pnpm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
     if len(tokens) < 2:
         return None
-    if tokens[1] in {"add", "install"}:
+    if tokens[1] in {"add", "install", "i"}:
         return _build_intent(
             "pnpm",
             "install",

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -30,6 +30,7 @@ from ..stable_digest import stable_digest_hex
 from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
 from .js_semver import highest_js_version_for_selector, version_matches_js_selector
+from .manifest_dependency_targets import evaluation_targets as _manifest_evaluation_targets
 from .package_intent_common import split_python_extras
 from .package_manifest_diff import (
     _DeadlineExceededError,
@@ -1262,109 +1263,15 @@ def _persist_evidence(
         )
 
 
-_MANIFEST_ECOSYSTEMS = {
-    "package.json": "npm",
-    "pyproject.toml": "pypi",
-    "requirements.txt": "pypi",
-    "pipfile": "pypi",
-    "cargo.toml": "cargo",
-    "go.mod": "go",
-    "composer.json": "packagist",
-    "gemfile": "rubygems",
-}
-
-
-def _manifest_ecosystem_for_path(path: str) -> str | None:
-    manifest_name = Path(path).name.lower()
-    return _MANIFEST_ECOSYSTEMS.get(manifest_name)
-
-
 def _evaluation_targets(
     artifact: GuardArtifact,
     workspace_dir: Path | None,
 ) -> tuple[dict[str, object], ...]:
-    explicit_targets = _targets_from_artifact(artifact)
-    if explicit_targets:
-        return explicit_targets
-    intent_kind = _optional_string(artifact.metadata.get("intent_kind"))
-    if intent_kind not in {None, "install", "sync"}:
-        return ()
-    return _unsynced_manifest_dependency_targets(artifact, workspace_dir)
-
-
-def _unsynced_manifest_dependency_targets(
-    artifact: GuardArtifact,
-    workspace_dir: Path | None,
-) -> tuple[dict[str, object], ...]:
-    if workspace_dir is None:
-        return ()
-    manifest_paths = artifact.metadata.get("manifest_paths")
-    if not isinstance(manifest_paths, list) or not manifest_paths:
-        return ()
-    package_manager = str(artifact.metadata.get("package_manager") or "npm")
-    redacted_command = _optional_string(artifact.metadata.get("redacted_command"))
-    lockfile_paths = artifact.metadata.get("lockfile_paths")
-    lockfile_names: set[str] = set()
-    if isinstance(lockfile_paths, list):
-        for relative_path in lockfile_paths:
-            if not isinstance(relative_path, str) or not relative_path:
-                continue
-            lockfile_path = workspace_dir / relative_path
-            if not lockfile_path.exists():
-                continue
-            try:
-                lockfile_text = lockfile_path.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
-                continue
-            lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name) or "npm"
-            for package_name in parse_manifest_dependencies(path=relative_path, text=lockfile_text):
-                lockfile_names.add(_normalize_package_name(lockfile_ecosystem, package_name))
-    unsynced_targets: list[dict[str, object]] = []
-    for relative_path in manifest_paths:
-        if not isinstance(relative_path, str) or not relative_path:
-            continue
-        ecosystem = _manifest_ecosystem_for_path(relative_path)
-        if ecosystem is None:
-            continue
-        manifest_path = workspace_dir / relative_path
-        if not manifest_path.exists():
-            continue
-        try:
-            manifest_text = manifest_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
-            continue
-        dependency_map = _artifact_manifest_dependency_map(
-            package_manager=package_manager,
-            relative_path=relative_path,
-            manifest_text=manifest_text,
-        )
-        for package_name, specifier in dependency_map.items():
-            normalized_name = _normalize_package_name(ecosystem, package_name)
-            if normalized_name in lockfile_names:
-                continue
-            namespace, name = _split_namespace_name(package_name)
-            exact_version = _manifest_exact_version(ecosystem, specifier)
-            unsynced_targets.append(
-                {
-                    "ecosystem": ecosystem,
-                    "package_name": package_name,
-                    "normalized_name": normalized_name,
-                    "namespace": namespace,
-                    "name": name,
-                    "raw_spec": package_name if exact_version is None else f"{package_name}@{exact_version}",
-                    "version": exact_version,
-                    "range": specifier if exact_version is None else None,
-                    "source_url": _source_url_from_specifier(specifier),
-                    "alias": None,
-                    "dependency_group": None,
-                    "extras": (),
-                    "editable": False,
-                    "package_manager": package_manager,
-                    "redacted_command": redacted_command,
-                    "manifest_unsynced": True,
-                }
-            )
-    return tuple(unsynced_targets)
+    return _manifest_evaluation_targets(
+        artifact,
+        workspace_dir,
+        explicit_targets=_targets_from_artifact(artifact),
+    )
 
 
 def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], ...]:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -977,6 +977,20 @@ def _evaluate_with_bundle(
     packages: list[dict[str, object]] = []
     lockfile_versions = _lockfile_dependency_versions(workspace_dir, artifact, targets)
     for target in targets:
+        if target.get("manifest_unsynced") is True:
+            packages.append(
+                _heuristic_package_result(
+                    target=target,
+                    decision="ask",
+                    code="manifest_lockfile_unsynced",
+                    message=(
+                        f"{target['package_name']} is declared in the project manifest but is not pinned "
+                        "in the existing lockfile yet, so Guard requires review before install."
+                    ),
+                    severity="high",
+                )
+            )
+            continue
         resolved_version = _resolved_target_version(
             target=target,
             lockfile_versions=lockfile_versions,
@@ -1010,19 +1024,6 @@ def _evaluate_with_bundle(
             packages.append(confusion_result)
             continue
         if resolved_version is None:
-            if target.get("manifest_unsynced") is True:
-                packages.append(
-                    _heuristic_package_result(
-                        target=target,
-                        decision="ask",
-                        code="manifest_lockfile_unsynced",
-                        message=(
-                            f"{target['package_name']} is declared in the project manifest but is not pinned "
-                            "in the existing lockfile yet, so Guard requires review before install."
-                        ),
-                        severity="high",
-                    )
-                )
             continue
         offline = evaluate_cached_supply_chain_bundle(
             bundle_response,
@@ -1124,6 +1125,20 @@ def _heuristic_result(
 ) -> _EvaluationDraft | None:
     packages: list[dict[str, object]] = []
     for target in targets:
+        if target.get("manifest_unsynced") is True:
+            packages.append(
+                _heuristic_package_result(
+                    target=target,
+                    decision="ask",
+                    code="manifest_lockfile_unsynced",
+                    message=(
+                        f"{target['package_name']} is declared in the project manifest but is not pinned "
+                        "in the existing lockfile yet, so Guard requires review before install."
+                    ),
+                    severity="high",
+                )
+            )
+            continue
         lockfile_parse_warning = _lockfile_parse_warning_result(
             target=target,
             artifact=artifact,
@@ -1176,17 +1191,6 @@ def _heuristic_result(
                 target,
                 store=store,
                 workspace_dir=workspace_dir,
-            )
-        if package_result is None and target.get("manifest_unsynced") is True:
-            package_result = _heuristic_package_result(
-                target=target,
-                decision="ask",
-                code="manifest_lockfile_unsynced",
-                message=(
-                    f"{target['package_name']} is declared in the project manifest but is not pinned "
-                    "in the existing lockfile yet, so Guard requires review before install."
-                ),
-                severity="high",
             )
         if package_result is None:
             if lockfile_parse_warning is not None:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -198,7 +198,7 @@ def evaluate_package_request_artifact(
 ) -> PackageRequestEvaluation:
     now_value = now or datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
     now_timestamp = _parse_evaluation_timestamp(now_value)
-    targets = _targets_from_artifact(artifact)
+    targets = _evaluation_targets(artifact, workspace_dir)
     package_intent_hash = artifact.artifact_id.rsplit(":", 1)[-1]
     workspace_id = store.get_cloud_workspace_id()
     bundle_payload = store.get_cached_supply_chain_bundle(workspace_id) if workspace_id is not None else None
@@ -1010,6 +1010,19 @@ def _evaluate_with_bundle(
             packages.append(confusion_result)
             continue
         if resolved_version is None:
+            if target.get("manifest_unsynced") is True:
+                packages.append(
+                    _heuristic_package_result(
+                        target=target,
+                        decision="ask",
+                        code="manifest_lockfile_unsynced",
+                        message=(
+                            f"{target['package_name']} is declared in the project manifest but is not pinned "
+                            "in the existing lockfile yet, so Guard requires review before install."
+                        ),
+                        severity="high",
+                    )
+                )
             continue
         offline = evaluate_cached_supply_chain_bundle(
             bundle_response,
@@ -1164,6 +1177,17 @@ def _heuristic_result(
                 store=store,
                 workspace_dir=workspace_dir,
             )
+        if package_result is None and target.get("manifest_unsynced") is True:
+            package_result = _heuristic_package_result(
+                target=target,
+                decision="ask",
+                code="manifest_lockfile_unsynced",
+                message=(
+                    f"{target['package_name']} is declared in the project manifest but is not pinned "
+                    "in the existing lockfile yet, so Guard requires review before install."
+                ),
+                severity="high",
+            )
         if package_result is None:
             if lockfile_parse_warning is not None:
                 packages.append(lockfile_parse_warning)
@@ -1232,6 +1256,111 @@ def _persist_evidence(
                 created_at=now,
             )
         )
+
+
+_MANIFEST_ECOSYSTEMS = {
+    "package.json": "npm",
+    "pyproject.toml": "pypi",
+    "requirements.txt": "pypi",
+    "pipfile": "pypi",
+    "cargo.toml": "cargo",
+    "go.mod": "go",
+    "composer.json": "packagist",
+    "gemfile": "rubygems",
+}
+
+
+def _manifest_ecosystem_for_path(path: str) -> str | None:
+    manifest_name = Path(path).name.lower()
+    return _MANIFEST_ECOSYSTEMS.get(manifest_name)
+
+
+def _evaluation_targets(
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+) -> tuple[dict[str, object], ...]:
+    explicit_targets = _targets_from_artifact(artifact)
+    if explicit_targets:
+        return explicit_targets
+    intent_kind = _optional_string(artifact.metadata.get("intent_kind"))
+    if intent_kind not in {None, "install", "sync"}:
+        return ()
+    return _unsynced_manifest_dependency_targets(artifact, workspace_dir)
+
+
+def _unsynced_manifest_dependency_targets(
+    artifact: GuardArtifact,
+    workspace_dir: Path | None,
+) -> tuple[dict[str, object], ...]:
+    if workspace_dir is None:
+        return ()
+    manifest_paths = artifact.metadata.get("manifest_paths")
+    if not isinstance(manifest_paths, list) or not manifest_paths:
+        return ()
+    package_manager = str(artifact.metadata.get("package_manager") or "npm")
+    redacted_command = _optional_string(artifact.metadata.get("redacted_command"))
+    lockfile_paths = artifact.metadata.get("lockfile_paths")
+    lockfile_names: set[str] = set()
+    if isinstance(lockfile_paths, list):
+        for relative_path in lockfile_paths:
+            if not isinstance(relative_path, str) or not relative_path:
+                continue
+            lockfile_path = workspace_dir / relative_path
+            if not lockfile_path.exists():
+                continue
+            try:
+                lockfile_text = lockfile_path.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name) or "npm"
+            for package_name in parse_manifest_dependencies(path=relative_path, text=lockfile_text):
+                lockfile_names.add(_normalize_package_name(lockfile_ecosystem, package_name))
+    unsynced_targets: list[dict[str, object]] = []
+    for relative_path in manifest_paths:
+        if not isinstance(relative_path, str) or not relative_path:
+            continue
+        ecosystem = _manifest_ecosystem_for_path(relative_path)
+        if ecosystem is None:
+            continue
+        manifest_path = workspace_dir / relative_path
+        if not manifest_path.exists():
+            continue
+        try:
+            manifest_text = manifest_path.read_text(encoding="utf-8")
+        except (OSError, UnicodeDecodeError):
+            continue
+        dependency_map = _artifact_manifest_dependency_map(
+            package_manager=package_manager,
+            relative_path=relative_path,
+            manifest_text=manifest_text,
+        )
+        for package_name, specifier in dependency_map.items():
+            normalized_name = _normalize_package_name(ecosystem, package_name)
+            if normalized_name in lockfile_names:
+                continue
+            namespace, name = _split_namespace_name(package_name)
+            exact_version = _manifest_exact_version(ecosystem, specifier)
+            unsynced_targets.append(
+                {
+                    "ecosystem": ecosystem,
+                    "package_name": package_name,
+                    "normalized_name": normalized_name,
+                    "namespace": namespace,
+                    "name": name,
+                    "raw_spec": package_name if exact_version is None else f"{package_name}@{exact_version}",
+                    "version": exact_version,
+                    "range": specifier if exact_version is None else None,
+                    "source_url": _source_url_from_specifier(specifier),
+                    "alias": None,
+                    "dependency_group": None,
+                    "extras": (),
+                    "editable": False,
+                    "package_manager": package_manager,
+                    "redacted_command": redacted_command,
+                    "manifest_unsynced": True,
+                }
+            )
+    return tuple(unsynced_targets)
 
 
 def _targets_from_artifact(artifact: GuardArtifact) -> tuple[dict[str, object], ...]:
@@ -1389,7 +1518,7 @@ def _transitive_lockfile_results(
     bundle_index = _bundle_package_index(bundle_response)
     direct_target_names_by_ecosystem: dict[str, set[str]] = {}
     all_direct_target_names: set[str] = set()
-    direct_targets = _targets_from_artifact(artifact)
+    direct_targets = _evaluation_targets(artifact, workspace_dir)
     for target in direct_targets:
         ecosystem = _optional_string(target.get("ecosystem")) or "npm"
         candidate_names = {str(target["normalized_name"]), *_target_candidate_names(target)}

--- a/tests/test_guard_manifest_install_firewall.py
+++ b/tests/test_guard_manifest_install_firewall.py
@@ -1,0 +1,142 @@
+"""Regression tests for manifest-only install supply-chain coverage."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.local_supply_chain import build_package_protect_payload
+from codex_plugin_scanner.guard.models import PolicyDecision
+from codex_plugin_scanner.guard.runtime.package_intent import build_package_request_artifact
+from codex_plugin_scanner.guard.runtime.package_intent_parser import parse_package_intent
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _write_pnpm_workspace(workspace_dir: Path, *, extra_dependency: str | None = None) -> None:
+    dependencies = {"lodash": "^4.17.21"}
+    if extra_dependency is not None:
+        dependencies[extra_dependency] = "^1.0.0"
+    (workspace_dir / "package.json").write_text(
+        json.dumps({"name": "demo", "dependencies": dependencies}, indent=2),
+        encoding="utf-8",
+    )
+    (workspace_dir / "pnpm-lock.yaml").write_text(
+        "\n".join(
+            [
+                "lockfileVersion: '9.0'",
+                "packages:",
+                "  lodash@4.17.21:",
+                "    resolution: {integrity: sha256-demo}",
+                "importers:",
+                "  .:",
+                "    dependencies:",
+                "      lodash: 4.17.21",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_parse_package_intent_supports_pnpm_install_alias(tmp_path: Path) -> None:
+    _write_pnpm_workspace(tmp_path)
+
+    intent = parse_package_intent("pnpm i", workspace=tmp_path)
+
+    assert intent is not None
+    assert intent.package_manager == "pnpm"
+    assert intent.intent_kind == "install"
+    assert intent.targets == ()
+    assert intent.manifest_paths == ("package.json",)
+    assert intent.lockfile_paths == ("pnpm-lock.yaml",)
+
+
+def test_evaluate_package_request_artifact_requires_review_for_unsynced_manifest_dependency(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_pnpm_workspace(workspace_dir, extra_dependency="evilpkg")
+
+    intent = parse_package_intent("pnpm install", workspace=workspace_dir)
+    assert intent is not None
+    artifact = build_package_request_artifact(
+        "guard-cli",
+        intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-06-14T00:00:00Z",
+    )
+
+    assert result.decision == "ask"
+    assert result.policy_action == "require-reapproval"
+    assert any(
+        isinstance(reason, dict) and reason.get("code") == "manifest_lockfile_unsynced" for reason in result.reasons
+    )
+    assert any(package.get("name") == "evilpkg" for package in result.packages)
+
+
+def test_build_package_protect_payload_reprompts_after_manifest_edit_despite_saved_allow(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_pnpm_workspace(workspace_dir)
+    command = ["pnpm", "install"]
+
+    baseline_payload, baseline_rc = build_package_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=True,
+        now="2026-06-14T00:00:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert baseline_rc == 0
+    receipt = baseline_payload["receipt"]
+    assert isinstance(receipt, dict)
+    store.upsert_policy(
+        PolicyDecision(
+            harness="guard-cli",
+            scope="artifact",
+            action="allow",
+            artifact_id=str(receipt["artifact_id"]),
+            artifact_hash=str(receipt["artifact_hash"]),
+            workspace=str(workspace_dir),
+            publisher=None,
+            reason="reviewed",
+        ),
+        "2026-06-14T00:00:00Z",
+    )
+
+    _write_pnpm_workspace(workspace_dir, extra_dependency="evilpkg")
+    retry_payload, retry_rc = build_package_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=True,
+        now="2026-06-14T00:01:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+
+    assert retry_rc == 2
+    assert retry_payload["verdict"]["action"] == "review"
+    evaluation = retry_payload["supply_chain_evaluation"]
+    assert isinstance(evaluation, dict)
+    assert evaluation["decision"] == "ask"
+    assert not any(
+        isinstance(reason, dict) and reason.get("code") == "saved_package_approval"
+        for reason in evaluation.get("reasons", [])
+    )


### PR DESCRIPTION
## Summary
- Detect manifest dependencies that are not yet pinned in the lockfile during bare install/sync package requests and require review before execution.
- Parse `pnpm i` as an install intent and always run package firewall evaluation in runtime hooks using manifest/lockfile content hashes for saved approvals.

## Testing
- `PYTHONPATH=src pytest -q tests/test_guard_manifest_install_firewall.py`
- `PYTHONPATH=src pytest -q tests/test_guard_package_shims.py::test_guard_protect_saved_approval_does_not_bypass_new_bundle_block_for_unpinned_package tests/test_guard_package_shims.py::test_guard_protect_npm_ci_requires_fresh_approval_after_lockfile_change`
