### PR TITLE
feat(dashboard): align Policy page layout with M1–M4 mockups

### DIFF
--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -182,11 +182,11 @@ export function scopeLabel(scope: string, variant: "review" | "policy" = "review
       case "workspace":
         return "This project";
       case "harness":
-        return "This app";
+        return "This harness";
       case "publisher":
-        return "This source";
+        return "This cwd";
       case "global":
-        return "Every project";
+        return "Team policy";
       default:
         return scope;
     }

--- a/dashboard/src/policy-cloud-exception-request-panel.tsx
+++ b/dashboard/src/policy-cloud-exception-request-panel.tsx
@@ -20,23 +20,23 @@ const SCOPE_OPTIONS: Array<{
 }> = [
   {
     value: "artifact",
-    label: "One specific action",
-    description: "Limit the exception to a single artifact fingerprint.",
+    label: "Exact action",
+    description: "Limit the exception to one specific action fingerprint.",
   },
   {
     value: "publisher",
-    label: "Publisher",
-    description: "Apply to packages or plugins from one publisher.",
-  },
-  {
-    value: "harness",
-    label: "App",
-    description: "Apply across one harness such as Codex or Cursor.",
+    label: "This cwd",
+    description: "Reuse within the current working directory scope.",
   },
   {
     value: "workspace",
-    label: "Project",
+    label: "This project",
     description: "Apply within the current project folder on this device.",
+  },
+  {
+    value: "harness",
+    label: "This harness",
+    description: "Apply across one harness such as Codex or Cursor.",
   },
 ];
 
@@ -286,7 +286,7 @@ export function PolicyCloudExceptionRequestPanel({
       }
     >
       <p className="mb-4 text-sm text-brand-dark/75">
-        Submit a governed risk acceptance to Guard Cloud. This does not create a local remembered rule.
+        Ask Guard Cloud to create a policy override. Local Review handles reusable approvals.
       </p>
 
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_280px] lg:items-start">

--- a/dashboard/src/policy-cloud-exceptions-ia.test.tsx
+++ b/dashboard/src/policy-cloud-exceptions-ia.test.tsx
@@ -18,20 +18,22 @@ assert(resolvePolicyViewLabel("rules") === "Remembered rules", "rules view label
 const workspaceSource = readFileSync(join(here, "policy-workspace.tsx"), "utf8");
 const tabSource = readFileSync(join(here, "policy-cloud-exceptions-tab.tsx"), "utf8");
 const pageSource = readFileSync(join(here, "policy-workspace-page.tsx"), "utf8");
-const sidebarSource = readFileSync(join(here, "approval-center-primitives.tsx"), "utf8");
+const chromeSource = readFileSync(join(here, "policy-page-chrome.tsx"), "utf8");
 
 assert(!workspaceSource.includes("PolicyExceptionForm"), "policy workspace no longer mounts PolicyExceptionForm");
 assert(!workspaceSource.includes("New exception"), "policy workspace removes local New exception copy");
-assert(tabSource.includes("+ Request cloud exception"), "cloud exceptions tab exposes request CTA");
+assert(chromeSource.includes("+ Request cloud exception"), "policy header exposes request CTA on exceptions tab");
+assert(chromeSource.includes("PolicyExceptionsToolbar"), "policy page chrome exports exceptions toolbar");
 assert(tabSource.includes("PolicyCloudExceptionRequestPanel"), "cloud exceptions tab opens in-dashboard request panel");
 assert(tabSource.includes("fetchCloudExceptions"), "cloud exceptions tab loads synced exceptions");
 assert(tabSource.includes("PolicyCloudExceptionsSummary"), "cloud exceptions tab renders summary cards");
 assert(tabSource.includes("PolicyCloudExceptionDetailPanel"), "cloud exceptions tab renders detail panel");
 assert(tabSource.includes("PolicyCloudExceptionsList"), "cloud exceptions tab renders grouped lists");
-assert(tabSource.includes("Open Guard Cloud"), "cloud exceptions tab exposes Open Guard Cloud CTA");
+assert(chromeSource.includes("Open Guard Cloud"), "policy header exposes Open Guard Cloud on exceptions tab");
 assert(tabSource.includes("Guard Cloud is not connected"), "disconnected Cloud copy present");
-assert(!pageSource.includes("add custom exceptions"), "page header removes local exception authoring copy");
+assert(pageSource.includes("add custom exceptions here"), "page header uses mockup description");
 assert(!workspaceSource.includes("bypass"), "policy workspace removes bypass copy");
+const sidebarSource = readFileSync(join(here, "approval-center-primitives.tsx"), "utf8");
 assert(sidebarSource.includes('label: "Policy"'), "sidebar Policy label unchanged");
 
 console.log("policy-cloud-exceptions-ia.test.ts: all assertions passed");

--- a/dashboard/src/policy-cloud-exceptions-tab.tsx
+++ b/dashboard/src/policy-cloud-exceptions-tab.tsx
@@ -12,7 +12,7 @@ import {
   groupCloudExceptions,
   summarizeCloudExceptions,
 } from "./policy-cloud-exceptions-utils";
-import { resolveCloudPolicyControlsUrl } from "./policy-workspace-helpers";
+import { resolveCloudExceptionsConnected, resolveCloudPolicyControlsUrl } from "./policy-workspace-helpers";
 
 type PolicyCloudExceptionsTabProps = {
   snapshot: GuardRuntimeSnapshot;
@@ -21,10 +21,6 @@ type PolicyCloudExceptionsTabProps = {
 };
 
 type LoadState = "loading" | "ready" | "error";
-
-function resolveCloudExceptionsConnected(snapshot: GuardRuntimeSnapshot): boolean {
-  return snapshot.cloud_state === "paired_active" || snapshot.cloud_state === "paired_waiting";
-}
 
 export function PolicyCloudExceptionsTab({
   snapshot,

--- a/dashboard/src/policy-cloud-exceptions-tab.tsx
+++ b/dashboard/src/policy-cloud-exceptions-tab.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { HiMiniCloudArrowUp } from "react-icons/hi2";
 import { ActionButton, EmptyState } from "./approval-center-primitives";
 import { fetchCloudExceptionRequests, fetchCloudExceptions } from "./guard-api";
 import type { GuardCloudException } from "./guard-types";
@@ -17,6 +16,8 @@ import { resolveCloudPolicyControlsUrl } from "./policy-workspace-helpers";
 
 type PolicyCloudExceptionsTabProps = {
   snapshot: GuardRuntimeSnapshot;
+  requestOpen?: boolean;
+  onRequestOpenChange?: (open: boolean) => void;
 };
 
 type LoadState = "loading" | "ready" | "error";
@@ -27,8 +28,12 @@ function resolveCloudExceptionsConnected(snapshot: GuardRuntimeSnapshot): boolea
 
 export function PolicyCloudExceptionsTab({
   snapshot,
+  requestOpen: requestOpenProp,
+  onRequestOpenChange,
 }: PolicyCloudExceptionsTabProps) {
-  const [requestOpen, setRequestOpen] = useState(false);
+  const [requestOpenInternal, setRequestOpenInternal] = useState(false);
+  const requestOpen = requestOpenProp ?? requestOpenInternal;
+  const setRequestOpen = onRequestOpenChange ?? setRequestOpenInternal;
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [loadError, setLoadError] = useState<string | null>(null);
   const [exceptions, setExceptions] = useState<GuardCloudException[]>([]);
@@ -70,18 +75,14 @@ export function PolicyCloudExceptionsTab({
     void reloadData();
   }, [reloadData, reloadToken]);
 
-  const handleOpenRequestPanel = useCallback(() => {
-    setRequestOpen(true);
-  }, []);
-
   const handleCloseRequestPanel = useCallback(() => {
     setRequestOpen(false);
-  }, []);
+  }, [setRequestOpen]);
 
   const handleRequestSubmitted = useCallback(() => {
     setRequestOpen(false);
     setReloadToken((current) => current + 1);
-  }, []);
+  }, [setRequestOpen]);
 
   const handleRetryLoad = useCallback(() => {
     setReloadToken((current) => current + 1);
@@ -129,27 +130,6 @@ export function PolicyCloudExceptionsTab({
       <div className="space-y-4">
         <div className="rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] px-4 py-3 text-sm text-brand-dark/80">
           Exceptions are approved in Guard Cloud, then enforced locally as signed policy bundle entries.
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          <ActionButton
-            variant="primary"
-            onClick={handleOpenRequestPanel}
-            disabled={!cloudConnected}
-          >
-            + Request cloud exception
-          </ActionButton>
-          {cloudControlsUrl ? (
-            <ActionButton href={cloudControlsUrl} variant="secondary">
-              <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
-              Open Guard Cloud
-            </ActionButton>
-          ) : null}
-          {!cloudConnected && connectUrl ? (
-            <ActionButton href={connectUrl} variant="secondary">
-              Connect Guard Cloud
-            </ActionButton>
-          ) : null}
         </div>
 
         {!cloudConnected ? (

--- a/dashboard/src/policy-guard-cloud-bundle-card.tsx
+++ b/dashboard/src/policy-guard-cloud-bundle-card.tsx
@@ -1,4 +1,5 @@
-import { HiMiniCloudArrowUp } from "react-icons/hi2";
+import { useCallback } from "react";
+import { HiMiniCheckCircle, HiMiniClipboardDocument, HiMiniCloudArrowUp } from "react-icons/hi2";
 import { ActionButton, SectionLabel, Tag } from "./approval-center-primitives";
 import { formatRelativeTime } from "./approval-center-utils";
 import type { GuardRuntimeSnapshot } from "./guard-types";
@@ -17,6 +18,15 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
   const lastAckAt =
     snapshot.runtime_state?.last_heartbeat_at?.trim() ?? snapshot.generated_at?.trim() ?? null;
+  const policyHash = cloudBundleCopy?.hash?.slice(0, 8) ?? null;
+
+  const handleCopyHash = useCallback(() => {
+    const fullHash = cloudBundleCopy?.hash?.trim();
+    if (!fullHash || !navigator.clipboard?.writeText) {
+      return;
+    }
+    void navigator.clipboard.writeText(fullHash);
+  }, [cloudBundleCopy?.hash]);
 
   if (!cloudBundleCopy) {
     return (
@@ -37,32 +47,50 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
     );
   }
 
+  const synced = cloudBundleCopy.tone === "green";
+
   return (
     <div className={resolveCloudBundleSurfaceClass(cloudBundleCopy.tone)}>
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
           <SectionLabel>Guard Cloud bundle</SectionLabel>
-          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+          <div className="mt-3 grid gap-4 sm:grid-cols-3">
             <div>
               <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Status</p>
-              <div className="mt-1">
-                <Tag tone={cloudBundleCopy.tone === "green" ? "green" : "amber"}>{cloudBundleCopy.label}</Tag>
+              <div className="mt-1.5 flex items-center gap-1.5">
+                {synced ? (
+                  <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+                ) : null}
+                <Tag tone={synced ? "green" : "amber"}>{cloudBundleCopy.label}</Tag>
+              </div>
+              <p className="mt-1 text-xs text-slate-500">{cloudBundleCopy.detail}</p>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Policy hash</p>
+              <div className="mt-1.5 flex items-center gap-1.5">
+                <p className="font-mono text-sm text-brand-dark">{policyHash ?? "Unavailable"}</p>
+                {policyHash ? (
+                  <button
+                    type="button"
+                    onClick={handleCopyHash}
+                    className="rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark"
+                    aria-label="Copy policy hash"
+                  >
+                    <HiMiniClipboardDocument className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                ) : null}
               </div>
             </div>
             <div>
-              <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Bundle hash</p>
-              <p className="mt-1 font-mono text-sm text-brand-dark">
-                {cloudBundleCopy.hash?.slice(0, 8) ?? "Unavailable"}
-              </p>
-            </div>
-            <div>
               <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last ack</p>
-              <p className="mt-1 text-sm text-brand-dark">
-                {lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}
-              </p>
+              <div className="mt-1.5 flex items-center gap-1.5">
+                {lastAckAt ? (
+                  <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+                ) : null}
+                <p className="text-sm text-brand-dark">{lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}</p>
+              </div>
             </div>
           </div>
-          <p className="mt-2 text-sm text-brand-dark/75">{cloudBundleCopy.detail}</p>
         </div>
         {cloudControlsUrl ? (
           <ActionButton href={cloudControlsUrl} variant="secondary">

--- a/dashboard/src/policy-page-chrome.tsx
+++ b/dashboard/src/policy-page-chrome.tsx
@@ -1,6 +1,5 @@
 import { useCallback, type KeyboardEvent } from "react";
-import { HiMiniArrowPath } from "react-icons/hi2";
-import { HiMiniCloudArrowUp } from "react-icons/hi2";
+import { HiMiniArrowPath, HiMiniCloudArrowUp } from "react-icons/hi2";
 import { ActionButton, Badge } from "./approval-center-primitives";
 import type { GuardRuntimeSnapshot } from "./guard-types";
 import { resolvePolicyViewLabel, type PolicyPageView } from "./policy-workspace";

--- a/dashboard/src/policy-page-chrome.tsx
+++ b/dashboard/src/policy-page-chrome.tsx
@@ -1,5 +1,6 @@
 import { useCallback, type KeyboardEvent } from "react";
 import { HiMiniArrowPath } from "react-icons/hi2";
+import { HiMiniCloudArrowUp } from "react-icons/hi2";
 import { ActionButton, Badge } from "./approval-center-primitives";
 import type { GuardRuntimeSnapshot } from "./guard-types";
 import { resolvePolicyViewLabel, type PolicyPageView } from "./policy-workspace";
@@ -90,6 +91,39 @@ export function PolicyPageToolbar({ snapshot, onReloadPolicy, reloading = false 
         <ActionButton variant="secondary" onClick={onReloadPolicy} disabled={reloading}>
           <HiMiniArrowPath className={`mr-1.5 h-4 w-4 ${reloading ? "animate-spin" : ""}`} aria-hidden="true" />
           Reload policy
+        </ActionButton>
+      ) : null}
+    </div>
+  );
+}
+
+type PolicyExceptionsToolbarProps = {
+  cloudConnected: boolean;
+  cloudControlsUrl: string | null;
+  connectUrl: string | null;
+  onRequestException: () => void;
+};
+
+export function PolicyExceptionsToolbar({
+  cloudConnected,
+  cloudControlsUrl,
+  connectUrl,
+  onRequestException,
+}: PolicyExceptionsToolbarProps) {
+  return (
+    <div className="flex flex-wrap items-center justify-end gap-2">
+      <ActionButton variant="primary" onClick={onRequestException} disabled={!cloudConnected}>
+        + Request cloud exception
+      </ActionButton>
+      {cloudControlsUrl ? (
+        <ActionButton href={cloudControlsUrl} variant="secondary">
+          <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          Open Guard Cloud
+        </ActionButton>
+      ) : null}
+      {!cloudConnected && connectUrl ? (
+        <ActionButton href={connectUrl} variant="secondary">
+          Connect Guard Cloud
         </ActionButton>
       ) : null}
     </div>

--- a/dashboard/src/policy-remembered-cloud-rules.tsx
+++ b/dashboard/src/policy-remembered-cloud-rules.tsx
@@ -13,13 +13,15 @@ export function PolicyRememberedCloudRules({
   return (
     <GroupedPolicySection
       title="From Guard Cloud"
-      description="Synced team rules are read-only here. Edit them in Guard Cloud Controls."
+      badge="Team policy rules"
+      description="Managed by your team in Guard Cloud. These rules are read-only locally."
       policies={policies}
       cloudControlsUrl={cloudControlsUrl}
       emptyTitle="No Guard Cloud rules synced"
       emptyBody="Connect Guard Cloud to sync shared policy bundles."
       defaultOpen={policies.length > 0}
       cloudVariant
+      viewAllLabel="View all cloud rules ({count}) →"
     />
   );
 }

--- a/dashboard/src/policy-remembered-local-rules.tsx
+++ b/dashboard/src/policy-remembered-local-rules.tsx
@@ -15,13 +15,15 @@ export function PolicyRememberedLocalRules({
   return (
     <GroupedPolicySection
       title="Remembered on this device"
-      description="Choices you saved from Inbox. Each row shows the exact command or action Guard will remember, and where it applies."
+      badge="Local rules"
+      description="Decisions you've remembered on this machine."
       policies={policies}
       cloudControlsUrl={cloudControlsUrl}
       onClearPolicy={onClearPolicy}
       emptyTitle="No local remembered rules yet"
       emptyBody="Approve or block in Inbox and Guard remembers the decision here in plain language."
       defaultOpen
+      viewAllLabel="View all local rules ({count}) →"
     />
   );
 }

--- a/dashboard/src/policy-remembered-rules-right-rail.tsx
+++ b/dashboard/src/policy-remembered-rules-right-rail.tsx
@@ -1,15 +1,41 @@
-import { HiMiniShieldCheck } from "react-icons/hi2";
-import { SectionLabel, Tag } from "./approval-center-primitives";
-import { scopeLabel } from "./approval-center-utils";
+import {
+  HiMiniArrowPath,
+  HiMiniCloudArrowUp,
+  HiMiniFolder,
+  HiMiniGlobeAlt,
+  HiMiniShieldCheck,
+  HiMiniUsers,
+} from "react-icons/hi2";
+import { ActionButton, SectionLabel, Tag } from "./approval-center-primitives";
 import type { GuardRuntimeSnapshot } from "./guard-types";
 import { resolveCloudPolicyControlsUrl, resolveSecurityModeCopy } from "./policy-workspace-helpers";
 
 const REVIEW_SCOPE_LADDER = [
-  { scope: "artifact", detail: "Guard remembers only the next matching retry." },
-  { scope: "workspace", detail: "Guard remembers the same action in this project folder." },
-  { scope: "publisher", detail: "Guard remembers actions from the same source in this app." },
-  { scope: "harness", detail: "Guard remembers the action across this app." },
-  { scope: "global", detail: "Guard remembers the action on every project on this device." },
+  {
+    label: "Once",
+    detail: "One time only.",
+    icon: HiMiniArrowPath,
+  },
+  {
+    label: "This cwd",
+    detail: "Reuse in this working directory.",
+    icon: HiMiniFolder,
+  },
+  {
+    label: "This project",
+    detail: "Reuse across this project.",
+    icon: HiMiniFolder,
+  },
+  {
+    label: "This harness",
+    detail: "Reuse across this tool harness.",
+    icon: HiMiniGlobeAlt,
+  },
+  {
+    label: "Team policy",
+    detail: "Organization-wide policy.",
+    icon: HiMiniUsers,
+  },
 ] as const;
 
 type PolicyRememberedRulesRightRailProps = {
@@ -33,38 +59,40 @@ export function PolicyRememberedRulesRightRail({
             <HiMiniShieldCheck className="h-5 w-5" aria-hidden="true" />
           </span>
           <div>
-            <div className="flex flex-wrap items-center gap-2">
-              <p className="text-sm font-semibold text-brand-dark">{modeCopy.label}</p>
-              <Tag tone={modeCopy.tone}>{modeCopy.tone === "attention" ? "Protect" : "Active"}</Tag>
-            </div>
+            <p className="text-sm font-semibold text-brand-dark">{modeCopy.label}</p>
             <p className="mt-1 text-sm leading-relaxed text-slate-600">{modeCopy.description}</p>
           </div>
         </div>
       </div>
 
-      <div className="rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600">
+      <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
         <p className="font-medium text-brand-dark">Approvals are still fast</p>
         <p className="mt-1 text-xs leading-relaxed text-slate-500">
           When you approve in Inbox, you pick how broadly Guard should remember the decision.
         </p>
         <ul className="mt-3 space-y-2.5">
-          {REVIEW_SCOPE_LADDER.map((step) => (
-            <li key={step.scope} className="flex gap-2.5">
-              <span className="mt-0.5 h-2 w-2 shrink-0 rounded-full bg-brand-blue/70" aria-hidden="true" />
-              <div>
-                <p className="text-sm font-medium text-brand-dark">{scopeLabel(step.scope, "policy")}</p>
-                <p className="text-xs leading-relaxed text-slate-500">{step.detail}</p>
-              </div>
-            </li>
-          ))}
+          {REVIEW_SCOPE_LADDER.map((step) => {
+            const Icon = step.icon;
+            return (
+              <li key={step.label} className="flex gap-2.5">
+                <span className="mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+                  <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                </span>
+                <div>
+                  <p className="text-sm font-medium text-brand-dark">{step.label}</p>
+                  <p className="text-xs leading-relaxed text-slate-500">{step.detail}</p>
+                </div>
+              </li>
+            );
+          })}
         </ul>
       </div>
 
       <div className="rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
         <p className="font-medium text-brand-dark">Cloud exceptions</p>
         <p className="mt-2 text-sm leading-relaxed text-slate-600">
-          Governed risk acceptances override team policy when approved in Guard Cloud. They sync as signed
-          bundle entries on this device.
+          Governed risk acceptances override team policy when approved in Guard Cloud. They sync as signed bundle
+          entries on this device.
         </p>
         <button
           type="button"
@@ -74,16 +102,18 @@ export function PolicyRememberedRulesRightRail({
           Open Cloud exceptions tab
         </button>
         {cloudControlsUrl ? (
-          <a
-            href={cloudControlsUrl}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="mt-2 block text-sm font-medium text-brand-blue hover:underline"
-          >
-            Open Guard Cloud
-          </a>
+          <div className="mt-3">
+            <ActionButton href={cloudControlsUrl} variant="secondary">
+              <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              Open Guard Cloud
+            </ActionButton>
+          </div>
         ) : null}
       </div>
+
+      <p className="text-xs leading-relaxed text-slate-500">
+        Local remembered rules are for your machine only. Cloud exceptions and team policy sync from Guard Cloud.
+      </p>
     </aside>
   );
 }

--- a/dashboard/src/policy-remembered-rules-tab.tsx
+++ b/dashboard/src/policy-remembered-rules-tab.tsx
@@ -116,7 +116,7 @@ export function PolicyRememberedRulesTab({
             <HiMiniMagnifyingGlass className="h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
             <input
               type="search"
-              placeholder="Search command, project, path, or app…"
+              placeholder="Search by app, action, or reason…"
               value={searchQuery}
               onChange={handleSearchChange}
               aria-label="Search policies"

--- a/dashboard/src/policy-remembered-rules.test.tsx
+++ b/dashboard/src/policy-remembered-rules.test.tsx
@@ -30,14 +30,14 @@ const viewsSource = readFileSync(join(here, "policy-workspace-views.tsx"), "utf8
 
 assert(localSource.includes("No local remembered rules yet"), "local rules empty state title");
 assert(localSource.includes("Approve or block in Inbox"), "local rules empty state body");
+assert(localSource.includes("Local rules"), "local rules section badge");
+assert(localSource.includes("View all local rules"), "local rules view-all link");
 assert(localSource.includes("onClearPolicy"), "local rules support remove action");
-
 assert(cloudSource.includes("No Guard Cloud rules synced"), "cloud rules empty state title");
-assert(cloudSource.includes("Connect Guard Cloud"), "cloud rules empty state body");
 assert(cloudSource.includes("cloudVariant"), "cloud rules use cloud table variant");
 assert(!cloudSource.includes("onClearPolicy"), "cloud rules are read-only without remove");
 
-assert(tabSource.includes('placeholder="Search command, project, path, or app…"'), "tab preserves search");
+assert(tabSource.includes('placeholder="Search by app, action, or reason…"'), "tab preserves search");
 assert(tabSource.includes('aria-label="Filter by app"'), "tab preserves app filter");
 assert(tabSource.includes("All assets"), "tab uses mockup asset filter label");
 assert(tabSource.includes('aria-label="Filter by action type"'), "tab preserves family filter");
@@ -48,9 +48,9 @@ assert(tabSource.includes("PolicyRememberedRulesRightRail"), "tab mounts right r
 
 assert(railSource.includes("Active mode"), "right rail shows active mode card");
 assert(railSource.includes("Approvals are still fast"), "right rail explains fast approvals");
-assert(railSource.includes('scope: "artifact"'), "scope ladder includes narrowest scope");
-assert(railSource.includes('scope: "global"'), "scope ladder includes widest scope");
-assert(railSource.includes('scopeLabel(step.scope, "policy")'), "scope ladder renders policy scope labels");
+assert(railSource.includes("Once"), "scope ladder includes Once");
+assert(railSource.includes("Team policy"), "scope ladder includes Team policy");
+assert(railSource.includes("This cwd"), "scope ladder includes This cwd");
 assert(railSource.includes("Open Cloud exceptions tab"), "right rail links to Cloud exceptions tab");
 
 assert(workspaceSource.includes("PolicyRememberedRulesTab"), "workspace uses remembered rules tab");
@@ -59,7 +59,7 @@ assert(pageSource.includes("PolicyUnderlineTabBar"), "page hosts underline polic
 assert(pageSource.includes("PolicyPageToolbar"), "page hosts policy toolbar");
 assert(chromeSource.includes("Reload policy"), "policy toolbar exposes reload policy");
 
-assert(viewsSource.includes("Rule"), "rules list uses rule column");
+assert(viewsSource.includes("Description"), "rules list uses description column");
 assert(viewsSource.includes("Source"), "rules list shows source column");
 assert(viewsSource.includes('scopeLabel(policy.scope, "policy")'), "rules list uses policy scope labels");
 assert(viewsSource.includes("display.pathLine"), "rules list shows approval path");

--- a/dashboard/src/policy-strict-config-ia.test.ts
+++ b/dashboard/src/policy-strict-config-ia.test.ts
@@ -17,6 +17,7 @@ assert(!workspaceSource.includes("StrictModeView"), "legacy strict mode view rem
 assert(tabSource.includes("fetchSettings"), "strict config tab loads settings");
 assert(tabSource.includes("Evaluation order"), "strict config tab shows evaluation order");
 assert(tabSource.includes("Policy simulator"), "strict config tab includes simulator");
-assert(tabSource.includes("Signed Cloud bundle ack"), "strict config tab explains bundle acknowledgement");
+assert(tabSource.includes("Local enforcement preview"), "strict config tab shows enforcement preview");
+assert(tabSource.includes("Run simulation"), "strict config tab exposes run simulation");
 
 console.log("policy-strict-config-ia.test.ts: all assertions passed");

--- a/dashboard/src/policy-strict-config-segmented.tsx
+++ b/dashboard/src/policy-strict-config-segmented.tsx
@@ -38,7 +38,7 @@ export function StrictConfigActionSegmented({
   const showAdvanced = !PRIMARY_STRICT_ACTION_VALUES.has(value);
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-3 py-4 first:pt-0 last:pb-0">
       <div>
         <p className="text-sm font-medium text-brand-dark">{label}</p>
         {help ? <p className="mt-0.5 text-xs text-slate-500">{help}</p> : null}

--- a/dashboard/src/policy-strict-config-tab.tsx
+++ b/dashboard/src/policy-strict-config-tab.tsx
@@ -1,6 +1,17 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ChangeEvent } from "react";
-import { ActionButton, EmptyState, SectionLabel, Tag } from "./approval-center-primitives";
+import {
+  HiMiniArrowPath,
+  HiMiniArrowRight,
+  HiMiniBeaker,
+  HiMiniCheckCircle,
+  HiMiniCloud,
+  HiMiniNoSymbol,
+  HiMiniPlay,
+  HiMiniQueueList,
+  HiMiniShieldCheck,
+} from "react-icons/hi2";
+import { ActionButton, Badge, EmptyState, SectionLabel, Tag } from "./approval-center-primitives";
 import { formatRelativeTime, policyActionLabel } from "./approval-center-utils";
 import { fetchSettings, updateSettings } from "./guard-api";
 import type { GuardRuntimeSnapshot, GuardSettings } from "./guard-types";
@@ -8,7 +19,6 @@ import {
   fingerprintLocalPolicySettings,
   resolveStrictFileWriteAction,
   simulateStrictPolicyOutcome,
-  STRICT_POLICY_LAYER_OPTIONS,
   STRICT_POLICY_EVALUATION_ORDER,
 } from "./policy-strict-config-utils";
 import {
@@ -23,14 +33,31 @@ type PolicyStrictConfigTabProps = {
   snapshot: GuardRuntimeSnapshot;
   onOpenSettings?: () => void;
   onOpenInbox?: () => void;
+  onReloadPolicy?: () => void;
+  reloadingPolicy?: boolean;
 };
 
 type LoadState = "loading" | "ready" | "error";
 
+const EVALUATION_STEPS = [
+  { label: "Local rule", icon: HiMiniQueueList, tone: "purple" },
+  { label: "Cloud policy", icon: HiMiniCloud, tone: "blue" },
+  { label: "Cloud exception", icon: HiMiniCloud, tone: "blue" },
+  { label: "Strict fallback", icon: HiMiniShieldCheck, tone: "amber" },
+  { label: "Ask or block", icon: HiMiniNoSymbol, tone: "red" },
+] as const;
+
+const WHAT_CHANGES_BULLETS = [
+  "First-time actions follow your default strict action.",
+  "Changed tool hashes trigger your configured review path.",
+  "New network domains and subprocesses use strict fallback rules.",
+  "Cloud exceptions and remembered rules still win when they match.",
+] as const;
+
 const TEST_SCENARIOS = [
   {
     id: "first-time",
-    label: "First-time action",
+    label: "New tool contacting unknown domain",
     remembered: "none" as const,
     cloudPolicy: "none" as const,
     cloudException: false,
@@ -51,56 +78,23 @@ const TEST_SCENARIOS = [
   },
 ] as const;
 
-type SimLayerSelectProps = {
-  label: string;
-  value: "allow" | "block" | "none";
-  onChange: (value: "allow" | "block" | "none") => void;
-};
-
-function SimLayerSelect({ label, value, onChange }: SimLayerSelectProps) {
-  const handleChange = useCallback(
-    (event: ChangeEvent<HTMLSelectElement>) => {
-      const nextValue = event.target.value;
-      if (nextValue === "allow" || nextValue === "block" || nextValue === "none") {
-        onChange(nextValue);
-      }
-    },
-    [onChange],
-  );
-
-  return (
-    <label className="block space-y-1.5">
-      <span className="text-sm font-medium text-brand-dark">{label}</span>
-      <select
-        value={value}
-        onChange={handleChange}
-        className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark"
-      >
-        {STRICT_POLICY_LAYER_OPTIONS.map((option) => (
-          <option key={option.value} value={option.value}>
-            {option.label}
-          </option>
-        ))}
-      </select>
-    </label>
-  );
-}
-
 export function PolicyStrictConfigTab({
   snapshot,
   onOpenSettings,
   onOpenInbox,
+  onReloadPolicy,
+  reloadingPolicy = false,
 }: PolicyStrictConfigTabProps) {
   const [loadState, setLoadState] = useState<LoadState>("loading");
   const [loadError, setLoadError] = useState<string | null>(null);
   const [settings, setSettings] = useState<GuardSettings | null>(null);
-  const [configPath, setConfigPath] = useState<string | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savingKey, setSavingKey] = useState<string | null>(null);
   const [simRemembered, setSimRemembered] = useState<"allow" | "block" | "none">("none");
   const [simCloudPolicy, setSimCloudPolicy] = useState<"allow" | "block" | "none">("none");
   const [simCloudException, setSimCloudException] = useState(false);
   const [scenarioId, setScenarioId] = useState<string>(TEST_SCENARIOS[0].id);
+  const [simulationVisible, setSimulationVisible] = useState(false);
 
   const isStrict = settings?.security_level === "strict";
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
@@ -116,7 +110,6 @@ export function PolicyStrictConfigTab({
           return;
         }
         setSettings(payload.settings);
-        setConfigPath(payload.config_path);
         setLoadState("ready");
       })
       .catch((error) => {
@@ -182,16 +175,15 @@ export function PolicyStrictConfigTab({
   const handleSimCloudExceptionChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     setSimCloudException(event.target.checked);
   }, []);
-  const handleSimRememberedChange = useCallback((value: "allow" | "block" | "none") => {
-    setSimRemembered(value);
-  }, []);
-  const handleSimCloudPolicyChange = useCallback((value: "allow" | "block" | "none") => {
-    setSimCloudPolicy(value);
+
+  const handleRunSimulation = useCallback(() => {
+    setSimulationVisible(true);
   }, []);
 
   const handleScenarioChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
     const nextId = event.target.value;
     setScenarioId(nextId);
+    setSimulationVisible(false);
     const scenario = TEST_SCENARIOS.find((item) => item.id === nextId);
     if (!scenario) {
       return;
@@ -222,22 +214,29 @@ export function PolicyStrictConfigTab({
 
   const fileWriteAction = resolveStrictFileWriteAction(settings);
   const controlsDisabled = savingKey !== null;
+  const lastReloadAt = snapshot.runtime_state?.started_at ?? null;
+  const daemonAckLabel = cloudBundleCopy?.label ?? "Pending";
+  const expectedAction = simulation?.outcome ?? settings.default_action;
 
   return (
     <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start">
       <div className="space-y-4">
-        <div
-          className={`rounded-2xl border p-5 ${isStrict ? "border-brand-green/20 bg-brand-green/[0.04]" : "border-slate-200 bg-slate-50/40"}`}
-        >
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            <div>
-              <div className="mb-2 flex flex-wrap items-center gap-2">
-                <SectionLabel>Strict mode</SectionLabel>
-                <Tag tone={isStrict ? "green" : "slate"}>{isStrict ? "Enabled" : "Disabled"}</Tag>
+        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div className="flex items-start gap-3">
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue">
+                <HiMiniShieldCheck className="h-5 w-5" aria-hidden="true" />
+              </span>
+              <div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <h3 className="text-base font-semibold text-brand-dark">Strict mode</h3>
+                  <Tag tone={isStrict ? "green" : "slate"}>{isStrict ? "Enabled" : "Disabled"}</Tag>
+                </div>
+                <p className="mt-1 text-sm text-slate-600">Local enforcement tuning.</p>
+                <p className="mt-2 text-sm text-brand-dark/75">
+                  Guard asks before risky actions that are not already allowed by policy.
+                </p>
               </div>
-              <p className="text-sm text-brand-dark/75">
-                Local strict policy applies when no remembered rule, Cloud policy, or Cloud exception matches.
-              </p>
             </div>
             {!isStrict && onOpenSettings ? (
               <ActionButton variant="secondary" onClick={onOpenSettings}>
@@ -245,41 +244,49 @@ export function PolicyStrictConfigTab({
               </ActionButton>
             ) : null}
           </div>
-          <dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2">
+          <dl className="mt-5 grid gap-4 border-t border-slate-100 pt-4 sm:grid-cols-2 lg:grid-cols-4">
             <div>
-              <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Local policy hash</dt>
-              <dd className="mt-1 font-mono text-xs text-brand-dark">{localPolicyHash}</dd>
+              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Strict mode</dt>
+              <dd className="mt-1.5 text-sm font-medium text-brand-dark">{isStrict ? "Enabled" : "Disabled"}</dd>
             </div>
             <div>
-              <dt className="text-xs font-medium uppercase tracking-wide text-slate-500">Daemon last reload</dt>
-              <dd className="mt-1 text-brand-dark">
-                {snapshot.runtime_state?.started_at
-                  ? formatRelativeTime(snapshot.runtime_state.started_at)
-                  : "Unavailable"}
+              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Policy hash</dt>
+              <dd className="mt-1.5 flex items-center gap-1.5 font-mono text-sm text-brand-dark">{localPolicyHash}</dd>
+            </div>
+            <div>
+              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Daemon ack</dt>
+              <dd className="mt-1.5 flex items-center gap-1.5 text-sm text-brand-dark">
+                <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+                {daemonAckLabel}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last reload</dt>
+              <dd className="mt-1.5 text-sm text-brand-dark">
+                {lastReloadAt ? formatRelativeTime(lastReloadAt) : "Unavailable"}
               </dd>
             </div>
           </dl>
-          {cloudBundleCopy ? (
-            <div className="mt-4 rounded-xl border border-slate-100 bg-white/70 p-3">
-              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Signed Cloud bundle ack</p>
-              <p className="mt-1 text-sm font-medium text-brand-dark">{cloudBundleCopy.label}</p>
-              <p className="mt-1 text-sm text-slate-600">{cloudBundleCopy.detail}</p>
-              {snapshot.cloud_policy_bundle_hash ? (
-                <p className="mt-2 break-all font-mono text-[11px] text-slate-500">
-                  {snapshot.cloud_policy_bundle_hash}
-                </p>
-              ) : null}
+          {onReloadPolicy ? (
+            <div className="mt-4 flex justify-end border-t border-slate-100 pt-4">
+              <ActionButton variant="secondary" onClick={onReloadPolicy} disabled={reloadingPolicy}>
+                <HiMiniArrowPath className={`mr-1.5 h-4 w-4 ${reloadingPolicy ? "animate-spin" : ""}`} aria-hidden="true" />
+                Reload policy
+              </ActionButton>
             </div>
           ) : null}
         </div>
 
         <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <SectionLabel>Local strict policy</SectionLabel>
-          <p className="mt-2 text-sm text-slate-600">
-            Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches.
-          </p>
-          <p className="mt-1 text-xs text-slate-500">Config file: {configPath ?? "Unavailable"}</p>
-          <div className="mt-5 space-y-5">
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <SectionLabel>Local strict policy</SectionLabel>
+              <p className="mt-2 text-sm text-slate-600">
+                Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches.
+              </p>
+            </div>
+          </div>
+          <div className="mt-5 divide-y divide-slate-100">
             <StrictConfigActionSegmented
               label="Default action"
               help="First-time actions with no prior decision."
@@ -310,7 +317,7 @@ export function PolicyStrictConfigTab({
               disabled={controlsDisabled}
             />
             <StrictConfigActionSegmented
-              label="Destructive file write action"
+              label="File write action"
               help="Backed by the destructive shell risk control."
               value={fileWriteAction}
               settingKey="destructive_shell"
@@ -318,60 +325,83 @@ export function PolicyStrictConfigTab({
               disabled={controlsDisabled}
             />
           </div>
+          <p className="mt-4 text-xs text-slate-500">
+            These settings apply only when no remembered rule, Cloud policy, or Cloud exception covers the action.
+          </p>
           {saveError ? <p className="mt-3 text-sm text-red-600">{saveError}</p> : null}
           {savingKey ? <p className="mt-3 text-sm text-slate-500">Saving {savingKey.replace(/_/g, " ")}…</p> : null}
         </div>
 
         <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <SectionLabel>Evaluation order</SectionLabel>
-          <div className="mt-4 flex flex-wrap items-center gap-2 text-sm text-brand-dark/80">
-            {STRICT_POLICY_EVALUATION_ORDER.map((step, index) => (
-              <div key={step} className="flex items-center gap-2">
-                <span className="rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 font-medium">{step}</span>
-                {index < STRICT_POLICY_EVALUATION_ORDER.length - 1 ? (
-                  <span className="text-slate-400" aria-hidden="true">
-                    →
+          <SectionLabel>Local enforcement preview</SectionLabel>
+          <p className="mt-2 text-sm text-slate-600">Evaluation order when Guard decides what to do next.</p>
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            {EVALUATION_STEPS.map((step, index) => {
+              const Icon = step.icon;
+              return (
+                <div key={step.label} className="flex items-center gap-2">
+                  <span className="inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-brand-dark">
+                    <Icon className="h-4 w-4 text-brand-blue" aria-hidden="true" />
+                    {step.label}
                   </span>
-                ) : null}
-              </div>
-            ))}
+                  {index < EVALUATION_STEPS.length - 1 ? (
+                    <HiMiniArrowRight className="h-4 w-4 text-slate-400" aria-hidden="true" />
+                  ) : null}
+                </div>
+              );
+            })}
           </div>
+          <p className="mt-4 text-xs text-slate-500">
+            Evaluation order: {STRICT_POLICY_EVALUATION_ORDER.join(" → ")}. Tune fallback behavior locally; team policy
+            still syncs from Guard Cloud.
+          </p>
         </div>
       </div>
 
       <aside className="space-y-4 lg:sticky lg:top-4">
         <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
           <SectionLabel>What this changes</SectionLabel>
-          <p className="mt-2 text-sm text-brand-dark/75">
-            Stricter fallback controls increase review and block outcomes for first-time or changed actions on this
-            device.
-          </p>
+          <ul className="mt-3 space-y-2 text-sm text-slate-600">
+            {WHAT_CHANGES_BULLETS.map((item) => (
+              <li key={item} className="flex gap-2">
+                <HiMiniCheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
+                <span>{item}</span>
+              </li>
+            ))}
+          </ul>
         </div>
 
         <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-          <SectionLabel>Affected inbox</SectionLabel>
-          <p className="mt-2 text-3xl font-semibold text-brand-dark">{pendingInboxCount}</p>
+          <SectionLabel>Affected pending Inbox items</SectionLabel>
+          <p className="mt-2 text-4xl font-semibold tabular-nums text-brand-dark">{pendingInboxCount}</p>
           <p className="mt-1 text-sm text-slate-600">
             Pending review item{pendingInboxCount === 1 ? "" : "s"} may be affected by stricter fallback controls.
           </p>
-          {onOpenInbox && pendingInboxCount > 0 ? (
+          {onOpenInbox ? (
             <div className="mt-3">
               <ActionButton variant="secondary" onClick={onOpenInbox}>
                 Open Inbox
+                <HiMiniArrowRight className="ml-1.5 h-4 w-4" aria-hidden="true" />
               </ActionButton>
             </div>
           ) : null}
         </div>
 
-        <div className="rounded-2xl border border-slate-100 bg-slate-50/80 p-4 text-sm text-slate-600">
-          Cloud exceptions still require signed bundle acknowledgement before they apply locally.
+        <div className="rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
+          <p className="font-medium text-brand-dark">Cloud exceptions still apply</p>
+          <p className="mt-2 leading-relaxed">
+            Signed Cloud exceptions still require bundle acknowledgement before they apply locally.
+          </p>
         </div>
 
         <div className="rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4 shadow-sm">
-          <SectionLabel>Test policy</SectionLabel>
-          <p className="mt-2 text-sm text-slate-600">
-            Policy simulator: preview which layer wins for a hypothetical action without changing live policy.
-          </p>
+          <div className="flex items-start gap-2">
+            <HiMiniBeaker className="mt-0.5 h-5 w-5 shrink-0 text-brand-blue" aria-hidden="true" />
+            <div className="min-w-0 flex-1">
+              <SectionLabel>Test policy</SectionLabel>
+              <p className="mt-2 text-sm text-slate-600">Simulate how Guard will respond.</p>
+            </div>
+          </div>
           <label className="mt-4 block space-y-1.5">
             <span className="text-sm font-medium text-brand-dark">Scenario</span>
             <select
@@ -386,18 +416,24 @@ export function PolicyStrictConfigTab({
               ))}
             </select>
           </label>
-          <div className="mt-4 space-y-3">
-            <SimLayerSelect label="Remembered rule" value={simRemembered} onChange={handleSimRememberedChange} />
-            <SimLayerSelect label="Cloud policy" value={simCloudPolicy} onChange={handleSimCloudPolicyChange} />
-            <label className="flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark">
-              <input type="checkbox" checked={simCloudException} onChange={handleSimCloudExceptionChange} />
-              Active Cloud exception
-            </label>
+          <div className="mt-4 flex flex-wrap items-center justify-between gap-2">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Expected action</p>
+              <div className="mt-1">
+                <Badge tone={expectedAction === "block" ? "destructive" : expectedAction === "allow" ? "success" : "warning"}>
+                  {policyActionLabel(expectedAction)}
+                </Badge>
+              </div>
+            </div>
+            <ActionButton variant="secondary" onClick={handleRunSimulation}>
+              <HiMiniPlay className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              Run simulation
+            </ActionButton>
           </div>
-          {simulation ? (
+          {simulationVisible && simulation ? (
             <div className="mt-4 rounded-xl border border-slate-100 bg-white p-4">
               <p className="text-sm font-medium text-brand-dark">
-                Outcome: {policyActionLabel(simulation.outcome)} ({simulation.winningStep})
+                Policy simulator outcome: {policyActionLabel(simulation.outcome)} ({simulation.winningStep})
               </p>
               <ul className="mt-2 space-y-1 text-xs text-slate-600">
                 {simulation.path.map((step) => (

--- a/dashboard/src/policy-strict-config-tab.tsx
+++ b/dashboard/src/policy-strict-config-tab.tsx
@@ -388,7 +388,7 @@ export function PolicyStrictConfigTab({
           <p className="mt-1 text-sm text-slate-600">
             Pending review item{pendingInboxCount === 1 ? "" : "s"} may be affected by stricter fallback controls.
           </p>
-          {onOpenInbox ? (
+          {onOpenInbox && pendingInboxCount > 0 ? (
             <div className="mt-3">
               <ActionButton variant="secondary" onClick={onOpenInbox}>
                 Open Inbox

--- a/dashboard/src/policy-strict-config-tab.tsx
+++ b/dashboard/src/policy-strict-config-tab.tsx
@@ -78,6 +78,19 @@ const TEST_SCENARIOS = [
   },
 ] as const;
 
+function resolveExpectedActionTone(action: string): "success" | "destructive" | "warning" | "default" {
+  if (action === "block") {
+    return "destructive";
+  }
+  if (action === "allow") {
+    return "success";
+  }
+  if (action === "warn" || action === "review" || action === "require-reapproval") {
+    return "warning";
+  }
+  return "default";
+}
+
 export function PolicyStrictConfigTab({
   snapshot,
   onOpenSettings,
@@ -172,10 +185,6 @@ export function PolicyStrictConfigTab({
     [persistSetting],
   );
 
-  const handleSimCloudExceptionChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setSimCloudException(event.target.checked);
-  }, []);
-
   const handleRunSimulation = useCallback(() => {
     setSimulationVisible(true);
   }, []);
@@ -256,7 +265,9 @@ export function PolicyStrictConfigTab({
             <div>
               <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Daemon ack</dt>
               <dd className="mt-1.5 flex items-center gap-1.5 text-sm text-brand-dark">
-                <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+                {cloudBundleCopy ? (
+                  <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+                ) : null}
                 {daemonAckLabel}
               </dd>
             </div>
@@ -420,7 +431,7 @@ export function PolicyStrictConfigTab({
             <div>
               <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Expected action</p>
               <div className="mt-1">
-                <Badge tone={expectedAction === "block" ? "destructive" : expectedAction === "allow" ? "success" : "warning"}>
+                <Badge tone={resolveExpectedActionTone(expectedAction)}>
                   {policyActionLabel(expectedAction)}
                 </Badge>
               </div>

--- a/dashboard/src/policy-workspace-helpers.ts
+++ b/dashboard/src/policy-workspace-helpers.ts
@@ -475,3 +475,9 @@ export function resolveCloudPolicyBundleCopy(snapshot: {
     tone: "green",
   };
 }
+
+export function resolveCloudExceptionsConnected(snapshot: {
+  cloud_state?: string | null;
+}): boolean {
+  return snapshot.cloud_state === "paired_active" || snapshot.cloud_state === "paired_waiting";
+}

--- a/dashboard/src/policy-workspace-page.tsx
+++ b/dashboard/src/policy-workspace-page.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useState, Suspense, lazy } from "react";
 import type { GuardPolicyDecision, GuardRuntimeSnapshot } from "./guard-types";
 import { WorkspacePageHeader } from "./workspace-page-header";
-import { PolicyPageToolbar, PolicyUnderlineTabBar } from "./policy-page-chrome";
+import { PolicyExceptionsToolbar, PolicyPageToolbar, PolicyUnderlineTabBar } from "./policy-page-chrome";
 import type { PolicyPageView } from "./policy-workspace";
+import { resolveCloudPolicyControlsUrl } from "./policy-workspace-helpers";
 
 const PolicyWorkspace = lazy(() =>
   import("./policy-workspace").then((module) => ({ default: module.PolicyWorkspace })),
@@ -22,6 +23,10 @@ export function PolicyWorkspacePage(props: {
 }) {
   const [activeView, setActiveView] = useState<PolicyPageView>("rules");
   const [reloading, setReloading] = useState(false);
+  const [exceptionRequestOpen, setExceptionRequestOpen] = useState(false);
+  const cloudControlsUrl = resolveCloudPolicyControlsUrl(props.snapshot);
+  const cloudConnected =
+    props.snapshot.cloud_state === "paired_active" || props.snapshot.cloud_state === "paired_waiting";
 
   const handleOpenSettings = useCallback(() => props.onOpenSettings(), [props]);
   const handleOpenInbox = useCallback(() => props.onOpenInbox(), [props]);
@@ -41,13 +46,22 @@ export function PolicyWorkspacePage(props: {
       <WorkspacePageHeader
         eyebrow="Policy"
         title="Remembered rules and exceptions"
-        description="See what Guard will do next time, in plain language. Remove local remembered rules here or request Cloud exceptions when Guard Cloud is connected."
+        description="See what Guard will do next time, in plain language. Remove local rules or add custom exceptions here."
         actions={
-          <PolicyPageToolbar
-            snapshot={props.snapshot}
-            onReloadPolicy={handleReloadPolicy}
-            reloading={reloading}
-          />
+          activeView === "exceptions" ? (
+            <PolicyExceptionsToolbar
+              cloudConnected={cloudConnected}
+              cloudControlsUrl={cloudControlsUrl}
+              connectUrl={props.snapshot.connect_url?.trim() || null}
+              onRequestException={() => setExceptionRequestOpen(true)}
+            />
+          ) : (
+            <PolicyPageToolbar
+              snapshot={props.snapshot}
+              onReloadPolicy={handleReloadPolicy}
+              reloading={reloading}
+            />
+          )
         }
       />
       <PolicyUnderlineTabBar activeView={activeView} onViewChange={handleViewChange} />
@@ -60,6 +74,10 @@ export function PolicyWorkspacePage(props: {
           onOpenSettings={handleOpenSettings}
           onOpenInbox={handleOpenInbox}
           onOpenCloudExceptions={() => setActiveView("exceptions")}
+          exceptionRequestOpen={exceptionRequestOpen}
+          onExceptionRequestOpenChange={setExceptionRequestOpen}
+          onReloadPolicy={handleReloadPolicy}
+          reloadingPolicy={reloading}
         />
       </Suspense>
     </div>

--- a/dashboard/src/policy-workspace-page.tsx
+++ b/dashboard/src/policy-workspace-page.tsx
@@ -3,7 +3,7 @@ import type { GuardPolicyDecision, GuardRuntimeSnapshot } from "./guard-types";
 import { WorkspacePageHeader } from "./workspace-page-header";
 import { PolicyExceptionsToolbar, PolicyPageToolbar, PolicyUnderlineTabBar } from "./policy-page-chrome";
 import type { PolicyPageView } from "./policy-workspace";
-import { resolveCloudPolicyControlsUrl } from "./policy-workspace-helpers";
+import { resolveCloudPolicyControlsUrl, resolveCloudExceptionsConnected } from "./policy-workspace-helpers";
 
 const PolicyWorkspace = lazy(() =>
   import("./policy-workspace").then((module) => ({ default: module.PolicyWorkspace })),
@@ -25,8 +25,7 @@ export function PolicyWorkspacePage(props: {
   const [reloading, setReloading] = useState(false);
   const [exceptionRequestOpen, setExceptionRequestOpen] = useState(false);
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(props.snapshot);
-  const cloudConnected =
-    props.snapshot.cloud_state === "paired_active" || props.snapshot.cloud_state === "paired_waiting";
+  const cloudConnected = resolveCloudExceptionsConnected(props.snapshot);
 
   const handleOpenSettings = useCallback(() => props.onOpenSettings(), [props]);
   const handleOpenInbox = useCallback(() => props.onOpenInbox(), [props]);

--- a/dashboard/src/policy-workspace-views.tsx
+++ b/dashboard/src/policy-workspace-views.tsx
@@ -28,10 +28,13 @@ import {
 export type PolicySortKey = "app" | "updated";
 export type PolicySortState = { key: PolicySortKey; direction: "asc" | "desc" } | null;
 
-const PAGE_SIZE = 30;
+const PAGE_SIZE = 5;
 
 const RULE_GRID_CLASS =
-  "grid grid-cols-[minmax(0,1fr)] items-start gap-x-3 gap-y-3 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50/80 md:grid-cols-[72px_minmax(220px,1.4fr)_100px_96px_88px_104px_minmax(120px,1fr)]";
+  "grid grid-cols-[minmax(0,1fr)] items-center gap-x-3 gap-y-2 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50/80 md:grid-cols-[40px_72px_minmax(200px,1.4fr)_88px_96px_88px_104px_minmax(120px,1fr)_72px]";
+
+const RULE_HEADER_CLASS =
+  "hidden border-b border-slate-100 bg-slate-50/80 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500 md:grid md:grid-cols-[40px_72px_minmax(200px,1.4fr)_88px_96px_88px_104px_minmax(120px,1fr)_72px] md:gap-x-3";
 
 function resolveActionTone(action: string): "success" | "destructive" | "warning" | "default" {
   if (action === "allow") {
@@ -81,19 +84,22 @@ function PolicyRuleRow({ policy, cloudControlsUrl, onClear, cloudVariant = false
 
   return (
     <article className={RULE_GRID_CLASS} role="listitem">
-      <div className="flex items-start gap-2 md:col-start-1">
-        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500">
+      <div className="hidden items-center justify-center md:flex">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500">
+          <Icon className="h-4 w-4" aria-hidden="true" />
+        </span>
+      </div>
+
+      <div className="flex items-center gap-2 md:col-start-2">
+        <span className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500 md:hidden">
           <Icon className="h-4 w-4" aria-hidden="true" />
         </span>
         <Badge tone={resolveActionTone(policy.action)}>{policyActionLabel(policy.action)}</Badge>
       </div>
 
-      <div className="min-w-0 md:col-start-2">
+      <div className="min-w-0 md:col-start-3">
         <p className="text-sm font-semibold leading-snug text-brand-dark">{title}</p>
-        {display.kindLine ? <p className="mt-1 text-xs text-slate-500">{display.kindLine}</p> : null}
-        {display.pathLine ? (
-          <p className="mt-1 break-all font-mono text-[11px] leading-relaxed text-slate-500">{display.pathLine}</p>
-        ) : null}
+        {display.kindLine ? <p className="mt-0.5 text-xs text-slate-500">{display.kindLine}</p> : null}
         <div className="mt-2 flex flex-wrap gap-3 text-xs text-slate-600 md:hidden">
           <span>{resolvePolicyRowSourceLabel(policy)}</span>
           <span>{scopeTag}</span>
@@ -101,23 +107,23 @@ function PolicyRuleRow({ policy, cloudControlsUrl, onClear, cloudVariant = false
         </div>
       </div>
 
-      <div className="hidden text-sm text-brand-dark md:col-start-3 md:block">
+      <div className="hidden text-sm text-brand-dark md:col-start-4 md:block">
         {cloudManaged ? <Tag tone="blue">{resolvePolicyRowSourceLabel(policy)}</Tag> : resolvePolicyRowSourceLabel(policy)}
       </div>
 
-      <div className="hidden md:col-start-4 md:block">
+      <div className="hidden md:col-start-5 md:block">
         <Tag tone="blue">{scopeTag}</Tag>
       </div>
 
-      <div className="hidden text-sm text-brand-dark md:col-start-5 md:block">
+      <div className="hidden text-sm text-brand-dark md:col-start-6 md:block">
         {harnessDisplayName(policy.harness)}
       </div>
 
-      <div className="hidden whitespace-nowrap text-xs text-slate-500 md:col-start-6 md:block">
+      <div className="hidden whitespace-nowrap text-xs text-slate-500 md:col-start-7 md:block">
         {policy.updated_at ? formatRelativeTime(policy.updated_at) : "—"}
       </div>
 
-      <div className="flex min-w-0 flex-col items-start gap-2 md:col-start-7 md:items-end">
+      <div className="hidden min-w-0 md:col-start-8 md:block">
         {!cloudManaged ? (
           <a
             href={guardAwareHref(resolvePolicyEvidenceHref(policy))}
@@ -132,12 +138,15 @@ function PolicyRuleRow({ policy, cloudControlsUrl, onClear, cloudVariant = false
             href={cloudControlsUrl}
             target="_blank"
             rel="noopener noreferrer"
-            className="inline-flex items-center gap-1 text-sm font-medium text-brand-blue hover:underline"
+            className="inline-flex items-center gap-1 text-xs font-medium text-brand-blue hover:underline"
           >
-            <HiMiniCloudArrowUp className="h-4 w-4" aria-hidden="true" />
+            <HiMiniCloudArrowUp className="h-3.5 w-3.5" aria-hidden="true" />
             View on cloud
           </a>
         ) : null}
+      </div>
+
+      <div className="hidden items-center justify-end md:col-start-9 md:flex">
         {cloudManaged ? (
           <span className="inline-flex items-center gap-1 text-xs font-medium text-slate-500" title="Read-only Cloud policy">
             <HiMiniLockClosed className="h-3.5 w-3.5" aria-hidden="true" />
@@ -167,6 +176,7 @@ type PolicyRuleTableProps = {
   emptyBody: string;
   cloudVariant?: boolean;
   totalCount?: number;
+  viewAllLabel?: string;
 };
 
 export function PolicyRuleTable({
@@ -177,16 +187,25 @@ export function PolicyRuleTable({
   emptyBody,
   cloudVariant = false,
   totalCount,
+  viewAllLabel,
 }: PolicyRuleTableProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
+  const [expanded, setExpanded] = useState(false);
 
-  const visiblePolicies = useMemo(() => policies.slice(0, visibleCount), [policies, visibleCount]);
-  const remaining = policies.length - visibleCount;
-  const hasMore = remaining > 0;
+  const visiblePolicies = useMemo(
+    () => (expanded ? policies : policies.slice(0, visibleCount)),
+    [expanded, policies, visibleCount],
+  );
+  const remaining = policies.length - visiblePolicies.length;
+  const hasMore = !expanded && remaining > 0;
   const listTotal = totalCount ?? policies.length;
 
   const handleShowMore = useCallback(() => {
     setVisibleCount((current) => current + PAGE_SIZE);
+  }, []);
+
+  const handleViewAll = useCallback(() => {
+    setExpanded(true);
   }, []);
 
   if (policies.length === 0) {
@@ -196,17 +215,16 @@ export function PolicyRuleTable({
   return (
     <div className="space-y-3">
       <div className="overflow-x-auto rounded-2xl border border-slate-100 bg-white shadow-sm">
-        <div
-          className="hidden border-b border-slate-100 bg-slate-50/80 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500 md:grid md:grid-cols-[72px_minmax(220px,1.4fr)_100px_96px_88px_104px_minmax(120px,1fr)] md:gap-x-3"
-          aria-hidden="true"
-        >
+        <div className={RULE_HEADER_CLASS} aria-hidden="true">
+          <span />
           <span>Action</span>
-          <span>Rule</span>
+          <span>Description</span>
           <span>Source</span>
           <span>Scope</span>
           <span>{cloudVariant ? "Applies to" : "Harness"}</span>
           <span>Last updated</span>
-          <span className="text-right">{cloudVariant ? "Policy" : "Approval record"}</span>
+          <span>{cloudVariant ? "Policy" : "Approval record"}</span>
+          <span className="text-right">{cloudVariant ? "" : "Actions"}</span>
         </div>
         <div role="list">
           {visiblePolicies.map((policy) => (
@@ -220,7 +238,17 @@ export function PolicyRuleTable({
           ))}
         </div>
       </div>
-      {hasMore ? (
+      {hasMore && viewAllLabel ? (
+        <div className="flex justify-center pt-1">
+          <button
+            type="button"
+            onClick={handleViewAll}
+            className="text-sm font-medium text-brand-blue hover:underline"
+          >
+            {viewAllLabel.replace("{count}", String(listTotal))}
+          </button>
+        </div>
+      ) : hasMore ? (
         <div className="flex justify-center pt-1">
           <button
             type="button"
@@ -237,6 +265,7 @@ export function PolicyRuleTable({
 
 type GroupedPolicySectionProps = {
   title: string;
+  badge?: string;
   description: string;
   policies: GuardPolicyDecision[];
   cloudControlsUrl: string | null;
@@ -245,10 +274,12 @@ type GroupedPolicySectionProps = {
   emptyBody: string;
   defaultOpen?: boolean;
   cloudVariant?: boolean;
+  viewAllLabel?: string;
 };
 
 export function GroupedPolicySection({
   title,
+  badge,
   description,
   policies,
   cloudControlsUrl,
@@ -257,6 +288,7 @@ export function GroupedPolicySection({
   emptyBody,
   defaultOpen = true,
   cloudVariant = false,
+  viewAllLabel,
 }: GroupedPolicySectionProps) {
   const [open, setOpen] = useState(defaultOpen);
   const handleToggle = useCallback(() => setOpen((current) => !current), []);
@@ -265,10 +297,11 @@ export function GroupedPolicySection({
   if (policies.length === 0) {
     return (
       <section className="space-y-2">
-        <div>
+        <div className="flex flex-wrap items-center gap-2">
           <h2 className="text-base font-semibold text-brand-dark">{title}</h2>
-          <p className="text-sm text-slate-500">{description}</p>
+          {badge ? <Tag tone="slate">{badge}</Tag> : null}
         </div>
+        <p className="text-sm text-slate-500">{description}</p>
         <EmptyState title={emptyTitle} body={emptyBody} tone="teach" />
       </section>
     );
@@ -279,15 +312,18 @@ export function GroupedPolicySection({
       <button
         type="button"
         onClick={handleToggle}
-        className="flex w-full items-center justify-between gap-3 rounded-xl border border-slate-100 bg-slate-50/70 px-4 py-3 text-left"
+        className="flex w-full items-start justify-between gap-3 text-left"
         aria-expanded={open}
       >
-        <div>
-          <h2 className="text-base font-semibold text-brand-dark">{title}</h2>
-          <p className="text-sm text-slate-500">{description}</p>
+        <div className="min-w-0">
+          <div className="flex flex-wrap items-center gap-2">
+            <h2 className="text-base font-semibold text-brand-dark">{title}</h2>
+            {badge ? <Tag tone="slate">{badge}</Tag> : null}
+          </div>
+          <p className="mt-1 text-sm text-slate-500">{description}</p>
         </div>
-        <div className="flex items-center gap-2">
-          <Tag tone="slate">{ruleLabel}</Tag>
+        <div className="flex shrink-0 items-center gap-2 pt-0.5">
+          <span className="text-sm text-slate-500">{ruleLabel}</span>
           {open ? (
             <HiMiniChevronUp className="h-4 w-4 text-slate-400" aria-hidden="true" />
           ) : (
@@ -304,6 +340,7 @@ export function GroupedPolicySection({
           emptyBody={emptyBody}
           cloudVariant={cloudVariant}
           totalCount={policies.length}
+          viewAllLabel={viewAllLabel}
         />
       ) : null}
     </section>

--- a/dashboard/src/policy-workspace-views.tsx
+++ b/dashboard/src/policy-workspace-views.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import {
   HiMiniTrash,
   HiMiniCloudArrowUp,
@@ -191,6 +191,11 @@ export function PolicyRuleTable({
 }: PolicyRuleTableProps) {
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
   const [expanded, setExpanded] = useState(false);
+
+  useEffect(() => {
+    setExpanded(false);
+    setVisibleCount(PAGE_SIZE);
+  }, [policies]);
 
   const visiblePolicies = useMemo(
     () => (expanded ? policies : policies.slice(0, visibleCount)),

--- a/dashboard/src/policy-workspace-views.tsx
+++ b/dashboard/src/policy-workspace-views.tsx
@@ -100,6 +100,9 @@ function PolicyRuleRow({ policy, cloudControlsUrl, onClear, cloudVariant = false
       <div className="min-w-0 md:col-start-3">
         <p className="text-sm font-semibold leading-snug text-brand-dark">{title}</p>
         {display.kindLine ? <p className="mt-0.5 text-xs text-slate-500">{display.kindLine}</p> : null}
+        {display.pathLine ? (
+          <p className="mt-0.5 break-all font-mono text-[11px] leading-relaxed text-slate-500">{display.pathLine}</p>
+        ) : null}
         <div className="mt-2 flex flex-wrap gap-3 text-xs text-slate-600 md:hidden">
           <span>{resolvePolicyRowSourceLabel(policy)}</span>
           <span>{scopeTag}</span>

--- a/dashboard/src/policy-workspace.tsx
+++ b/dashboard/src/policy-workspace.tsx
@@ -30,6 +30,10 @@ type PolicyWorkspaceProps = {
   onOpenSettings?: () => void;
   onOpenInbox?: () => void;
   onOpenCloudExceptions?: () => void;
+  exceptionRequestOpen?: boolean;
+  onExceptionRequestOpenChange?: (open: boolean) => void;
+  onReloadPolicy?: () => void;
+  reloadingPolicy?: boolean;
 };
 
 export function PolicyWorkspace({
@@ -40,6 +44,10 @@ export function PolicyWorkspace({
   onOpenSettings,
   onOpenInbox,
   onOpenCloudExceptions,
+  exceptionRequestOpen = false,
+  onExceptionRequestOpenChange,
+  onReloadPolicy,
+  reloadingPolicy = false,
 }: PolicyWorkspaceProps) {
   if (activeView === "rules") {
     return (
@@ -58,14 +66,24 @@ export function PolicyWorkspace({
   if (activeView === "exceptions") {
     return (
       <div id="policy-panel-exceptions" role="tabpanel" aria-labelledby="policy-tab-exceptions">
-        <PolicyCloudExceptionsTab snapshot={snapshot} />
+        <PolicyCloudExceptionsTab
+          snapshot={snapshot}
+          requestOpen={exceptionRequestOpen}
+          onRequestOpenChange={onExceptionRequestOpenChange}
+        />
       </div>
     );
   }
 
   return (
     <div id="policy-panel-strict" role="tabpanel" aria-labelledby="policy-tab-strict">
-      <PolicyStrictConfigTab snapshot={snapshot} onOpenSettings={onOpenSettings} onOpenInbox={onOpenInbox} />
+      <PolicyStrictConfigTab
+        snapshot={snapshot}
+        onOpenSettings={onOpenSettings}
+        onOpenInbox={onOpenInbox}
+        onReloadPolicy={onReloadPolicy}
+        reloadingPolicy={reloadingPolicy}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Align Policy page layout across Remembered rules, Cloud exceptions, and Strict config with the approved M1–M4 mockups.
- Move Cloud exception header CTAs to the page toolbar, refresh remembered-rules table chrome, bundle card, right rail, and strict-config preview rail.
- Keep production UI on real daemon/Cloud data with honest empty states; no fixture rows or hardcoded counts.

## Testing
- `cd dashboard && npm test -- --testPathPattern="policy-"`
- `cd dashboard && npm run build`

