### PR TITLE
feat(guard): enforce local policy integrity

### DIFF
--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -232,6 +232,43 @@ Use these actions in config or saved decisions:
 - `sandbox-required`
 - `require-reapproval`
 
+### Local policy integrity
+
+Saved `allow` and `block` rows in `$HOME/.hol-guard/guard.db` are only authoritative
+when Guard can verify an HMAC envelope signed with Guard-controlled key material
+stored outside the SQLite database. The approval password gate proves *who* is
+asking Guard to remember trust. The integrity envelope proves the saved row was
+written through Guard, not forged by editing `guard.db` directly.
+
+Inspect local policy integrity:
+
+```bash
+hol-guard policies integrity-status
+hol-guard policies verify
+```
+
+If you upgraded from an older local database, legacy unsigned rows start in
+`warn` so Guard can show what must be migrated without silently blessing those
+rows forever. Rows can also show `unknown_key` after an OS keyring reset or
+reinstall. Move to `enforce` with an explicit migration after reviewing the
+listed rows:
+
+```bash
+hol-guard policies migrate-local-integrity --preserve-all-local
+```
+
+Or clear untrusted local history and force fresh approvals:
+
+```bash
+hol-guard policies migrate-local-integrity --clear-unselected
+```
+
+Remove invalid or tampered local rows after review:
+
+```bash
+hol-guard policies repair --clear-invalid
+```
+
 ## Require proof before remembered trust
 
 The approval gate protects the places where Guard would otherwise remember trust: scoped allow decisions, broad/global allow, policy clears, settings changes, approval-history clears, native approval persistence, and cloud/headless policy sync. Enforcement lives in the daemon and store layer, so the dashboard and CLI cannot bypass it.

--- a/docs/guard/local-vs-cloud.md
+++ b/docs/guard/local-vs-cloud.md
@@ -11,7 +11,9 @@ Available without a Cloud subscription or sign-in:
   sit in front of supported AI harnesses before tools, MCP servers, or skills
   execute.
 - **Local policy decisions** — home config, project overrides, saved allow/deny
-  rules, and built-in recommendations resolve on this machine.
+  rules, and built-in recommendations resolve on this machine. Saved local
+  decisions are verified against Guard-managed integrity key material before
+  they become authoritative again.
 - **Local blocking and warnings** — Guard can stop or warn on supported risky
   shell commands, file reads, MCP tool calls, skill loads, and prompt-sensitive
   actions before side effects occur.
@@ -23,6 +25,10 @@ Available without a Cloud subscription or sign-in:
 - **Local approval and review paths** — inline harness approval, the local
   approval center on `127.0.0.1`, and `hol-guard approvals` resolve decisions
   without Cloud.
+- **Local policy integrity tooling** — `hol-guard policies verify`,
+  `integrity-status`, `migrate-local-integrity`, and `repair --clear-invalid`
+  let an operator detect unsigned, unknown-key, or tampered local policy rows
+  and move to enforce mode deliberately.
 - **Cloud-outage independence** — if Guard Cloud is unavailable, you are signed
   out, or never connected, local interception, policy, blocking, receipts, and
   approvals continue on the machine.

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -216,7 +216,8 @@ def _run_guard_policies_command(
     input_text: str | None = None,
     output_stream: TextIO | None = None,
 ) -> int:
-    if getattr(args, "policies_command", None) == "clear":
+    policies_command = getattr(args, "policies_command", None)
+    if policies_command == "clear":
         harness = getattr(args, "harness", None)
         clear_all = bool(getattr(args, "all", False))
         if clear_all and harness is not None:
@@ -281,6 +282,96 @@ def _run_guard_policies_command(
             },
             getattr(args, "json", False),
         )
+        return 0
+    if policies_command == "verify":
+        payload = store.verify_policy_integrity(getattr(args, "harness", None))
+        _emit("policies", payload, getattr(args, "json", False))
+        counts = payload.get("counts")
+        if not isinstance(counts, dict) or payload.get("enforcement") != "enforce":
+            return 0
+        blocking_statuses = ("tampered", "unknown_key", "missing_integrity", "degraded_mode")
+        if any(int(counts.get(status, 0) or 0) > 0 for status in blocking_statuses):
+            return 1
+        return 0
+    if policies_command == "integrity-status":
+        payload = store.get_policy_integrity_status(getattr(args, "harness", None))
+        _emit("policies", payload, getattr(args, "json", False))
+        return 0
+    if policies_command == "repair":
+        clear_invalid = bool(getattr(args, "clear_invalid", False))
+        try:
+            approval_gate_grant = None
+            if clear_invalid:
+                gate_input = prompt_for_approval_gate(store.guard_home, use_cooldown=False)
+                approval_gate_grant = require_high_risk(
+                    store.guard_home,
+                    purpose="policy_clear",
+                    approval_gate_input=gate_input,
+                )
+            payload = store.repair_policy_integrity(
+                clear_invalid=clear_invalid,
+                harness=getattr(args, "harness", None),
+                approval_gate_grant=approval_gate_grant,
+                now=_now(),
+            )
+        except ApprovalGateError as error:
+            _emit("policies", approval_gate_cli_payload(error), getattr(args, "json", False))
+            return 4
+        _emit("policies", payload, getattr(args, "json", False))
+        return 0
+    if policies_command == "migrate-local-integrity":
+        preserve_all_local = bool(getattr(args, "preserve_all_local", False))
+        clear_unselected = bool(getattr(args, "clear_unselected", False))
+        migratable_statuses = {"missing_integrity", "unknown_key"}
+        preserve_ids = {
+            int(value)
+            for value in (getattr(args, "decision_ids", None) or [])
+            if isinstance(value, int)
+        }
+        if not preserve_all_local and not preserve_ids and not clear_unselected:
+            _emit(
+                "policies",
+                {
+                    "error": "Choose --preserve-all-local, one or more --decision-id values, or --clear-unselected.",
+                    "operation": "migrate-local-integrity",
+                },
+                getattr(args, "json", False),
+            )
+            return 2
+        if preserve_all_local:
+            verify_payload = store.verify_policy_integrity(getattr(args, "harness", None))
+            preserve_ids.update(
+                int(item["decision_id"])
+                for item in verify_payload.get("items", [])
+                if isinstance(item, dict)
+                and item.get("integrity_status") in migratable_statuses
+                and isinstance(item.get("decision_id"), int)
+            )
+        try:
+            gate_input = prompt_for_approval_gate(store.guard_home, use_cooldown=False)
+            approval_gate_grant = require_high_risk(
+                store.guard_home,
+                purpose="policy_clear",
+                approval_gate_input=gate_input,
+            )
+            payload = store.migrate_local_policy_integrity(
+                preserve_decision_ids=preserve_ids,
+                clear_unselected=clear_unselected,
+                harness=getattr(args, "harness", None),
+                approval_gate_grant=approval_gate_grant,
+                now=_now(),
+            )
+        except ApprovalGateError as error:
+            _emit("policies", approval_gate_cli_payload(error), getattr(args, "json", False))
+            return 4
+        except RuntimeError as error:
+            _emit(
+                "policies",
+                {"error": str(error), "operation": "migrate-local-integrity"},
+                getattr(args, "json", False),
+            )
+            return 1
+        _emit("policies", payload, getattr(args, "json", False))
         return 0
     policy_items = store.list_policy_decisions(getattr(args, "harness", None))
     items = _filter_policy_items(policy_items, active_only=True)

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -14,7 +14,11 @@ def _configure_guard_policy_parsers(
     guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
     policies_parser = guard_subparsers.add_parser("policies", help="List or clear stored Guard policy decisions")
-    policies_parser.add_argument("policies_command", nargs="?", choices=("clear",))
+    policies_parser.add_argument(
+        "policies_command",
+        nargs="?",
+        choices=("clear", "verify", "integrity-status", "repair", "migrate-local-integrity"),
+    )
     policies_parser.add_argument("--harness")
     policies_parser.add_argument("--source")
     policies_parser.add_argument("--scope", choices=("artifact", "workspace", "publisher", "harness", "global"))
@@ -22,6 +26,28 @@ def _configure_guard_policy_parsers(
     policies_parser.add_argument("--artifact-hash")
     policies_parser.add_argument("--policy-workspace", dest="policy_workspace")
     policies_parser.add_argument("--publisher")
+    policies_parser.add_argument(
+        "--decision-id",
+        dest="decision_ids",
+        action="append",
+        type=int,
+        help="Policy decision ID to preserve during migrate-local-integrity; repeat to keep multiple rows",
+    )
+    policies_parser.add_argument(
+        "--preserve-all-local",
+        action="store_true",
+        help="Preserve every local policy row eligible for re-signing during migrate-local-integrity",
+    )
+    policies_parser.add_argument(
+        "--clear-unselected",
+        action="store_true",
+        help="Delete eligible local policy rows not preserved during migrate-local-integrity",
+    )
+    policies_parser.add_argument(
+        "--clear-invalid",
+        action="store_true",
+        help="Delete invalid local policy rows during policies repair",
+    )
     policies_parser.add_argument(
         "--all",
         action="store_true",

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -719,6 +719,61 @@ def _render_inventory(console: Console, payload: dict[str, object]) -> None:
 
 
 def _render_policies(console: Console, payload: dict[str, object]) -> None:
+    if "counts" in payload or payload.get("operation") == "migrate-local-integrity":
+        counts = payload.get("counts") if isinstance(payload.get("counts"), dict) else {}
+        degraded_reasons = [str(item) for item in payload.get("degraded_reasons", []) if isinstance(item, str)]
+        body = Table.grid(padding=(0, 1))
+        body.add_row("Mode", str(payload.get("mode") or "unknown"))
+        body.add_row("Enforcement", str(payload.get("enforcement") or "unknown"))
+        body.add_row("Backend", str(payload.get("backend") or "unknown"))
+        body.add_row("Local rows", str(int(payload.get("local_rows_scanned", 0) or 0)))
+        if payload.get("key_id"):
+            body.add_row("Key", str(payload.get("key_id")))
+        if payload.get("backup_path"):
+            body.add_row("Backup", str(payload.get("backup_path")))
+        if "cleared" in payload:
+            body.add_row("Cleared", str(int(payload.get("cleared", 0) or 0)))
+        for label, key in (
+            ("Valid", "valid"),
+            ("Unsigned", "missing_integrity"),
+            ("Tampered", "tampered"),
+            ("Unknown key", "unknown_key"),
+            ("Degraded", "degraded_mode"),
+        ):
+            body.add_row(label, str(int(counts.get(key, 0) or 0)))
+        if degraded_reasons:
+            body.add_row("Reasons", ", ".join(degraded_reasons))
+        title = "Guard policy integrity"
+        if "backup_path" in payload:
+            title = "Guard policy migration"
+        elif "clear_invalid" in payload:
+            title = "Guard policy repair"
+        elif "items" in payload:
+            title = "Guard policy verify"
+        border_style = "red" if payload.get("error") else "cyan"
+        console.print(Panel(body, title=title, border_style=border_style))
+        if payload.get("error"):
+            console.print(str(payload.get("error")))
+            return
+        invalid_items = _coerce_dict_list(payload.get("items"))
+        if not invalid_items:
+            return
+        table = Table(box=box.SIMPLE_HEAVY, show_header=True)
+        table.add_column("Harness", style="cyan")
+        table.add_column("Action")
+        table.add_column("Artifact", style="bold")
+        table.add_column("Integrity")
+        table.add_column("Updated")
+        for item in invalid_items:
+            table.add_row(
+                str(item.get("harness") or "unknown"),
+                _action_text(str(item.get("action") or "warn")),
+                str(item.get("artifact_id") or "all artifacts"),
+                str(item.get("integrity_status") or "unknown"),
+                str(item.get("updated_at") or "unknown"),
+            )
+        console.print(table)
+        return
     if "cleared" in payload or "error" in payload:
         error = payload.get("error")
         cleared = int(payload.get("cleared", 0) or 0)
@@ -748,6 +803,7 @@ def _render_policies(console: Console, payload: dict[str, object]) -> None:
     table.add_column("Harness", style="cyan")
     table.add_column("Scope")
     table.add_column("Action")
+    table.add_column("Integrity")
     table.add_column("Artifact", style="bold")
     table.add_column("Publisher")
     table.add_column("Owner")
@@ -757,6 +813,7 @@ def _render_policies(console: Console, payload: dict[str, object]) -> None:
             str(item.get("harness") or "unknown"),
             str(item.get("scope") or "harness"),
             _action_text(str(item.get("action") or "warn")),
+            str(item.get("integrity_status") or "remote"),
             str(item.get("artifact_id") or "all artifacts"),
             str(item.get("publisher") or "—"),
             str(item.get("owner") or "—"),

--- a/src/codex_plugin_scanner/guard/policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/policy_integrity.py
@@ -1,0 +1,173 @@
+"""Local policy row integrity helpers."""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Literal
+
+POLICY_INTEGRITY_VERSION = 1
+POLICY_INTEGRITY_MAC_ALGORITHM = "hmac-sha256"
+REMOTE_POLICY_SOURCES = frozenset({"cloud-sync", "team-policy", "policy-bundle"})
+
+PolicyIntegrityStatus = Literal[
+    "valid",
+    "missing_integrity",
+    "tampered",
+    "unknown_key",
+    "degraded_mode",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PolicyIntegrityVerificationResult:
+    status: PolicyIntegrityStatus
+    payload_hash: str | None = None
+    key_id: str | None = None
+    message: str | None = None
+
+
+def is_remote_policy_source(source: str | None) -> bool:
+    return isinstance(source, str) and source in REMOTE_POLICY_SOURCES
+
+
+def canonical_policy_payload(
+    row: Mapping[str, object],
+    *,
+    integrity_version: int | None = None,
+) -> bytes:
+    payload = {
+        "action": _string_or_none(_mapping_value(row, "action")),
+        "artifact_hash": _string_or_none(_mapping_value(row, "artifact_hash")),
+        "artifact_id": _string_or_none(_mapping_value(row, "artifact_id")),
+        "expires_at": _string_or_none(_mapping_value(row, "expires_at")),
+        "harness": _string_or_none(_mapping_value(row, "harness")),
+        "integrity_version": integrity_version
+        if integrity_version is not None
+        else (_int_or_none(_mapping_value(row, "integrity_version")) or POLICY_INTEGRITY_VERSION),
+        "publisher": _string_or_none(_mapping_value(row, "publisher")),
+        "scope": _string_or_none(_mapping_value(row, "scope")),
+        "source": _string_or_none(_mapping_value(row, "source")),
+        "updated_at": _string_or_none(_mapping_value(row, "updated_at")),
+        "workspace": _string_or_none(_mapping_value(row, "workspace")),
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+
+
+def sign_local_policy_row(
+    row: Mapping[str, object],
+    key: bytes,
+    *,
+    key_id: str,
+    signed_at: str,
+) -> dict[str, object]:
+    payload = canonical_policy_payload(row, integrity_version=POLICY_INTEGRITY_VERSION)
+    payload_hash = hashlib.sha256(payload).hexdigest()
+    payload_mac = hmac.new(key, payload, hashlib.sha256).hexdigest()
+    return {
+        "integrity_version": POLICY_INTEGRITY_VERSION,
+        "payload_hash": payload_hash,
+        "payload_mac": payload_mac,
+        "integrity_key_id": key_id,
+        "signed_at": signed_at,
+    }
+
+
+def verify_local_policy_row(
+    row: Mapping[str, object],
+    *,
+    key: bytes | None,
+    key_id: str | None,
+    degraded_mode: bool = False,
+) -> PolicyIntegrityVerificationResult:
+    stored_key_id = _string_or_none(_mapping_value(row, "integrity_key_id"))
+    stored_payload_hash = _string_or_none(_mapping_value(row, "payload_hash"))
+    stored_payload_mac = _string_or_none(_mapping_value(row, "payload_mac"))
+    stored_signed_at = _string_or_none(_mapping_value(row, "signed_at"))
+    version = _int_or_none(_mapping_value(row, "integrity_version"))
+
+    if degraded_mode:
+        return PolicyIntegrityVerificationResult(
+            status="degraded_mode",
+            payload_hash=stored_payload_hash,
+            key_id=stored_key_id,
+            message="policy_integrity_backend_unavailable",
+        )
+    if (
+        version is None
+        or stored_key_id is None
+        or stored_payload_hash is None
+        or stored_payload_mac is None
+        or stored_signed_at is None
+    ):
+        return PolicyIntegrityVerificationResult(
+            status="missing_integrity",
+            payload_hash=stored_payload_hash,
+            key_id=stored_key_id,
+            message="policy_integrity_metadata_missing",
+        )
+    if version != POLICY_INTEGRITY_VERSION:
+        return PolicyIntegrityVerificationResult(
+            status="tampered",
+            payload_hash=stored_payload_hash,
+            key_id=stored_key_id,
+            message="policy_integrity_version_mismatch",
+        )
+    if key is None or key_id is None or stored_key_id != key_id:
+        return PolicyIntegrityVerificationResult(
+            status="unknown_key",
+            payload_hash=stored_payload_hash,
+            key_id=stored_key_id,
+            message="policy_integrity_key_unavailable",
+        )
+
+    payload = canonical_policy_payload(row, integrity_version=version)
+    computed_payload_hash = hashlib.sha256(payload).hexdigest()
+    if not hmac.compare_digest(stored_payload_hash, computed_payload_hash):
+        return PolicyIntegrityVerificationResult(
+            status="tampered",
+            payload_hash=computed_payload_hash,
+            key_id=stored_key_id,
+            message="policy_integrity_payload_hash_mismatch",
+        )
+
+    computed_payload_mac = hmac.new(key, payload, hashlib.sha256).hexdigest()
+    if not hmac.compare_digest(stored_payload_mac, computed_payload_mac):
+        return PolicyIntegrityVerificationResult(
+            status="tampered",
+            payload_hash=computed_payload_hash,
+            key_id=stored_key_id,
+            message="policy_integrity_mac_mismatch",
+        )
+    return PolicyIntegrityVerificationResult(
+        status="valid",
+        payload_hash=computed_payload_hash,
+        key_id=stored_key_id,
+        message=POLICY_INTEGRITY_MAC_ALGORITHM,
+    )
+
+
+def _string_or_none(value: object) -> str | None:
+    return value if isinstance(value, str) and value else None
+
+
+def _int_or_none(value: object) -> int | None:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        stripped = value.strip()
+        if stripped.isdigit():
+            return int(stripped)
+    return None
+
+
+def _mapping_value(row: Mapping[str, object], key: str) -> object:
+    try:
+        return row[key]
+    except KeyError:
+        return None

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -26,6 +26,13 @@ from .approval_gate import ApprovalGateGrant, require_policy_clear, require_poli
 from .cli.oauth_client import resolve_guard_oauth_client_config, validate_guard_sync_endpoint
 from .edge_events import build_receipt_event
 from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
+from .policy_integrity import (
+    REMOTE_POLICY_SOURCES,
+    PolicyIntegrityVerificationResult,
+    is_remote_policy_source,
+    sign_local_policy_row,
+    verify_local_policy_row,
+)
 from .runtime.actions import GuardActionEnvelope
 from .runtime.scanner_cache import scanner_cache_key
 from .schemas.guard_event_v1 import GuardEventV1
@@ -153,6 +160,7 @@ from .store_threat_intel import (
 from .types import CapabilitySet
 
 _SYNC_TOKEN_REF = "guard-cloud-token"
+_POLICY_INTEGRITY_KEY_REF = "guard-policy-integrity-key"
 _OAUTH_LOCAL_CREDENTIALS_REF = "guard-oauth-local-credentials"
 _SYNC_TOKEN_HASH_KEY = "token_sha256"
 _OAUTH_LOCAL_CREDENTIALS_STATE_KEY = "oauth_local_credentials"
@@ -179,6 +187,15 @@ _DEVICE_ROW_KEY = "local-device"
 _MAX_RESOLVED_SCOPE_IDS = 200
 _SQLITE_ID_BATCH_SIZE = 500
 _WORKSPACE_POLICY_KEY_PREFIX = "workspace:"
+_POLICY_INTEGRITY_STATE_KEY = "policy_integrity"
+_POLICY_INTEGRITY_ENFORCEMENTS = frozenset({"warn", "enforce"})
+_POLICY_INTEGRITY_STATUSES = (
+    "valid",
+    "missing_integrity",
+    "tampered",
+    "unknown_key",
+    "degraded_mode",
+)
 _SCOPED_HARNESS_FAMILIES = frozenset(
     {
         "file-read",
@@ -200,7 +217,8 @@ _SCOPED_RUNTIME_EXACT_FAMILIES = frozenset(
     }
 )
 _RUNTIME_SCOPED_EXACT_MATCH_PREFIX = "runtime-exact:"
-_REMOTE_POLICY_SOURCES = frozenset({"cloud-sync", "team-policy", "policy-bundle"})
+_REMOTE_POLICY_SOURCE_PARAMS = tuple(sorted(REMOTE_POLICY_SOURCES))
+_REMOTE_POLICY_SOURCE_PLACEHOLDERS = "(" + ",".join("?" for _ in _REMOTE_POLICY_SOURCE_PARAMS) + ")"
 _POLICY_SCOPES = frozenset({"artifact", "workspace", "publisher", "harness", "global"})
 _SLOW_STORE_WARNING_ENV = "HOL_GUARD_WARN_SLOW_STORE"
 _SECRET_FINGERPRINT_PREFIX = "pbkdf2-sha256$"
@@ -211,6 +229,7 @@ _CLOUD_SYNC_LOCK_TIMEOUT_SECONDS = 30.0
 _CLOUD_SYNC_LOCK_POLL_SECONDS = 0.05
 _GUARD_STORE_PRIVATE_DIR_MODE = 0o700
 _GUARD_STORE_PRIVATE_FILE_MODE = 0o600
+_POLICY_INTEGRITY_MIGRATION_ELIGIBLE_STATUSES = frozenset({"missing_integrity", "unknown_key"})
 
 
 def _oauth_sync_url_from_issuer(issuer: str) -> str:
@@ -753,6 +772,12 @@ def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
     return fallback_store
 
 
+def _build_policy_integrity_secret_store() -> SystemKeyringSecretStore | None:
+    if SystemKeyringSecretStore._is_available():
+        return SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    return None
+
+
 def _secret_store_backend_name(secret_store: SecretStore) -> str:
     if isinstance(secret_store, SystemKeyringSecretStore):
         return "system-keyring"
@@ -803,8 +828,10 @@ class GuardStore:
         _set_private_mode(self.guard_home, _GUARD_STORE_PRIVATE_DIR_MODE)
         self._secret_store = _build_secret_store(self.guard_home)
         self._oauth_secret_store = _build_oauth_secret_store(self.guard_home)
+        self._policy_integrity_secret_store = _build_policy_integrity_secret_store()
         self._cached_oauth_secret_payload: tuple[str, str, str] | None = None
         self._sync_token_ref = self._build_scoped_secret_ref(_SYNC_TOKEN_REF)
+        self._policy_integrity_key_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_KEY_REF)
         self._oauth_local_credentials_ref = self._build_scoped_secret_ref(_OAUTH_LOCAL_CREDENTIALS_REF)
         self._guard_event_queue_limit = max(1, guard_event_queue_limit)
         self.path = self.guard_home / "guard.db"
@@ -917,6 +944,203 @@ class GuardStore:
         if token is None:
             return []
         return [token]
+
+    def _policy_integrity_backend_name(self) -> str:
+        if self._policy_integrity_secret_store is None:
+            return "unavailable"
+        return _secret_store_backend_name(self._policy_integrity_secret_store)
+
+    def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is None:
+            return None, None
+        encoded_key = self._get_secret_from_store(secret_store, self._policy_integrity_key_ref)
+        if encoded_key is None and create:
+            generated_key = base64.urlsafe_b64encode(os.urandom(32)).decode("ascii")
+            try:
+                secret_store.set_secret(self._policy_integrity_key_ref, generated_key)
+            except Exception:
+                return None, None
+            encoded_key = self._get_secret_from_store(secret_store, self._policy_integrity_key_ref)
+        if encoded_key is None:
+            return None, None
+        try:
+            raw_key = base64.urlsafe_b64decode(encoded_key.encode("ascii"))
+        except Exception:
+            return None, None
+        if len(raw_key) != 32:
+            return None, None
+        key_id = self._versioned_secret_ref(self._policy_integrity_key_ref, sha256(raw_key).hexdigest())
+        return raw_key, key_id
+
+    def _policy_integrity_path_warnings(self) -> list[str]:
+        warnings: list[str] = []
+        if self.guard_home.is_symlink():
+            warnings.append("guard_home_symlink")
+        if self.path.exists() and self.path.is_symlink():
+            warnings.append("guard_db_symlink")
+        if os.name == "nt":
+            return warnings
+        try:
+            if self.guard_home.stat().st_mode & 0o077:
+                warnings.append("guard_home_permissions")
+        except OSError:
+            warnings.append("guard_home_inaccessible")
+        if not self.path.exists():
+            return warnings
+        try:
+            if self.path.stat().st_mode & 0o077:
+                warnings.append("guard_db_permissions")
+        except OSError:
+            warnings.append("guard_db_inaccessible")
+        return warnings
+
+    @staticmethod
+    def _load_policy_integrity_state(connection: sqlite3.Connection) -> dict[str, object] | None:
+        row = connection.execute(
+            "select payload_json from sync_state where state_key = ?",
+            (_POLICY_INTEGRITY_STATE_KEY,),
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            payload = json.loads(str(row["payload_json"]))
+        except json.JSONDecodeError:
+            return None
+        return payload if isinstance(payload, dict) else None
+
+    @staticmethod
+    def _store_policy_integrity_state(
+        connection: sqlite3.Connection,
+        payload: dict[str, object],
+        *,
+        now: str,
+    ) -> None:
+        connection.execute(
+            """
+            insert into sync_state (state_key, payload_json, updated_at)
+            values (?, ?, ?)
+            on conflict(state_key) do update set
+              payload_json = excluded.payload_json,
+              updated_at = excluded.updated_at
+            """,
+            (
+                _POLICY_INTEGRITY_STATE_KEY,
+                json.dumps(payload, sort_keys=True, separators=(",", ":")),
+                now,
+            ),
+        )
+
+    @staticmethod
+    def _count_legacy_local_policy_rows(connection: sqlite3.Connection) -> int:
+        row = connection.execute(
+            f"""
+            select count(*) as total
+            from policy_decisions
+            where source not in {_REMOTE_POLICY_SOURCE_PLACEHOLDERS}
+              and (
+                integrity_version is null
+                or payload_hash is null
+                or payload_mac is null
+                or integrity_key_id is null
+                or signed_at is null
+              )
+            """,
+            _REMOTE_POLICY_SOURCE_PARAMS,
+        ).fetchone()
+        return int(row["total"]) if row is not None else 0
+
+    def _refresh_policy_integrity_state(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        now: str,
+        create_key: bool,
+        secret_material: tuple[bytes | None, str | None] | None = None,
+    ) -> dict[str, object]:
+        existing = self._load_policy_integrity_state(connection) or {}
+        warnings = self._policy_integrity_path_warnings()
+        raw_key, key_id = (
+            secret_material
+            if secret_material is not None
+            else self._policy_integrity_secret_material(create=create_key)
+        )
+        if self._policy_integrity_secret_store is None:
+            warnings.append("system_keyring_unavailable")
+        elif raw_key is None or key_id is None:
+            warnings.append("policy_integrity_key_unavailable")
+        mode = "protected" if not warnings else "degraded"
+        stored_enforcement = existing.get("enforcement")
+        if isinstance(stored_enforcement, str) and stored_enforcement in _POLICY_INTEGRITY_ENFORCEMENTS:
+            enforcement = stored_enforcement
+        else:
+            has_only_signed_rows = self._count_legacy_local_policy_rows(connection) == 0
+            enforcement = "enforce" if mode == "protected" and has_only_signed_rows else "warn"
+        payload: dict[str, object] = {
+            "backend": self._policy_integrity_backend_name(),
+            "degraded_reasons": list(dict.fromkeys(warnings)),
+            "enforcement": enforcement,
+            "key_id": key_id,
+            "mode": mode,
+        }
+        if payload != existing:
+            self._store_policy_integrity_state(connection, payload, now=now)
+        return payload
+
+    def _policy_integrity_result_for_row(
+        self,
+        row: sqlite3.Row,
+        *,
+        mode: str,
+        key: bytes | None,
+        key_id: str | None,
+    ) -> PolicyIntegrityVerificationResult:
+        source = str(row["source"]) if row["source"] is not None else None
+        if is_remote_policy_source(source):
+            return PolicyIntegrityVerificationResult(status="valid")
+        return verify_local_policy_row(
+            row,
+            key=key,
+            key_id=key_id,
+            degraded_mode=mode != "protected",
+        )
+
+    @staticmethod
+    def _policy_row_payload(
+        row: sqlite3.Row,
+        *,
+        integrity_result: PolicyIntegrityVerificationResult | None = None,
+        state: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        source = str(row["source"])
+        payload: dict[str, object] = {
+            "action": str(row["action"]),
+            "artifact_hash": row["artifact_hash"],
+            "artifact_id": row["artifact_id"],
+            "decision_id": int(row["decision_id"]) if row["decision_id"] is not None else None,
+            "expires_at": row["expires_at"],
+            "harness": str(row["harness"]),
+            "owner": row["owner"],
+            "publisher": row["publisher"],
+            "reason": row["reason"],
+            "scope": str(row["scope"]),
+            "source": source,
+            "updated_at": str(row["updated_at"]),
+            "workspace": row["workspace"],
+        }
+        if integrity_result is not None and not is_remote_policy_source(source):
+            payload["integrity_status"] = integrity_result.status
+            payload["integrity_message"] = integrity_result.message
+        if state is not None and not is_remote_policy_source(source):
+            payload["integrity_mode"] = state.get("mode")
+            payload["integrity_enforcement"] = state.get("enforcement")
+        if row["integrity_version"] is not None:
+            payload["integrity_version"] = int(row["integrity_version"])
+        if row["integrity_key_id"] is not None:
+            payload["integrity_key_id"] = str(row["integrity_key_id"])
+        if row["signed_at"] is not None:
+            payload["signed_at"] = str(row["signed_at"])
+        return payload
 
     def _repair_store_permissions(self) -> None:
         _set_private_mode(self.guard_home, _GUARD_STORE_PRIVATE_DIR_MODE)
@@ -1308,6 +1532,11 @@ class GuardStore:
             self._ensure_policy_column(connection, "owner", "text")
             self._ensure_policy_column(connection, "source", "text not null default 'local'")
             self._ensure_policy_column(connection, "expires_at", "text")
+            self._ensure_policy_column(connection, "integrity_version", "integer")
+            self._ensure_policy_column(connection, "payload_hash", "text")
+            self._ensure_policy_column(connection, "payload_mac", "text")
+            self._ensure_policy_column(connection, "integrity_key_id", "text")
+            self._ensure_policy_column(connection, "signed_at", "text")
             self._ensure_runtime_receipts_column(connection, "capabilities_summary", "text not null default ''")
             self._ensure_runtime_receipts_column(connection, "scanner_evidence_json", "text not null default '[]'")
             self._ensure_runtime_receipts_column(connection, "diff_summary", "text")
@@ -1354,12 +1583,16 @@ class GuardStore:
                 if receipt_rollups_need_backfill(connection):
                     backfill_receipt_rollups(connection)
                 self._record_schema_version(connection, version=6)
+            if not self._schema_version_applied(connection, version=7):
+                self._record_schema_version(connection, version=7)
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")
             self._ensure_local_device(connection)
             if not self._schema_version_applied(connection, version=2):
                 self._record_schema_version(connection, version=2)
             connection.execute("pragma journal_mode=WAL")
+            self._repair_store_permissions()
+            self._refresh_policy_integrity_state(connection, now=_now(), create_key=True)
 
     @staticmethod
     def _ensure_policy_column(connection: sqlite3.Connection, column_name: str, column_type: str) -> None:
@@ -1965,7 +2198,43 @@ class GuardStore:
         )
         _validate_scoped_policy_artifact_target(decision.scope, decision.artifact_id)
         artifact_id, artifact_hash, workspace, publisher = self._normalized_policy_keys(decision)
+        signing_payload = {
+            "harness": decision.harness,
+            "scope": decision.scope,
+            "artifact_id": artifact_id,
+            "artifact_hash": artifact_hash,
+            "workspace": workspace,
+            "publisher": publisher,
+            "action": decision.action,
+            "source": decision.source,
+            "expires_at": decision.expires_at,
+            "updated_at": now,
+        }
+        integrity_values: dict[str, object] = {
+            "integrity_version": None,
+            "payload_hash": None,
+            "payload_mac": None,
+            "integrity_key_id": None,
+            "signed_at": None,
+        }
         with self._connect() as connection:
+            secret_material = (None, None)
+            if not is_remote_policy_source(decision.source):
+                secret_material = self._policy_integrity_secret_material(create=True)
+                key, key_id = secret_material
+                if key is not None and key_id is not None:
+                    integrity_values = sign_local_policy_row(
+                        signing_payload,
+                        key,
+                        key_id=key_id,
+                        signed_at=now,
+                    )
+            self._refresh_policy_integrity_state(
+                connection,
+                now=now,
+                create_key=False,
+                secret_material=secret_material,
+            )
             connection.execute(
                 """
                 delete from policy_decisions
@@ -1980,9 +2249,9 @@ class GuardStore:
                 """
                 insert into policy_decisions (
                   harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
-                  expires_at, updated_at
+                  expires_at, updated_at, integrity_version, payload_hash, payload_mac, integrity_key_id, signed_at
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     decision.harness,
@@ -1997,6 +2266,11 @@ class GuardStore:
                     decision.source,
                     decision.expires_at,
                     now,
+                    integrity_values["integrity_version"],
+                    integrity_values["payload_hash"],
+                    integrity_values["payload_mac"],
+                    integrity_values["integrity_key_id"],
+                    integrity_values["signed_at"],
                 ),
             )
 
@@ -2016,7 +2290,8 @@ class GuardStore:
             )
         with self._connect() as connection:
             connection.execute(
-                "delete from policy_decisions where source in ('cloud-sync', 'team-policy', 'policy-bundle')"
+                f"delete from policy_decisions where source in {_REMOTE_POLICY_SOURCE_PLACEHOLDERS}",
+                _REMOTE_POLICY_SOURCE_PARAMS,
             )
             for decision in decisions:
                 _validate_scoped_policy_artifact_target(decision.scope, decision.artifact_id)
@@ -2025,9 +2300,9 @@ class GuardStore:
                     """
                     insert into policy_decisions (
                       harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
-                      expires_at, updated_at
+                      expires_at, updated_at, integrity_version, payload_hash, payload_mac, integrity_key_id, signed_at
                     )
-                    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         decision.harness,
@@ -2042,6 +2317,11 @@ class GuardStore:
                         decision.source,
                         decision.expires_at,
                         now,
+                        None,
+                        None,
+                        None,
+                        None,
+                        None,
                     ),
                 )
 
@@ -2072,14 +2352,20 @@ class GuardStore:
         workspace: str | None = None,
         publisher: str | None = None,
         now: str | None = None,
-    ) -> dict[str, str | None] | None:
+    ) -> dict[str, object] | None:
         current_time = now or _now()
         workspace_key = _workspace_policy_key(workspace)
         action_family_key = _artifact_family_key(artifact_id)
+        events: list[tuple[str, dict[str, object]]] = []
+        selected_payload: dict[str, object] | None = None
         with self._connect() as connection:
+            state = self._refresh_policy_integrity_state(connection, now=current_time, create_key=True)
+            key, key_id = self._policy_integrity_secret_material(create=True)
             rows = connection.execute(
                 """
-                select harness, scope, artifact_id, action, artifact_hash, workspace, publisher, source
+                select decision_id, harness, scope, artifact_id, action, artifact_hash, workspace, publisher, source,
+                       reason, owner, expires_at, updated_at, integrity_version, payload_hash, payload_mac,
+                       integrity_key_id, signed_at
                 from policy_decisions
                 where (harness = ? or harness = '*') and (
                   (
@@ -2136,13 +2422,10 @@ class GuardStore:
                     current_time,
                 ),
             ).fetchall()
-        if not rows:
-            return None
-        row = next(
-            (
-                candidate
-                for candidate in rows
-                if not _scoped_runtime_row_requires_exact_match(
+            if not rows:
+                return None
+            for candidate in rows:
+                if _scoped_runtime_row_requires_exact_match(
                     scope=str(candidate["scope"]),
                     stored_artifact_id=(
                         str(candidate["artifact_id"]) if isinstance(candidate["artifact_id"], str) else None
@@ -2152,22 +2435,63 @@ class GuardStore:
                     ),
                     source=str(candidate["source"]),
                     requested_artifact_id=artifact_id,
+                ):
+                    continue
+                integrity_result = self._policy_integrity_result_for_row(
+                    candidate,
+                    mode=str(state.get("mode") or "degraded"),
+                    key=key,
+                    key_id=key_id,
                 )
-            ),
-            None,
-        )
-        if row is None:
-            return None
-        return {
-            "harness": row["harness"],
-            "scope": row["scope"],
-            "artifact_id": row["artifact_id"],
-            "artifact_hash": row["artifact_hash"],
-            "workspace": row["workspace"],
-            "publisher": row["publisher"],
-            "action": row["action"],
-            "source": row["source"],
-        }
+                if integrity_result.status == "valid":
+                    selected_payload = self._policy_row_payload(
+                        candidate,
+                        integrity_result=integrity_result,
+                        state=state,
+                    )
+                    break
+                if integrity_result.status == "missing_integrity" and state.get("enforcement") == "warn":
+                    events.append(
+                        (
+                            "policy_integrity_warning",
+                            {
+                                "decision_id": int(candidate["decision_id"]),
+                                "harness": str(candidate["harness"]),
+                                "artifact_id": candidate["artifact_id"],
+                                "integrity_status": integrity_result.status,
+                            },
+                        )
+                    )
+                    _store_logger.warning(
+                        "Guard honored legacy unsigned local policy decision %s while integrity enforcement is warn.",
+                        candidate["decision_id"],
+                    )
+                    selected_payload = self._policy_row_payload(
+                        candidate,
+                        integrity_result=integrity_result,
+                        state=state,
+                    )
+                    break
+                events.append(
+                    (
+                        "policy_integrity_violation",
+                        {
+                            "decision_id": int(candidate["decision_id"]),
+                            "harness": str(candidate["harness"]),
+                            "artifact_id": candidate["artifact_id"],
+                            "integrity_status": integrity_result.status,
+                            "message": integrity_result.message,
+                        },
+                    )
+                )
+                _store_logger.warning(
+                    "Guard ignored local policy decision %s because integrity status was %s.",
+                    candidate["decision_id"],
+                    integrity_result.status,
+                )
+        for event_name, payload in events:
+            self.add_event(event_name, payload, current_time)
+        return selected_payload
 
     @staticmethod
     def _normalized_policy_keys(decision: PolicyDecision) -> tuple[str | None, str | None, str | None, str | None]:
@@ -3009,7 +3333,8 @@ class GuardStore:
     def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]:
         query = """
             select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher,
-                   action, reason, owner, source, expires_at, updated_at
+                   action, reason, owner, source, expires_at, updated_at, integrity_version,
+                   payload_hash, payload_mac, integrity_key_id, signed_at
             from policy_decisions
         """
         params: tuple[object, ...] = ()
@@ -3018,6 +3343,8 @@ class GuardStore:
             params = (harness,)
         query += " order by updated_at desc"
         with self._connect() as connection:
+            state = self._refresh_policy_integrity_state(connection, now=_now(), create_key=True)
+            key, key_id = self._policy_integrity_secret_material(create=True)
             rows = connection.execute(query, params).fetchall()
             lookup_items = [
                 (
@@ -3028,10 +3355,26 @@ class GuardStore:
                 for row in rows
             ]
             source_context_index = build_policy_source_context_index(connection, items=lookup_items)
-            return [
-                self._policy_decision_dict_from_row(connection, row, source_context_index=source_context_index)
-                for row in rows
-            ]
+            items: list[dict[str, object]] = []
+            for row in rows:
+                payload = self._policy_decision_dict_from_row(
+                    connection,
+                    row,
+                    source_context_index=source_context_index,
+                )
+                if not is_remote_policy_source(str(row["source"])):
+                    integrity_result = self._policy_integrity_result_for_row(
+                        row,
+                        mode=str(state.get("mode") or "degraded"),
+                        key=key,
+                        key_id=key_id,
+                    )
+                    payload["integrity_status"] = integrity_result.status
+                    payload["integrity_message"] = integrity_result.message
+                    payload["integrity_mode"] = state.get("mode")
+                    payload["integrity_enforcement"] = state.get("enforcement")
+                items.append(payload)
+            return items
 
     @staticmethod
     def _policy_decision_dict_from_row(
@@ -3079,9 +3422,233 @@ class GuardStore:
             "expires_at": row["expires_at"],
             "updated_at": str(row["updated_at"]),
         }
+        if row["integrity_version"] is not None:
+            payload["integrity_version"] = int(row["integrity_version"])
+        if row["integrity_key_id"] is not None:
+            payload["integrity_key_id"] = str(row["integrity_key_id"])
+        if row["signed_at"] is not None:
+            payload["signed_at"] = str(row["signed_at"])
         if source_context is not None:
             payload.update(source_context)
         return payload
+
+    @staticmethod
+    def _load_local_policy_rows(
+        connection: sqlite3.Connection,
+        *,
+        harness: str | None = None,
+    ) -> list[sqlite3.Row]:
+        query = f"""
+            select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher,
+                   action, reason, owner, source, expires_at, updated_at, integrity_version,
+                   payload_hash, payload_mac, integrity_key_id, signed_at
+            from policy_decisions
+            where source not in {_REMOTE_POLICY_SOURCE_PLACEHOLDERS}
+        """
+        params: tuple[object, ...] = _REMOTE_POLICY_SOURCE_PARAMS
+        if harness is not None:
+            query += " and harness = ?"
+            params = (*params, harness)
+        query += " order by updated_at desc"
+        return connection.execute(query, params).fetchall()
+
+    def _policy_integrity_scan(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        now: str,
+        harness: str | None = None,
+    ) -> tuple[dict[str, object], dict[str, int], list[dict[str, object]]]:
+        state = self._refresh_policy_integrity_state(connection, now=now, create_key=True)
+        key, key_id = self._policy_integrity_secret_material(create=True)
+        counts = {status: 0 for status in _POLICY_INTEGRITY_STATUSES}
+        items: list[dict[str, object]] = []
+        for row in self._load_local_policy_rows(connection, harness=harness):
+            integrity_result = self._policy_integrity_result_for_row(
+                row,
+                mode=str(state.get("mode") or "degraded"),
+                key=key,
+                key_id=key_id,
+            )
+            counts[integrity_result.status] += 1
+            item = self._policy_decision_dict_from_row(connection, row)
+            item["integrity_status"] = integrity_result.status
+            item["integrity_message"] = integrity_result.message
+            item["integrity_mode"] = state.get("mode")
+            item["integrity_enforcement"] = state.get("enforcement")
+            items.append(item)
+        return state, counts, items
+
+    def _backup_policy_database(self, connection: sqlite3.Connection, *, now: str) -> str:
+        timestamp = "".join(ch if ch.isalnum() else "-" for ch in now).strip("-") or "backup"
+        backup_path = self.guard_home / f"guard.db.pre-integrity-{timestamp}"
+        backup_connection = sqlite3.connect(backup_path)
+        try:
+            connection.backup(backup_connection)
+        finally:
+            backup_connection.close()
+            if backup_path.exists():
+                _set_private_mode(backup_path, _GUARD_STORE_PRIVATE_FILE_MODE)
+        return str(backup_path)
+
+    def get_policy_integrity_status(self, harness: str | None = None) -> dict[str, object]:
+        now = _now()
+        with self._connect() as connection:
+            state, counts, _items = self._policy_integrity_scan(connection, now=now, harness=harness)
+        return {
+            "generated_at": now,
+            "harness": harness,
+            "backend": state.get("backend"),
+            "mode": state.get("mode"),
+            "enforcement": state.get("enforcement"),
+            "key_id": state.get("key_id"),
+            "degraded_reasons": state.get("degraded_reasons", []),
+            "counts": counts,
+            "local_rows_scanned": sum(counts.values()),
+        }
+
+    def verify_policy_integrity(self, harness: str | None = None) -> dict[str, object]:
+        now = _now()
+        with self._connect() as connection:
+            state, counts, items = self._policy_integrity_scan(connection, now=now, harness=harness)
+        invalid_items = [item for item in items if item.get("integrity_status") != "valid"]
+        return {
+            "generated_at": now,
+            "harness": harness,
+            "backend": state.get("backend"),
+            "mode": state.get("mode"),
+            "enforcement": state.get("enforcement"),
+            "key_id": state.get("key_id"),
+            "degraded_reasons": state.get("degraded_reasons", []),
+            "counts": counts,
+            "local_rows_scanned": sum(counts.values()),
+            "items": invalid_items,
+        }
+
+    def repair_policy_integrity(
+        self,
+        *,
+        clear_invalid: bool,
+        harness: str | None = None,
+        approval_gate_grant: ApprovalGateGrant | None = None,
+        now: str | None = None,
+    ) -> dict[str, object]:
+        current_time = now or _now()
+        if clear_invalid:
+            require_policy_clear(self.guard_home, approval_gate_grant=approval_gate_grant, now=current_time)
+        with self._connect() as connection:
+            _state, _counts, items = self._policy_integrity_scan(connection, now=current_time, harness=harness)
+            invalid_ids = [
+                int(item["decision_id"])
+                for item in items
+                if item.get("integrity_status") != "valid" and isinstance(item.get("decision_id"), int)
+            ]
+            cleared = 0
+            if clear_invalid and invalid_ids:
+                for chunk in _chunks(invalid_ids, _SQLITE_ID_BATCH_SIZE):
+                    placeholders = ",".join("?" for _ in chunk)
+                    cursor = connection.execute(
+                        f"delete from policy_decisions where decision_id in ({placeholders})",
+                        tuple(chunk),
+                    )
+                    cleared += int(cursor.rowcount if cursor.rowcount is not None else 0)
+            state, counts, remaining_items = self._policy_integrity_scan(connection, now=current_time, harness=harness)
+        return {
+            "generated_at": current_time,
+            "harness": harness,
+            "backend": state.get("backend"),
+            "mode": state.get("mode"),
+            "enforcement": state.get("enforcement"),
+            "key_id": state.get("key_id"),
+            "degraded_reasons": state.get("degraded_reasons", []),
+            "counts": counts,
+            "local_rows_scanned": sum(counts.values()),
+            "cleared": cleared,
+            "clear_invalid": clear_invalid,
+            "items": [item for item in remaining_items if item.get("integrity_status") != "valid"],
+        }
+
+    def migrate_local_policy_integrity(
+        self,
+        *,
+        preserve_decision_ids: set[int],
+        clear_unselected: bool,
+        harness: str | None = None,
+        approval_gate_grant: ApprovalGateGrant | None = None,
+        now: str,
+    ) -> dict[str, object]:
+        require_policy_clear(self.guard_home, approval_gate_grant=approval_gate_grant, now=now)
+        with self._connect() as connection:
+            state = self._refresh_policy_integrity_state(connection, now=now, create_key=True)
+            if state.get("mode") != "protected":
+                raise RuntimeError("Guard policy integrity migration requires a protected system keyring backend.")
+            key, key_id = self._policy_integrity_secret_material(create=True)
+            if key is None or key_id is None:
+                raise RuntimeError("Guard could not access the policy integrity key.")
+            backup_path = self._backup_policy_database(connection, now=now)
+            rows = self._load_local_policy_rows(connection, harness=harness)
+            preserved = 0
+            cleared = 0
+            legacy_ids: list[int] = []
+            unknown_key_ids: list[int] = []
+            for row in rows:
+                integrity_result = verify_local_policy_row(row, key=key, key_id=key_id, degraded_mode=False)
+                if integrity_result.status not in _POLICY_INTEGRITY_MIGRATION_ELIGIBLE_STATUSES:
+                    continue
+                decision_id = int(row["decision_id"])
+                if integrity_result.status == "missing_integrity":
+                    legacy_ids.append(decision_id)
+                else:
+                    unknown_key_ids.append(decision_id)
+                if decision_id in preserve_decision_ids:
+                    signed = sign_local_policy_row(row, key, key_id=key_id, signed_at=now)
+                    connection.execute(
+                        """
+                        update policy_decisions
+                        set integrity_version = ?,
+                            payload_hash = ?,
+                            payload_mac = ?,
+                            integrity_key_id = ?,
+                            signed_at = ?
+                        where decision_id = ?
+                        """,
+                        (
+                            signed["integrity_version"],
+                            signed["payload_hash"],
+                            signed["payload_mac"],
+                            signed["integrity_key_id"],
+                            signed["signed_at"],
+                            decision_id,
+                        ),
+                    )
+                    preserved += 1
+                elif clear_unselected:
+                    cursor = connection.execute(
+                        "delete from policy_decisions where decision_id = ?",
+                        (decision_id,),
+                    )
+                    cleared += int(cursor.rowcount if cursor.rowcount is not None else 0)
+            next_state = dict(state)
+            next_state["enforcement"] = "enforce"
+            self._store_policy_integrity_state(connection, next_state, now=now)
+            final_state, counts, items = self._policy_integrity_scan(connection, now=now, harness=harness)
+        return {
+            "generated_at": now,
+            "harness": harness,
+            "backup_path": backup_path,
+            "backend": final_state.get("backend"),
+            "mode": final_state.get("mode"),
+            "enforcement": final_state.get("enforcement"),
+            "key_id": final_state.get("key_id"),
+            "degraded_reasons": final_state.get("degraded_reasons", []),
+            "legacy_row_ids": legacy_ids,
+            "unknown_key_row_ids": unknown_key_ids,
+            "preserved": preserved,
+            "cleared": cleared,
+            "counts": counts,
+            "local_rows_scanned": sum(counts.values()),
+            "items": [item for item in items if item.get("integrity_status") != "valid"],
+        }
 
     def clear_policy_decisions(
         self,
@@ -5223,7 +5790,7 @@ def _scoped_runtime_row_requires_exact_match(
 ) -> bool:
     if scope not in {"harness", "global"}:
         return False
-    if source in _REMOTE_POLICY_SOURCES:
+    if source in REMOTE_POLICY_SOURCES:
         return False
     family_key = _artifact_family_key(stored_artifact_id)
     if family_key is None or _family_key_value(family_key) not in _SCOPED_RUNTIME_EXACT_FAMILIES:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import sys
 from collections.abc import Callable
@@ -8,14 +9,18 @@ from pathlib import Path
 import pytest
 
 SRC_PATH = Path(__file__).resolve().parents[1] / "src"
+SUPPORT_PATH = Path(__file__).resolve().parent / "support"
 
 if str(SRC_PATH) not in sys.path:
     sys.path.insert(0, str(SRC_PATH))
+if str(SUPPORT_PATH) not in sys.path:
+    sys.path.insert(0, str(SUPPORT_PATH))
 
 existing_pythonpath = os.environ.get("PYTHONPATH", "")
 pythonpath_entries = [entry for entry in existing_pythonpath.split(os.pathsep) if entry]
-if str(SRC_PATH) not in pythonpath_entries:
-    os.environ["PYTHONPATH"] = os.pathsep.join([str(SRC_PATH), *pythonpath_entries])
+pythonpath_prefix = [str(path) for path in (SUPPORT_PATH, SRC_PATH) if str(path) not in pythonpath_entries]
+if pythonpath_prefix:
+    os.environ["PYTHONPATH"] = os.pathsep.join([*pythonpath_prefix, *pythonpath_entries])
 
 
 @pytest.fixture(autouse=True)
@@ -25,8 +30,104 @@ def _disable_real_macos_keychain(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
 
 
+class _FakeSystemKeyringModule:
+    def __init__(self) -> None:
+        self._secrets: dict[tuple[str, str], str] = {}
+
+    @staticmethod
+    def _store_path() -> Path | None:
+        value = os.environ.get("HOL_GUARD_TEST_KEYRING_FILE", "").strip()
+        return Path(value) if value else None
+
+    def _load(self) -> dict[tuple[str, str], str]:
+        store_path = self._store_path()
+        if store_path is None or not store_path.is_file():
+            return dict(self._secrets)
+        payload = json.loads(store_path.read_text(encoding="utf-8"))
+        return {
+            (str(service_name), str(secret_id)): str(secret_value)
+            for service_name, secrets in payload.items()
+            if isinstance(service_name, str) and isinstance(secrets, dict)
+            for secret_id, secret_value in secrets.items()
+            if isinstance(secret_id, str) and isinstance(secret_value, str)
+        }
+
+    def _persist(self, secrets: dict[tuple[str, str], str]) -> None:
+        self._secrets = dict(secrets)
+        store_path = self._store_path()
+        if store_path is None:
+            return
+        payload: dict[str, dict[str, str]] = {}
+        for (service_name, secret_id), secret_value in secrets.items():
+            payload.setdefault(service_name, {})[secret_id] = secret_value
+        store_path.parent.mkdir(parents=True, exist_ok=True)
+        store_path.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+
+    @staticmethod
+    def get_keyring():
+        class _Backend:
+            priority = 1
+
+        return _Backend()
+
+    def set_password(self, service_name: str, secret_id: str, value: str) -> None:
+        secrets = self._load()
+        secrets[(service_name, secret_id)] = value
+        self._persist(secrets)
+
+    def get_password(self, service_name: str, secret_id: str) -> str | None:
+        return self._load().get((service_name, secret_id))
+
+    def delete_password(self, service_name: str, secret_id: str) -> None:
+        secrets = self._load()
+        secrets.pop((service_name, secret_id), None)
+        self._persist(secrets)
+
+
 @pytest.fixture
-def seed_connected_oauth_without_entitlement() -> Callable[["GuardStore"], None]:
+def install_fake_system_keyring(monkeypatch: pytest.MonkeyPatch) -> Callable[[], _FakeSystemKeyringModule]:
+    from codex_plugin_scanner.guard.store import SystemKeyringSecretStore
+
+    def _install() -> _FakeSystemKeyringModule:
+        module = _FakeSystemKeyringModule()
+        monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
+        monkeypatch.setattr(
+            SystemKeyringSecretStore,
+            "_macos_default_keychain_is_usable",
+            classmethod(lambda cls: True),
+        )
+        return module
+
+    return _install
+
+
+_FAKE_SYSTEM_KEYRING_DISABLED_FILES = {
+    "test_guard_store_migrations.py",
+}
+
+_FAKE_SYSTEM_KEYRING_DISABLED_NODEIDS = {
+    "tests/test_guard_cli.py::TestGuardCli::test_guard_status_reports_oauth_key_storage_health",
+}
+
+
+@pytest.fixture(autouse=True)
+def _policy_integrity_keyring_for_selected_tests(
+    request: pytest.FixtureRequest,
+    install_fake_system_keyring,
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    if (
+        request.node.path.name in _FAKE_SYSTEM_KEYRING_DISABLED_FILES
+        or request.node.nodeid in _FAKE_SYSTEM_KEYRING_DISABLED_NODEIDS
+    ):
+        return
+    monkeypatch.setenv("HOL_GUARD_TEST_KEYRING_FILE", str(tmp_path / "fake-system-keyring.json"))
+    install_fake_system_keyring()
+
+
+@pytest.fixture
+def seed_connected_oauth_without_entitlement() -> Callable[[object], None]:
     from codex_plugin_scanner.guard.store import GuardStore
 
     def _seed(store: GuardStore) -> None:

--- a/tests/support/keyring.py
+++ b/tests/support/keyring.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+
+def _store_path() -> Path | None:
+    value = os.environ.get("HOL_GUARD_TEST_KEYRING_FILE", "").strip()
+    return Path(value) if value else None
+
+
+def _load() -> dict[tuple[str, str], str]:
+    store_path = _store_path()
+    if store_path is None or not store_path.is_file():
+        return {}
+    payload = json.loads(store_path.read_text(encoding="utf-8"))
+    return {
+        (str(service_name), str(secret_id)): str(secret_value)
+        for service_name, secrets in payload.items()
+        if isinstance(service_name, str) and isinstance(secrets, dict)
+        for secret_id, secret_value in secrets.items()
+        if isinstance(secret_id, str) and isinstance(secret_value, str)
+    }
+
+
+def _persist(secrets: dict[tuple[str, str], str]) -> None:
+    store_path = _store_path()
+    if store_path is None:
+        return
+    payload: dict[str, dict[str, str]] = {}
+    for (service_name, secret_id), secret_value in secrets.items():
+        payload.setdefault(service_name, {})[secret_id] = secret_value
+    store_path.parent.mkdir(parents=True, exist_ok=True)
+    store_path.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+
+
+def get_keyring():
+    class _Backend:
+        priority = 1 if _store_path() is not None else 0
+
+    return _Backend()
+
+
+def set_password(service_name: str, secret_id: str, value: str) -> None:
+    secrets = _load()
+    secrets[(service_name, secret_id)] = value
+    _persist(secrets)
+
+
+def get_password(service_name: str, secret_id: str) -> str | None:
+    return _load().get((service_name, secret_id))
+
+
+def delete_password(service_name: str, secret_id: str) -> None:
+    secrets = _load()
+    secrets.pop((service_name, secret_id), None)
+    _persist(secrets)

--- a/tests/test_guard_manifest_install_firewall.py
+++ b/tests/test_guard_manifest_install_firewall.py
@@ -5,12 +5,19 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.local_supply_chain import build_package_protect_payload
 from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.runtime.package_intent import build_package_request_artifact
 from codex_plugin_scanner.guard.runtime.package_intent_parser import parse_package_intent
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from codex_plugin_scanner.guard.store import GuardStore
+
+
+@pytest.fixture(autouse=True)
+def _fake_policy_integrity_keyring(install_fake_system_keyring) -> None:
+    install_fake_system_keyring()
 
 
 def _write_pnpm_workspace(workspace_dir: Path, *, extra_dependency: str | None = None) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1,0 +1,503 @@
+"""Regression tests for local Guard policy integrity enforcement."""
+
+from __future__ import annotations
+
+import base64
+import json
+import sqlite3
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.models import PolicyDecision
+from codex_plugin_scanner.guard.store import GuardStore, SystemKeyringSecretStore
+
+
+@pytest.fixture(autouse=True)
+def _fake_policy_integrity_keyring(install_fake_system_keyring) -> None:
+    install_fake_system_keyring()
+
+
+def _store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard-home")
+
+
+def _decision(
+    *,
+    artifact_id: str = "codex:project:workspace-skill",
+    artifact_hash: str = "hash-123",
+    action: str = "allow",
+    source: str = "local",
+) -> PolicyDecision:
+    return PolicyDecision(
+        harness="codex",
+        scope="artifact",
+        action=action,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+        reason="reviewed",
+        source=source,
+    )
+
+
+def _policy_row(home_dir: Path, *, artifact_id: str) -> sqlite3.Row:
+    with sqlite3.connect(home_dir / "guard.db") as connection:
+        connection.row_factory = sqlite3.Row
+        row = connection.execute(
+            "select * from policy_decisions where artifact_id = ?",
+            (artifact_id,),
+        ).fetchone()
+    assert row is not None
+    return row
+
+
+def _policy_integrity_state_payload(home_dir: Path) -> dict[str, object]:
+    with sqlite3.connect(home_dir / "guard.db") as connection:
+        row = connection.execute("select payload_json from sync_state where state_key = 'policy_integrity'").fetchone()
+    assert row is not None
+    return json.loads(str(row[0]))
+
+
+def _strip_policy_integrity(home_dir: Path, *, artifact_id: str) -> None:
+    with sqlite3.connect(home_dir / "guard.db") as connection:
+        connection.execute(
+            """
+            update policy_decisions
+            set integrity_version = null,
+                payload_hash = null,
+                payload_mac = null,
+                integrity_key_id = null,
+                signed_at = null
+            where artifact_id = ?
+            """,
+            (artifact_id,),
+        )
+
+
+def _set_policy_integrity_state(
+    home_dir: Path,
+    *,
+    backend: str,
+    mode: str,
+    enforcement: str,
+    key_id: str | None,
+    degraded_reasons: list[str] | None = None,
+) -> None:
+    payload = {
+        "backend": backend,
+        "degraded_reasons": degraded_reasons or [],
+        "enforcement": enforcement,
+        "key_id": key_id,
+        "mode": mode,
+    }
+    with sqlite3.connect(home_dir / "guard.db") as connection:
+        connection.execute(
+            """
+            insert into sync_state (state_key, payload_json, updated_at)
+            values ('policy_integrity', ?, ?)
+            on conflict(state_key) do update set
+              payload_json = excluded.payload_json,
+              updated_at = excluded.updated_at
+            """,
+            (json.dumps(payload, sort_keys=True, separators=(",", ":")), "2026-06-14T00:00:00Z"),
+        )
+
+
+def _rotate_policy_integrity_key(store: GuardStore, *, raw_key: bytes) -> None:
+    secret_store = store._policy_integrity_secret_store
+    assert secret_store is not None
+    secret_store.set_secret(
+        store._policy_integrity_key_ref,
+        base64.urlsafe_b64encode(raw_key).decode("ascii"),
+    )
+
+
+def test_upsert_policy_signs_local_row_and_resolve_honors_it(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(_decision(), "2026-06-14T00:00:00Z")
+
+    row = _policy_row(store.guard_home, artifact_id="codex:project:workspace-skill")
+    resolved = store.resolve_policy_decision(
+        "codex",
+        "codex:project:workspace-skill",
+        "hash-123",
+        now="2026-06-14T00:01:00Z",
+    )
+
+    assert row["integrity_version"] == 1
+    assert isinstance(row["payload_hash"], str) and row["payload_hash"]
+    assert isinstance(row["payload_mac"], str) and row["payload_mac"]
+    assert isinstance(row["integrity_key_id"], str) and row["integrity_key_id"]
+    assert resolved is not None
+    assert resolved["action"] == "allow"
+    assert resolved["integrity_status"] == "valid"
+
+
+def test_direct_sqlite_insert_is_ignored_in_enforce_mode(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute(
+            """
+            insert into policy_decisions (
+              harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
+              expires_at, updated_at
+            )
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "codex",
+                "artifact",
+                "codex:project:forged",
+                "hash-forged",
+                None,
+                None,
+                "allow",
+                "forged",
+                None,
+                "local",
+                None,
+                "2026-06-14T00:00:00Z",
+            ),
+        )
+
+    resolved = store.resolve_policy(
+        "codex",
+        "codex:project:forged",
+        "hash-forged",
+        now="2026-06-14T00:01:00Z",
+    )
+    verify = store.verify_policy_integrity()
+
+    assert resolved is None
+    assert verify["enforcement"] == "enforce"
+    assert verify["counts"]["missing_integrity"] == 1
+
+
+def test_upsert_policy_uses_single_integrity_key_lookup_per_write(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    original_lookup = store._policy_integrity_secret_material
+    lookup_calls = 0
+
+    def _flaky_lookup(*, create: bool) -> tuple[bytes | None, str | None]:
+        nonlocal lookup_calls
+        lookup_calls += 1
+        if lookup_calls == 1:
+            return None, None
+        return original_lookup(create=create)
+
+    monkeypatch.setattr(store, "_policy_integrity_secret_material", _flaky_lookup)
+
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:transient", artifact_hash="hash-transient"),
+        "2026-06-14T00:00:00Z",
+    )
+
+    row = _policy_row(store.guard_home, artifact_id="codex:project:transient")
+    state = _policy_integrity_state_payload(store.guard_home)
+
+    assert lookup_calls == 1
+    assert row["integrity_version"] is None
+    assert state["mode"] == "degraded"
+    assert state["key_id"] is None
+
+
+def test_tampered_signed_row_is_ignored_and_event_emitted(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:tampered", artifact_hash="hash-tampered"),
+        "2026-06-14T00:00:00Z",
+    )
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where artifact_id = ?",
+            ("deadbeef", "codex:project:tampered"),
+        )
+
+    resolved = store.resolve_policy(
+        "codex",
+        "codex:project:tampered",
+        "hash-tampered",
+        now="2026-06-14T00:01:00Z",
+    )
+    events = store.list_events(limit=100, event_name="policy_integrity_violation")
+
+    assert resolved is None
+    assert any(event.get("payload", {}).get("artifact_id") == "codex:project:tampered" for event in events)
+
+
+def test_remote_policy_row_is_honored_without_local_mac(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.replace_remote_policies(
+        [_decision(artifact_id="codex:project:remote", artifact_hash="hash-remote", source="cloud-sync")],
+        "2026-06-14T00:00:00Z",
+    )
+
+    resolved = store.resolve_policy(
+        "codex",
+        "codex:project:remote",
+        "hash-remote",
+        now="2026-06-14T00:01:00Z",
+    )
+
+    assert resolved == "allow"
+
+
+def test_legacy_unsigned_row_warn_mode_then_enforce_mode(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:legacy", artifact_hash="hash-legacy"),
+        "2026-06-14T00:00:00Z",
+    )
+    status = store.get_policy_integrity_status()
+    _strip_policy_integrity(store.guard_home, artifact_id="codex:project:legacy")
+    _set_policy_integrity_state(
+        store.guard_home,
+        backend=str(status["backend"]),
+        mode="protected",
+        enforcement="warn",
+        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
+    )
+
+    warned = store.resolve_policy_decision(
+        "codex",
+        "codex:project:legacy",
+        "hash-legacy",
+        now="2026-06-14T00:01:00Z",
+    )
+    _set_policy_integrity_state(
+        store.guard_home,
+        backend=str(status["backend"]),
+        mode="protected",
+        enforcement="enforce",
+        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
+    )
+    enforced = store.resolve_policy(
+        "codex",
+        "codex:project:legacy",
+        "hash-legacy",
+        now="2026-06-14T00:02:00Z",
+    )
+
+    assert warned is not None
+    assert warned["integrity_status"] == "missing_integrity"
+    assert enforced is None
+
+
+def test_migrate_local_policy_integrity_preserves_selected_rows_only(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:legacy-one", artifact_hash="hash-one"),
+        "2026-06-14T00:00:00Z",
+    )
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:legacy-two", artifact_hash="hash-two"),
+        "2026-06-14T00:00:00Z",
+    )
+    status = store.get_policy_integrity_status()
+    _strip_policy_integrity(store.guard_home, artifact_id="codex:project:legacy-one")
+    _strip_policy_integrity(store.guard_home, artifact_id="codex:project:legacy-two")
+    _set_policy_integrity_state(
+        store.guard_home,
+        backend=str(status["backend"]),
+        mode="protected",
+        enforcement="warn",
+        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
+    )
+
+    items = store.verify_policy_integrity()["items"]
+    preserve_id = next(
+        int(item["decision_id"]) for item in items if item.get("artifact_id") == "codex:project:legacy-one"
+    )
+    payload = store.migrate_local_policy_integrity(
+        preserve_decision_ids={preserve_id},
+        clear_unselected=False,
+        now="2026-06-14T00:05:00Z",
+    )
+
+    first = store.resolve_policy("codex", "codex:project:legacy-one", "hash-one", now="2026-06-14T00:06:00Z")
+    second = store.resolve_policy("codex", "codex:project:legacy-two", "hash-two", now="2026-06-14T00:06:00Z")
+
+    assert Path(str(payload["backup_path"])).exists()
+    assert payload["enforcement"] == "enforce"
+    assert payload["counts"]["valid"] == 1
+    assert payload["counts"]["missing_integrity"] == 1
+    assert first == "allow"
+    assert second is None
+
+
+def test_migrate_local_policy_integrity_re_signs_unknown_key_rows(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:rotated", artifact_hash="hash-rotated"),
+        "2026-06-14T00:00:00Z",
+    )
+    _rotate_policy_integrity_key(store, raw_key=b"2" * 32)
+
+    verify_payload = store.verify_policy_integrity()
+    preserve_id = next(
+        int(item["decision_id"])
+        for item in verify_payload["items"]
+        if item.get("artifact_id") == "codex:project:rotated"
+    )
+    payload = store.migrate_local_policy_integrity(
+        preserve_decision_ids={preserve_id},
+        clear_unselected=False,
+        now="2026-06-14T00:05:00Z",
+    )
+
+    resolved = store.resolve_policy("codex", "codex:project:rotated", "hash-rotated", now="2026-06-14T00:06:00Z")
+
+    assert verify_payload["counts"]["unknown_key"] == 1
+    assert payload["unknown_key_row_ids"] == [preserve_id]
+    assert payload["counts"]["valid"] == 1
+    assert resolved == "allow"
+
+
+def test_policies_cli_verify_status_migrate_and_repair(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    store.upsert_policy(_decision(artifact_id="codex:project:cli", artifact_hash="hash-cli"), "2026-06-14T00:00:00Z")
+    status = store.get_policy_integrity_status()
+    _strip_policy_integrity(home_dir, artifact_id="codex:project:cli")
+    _set_policy_integrity_state(
+        home_dir,
+        backend=str(status["backend"]),
+        mode="protected",
+        enforcement="warn",
+        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
+    )
+
+    verify_rc = main(["guard", "policies", "verify", "--home", str(home_dir), "--json"])
+    verify_payload = json.loads(capsys.readouterr().out)
+    assert verify_rc == 0
+    assert verify_payload["counts"]["missing_integrity"] == 1
+
+    status_rc = main(["guard", "policies", "integrity-status", "--home", str(home_dir), "--json"])
+    status_payload = json.loads(capsys.readouterr().out)
+    assert status_rc == 0
+    assert status_payload["enforcement"] == "warn"
+
+    migrate_rc = main(
+        [
+            "guard",
+            "policies",
+            "migrate-local-integrity",
+            "--home",
+            str(home_dir),
+            "--preserve-all-local",
+            "--json",
+        ]
+    )
+    migrate_payload = json.loads(capsys.readouterr().out)
+    assert migrate_rc == 0
+    assert migrate_payload["preserved"] == 1
+    assert migrate_payload["enforcement"] == "enforce"
+
+    _strip_policy_integrity(home_dir, artifact_id="codex:project:cli")
+    _set_policy_integrity_state(
+        home_dir,
+        backend=str(status["backend"]),
+        mode="protected",
+        enforcement="enforce",
+        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
+    )
+    repair_rc = main(
+        [
+            "guard",
+            "policies",
+            "repair",
+            "--home",
+            str(home_dir),
+            "--clear-invalid",
+            "--json",
+        ]
+    )
+    repair_payload = json.loads(capsys.readouterr().out)
+    assert repair_rc == 0
+    assert repair_payload["cleared"] == 1
+    assert GuardStore(home_dir).list_policy_decisions() == []
+
+
+def test_policies_cli_migrate_preserve_all_local_re_signs_unknown_key_rows(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:cli-rotated", artifact_hash="hash-cli-rotated"),
+        "2026-06-14T00:00:00Z",
+    )
+    _rotate_policy_integrity_key(store, raw_key=b"3" * 32)
+    assert store.verify_policy_integrity()["counts"]["unknown_key"] == 1
+
+    migrate_rc = main(
+        [
+            "guard",
+            "policies",
+            "migrate-local-integrity",
+            "--home",
+            str(home_dir),
+            "--preserve-all-local",
+            "--json",
+        ]
+    )
+    migrate_payload = json.loads(capsys.readouterr().out)
+
+    assert migrate_rc == 0
+    assert migrate_payload["preserved"] == 1
+    assert migrate_payload["counts"]["valid"] == 1
+
+
+def test_backup_policy_database_sets_private_mode_when_backup_fails(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    calls: list[tuple[Path, int]] = []
+
+    def _fake_set_private_mode(path: Path, mode: int) -> None:
+        calls.append((Path(path), mode))
+
+    class _BrokenBackupConnection:
+        def backup(self, backup_connection: sqlite3.Connection) -> None:
+            raise sqlite3.OperationalError("boom")
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.store._set_private_mode", _fake_set_private_mode)
+
+    with pytest.raises(sqlite3.OperationalError, match="boom"):
+        store._backup_policy_database(
+            cast(sqlite3.Connection, _BrokenBackupConnection()),
+            now="2026-06-14T00:05:00Z",
+        )
+
+    assert calls
+    assert calls[-1][0].exists()
+    assert calls[-1][0].name.startswith("guard.db.pre-integrity-")
+    assert calls[-1][1] == 0o600
+
+
+def test_degraded_mode_persistent_local_allow_is_not_authoritative(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(SystemKeyringSecretStore, "_is_available", classmethod(lambda cls: False))
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:degraded", artifact_hash="hash-degraded"),
+        "2026-06-14T00:00:00Z",
+    )
+
+    resolved = store.resolve_policy(
+        "codex",
+        "codex:project:degraded",
+        "hash-degraded",
+        now="2026-06-14T00:01:00Z",
+    )
+    verify = store.verify_policy_integrity()
+
+    assert resolved is None
+    assert verify["mode"] == "degraded"
+    assert verify["counts"]["degraded_mode"] == 1

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -32,6 +32,8 @@ class _FakeSystemKeyringModule:
         self.fail_on_set = False
         self.get_password_calls = 0
         self.set_password_calls = 0
+        self.get_password_calls_by_service: dict[str, int] = {}
+        self.set_password_calls_by_service: dict[str, int] = {}
 
     @staticmethod
     def get_keyring():
@@ -44,10 +46,12 @@ class _FakeSystemKeyringModule:
         if self.fail_on_set:
             raise RuntimeError("system keyring unavailable")
         self.set_password_calls += 1
+        self.set_password_calls_by_service[service_name] = self.set_password_calls_by_service.get(service_name, 0) + 1
         self._secrets[(service_name, secret_id)] = value
 
     def get_password(self, service_name: str, secret_id: str) -> str | None:
         self.get_password_calls += 1
+        self.get_password_calls_by_service[service_name] = self.get_password_calls_by_service.get(service_name, 0) + 1
         return self._secrets.get((service_name, secret_id))
 
     def delete_password(self, service_name: str, secret_id: str) -> None:
@@ -61,12 +65,11 @@ def _install_fake_system_keyring(
 ) -> _FakeSystemKeyringModule:
     module = _FakeSystemKeyringModule()
     monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
-    if usable_macos_keychain:
-        monkeypatch.setattr(
-            SystemKeyringSecretStore,
-            "_macos_default_keychain_is_usable",
-            classmethod(lambda cls: True),
-        )
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_macos_default_keychain_is_usable",
+        classmethod(lambda cls: usable_macos_keychain),
+    )
     return module
 
 
@@ -114,12 +117,8 @@ def test_guard_store_repairs_missing_evidence_table_when_schema_v4_is_applied(tm
     guard_home.mkdir()
     database_path = guard_home / "guard.db"
     with sqlite3.connect(database_path) as connection:
-        connection.execute(
-            "create table schema_migrations (version integer primary key, applied_at text not null)"
-        )
-        connection.execute(
-            "insert into schema_migrations (version, applied_at) values (4, '2026-01-01T00:00:00Z')"
-        )
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute("insert into schema_migrations (version, applied_at) values (4, '2026-01-01T00:00:00Z')")
         connection.execute(
             """
             create table harness_installations (
@@ -164,12 +163,8 @@ def test_guard_store_repairs_incomplete_evidence_table_missing_action_identity(t
     guard_home.mkdir()
     database_path = guard_home / "guard.db"
     with sqlite3.connect(database_path) as connection:
-        connection.execute(
-            "create table schema_migrations (version integer primary key, applied_at text not null)"
-        )
-        connection.execute(
-            "insert into schema_migrations (version, applied_at) values (4, '2026-01-01T00:00:00Z')"
-        )
+        connection.execute("create table schema_migrations (version integer primary key, applied_at text not null)")
+        connection.execute("insert into schema_migrations (version, applied_at) values (4, '2026-01-01T00:00:00Z')")
         _incomplete_evidence_table(connection)
 
     store = GuardStore(guard_home)
@@ -190,10 +185,7 @@ def test_guard_store_repairs_incomplete_evidence_table_missing_action_identity(t
     )
 
     with sqlite3.connect(database_path) as connection:
-        columns = {
-            str(row[1])
-            for row in connection.execute("pragma table_info(guard_evidence)").fetchall()
-        }
+        columns = {str(row[1]) for row in connection.execute("pragma table_info(guard_evidence)").fetchall()}
         row = connection.execute(
             "select action_identity from guard_evidence where evidence_id = 'evidence-legacy'"
         ).fetchone()
@@ -1077,7 +1069,7 @@ def test_set_oauth_local_credentials_skips_keyring_rewrite_when_secret_material_
         now="2026-06-01T00:00:00+00:00",
     )
 
-    assert fake_keyring.set_password_calls == 1
+    assert fake_keyring.set_password_calls_by_service.get("hol-guard.oauth", 0) == 1
 
     store.set_oauth_local_credentials(
         issuer="https://hol.org",
@@ -1094,7 +1086,7 @@ def test_set_oauth_local_credentials_skips_keyring_rewrite_when_secret_material_
         now="2026-06-01T00:05:00+00:00",
     )
 
-    assert fake_keyring.set_password_calls == 1
+    assert fake_keyring.set_password_calls_by_service.get("hol-guard.oauth", 0) == 1
     credentials = store.get_oauth_local_credentials()
 
     assert credentials is not None
@@ -1118,7 +1110,7 @@ def test_set_oauth_local_credentials_skips_keyring_rewrite_when_secret_material_
         now="2026-06-01T00:10:00+00:00",
     )
 
-    assert fake_keyring.set_password_calls == 2
+    assert fake_keyring.set_password_calls_by_service.get("hol-guard.oauth", 0) == 2
     rotated_credentials = store.get_oauth_local_credentials()
 
     assert rotated_credentials is not None
@@ -1167,7 +1159,7 @@ def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before
         "workspace_id": "workspace-123",
     }
     assert fallback_reads == 1
-    assert fake_keyring.get_password_calls == 0
+    assert fake_keyring.get_password_calls_by_service.get("hol-guard.oauth", 0) == 0
 
 
 def test_get_oauth_local_credentials_fails_closed_when_fallback_hash_is_stale(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Sign local policy rows with keyring-backed integrity metadata and ignore invalid local rows on read
- Add policy integrity verify, migrate, repair, and status workflows with docs and regression coverage

## Testing
- `python3 -m pytest tests/test_guard_policy_integrity.py tests/test_guard_manifest_install_firewall.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/policy_integrity.py src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py src/codex_plugin_scanner/guard/cli/commands_parser_policy.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_policy_integrity.py tests/test_guard_manifest_install_firewall.py tests/conftest.py`

## Notes
- Exercised a direct SQLite tamper proof locally to confirm forged local rows are non-authoritative while signed rows still resolve.
