### PR TITLE
feat(guard): harden local policy integrity

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -289,7 +289,7 @@ def _run_guard_policies_command(
         counts = payload.get("counts")
         if not isinstance(counts, dict) or payload.get("enforcement") != "enforce":
             return 0
-        blocking_statuses = ("tampered", "unknown_key", "missing_integrity", "degraded_mode")
+        blocking_statuses = ("tampered", "unknown_key", "missing_integrity", "rollback_detected", "degraded_mode")
         if any(int(counts.get(status, 0) or 0) > 0 for status in blocking_statuses):
             return 1
         return 0

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -738,6 +738,7 @@ def _render_policies(console: Console, payload: dict[str, object]) -> None:
             ("Unsigned", "missing_integrity"),
             ("Tampered", "tampered"),
             ("Unknown key", "unknown_key"),
+            ("Rolled back", "rollback_detected"),
             ("Degraded", "degraded_mode"),
         ):
             body.add_row(label, str(int(counts.get(key, 0) or 0)))

--- a/src/codex_plugin_scanner/guard/policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/policy_integrity.py
@@ -9,8 +9,10 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Literal
 
-POLICY_INTEGRITY_VERSION = 1
+POLICY_INTEGRITY_VERSION = 2
 POLICY_INTEGRITY_MAC_ALGORITHM = "hmac-sha256"
+_LEGACY_POLICY_INTEGRITY_VERSION = 1
+_SUPPORTED_POLICY_INTEGRITY_VERSIONS = frozenset({_LEGACY_POLICY_INTEGRITY_VERSION, POLICY_INTEGRITY_VERSION})
 REMOTE_POLICY_SOURCES = frozenset({"cloud-sync", "team-policy", "policy-bundle"})
 
 PolicyIntegrityStatus = Literal[
@@ -18,6 +20,7 @@ PolicyIntegrityStatus = Literal[
     "missing_integrity",
     "tampered",
     "unknown_key",
+    "rollback_detected",
     "degraded_mode",
 ]
 
@@ -39,21 +42,29 @@ def canonical_policy_payload(
     *,
     integrity_version: int | None = None,
 ) -> bytes:
-    payload = {
+    resolved_version = (
+        integrity_version
+        if integrity_version is not None
+        else (_int_or_none(_mapping_value(row, "integrity_version")) or POLICY_INTEGRITY_VERSION)
+    )
+    payload: dict[str, object] = {
         "action": _string_or_none(_mapping_value(row, "action")),
         "artifact_hash": _string_or_none(_mapping_value(row, "artifact_hash")),
         "artifact_id": _string_or_none(_mapping_value(row, "artifact_id")),
         "expires_at": _string_or_none(_mapping_value(row, "expires_at")),
         "harness": _string_or_none(_mapping_value(row, "harness")),
-        "integrity_version": integrity_version
-        if integrity_version is not None
-        else (_int_or_none(_mapping_value(row, "integrity_version")) or POLICY_INTEGRITY_VERSION),
+        "integrity_version": resolved_version,
         "publisher": _string_or_none(_mapping_value(row, "publisher")),
         "scope": _string_or_none(_mapping_value(row, "scope")),
         "source": _string_or_none(_mapping_value(row, "source")),
         "updated_at": _string_or_none(_mapping_value(row, "updated_at")),
         "workspace": _string_or_none(_mapping_value(row, "workspace")),
     }
+    if resolved_version == POLICY_INTEGRITY_VERSION:
+        payload["decision_id"] = _int_or_none(_mapping_value(row, "decision_id"))
+        payload["integrity_generation"] = _int_or_none(_mapping_value(row, "integrity_generation"))
+        payload["owner"] = _string_or_none(_mapping_value(row, "owner"))
+        payload["reason"] = _string_or_none(_mapping_value(row, "reason"))
     return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
 
 
@@ -63,12 +74,16 @@ def sign_local_policy_row(
     *,
     key_id: str,
     signed_at: str,
+    generation: int,
 ) -> dict[str, object]:
-    payload = canonical_policy_payload(row, integrity_version=POLICY_INTEGRITY_VERSION)
+    signing_row = dict(row)
+    signing_row["integrity_generation"] = generation
+    payload = canonical_policy_payload(signing_row, integrity_version=POLICY_INTEGRITY_VERSION)
     payload_hash = hashlib.sha256(payload).hexdigest()
     payload_mac = hmac.new(key, payload, hashlib.sha256).hexdigest()
     return {
         "integrity_version": POLICY_INTEGRITY_VERSION,
+        "integrity_generation": generation,
         "payload_hash": payload_hash,
         "payload_mac": payload_mac,
         "integrity_key_id": key_id,
@@ -82,6 +97,7 @@ def verify_local_policy_row(
     key: bytes | None,
     key_id: str | None,
     degraded_mode: bool = False,
+    trusted_generation: int | None = None,
 ) -> PolicyIntegrityVerificationResult:
     stored_key_id = _string_or_none(_mapping_value(row, "integrity_key_id"))
     stored_payload_hash = _string_or_none(_mapping_value(row, "payload_hash"))
@@ -109,12 +125,12 @@ def verify_local_policy_row(
             key_id=stored_key_id,
             message="policy_integrity_metadata_missing",
         )
-    if version != POLICY_INTEGRITY_VERSION:
+    if version not in _SUPPORTED_POLICY_INTEGRITY_VERSIONS:
         return PolicyIntegrityVerificationResult(
             status="tampered",
             payload_hash=stored_payload_hash,
             key_id=stored_key_id,
-            message="policy_integrity_version_mismatch",
+            message="policy_integrity_version_unsupported",
         )
     if key is None or key_id is None or stored_key_id != key_id:
         return PolicyIntegrityVerificationResult(
@@ -142,6 +158,15 @@ def verify_local_policy_row(
             key_id=stored_key_id,
             message="policy_integrity_mac_mismatch",
         )
+    if version == POLICY_INTEGRITY_VERSION and trusted_generation is not None:
+        stored_generation = _int_or_none(_mapping_value(row, "integrity_generation"))
+        if stored_generation != trusted_generation:
+            return PolicyIntegrityVerificationResult(
+                status="rollback_detected",
+                payload_hash=computed_payload_hash,
+                key_id=stored_key_id,
+                message="policy_integrity_generation_rollback",
+            )
     return PolicyIntegrityVerificationResult(
         status="valid",
         payload_hash=computed_payload_hash,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -161,6 +161,7 @@ from .types import CapabilitySet
 
 _SYNC_TOKEN_REF = "guard-cloud-token"
 _POLICY_INTEGRITY_KEY_REF = "guard-policy-integrity-key"
+_POLICY_INTEGRITY_CONTROL_REF = "guard-policy-integrity-control"
 _OAUTH_LOCAL_CREDENTIALS_REF = "guard-oauth-local-credentials"
 _SYNC_TOKEN_HASH_KEY = "token_sha256"
 _OAUTH_LOCAL_CREDENTIALS_STATE_KEY = "oauth_local_credentials"
@@ -188,12 +189,14 @@ _MAX_RESOLVED_SCOPE_IDS = 200
 _SQLITE_ID_BATCH_SIZE = 500
 _WORKSPACE_POLICY_KEY_PREFIX = "workspace:"
 _POLICY_INTEGRITY_STATE_KEY = "policy_integrity"
+_POLICY_INTEGRITY_CONTROL_VERSION = 1
 _POLICY_INTEGRITY_ENFORCEMENTS = frozenset({"warn", "enforce"})
 _POLICY_INTEGRITY_STATUSES = (
     "valid",
     "missing_integrity",
     "tampered",
     "unknown_key",
+    "rollback_detected",
     "degraded_mode",
 )
 _SCOPED_HARNESS_FAMILIES = frozenset(
@@ -832,6 +835,7 @@ class GuardStore:
         self._cached_oauth_secret_payload: tuple[str, str, str] | None = None
         self._sync_token_ref = self._build_scoped_secret_ref(_SYNC_TOKEN_REF)
         self._policy_integrity_key_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_KEY_REF)
+        self._policy_integrity_control_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_CONTROL_REF)
         self._oauth_local_credentials_ref = self._build_scoped_secret_ref(_OAUTH_LOCAL_CREDENTIALS_REF)
         self._guard_event_queue_limit = max(1, guard_event_queue_limit)
         self.path = self.guard_home / "guard.db"
@@ -973,6 +977,79 @@ class GuardStore:
         key_id = self._versioned_secret_ref(self._policy_integrity_key_ref, sha256(raw_key).hexdigest())
         return raw_key, key_id
 
+    @staticmethod
+    def _default_policy_integrity_control_state() -> dict[str, object]:
+        return {
+            "cutover_complete": False,
+            "generation": 0,
+            "pending_generation": None,
+            "version": _POLICY_INTEGRITY_CONTROL_VERSION,
+        }
+
+    @staticmethod
+    def _normalize_policy_integrity_control_state(payload: object) -> dict[str, object] | None:
+        if not isinstance(payload, dict):
+            return None
+        version = payload.get("version")
+        generation = payload.get("generation")
+        pending_generation = payload.get("pending_generation")
+        cutover_complete = payload.get("cutover_complete")
+        if version != _POLICY_INTEGRITY_CONTROL_VERSION:
+            return None
+        if isinstance(generation, bool) or not isinstance(generation, int) or generation < 0:
+            return None
+        if pending_generation is not None and (
+            isinstance(pending_generation, bool)
+            or not isinstance(pending_generation, int)
+            or pending_generation <= generation
+        ):
+            return None
+        if not isinstance(cutover_complete, bool):
+            return None
+        return {
+            "cutover_complete": cutover_complete,
+            "generation": generation,
+            "pending_generation": pending_generation,
+            "version": version,
+        }
+
+    def _load_policy_integrity_control_state(self, *, create: bool) -> dict[str, object] | None:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is None:
+            return None
+        payload_json = self._get_secret_from_store(secret_store, self._policy_integrity_control_ref)
+        payload: dict[str, object] | None = None
+        if payload_json is not None:
+            try:
+                payload = self._normalize_policy_integrity_control_state(json.loads(payload_json))
+            except json.JSONDecodeError:
+                payload = None
+        if payload is not None or not create:
+            return payload
+        payload = self._default_policy_integrity_control_state()
+        if not self._store_policy_integrity_control_state(payload):
+            return None
+        return self._load_policy_integrity_control_state(create=False)
+
+    def _store_policy_integrity_control_state(self, payload: dict[str, object]) -> bool:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is None:
+            return False
+        normalized = self._normalize_policy_integrity_control_state(payload)
+        if normalized is None:
+            return False
+        try:
+            secret_store.set_secret(
+                self._policy_integrity_control_ref,
+                json.dumps(normalized, sort_keys=True, separators=(",", ":")),
+            )
+        except Exception:
+            return False
+        return True
+
+    def _finalize_policy_integrity_control_state(self, payload: dict[str, object]) -> None:
+        self._store_policy_integrity_control_state(payload)
+
     def _policy_integrity_path_warnings(self) -> list[str]:
         warnings: list[str] = []
         if self.guard_home.is_symlink():
@@ -1050,6 +1127,152 @@ class GuardStore:
         ).fetchone()
         return int(row["total"]) if row is not None else 0
 
+    @staticmethod
+    def _count_local_policy_rows(
+        connection: sqlite3.Connection,
+        *,
+        harness: str | None = None,
+    ) -> int:
+        query = f"""
+            select count(*) as total
+            from policy_decisions
+            where source not in {_REMOTE_POLICY_SOURCE_PLACEHOLDERS}
+        """
+        params: tuple[object, ...] = _REMOTE_POLICY_SOURCE_PARAMS
+        if harness is not None:
+            query += " and harness = ?"
+            params = (*params, harness)
+        row = connection.execute(query, params).fetchone()
+        return int(row["total"]) if row is not None else 0
+
+    def _advance_policy_integrity_generation(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        now: str,
+        key: bytes,
+        key_id: str,
+        trusted_state: dict[str, object],
+        force_sign_decision_ids: set[int] | None = None,
+        harness: str | None = None,
+    ) -> dict[str, object]:
+        current_generation = int(trusted_state["generation"])
+        next_generation = current_generation + 1
+        sign_ids = force_sign_decision_ids or set()
+        pending_state = {
+            "cutover_complete": True,
+            "generation": current_generation,
+            "pending_generation": next_generation,
+            "version": _POLICY_INTEGRITY_CONTROL_VERSION,
+        }
+        if not self._store_policy_integrity_control_state(pending_state):
+            raise RuntimeError("Guard could not persist the policy integrity control state.")
+        for row in self._load_local_policy_rows(connection, harness=harness):
+            decision_id = int(row["decision_id"])
+            should_sign = decision_id in sign_ids
+            if not should_sign:
+                integrity_result = verify_local_policy_row(
+                    row,
+                    key=key,
+                    key_id=key_id,
+                    degraded_mode=False,
+                    trusted_generation=current_generation,
+                )
+                should_sign = integrity_result.status == "valid"
+            if not should_sign:
+                continue
+            signed = sign_local_policy_row(
+                row,
+                key,
+                key_id=key_id,
+                signed_at=now,
+                generation=next_generation,
+            )
+            connection.execute(
+                """
+                update policy_decisions
+                set integrity_version = ?,
+                    integrity_generation = ?,
+                    payload_hash = ?,
+                    payload_mac = ?,
+                    integrity_key_id = ?,
+                    signed_at = ?
+                where decision_id = ?
+                """,
+                (
+                    signed["integrity_version"],
+                    signed["integrity_generation"],
+                    signed["payload_hash"],
+                    signed["payload_mac"],
+                    signed["integrity_key_id"],
+                    signed["signed_at"],
+                    decision_id,
+                ),
+            )
+        return {
+            "cutover_complete": True,
+            "generation": next_generation,
+            "pending_generation": None,
+            "version": _POLICY_INTEGRITY_CONTROL_VERSION,
+        }
+
+    def _reconcile_policy_integrity_pending_generation(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        key: bytes,
+        key_id: str,
+        trusted_state: dict[str, object],
+    ) -> dict[str, object]:
+        current_generation = int(trusted_state["generation"])
+        pending_generation = trusted_state.get("pending_generation")
+        if not isinstance(pending_generation, int) or pending_generation <= current_generation:
+            return trusted_state
+        rows = self._load_local_policy_rows(connection)
+        if not rows:
+            next_state = {
+                "cutover_complete": True,
+                "generation": pending_generation,
+                "pending_generation": None,
+                "version": _POLICY_INTEGRITY_CONTROL_VERSION,
+            }
+        else:
+            pending_valid = 0
+            current_valid = 0
+            for row in rows:
+                pending_result = verify_local_policy_row(
+                    row,
+                    key=key,
+                    key_id=key_id,
+                    degraded_mode=False,
+                    trusted_generation=pending_generation,
+                )
+                if pending_result.status == "valid":
+                    pending_valid += 1
+                    continue
+                current_result = verify_local_policy_row(
+                    row,
+                    key=key,
+                    key_id=key_id,
+                    degraded_mode=False,
+                    trusted_generation=current_generation,
+                )
+                if current_result.status == "valid":
+                    current_valid += 1
+            if pending_valid > 0 or current_valid == 0:
+                next_state = {
+                    "cutover_complete": True,
+                    "generation": pending_generation,
+                    "pending_generation": None,
+                    "version": _POLICY_INTEGRITY_CONTROL_VERSION,
+                }
+            else:
+                next_state = dict(trusted_state)
+                next_state["pending_generation"] = None
+        if not self._store_policy_integrity_control_state(next_state):
+            raise RuntimeError("Guard could not persist the policy integrity control state.")
+        return next_state
+
     def _refresh_policy_integrity_state(
         self,
         connection: sqlite3.Connection,
@@ -1057,9 +1280,11 @@ class GuardStore:
         now: str,
         create_key: bool,
         secret_material: tuple[bytes | None, str | None] | None = None,
+        allow_cutover_resign: bool = True,
     ) -> dict[str, object]:
         existing = self._load_policy_integrity_state(connection) or {}
         warnings = self._policy_integrity_path_warnings()
+        trusted_state = self._load_policy_integrity_control_state(create=create_key)
         raw_key, key_id = (
             secret_material
             if secret_material is not None
@@ -1069,17 +1294,40 @@ class GuardStore:
             warnings.append("system_keyring_unavailable")
         elif raw_key is None or key_id is None:
             warnings.append("policy_integrity_key_unavailable")
+        if trusted_state is None:
+            warnings.append("policy_integrity_control_unavailable")
+        if not warnings and trusted_state is not None and raw_key is not None and key_id is not None:
+            try:
+                trusted_state = self._reconcile_policy_integrity_pending_generation(
+                    connection,
+                    key=raw_key,
+                    key_id=key_id,
+                    trusted_state=trusted_state,
+                )
+            except RuntimeError:
+                warnings.append("policy_integrity_control_unavailable")
+        has_only_signed_rows = self._count_legacy_local_policy_rows(connection) == 0
+        if (
+            not warnings
+            and trusted_state is not None
+            and not bool(trusted_state.get("cutover_complete"))
+            and has_only_signed_rows
+        ):
+            next_trusted_state = dict(trusted_state)
+            next_trusted_state["cutover_complete"] = True
+            if not self._store_policy_integrity_control_state(next_trusted_state):
+                warnings.append("policy_integrity_control_unavailable")
+            else:
+                trusted_state = next_trusted_state
         mode = "protected" if not warnings else "degraded"
-        stored_enforcement = existing.get("enforcement")
-        if isinstance(stored_enforcement, str) and stored_enforcement in _POLICY_INTEGRITY_ENFORCEMENTS:
-            enforcement = stored_enforcement
-        else:
-            has_only_signed_rows = self._count_legacy_local_policy_rows(connection) == 0
-            enforcement = "enforce" if mode == "protected" and has_only_signed_rows else "warn"
+        cutover_complete = bool(trusted_state.get("cutover_complete")) if trusted_state is not None else False
+        enforcement = "enforce" if mode == "protected" and cutover_complete else "warn"
         payload: dict[str, object] = {
             "backend": self._policy_integrity_backend_name(),
+            "cutover_complete": cutover_complete,
             "degraded_reasons": list(dict.fromkeys(warnings)),
             "enforcement": enforcement,
+            "generation": trusted_state.get("generation") if trusted_state is not None else None,
             "key_id": key_id,
             "mode": mode,
         }
@@ -1094,6 +1342,7 @@ class GuardStore:
         mode: str,
         key: bytes | None,
         key_id: str | None,
+        trusted_generation: int | None = None,
     ) -> PolicyIntegrityVerificationResult:
         source = str(row["source"]) if row["source"] is not None else None
         if is_remote_policy_source(source):
@@ -1103,6 +1352,7 @@ class GuardStore:
             key=key,
             key_id=key_id,
             degraded_mode=mode != "protected",
+            trusted_generation=trusted_generation,
         )
 
     @staticmethod
@@ -1136,6 +1386,8 @@ class GuardStore:
             payload["integrity_enforcement"] = state.get("enforcement")
         if row["integrity_version"] is not None:
             payload["integrity_version"] = int(row["integrity_version"])
+        if row["integrity_generation"] is not None:
+            payload["integrity_generation"] = int(row["integrity_generation"])
         if row["integrity_key_id"] is not None:
             payload["integrity_key_id"] = str(row["integrity_key_id"])
         if row["signed_at"] is not None:
@@ -1533,6 +1785,7 @@ class GuardStore:
             self._ensure_policy_column(connection, "source", "text not null default 'local'")
             self._ensure_policy_column(connection, "expires_at", "text")
             self._ensure_policy_column(connection, "integrity_version", "integer")
+            self._ensure_policy_column(connection, "integrity_generation", "integer")
             self._ensure_policy_column(connection, "payload_hash", "text")
             self._ensure_policy_column(connection, "payload_mac", "text")
             self._ensure_policy_column(connection, "integrity_key_id", "text")
@@ -1585,6 +1838,8 @@ class GuardStore:
                 self._record_schema_version(connection, version=6)
             if not self._schema_version_applied(connection, version=7):
                 self._record_schema_version(connection, version=7)
+            if not self._schema_version_applied(connection, version=8):
+                self._record_schema_version(connection, version=8)
             self._ensure_attachment_column(connection, "lease_id", "text not null default ''")
             self._ensure_attachment_column(connection, "lease_expires_at", "text")
             self._ensure_local_device(connection)
@@ -2198,42 +2453,17 @@ class GuardStore:
         )
         _validate_scoped_policy_artifact_target(decision.scope, decision.artifact_id)
         artifact_id, artifact_hash, workspace, publisher = self._normalized_policy_keys(decision)
-        signing_payload = {
-            "harness": decision.harness,
-            "scope": decision.scope,
-            "artifact_id": artifact_id,
-            "artifact_hash": artifact_hash,
-            "workspace": workspace,
-            "publisher": publisher,
-            "action": decision.action,
-            "source": decision.source,
-            "expires_at": decision.expires_at,
-            "updated_at": now,
-        }
-        integrity_values: dict[str, object] = {
-            "integrity_version": None,
-            "payload_hash": None,
-            "payload_mac": None,
-            "integrity_key_id": None,
-            "signed_at": None,
-        }
+        next_control_state: dict[str, object] | None = None
         with self._connect() as connection:
             secret_material = (None, None)
             if not is_remote_policy_source(decision.source):
                 secret_material = self._policy_integrity_secret_material(create=True)
-                key, key_id = secret_material
-                if key is not None and key_id is not None:
-                    integrity_values = sign_local_policy_row(
-                        signing_payload,
-                        key,
-                        key_id=key_id,
-                        signed_at=now,
-                    )
-            self._refresh_policy_integrity_state(
+            state = self._refresh_policy_integrity_state(
                 connection,
                 now=now,
-                create_key=False,
+                create_key=not is_remote_policy_source(decision.source),
                 secret_material=secret_material,
+                allow_cutover_resign=False,
             )
             connection.execute(
                 """
@@ -2245,13 +2475,14 @@ class GuardStore:
                 """,
                 (decision.harness, decision.scope, artifact_id, artifact_hash, workspace, publisher),
             )
-            connection.execute(
+            cursor = connection.execute(
                 """
                 insert into policy_decisions (
                   harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
-                  expires_at, updated_at, integrity_version, payload_hash, payload_mac, integrity_key_id, signed_at
+                  expires_at, updated_at, integrity_version, integrity_generation, payload_hash, payload_mac,
+                  integrity_key_id, signed_at
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     decision.harness,
@@ -2266,13 +2497,30 @@ class GuardStore:
                     decision.source,
                     decision.expires_at,
                     now,
-                    integrity_values["integrity_version"],
-                    integrity_values["payload_hash"],
-                    integrity_values["payload_mac"],
-                    integrity_values["integrity_key_id"],
-                    integrity_values["signed_at"],
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
+                    None,
                 ),
             )
+            if not is_remote_policy_source(decision.source) and state.get("mode") == "protected":
+                key, key_id = secret_material
+                if key is not None and key_id is not None:
+                    trusted_state = self._load_policy_integrity_control_state(create=True)
+                    if trusted_state is not None:
+                        next_control_state = self._advance_policy_integrity_generation(
+                            connection,
+                            now=now,
+                            key=key,
+                            key_id=key_id,
+                            trusted_state=trusted_state,
+                            force_sign_decision_ids={int(cursor.lastrowid)},
+                        )
+                        connection.commit()
+        if next_control_state is not None:
+            self._finalize_policy_integrity_control_state(next_control_state)
 
     def replace_remote_policies(
         self,
@@ -2300,9 +2548,10 @@ class GuardStore:
                     """
                     insert into policy_decisions (
                       harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
-                      expires_at, updated_at, integrity_version, payload_hash, payload_mac, integrity_key_id, signed_at
+                      expires_at, updated_at, integrity_version, integrity_generation, payload_hash, payload_mac,
+                      integrity_key_id, signed_at
                     )
-                    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         decision.harness,
@@ -2317,6 +2566,7 @@ class GuardStore:
                         decision.source,
                         decision.expires_at,
                         now,
+                        None,
                         None,
                         None,
                         None,
@@ -2364,7 +2614,8 @@ class GuardStore:
             rows = connection.execute(
                 """
                 select decision_id, harness, scope, artifact_id, action, artifact_hash, workspace, publisher, source,
-                       reason, owner, expires_at, updated_at, integrity_version, payload_hash, payload_mac,
+                       reason, owner, expires_at, updated_at, integrity_version, integrity_generation,
+                       payload_hash, payload_mac,
                        integrity_key_id, signed_at
                 from policy_decisions
                 where (harness = ? or harness = '*') and (
@@ -2442,6 +2693,7 @@ class GuardStore:
                     mode=str(state.get("mode") or "degraded"),
                     key=key,
                     key_id=key_id,
+                    trusted_generation=(int(state["generation"]) if isinstance(state.get("generation"), int) else None),
                 )
                 if integrity_result.status == "valid":
                     selected_payload = self._policy_row_payload(
@@ -3334,6 +3586,7 @@ class GuardStore:
         query = """
             select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher,
                    action, reason, owner, source, expires_at, updated_at, integrity_version,
+                   integrity_generation,
                    payload_hash, payload_mac, integrity_key_id, signed_at
             from policy_decisions
         """
@@ -3368,6 +3621,9 @@ class GuardStore:
                         mode=str(state.get("mode") or "degraded"),
                         key=key,
                         key_id=key_id,
+                        trusted_generation=(
+                            int(state["generation"]) if isinstance(state.get("generation"), int) else None
+                        ),
                     )
                     payload["integrity_status"] = integrity_result.status
                     payload["integrity_message"] = integrity_result.message
@@ -3424,6 +3680,8 @@ class GuardStore:
         }
         if row["integrity_version"] is not None:
             payload["integrity_version"] = int(row["integrity_version"])
+        if row["integrity_generation"] is not None:
+            payload["integrity_generation"] = int(row["integrity_generation"])
         if row["integrity_key_id"] is not None:
             payload["integrity_key_id"] = str(row["integrity_key_id"])
         if row["signed_at"] is not None:
@@ -3441,6 +3699,7 @@ class GuardStore:
         query = f"""
             select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher,
                    action, reason, owner, source, expires_at, updated_at, integrity_version,
+                   integrity_generation,
                    payload_hash, payload_mac, integrity_key_id, signed_at
             from policy_decisions
             where source not in {_REMOTE_POLICY_SOURCE_PLACEHOLDERS}
@@ -3469,6 +3728,7 @@ class GuardStore:
                 mode=str(state.get("mode") or "degraded"),
                 key=key,
                 key_id=key_id,
+                trusted_generation=(int(state["generation"]) if isinstance(state.get("generation"), int) else None),
             )
             counts[integrity_result.status] += 1
             item = self._policy_decision_dict_from_row(connection, row)
@@ -3499,8 +3759,10 @@ class GuardStore:
             "generated_at": now,
             "harness": harness,
             "backend": state.get("backend"),
+            "cutover_complete": state.get("cutover_complete"),
             "mode": state.get("mode"),
             "enforcement": state.get("enforcement"),
+            "generation": state.get("generation"),
             "key_id": state.get("key_id"),
             "degraded_reasons": state.get("degraded_reasons", []),
             "counts": counts,
@@ -3516,8 +3778,10 @@ class GuardStore:
             "generated_at": now,
             "harness": harness,
             "backend": state.get("backend"),
+            "cutover_complete": state.get("cutover_complete"),
             "mode": state.get("mode"),
             "enforcement": state.get("enforcement"),
+            "generation": state.get("generation"),
             "key_id": state.get("key_id"),
             "degraded_reasons": state.get("degraded_reasons", []),
             "counts": counts,
@@ -3536,8 +3800,9 @@ class GuardStore:
         current_time = now or _now()
         if clear_invalid:
             require_policy_clear(self.guard_home, approval_gate_grant=approval_gate_grant, now=current_time)
+        next_control_state: dict[str, object] | None = None
         with self._connect() as connection:
-            _state, _counts, items = self._policy_integrity_scan(connection, now=current_time, harness=harness)
+            state, _counts, items = self._policy_integrity_scan(connection, now=current_time, harness=harness)
             invalid_ids = [
                 int(item["decision_id"])
                 for item in items
@@ -3552,13 +3817,29 @@ class GuardStore:
                         tuple(chunk),
                     )
                     cleared += int(cursor.rowcount if cursor.rowcount is not None else 0)
+                if cleared > 0 and state.get("mode") == "protected":
+                    key, key_id = self._policy_integrity_secret_material(create=True)
+                    trusted_state = self._load_policy_integrity_control_state(create=True)
+                    if key is not None and key_id is not None and trusted_state is not None:
+                        next_control_state = self._advance_policy_integrity_generation(
+                            connection,
+                            now=current_time,
+                            key=key,
+                            key_id=key_id,
+                            trusted_state=trusted_state,
+                        )
+                        connection.commit()
+            if next_control_state is not None:
+                self._finalize_policy_integrity_control_state(next_control_state)
             state, counts, remaining_items = self._policy_integrity_scan(connection, now=current_time, harness=harness)
         return {
             "generated_at": current_time,
             "harness": harness,
             "backend": state.get("backend"),
+            "cutover_complete": state.get("cutover_complete"),
             "mode": state.get("mode"),
             "enforcement": state.get("enforcement"),
+            "generation": state.get("generation"),
             "key_id": state.get("key_id"),
             "degraded_reasons": state.get("degraded_reasons", []),
             "counts": counts,
@@ -3578,49 +3859,58 @@ class GuardStore:
         now: str,
     ) -> dict[str, object]:
         require_policy_clear(self.guard_home, approval_gate_grant=approval_gate_grant, now=now)
+        next_control_state: dict[str, object] | None = None
         with self._connect() as connection:
-            state = self._refresh_policy_integrity_state(connection, now=now, create_key=True)
+            state = self._refresh_policy_integrity_state(
+                connection,
+                now=now,
+                create_key=True,
+                allow_cutover_resign=False,
+            )
             if state.get("mode") != "protected":
                 raise RuntimeError("Guard policy integrity migration requires a protected system keyring backend.")
             key, key_id = self._policy_integrity_secret_material(create=True)
             if key is None or key_id is None:
                 raise RuntimeError("Guard could not access the policy integrity key.")
+            trusted_state = self._load_policy_integrity_control_state(create=True)
+            if trusted_state is None:
+                raise RuntimeError("Guard could not access the policy integrity control state.")
             backup_path = self._backup_policy_database(connection, now=now)
             rows = self._load_local_policy_rows(connection, harness=harness)
             preserved = 0
             cleared = 0
             legacy_ids: list[int] = []
             unknown_key_ids: list[int] = []
+            rollback_row_ids: list[int] = []
+            blocked_preserve_row_ids: list[int] = []
+            selected_preserved_ids: set[int] = set()
             for row in rows:
-                integrity_result = verify_local_policy_row(row, key=key, key_id=key_id, degraded_mode=False)
-                if integrity_result.status not in _POLICY_INTEGRITY_MIGRATION_ELIGIBLE_STATUSES:
-                    continue
                 decision_id = int(row["decision_id"])
+                integrity_result = verify_local_policy_row(
+                    row,
+                    key=key,
+                    key_id=key_id,
+                    degraded_mode=False,
+                    trusted_generation=int(trusted_state["generation"]),
+                )
+                if integrity_result.status not in _POLICY_INTEGRITY_MIGRATION_ELIGIBLE_STATUSES:
+                    if integrity_result.status == "rollback_detected":
+                        rollback_row_ids.append(decision_id)
+                        if decision_id in preserve_decision_ids:
+                            blocked_preserve_row_ids.append(decision_id)
+                        elif clear_unselected:
+                            cursor = connection.execute(
+                                "delete from policy_decisions where decision_id = ?",
+                                (decision_id,),
+                            )
+                            cleared += int(cursor.rowcount if cursor.rowcount is not None else 0)
+                    continue
                 if integrity_result.status == "missing_integrity":
                     legacy_ids.append(decision_id)
                 else:
                     unknown_key_ids.append(decision_id)
                 if decision_id in preserve_decision_ids:
-                    signed = sign_local_policy_row(row, key, key_id=key_id, signed_at=now)
-                    connection.execute(
-                        """
-                        update policy_decisions
-                        set integrity_version = ?,
-                            payload_hash = ?,
-                            payload_mac = ?,
-                            integrity_key_id = ?,
-                            signed_at = ?
-                        where decision_id = ?
-                        """,
-                        (
-                            signed["integrity_version"],
-                            signed["payload_hash"],
-                            signed["payload_mac"],
-                            signed["integrity_key_id"],
-                            signed["signed_at"],
-                            decision_id,
-                        ),
-                    )
+                    selected_preserved_ids.add(decision_id)
                     preserved += 1
                 elif clear_unselected:
                     cursor = connection.execute(
@@ -3628,21 +3918,33 @@ class GuardStore:
                         (decision_id,),
                     )
                     cleared += int(cursor.rowcount if cursor.rowcount is not None else 0)
-            next_state = dict(state)
-            next_state["enforcement"] = "enforce"
-            self._store_policy_integrity_state(connection, next_state, now=now)
+            next_control_state = self._advance_policy_integrity_generation(
+                connection,
+                now=now,
+                key=key,
+                key_id=key_id,
+                trusted_state=trusted_state,
+                force_sign_decision_ids=selected_preserved_ids,
+            )
+            connection.commit()
+            if next_control_state is not None:
+                self._finalize_policy_integrity_control_state(next_control_state)
             final_state, counts, items = self._policy_integrity_scan(connection, now=now, harness=harness)
         return {
             "generated_at": now,
             "harness": harness,
             "backup_path": backup_path,
             "backend": final_state.get("backend"),
+            "cutover_complete": final_state.get("cutover_complete"),
             "mode": final_state.get("mode"),
             "enforcement": final_state.get("enforcement"),
+            "generation": final_state.get("generation"),
             "key_id": final_state.get("key_id"),
             "degraded_reasons": final_state.get("degraded_reasons", []),
             "legacy_row_ids": legacy_ids,
+            "rollback_row_ids": rollback_row_ids,
             "unknown_key_row_ids": unknown_key_ids,
+            "blocked_preserve_row_ids": blocked_preserve_row_ids,
             "preserved": preserved,
             "cleared": cleared,
             "counts": counts,
@@ -3665,6 +3967,7 @@ class GuardStore:
         approval_gate_grant: ApprovalGateGrant | None = None,
     ) -> int:
         require_policy_clear(self.guard_home, approval_gate_grant=approval_gate_grant)
+        current_time = _now()
         conditions: list[str] = []
         params: list[object] = []
         if harness is not None:
@@ -3698,9 +4001,41 @@ class GuardStore:
         query = "delete from policy_decisions"
         if conditions:
             query += " where " + " and ".join(conditions)
+        next_control_state: dict[str, object] | None = None
         with self._connect() as connection:
+            local_query = (
+                f"select decision_id from policy_decisions where source not in {_REMOTE_POLICY_SOURCE_PLACEHOLDERS}"
+            )
+            local_params: list[object] = list(_REMOTE_POLICY_SOURCE_PARAMS)
+            if conditions:
+                local_query += " and " + " and ".join(conditions)
+                local_params.extend(params)
+            local_ids = {
+                int(row["decision_id"]) for row in connection.execute(local_query, tuple(local_params)).fetchall()
+            }
+            state = self._refresh_policy_integrity_state(
+                connection,
+                now=current_time,
+                create_key=True,
+                allow_cutover_resign=False,
+            )
             cursor = connection.execute(query, tuple(params))
-            return int(cursor.rowcount if cursor.rowcount is not None else 0)
+            cleared = int(cursor.rowcount if cursor.rowcount is not None else 0)
+            if local_ids and state.get("mode") == "protected":
+                key, key_id = self._policy_integrity_secret_material(create=True)
+                trusted_state = self._load_policy_integrity_control_state(create=True)
+                if key is not None and key_id is not None and trusted_state is not None:
+                    next_control_state = self._advance_policy_integrity_generation(
+                        connection,
+                        now=current_time,
+                        key=key,
+                        key_id=key_id,
+                        trusted_state=trusted_state,
+                    )
+                    connection.commit()
+        if next_control_state is not None:
+            self._finalize_policy_integrity_control_state(next_control_state)
+        return cleared
 
     def get_latest_diff(self, harness: str, artifact_id: str) -> dict[str, object] | None:
         with self._connect() as connection:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -60,12 +60,27 @@ def _policy_integrity_state_payload(home_dir: Path) -> dict[str, object]:
     return json.loads(str(row[0]))
 
 
+def _policy_integrity_control_payload(store: GuardStore) -> dict[str, object]:
+    secret_store = store._policy_integrity_secret_store
+    assert secret_store is not None
+    payload_json = secret_store.get_secret(store._policy_integrity_control_ref)
+    assert payload_json is not None
+    return json.loads(payload_json)
+
+
+def _delete_policy_integrity_control_state(store: GuardStore) -> None:
+    secret_store = store._policy_integrity_secret_store
+    assert secret_store is not None
+    secret_store.delete_secret(store._policy_integrity_control_ref)
+
+
 def _strip_policy_integrity(home_dir: Path, *, artifact_id: str) -> None:
     with sqlite3.connect(home_dir / "guard.db") as connection:
         connection.execute(
             """
             update policy_decisions
             set integrity_version = null,
+                integrity_generation = null,
                 payload_hash = null,
                 payload_mac = null,
                 integrity_key_id = null,
@@ -76,7 +91,7 @@ def _strip_policy_integrity(home_dir: Path, *, artifact_id: str) -> None:
         )
 
 
-def _set_policy_integrity_state(
+def _tamper_policy_integrity_state(
     home_dir: Path,
     *,
     backend: str,
@@ -119,6 +134,7 @@ def test_upsert_policy_signs_local_row_and_resolve_honors_it(tmp_path: Path) -> 
     store.upsert_policy(_decision(), "2026-06-14T00:00:00Z")
 
     row = _policy_row(store.guard_home, artifact_id="codex:project:workspace-skill")
+    control = _policy_integrity_control_payload(store)
     resolved = store.resolve_policy_decision(
         "codex",
         "codex:project:workspace-skill",
@@ -126,10 +142,13 @@ def test_upsert_policy_signs_local_row_and_resolve_honors_it(tmp_path: Path) -> 
         now="2026-06-14T00:01:00Z",
     )
 
-    assert row["integrity_version"] == 1
+    assert row["integrity_version"] == 2
+    assert row["integrity_generation"] == 1
     assert isinstance(row["payload_hash"], str) and row["payload_hash"]
     assert isinstance(row["payload_mac"], str) and row["payload_mac"]
     assert isinstance(row["integrity_key_id"], str) and row["integrity_key_id"]
+    assert control["cutover_complete"] is True
+    assert control["generation"] == 1
     assert resolved is not None
     assert resolved["action"] == "allow"
     assert resolved["integrity_status"] == "valid"
@@ -167,6 +186,59 @@ def test_direct_sqlite_insert_is_ignored_in_enforce_mode(tmp_path: Path) -> None
         "codex:project:forged",
         "hash-forged",
         now="2026-06-14T00:01:00Z",
+    )
+    verify = store.verify_policy_integrity()
+
+    assert resolved is None
+    assert verify["enforcement"] == "enforce"
+    assert verify["counts"]["missing_integrity"] == 1
+
+
+def test_sync_state_tamper_cannot_downgrade_enforcement(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:baseline", artifact_hash="hash-baseline"),
+        "2026-06-14T00:00:00Z",
+    )
+
+    status = store.get_policy_integrity_status()
+    _tamper_policy_integrity_state(
+        store.guard_home,
+        backend=str(status["backend"]),
+        mode="protected",
+        enforcement="warn",
+        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
+    )
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute(
+            """
+            insert into policy_decisions (
+              harness, scope, artifact_id, artifact_hash, workspace, publisher, action, reason, owner, source,
+              expires_at, updated_at
+            )
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                "codex",
+                "artifact",
+                "codex:project:forged-sync-state",
+                "hash-forged-sync-state",
+                None,
+                None,
+                "allow",
+                "forged",
+                None,
+                "local",
+                None,
+                "2026-06-14T00:01:00Z",
+            ),
+        )
+
+    resolved = store.resolve_policy(
+        "codex",
+        "codex:project:forged-sync-state",
+        "hash-forged-sync-state",
+        now="2026-06-14T00:02:00Z",
     )
     verify = store.verify_policy_integrity()
 
@@ -247,44 +319,38 @@ def test_remote_policy_row_is_honored_without_local_mac(tmp_path: Path) -> None:
     assert resolved == "allow"
 
 
-def test_legacy_unsigned_row_warn_mode_then_enforce_mode(tmp_path: Path) -> None:
+def test_legacy_unsigned_row_warn_mode_then_trusted_local_write_enforces(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store.upsert_policy(
         _decision(artifact_id="codex:project:legacy", artifact_hash="hash-legacy"),
         "2026-06-14T00:00:00Z",
     )
-    status = store.get_policy_integrity_status()
     _strip_policy_integrity(store.guard_home, artifact_id="codex:project:legacy")
-    _set_policy_integrity_state(
-        store.guard_home,
-        backend=str(status["backend"]),
-        mode="protected",
-        enforcement="warn",
-        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
-    )
+    _delete_policy_integrity_control_state(store)
 
+    warned_status = store.get_policy_integrity_status()
     warned = store.resolve_policy_decision(
         "codex",
         "codex:project:legacy",
         "hash-legacy",
         now="2026-06-14T00:01:00Z",
     )
-    _set_policy_integrity_state(
-        store.guard_home,
-        backend=str(status["backend"]),
-        mode="protected",
-        enforcement="enforce",
-        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:fresh", artifact_hash="hash-fresh"),
+        "2026-06-14T00:02:00Z",
     )
+    enforced_status = store.get_policy_integrity_status()
     enforced = store.resolve_policy(
         "codex",
         "codex:project:legacy",
         "hash-legacy",
-        now="2026-06-14T00:02:00Z",
+        now="2026-06-14T00:03:00Z",
     )
 
+    assert warned_status["enforcement"] == "warn"
     assert warned is not None
     assert warned["integrity_status"] == "missing_integrity"
+    assert enforced_status["enforcement"] == "enforce"
     assert enforced is None
 
 
@@ -298,16 +364,9 @@ def test_migrate_local_policy_integrity_preserves_selected_rows_only(tmp_path: P
         _decision(artifact_id="codex:project:legacy-two", artifact_hash="hash-two"),
         "2026-06-14T00:00:00Z",
     )
-    status = store.get_policy_integrity_status()
     _strip_policy_integrity(store.guard_home, artifact_id="codex:project:legacy-one")
     _strip_policy_integrity(store.guard_home, artifact_id="codex:project:legacy-two")
-    _set_policy_integrity_state(
-        store.guard_home,
-        backend=str(status["backend"]),
-        mode="protected",
-        enforcement="warn",
-        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
-    )
+    _delete_policy_integrity_control_state(store)
 
     items = store.verify_policy_integrity()["items"]
     preserve_id = next(
@@ -358,19 +417,144 @@ def test_migrate_local_policy_integrity_re_signs_unknown_key_rows(tmp_path: Path
     assert resolved == "allow"
 
 
+def test_pending_generation_recovers_when_post_commit_control_write_is_skipped(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:baseline", artifact_hash="hash-baseline"),
+        "2026-06-14T00:00:00Z",
+    )
+    monkeypatch.setattr(store, "_finalize_policy_integrity_control_state", lambda payload: None)
+
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:pending", artifact_hash="hash-pending"),
+        "2026-06-14T00:01:00Z",
+    )
+
+    pending_control = _policy_integrity_control_payload(store)
+    verify = store.verify_policy_integrity()
+    recovered_control = _policy_integrity_control_payload(store)
+
+    assert pending_control["generation"] == 1
+    assert pending_control["pending_generation"] == 2
+    assert verify["counts"]["valid"] == 2
+    assert recovered_control["generation"] == 2
+    assert recovered_control["pending_generation"] is None
+
+
+def test_signed_rollback_snapshot_is_detected_and_repair_advances_generation(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:rollback", artifact_hash="hash-rollback"),
+        "2026-06-14T00:00:00Z",
+    )
+    snapshot = _policy_row(store.guard_home, artifact_id="codex:project:rollback")
+    assert snapshot["integrity_generation"] == 1
+
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:current", artifact_hash="hash-current"),
+        "2026-06-14T00:01:00Z",
+    )
+
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute(
+            """
+            update policy_decisions
+            set integrity_version = ?,
+                integrity_generation = ?,
+                payload_hash = ?,
+                payload_mac = ?,
+                integrity_key_id = ?,
+                signed_at = ?
+            where artifact_id = ?
+            """,
+            (
+                snapshot["integrity_version"],
+                snapshot["integrity_generation"],
+                snapshot["payload_hash"],
+                snapshot["payload_mac"],
+                snapshot["integrity_key_id"],
+                snapshot["signed_at"],
+                "codex:project:rollback",
+            ),
+        )
+
+    verify = store.verify_policy_integrity()
+    rollback_item = next(
+        item for item in verify["items"] if item.get("artifact_id") == "codex:project:rollback"
+    )
+    repair = store.repair_policy_integrity(clear_invalid=True, now="2026-06-14T00:02:00Z")
+    control = _policy_integrity_control_payload(store)
+    resolved = store.resolve_policy("codex", "codex:project:current", "hash-current", now="2026-06-14T00:03:00Z")
+
+    assert verify["counts"]["rollback_detected"] == 1
+    assert rollback_item["integrity_status"] == "rollback_detected"
+    assert rollback_item["integrity_message"] == "policy_integrity_generation_rollback"
+    assert repair["cleared"] == 1
+    assert repair["counts"]["valid"] == 1
+    assert repair["counts"]["rollback_detected"] == 0
+    assert control["generation"] == 3
+    assert resolved == "allow"
+
+
+def test_migrate_local_policy_integrity_reports_rollback_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    monkeypatch.setattr(store, "_backup_policy_database", lambda connection, *, now: "guard.db.pre-integrity-test")
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:rollback-migrate", artifact_hash="hash-rollback-migrate"),
+        "2026-06-14T00:00:00Z",
+    )
+    snapshot = _policy_row(store.guard_home, artifact_id="codex:project:rollback-migrate")
+    rollback_id = int(snapshot["decision_id"])
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:rollback-peer", artifact_hash="hash-rollback-peer"),
+        "2026-06-14T00:01:00Z",
+    )
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute(
+            """
+            update policy_decisions
+            set integrity_version = ?,
+                integrity_generation = ?,
+                payload_hash = ?,
+                payload_mac = ?,
+                integrity_key_id = ?,
+                signed_at = ?
+            where decision_id = ?
+            """,
+            (
+                snapshot["integrity_version"],
+                snapshot["integrity_generation"],
+                snapshot["payload_hash"],
+                snapshot["payload_mac"],
+                snapshot["integrity_key_id"],
+                snapshot["signed_at"],
+                rollback_id,
+            ),
+        )
+
+    payload = store.migrate_local_policy_integrity(
+        preserve_decision_ids={rollback_id},
+        clear_unselected=False,
+        now="2026-06-14T00:02:00Z",
+    )
+
+    assert payload["rollback_row_ids"] == [rollback_id]
+    assert payload["blocked_preserve_row_ids"] == [rollback_id]
+    assert payload["counts"]["rollback_detected"] == 1
+
+
 def test_policies_cli_verify_status_migrate_and_repair(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
     store.upsert_policy(_decision(artifact_id="codex:project:cli", artifact_hash="hash-cli"), "2026-06-14T00:00:00Z")
-    status = store.get_policy_integrity_status()
     _strip_policy_integrity(home_dir, artifact_id="codex:project:cli")
-    _set_policy_integrity_state(
-        home_dir,
-        backend=str(status["backend"]),
-        mode="protected",
-        enforcement="warn",
-        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
-    )
+    _delete_policy_integrity_control_state(store)
 
     verify_rc = main(["guard", "policies", "verify", "--home", str(home_dir), "--json"])
     verify_payload = json.loads(capsys.readouterr().out)
@@ -399,13 +583,6 @@ def test_policies_cli_verify_status_migrate_and_repair(tmp_path: Path, capsys) -
     assert migrate_payload["enforcement"] == "enforce"
 
     _strip_policy_integrity(home_dir, artifact_id="codex:project:cli")
-    _set_policy_integrity_state(
-        home_dir,
-        backend=str(status["backend"]),
-        mode="protected",
-        enforcement="enforce",
-        key_id=status["key_id"] if isinstance(status["key_id"], str) else None,
-    )
     repair_rc = main(
         [
             "guard",
@@ -421,6 +598,48 @@ def test_policies_cli_verify_status_migrate_and_repair(tmp_path: Path, capsys) -
     assert repair_rc == 0
     assert repair_payload["cleared"] == 1
     assert GuardStore(home_dir).list_policy_decisions() == []
+
+
+def test_policies_cli_verify_returns_nonzero_for_rollback_detected(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:cli-rollback", artifact_hash="hash-cli-rollback"),
+        "2026-06-14T00:00:00Z",
+    )
+    snapshot = _policy_row(home_dir, artifact_id="codex:project:cli-rollback")
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:cli-current", artifact_hash="hash-cli-current"),
+        "2026-06-14T00:01:00Z",
+    )
+    with sqlite3.connect(home_dir / "guard.db") as connection:
+        connection.execute(
+            """
+            update policy_decisions
+            set integrity_version = ?,
+                integrity_generation = ?,
+                payload_hash = ?,
+                payload_mac = ?,
+                integrity_key_id = ?,
+                signed_at = ?
+            where artifact_id = ?
+            """,
+            (
+                snapshot["integrity_version"],
+                snapshot["integrity_generation"],
+                snapshot["payload_hash"],
+                snapshot["payload_mac"],
+                snapshot["integrity_key_id"],
+                snapshot["signed_at"],
+                "codex:project:cli-rollback",
+            ),
+        )
+
+    verify_rc = main(["guard", "policies", "verify", "--home", str(home_dir), "--json"])
+    verify_payload = json.loads(capsys.readouterr().out)
+
+    assert verify_rc == 1
+    assert verify_payload["counts"]["rollback_detected"] == 1
 
 
 def test_policies_cli_migrate_preserve_all_local_re_signs_unknown_key_rows(tmp_path: Path, capsys) -> None:
@@ -500,4 +719,30 @@ def test_degraded_mode_persistent_local_allow_is_not_authoritative(
 
     assert resolved is None
     assert verify["mode"] == "degraded"
+    assert verify["counts"]["degraded_mode"] == 1
+
+
+def test_symlinked_guard_home_forces_degraded_local_policy_authority(tmp_path: Path) -> None:
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    link_home = tmp_path / "link-home"
+    link_home.symlink_to(real_home, target_is_directory=True)
+
+    store = GuardStore(link_home)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:symlinked", artifact_hash="hash-symlinked"),
+        "2026-06-14T00:00:00Z",
+    )
+
+    resolved = store.resolve_policy(
+        "codex",
+        "codex:project:symlinked",
+        "hash-symlinked",
+        now="2026-06-14T00:01:00Z",
+    )
+    verify = store.verify_policy_integrity()
+
+    assert resolved is None
+    assert verify["mode"] == "degraded"
+    assert "guard_home_symlink" in verify["degraded_reasons"]
     assert verify["counts"]["degraded_mode"] == 1


### PR DESCRIPTION
## Summary
- remove the SQLite-controlled policy-integrity downgrade path by deriving enforcement from keyring-backed control state
- add generation-based rollback detection and re-sign surviving local policy rows on trusted local mutations
- degrade local policy authority on unsafe paths and cover the new cutover, rollback, migration, repair, and CLI flows with tests

## Testing
- `python3 -m pytest tests/test_guard_policy_integrity.py tests/test_guard_manifest_install_firewall.py tests/test_policy_decision_source_context.py -q`
- `python3 -m pytest tests/test_guard_cli.py::TestGuardCli::test_guard_harness_policy_overrides_across_workspaces -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/policy_integrity.py tests/test_guard_policy_integrity.py`
