### PR TITLE
fix(guard): treat Guard Cloud outages as retryable sync failures

### DIFF
--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -593,6 +593,7 @@ export type GuardHarnessActionErrorPayload = {
   harness?: string;
   confirmation_phrase?: string;
   confirm_command?: string;
+  retryable?: boolean;
 };
 
 export type GuardInventoryItem = {

--- a/dashboard/src/harness-action-errors.test.ts
+++ b/dashboard/src/harness-action-errors.test.ts
@@ -3,6 +3,7 @@ import {
   isApprovalGateRequiredError,
   isGuardHarnessActionError,
   isSupplyChainSyncConnectError,
+  isSupplyChainSyncRetryableError,
   readHarnessActionUserMessage,
   resolveApprovalGateSyncFailure,
 } from "./harness-action-errors";
@@ -139,6 +140,26 @@ assert(
     }),
   ),
   "sync transport failures are not connect errors",
+);
+
+assert(
+  isSupplyChainSyncRetryableError(
+    makeHarnessError(503, {
+      error: "supply_chain_sync_unavailable",
+      message: "Guard Cloud is unavailable. Local Guard keeps protecting this machine.",
+      retryable: true,
+    }),
+  ),
+  "retryable cloud outage sync errors are detected",
+);
+assert(
+  !isSupplyChainSyncRetryableError(
+    makeHarnessError(503, {
+      error: "supply_chain_sync_unavailable",
+      message: "Supply-chain sync is not available on this device.",
+    }),
+  ),
+  "non-retryable sync unavailable errors are not retryable",
 );
 
 const networkFailure = resolveApprovalGateSyncFailure(new Error("Failed to fetch"), {

--- a/dashboard/src/harness-action-errors.ts
+++ b/dashboard/src/harness-action-errors.ts
@@ -77,6 +77,16 @@ export function isSupplyChainSyncConnectError(error: unknown): boolean {
   return code !== null && SUPPLY_CHAIN_CONNECT_ERROR_CODES.has(code);
 }
 
+export function isSupplyChainSyncRetryableError(error: unknown): boolean {
+  if (!isGuardHarnessActionError(error)) {
+    return false;
+  }
+  if (readHarnessActionErrorCode(error) !== "supply_chain_sync_unavailable") {
+    return false;
+  }
+  return error.payload?.retryable === true;
+}
+
 export function readHarnessActionUserMessage(error: unknown, fallback: string): string {
   if (error instanceof Error && GUARD_FETCH_NETWORK_ERROR_MESSAGE.test(error.message)) {
     return "Guard lost connection while syncing supply-chain intel. Confirm the local daemon is still running, then try again.";

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -19,6 +19,7 @@ import {
 import {
   isApprovalGateRequiredError,
   isSupplyChainSyncConnectError,
+  isSupplyChainSyncRetryableError,
   readHarnessActionUserMessage,
   resolveApprovalGateSyncFailure,
 } from "./harness-action-errors";
@@ -382,6 +383,16 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
             return;
           }
         }
+        if (isSupplyChainSyncRetryableError(err)) {
+          const message = readHarnessActionUserMessage(
+            err,
+            "Guard Cloud is temporarily unavailable. Try syncing again in a few minutes.",
+          );
+          setAuditRecoveryError(message);
+          setAuditRecoveryPhase("ready");
+          setLastFailed({ op: "sync", manager: null, message });
+          return;
+        }
         const failure = resolveApprovalGateSyncFailure(err, {
           hasCredentials: credentials !== undefined,
         });
@@ -598,6 +609,17 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
             setAuditRecoveryError(null);
             return;
           }
+        }
+        if (isSupplyChainSyncRetryableError(err)) {
+          const message = readHarnessActionUserMessage(
+            err,
+            "Guard Cloud is temporarily unavailable. Try syncing again in a few minutes.",
+          );
+          setAuditRecoveryGate(createSupplyChainSyncApprovalGate());
+          setAuditRecoveryPhase("ready");
+          setAuditRecoveryError(message);
+          setLastFailed({ op, manager: null, message });
+          return;
         }
         const message = readHarnessActionUserMessage(err, "Operation failed.");
         setLastFailed({ op, manager: null, message });

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -615,7 +615,6 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
             err,
             "Guard Cloud is temporarily unavailable. Try syncing again in a few minutes.",
           );
-          setAuditRecoveryGate(createSupplyChainSyncApprovalGate());
           setAuditRecoveryPhase("ready");
           setAuditRecoveryError(message);
           setLastFailed({ op, manager: null, message });

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -302,14 +302,14 @@ def _supply_chain_package_action_error_response(
             },
         )
     if isinstance(error, GuardSyncNotAvailableError):
-        return (
-            503,
-            {
-                "error": "supply_chain_sync_unavailable",
-                "message": str(error).strip() or "Supply-chain sync is not available on this device.",
-                "operation": operation,
-            },
-        )
+        payload: dict[str, object] = {
+            "error": "supply_chain_sync_unavailable",
+            "message": str(error).strip() or "Supply-chain sync is not available on this device.",
+            "operation": operation,
+        }
+        if error.retryable:
+            payload["retryable"] = True
+        return (503, payload)
     message = str(error).strip() or "Guard supply-chain bundle sync failed."
     return (
         502,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1433,23 +1433,33 @@ def sync_receipts(
     return summary
 
 
-def _guard_cloud_http_error_is_retryable(error: urllib.error.HTTPError) -> bool:
+def _guard_cloud_http_error_details(error: urllib.error.HTTPError) -> tuple[str, bool]:
     try:
         raw_body = error.read().decode("utf-8", errors="replace")
     except OSError:
-        return error.code in {503, 524}
-    try:
-        payload = json.loads(raw_body) if raw_body else None
-    except json.JSONDecodeError:
-        payload = None
+        raw_body = ""
+    retryable = error.code in {503, 524}
+    payload: object = None
+    if raw_body:
+        try:
+            payload = json.loads(raw_body)
+        except json.JSONDecodeError:
+            payload = None
+    message: str | None = None
     if isinstance(payload, dict):
+        message = _read_guard_cloud_error_message(payload)
         guard_error = payload.get("guardError")
-        if isinstance(guard_error, dict) and guard_error.get("retryable") is True:
-            return True
-        guard_code = guard_error.get("code") if isinstance(guard_error, dict) else None
-        if isinstance(guard_code, str) and guard_code.strip().lower() in {"guard_unavailable", "guard_cloud_unavailable"}:
-            return True
-    return error.code in {503, 524}
+        if isinstance(guard_error, dict):
+            if guard_error.get("retryable") is True:
+                retryable = True
+            guard_code = guard_error.get("code")
+            unavailable_codes = {"guard_unavailable", "guard_cloud_unavailable"}
+            if isinstance(guard_code, str) and guard_code.strip().lower() in unavailable_codes:
+                retryable = True
+    if message is None:
+        normalized_body = raw_body.strip()
+        message = normalized_body or f"HTTP Error {error.code}: {error.reason}"
+    return message, retryable
 
 
 def _fetch_supply_chain_bundle_payload(request: urllib.request.Request) -> dict[str, object]:
@@ -1465,8 +1475,8 @@ def _fetch_supply_chain_bundle_payload(request: urllib.request.Request) -> dict[
             if is_plan_restricted:
                 raise GuardSyncNotAvailableError(message) from error
             raise RuntimeError(message) from error
-        message = _sync_http_error_message(error)
-        if _guard_cloud_http_error_is_retryable(error):
+        message, retryable = _guard_cloud_http_error_details(error)
+        if retryable:
             raise GuardSyncNotAvailableError(message, retryable=True) from error
         raise RuntimeError(message) from error
     except OSError as error:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -261,7 +261,13 @@ class GuardSyncNotConfiguredError(RuntimeError):
 
 
 class GuardSyncNotAvailableError(RuntimeError):
-    """Raised when the sync endpoint returns 403 (free-plan restriction)."""
+    """Raised when Guard Cloud sync is blocked by plan limits or temporary outages."""
+
+    retryable: bool
+
+    def __init__(self, message: str, *, retryable: bool = False) -> None:
+        super().__init__(message)
+        self.retryable = retryable
 
 
 class GuardSyncAuthorizationExpiredError(GuardSyncNotConfiguredError):
@@ -1427,6 +1433,25 @@ def sync_receipts(
     return summary
 
 
+def _guard_cloud_http_error_is_retryable(error: urllib.error.HTTPError) -> bool:
+    try:
+        raw_body = error.read().decode("utf-8", errors="replace")
+    except OSError:
+        return error.code in {503, 524}
+    try:
+        payload = json.loads(raw_body) if raw_body else None
+    except json.JSONDecodeError:
+        payload = None
+    if isinstance(payload, dict):
+        guard_error = payload.get("guardError")
+        if isinstance(guard_error, dict) and guard_error.get("retryable") is True:
+            return True
+        guard_code = guard_error.get("code") if isinstance(guard_error, dict) else None
+        if isinstance(guard_code, str) and guard_code.strip().lower() in {"guard_unavailable", "guard_cloud_unavailable"}:
+            return True
+    return error.code in {503, 524}
+
+
 def _fetch_supply_chain_bundle_payload(request: urllib.request.Request) -> dict[str, object]:
     try:
         return _urlopen_json_with_timeout_retry(
@@ -1440,7 +1465,10 @@ def _fetch_supply_chain_bundle_payload(request: urllib.request.Request) -> dict[
             if is_plan_restricted:
                 raise GuardSyncNotAvailableError(message) from error
             raise RuntimeError(message) from error
-        raise RuntimeError(_sync_http_error_message(error)) from error
+        message = _sync_http_error_message(error)
+        if _guard_cloud_http_error_is_retryable(error):
+            raise GuardSyncNotAvailableError(message, retryable=True) from error
+        raise RuntimeError(message) from error
     except OSError as error:
         raise RuntimeError(_sync_url_error_message(error)) from error
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -27,7 +27,10 @@ from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payl
 from codex_plugin_scanner.guard.local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
-from codex_plugin_scanner.guard.runtime.runner import GuardSyncAuthorizationExpiredError
+from codex_plugin_scanner.guard.runtime.runner import (
+    GuardSyncAuthorizationExpiredError,
+    GuardSyncNotAvailableError,
+)
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.test_guard_supply_chain_evaluator import WORKSPACE_ID, _bundle_response, _package
@@ -651,6 +654,56 @@ def test_supply_chain_sync_returns_json_when_bundle_sync_fails_after_approval(
     assert payload["error"] == "supply_chain_sync_failed"
     assert payload["operation"] == "sync"
     assert "simulated network failure" in str(payload["message"])
+
+
+def test_supply_chain_sync_returns_retryable_unavailable_when_cloud_outage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "premium", "workspace_id": "workspace-1"},
+        "2026-06-09T12:00:00.000Z",
+    )
+    update_approval_gate_settings(
+        store.guard_home,
+        {
+            "enabled": True,
+            "new_password": "phase07-password",
+            "confirm_password": "phase07-password",
+        },
+    )
+
+    def _fail_sync(_store: GuardStore) -> dict[str, object]:
+        raise GuardSyncNotAvailableError(
+            "Guard Cloud is unavailable. Local Guard keeps protecting this machine.",
+            retryable=True,
+        )
+
+    monkeypatch.setattr(daemon_server, "sync_supply_chain_bundle", _fail_sync)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/sync",
+                token=token,
+                payload={
+                    "workspace_id": "workspace-1",
+                    "approval_password": "phase07-password",
+                },
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 503
+    assert payload["error"] == "supply_chain_sync_unavailable"
+    assert payload["retryable"] is True
+    assert payload["operation"] == "sync"
 
 
 def test_supply_chain_sync_returns_reconnect_error_when_auth_expired(

--- a/tests/test_guard_sync_http_error_message.py
+++ b/tests/test_guard_sync_http_error_message.py
@@ -1,8 +1,15 @@
 import io
 import json
 import urllib.error
+import urllib.request
 
-from codex_plugin_scanner.guard.runtime.runner import _sync_http_error_message
+import pytest
+
+from codex_plugin_scanner.guard.runtime.runner import (
+    GuardSyncNotAvailableError,
+    _fetch_supply_chain_bundle_payload,
+    _sync_http_error_message,
+)
 
 
 def _http_error(body: str, *, code: int = 500, reason: str = "Error") -> urllib.error.HTTPError:
@@ -73,3 +80,39 @@ def test_sync_http_error_message_falls_back_to_raw_body() -> None:
 
 def test_sync_http_error_message_falls_back_to_http_reason() -> None:
     assert _sync_http_error_message(_http_error("", code=502, reason="Bad Gateway")) == "HTTP Error 502: Bad Gateway"
+
+
+def test_fetch_supply_chain_bundle_payload_raises_retryable_unavailable_on_guard_cloud_outage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    body = json.dumps(
+        {
+            "ok": False,
+            "error": "Guard Cloud is unavailable. Local Guard keeps protecting this machine.",
+            "guardError": {
+                "code": "guard_unavailable",
+                "message": "Guard Cloud is unavailable. Local Guard keeps protecting this machine.",
+                "retryable": True,
+                "status": 503,
+            },
+        }
+    )
+
+    def _raise_service_unavailable(*_args: object, **_kwargs: object) -> dict[str, object]:
+        raise urllib.error.HTTPError(
+            url="https://hol.org/api/guard/supply-chain/bundle?workspaceId=test",
+            code=503,
+            msg="Service Unavailable",
+            hdrs={},
+            fp=io.BytesIO(body.encode("utf-8")),
+        )
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.runtime.runner._urlopen_json_with_timeout_retry",
+        _raise_service_unavailable,
+    )
+    request = urllib.request.Request("https://hol.org/api/guard/supply-chain/bundle?workspaceId=test")
+    with pytest.raises(GuardSyncNotAvailableError) as exc_info:
+        _fetch_supply_chain_bundle_payload(request)
+    assert exc_info.value.retryable is True
+    assert "Guard Cloud is unavailable" in str(exc_info.value)


### PR DESCRIPTION
## Summary
- Classify hol.org `guard_unavailable` 503 bundle responses as retryable `GuardSyncNotAvailableError` instead of generic 502 sync failures
- Return structured `supply_chain_sync_unavailable` JSON with `retryable: true` from `/v1/supply-chain/sync`
- Keep audit recovery on the sync step with a clear retry path when Guard Cloud is temporarily down

## Testing
- `python3 -m pytest tests/test_guard_sync_http_error_message.py tests/test_guard_headless_daemon_api.py::test_supply_chain_sync_returns_retryable_unavailable_when_cloud_outage tests/test_guard_headless_daemon_api.py::test_supply_chain_sync_returns_json_when_bundle_sync_fails_after_approval -q`
