### PR TITLE
fix(guard): contain manifest and lockfile reads within workspace

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -54,6 +54,11 @@ from .runtime.supply_chain_package_eval import (
     evaluate_package_request_artifact,
 )
 from .runtime.supply_chain_support import ecosystem_support_matrix
+from .runtime.workspace_path_guard import (
+    read_bytes_within_workspace,
+    read_text_within_workspace,
+    resolve_path_within_workspace,
+)
 from .shims import package_shim_status, package_shim_supported_managers
 from .stable_digest import stable_digest_hex
 from .store import GuardStore
@@ -363,11 +368,7 @@ def _is_audit_sensitive_basename(name: str) -> bool:
 def _read_workspace_audit_text(workspace_dir: Path, relative_path: str) -> str | None:
     if _is_audit_sensitive_basename(Path(relative_path).name):
         return None
-    disk_path = workspace_dir / relative_path
-    try:
-        return disk_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
-        return None
+    return read_text_within_workspace(workspace_dir, relative_path)
 
 
 def _workspace_has_project_markers(workspace_dir: Path) -> bool:
@@ -1961,20 +1962,16 @@ def _workspace_audit_lockfile_context(
 ) -> dict[str, object] | None:
     if not lockfile_paths:
         return None
-    lockfile_path = workspace_dir / lockfile_paths[0]
-    if not lockfile_path.exists():
+    lockfile_path = resolve_path_within_workspace(workspace_dir, lockfile_paths[0])
+    if lockfile_path is None or not lockfile_path.exists():
         return None
     lockfile_text = _read_workspace_audit_text(workspace_dir, lockfile_paths[0])
     if lockfile_text is None:
         return None
     manifest_hash = None
     if manifest_paths:
-        manifest_path = workspace_dir / manifest_paths[0]
-        try:
-            manifest_bytes = manifest_path.read_bytes()
-        except OSError:
-            manifest_bytes = None
-        if manifest_bytes is not None and not _is_audit_sensitive_basename(manifest_path.name):
+        manifest_bytes = read_bytes_within_workspace(workspace_dir, manifest_paths[0])
+        if manifest_bytes is not None and not _is_audit_sensitive_basename(Path(manifest_paths[0]).name):
             manifest_hash = stable_digest_hex(manifest_bytes)
     return {
         "dependencyCount": len(inventory),
@@ -2012,13 +2009,10 @@ def _workspace_audit_fingerprint(
 def _hash_existing_paths(workspace_dir: Path, relative_paths: Sequence[str]) -> list[str]:
     hashes: list[str] = []
     for relative_path in relative_paths:
-        disk_path = workspace_dir / relative_path
-        if not disk_path.exists():
+        payload = read_bytes_within_workspace(workspace_dir, relative_path)
+        if payload is None:
             continue
-        try:
-            hashes.append(stable_digest_hex(disk_path.read_bytes()))
-        except OSError:
-            continue
+        hashes.append(stable_digest_hex(payload))
     return hashes
 
 

--- a/src/codex_plugin_scanner/guard/runtime/manifest_dependency_targets.py
+++ b/src/codex_plugin_scanner/guard/runtime/manifest_dependency_targets.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from ..models import GuardArtifact
 from .package_manifest_diff import parse_manifest_dependencies
+from .workspace_path_guard import read_text_within_workspace, resolve_path_within_workspace
 
 _MANIFEST_ECOSYSTEMS = {
     "package.json": "npm",
@@ -67,12 +68,11 @@ def unsynced_manifest_dependency_targets(
         for relative_path in lockfile_paths:
             if not isinstance(relative_path, str) or not relative_path:
                 continue
-            lockfile_path = workspace_dir / relative_path
-            if not lockfile_path.exists():
+            lockfile_path = resolve_path_within_workspace(workspace_dir, relative_path)
+            if lockfile_path is None or not lockfile_path.exists():
                 continue
-            try:
-                lockfile_text = lockfile_path.read_text(encoding="utf-8")
-            except (OSError, UnicodeDecodeError):
+            lockfile_text = read_text_within_workspace(workspace_dir, relative_path)
+            if lockfile_text is None:
                 continue
             lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name) or "npm"
             for package_name in parse_manifest_dependencies(path=relative_path, text=lockfile_text):
@@ -84,12 +84,11 @@ def unsynced_manifest_dependency_targets(
         ecosystem = _manifest_ecosystem_for_path(relative_path)
         if ecosystem is None:
             continue
-        manifest_path = workspace_dir / relative_path
-        if not manifest_path.exists():
+        manifest_path = resolve_path_within_workspace(workspace_dir, relative_path)
+        if manifest_path is None or not manifest_path.exists():
             continue
-        try:
-            manifest_text = manifest_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        manifest_text = read_text_within_workspace(workspace_dir, relative_path)
+        if manifest_text is None:
             continue
         dependency_map = _artifact_manifest_dependency_map(
             package_manager=package_manager,

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -12,6 +12,7 @@ from typing import Literal
 
 from ..models import GuardArtifact
 from .mcp_protection import _split_package_token
+from .workspace_path_guard import existing_paths_within_workspace
 
 IntentKind = Literal["install", "execute", "sync"]
 _EXTRAS_RE = re.compile(r"^(?P<name>[A-Za-z0-9_.-]+)\[(?P<extras>[A-Za-z0-9_,.-]+)\]$")
@@ -176,19 +177,7 @@ def flag_tokens(tokens: tuple[str, ...]) -> tuple[str, ...]:
 
 
 def existing_relative_paths(workspace: Path | None, candidates: tuple[str, ...] | list[str]) -> tuple[str, ...]:
-    if workspace is None:
-        return ()
-    resolved: list[str] = []
-    for candidate in candidates:
-        if not candidate:
-            continue
-        path = Path(candidate)
-        disk_path = path if path.is_absolute() else workspace / path
-        if disk_path.exists():
-            normalized = candidate if not path.is_absolute() else path.name
-            if normalized not in resolved:
-                resolved.append(normalized)
-    return tuple(resolved)
+    return existing_paths_within_workspace(workspace, candidates)
 
 
 def first_positional(tokens: tuple[str, ...], *, skip_value_options: set[str]) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -60,6 +60,11 @@ from .supply_chain_bundle_models import (
 )
 from .supply_chain_bundle_runtime import _is_high_confidence_block
 from .supply_chain_support import ecosystem_support_metadata
+from .workspace_path_guard import (
+    read_bytes_within_workspace,
+    read_text_within_workspace,
+    resolve_path_within_workspace,
+)
 
 _DECISION_RANK = {"allow": 0, "monitor": 1, "warn": 2, "ask": 3, "block": 4}
 _SEVERITY_RANK = {"unknown": 0, "low": 1, "medium": 2, "high": 3, "critical": 4}
@@ -1392,12 +1397,11 @@ def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> di
     lockfile_paths = artifact.metadata.get("lockfile_paths")
     if not isinstance(lockfile_paths, list) or not lockfile_paths:
         return None
-    lockfile_path = workspace_dir / str(lockfile_paths[0])
-    if not lockfile_path.exists():
+    lockfile_path = resolve_path_within_workspace(workspace_dir, str(lockfile_paths[0]))
+    if lockfile_path is None or not lockfile_path.exists():
         return None
-    try:
-        lockfile_text = lockfile_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    lockfile_text = read_text_within_workspace(workspace_dir, str(lockfile_paths[0]))
+    if lockfile_text is None:
         return None
     dependencies = _safe_dependency_map_for_path(
         str(lockfile_path.name), lockfile_text, deadline=time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS
@@ -1436,8 +1440,8 @@ def _transitive_lockfile_results(
         direct_target_names_by_ecosystem.setdefault(ecosystem, set()).update(candidate_names)
         all_direct_target_names.update(candidate_names)
     for relative_path in lockfile_paths:
-        lockfile_path = workspace_dir / str(relative_path)
-        if not lockfile_path.exists():
+        lockfile_path = resolve_path_within_workspace(workspace_dir, str(relative_path))
+        if lockfile_path is None or not lockfile_path.exists():
             continue
         lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name)
         direct_target_names = (
@@ -1445,9 +1449,8 @@ def _transitive_lockfile_results(
             if lockfile_ecosystem is not None
             else all_direct_target_names
         )
-        try:
-            lockfile_text = lockfile_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        lockfile_text = read_text_within_workspace(workspace_dir, str(relative_path))
+        if lockfile_text is None:
             continue
         dependency_entries: list[tuple[str, str, str, bool]] = []
         parse_deadline = time.monotonic() + _LOCKFILE_PARSE_BUDGET_SECONDS
@@ -1835,9 +1838,11 @@ def _bun_lockfile_binary_fallback_packages(
         return []
     bun_lock_path = next(
         (
-            workspace_dir / str(relative_path)
+            resolved
             for relative_path in lockfile_paths
-            if Path(str(relative_path)).name == "bun.lockb" and (workspace_dir / str(relative_path)).exists()
+            if Path(str(relative_path)).name == "bun.lockb"
+            and (resolved := resolve_path_within_workspace(workspace_dir, str(relative_path))) is not None
+            and resolved.exists()
         ),
         None,
     )
@@ -2170,12 +2175,19 @@ def _go_replace_result(
     manifest_paths = artifact.metadata.get("manifest_paths")
     if not isinstance(manifest_paths, list):
         return None
-    go_mod_path = next((workspace_dir / str(path) for path in manifest_paths if Path(str(path)).name == "go.mod"), None)
-    if go_mod_path is None or not go_mod_path.exists():
+    go_mod_relative_path = next(
+        (
+            str(path)
+            for path in manifest_paths
+            if Path(str(path)).name == "go.mod"
+            and resolve_path_within_workspace(workspace_dir, str(path)) is not None
+        ),
+        None,
+    )
+    if go_mod_relative_path is None:
         return None
-    try:
-        go_mod_text = go_mod_path.read_text(encoding="utf-8")
-    except (OSError, UnicodeDecodeError):
+    go_mod_text = read_text_within_workspace(workspace_dir, go_mod_relative_path)
+    if go_mod_text is None:
         return None
     replacements = _go_mod_replace_map(go_mod_text)
     for candidate in _target_candidate_names(target):
@@ -2442,12 +2454,11 @@ def _lockfile_dependency_versions(
         ecosystem="pypi",
     )
     for relative_path in lockfile_paths:
-        lockfile_path = workspace_dir / str(relative_path)
-        if not lockfile_path.exists():
+        lockfile_path = resolve_path_within_workspace(workspace_dir, str(relative_path))
+        if lockfile_path is None or not lockfile_path.exists():
             continue
-        try:
-            lockfile_text = lockfile_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        lockfile_text = read_text_within_workspace(workspace_dir, str(relative_path))
+        if lockfile_text is None:
             continue
         if lockfile_path.name == "package-lock.json":
             versions.update(_package_lock_target_versions(lockfile_text, targets))
@@ -2498,12 +2509,11 @@ def _manifest_direct_dependency_names(
     package_manager = str(artifact.metadata.get("package_manager") or "npm")
     direct_names: set[str] = set()
     for relative_path in manifest_paths:
-        manifest_path = workspace_dir / str(relative_path)
-        if not manifest_path.exists():
+        manifest_path = resolve_path_within_workspace(workspace_dir, str(relative_path))
+        if manifest_path is None or not manifest_path.exists():
             continue
-        try:
-            manifest_text = manifest_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        manifest_text = read_text_within_workspace(workspace_dir, str(relative_path))
+        if manifest_text is None:
             continue
         dependency_map = _artifact_manifest_dependency_map(
             package_manager=package_manager,
@@ -2529,12 +2539,11 @@ def _manifest_dependency_versions(
     keyed_targets = {target_key: target for target in targets if (target_key := _lockfile_target_key(target))}
     versions: dict[tuple[str, str | None], str] = {}
     for relative_path in manifest_paths:
-        manifest_path = workspace_dir / str(relative_path)
-        if not manifest_path.exists():
+        manifest_path = resolve_path_within_workspace(workspace_dir, str(relative_path))
+        if manifest_path is None or not manifest_path.exists():
             continue
-        try:
-            manifest_text = manifest_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        manifest_text = read_text_within_workspace(workspace_dir, str(relative_path))
+        if manifest_text is None:
             continue
         dependency_map = _artifact_manifest_dependency_map(
             package_manager=package_manager,
@@ -3277,15 +3286,14 @@ def _lockfile_parse_warning_result(
         return None
     target_ecosystem = _optional_string(target.get("ecosystem")) or "npm"
     for relative_path in lockfile_paths:
-        lockfile_path = workspace_dir / str(relative_path)
-        if not lockfile_path.exists():
+        lockfile_path = resolve_path_within_workspace(workspace_dir, str(relative_path))
+        if lockfile_path is None or not lockfile_path.exists():
             continue
         lockfile_ecosystem = _lockfile_ecosystem(lockfile_path.name)
         if lockfile_ecosystem is not None and lockfile_ecosystem != target_ecosystem:
             continue
-        try:
-            lockfile_text = lockfile_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeDecodeError):
+        lockfile_text = read_text_within_workspace(workspace_dir, str(relative_path))
+        if lockfile_text is None:
             continue
         _dependency_map, error = _safe_dependency_map_result_for_path(
             lockfile_path.name,
@@ -3472,13 +3480,10 @@ def _hash_paths(workspace_dir: Path | None, raw_paths: object) -> list[str]:
         return []
     hashes: list[str] = []
     for item in raw_paths:
-        path = workspace_dir / str(item)
-        if not path.exists():
+        payload = read_bytes_within_workspace(workspace_dir, str(item))
+        if payload is None:
             continue
-        try:
-            hashes.append(stable_digest_hex(path.read_bytes()))
-        except OSError:
-            continue
+        hashes.append(stable_digest_hex(payload))
     return hashes
 
 

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2179,7 +2179,9 @@ def _go_replace_result(
         (
             str(path)
             for path in manifest_paths
-            if Path(str(path)).name == "go.mod" and resolve_path_within_workspace(workspace_dir, str(path)) is not None
+            if Path(str(path)).name == "go.mod"
+            and (resolved := resolve_path_within_workspace(workspace_dir, str(path))) is not None
+            and resolved.exists()
         ),
         None,
     )

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2179,8 +2179,7 @@ def _go_replace_result(
         (
             str(path)
             for path in manifest_paths
-            if Path(str(path)).name == "go.mod"
-            and resolve_path_within_workspace(workspace_dir, str(path)) is not None
+            if Path(str(path)).name == "go.mod" and resolve_path_within_workspace(workspace_dir, str(path)) is not None
         ),
         None,
     )

--- a/src/codex_plugin_scanner/guard/runtime/workspace_path_guard.py
+++ b/src/codex_plugin_scanner/guard/runtime/workspace_path_guard.py
@@ -1,0 +1,67 @@
+"""Contain workspace-relative manifest and lockfile reads."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def resolve_path_within_workspace(workspace_dir: Path, relative_path: str) -> Path | None:
+    """Resolve a workspace-relative path and ensure it remains inside the workspace."""
+
+    if not relative_path:
+        return None
+    candidate = Path(relative_path)
+    if candidate.is_absolute():
+        return None
+    workspace_root = workspace_dir.expanduser().resolve()
+    try:
+        resolved = (workspace_root / candidate).resolve()
+        resolved.relative_to(workspace_root)
+    except (OSError, ValueError):
+        return None
+    return resolved
+
+
+def read_text_within_workspace(workspace_dir: Path, relative_path: str) -> str | None:
+    resolved = resolve_path_within_workspace(workspace_dir, relative_path)
+    if resolved is None or not resolved.is_file():
+        return None
+    try:
+        return resolved.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return None
+
+
+def read_bytes_within_workspace(workspace_dir: Path, relative_path: str) -> bytes | None:
+    resolved = resolve_path_within_workspace(workspace_dir, relative_path)
+    if resolved is None or not resolved.is_file():
+        return None
+    try:
+        return resolved.read_bytes()
+    except OSError:
+        return None
+
+
+def existing_paths_within_workspace(
+    workspace: Path | None,
+    candidates: tuple[str, ...] | list[str],
+) -> tuple[str, ...]:
+    """Return workspace-contained relative paths that exist on disk."""
+
+    if workspace is None:
+        return ()
+    workspace_root = workspace.expanduser().resolve()
+    resolved_paths: list[str] = []
+    for candidate in candidates:
+        if not candidate:
+            continue
+        disk_path = resolve_path_within_workspace(workspace_root, candidate)
+        if disk_path is None or not disk_path.exists():
+            continue
+        try:
+            normalized = disk_path.relative_to(workspace_root).as_posix()
+        except ValueError:
+            continue
+        if normalized not in resolved_paths:
+            resolved_paths.append(normalized)
+    return tuple(resolved_paths)

--- a/tests/test_guard_manifest_path_traversal.py
+++ b/tests/test_guard_manifest_path_traversal.py
@@ -1,0 +1,106 @@
+"""Regression tests for workspace-contained manifest and lockfile reads."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime.manifest_dependency_targets import unsynced_manifest_dependency_targets
+from codex_plugin_scanner.guard.runtime.package_intent import build_package_request_artifact
+from codex_plugin_scanner.guard.runtime.package_intent_parser import parse_package_intent
+from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluate_package_request_artifact
+from codex_plugin_scanner.guard.runtime.workspace_path_guard import (
+    existing_paths_within_workspace,
+    read_text_within_workspace,
+    resolve_path_within_workspace,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_resolve_path_within_workspace_rejects_parent_traversal(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    workspace.mkdir()
+    (outside / "requirements.txt").write_text("leakpkg==1.0.0\n", encoding="utf-8")
+
+    assert resolve_path_within_workspace(workspace, "../outside/requirements.txt") is None
+    assert read_text_within_workspace(workspace, "../outside/requirements.txt") is None
+    assert existing_paths_within_workspace(workspace, ("../outside/requirements.txt",)) == ()
+
+
+def test_resolve_path_within_workspace_rejects_symlink_escape(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    secret = tmp_path / "secret.env"
+    workspace.mkdir()
+    secret.write_text("AWS_SECRET_ACCESS_KEY=super-secret\n", encoding="utf-8")
+    (workspace / "requirements.txt").symlink_to(secret)
+
+    assert resolve_path_within_workspace(workspace, "requirements.txt") is None
+    assert read_text_within_workspace(workspace, "requirements.txt") is None
+
+
+def test_parse_pip_intent_ignores_requirements_outside_workspace(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    (outside / "requirements.txt").write_text("leakpkg==1.0.0\n", encoding="utf-8")
+
+    intent = parse_package_intent("pip install -r ../outside/requirements.txt", workspace=workspace)
+
+    assert intent is not None
+    assert intent.manifest_paths == ()
+
+
+def test_unsynced_manifest_targets_do_not_read_symlinked_requirements(tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    secret = tmp_path / "secret.env"
+    workspace.mkdir()
+    secret.write_text("AWS_SECRET_ACCESS_KEY=super-secret\n", encoding="utf-8")
+    (workspace / "requirements.txt").symlink_to(secret)
+    (workspace / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+
+    intent = parse_package_intent("pip install", workspace=workspace)
+    assert intent is not None
+    artifact = build_package_request_artifact(
+        "guard-cli",
+        intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+
+    targets = unsynced_manifest_dependency_targets(artifact, workspace)
+
+    assert not any("AWS_SECRET" in str(target.get("package_name")) for target in targets)
+    assert not any("super-secret" in str(target.get("range")) for target in targets)
+
+
+def test_evaluate_package_request_artifact_does_not_leak_traversal_requirements(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    workspace = tmp_path / "workspace"
+    outside = tmp_path / "outside"
+    workspace.mkdir()
+    outside.mkdir()
+    (outside / "requirements.txt").write_text("AWS_SECRET_ACCESS_KEY=super-secret\n", encoding="utf-8")
+    (workspace / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+
+    intent = parse_package_intent("pip install -r ../outside/requirements.txt", workspace=workspace)
+    assert intent is not None
+    artifact = build_package_request_artifact(
+        "guard-cli",
+        intent,
+        config_path="hol-guard.toml",
+        source_scope="project",
+    )
+
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace,
+        now="2026-06-14T00:00:00Z",
+    )
+
+    serialized = json.dumps(result.to_dict())
+    assert "AWS_SECRET_ACCESS_KEY" not in serialized
+    assert "super-secret" not in serialized


### PR DESCRIPTION
## Summary
- Add workspace path containment checks before Guard reads manifest or lockfile paths from package install metadata.
- Reject parent traversal, absolute paths, and symlink escapes so unsynced dependency discovery cannot leak local file contents into supply-chain evaluation.
- Add regression tests for pip `-r` traversal and symlinked requirements files.

## Testing
- `python3 -m pytest tests/test_guard_manifest_path_traversal.py -q`
- `python3 -m pytest tests/test_guard_manifest_install_firewall.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/workspace_path_guard.py src/codex_plugin_scanner/guard/runtime/manifest_dependency_targets.py src/codex_plugin_scanner/guard/runtime/package_intent_common.py src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_manifest_path_traversal.py`
