### PR TITLE
fix(guard): require local confirmation for cloud removals

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -407,8 +407,7 @@ def _app_remove_confirmation_payload(
         "confirmation_phrase": confirmation_phrase,
         "harness": harness,
         "summary": (
-            "Run the local disconnect command on this machine to confirm "
-            f"removing Guard protection for {harness}."
+            f"Run the local disconnect command on this machine to confirm removing Guard protection for {harness}."
         ),
         "surface": surface,
     }

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -13,6 +13,7 @@ from ..cli.install_commands import (
     apply_managed_install,
     build_harness_verification,
     list_harness_setup_items,
+    uninstall_confirmation_token,
 )
 from ..config import load_guard_config
 from ..local_supply_chain import (
@@ -28,7 +29,6 @@ from ..shims import (
     package_shim_status,
     package_shim_supported_managers,
     probe_package_shim_intercepts,
-    uninstall_package_shims,
 )
 from ..store import GuardStore
 
@@ -123,7 +123,10 @@ def _execute_package_shim_operation(
         )
     if operation == "guard.packageShims.remove":
         managers = _package_shim_managers(payload)
-        return _result(uninstall_package_shims(command_context, managers=managers), generated_at=generated_at)
+        return _waiting_local_confirm(
+            _package_shim_remove_confirmation_payload(managers),
+            generated_at=generated_at,
+        )
     if operation == "guard.packageShims.test":
         managers = _package_shim_managers(payload)
         return _result(
@@ -198,17 +201,8 @@ def _execute_app_operation(
         result["action"] = "repair"
         return _result(result, generated_at=generated_at)
     if operation == "guard.app.remove":
-        return _result(
-            apply_managed_install(
-                "uninstall",
-                harness,
-                False,
-                context,
-                store,
-                workspace,
-                generated_at,
-                surface=surface,
-            ),
+        return _waiting_local_confirm(
+            _app_remove_confirmation_payload(harness=harness, surface=surface),
             generated_at=generated_at,
         )
     return {
@@ -378,6 +372,48 @@ def _package_shim_managers(payload: dict[str, object]) -> tuple[str, ...] | None
     return normalized
 
 
+def _package_shim_remove_confirmation_payload(
+    managers: tuple[str, ...] | None,
+) -> dict[str, object]:
+    confirm_parts = ["hol-guard", "package-shims", "uninstall"]
+    if managers:
+        for manager in managers:
+            confirm_parts.extend(["--manager", manager])
+    summary = "Run the local package-shim uninstall command on this machine to confirm removal."
+    if managers:
+        summary = (
+            "Run the local package-shim uninstall command on this machine to "
+            f"confirm removal for {', '.join(managers)}."
+        )
+    return {
+        "confirm_command": " ".join(confirm_parts),
+        "managers": list(managers or ()),
+        "summary": summary,
+    }
+
+
+def _app_remove_confirmation_payload(
+    *,
+    harness: str,
+    surface: str | None,
+) -> dict[str, object]:
+    confirmation_phrase = uninstall_confirmation_token(harness)
+    confirm_parts = ["hol-guard", "apps", "disconnect", harness]
+    if surface is not None:
+        confirm_parts.extend(["--surface", surface])
+    confirm_parts.extend(["--confirm", confirmation_phrase])
+    return {
+        "confirm_command": " ".join(confirm_parts),
+        "confirmation_phrase": confirmation_phrase,
+        "harness": harness,
+        "summary": (
+            "Run the local disconnect command on this machine to confirm "
+            f"removing Guard protection for {harness}."
+        ),
+        "surface": surface,
+    }
+
+
 def command_job_operation(job: dict[str, object]) -> str:
     operation = job.get("operation")
     return operation if isinstance(operation, str) else ""
@@ -406,6 +442,16 @@ def _result(data: dict[str, object], *, generated_at: str) -> dict[str, object]:
         "data": data,
         "generatedAt": generated_at,
     }
+
+
+def _waiting_local_confirm(
+    data: dict[str, object],
+    *,
+    generated_at: str,
+) -> dict[str, object]:
+    payload = _result(data, generated_at=generated_at)
+    payload["waitingLocalConfirm"] = True
+    return payload
 
 
 def _now() -> str:

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -245,11 +245,13 @@ def _heartbeat(auth_context: dict[str, object], job: dict[str, object]) -> None:
 
 def _result_payload(job: dict[str, object], execution: dict[str, object]) -> dict[str, object]:
     if execution.get("waitingLocalConfirm") is True:
+        sanitized_execution = dict(execution)
+        sanitized_execution.pop("waitingLocalConfirm", None)
         return {
             "leaseId": _lease_id(job),
             "idempotencyKey": f"{_job_id(job)}:{_lease_id(job)}:waiting_local_confirm",
             "status": "waiting_local_confirm",
-            "result": execution,
+            "result": sanitized_execution,
         }
     failure_code = execution.get("failureCode")
     if isinstance(failure_code, str) and failure_code:

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -244,6 +244,13 @@ def _heartbeat(auth_context: dict[str, object], job: dict[str, object]) -> None:
 
 
 def _result_payload(job: dict[str, object], execution: dict[str, object]) -> dict[str, object]:
+    if execution.get("waitingLocalConfirm") is True:
+        return {
+            "leaseId": _lease_id(job),
+            "idempotencyKey": f"{_job_id(job)}:{_lease_id(job)}:waiting_local_confirm",
+            "status": "waiting_local_confirm",
+            "result": execution,
+        }
     failure_code = execution.get("failureCode")
     if isinstance(failure_code, str) and failure_code:
         payload: dict[str, object] = {

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -345,6 +345,56 @@ def test_poll_once_posts_failed_result_when_execution_raises(tmp_path: Path, mon
     assert "shim status failed" in str(result_payloads[0]["failureMessage"])
 
 
+def test_poll_once_posts_waiting_local_confirm_result_for_destructive_job(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    result_payloads: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
+    )
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        if path == "/lease":
+            return {
+                "item": {
+                    "id": "job-6",
+                    "leaseId": "lease-6",
+                    "operation": "guard.packageShims.remove",
+                    "payload": {"managers": ["npm"]},
+                }
+            }
+        if path.endswith("/result"):
+            result_payloads.append(payload)
+        return {"ok": True}
+
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+
+    status = command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    assert status["state"] == "idle"
+    assert result_payloads[0]["status"] == "waiting_local_confirm"
+    assert result_payloads[0]["idempotencyKey"] == "job-6:lease-6:waiting_local_confirm"
+    result = result_payloads[0]["result"]
+    assert isinstance(result, dict)
+    data = result["data"]
+    assert isinstance(data, dict)
+    assert data["confirm_command"] == "hol-guard package-shims uninstall --manager npm"
+    assert data["summary"] == (
+        "Run the local package-shim uninstall command on this machine to "
+        "confirm removal for npm."
+    )
+
+
 def test_poll_once_retries_pending_result_before_leasing(tmp_path: Path, monkeypatch) -> None:
     store = FakeStore(tmp_path / "guard-home")
     store.set_sync_payload(
@@ -642,6 +692,68 @@ def test_executor_dispatches_app_connect(tmp_path: Path, monkeypatch) -> None:
     assert calls == [("install", "codex", "cli")]
     assert result["generatedAt"] == "2026-06-13T00:00:00+00:00"
     assert isinstance(result["data"], dict)
+
+
+def test_executor_returns_waiting_local_confirm_for_package_shim_remove(tmp_path: Path) -> None:
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.packageShims.remove",
+            "payload": {"managers": ["npm"]},
+        },
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["waitingLocalConfirm"] is True
+    assert result["data"] == {
+        "confirm_command": "hol-guard package-shims uninstall --manager npm",
+        "managers": ["npm"],
+        "summary": (
+            "Run the local package-shim uninstall command on this machine to "
+            "confirm removal for npm."
+        ),
+    }
+
+
+def test_executor_returns_waiting_local_confirm_for_app_remove(tmp_path: Path, monkeypatch) -> None:
+    def fake_apply_managed_install(
+        command: str,
+        requested_harness: str | None,
+        install_all: bool,
+        context: HarnessContext,
+        store: object,
+        workspace: str | None,
+        now: str,
+        *,
+        surface: str | None = None,
+    ) -> dict[str, object]:
+        del command, requested_harness, install_all, context, store, workspace, now, surface
+        raise AssertionError("app remove should not uninstall without local confirmation")
+
+    monkeypatch.setattr(command_executors, "apply_managed_install", fake_apply_managed_install)
+
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.app.remove",
+            "payload": {"harness": "codex", "surface": "cli"},
+        },
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["waitingLocalConfirm"] is True
+    assert result["data"] == {
+        "confirm_command": "hol-guard apps disconnect codex --surface cli --confirm disconnect-codex",
+        "confirmation_phrase": "disconnect-codex",
+        "harness": "codex",
+        "summary": (
+            "Run the local disconnect command on this machine to confirm "
+            "removing Guard protection for codex."
+        ),
+        "surface": "cli",
+    }
 
 
 def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -386,12 +386,12 @@ def test_poll_once_posts_waiting_local_confirm_result_for_destructive_job(
     assert result_payloads[0]["idempotencyKey"] == "job-6:lease-6:waiting_local_confirm"
     result = result_payloads[0]["result"]
     assert isinstance(result, dict)
+    assert "waitingLocalConfirm" not in result
     data = result["data"]
     assert isinstance(data, dict)
     assert data["confirm_command"] == "hol-guard package-shims uninstall --manager npm"
     assert data["summary"] == (
-        "Run the local package-shim uninstall command on this machine to "
-        "confirm removal for npm."
+        "Run the local package-shim uninstall command on this machine to confirm removal for npm."
     )
 
 
@@ -709,10 +709,26 @@ def test_executor_returns_waiting_local_confirm_for_package_shim_remove(tmp_path
     assert result["data"] == {
         "confirm_command": "hol-guard package-shims uninstall --manager npm",
         "managers": ["npm"],
-        "summary": (
-            "Run the local package-shim uninstall command on this machine to "
-            "confirm removal for npm."
-        ),
+        "summary": ("Run the local package-shim uninstall command on this machine to confirm removal for npm."),
+    }
+
+
+def test_executor_returns_waiting_local_confirm_for_package_shim_remove_all_managers(tmp_path: Path) -> None:
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.packageShims.remove",
+            "payload": {},
+        },
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["waitingLocalConfirm"] is True
+    assert result["data"] == {
+        "confirm_command": "hol-guard package-shims uninstall",
+        "managers": [],
+        "summary": "Run the local package-shim uninstall command on this machine to confirm removal.",
     }
 
 
@@ -748,11 +764,48 @@ def test_executor_returns_waiting_local_confirm_for_app_remove(tmp_path: Path, m
         "confirm_command": "hol-guard apps disconnect codex --surface cli --confirm disconnect-codex",
         "confirmation_phrase": "disconnect-codex",
         "harness": "codex",
-        "summary": (
-            "Run the local disconnect command on this machine to confirm "
-            "removing Guard protection for codex."
-        ),
+        "summary": ("Run the local disconnect command on this machine to confirm removing Guard protection for codex."),
         "surface": "cli",
+    }
+
+
+def test_executor_returns_waiting_local_confirm_for_app_remove_without_surface(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    def fake_apply_managed_install(
+        command: str,
+        requested_harness: str | None,
+        install_all: bool,
+        context: HarnessContext,
+        store: object,
+        workspace: str | None,
+        now: str,
+        *,
+        surface: str | None = None,
+    ) -> dict[str, object]:
+        del command, requested_harness, install_all, context, store, workspace, now, surface
+        raise AssertionError("app remove should not uninstall without local confirmation")
+
+    monkeypatch.setattr(command_executors, "apply_managed_install", fake_apply_managed_install)
+
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.app.remove",
+            "payload": {"harness": "codex"},
+        },
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["waitingLocalConfirm"] is True
+    assert result["data"] == {
+        "confirm_command": "hol-guard apps disconnect codex --confirm disconnect-codex",
+        "confirmation_phrase": "disconnect-codex",
+        "harness": "codex",
+        "summary": ("Run the local disconnect command on this machine to confirm removing Guard protection for codex."),
+        "surface": None,
     }
 
 


### PR DESCRIPTION
## Summary
- stop destructive Guard Cloud remove jobs at local confirmation instead of uninstalling immediately
- post `waiting_local_confirm` results with the exact local CLI command needed on the device
- add command queue regression coverage for destructive waiting states

## Testing
- `/Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/.venv/bin/pytest tests/test_guard_command_queue.py`
