### PR TITLE
fix(guard): cap codex hook waits and skip source-view false positives

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -258,7 +258,7 @@ _HOOK_DAEMON_PERMISSIVE_REASON = (
 _HOOK_DAEMON_PRESERVED_DENY_REASON = (
     "HOL Guard daemon was unreachable; preserving the existing deny decision for this action."
 )
-_CODEX_PROMPT_APPROVAL_WAIT_MAX_SECONDS = 8
+_CODEX_BROWSER_APPROVAL_WAIT_MAX_SECONDS = 8
 _GUARD_HELP_GROUPS = (
     "HOL Guard AI Antivirus command center:\n"
     "  start        First-run protection setup for one local AI harness\n"

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
@@ -407,7 +407,7 @@ def _codex_source_inspection_can_skip_secret_output(
         return False
     if _codex_command_references_sensitive_local_source(command_text, cwd=cwd):
         return False
-    if _codex_command_targets_secret_like_source_name(command_text):
+    if _codex_command_targets_secret_like_source_name(command_text, cwd=cwd, home_dir=home_dir):
         return False
     non_medium_matches = [match for match in content_matches if match.sensitivity != "medium"]
     if non_medium_matches:
@@ -443,25 +443,50 @@ def _codex_command_references_benign_source_dotfile(command_text: str) -> bool:
         return False
     return any(Path(part).name.lower() in _CODEX_BENIGN_SOURCE_DOTFILES for part in parts)
 
-def _codex_command_targets_secret_like_source_name(command_text: str) -> bool:
-    dangerous_stems = {
-        "auth",
-        "credential",
-        "credentials",
-        "passwd",
-        "password",
-        "private-key",
-        "private_key",
-        "secret",
-        "secrets",
-        "token",
-    }
+def _codex_source_name_stem_is_secret_like(stem: str, *, dangerous_stems: frozenset[str]) -> bool:
+    lowered = stem.lower()
+    if lowered in dangerous_stems:
+        return True
+    return any(
+        segment in dangerous_stems
+        for segment in re.split(r"[-_]+", lowered)
+        if segment
+    )
+
+
+def _codex_command_targets_secret_like_source_name(
+    command_text: str,
+    *,
+    cwd: Path | None = None,
+    home_dir: Path | None = None,
+) -> bool:
+    dangerous_stems = frozenset(
+        {
+            "auth",
+            "credential",
+            "credentials",
+            "passwd",
+            "password",
+            "private-key",
+            "private_key",
+            "secret",
+            "secrets",
+            "token",
+        }
+    )
     chained_segments = _split_codex_safe_read_only_chain(command_text)
     if chained_segments is not None:
-        return any(_codex_command_targets_secret_like_source_name(segment) for segment in chained_segments)
+        return any(
+            _codex_command_targets_secret_like_source_name(segment, cwd=cwd, home_dir=home_dir)
+            for segment in chained_segments
+        )
     pipeline_segments = _split_codex_safe_read_only_pipeline(command_text)
     if pipeline_segments:
-        return _codex_command_targets_secret_like_source_name(pipeline_segments[0])
+        return _codex_command_targets_secret_like_source_name(
+            pipeline_segments[0],
+            cwd=cwd,
+            home_dir=home_dir,
+        )
     try:
         parts = shlex.split(command_text)
     except ValueError:
@@ -472,8 +497,13 @@ def _codex_command_targets_secret_like_source_name(command_text: str) -> bool:
             continue
         name = Path(stripped).name.lower().lstrip(".")
         stem = Path(name).stem or name
-        if stem in dangerous_stems or name.startswith("id_"):
-            return True
+        if not _codex_source_name_stem_is_secret_like(stem, dangerous_stems=dangerous_stems) and not name.startswith(
+            "id_"
+        ):
+            continue
+        if cwd is not None and _codex_search_target_is_source_like(stripped, cwd=cwd, home_dir=home_dir):
+            continue
+        return True
     return False
 
 __all__ = """
@@ -494,6 +524,7 @@ _codex_env_assignment_uses_shell_expansion _codex_local_secret_source_label
 _codex_output_is_only_benign_secret_fixture _codex_output_uses_placeholder_private_key_fixture
 _codex_pipeline_segment_may_read_local_content _codex_post_tool_command_is_read_only_source_inspection
 _codex_post_tool_command_text _codex_shell_split _codex_source_inspection_can_skip_secret_output
+_codex_source_name_stem_is_secret_like
 _codex_strip_command_wrapper _codex_strip_env_wrapper _codex_tool_output_request_summary
 _codex_tool_output_runtime_summary _codex_unwrapped_command_parts
 """.split()

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
@@ -459,16 +459,14 @@ _CODEX_SECRET_LIKE_SOURCE_NAME_STEMS = frozenset(
 )
 
 
-def _codex_source_name_stem_is_secret_like(stem: str, *, split_compound: bool) -> bool:
+def _codex_source_name_stem_has_compound_secret_segment(stem: str, *, split_compound: bool) -> bool:
     lowered = stem.lower()
-    if lowered in _CODEX_SECRET_LIKE_SOURCE_NAME_STEMS:
-        return True
     if not split_compound:
         return False
     return any(
         segment in _CODEX_SECRET_LIKE_SOURCE_NAME_STEMS
         for segment in re.split(r"[-_]+", lowered)
-        if segment
+        if segment and segment != lowered
     )
 
 
@@ -501,11 +499,18 @@ def _codex_command_targets_secret_like_source_name(
             continue
         name = Path(stripped).name.lower().lstrip(".")
         stem = Path(name).stem or name
-        if not _codex_source_name_stem_is_secret_like(stem, split_compound=cwd is not None) and not name.startswith(
-            "id_"
-        ):
+        exact_secret_like = stem.lower() in _CODEX_SECRET_LIKE_SOURCE_NAME_STEMS
+        compound_secret_like = _codex_source_name_stem_has_compound_secret_segment(
+            stem,
+            split_compound=cwd is not None,
+        )
+        if not exact_secret_like and not compound_secret_like and not name.startswith("id_"):
             continue
-        if cwd is not None and _codex_search_target_is_source_like(stripped, cwd=cwd, home_dir=home_dir):
+        if compound_secret_like and cwd is not None and _codex_search_target_is_source_like(
+            stripped,
+            cwd=cwd,
+            home_dir=home_dir,
+        ):
             continue
         return True
     return False
@@ -528,7 +533,7 @@ _codex_env_assignment_uses_shell_expansion _codex_local_secret_source_label
 _codex_output_is_only_benign_secret_fixture _codex_output_uses_placeholder_private_key_fixture
 _codex_pipeline_segment_may_read_local_content _codex_post_tool_command_is_read_only_source_inspection
 _codex_post_tool_command_text _codex_shell_split _codex_source_inspection_can_skip_secret_output
-_codex_source_name_stem_is_secret_like
+_codex_source_name_stem_has_compound_secret_segment
 _codex_strip_command_wrapper _codex_strip_env_wrapper _codex_tool_output_request_summary
 _codex_tool_output_runtime_summary _codex_unwrapped_command_parts
 """.split()

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
@@ -443,12 +443,30 @@ def _codex_command_references_benign_source_dotfile(command_text: str) -> bool:
         return False
     return any(Path(part).name.lower() in _CODEX_BENIGN_SOURCE_DOTFILES for part in parts)
 
-def _codex_source_name_stem_is_secret_like(stem: str, *, dangerous_stems: frozenset[str]) -> bool:
+_CODEX_SECRET_LIKE_SOURCE_NAME_STEMS = frozenset(
+    {
+        "auth",
+        "credential",
+        "credentials",
+        "passwd",
+        "password",
+        "private-key",
+        "private_key",
+        "secret",
+        "secrets",
+        "token",
+    }
+)
+
+
+def _codex_source_name_stem_is_secret_like(stem: str, *, split_compound: bool) -> bool:
     lowered = stem.lower()
-    if lowered in dangerous_stems:
+    if lowered in _CODEX_SECRET_LIKE_SOURCE_NAME_STEMS:
         return True
+    if not split_compound:
+        return False
     return any(
-        segment in dangerous_stems
+        segment in _CODEX_SECRET_LIKE_SOURCE_NAME_STEMS
         for segment in re.split(r"[-_]+", lowered)
         if segment
     )
@@ -460,20 +478,6 @@ def _codex_command_targets_secret_like_source_name(
     cwd: Path | None = None,
     home_dir: Path | None = None,
 ) -> bool:
-    dangerous_stems = frozenset(
-        {
-            "auth",
-            "credential",
-            "credentials",
-            "passwd",
-            "password",
-            "private-key",
-            "private_key",
-            "secret",
-            "secrets",
-            "token",
-        }
-    )
     chained_segments = _split_codex_safe_read_only_chain(command_text)
     if chained_segments is not None:
         return any(
@@ -497,7 +501,7 @@ def _codex_command_targets_secret_like_source_name(
             continue
         name = Path(stripped).name.lower().lstrip(".")
         stem = Path(name).stem or name
-        if not _codex_source_name_stem_is_secret_like(stem, dangerous_stems=dangerous_stems) and not name.startswith(
+        if not _codex_source_name_stem_is_secret_like(stem, split_compound=cwd is not None) and not name.startswith(
             "id_"
         ):
             continue

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -490,7 +490,10 @@ def _open_codex_live_approval(response_payload: Mapping[str, object], *, guard_h
 
 __all__ = [
     "_apps_disconnect_confirm_command", "_attach_primary_approval_link", "_build_cisco_scan_options",
-    "_codex_browser_approval_decision", "_codex_browser_wait_metadata", "_codex_browser_wait_timeout_seconds", "_codex_can_use_browser_approval",
+    "_codex_browser_approval_decision",
+    "_codex_browser_wait_metadata",
+    "_codex_browser_wait_timeout_seconds",
+    "_codex_can_use_browser_approval",
     "_codex_hook_waits_for_browser_approval", "_codex_pretooluse_live_wait_candidate", "_emit",
     "_guard_cloud_app_error_payload", "_guard_cloud_app_urls", "_open_codex_live_approval",
     "_open_guard_cloud_app", "_policy_write_needs_approval_gate", "_policy_write_requires_approval_gate",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -316,9 +316,10 @@ def _codex_browser_approval_decision(
     ]
     if not request_ids:
         return None
-    wait_timeout_seconds = max(config.approval_wait_timeout_seconds, 0)
-    if event_name == "UserPromptSubmit":
-        wait_timeout_seconds = min(wait_timeout_seconds, _CODEX_PROMPT_APPROVAL_WAIT_MAX_SECONDS)
+    wait_timeout_seconds = _codex_browser_wait_timeout_seconds(
+        event_name=event_name,
+        configured_timeout=config.approval_wait_timeout_seconds,
+    )
     if wait_timeout_seconds <= 0:
         return None
     if event_name == "PreToolUse":
@@ -381,9 +382,10 @@ def _codex_browser_wait_metadata(
     )
     if not waits_for_browser:
         return {"codex_hook_waits_for_browser_approval": False}
-    wait_timeout_seconds = max(config.approval_wait_timeout_seconds, 0)
-    if event_name == "UserPromptSubmit":
-        wait_timeout_seconds = min(wait_timeout_seconds, _CODEX_PROMPT_APPROVAL_WAIT_MAX_SECONDS)
+    wait_timeout_seconds = _codex_browser_wait_timeout_seconds(
+        event_name=event_name,
+        configured_timeout=config.approval_wait_timeout_seconds,
+    )
     started_at = datetime.now(timezone.utc)
     deadline_at = started_at + timedelta(seconds=wait_timeout_seconds)
     return {
@@ -392,6 +394,13 @@ def _codex_browser_wait_metadata(
         "codex_browser_wait_deadline_at": deadline_at.isoformat(),
         "codex_browser_wait_timeout_seconds": wait_timeout_seconds,
     }
+
+def _codex_browser_wait_timeout_seconds(*, event_name: str, configured_timeout: int) -> int:
+    wait_timeout_seconds = max(configured_timeout, 0)
+    if event_name in {"UserPromptSubmit", "PreToolUse", "PostToolUse"}:
+        wait_timeout_seconds = min(wait_timeout_seconds, _CODEX_PROMPT_APPROVAL_WAIT_MAX_SECONDS)
+    return wait_timeout_seconds
+
 
 def _codex_pretooluse_live_wait_candidate(payload: Mapping[str, object] | None) -> bool:
     if not isinstance(payload, Mapping):
@@ -481,7 +490,7 @@ def _open_codex_live_approval(response_payload: Mapping[str, object], *, guard_h
 
 __all__ = [
     "_apps_disconnect_confirm_command", "_attach_primary_approval_link", "_build_cisco_scan_options",
-    "_codex_browser_approval_decision", "_codex_browser_wait_metadata", "_codex_can_use_browser_approval",
+    "_codex_browser_approval_decision", "_codex_browser_wait_metadata", "_codex_browser_wait_timeout_seconds", "_codex_can_use_browser_approval",
     "_codex_hook_waits_for_browser_approval", "_codex_pretooluse_live_wait_candidate", "_emit",
     "_guard_cloud_app_error_payload", "_guard_cloud_app_urls", "_open_codex_live_approval",
     "_open_guard_cloud_app", "_policy_write_needs_approval_gate", "_policy_write_requires_approval_gate",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -398,7 +398,7 @@ def _codex_browser_wait_metadata(
 def _codex_browser_wait_timeout_seconds(*, event_name: str, configured_timeout: int) -> int:
     wait_timeout_seconds = max(configured_timeout, 0)
     if event_name in {"UserPromptSubmit", "PreToolUse", "PostToolUse"}:
-        wait_timeout_seconds = min(wait_timeout_seconds, _CODEX_PROMPT_APPROVAL_WAIT_MAX_SECONDS)
+        wait_timeout_seconds = min(wait_timeout_seconds, _CODEX_BROWSER_APPROVAL_WAIT_MAX_SECONDS)
     return wait_timeout_seconds
 
 

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -398,6 +398,80 @@ def test_guard_hook_ask_package_live_wait_surfaces_approval_url(
     assert opened_urls[0] in captured.err
 
 
+def test_guard_hook_ask_package_live_wait_caps_browser_approval_wait(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
+    )
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            action="block",
+            policy_rules=[
+                {
+                    "action": "review",
+                    "ruleId": "policy-review-1",
+                    "ecosystemSelector": "npm",
+                    "enabled": True,
+                    "expiresAt": "2099-01-01T00:00:00Z",
+                    "harnessSelector": "codex",
+                    "packageSelector": "minimist",
+                    "priority": 1,
+                    "severityThreshold": "low",
+                    "versionRangeSelector": "1.2.8",
+                }
+            ],
+        ),
+        "2026-05-19T00:00:00Z",
+    )
+    (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 120\n", encoding="utf-8")
+    observed_timeouts: list[int] = []
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+
+    def fail_daemon(_home: Path) -> object:
+        raise RuntimeError("no daemon")
+
+    monkeypatch.setattr(guard_commands_module, "load_guard_surface_daemon_client", fail_daemon)
+    monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _url: None)
+
+    def unresolved_wait(**kwargs: object) -> dict[str, object]:
+        timeout_seconds = kwargs.get("timeout_seconds")
+        assert isinstance(timeout_seconds, int)
+        observed_timeouts.append(timeout_seconds)
+        return {"resolved": False, "status": "timeout", "items": []}
+
+    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", unresolved_wait)
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert observed_timeouts == [8]
+    assert "/requests/" in captured.out or "/requests/" in captured.err
+
+
 def test_guard_hook_warns_for_package_request_without_blocking(
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],

--- a/tests/test_guard_phase04_harness_ux.py
+++ b/tests/test_guard_phase04_harness_ux.py
@@ -221,6 +221,46 @@ def test_gr076b_codex_prompt_secret_read_caps_browser_approval_wait(
     assert "/requests/" in str(payload["reason"])
 
 
+def test_codex_post_tool_secret_output_caps_browser_approval_wait(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    (guard_home / "config.toml").write_text("approval_wait_timeout_seconds = 120\n", encoding="utf-8")
+    observed_timeouts: list[int] = []
+
+    def unresolved_wait(*args: object, **kwargs: object) -> dict[str, object]:
+        del args
+        timeout_seconds = kwargs.get("timeout_seconds")
+        assert isinstance(timeout_seconds, int)
+        observed_timeouts.append(timeout_seconds)
+        return {"resolved": False, "status": "timeout", "items": []}
+
+    monkeypatch.setattr(guard_commands_module, "wait_for_approval_requests", unresolved_wait)
+
+    exit_code, output = _run_hook(
+        tmp_path,
+        harness="codex",
+        json_output=False,
+        payload={
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cat ~/.npmrc"},
+            "tool_response": {"stdout": "//registry.npmjs.org/:_authToken=npm_secret_fixture_value\n"},
+        },
+    )
+
+    payload = _json_line(output)
+
+    assert exit_code == 0
+    assert payload["decision"] == "block"
+    assert payload["continue"] is False
+    assert observed_timeouts == [8]
+    assert "Open HOL Guard" in str(payload["reason"])
+    assert "/requests/" in str(payload["reason"])
+
+
 def test_gr077_codex_shell_exfil_canary_gets_native_denial(tmp_path: Path) -> None:
     exit_code, output = _run_hook(
         tmp_path,

--- a/tests/test_guard_source_view_secret_fixtures.py
+++ b/tests/test_guard_source_view_secret_fixtures.py
@@ -42,6 +42,38 @@ def test_codex_source_view_allows_placeholder_private_key_fixture_output(tmp_pat
     assert artifact is None
 
 
+def test_codex_source_view_allows_oauth_token_service_source_output(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "src" / "oauth-token-service.ts"
+    source_contents = (
+        "export class OAuthTokenService {\n"
+        "  refreshAccessToken(): string {\n"
+        '    return "placeholder-access-token";\n'
+        "  }\n"
+        "}\n"
+    )
+    _write_text(source_file, source_contents)
+
+    command = "sed -n '1,20p' src/oauth-token-service.ts"
+
+    assert not guard_commands_module._codex_command_targets_secret_like_source_name(
+        command,
+        cwd=workspace_dir,
+    )
+    artifact = guard_commands_module._codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "tool_response": {"stdout": source_contents},
+        },
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        source_scope="workspace",
+        cwd=workspace_dir,
+    )
+
+    assert artifact is None
+
+
 def test_codex_source_view_still_blocks_real_private_key_output(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "tests" / "test_connect_fixture.py"

--- a/tests/test_guard_source_view_secret_fixtures.py
+++ b/tests/test_guard_source_view_secret_fixtures.py
@@ -81,6 +81,17 @@ def test_codex_source_view_compound_token_stem_stays_non_secret_without_cwd() ->
     assert guard_commands_module._codex_command_targets_secret_like_source_name("sed -n '1,20p' token.ts")
 
 
+def test_codex_source_view_exact_secret_stem_stays_secret_with_cwd(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    source_file = workspace_dir / "config" / "secrets.yaml"
+    _write_text(source_file, "token: fixture-only\n")
+
+    assert guard_commands_module._codex_command_targets_secret_like_source_name(
+        "head -40 config/secrets.yaml",
+        cwd=workspace_dir,
+    )
+
+
 def test_codex_source_view_still_blocks_real_private_key_output(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "tests" / "test_connect_fixture.py"

--- a/tests/test_guard_source_view_secret_fixtures.py
+++ b/tests/test_guard_source_view_secret_fixtures.py
@@ -74,6 +74,13 @@ def test_codex_source_view_allows_oauth_token_service_source_output(tmp_path: Pa
     assert artifact is None
 
 
+def test_codex_source_view_compound_token_stem_stays_non_secret_without_cwd() -> None:
+    command = "sed -n '1,20p' src/oauth-token-service.ts"
+
+    assert not guard_commands_module._codex_command_targets_secret_like_source_name(command)
+    assert guard_commands_module._codex_command_targets_secret_like_source_name("sed -n '1,20p' token.ts")
+
+
 def test_codex_source_view_still_blocks_real_private_key_output(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     source_file = workspace_dir / "tests" / "test_connect_fixture.py"


### PR DESCRIPTION
## Summary
- cap Codex live browser waits for guarded `PreToolUse`, `PostToolUse`, and prompt review flows so hooks return promptly instead of sitting for the full approval timeout
- let read-only source inspections of source-like files such as `oauth-token-service.ts` bypass token-name false positives, with regressions for source views and bounded waits

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_source_view_secret_fixtures.py tests/test_guard_phase04_harness_ux.py::test_gr076b_codex_prompt_secret_read_caps_browser_approval_wait tests/test_guard_phase04_harness_ux.py::test_codex_post_tool_secret_output_caps_browser_approval_wait tests/test_guard_phase04_harness_ux.py::test_gr077b_codex_read_secret_file_gets_native_denial tests/test_guard_package_hook.py::test_guard_hook_ask_package_live_wait_caps_browser_approval_wait -q`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_source_view_secret_fixtures.py tests/test_guard_phase04_harness_ux.py::test_codex_post_tool_secret_output_caps_browser_approval_wait tests/test_guard_package_hook.py::test_guard_hook_ask_package_live_wait_caps_browser_approval_wait -q`
