### PR TITLE
fix(guard): batch policy source context lookups for /v1/policy

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -94,7 +94,11 @@ from .store_evidence import (
 from .store_evidence import (
     store_evidence as _store_evidence_impl,
 )
-from .store_policy_source_context import find_policy_source_context
+from .store_policy_source_context import (
+    PolicySourceContextIndex,
+    build_policy_source_context_index,
+    lookup_policy_source_context,
+)
 from .store_receipt_rollups import (
     backfill_receipt_rollups,
     count_receipts_from_rollups,
@@ -3015,22 +3019,51 @@ class GuardStore:
         query += " order by updated_at desc"
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
-            return [self._policy_decision_dict_from_row(connection, row) for row in rows]
+            lookup_items = [
+                (
+                    str(row["harness"]),
+                    str(row["artifact_id"]) if row["artifact_id"] is not None else None,
+                    str(row["artifact_hash"]) if row["artifact_hash"] is not None else None,
+                )
+                for row in rows
+            ]
+            source_context_index = build_policy_source_context_index(connection, items=lookup_items)
+            return [
+                self._policy_decision_dict_from_row(connection, row, source_context_index=source_context_index)
+                for row in rows
+            ]
 
     @staticmethod
-    def _policy_decision_dict_from_row(connection: sqlite3.Connection, row: sqlite3.Row) -> dict[str, object]:
+    def _policy_decision_dict_from_row(
+        connection: sqlite3.Connection,
+        row: sqlite3.Row,
+        *,
+        source_context_index: PolicySourceContextIndex | None = None,
+    ) -> dict[str, object]:
         harness = str(row["harness"])
         artifact_id = row["artifact_id"]
         artifact_hash = row["artifact_hash"]
         workspace = row["workspace"]
-        source_context = find_policy_source_context(
-            connection,
-            harness=harness,
-            artifact_id=str(artifact_id) if artifact_id is not None else None,
-            artifact_hash=str(artifact_hash) if artifact_hash is not None else None,
-            workspace=str(workspace) if workspace is not None else None,
-            reason=str(row["reason"]) if row["reason"] is not None else None,
-        )
+        if source_context_index is not None:
+            source_context = lookup_policy_source_context(
+                source_context_index,
+                harness=harness,
+                artifact_id=str(artifact_id) if artifact_id is not None else None,
+                artifact_hash=str(artifact_hash) if artifact_hash is not None else None,
+                workspace=str(workspace) if workspace is not None else None,
+                reason=str(row["reason"]) if row["reason"] is not None else None,
+            )
+        else:
+            from .store_policy_source_context import find_policy_source_context
+
+            source_context = find_policy_source_context(
+                connection,
+                harness=harness,
+                artifact_id=str(artifact_id) if artifact_id is not None else None,
+                artifact_hash=str(artifact_hash) if artifact_hash is not None else None,
+                workspace=str(workspace) if workspace is not None else None,
+                reason=str(row["reason"]) if row["reason"] is not None else None,
+            )
         payload: dict[str, object] = {
             "decision_id": int(row["decision_id"]),
             "harness": harness,

--- a/src/codex_plugin_scanner/guard/store_policy_source_context.py
+++ b/src/codex_plugin_scanner/guard/store_policy_source_context.py
@@ -621,7 +621,7 @@ def build_policy_source_context_index(
                 for variant in _artifact_hash_match_variants(str(artifact_hash)):
                     _append_indexed_row(index.receipts_by_harness_hash, (harness, variant), row)
 
-    if harnesses and artifact_ids and not include_all_harnesses:
+    if harnesses and artifact_ids:
         harness_placeholders = ", ".join("?" for _ in harnesses)
         artifact_placeholders = ", ".join("?" for _ in artifact_ids)
         inventory_rows = connection.execute(

--- a/src/codex_plugin_scanner/guard/store_policy_source_context.py
+++ b/src/codex_plugin_scanner/guard/store_policy_source_context.py
@@ -473,6 +473,105 @@ def _append_indexed_row(
     bucket.append(row)
 
 
+def _policy_harness_scope(items: list[tuple[str, str | None, str | None]]) -> tuple[bool, list[str]]:
+    harnesses = {harness for harness, _, _ in items if harness}
+    include_all_harnesses = "*" in harnesses
+    concrete_harnesses = sorted(harness for harness in harnesses if harness != "*")
+    return include_all_harnesses, concrete_harnesses
+
+
+def _harness_filter_sql(include_all_harnesses: bool, harnesses: list[str]) -> tuple[str, list[object]]:
+    if include_all_harnesses or not harnesses:
+        return "", []
+    placeholders = ", ".join("?" for _ in harnesses)
+    return f"and harness in ({placeholders})", list(harnesses)
+
+
+def _extend_receipt_hash_candidates(
+    index: PolicySourceContextIndex,
+    harness: str,
+    variant: str,
+    candidates: list[sqlite3.Row],
+) -> None:
+    if harness == "*":
+        for (row_harness, row_variant), rows in index.receipts_by_harness_hash.items():
+            if row_variant == variant:
+                candidates.extend(rows)
+        return
+    candidates.extend(index.receipts_by_harness_hash.get((harness, variant), []))
+
+
+def _extend_receipt_artifact_candidates(
+    index: PolicySourceContextIndex,
+    harness: str,
+    artifact_id: str,
+    candidates: list[sqlite3.Row],
+) -> None:
+    if harness == "*":
+        for (row_harness, row_artifact_id), rows in index.receipts_by_harness_artifact.items():
+            if row_artifact_id == artifact_id:
+                candidates.extend(rows)
+        return
+    candidates.extend(index.receipts_by_harness_artifact.get((harness, artifact_id), []))
+
+
+def _extend_approval_hash_candidates(
+    index: PolicySourceContextIndex,
+    harness: str,
+    variant: str,
+    candidates: list[sqlite3.Row],
+) -> None:
+    if harness == "*":
+        for (row_harness, row_variant), rows in index.approvals_by_harness_hash.items():
+            if row_variant == variant:
+                candidates.extend(rows)
+        return
+    candidates.extend(index.approvals_by_harness_hash.get((harness, variant), []))
+
+
+def _extend_approval_artifact_candidates(
+    index: PolicySourceContextIndex,
+    harness: str,
+    artifact_id: str,
+    candidates: list[sqlite3.Row],
+) -> None:
+    if harness == "*":
+        for (row_harness, row_artifact_id), rows in index.approvals_by_harness_artifact.items():
+            if row_artifact_id == artifact_id:
+                candidates.extend(rows)
+        return
+    candidates.extend(index.approvals_by_harness_artifact.get((harness, artifact_id), []))
+
+
+def _filter_approval_candidates(
+    rows: list[sqlite3.Row],
+    *,
+    harness: str,
+    artifact_id: str | None,
+    artifact_hash: str | None,
+) -> list[sqlite3.Row]:
+    if not artifact_id and not artifact_hash:
+        return []
+    hash_variants = set(_artifact_hash_match_variants(artifact_hash)) if artifact_hash else set()
+    filtered: list[sqlite3.Row] = []
+    seen_request_ids: set[str] = set()
+    for row in rows:
+        if harness != "*" and str(row["harness"]) != harness:
+            continue
+        if artifact_id and str(row["artifact_id"]) != artifact_id:
+            continue
+        if artifact_hash:
+            row_hash = str(row["artifact_hash"]) if row["artifact_hash"] is not None else ""
+            if row_hash not in hash_variants:
+                continue
+        request_id = str(row["request_id"])
+        if request_id in seen_request_ids:
+            continue
+        seen_request_ids.add(request_id)
+        filtered.append(row)
+    return filtered
+
+
 def build_policy_source_context_index(
     connection: sqlite3.Connection,
     *,
@@ -482,17 +581,18 @@ def build_policy_source_context_index(
     if not items:
         return index
 
-    harnesses = sorted({harness for harness, _, _ in items if harness})
+    include_all_harnesses, harnesses = _policy_harness_scope(items)
     artifact_ids = sorted({artifact_id for _, artifact_id, _ in items if artifact_id})
     hash_variants: set[str] = set()
     for _, _, artifact_hash in items:
         if artifact_hash:
             hash_variants.update(_artifact_hash_match_variants(artifact_hash))
 
-    if harnesses and (artifact_ids or hash_variants):
-        harness_placeholders = ", ".join("?" for _ in harnesses)
+    harness_filter_sql, harness_filter_params = _harness_filter_sql(include_all_harnesses, harnesses)
+
+    if artifact_ids or hash_variants:
         match_clauses: list[str] = []
-        params: list[object] = [*harnesses]
+        params: list[object] = []
         if artifact_ids:
             artifact_placeholders = ", ".join("?" for _ in artifact_ids)
             match_clauses.append(f"artifact_id in ({artifact_placeholders})")
@@ -505,11 +605,11 @@ def build_policy_source_context_index(
             f"""
             select {_POLICY_RECEIPT_COLUMNS}
             from runtime_receipts
-            where harness in ({harness_placeholders})
-              and ({" or ".join(match_clauses)})
+            where ({" or ".join(match_clauses)})
+            {harness_filter_sql}
             order by timestamp desc
             """,
-            tuple(params),
+            tuple([*params, *harness_filter_params]),
         ).fetchall()
         for row in receipt_rows:
             harness = str(row["harness"])
@@ -521,7 +621,7 @@ def build_policy_source_context_index(
                 for variant in _artifact_hash_match_variants(str(artifact_hash)):
                     _append_indexed_row(index.receipts_by_harness_hash, (harness, variant), row)
 
-    if harnesses and artifact_ids:
+    if harnesses and artifact_ids and not include_all_harnesses:
         harness_placeholders = ", ".join("?" for _ in harnesses)
         artifact_placeholders = ", ".join("?" for _ in artifact_ids)
         inventory_rows = connection.execute(
@@ -536,10 +636,9 @@ def build_policy_source_context_index(
         for row in inventory_rows:
             index.inventory_by_harness_artifact[(str(row["harness"]), str(row["artifact_id"]))] = row
 
-    if harnesses and (artifact_ids or hash_variants):
-        harness_placeholders = ", ".join("?" for _ in harnesses)
+    if artifact_ids or hash_variants:
         match_clauses = []
-        params = [*harnesses]
+        params: list[object] = []
         if artifact_ids:
             artifact_placeholders = ", ".join("?" for _ in artifact_ids)
             match_clauses.append(f"artifact_id in ({artifact_placeholders})")
@@ -553,11 +652,11 @@ def build_policy_source_context_index(
             select {_POLICY_APPROVAL_COLUMNS}
             from approval_requests
             where status = 'resolved'
-              and harness in ({harness_placeholders})
               and ({" or ".join(match_clauses)})
+            {harness_filter_sql}
             order by resolved_at desc
             """,
-            tuple(params),
+            tuple([*params, *harness_filter_params]),
         ).fetchall()
         for row in approval_rows:
             harness = str(row["harness"])
@@ -584,23 +683,29 @@ def lookup_policy_source_context(
     receipt_candidates: list[sqlite3.Row] = []
     if artifact_hash:
         for variant in _artifact_hash_match_variants(artifact_hash):
-            receipt_candidates.extend(index.receipts_by_harness_hash.get((harness, variant), []))
-    if artifact_id:
-        receipt_candidates.extend(index.receipts_by_harness_artifact.get((harness, artifact_id), []))
+            _extend_receipt_hash_candidates(index, harness, variant, receipt_candidates)
+    elif artifact_id:
+        _extend_receipt_artifact_candidates(index, harness, artifact_id, receipt_candidates)
     receipt_row = _select_best_receipt_row(receipt_candidates, artifact_id)
 
     inventory_row = (
         index.inventory_by_harness_artifact.get((harness, artifact_id))
-        if artifact_id is not None and artifact_id.strip()
+        if artifact_id is not None and artifact_id.strip() and harness != "*"
         else None
     )
 
-    approval_candidates: list[sqlite3.Row] = []
+    approval_candidates_raw: list[sqlite3.Row] = []
     if artifact_id:
-        approval_candidates.extend(index.approvals_by_harness_artifact.get((harness, artifact_id), []))
+        _extend_approval_artifact_candidates(index, harness, artifact_id, approval_candidates_raw)
     if artifact_hash:
         for variant in _artifact_hash_match_variants(artifact_hash):
-            approval_candidates.extend(index.approvals_by_harness_hash.get((harness, variant), []))
+            _extend_approval_hash_candidates(index, harness, variant, approval_candidates_raw)
+    approval_candidates = _filter_approval_candidates(
+        approval_candidates_raw,
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+    )
     approval_row = _select_best_approval_row(approval_candidates, artifact_id)
 
     return _build_policy_source_context_from_rows(

--- a/src/codex_plugin_scanner/guard/store_policy_source_context.py
+++ b/src/codex_plugin_scanner/guard/store_policy_source_context.py
@@ -461,7 +461,11 @@ class PolicySourceContextIndex:
     approvals_by_harness_hash: dict[tuple[str, str], list[sqlite3.Row]] = field(default_factory=dict)
 
 
-def _append_indexed_row(index: dict[tuple[str, str], list[sqlite3.Row]], key: tuple[str, str], row: sqlite3.Row) -> None:
+def _append_indexed_row(
+    index: dict[tuple[str, str], list[sqlite3.Row]],
+    key: tuple[str, str],
+    row: sqlite3.Row,
+) -> None:
     bucket = index.get(key)
     if bucket is None:
         index[key] = [row]

--- a/src/codex_plugin_scanner/guard/store_policy_source_context.py
+++ b/src/codex_plugin_scanner/guard/store_policy_source_context.py
@@ -494,7 +494,7 @@ def _extend_receipt_hash_candidates(
     candidates: list[sqlite3.Row],
 ) -> None:
     if harness == "*":
-        for (row_harness, row_variant), rows in index.receipts_by_harness_hash.items():
+        for (_, row_variant), rows in index.receipts_by_harness_hash.items():
             if row_variant == variant:
                 candidates.extend(rows)
         return
@@ -508,7 +508,7 @@ def _extend_receipt_artifact_candidates(
     candidates: list[sqlite3.Row],
 ) -> None:
     if harness == "*":
-        for (row_harness, row_artifact_id), rows in index.receipts_by_harness_artifact.items():
+        for (_, row_artifact_id), rows in index.receipts_by_harness_artifact.items():
             if row_artifact_id == artifact_id:
                 candidates.extend(rows)
         return
@@ -522,7 +522,7 @@ def _extend_approval_hash_candidates(
     candidates: list[sqlite3.Row],
 ) -> None:
     if harness == "*":
-        for (row_harness, row_variant), rows in index.approvals_by_harness_hash.items():
+        for (_, row_variant), rows in index.approvals_by_harness_hash.items():
             if row_variant == variant:
                 candidates.extend(rows)
         return
@@ -536,7 +536,7 @@ def _extend_approval_artifact_candidates(
     candidates: list[sqlite3.Row],
 ) -> None:
     if harness == "*":
-        for (row_harness, row_artifact_id), rows in index.approvals_by_harness_artifact.items():
+        for (_, row_artifact_id), rows in index.approvals_by_harness_artifact.items():
             if row_artifact_id == artifact_id:
                 candidates.extend(rows)
         return

--- a/src/codex_plugin_scanner/guard/store_policy_source_context.py
+++ b/src/codex_plugin_scanner/guard/store_policy_source_context.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+from dataclasses import dataclass, field
 from pathlib import Path
 
 _GENERIC_POLICY_REASONS = (
@@ -260,29 +261,14 @@ def _find_policy_approval_row(
     ).fetchone()
 
 
-def find_policy_source_context(
-    connection: sqlite3.Connection,
+def _build_policy_source_context_from_rows(
     *,
-    harness: str,
-    artifact_id: str | None,
-    artifact_hash: str | None,
+    receipt_row: sqlite3.Row | None,
+    inventory_row: sqlite3.Row | None,
+    approval_row: sqlite3.Row | None,
     workspace: str | None,
     reason: str | None,
 ) -> dict[str, str] | None:
-    receipt_row = _find_policy_source_receipt_row(
-        connection,
-        harness=harness,
-        artifact_id=artifact_id,
-        artifact_hash=artifact_hash,
-    )
-    inventory_row = _find_policy_inventory_row(connection, harness=harness, artifact_id=artifact_id)
-    approval_row = _find_policy_approval_row(
-        connection,
-        harness=harness,
-        artifact_id=artifact_id,
-        artifact_hash=artifact_hash,
-    )
-
     remembered_command: str | None = None
     remembered_context: str | None = None
     workspace_label: str | None = None
@@ -392,3 +378,231 @@ def find_policy_source_context(
     if source_scope_path is not None:
         payload["source_scope_path"] = source_scope_path
     return payload or None
+
+
+def find_policy_source_context(
+    connection: sqlite3.Connection,
+    *,
+    harness: str,
+    artifact_id: str | None,
+    artifact_hash: str | None,
+    workspace: str | None,
+    reason: str | None,
+) -> dict[str, str] | None:
+    receipt_row = _find_policy_source_receipt_row(
+        connection,
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+    )
+    inventory_row = _find_policy_inventory_row(connection, harness=harness, artifact_id=artifact_id)
+    approval_row = _find_policy_approval_row(
+        connection,
+        harness=harness,
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+    )
+    return _build_policy_source_context_from_rows(
+        receipt_row=receipt_row,
+        inventory_row=inventory_row,
+        approval_row=approval_row,
+        workspace=workspace,
+        reason=reason,
+    )
+
+
+_POLICY_RECEIPT_COLUMNS = """
+    receipt_id, artifact_name, capabilities_summary, provenance_summary, source_scope,
+    scanner_evidence_json, artifact_id, harness, artifact_hash, timestamp
+"""
+
+_POLICY_INVENTORY_COLUMNS = "artifact_name, launch_command, source_scope, harness, artifact_id"
+
+_POLICY_APPROVAL_COLUMNS = """
+    request_id, artifact_name, launch_summary, launch_target, workspace, resolved_at,
+    trigger_summary, resolution_scope, harness, artifact_id, artifact_hash
+"""
+
+
+def _row_sort_timestamp(value: object) -> str:
+    return str(value) if value is not None else ""
+
+
+def _select_best_receipt_row(rows: list[sqlite3.Row], artifact_id: str | None) -> sqlite3.Row | None:
+    if not rows:
+        return None
+    return max(
+        rows,
+        key=lambda row: (
+            1 if artifact_id and str(row["artifact_id"]) == artifact_id else 0,
+            _row_sort_timestamp(row["timestamp"]),
+        ),
+    )
+
+
+def _select_best_approval_row(rows: list[sqlite3.Row], artifact_id: str | None) -> sqlite3.Row | None:
+    if not rows:
+        return None
+    return max(
+        rows,
+        key=lambda row: (
+            1 if artifact_id and str(row["artifact_id"]) == artifact_id else 0,
+            _row_sort_timestamp(row["resolved_at"]),
+        ),
+    )
+
+
+@dataclass
+class PolicySourceContextIndex:
+    receipts_by_harness_artifact: dict[tuple[str, str], list[sqlite3.Row]] = field(default_factory=dict)
+    receipts_by_harness_hash: dict[tuple[str, str], list[sqlite3.Row]] = field(default_factory=dict)
+    inventory_by_harness_artifact: dict[tuple[str, str], sqlite3.Row] = field(default_factory=dict)
+    approvals_by_harness_artifact: dict[tuple[str, str], list[sqlite3.Row]] = field(default_factory=dict)
+    approvals_by_harness_hash: dict[tuple[str, str], list[sqlite3.Row]] = field(default_factory=dict)
+
+
+def _append_indexed_row(index: dict[tuple[str, str], list[sqlite3.Row]], key: tuple[str, str], row: sqlite3.Row) -> None:
+    bucket = index.get(key)
+    if bucket is None:
+        index[key] = [row]
+        return
+    bucket.append(row)
+
+
+def build_policy_source_context_index(
+    connection: sqlite3.Connection,
+    *,
+    items: list[tuple[str, str | None, str | None]],
+) -> PolicySourceContextIndex:
+    index = PolicySourceContextIndex()
+    if not items:
+        return index
+
+    harnesses = sorted({harness for harness, _, _ in items if harness})
+    artifact_ids = sorted({artifact_id for _, artifact_id, _ in items if artifact_id})
+    hash_variants: set[str] = set()
+    for _, _, artifact_hash in items:
+        if artifact_hash:
+            hash_variants.update(_artifact_hash_match_variants(artifact_hash))
+
+    if harnesses and (artifact_ids or hash_variants):
+        harness_placeholders = ", ".join("?" for _ in harnesses)
+        match_clauses: list[str] = []
+        params: list[object] = [*harnesses]
+        if artifact_ids:
+            artifact_placeholders = ", ".join("?" for _ in artifact_ids)
+            match_clauses.append(f"artifact_id in ({artifact_placeholders})")
+            params.extend(artifact_ids)
+        if hash_variants:
+            hash_placeholders = ", ".join("?" for _ in hash_variants)
+            match_clauses.append(f"artifact_hash in ({hash_placeholders})")
+            params.extend(sorted(hash_variants))
+        receipt_rows = connection.execute(
+            f"""
+            select {_POLICY_RECEIPT_COLUMNS}
+            from runtime_receipts
+            where harness in ({harness_placeholders})
+              and ({" or ".join(match_clauses)})
+            order by timestamp desc
+            """,
+            tuple(params),
+        ).fetchall()
+        for row in receipt_rows:
+            harness = str(row["harness"])
+            artifact_id = row["artifact_id"]
+            if artifact_id is not None and str(artifact_id).strip():
+                _append_indexed_row(index.receipts_by_harness_artifact, (harness, str(artifact_id)), row)
+            artifact_hash = row["artifact_hash"]
+            if artifact_hash is not None and str(artifact_hash).strip():
+                for variant in _artifact_hash_match_variants(str(artifact_hash)):
+                    _append_indexed_row(index.receipts_by_harness_hash, (harness, variant), row)
+
+    if harnesses and artifact_ids:
+        harness_placeholders = ", ".join("?" for _ in harnesses)
+        artifact_placeholders = ", ".join("?" for _ in artifact_ids)
+        inventory_rows = connection.execute(
+            f"""
+            select {_POLICY_INVENTORY_COLUMNS}
+            from artifact_inventory
+            where harness in ({harness_placeholders})
+              and artifact_id in ({artifact_placeholders})
+            """,
+            tuple([*harnesses, *artifact_ids]),
+        ).fetchall()
+        for row in inventory_rows:
+            index.inventory_by_harness_artifact[(str(row["harness"]), str(row["artifact_id"]))] = row
+
+    if harnesses and (artifact_ids or hash_variants):
+        harness_placeholders = ", ".join("?" for _ in harnesses)
+        match_clauses = []
+        params = [*harnesses]
+        if artifact_ids:
+            artifact_placeholders = ", ".join("?" for _ in artifact_ids)
+            match_clauses.append(f"artifact_id in ({artifact_placeholders})")
+            params.extend(artifact_ids)
+        if hash_variants:
+            hash_placeholders = ", ".join("?" for _ in hash_variants)
+            match_clauses.append(f"artifact_hash in ({hash_placeholders})")
+            params.extend(sorted(hash_variants))
+        approval_rows = connection.execute(
+            f"""
+            select {_POLICY_APPROVAL_COLUMNS}
+            from approval_requests
+            where status = 'resolved'
+              and harness in ({harness_placeholders})
+              and ({" or ".join(match_clauses)})
+            order by resolved_at desc
+            """,
+            tuple(params),
+        ).fetchall()
+        for row in approval_rows:
+            harness = str(row["harness"])
+            artifact_id = row["artifact_id"]
+            if artifact_id is not None and str(artifact_id).strip():
+                _append_indexed_row(index.approvals_by_harness_artifact, (harness, str(artifact_id)), row)
+            artifact_hash = row["artifact_hash"]
+            if artifact_hash is not None and str(artifact_hash).strip():
+                for variant in _artifact_hash_match_variants(str(artifact_hash)):
+                    _append_indexed_row(index.approvals_by_harness_hash, (harness, variant), row)
+
+    return index
+
+
+def lookup_policy_source_context(
+    index: PolicySourceContextIndex,
+    *,
+    harness: str,
+    artifact_id: str | None,
+    artifact_hash: str | None,
+    workspace: str | None,
+    reason: str | None,
+) -> dict[str, str] | None:
+    receipt_candidates: list[sqlite3.Row] = []
+    if artifact_hash:
+        for variant in _artifact_hash_match_variants(artifact_hash):
+            receipt_candidates.extend(index.receipts_by_harness_hash.get((harness, variant), []))
+    if artifact_id:
+        receipt_candidates.extend(index.receipts_by_harness_artifact.get((harness, artifact_id), []))
+    receipt_row = _select_best_receipt_row(receipt_candidates, artifact_id)
+
+    inventory_row = (
+        index.inventory_by_harness_artifact.get((harness, artifact_id))
+        if artifact_id is not None and artifact_id.strip()
+        else None
+    )
+
+    approval_candidates: list[sqlite3.Row] = []
+    if artifact_id:
+        approval_candidates.extend(index.approvals_by_harness_artifact.get((harness, artifact_id), []))
+    if artifact_hash:
+        for variant in _artifact_hash_match_variants(artifact_hash):
+            approval_candidates.extend(index.approvals_by_harness_hash.get((harness, variant), []))
+    approval_row = _select_best_approval_row(approval_candidates, artifact_id)
+
+    return _build_policy_source_context_from_rows(
+        receipt_row=receipt_row,
+        inventory_row=inventory_row,
+        approval_row=approval_row,
+        workspace=workspace,
+        reason=reason,
+    )

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -185,3 +185,82 @@ def test_list_policy_decisions_uses_trigger_summary_backticks(tmp_path) -> None:
     assert item["remembered_command"] == "git push origin main"
     assert item["source_scope_path"] == "/srv/projects/sample-broker"
     assert item["workspace_label"] == "sample-broker"
+
+
+def test_list_policy_decisions_batch_index_matches_single_lookup(tmp_path) -> None:
+    store = _store(tmp_path)
+    for index in range(3):
+        receipt = GuardReceipt(
+            receipt_id=f"receipt-batch-{index}",
+            timestamp=f"2026-06-14T12:00:{index:02d}+00:00",
+            harness="codex",
+            artifact_id=f"codex:project:package-request:batch{index}",
+            artifact_hash=f"batchhash{index:02d}abcdef1234567890abcdef1234567890abcdef12",
+            policy_decision="allow",
+            capabilities_summary=f"Package install via pnpm-{index}",
+            changed_capabilities=("package-request",),
+            provenance_summary="hook event for package install",
+            artifact_name=f"pnpm install {index}",
+            source_scope=f"/srv/projects/sample-{index}",
+        )
+        store.add_receipt(receipt)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="workspace",
+                action="allow",
+                artifact_id=f"codex:project:package-request:batch{index}",
+                artifact_hash=f"batchhash{index:02d}abcdef1234567890abcdef1234567890abcdef12",
+                workspace=f"workspace:batch{index}",
+                reason="approved in review",
+                source="local",
+            ),
+            f"2026-06-14T12:01:{index:02d}+00:00",
+        )
+
+    items = store.list_policy_decisions()
+    assert len(items) == 3
+    for item in items:
+        assert item["source_receipt_id"] is not None
+        assert item["remembered_command"] is not None
+
+
+def test_list_policy_decisions_scales_without_per_row_queries(tmp_path) -> None:
+    store = _store(tmp_path)
+    for index in range(120):
+        receipt = GuardReceipt(
+            receipt_id=f"receipt-perf-{index}",
+            timestamp=f"2026-06-14T12:00:{index % 60:02d}+00:00",
+            harness="codex",
+            artifact_id=f"codex:project:package-request:perf{index}",
+            artifact_hash=f"perfhash{index:03d}abcdef1234567890abcdef1234567890abcdef12",
+            policy_decision="allow",
+            capabilities_summary="Package install via pnpm",
+            changed_capabilities=("package-request",),
+            provenance_summary="hook event for package install",
+            artifact_name=f"pnpm install {index}",
+            source_scope="/srv/projects/sample-guard",
+        )
+        store.add_receipt(receipt)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="workspace",
+                action="allow",
+                artifact_id=f"codex:project:package-request:perf{index}",
+                artifact_hash=f"perfhash{index:03d}abcdef1234567890abcdef1234567890abcdef12",
+                workspace=f"workspace:perf{index}",
+                reason="approved in review",
+                source="local",
+            ),
+            f"2026-06-14T12:01:{index % 60:02d}+00:00",
+        )
+
+    import time
+
+    started = time.perf_counter()
+    items = store.list_policy_decisions()
+    elapsed = time.perf_counter() - started
+
+    assert len(items) == 120
+    assert elapsed < 2.0

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -256,11 +256,41 @@ def test_list_policy_decisions_scales_without_per_row_queries(tmp_path) -> None:
             f"2026-06-14T12:01:{index % 60:02d}+00:00",
         )
 
-    import time
-
-    started = time.perf_counter()
     items = store.list_policy_decisions()
-    elapsed = time.perf_counter() - started
-
     assert len(items) == 120
-    assert elapsed < 2.0
+    assert all(item["remembered_command"] is not None for item in items)
+
+
+def test_list_policy_decisions_supports_global_harness_scope(tmp_path) -> None:
+    store = _store(tmp_path)
+    receipt = GuardReceipt(
+        receipt_id="receipt-global-1",
+        timestamp="2026-06-14T12:00:00+00:00",
+        harness="codex",
+        artifact_id="codex:project:package-request:global1",
+        artifact_hash="globalhash1234567890abcdef1234567890abcdef1234567890ab",
+        policy_decision="allow",
+        capabilities_summary="Package install via pnpm",
+        changed_capabilities=("package-request",),
+        provenance_summary="hook event for package install",
+        artifact_name="pnpm install",
+        source_scope="/srv/projects/sample-guard",
+    )
+    store.add_receipt(receipt)
+    store.upsert_policy(
+        PolicyDecision(
+            harness="*",
+            scope="artifact",
+            action="allow",
+            artifact_id="codex:project:package-request:global1",
+            artifact_hash="globalhash1234567890abcdef1234567890abcdef1234567890ab",
+            workspace="workspace:global",
+            reason="approved in review",
+            source="local",
+        ),
+        "2026-06-14T12:01:00+00:00",
+    )
+
+    item = store.list_policy_decisions()[0]
+    assert item["source_receipt_id"] == "receipt-global-1"
+    assert item["remembered_command"] == "pnpm install"

--- a/tests/test_policy_decision_source_context.py
+++ b/tests/test_policy_decision_source_context.py
@@ -294,3 +294,61 @@ def test_list_policy_decisions_supports_global_harness_scope(tmp_path) -> None:
     item = store.list_policy_decisions()[0]
     assert item["source_receipt_id"] == "receipt-global-1"
     assert item["remembered_command"] == "pnpm install"
+
+
+def test_list_policy_decisions_keeps_inventory_context_with_global_policy(tmp_path) -> None:
+    store = _store(tmp_path)
+    with store._connect() as connection:
+        connection.execute(
+            """
+            insert into artifact_inventory (
+              artifact_id, harness, artifact_name, artifact_type, source_scope, config_path,
+              first_seen_at, last_seen_at, last_policy_action, artifact_hash
+            ) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "codex:project:package-request:mixed1",
+                "codex",
+                "pnpm",
+                "package_request",
+                "/srv/projects/sample-guard",
+                "config.json",
+                "2026-06-14T12:00:00+00:00",
+                "2026-06-14T12:00:00+00:00",
+                "allow",
+                "hash-mixed1",
+            ),
+        )
+        connection.execute(
+            "update artifact_inventory set launch_command = ? where artifact_id = ? and harness = ?",
+            ("pnpm install --frozen-lockfile", "codex:project:package-request:mixed1", "codex"),
+        )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="workspace",
+            action="allow",
+            artifact_id="codex:project:package-request:mixed1",
+            artifact_hash="hash-mixed1",
+            workspace="workspace:mixed",
+            reason="approved in review",
+            source="local",
+        ),
+        "2026-06-14T12:01:00+00:00",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="*",
+            scope="artifact",
+            action="allow",
+            artifact_id="codex:project:package-request:global-mixed",
+            artifact_hash="globalmixedhash1234567890abcdef1234567890abcdef12",
+            workspace="workspace:global",
+            reason="approved in review",
+            source="local",
+        ),
+        "2026-06-14T12:02:00+00:00",
+    )
+
+    items = {str(item["artifact_id"]): item for item in store.list_policy_decisions()}
+    assert items["codex:project:package-request:mixed1"]["remembered_command"] == "pnpm install --frozen-lockfile"


### PR DESCRIPTION
## Summary
- Batch-load receipt, inventory, and approval rows when listing policy decisions instead of querying per remembered rule.
- Keep policy source-context enrichment behavior while reducing `/v1/policy` latency for large local policy tables.

## Testing
- `python3 -m pytest tests/test_policy_decision_source_context.py -q`
- `python3 -m pytest tests/test_guard_headless_daemon_api.py -q -k policy`
