### PR TITLE
feat(guard): reinstall local-folder Guard installs from PyPI via dashboard

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -289,6 +289,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
     updateStatus,
     updatePhase,
     onUpdateGuard,
+    onReinstallGuard,
   } = useGuardUpdate({ onReconnected: props.onGuardReconnected });
 
   return (
@@ -302,6 +303,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
         updateStatus={updateStatus}
         updatePhase={updatePhase}
         onUpdateGuard={onUpdateGuard}
+        onReinstallGuard={onReinstallGuard}
       />
       <ShellSidebar
         queuedCount={queuedCount}
@@ -312,6 +314,7 @@ export function ApprovalCenterLayout(props: LayoutProps) {
         updateStatus={updateStatus}
         updatePhase={updatePhase}
         onUpdateGuard={onUpdateGuard}
+        onReinstallGuard={onReinstallGuard}
       />
       {mobileQueueOpen && props.view === "inbox" && props.requests.kind === "ready" && (
         <MobileQueueDrawer

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -75,6 +75,7 @@ export function ShellHeader(props: {
   guardVersion?: string | null;
   updateStatus?: GuardUpdateStatus | null;
   onUpdateGuard?: () => void;
+  onReinstallGuard?: () => void;
   updatePhase?: GuardUpdatePhase;
 }) {
   function handleMobileNavigationChange(event: ChangeEvent<HTMLSelectElement>) {
@@ -183,6 +184,7 @@ export function ShellSidebar(props: {
   guardVersion?: string | null;
   updateStatus?: GuardUpdateStatus | null;
   onUpdateGuard?: () => void;
+  onReinstallGuard?: () => void;
   updatePhase?: GuardUpdatePhase;
 }) {
   const collapsed = props.collapsed ?? false;
@@ -277,6 +279,7 @@ export function ShellSidebar(props: {
                   updateStatus={props.updateStatus}
                   updatePhase={props.updatePhase}
                   onUpdateGuard={props.onUpdateGuard}
+                  onReinstallGuard={props.onReinstallGuard}
                 />
               </div>
             </div>

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2061,6 +2061,12 @@ export function normalizeGuardUpdateStatus(raw: unknown): GuardUpdateStatus {
     auto_updatable: booleanValue(value.auto_updatable),
     update_available: booleanValue(value.update_available),
     blocked_reason: stringValue(value.blocked_reason),
+    recovery_reinstall_available:
+      value.recovery_reinstall_available === true ? true : undefined,
+    recovery_reinstall_command:
+      typeof value.recovery_reinstall_command === "string"
+        ? value.recovery_reinstall_command
+        : undefined,
     update_in_progress:
       typeof value.update_in_progress === "boolean" ? value.update_in_progress : undefined,
   };
@@ -2088,14 +2094,25 @@ export async function fetchGuardUpdateStatus(): Promise<GuardUpdateStatus> {
   return normalizeGuardUpdateStatus(payload);
 }
 
-export async function scheduleGuardUpdate(): Promise<GuardUpdateScheduleResult> {
+export async function scheduleGuardUpdate(
+  options?: { forcePypiReinstall?: boolean },
+): Promise<GuardUpdateScheduleResult> {
   if (isGuardDemoMode()) {
     return {
       scheduled: true,
       message: "Demo mode cannot update Guard.",
     };
   }
-  const response = await fetchWithGuardAuth("/v1/update", { method: "POST" });
+  const body =
+    options?.forcePypiReinstall === true
+      ? JSON.stringify({ force_pypi_reinstall: true })
+      : undefined;
+  const response = await fetchWithGuardAuth("/v1/update", {
+    method: "POST",
+    ...(body
+      ? { headers: { "Content-Type": "application/json" }, body }
+      : {}),
+  });
   const payload = (await response.json().catch(() => ({}))) as Record<string, unknown>;
   if (!response.ok) {
     const message =

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -833,6 +833,8 @@ export type GuardUpdateStatus = {
   auto_updatable: boolean;
   update_available: boolean;
   blocked_reason: string | null;
+  recovery_reinstall_available?: boolean;
+  recovery_reinstall_command?: string | null;
   update_in_progress?: boolean;
 };
 

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -834,7 +834,7 @@ export type GuardUpdateStatus = {
   update_available: boolean;
   blocked_reason: string | null;
   recovery_reinstall_available?: boolean;
-  recovery_reinstall_command?: string | null;
+  recovery_reinstall_command?: string;
   update_in_progress?: boolean;
 };
 

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -19,6 +19,7 @@ export type GuardUpdatePanelProps = {
   updateStatus?: GuardUpdateStatus | null;
   updatePhase?: GuardUpdatePhase;
   onUpdateGuard?: () => void;
+  onReinstallGuard?: () => void;
   compact?: boolean;
 };
 
@@ -45,6 +46,10 @@ function updateHelpCopy(status: GuardUpdateStatus | null | undefined, phase: Gua
   if (status?.update_available) {
     return "This restarts Guard for a moment. Open approvals will stay saved.";
   }
+  // Recovery case gets calmer copy that frames the fix instead of the dead end.
+  if (status && !status.auto_updatable && status.recovery_reinstall_available) {
+    return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
   if (status && !status.auto_updatable && status.blocked_reason) {
     return status.blocked_reason;
   }
@@ -60,6 +65,12 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
     props.updateStatus.auto_updatable &&
     phase !== "updating" &&
     phase !== "reconnecting";
+  const showReinstallButton =
+    props.updateStatus?.recovery_reinstall_available === true &&
+    props.updateStatus.auto_updatable !== true &&
+    phase !== "updating" &&
+    phase !== "reconnecting";
+  const busy = phase === "updating" || phase === "reconnecting";
 
   return (
     <div className={props.compact ? "space-y-1" : "space-y-2"}>
@@ -84,7 +95,17 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
           Update Guard
         </button>
       ) : null}
-      {(phase === "updating" || phase === "reconnecting") && (
+      {showReinstallButton && props.onReinstallGuard ? (
+        <button
+          type="button"
+          onClick={props.onReinstallGuard}
+          className="inline-flex min-h-11 w-full items-center justify-center gap-1.5 rounded-lg border border-brand-blue/30 bg-white px-3 py-2 text-sm font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40"
+        >
+          <HiMiniArrowPath className="h-4 w-4 shrink-0" aria-hidden="true" />
+          Reinstall from PyPI
+        </button>
+      ) : null}
+      {busy && (
         <p className="inline-flex min-h-11 items-center gap-2 text-[11px] font-medium text-brand-blue" role="status">
           <HiMiniArrowPath className="h-4 w-4 animate-spin" aria-hidden="true" />
           {phase === "updating" ? "Updating Guard…" : "Reconnecting…"}
@@ -175,41 +196,75 @@ export function useGuardUpdate(options?: { onReconnected?: () => void }) {
     [options],
   );
 
+  const scheduleAndWait = useCallback(
+    async (params: {
+      forcePypiReinstall?: boolean;
+      expectedPreviousVersion: string;
+      expectedLatestVersion: string | null;
+    }): Promise<void> => {
+      setUpdatePhase("updating");
+      try {
+        const scheduleResult = await scheduleGuardUpdate(
+          params.forcePypiReinstall === true ? { forcePypiReinstall: true } : undefined,
+        );
+        if (scheduleResult.scheduled === false && scheduleResult.error === "update_in_progress") {
+          setUpdatePhase("reconnecting");
+          const redirected = await waitForReconnect(
+            params.expectedPreviousVersion,
+            params.expectedLatestVersion,
+          );
+          if (!redirected) {
+            window.location.reload();
+          }
+          return;
+        }
+        if (scheduleResult.scheduled !== true) {
+          throw new Error(scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled.");
+        }
+        setUpdatePhase("reconnecting");
+        const redirected = await waitForReconnect(
+          params.expectedPreviousVersion,
+          params.expectedLatestVersion,
+        );
+        if (!redirected) {
+          window.location.reload();
+        }
+      } catch {
+        setUpdatePhase("error");
+      }
+    },
+    [waitForReconnect],
+  );
+
   const onUpdateGuard = useCallback(async () => {
     if (!updateStatus?.update_available || !updateStatus.auto_updatable) {
       return;
     }
-    const expectedPreviousVersion = updateStatus.current_version;
-    const expectedLatestVersion = updateStatus.latest_version;
-    setUpdatePhase("updating");
-    try {
-      const scheduleResult = await scheduleGuardUpdate();
-      if (scheduleResult.scheduled === false && scheduleResult.error === "update_in_progress") {
-        setUpdatePhase("reconnecting");
-        const redirected = await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
-        if (!redirected) {
-          window.location.reload();
-        }
-        return;
-      }
-      if (scheduleResult.scheduled !== true) {
-        throw new Error(scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled.");
-      }
-      setUpdatePhase("reconnecting");
-      const redirected = await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
-      if (!redirected) {
-        window.location.reload();
-      }
-    } catch {
-      setUpdatePhase("error");
+    await scheduleAndWait({
+      expectedPreviousVersion: updateStatus.current_version,
+      expectedLatestVersion: updateStatus.latest_version,
+    });
+  }, [scheduleAndWait, updateStatus]);
+
+  const onReinstallGuard = useCallback(async () => {
+    if (!updateStatus?.recovery_reinstall_available) {
+      return;
     }
-  }, [updateStatus, waitForReconnect]);
+    // A PyPI reinstall may land the same version; skip the version-change gate
+    // during reconnect by not pinning an expected previous/target version.
+    await scheduleAndWait({
+      forcePypiReinstall: true,
+      expectedPreviousVersion: "",
+      expectedLatestVersion: null,
+    });
+  }, [scheduleAndWait, updateStatus]);
 
   return {
     guardVersion: updateStatus?.current_version ?? null,
     updateStatus,
     updatePhase,
     onUpdateGuard,
+    onReinstallGuard,
     refreshUpdateStatus,
   };
 }

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -40,6 +40,36 @@ assert(blocked.auto_updatable === false, "auto_updatable false should normalize"
 assert(blocked.blocked_reason === "Local install only", "blocked_reason should normalize");
 assert(blocked.current_version === "unknown", "missing current_version should default to unknown");
 
+const recovery = normalizeGuardUpdateStatus({
+  current_version: "1.0.0",
+  auto_updatable: false,
+  update_available: false,
+  blocked_reason: "This install was set up from a local folder. Re-run your usual local install command instead.",
+  recovery_reinstall_available: true,
+  recovery_reinstall_command: "pipx install --force hol-guard",
+});
+
+assert(recovery.recovery_reinstall_available === true, "recovery_reinstall_available should pass through when true");
+assert(
+  recovery.recovery_reinstall_command === "pipx install --force hol-guard",
+  "recovery_reinstall_command should pass through",
+);
+
+const noRecovery = normalizeGuardUpdateStatus({
+  auto_updatable: false,
+  update_available: false,
+  blocked_reason: "This install was set up from local source code.",
+});
+
+assert(
+  noRecovery.recovery_reinstall_available === undefined,
+  "editable installs must not expose recovery_reinstall_available",
+);
+assert(
+  noRecovery.recovery_reinstall_command === undefined,
+  "editable installs must not expose recovery_reinstall_command",
+);
+
 const candidatePorts = buildGuardDaemonCandidatePorts(5474);
 assert(candidatePorts.length === 25, "candidate port scan should probe 25 ports");
 assert(candidatePorts[0] === 5474, "candidate ports should start from the preferred port");

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -712,9 +712,7 @@ def build_guard_update_status_payload() -> dict[str, object]:
     update_available = auto_updatable and version_check.get("update_available") is True
     latest_version = version_check.get("latest_version")
     recovery_reinstall_command = (
-        _shell_command(_update_command(installer, use_pypi=True))
-        if recovery_reinstall_available
-        else None
+        _shell_command(_update_command(installer, use_pypi=True)) if recovery_reinstall_available else None
     )
     return {
         "current_version": current_version,

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -49,6 +49,7 @@ def run_guard_update(
     store: GuardStore | None = None,
     workspace: str | None = None,
     now: str | None = None,
+    force_pypi_reinstall: bool = False,
 ) -> tuple[dict[str, object], int]:
     current_version = _current_version()
     installer = _installer_kind()
@@ -75,7 +76,11 @@ def run_guard_update(
                 "Automatic update is disabled for editable installs. Re-run your local install workflow instead."
             )
             return payload, 0
-        if local_source_install is not None and bool(local_source_install.get("path_exists")):
+        if (
+            local_source_install is not None
+            and bool(local_source_install.get("path_exists"))
+            and not force_pypi_reinstall
+        ):
             payload["status"] = "skipped"
             payload["changed"] = False
             payload["error"] = (
@@ -85,13 +90,15 @@ def run_guard_update(
         if local_source_install is not None and not bool(local_source_install.get("path_exists")):
             payload["recovery_source_install"] = True
     version_check = _version_check_payload(current_version)
-    use_pypi = _should_upgrade_from_pypi(
+    use_pypi = force_pypi_reinstall or _should_upgrade_from_pypi(
         current_version=current_version,
         version_check=version_check,
         vcs_install=vcs_install,
         local_source_install=local_source_install,
     )
     command = _update_command(installer, use_pypi=use_pypi)
+    if force_pypi_reinstall:
+        payload["recovery_reinstall"] = True
     payload.update(
         {
             "command": command,
@@ -686,6 +693,7 @@ def build_guard_update_status_payload() -> dict[str, object]:
     version_check = _version_check_payload(current_version)
     auto_updatable = True
     blocked_reason: str | None = None
+    recovery_reinstall_available = False
 
     if isinstance(direct_url, dict):
         if bool(_read_direct_url_dir_info(direct_url).get("editable")):
@@ -698,9 +706,16 @@ def build_guard_update_status_payload() -> dict[str, object]:
             blocked_reason = (
                 "This install was set up from a local folder. Re-run your usual local install command instead."
             )
+            # Recovery can convert this install back to a normal PyPI package.
+            recovery_reinstall_available = True
 
     update_available = auto_updatable and version_check.get("update_available") is True
     latest_version = version_check.get("latest_version")
+    recovery_reinstall_command = (
+        _shell_command(_update_command(installer, use_pypi=True))
+        if recovery_reinstall_available
+        else None
+    )
     return {
         "current_version": current_version,
         "latest_version": latest_version if isinstance(latest_version, str) else None,
@@ -709,6 +724,8 @@ def build_guard_update_status_payload() -> dict[str, object]:
         "auto_updatable": auto_updatable,
         "update_available": update_available,
         "blocked_reason": blocked_reason,
+        "recovery_reinstall_available": recovery_reinstall_available,
+        "recovery_reinstall_command": recovery_reinstall_command,
     }
 
 

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update.py
@@ -83,6 +83,7 @@ def build_dashboard_update_runner_command(
     *,
     daemon_pid: int,
     daemon_port: int,
+    force_pypi_reinstall: bool = False,
 ) -> list[str]:
     resolved_home = guard_home.expanduser().resolve()
     runner_script = dashboard_update_runner_script()
@@ -100,6 +101,8 @@ def build_dashboard_update_runner_command(
             str(daemon_port),
         ]
     )
+    if force_pypi_reinstall:
+        command.append("--force-pypi-reinstall")
     return command
 
 
@@ -121,6 +124,8 @@ def schedule_guard_dashboard_update(
     guard_home: Path,
     daemon_pid: int,
     daemon_port: int,
+    *,
+    force_pypi_reinstall: bool = False,
 ) -> dict[str, object]:
     guard_home = guard_home.expanduser().resolve()
     if dashboard_update_in_progress(guard_home):
@@ -136,6 +141,7 @@ def schedule_guard_dashboard_update(
         guard_home,
         daemon_pid=daemon_pid,
         daemon_port=daemon_port,
+        force_pypi_reinstall=force_pypi_reinstall,
     )
     kwargs = build_dashboard_update_runner_popen_kwargs(guard_home)
     if os.name == "nt":

--- a/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
+++ b/src/codex_plugin_scanner/guard/daemon/dashboard_update_runner.py
@@ -30,7 +30,10 @@ def main(argv: list[str] | None = None) -> int:
         clear_guard_daemon_state(guard_home)
         repair_approval_center_locator(guard_home)
 
-        update_payload, exit_code = run_guard_update(dry_run=False)
+        update_payload, exit_code = run_guard_update(
+            dry_run=False,
+            force_pypi_reinstall=args.force_pypi_reinstall,
+        )
         if exit_code != 0:
             message = update_payload.get("message") or update_payload.get("error") or "Guard update failed."
             print(str(message), file=sys.stderr)
@@ -51,6 +54,11 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     parser.add_argument("--guard-home", required=True)
     parser.add_argument("--daemon-pid", type=int, required=True)
     parser.add_argument("--daemon-port", type=int, required=True)
+    parser.add_argument(
+        "--force-pypi-reinstall",
+        action="store_true",
+        help="Reinstall hol-guard from PyPI to repair a local folder install.",
+    )
     return parser.parse_args(argv)
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1432,9 +1432,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if parsed.path == "/v1/update":
             force_pypi_reinstall = bool(payload.get("force_pypi_reinstall"))
             status_payload = build_guard_update_status_payload()
-            recovery_reinstall_available = bool(
-                status_payload.get("recovery_reinstall_available")
-            )
+            recovery_reinstall_available = bool(status_payload.get("recovery_reinstall_available"))
             if force_pypi_reinstall and not recovery_reinstall_available:
                 self._write_json(
                     {
@@ -1455,10 +1453,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     status=400,
                 )
                 return
-            if (
-                status_payload.get("update_available") is not True
-                and not force_pypi_reinstall
-            ):
+            if status_payload.get("update_available") is not True and not force_pypi_reinstall:
                 self._write_json(
                     {
                         "error": "update_not_available",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1430,8 +1430,22 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._handle_guard_cloud_connect_start()
             return
         if parsed.path == "/v1/update":
+            force_pypi_reinstall = bool(payload.get("force_pypi_reinstall"))
             status_payload = build_guard_update_status_payload()
-            if status_payload.get("auto_updatable") is not True:
+            recovery_reinstall_available = bool(
+                status_payload.get("recovery_reinstall_available")
+            )
+            if force_pypi_reinstall and not recovery_reinstall_available:
+                self._write_json(
+                    {
+                        "error": "update_not_supported",
+                        "message": status_payload.get("blocked_reason")
+                        or "Reinstall is not available for this install.",
+                    },
+                    status=400,
+                )
+                return
+            if status_payload.get("auto_updatable") is not True and not force_pypi_reinstall:
                 self._write_json(
                     {
                         "error": "update_not_supported",
@@ -1441,7 +1455,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     status=400,
                 )
                 return
-            if status_payload.get("update_available") is not True:
+            if (
+                status_payload.get("update_available") is not True
+                and not force_pypi_reinstall
+            ):
                 self._write_json(
                     {
                         "error": "update_not_available",
@@ -1458,6 +1475,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     guard_home,
                     daemon_pid=daemon_pid,
                     daemon_port=daemon_port,
+                    force_pypi_reinstall=force_pypi_reinstall,
                 )
             )
             return

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -60,6 +60,26 @@ def _post_json(daemon: GuardDaemonServer, path: str) -> tuple[int, dict[str, obj
         return error.code, payload
 
 
+def _post_json_body(
+    daemon: GuardDaemonServer, path: str, body: dict[str, object]
+) -> tuple[int, dict[str, object]]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{daemon.port}{path}",
+        data=json.dumps(body).encode("utf-8"),
+        headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+            assert isinstance(payload, dict)
+            return response.status, payload
+    except urllib.error.HTTPError as error:
+        payload = json.loads(error.read().decode("utf-8"))
+        assert isinstance(payload, dict)
+        return error.code, payload
+
+
 def test_build_guard_update_status_payload_shape(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.cli.update_commands._current_version",
@@ -127,7 +147,12 @@ def test_daemon_update_schedule_route(tmp_path: Path, monkeypatch: pytest.Monkey
     store = _store(tmp_path)
     scheduled: dict[str, object] = {}
 
-    def fake_schedule(guard_home: Path, daemon_pid: int, daemon_port: int) -> dict[str, object]:
+    def fake_schedule(
+        guard_home: Path,
+        daemon_pid: int,
+        daemon_port: int,
+        **kwargs: object,
+    ) -> dict[str, object]:
         scheduled["guard_home"] = guard_home
         scheduled["daemon_pid"] = daemon_pid
         scheduled["daemon_port"] = daemon_port
@@ -395,3 +420,195 @@ def test_dashboard_update_runner_retires_all_daemons_before_upgrade(
         "ensure",
         "clear_lock",
     ]
+
+
+def test_status_payload_exposes_recovery_for_local_folder_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._current_version",
+        lambda: "1.0.0",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._installer_kind",
+        lambda: "pipx",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._direct_url_payload",
+        lambda: {"url": "file:///home/me/hol-guard", "dir_info": {}},
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._local_source_install_payload",
+        lambda direct_url: {
+            "kind": "local_path",
+            "url": "file:///home/me/hol-guard",
+            "path": "/home/me/hol-guard",
+            "path_exists": True,
+        },
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._version_check_payload",
+        lambda current_version: {
+            "source": "pypi",
+            "status": "current",
+            "current_version": current_version,
+            "latest_version": current_version,
+            "update_available": False,
+        },
+    )
+
+    payload = build_guard_update_status_payload()
+
+    assert payload["auto_updatable"] is False
+    assert payload["recovery_reinstall_available"] is True
+    assert payload["recovery_reinstall_command"] == "pipx install --force hol-guard"
+
+
+def test_status_payload_hides_recovery_for_editable_install(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._current_version",
+        lambda: "1.0.0",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._installer_kind",
+        lambda: "pipx",
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._direct_url_payload",
+        lambda: {"url": "file:///home/me/hol-guard", "dir_info": {"editable": True}},
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._local_source_install_payload",
+        lambda direct_url: None,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.update_commands._version_check_payload",
+        lambda current_version: {
+            "source": "pypi",
+            "status": "current",
+            "current_version": current_version,
+            "latest_version": current_version,
+            "update_available": False,
+        },
+    )
+
+    payload = build_guard_update_status_payload()
+
+    assert payload["auto_updatable"] is False
+    assert payload["recovery_reinstall_available"] is False
+    assert payload["recovery_reinstall_command"] is None
+
+
+def test_daemon_update_schedules_recovery_reinstall_for_local_folder(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    scheduled: dict[str, object] = {}
+
+    def fake_schedule(guard_home, daemon_pid, daemon_port, **kwargs):
+        scheduled["guard_home"] = guard_home
+        scheduled["daemon_pid"] = daemon_pid
+        scheduled["daemon_port"] = daemon_port
+        scheduled["force_pypi_reinstall"] = kwargs.get("force_pypi_reinstall")
+        return {"scheduled": True, "message": "reinstall scheduled"}
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.server.build_guard_update_status_payload",
+        lambda: {
+            "current_version": "1.0.0",
+            "latest_version": "1.0.0",
+            "installer": "pipx",
+            "version_check": {
+                "source": "pypi",
+                "status": "current",
+                "current_version": "1.0.0",
+                "latest_version": "1.0.0",
+                "update_available": False,
+            },
+            "auto_updatable": False,
+            "update_available": False,
+            "blocked_reason": "This install was set up from a local folder.",
+            "recovery_reinstall_available": True,
+            "recovery_reinstall_command": "pipx install --force hol-guard",
+        },
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.server.schedule_guard_dashboard_update",
+        fake_schedule,
+    )
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _post_json_body(daemon, "/v1/update", {"force_pypi_reinstall": True})
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["scheduled"] is True
+    assert scheduled["force_pypi_reinstall"] is True
+
+
+def test_daemon_update_recovery_reinstall_rejected_for_editable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.server.build_guard_update_status_payload",
+        lambda: {
+            "current_version": "1.0.0",
+            "latest_version": "1.0.0",
+            "installer": "pipx",
+            "version_check": {
+                "source": "pypi",
+                "status": "current",
+                "current_version": "1.0.0",
+                "latest_version": "1.0.0",
+                "update_available": False,
+            },
+            "auto_updatable": False,
+            "update_available": False,
+            "blocked_reason": "This install was set up from local source code.",
+            "recovery_reinstall_available": False,
+            "recovery_reinstall_command": None,
+        },
+    )
+    schedule_mock = MagicMock()
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.daemon.server.schedule_guard_dashboard_update",
+        schedule_mock,
+    )
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        status, payload = _post_json_body(daemon, "/v1/update", {"force_pypi_reinstall": True})
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "update_not_supported"
+    schedule_mock.assert_not_called()
+
+
+def test_runner_command_appends_force_pypi_reinstall_flag(tmp_path: Path) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    command = build_dashboard_update_runner_command(
+        guard_home.resolve(),
+        daemon_pid=99,
+        daemon_port=1234,
+        force_pypi_reinstall=True,
+    )
+    assert "--force-pypi-reinstall" in command
+
+    command_without = build_dashboard_update_runner_command(
+        guard_home.resolve(),
+        daemon_pid=99,
+        daemon_port=1234,
+    )
+    assert "--force-pypi-reinstall" not in command_without


### PR DESCRIPTION
## Summary
- Expose `recovery_reinstall_available` and `recovery_reinstall_command` on the update status payload for installs created from a local folder (path exists).
- Let the dashboard update flow run a force PyPI reinstall for those installs, threaded through the detached runner and daemon reconnect path.
- Add a "Reinstall from PyPI" action to the local Guard panel so a local-folder install can be converted back to a normal package without leaving the dashboard.
- Editable installs remain blocked with no reinstall option, since reinstalling from PyPI would replace an active development install.

## Testing
- `python3 -m pytest tests/test_dashboard_update.py tests/test_guard_phase03_local_install.py tests/test_guard_phase03_remainder.py -q`
- `cd dashboard && npx vite build`
- `cd dashboard && npx tsx src/guard-update.test.ts`
- `cd dashboard && npx tsx src/approval-center-layout.test.ts`

## Notes
- Recovery reinstall is not version-gated: it converts the install source even when the version is current, so future in-dashboard updates work again.
