### PR TITLE
fix(dashboard): open Guard Cloud authorize URL from connect actions

### DIFF
--- a/dashboard/src/evidence/evidence-insights-share-modal.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-modal.tsx
@@ -10,6 +10,10 @@ import {
   type GuardInsightsShareResult,
 } from "../guard-api";
 import { ConnectFlowCard } from "../supply-chain-firewall-views";
+import {
+  openPackageFirewallAuthorizeWindow,
+  PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE,
+} from "../package-firewall-connect-browser";
 import { EvidenceInsightsShareSheet } from "./evidence-insights-share-sheet";
 import { GuardStatMetric } from "./guard-stat-metric";
 import { HomeInsightsMetrics } from "./evidence-insights-headline-bento";
@@ -92,6 +96,12 @@ export function EvidenceInsightsShareModal({
     try {
       const status = await startGuardCloudConnect();
       setConnectFlow(status.connect_flow);
+      if (
+        status.connect_flow?.authorize_url &&
+        !openPackageFirewallAuthorizeWindow(status.connect_flow.authorize_url)
+      ) {
+        setConnectError(PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE);
+      }
       if (!status.connect_required) {
         await refreshConnectState();
       }

--- a/dashboard/src/package-firewall-connect-browser.test.ts
+++ b/dashboard/src/package-firewall-connect-browser.test.ts
@@ -1,0 +1,51 @@
+import {
+  openPackageFirewallAuthorizeWindow,
+  PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE,
+} from "./package-firewall-connect-browser";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const openedUrls: string[] = [];
+
+Object.assign(globalThis, {
+  window: {
+    open: (url: string) => {
+      openedUrls.push(url);
+      return {};
+    },
+  },
+});
+
+assert(
+  openPackageFirewallAuthorizeWindow("https://hol.org/api/guard/oauth/authorize?client_id=test"),
+  "expected authorize window to open",
+);
+assert(openedUrls.length === 1, "expected one window.open call");
+assert(
+  openedUrls[0] === "https://hol.org/api/guard/oauth/authorize?client_id=test",
+  "expected authorize URL to be passed to window.open",
+);
+
+openedUrls.length = 0;
+assert(!openPackageFirewallAuthorizeWindow(null), "null authorize URL should not open");
+assert(openedUrls.length === 0, "null authorize URL should not call window.open");
+
+Object.assign(globalThis, {
+  window: {
+    open: () => null,
+  },
+});
+assert(
+  !openPackageFirewallAuthorizeWindow("https://hol.org/api/guard/oauth/authorize?client_id=test"),
+  "popup blocked should return false",
+);
+assert(
+  PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE.includes("Open sign-in page"),
+  "popup blocked message should mention manual link",
+);
+
+console.log("package-firewall-connect-browser.test.ts: all assertions passed");

--- a/dashboard/src/package-firewall-connect-browser.test.ts
+++ b/dashboard/src/package-firewall-connect-browser.test.ts
@@ -44,8 +44,8 @@ assert(
   "popup blocked should return false",
 );
 assert(
-  PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE.includes("Open sign-in page"),
-  "popup blocked message should mention manual link",
+  PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE.includes("manual sign-in link"),
+  "popup blocked message should mention manual sign-in link",
 );
 
 console.log("package-firewall-connect-browser.test.ts: all assertions passed");

--- a/dashboard/src/package-firewall-connect-browser.ts
+++ b/dashboard/src/package-firewall-connect-browser.ts
@@ -1,0 +1,12 @@
+export const PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE =
+  "Your browser blocked the Guard Cloud sign-in window. Use Open sign-in page below.";
+
+export function openPackageFirewallAuthorizeWindow(
+  authorizeUrl: string | null | undefined,
+): boolean {
+  if (!authorizeUrl || typeof window === "undefined") {
+    return false;
+  }
+  const popup = window.open(authorizeUrl, "_blank", "noopener,noreferrer");
+  return popup !== null;
+}

--- a/dashboard/src/package-firewall-connect-browser.ts
+++ b/dashboard/src/package-firewall-connect-browser.ts
@@ -1,5 +1,5 @@
 export const PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE =
-  "Your browser blocked the Guard Cloud sign-in window. Use Open sign-in page below.";
+  "Your browser blocked the Guard Cloud sign-in window. Use the manual sign-in link below.";
 
 export function openPackageFirewallAuthorizeWindow(
   authorizeUrl: string | null | undefined,
@@ -7,6 +7,10 @@ export function openPackageFirewallAuthorizeWindow(
   if (!authorizeUrl || typeof window === "undefined") {
     return false;
   }
-  const popup = window.open(authorizeUrl, "_blank", "noopener,noreferrer");
-  return popup !== null;
+  const popup = window.open(authorizeUrl, "_blank");
+  if (popup) {
+    popup.opener = null;
+    return true;
+  }
+  return false;
 }

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -23,6 +23,10 @@ import {
   readHarnessActionUserMessage,
   resolveApprovalGateSyncFailure,
 } from "./harness-action-errors";
+import {
+  openPackageFirewallAuthorizeWindow,
+  PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE,
+} from "./package-firewall-connect-browser";
 import { EntitlementNotice, ConnectFlowCard } from "./supply-chain-firewall-views";
 import type { CompletedOp } from "./supply-chain-firewall-views";
 import {
@@ -433,7 +437,13 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
     setConnectError(null);
     setActivationAssistError(null);
     try {
-      await startPackageFirewallConnect();
+      const connectFlow = await startPackageFirewallConnect();
+      if (
+        connectFlow?.authorize_url &&
+        !openPackageFirewallAuthorizeWindow(connectFlow.authorize_url)
+      ) {
+        setConnectError(PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE);
+      }
       await refreshAfterOp();
       await onStateChanged?.();
     } catch (error) {


### PR DESCRIPTION
## Summary
- Open the OAuth authorize URL in the browser when Connect Guard Cloud starts from the supply-chain dashboard.
- Apply the same authorize-window behavior for insights share connect flows.
- Show popup-blocked guidance when the browser blocks the sign-in window.

## Testing
- `cd dashboard && npx tsx src/package-firewall-connect-browser.test.ts`
- `cd dashboard && npx tsx src/package-firewall-connect.test.tsx`
