### PR TITLE
fix(cursor): persist MCP native approvals and queue warn prompts

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -20,7 +20,7 @@ _BLOCKING_MANAGED_HOOK_EVENTS = (
     "beforeMCPExecution",
     "beforeReadFile",
 )
-_OBSERVER_MANAGED_HOOK_EVENTS = ("afterShellExecution",)
+_OBSERVER_MANAGED_HOOK_EVENTS = ("afterShellExecution", "afterMCPExecution")
 _MANAGED_HOOK_EVENTS = _BLOCKING_MANAGED_HOOK_EVENTS + _OBSERVER_MANAGED_HOOK_EVENTS
 _MANAGED_HOOK_TIMEOUT_SECONDS = 45
 _LEGACY_MANAGED_COMMAND_MARKERS = (
@@ -63,6 +63,19 @@ def _cursor_shell_hook_payload(normalized: dict[str, object], *, hook_event_name
     return payload
 
 
+def _cursor_mcp_hook_payload(normalized: dict[str, object], *, hook_event_name: str) -> dict[str, object]:
+    payload = dict(normalized)
+    payload["hook_event_name"] = hook_event_name
+    tool_input = _tool_input_dict(payload.get("tool_input"))
+    payload["tool_input"] = tool_input
+    tool_name = payload.get("tool_name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        payload["tool_name"] = tool_name.strip()
+    else:
+        payload.setdefault("tool_name", "MCP")
+    return payload
+
+
 def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, object]:
     """Map Cursor hook stdin JSON into Guard hook normalization shape."""
 
@@ -70,22 +83,22 @@ def prepare_cursor_hook_payload(payload: Mapping[str, object]) -> dict[str, obje
     raw_event = _raw_hook_event_name(normalized)
     if raw_event == "aftershellexecution":
         return _cursor_shell_hook_payload(normalized, hook_event_name="afterShellExecution")
+    if raw_event == "aftermcpexecution":
+        return _cursor_mcp_hook_payload(normalized, hook_event_name="afterMCPExecution")
     if raw_event == "beforeshellexecution":
-        return _cursor_shell_hook_payload(normalized, hook_event_name="PreToolUse")
+        prepared = _cursor_shell_hook_payload(normalized, hook_event_name="PreToolUse")
+        prepared["cursor_source_hook_event"] = "beforeShellExecution"
+        return prepared
     if raw_event == "beforemcpexecution":
-        normalized["hook_event_name"] = "PreToolUse"
-        tool_name = normalized.get("tool_name")
-        if isinstance(tool_name, str) and tool_name.strip():
-            normalized["tool_name"] = tool_name.strip()
-        else:
-            normalized.setdefault("tool_name", "MCP")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        prepared = _cursor_mcp_hook_payload(normalized, hook_event_name="PreToolUse")
+        tool_input = _tool_input_dict(prepared.get("tool_input"))
         for key in ("url", "command"):
             value = normalized.get(key)
             if isinstance(value, str) and value.strip():
                 tool_input.setdefault(key, value.strip())
-        normalized["tool_input"] = tool_input
-        return normalized
+        prepared["tool_input"] = tool_input
+        prepared["cursor_source_hook_event"] = "beforeMCPExecution"
+        return prepared
     if raw_event == "beforereadfile":
         normalized["hook_event_name"] = "PreToolUse"
         normalized.setdefault("tool_name", "Read")
@@ -130,6 +143,19 @@ def cursor_hook_would_prompt_user(
         policy_action == "warn"
         and guard_payload is not None
         and _guard_payload_has_actionable_risk_for_policy(guard_payload)
+    )
+
+
+def cursor_hook_requires_approval_center_queue(
+    *,
+    policy_action: str,
+    guard_payload: Mapping[str, object] | None = None,
+) -> bool:
+    """Return True when Cursor native prompts should also appear in the approval center."""
+
+    return cursor_hook_would_prompt_user(
+        policy_action=policy_action,
+        guard_payload=guard_payload,
     )
 
 
@@ -620,27 +646,40 @@ def _cursor_shell_hook_payload(normalized: dict[str, object], hook_event_name: s
     return payload
 
 
+def _cursor_mcp_hook_payload(normalized: dict[str, object], hook_event_name: str) -> dict[str, object]:
+    payload = dict(normalized)
+    payload["hook_event_name"] = hook_event_name
+    tool_input = _tool_input_dict(payload.get("tool_input"))
+    payload["tool_input"] = tool_input
+    tool_name = payload.get("tool_name")
+    if isinstance(tool_name, str) and tool_name.strip():
+        payload["tool_name"] = tool_name.strip()
+    else:
+        payload.setdefault("tool_name", "MCP")
+    return payload
+
+
 def _prepare_cursor_hook_payload(payload: dict[str, object]) -> dict[str, object]:
     normalized = _infer_cursor_hook_event_name(payload)
     raw_event = _raw_hook_event_name(normalized)
     if raw_event == "aftershellexecution":
         return _cursor_shell_hook_payload(normalized, "afterShellExecution")
+    if raw_event == "aftermcpexecution":
+        return _cursor_mcp_hook_payload(normalized, "afterMCPExecution")
     if raw_event == "beforeshellexecution":
-        return _cursor_shell_hook_payload(normalized, "PreToolUse")
+        prepared = _cursor_shell_hook_payload(normalized, "PreToolUse")
+        prepared["cursor_source_hook_event"] = "beforeShellExecution"
+        return prepared
     if raw_event == "beforemcpexecution":
-        normalized["hook_event_name"] = "PreToolUse"
-        tool_name = normalized.get("tool_name")
-        if isinstance(tool_name, str) and tool_name.strip():
-            normalized["tool_name"] = tool_name.strip()
-        else:
-            normalized.setdefault("tool_name", "MCP")
-        tool_input = _tool_input_dict(normalized.get("tool_input"))
+        prepared = _cursor_mcp_hook_payload(normalized, "PreToolUse")
+        tool_input = _tool_input_dict(prepared.get("tool_input"))
         for key in ("url", "command"):
             value = normalized.get(key)
             if isinstance(value, str) and value.strip():
                 tool_input.setdefault(key, value.strip())
-        normalized["tool_input"] = tool_input
-        return normalized
+        prepared["tool_input"] = tool_input
+        prepared["cursor_source_hook_event"] = "beforeMCPExecution"
+        return prepared
     if raw_event == "beforereadfile":
         normalized["hook_event_name"] = "PreToolUse"
         normalized.setdefault("tool_name", "Read")
@@ -807,15 +846,21 @@ def _normalize_cursor_shell_command(command: str) -> str:
 
 
 def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:
-    command = payload.get("command")
-    if isinstance(command, str) and command.strip():
-        return _normalize_cursor_shell_command(command)
     tool_input = payload.get("tool_input")
+    nested_command: str | None = None
     if isinstance(tool_input, dict):
         nested = tool_input.get("command")
         if isinstance(nested, str) and nested.strip():
-            return _normalize_cursor_shell_command(nested)
-    return None
+            nested_command = _normalize_cursor_shell_command(nested)
+    command = payload.get("command")
+    if isinstance(command, str) and command.strip():
+        top_level = _normalize_cursor_shell_command(command)
+        if nested_command is not None:
+            first_token = command.strip().split(maxsplit=1)[0]
+            if Path(first_token).name.lower() == "lean-ctx":
+                return nested_command
+        return top_level
+    return nested_command
 
 
 def _cursor_shell_binding_path(conversation_id: str, command: str) -> Path:
@@ -858,8 +903,9 @@ def _load_cursor_hook_attestation_secret() -> bytes | None:
     return secret or None
 
 
-def _compute_cursor_after_shell_proof(
+def _compute_cursor_after_observer_proof(
     payload: Mapping[str, object],
+    observer_event: str,
     approval_binding: str | None = None,
 ) -> str | None:
     conversation_id = _cursor_conversation_id(payload)
@@ -869,7 +915,7 @@ def _compute_cursor_after_shell_proof(
     if conversation_id is None or command is None or resolved_binding is None or secret is None:
         return None
     message = chr(0).join(
-        (conversation_id, command, resolved_binding, "afterShellExecution")
+        (conversation_id, command, resolved_binding, observer_event.strip())
     ).encode("utf-8")
     return hmac.new(secret, message, hashlib.sha256).hexdigest()
 
@@ -901,9 +947,9 @@ def main() -> int:
             guard_argv.extend(["--workspace", workspace])
     guard_env = _hook_process_env()
     guard_env["HOL_GUARD_MANAGED_CURSOR_HOOK"] = "1"
-    if hook_event_name.strip().lower() == "aftershellexecution":
+    if hook_event_name.strip().lower() in {"aftershellexecution", "aftermcpexecution"}:
         approval_binding = _resolve_approval_binding(prepared)
-        proof = _compute_cursor_after_shell_proof(prepared, approval_binding)
+        proof = _compute_cursor_after_observer_proof(prepared, hook_event_name, approval_binding)
         if approval_binding:
             guard_env["HOL_GUARD_CURSOR_APPROVAL_BINDING"] = approval_binding
         if proof:
@@ -950,7 +996,7 @@ def main() -> int:
         except json.JSONDecodeError:
             guard_payload = {}
     policy_action = str(guard_payload.get("policy_action") or "allow")
-    if hook_event_name.strip().lower() == "aftershellexecution":
+    if hook_event_name.strip().lower() in {"aftershellexecution", "aftermcpexecution"}:
         print("{}")
         return 0
     if proc.returncode != 0 and not guard_payload:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -48,6 +48,10 @@ def _infer_cursor_hook_event_name(payload: Mapping[str, object]) -> dict[str, ob
     return normalized
 
 
+# Payload normalizers below are mirrored inside _HOOK_SCRIPT_TEMPLATE for the installed
+# Cursor hook script. Keep both copies in sync when changing observer or MCP behavior.
+
+
 def _cursor_shell_hook_payload(normalized: dict[str, object], *, hook_event_name: str) -> dict[str, object]:
     payload = dict(normalized)
     payload["hook_event_name"] = hook_event_name
@@ -151,7 +155,11 @@ def cursor_hook_requires_approval_center_queue(
     policy_action: str,
     guard_payload: Mapping[str, object] | None = None,
 ) -> bool:
-    """Return True when Cursor native prompts should also appear in the approval center."""
+    """Return True when Cursor native prompts should also appear in the approval center.
+
+    Currently equivalent to ``cursor_hook_would_prompt_user``; kept separate so the
+    two concepts can diverge without touching call sites.
+    """
 
     return cursor_hook_would_prompt_user(
         policy_action=policy_action,

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -1,4 +1,4 @@
-"""Cursor native shell approval attestation for afterShell observer hooks."""
+"""Cursor native approval attestation for afterShell and afterMCP observer hooks."""
 
 from __future__ import annotations
 
@@ -17,6 +17,11 @@ _MANAGED_HOOK_ENV = "HOL_GUARD_MANAGED_CURSOR_HOOK"
 _AFTER_SHELL_PROOF_ENV = "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF"
 _APPROVAL_BINDING_ENV = "HOL_GUARD_CURSOR_APPROVAL_BINDING"
 _AFTER_SHELL_PROOF_EVENT = "afterShellExecution"
+_AFTER_MCP_PROOF_EVENT = "afterMCPExecution"
+_CURSOR_BLOCKING_OBSERVER_EVENTS = {
+    "beforeShellExecution": _AFTER_SHELL_PROOF_EVENT,
+    "beforeMCPExecution": _AFTER_MCP_PROOF_EVENT,
+}
 _MAX_CURSOR_SHELL_NORMALIZE_BYTES = 8192
 _LEAN_CTX_COMMAND_MARKER = "lean-ctx"
 
@@ -106,11 +111,37 @@ def _cursor_shell_binding_segment(conversation_id: str) -> str:
     return cleaned
 
 
-def cursor_after_shell_proof_message(
+def is_lean_ctx_wrapper_command(command: str) -> bool:
+    stripped = command.strip()
+    if not stripped:
+        return False
+    first_token = stripped.split(maxsplit=1)[0]
+    return Path(first_token).name.lower() == _LEAN_CTX_COMMAND_MARKER
+
+
+def cursor_observer_event_for_blocking(blocking_event: str) -> str | None:
+    return _CURSOR_BLOCKING_OBSERVER_EVENTS.get(blocking_event.strip())
+
+
+def cursor_observer_event_for_payload(payload: Mapping[str, object]) -> str:
+    for key in ("hook_event_name", "hookEventName", "cursor_source_hook_event"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            normalized = value.strip()
+            if normalized in {_AFTER_SHELL_PROOF_EVENT, _AFTER_MCP_PROOF_EVENT}:
+                return normalized
+            mapped = cursor_observer_event_for_blocking(normalized)
+            if mapped is not None:
+                return mapped
+    return _AFTER_SHELL_PROOF_EVENT
+
+
+def cursor_after_observer_proof_message(
     *,
     conversation_id: str,
     command: str,
     approval_binding: str,
+    observer_event: str,
 ) -> bytes:
     return (
         chr(0)
@@ -119,10 +150,24 @@ def cursor_after_shell_proof_message(
                 conversation_id.strip(),
                 command.strip(),
                 approval_binding.strip(),
-                _AFTER_SHELL_PROOF_EVENT,
+                observer_event.strip(),
             )
         )
         .encode("utf-8")
+    )
+
+
+def cursor_after_shell_proof_message(
+    *,
+    conversation_id: str,
+    command: str,
+    approval_binding: str,
+) -> bytes:
+    return cursor_after_observer_proof_message(
+        conversation_id=conversation_id,
+        command=command,
+        approval_binding=approval_binding,
+        observer_event=_AFTER_SHELL_PROOF_EVENT,
     )
 
 
@@ -246,6 +291,25 @@ def ensure_cursor_approval_binding(payload: Mapping[str, object]) -> str:
     return f"hol-guard:{secrets.token_urlsafe(24)}"
 
 
+def compute_cursor_after_observer_proof(
+    *,
+    secret: bytes,
+    conversation_id: str,
+    command: str,
+    approval_binding: str,
+    observer_event: str,
+) -> str:
+    normalized_command = normalize_cursor_shell_command(command)
+    message = cursor_after_observer_proof_message(
+        conversation_id=conversation_id,
+        command=normalized_command,
+        approval_binding=approval_binding,
+        observer_event=observer_event,
+    )
+    digest = hmac.new(secret, message, hashlib.sha256).hexdigest()
+    return digest
+
+
 def compute_cursor_after_shell_proof(
     *,
     secret: bytes,
@@ -253,14 +317,34 @@ def compute_cursor_after_shell_proof(
     command: str,
     approval_binding: str,
 ) -> str:
-    normalized_command = normalize_cursor_shell_command(command)
-    message = cursor_after_shell_proof_message(
+    return compute_cursor_after_observer_proof(
+        secret=secret,
         conversation_id=conversation_id,
-        command=normalized_command,
+        command=command,
         approval_binding=approval_binding,
+        observer_event=_AFTER_SHELL_PROOF_EVENT,
     )
-    digest = hmac.new(secret, message, hashlib.sha256).hexdigest()
-    return digest
+
+
+def verify_cursor_after_observer_proof(
+    *,
+    secret: bytes,
+    conversation_id: str,
+    command: str,
+    approval_binding: str,
+    proof: str,
+    observer_event: str,
+) -> bool:
+    if not proof.strip():
+        return False
+    expected = compute_cursor_after_observer_proof(
+        secret=secret,
+        conversation_id=conversation_id,
+        command=command,
+        approval_binding=approval_binding,
+        observer_event=observer_event,
+    )
+    return hmac.compare_digest(expected, proof.strip())
 
 
 def verify_cursor_after_shell_proof(
@@ -271,15 +355,14 @@ def verify_cursor_after_shell_proof(
     approval_binding: str,
     proof: str,
 ) -> bool:
-    if not proof.strip():
-        return False
-    expected = compute_cursor_after_shell_proof(
+    return verify_cursor_after_observer_proof(
         secret=secret,
         conversation_id=conversation_id,
         command=command,
         approval_binding=approval_binding,
+        proof=proof,
+        observer_event=_AFTER_SHELL_PROOF_EVENT,
     )
-    return hmac.compare_digest(expected, proof.strip())
 
 
 def managed_cursor_hook_invocation(env: Mapping[str, str] | None = None) -> bool:
@@ -292,7 +375,7 @@ def after_shell_proof_from_env(env: Mapping[str, str] | None = None) -> str | No
     return _optional_string(source.get(_AFTER_SHELL_PROOF_ENV))
 
 
-def cursor_after_shell_trusted(
+def cursor_after_observer_trusted(
     *,
     guard_home: Path,
     pending: Mapping[str, object],
@@ -323,34 +406,64 @@ def cursor_after_shell_trusted(
         return False
     if not hmac.compare_digest(expected_proof.strip(), proof.strip()):
         return False
+    observer_event = _optional_string(pending.get("observer_event")) or cursor_observer_event_for_payload(
+        payload
+    )
     try:
         secret = ensure_cursor_hook_attestation_secret(guard_home)
     except OSError:
         return False
-    return verify_cursor_after_shell_proof(
+    return verify_cursor_after_observer_proof(
         secret=secret,
         conversation_id=conversation_id,
         command=normalize_cursor_shell_command(command),
         approval_binding=payload_binding,
         proof=proof,
+        observer_event=observer_event,
+    )
+
+
+def cursor_after_shell_trusted(
+    *,
+    guard_home: Path,
+    pending: Mapping[str, object],
+    payload: Mapping[str, object],
+    conversation_id: str,
+    command: str,
+    env: Mapping[str, str] | None = None,
+) -> bool:
+    return cursor_after_observer_trusted(
+        guard_home=guard_home,
+        pending=pending,
+        payload=payload,
+        conversation_id=conversation_id,
+        command=command,
+        env=env,
     )
 
 
 __all__ = [
     "after_shell_proof_from_env",
+    "compute_cursor_after_observer_proof",
     "compute_cursor_after_shell_proof",
+    "cursor_after_observer_proof_message",
+    "cursor_after_observer_trusted",
     "cursor_after_shell_proof_message",
     "cursor_after_shell_trusted",
     "cursor_generation_id",
     "cursor_hook_attestation_secret_path",
+    "cursor_observer_event_for_blocking",
+    "cursor_observer_event_for_payload",
     "cursor_shell_binding_path",
     "ensure_cursor_approval_binding",
     "ensure_cursor_hook_attestation_secret",
+    "is_lean_ctx_wrapper_command",
     "managed_cursor_hook_invocation",
     "normalize_cursor_shell_command",
     "read_cursor_shell_binding_file",
     "remove_cursor_shell_binding_file",
     "resolve_cursor_approval_binding",
+    "verify_cursor_after_observer_proof",
     "verify_cursor_after_shell_proof",
     "write_cursor_shell_binding_file",
 ]

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -406,9 +406,7 @@ def cursor_after_observer_trusted(
         return False
     if not hmac.compare_digest(expected_proof.strip(), proof.strip()):
         return False
-    observer_event = _optional_string(pending.get("observer_event")) or cursor_observer_event_for_payload(
-        payload
-    )
+    observer_event = _optional_string(pending.get("observer_event")) or cursor_observer_event_for_payload(payload)
     try:
         secret = ensure_cursor_hook_attestation_secret(guard_home)
     except OSError:

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -61,7 +61,7 @@ def _run_guard_hook_command(
                 runtime_workspace = current_workspace
     if (
         _canonical_harness_name(args.harness) == "cursor"
-        and _hook_event_name(payload) == "afterShellExecution"
+        and _hook_event_name(payload) in {"afterShellExecution", "afterMCPExecution"}
     ):
         if runtime_workspace is None:
             runtime_workspace = _workspace_from_cursor_project_dir()

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
@@ -37,7 +37,16 @@ def _review_runtime_artifact_hook(
     runtime_artifact_hash = state.runtime_artifact_hash
     scanner_evidence_payload = state.scanner_evidence_payload
     stored_policy_action = state.stored_policy_action
-    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+    from ..adapters.cursor_hooks import cursor_hook_requires_approval_center_queue
+
+    cursor_native_queue = (
+        _canonical_harness_name(args.harness) == "cursor"
+        and cursor_hook_requires_approval_center_queue(
+            policy_action=policy_action,
+            guard_payload=response_payload,
+        )
+    )
+    if policy_action in {"block", "sandbox-required", "require-reapproval"} or cursor_native_queue:
         native_reason = _runtime_artifact_native_reason(runtime_artifact, response_payload)
         additional_context = _claude_prompt_additional_context(
             harness=args.harness,
@@ -115,13 +124,18 @@ def _review_runtime_artifact_hook(
             approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)
             approval_center_url = ensure_guard_daemon(guard_home)
             runtime_detection = _runtime_detection(args.harness, runtime_artifact)
+            queued_policy_action = (
+                "require-reapproval"
+                if cursor_native_queue and policy_action in {"warn", "review"}
+                else policy_action
+            )
             evaluation_payload = {
                 "artifacts": [
                     {
                         "artifact_id": artifact_id,
                         "artifact_name": artifact_name,
                         "artifact_hash": runtime_artifact_hash,
-                        "policy_action": policy_action,
+                        "policy_action": queued_policy_action,
                         "changed_fields": changed_capabilities,
                         "artifact_type": runtime_artifact.artifact_type,
                         "source_scope": runtime_artifact.source_scope,
@@ -210,6 +224,10 @@ def _review_runtime_artifact_hook(
                 _canonical_harness_name(args.harness) == "cursor"
                 and event_name == "PreToolUse"
                 and runtime_artifact.artifact_type == "tool_action_request"
+                and cursor_hook_requires_approval_center_queue(
+                    policy_action=policy_action,
+                    guard_payload=response_payload,
+                )
             ):
                 from ..adapters.cursor_hooks import cursor_hook_would_prompt_user
 

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
@@ -296,9 +296,10 @@ def _cursor_shell_command_from_payload(payload: Mapping[str, object]) -> str | N
 
     tool_input_command = _hook_command_text(payload)
     top_level = _optional_string(payload.get("command"))
-    if tool_input_command is not None:
-        if top_level is None or is_lean_ctx_wrapper_command(top_level):
-            return normalize_cursor_shell_command(tool_input_command)
+    if tool_input_command is not None and (
+        top_level is None or is_lean_ctx_wrapper_command(top_level)
+    ):
+        return normalize_cursor_shell_command(tool_input_command)
     if top_level is not None:
         return normalize_cursor_shell_command(top_level)
     return None

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
@@ -282,17 +282,26 @@ def _cursor_conversation_id(payload: dict[str, object]) -> str | None:
         value = _optional_string(payload.get(key))
         if value is not None:
             return value
-    return _optional_string(os.environ.get("CURSOR_SESSION_ID"))
+    for env_key in ("CURSOR_SESSION_ID", "CURSOR_TRACE_ID"):
+        value = _optional_string(os.environ.get(env_key))
+        if value is not None:
+            return value
+    return None
 
 def _cursor_shell_command_from_payload(payload: Mapping[str, object]) -> str | None:
-    from ..adapters.cursor_native_approval import normalize_cursor_shell_command
+    from ..adapters.cursor_native_approval import (
+        is_lean_ctx_wrapper_command,
+        normalize_cursor_shell_command,
+    )
 
-    command = _optional_string(payload.get("command"))
-    if command is None:
-        command = _hook_command_text(payload)
-    if command is None:
-        return None
-    return normalize_cursor_shell_command(command)
+    tool_input_command = _hook_command_text(payload)
+    top_level = _optional_string(payload.get("command"))
+    if tool_input_command is not None:
+        if top_level is None or is_lean_ctx_wrapper_command(top_level):
+            return normalize_cursor_shell_command(tool_input_command)
+    if top_level is not None:
+        return normalize_cursor_shell_command(top_level)
+    return None
 
 def _cursor_shell_command_fingerprint(command: str) -> str:
     from ..adapters.cursor_native_approval import normalize_cursor_shell_command
@@ -359,9 +368,13 @@ def _cursor_pending_shell_is_fresh(pending: Mapping[str, object], *, now: str) -
     return 0 <= age_seconds <= _CURSOR_PENDING_SHELL_MAX_AGE_SECONDS
 
 def _cursor_after_shell_observed(payload: Mapping[str, object]) -> bool:
+    event_name = (_hook_event_name(payload) or "").strip().lower()
     duration = payload.get("duration")
     if isinstance(duration, (int, float)) and not isinstance(duration, bool):
         return duration >= 0
+    if event_name == "aftermcpexecution":
+        result_json = payload.get("result_json")
+        return isinstance(result_json, str) and bool(result_json.strip())
     output = payload.get("output")
     return isinstance(output, str)
 

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -8,6 +8,25 @@ from __future__ import annotations
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
+def _cursor_runtime_artifact_from_pending(pending: Mapping[str, object]) -> GuardArtifact | None:
+    artifact_id = _optional_string(pending.get("artifact_id"))
+    artifact_name = _optional_string(pending.get("artifact_name"))
+    artifact_type = _optional_string(pending.get("artifact_type"))
+    config_path = _optional_string(pending.get("config_path"))
+    source_scope = _optional_string(pending.get("source_scope"))
+    if artifact_id is None or artifact_name is None or artifact_type is None or config_path is None:
+        return None
+    command = _optional_string(pending.get("command"))
+    return GuardArtifact(
+        artifact_id=artifact_id,
+        name=artifact_name,
+        harness="cursor",
+        artifact_type=artifact_type,
+        source_scope=source_scope or "project",
+        config_path=config_path,
+        command=command,
+    )
+
 def _record_cursor_pending_shell_permission(
     *,
     store: GuardStore,
@@ -18,7 +37,8 @@ def _record_cursor_pending_shell_permission(
     artifact_hash: str,
 ) -> None:
     from ..adapters.cursor_native_approval import (
-        compute_cursor_after_shell_proof,
+        compute_cursor_after_observer_proof,
+        cursor_observer_event_for_payload,
         ensure_cursor_approval_binding,
         ensure_cursor_hook_attestation_secret,
         remove_cursor_shell_binding_file,
@@ -30,14 +50,16 @@ def _record_cursor_pending_shell_permission(
     if conversation_id is None or command is None:
         return
     approval_binding = ensure_cursor_approval_binding(payload)
+    observer_event = cursor_observer_event_for_payload(payload)
     saved_at = _now()
     try:
         secret = ensure_cursor_hook_attestation_secret(guard_home)
-        after_shell_proof = compute_cursor_after_shell_proof(
+        after_shell_proof = compute_cursor_after_observer_proof(
             secret=secret,
             conversation_id=conversation_id,
             command=command,
             approval_binding=approval_binding,
+            observer_event=observer_event,
         )
     except OSError:
         return
@@ -54,6 +76,7 @@ def _record_cursor_pending_shell_permission(
         "conversation_id": conversation_id,
         "approval_binding": approval_binding,
         "generation_id": approval_binding,
+        "observer_event": observer_event,
         "after_shell_proof": after_shell_proof,
         "native_source": "cursor-native",
     }
@@ -254,7 +277,7 @@ def _persist_cursor_native_permission_after_shell(
     workspace: Path | None,
     hook_env: Mapping[str, str] | None = None,
 ) -> bool:
-    from ..adapters.cursor_native_approval import cursor_after_shell_trusted
+    from ..adapters.cursor_native_approval import cursor_after_observer_trusted
 
     prepared = payload
     conversation_id = _cursor_conversation_id(prepared)
@@ -273,7 +296,7 @@ def _persist_cursor_native_permission_after_shell(
         return False
     if not _cursor_pending_shell_is_fresh(pending, now=now):
         return False
-    if not cursor_after_shell_trusted(
+    if not cursor_after_observer_trusted(
         guard_home=guard_home,
         pending=pending,
         payload=prepared,
@@ -296,9 +319,15 @@ def _persist_cursor_native_permission_after_shell(
         guard_home=guard_home,
         workspace=workspace,
     )
-    if runtime_artifact is None:
+    runtime_artifact_hash: str | None = None
+    if runtime_artifact is not None:
+        runtime_artifact_hash = artifact_hash(runtime_artifact)
+    else:
+        runtime_artifact = _cursor_runtime_artifact_from_pending(pending)
+        if runtime_artifact is not None:
+            runtime_artifact_hash = _optional_string(pending.get("artifact_hash"))
+    if runtime_artifact is None or runtime_artifact_hash is None:
         return False
-    runtime_artifact_hash = artifact_hash(runtime_artifact)
     session_saved = _record_cursor_native_shell_allow_state(
         store=store,
         conversation_id=conversation_id,
@@ -312,7 +341,7 @@ def _persist_cursor_native_permission_after_shell(
     _resolve_cursor_pending_approval_requests(
         store=store,
         pending=pending,
-        reason="Approved in Cursor native shell approval prompt.",
+        reason="Approved in Cursor native approval prompt.",
         now=now,
     )
     receipt = build_receipt(

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -166,6 +166,7 @@ _SHELL_TOOL_NAMES = frozenset(
         "ash",
         "bash",
         "cmd",
+        "ctx_shell",
         "dash",
         "powershell",
         "pwsh",

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -99,6 +99,7 @@ def test_managed_hook_events_exclude_pretooluse() -> None:
         "beforeMCPExecution",
         "beforeReadFile",
         "afterShellExecution",
+        "afterMCPExecution",
     )
 
 
@@ -269,9 +270,27 @@ def test_prepare_cursor_hook_payload_maps_before_mcp_execution() -> None:
         }
     )
     assert payload["tool_name"] == "plugin-notion-workspace-notion"
+    assert payload["cursor_source_hook_event"] == "beforeMCPExecution"
     tool_input = payload["tool_input"]
     assert isinstance(tool_input, dict)
     assert tool_input["url"] == "https://example.com/mcp"
+
+
+def test_prepare_cursor_hook_payload_maps_after_mcp_execution() -> None:
+    payload = prepare_cursor_hook_payload(
+        {
+            "hook_event_name": "afterMCPExecution",
+            "tool_name": "ctx_shell",
+            "tool_input": {"command": "pnpm test"},
+            "result_json": "{\"ok\": true}",
+            "duration": 42,
+        }
+    )
+    assert payload["hook_event_name"] == "afterMCPExecution"
+    assert payload["tool_name"] == "ctx_shell"
+    tool_input = payload["tool_input"]
+    assert isinstance(tool_input, dict)
+    assert tool_input["command"] == "pnpm test"
 
 
 def test_cursor_hook_response_from_guard_maps_read_ask_to_deny() -> None:
@@ -375,7 +394,7 @@ def test_cursor_hook_script_source_infers_event_before_prepare(tmp_path: Path) -
     assert 'hook_event_name = str(inferred.get("hook_event_name")' in source
     assert "aftershellexecution" in source.lower()
     assert "HOL_GUARD_MANAGED_CURSOR_HOOK" in source
-    assert "_compute_cursor_after_shell_proof" in source
+    assert "_compute_cursor_after_observer_proof" in source
 
 
 def test_install_cursor_hooks_registers_after_shell_observer(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -397,6 +416,8 @@ def test_install_cursor_hooks_registers_after_shell_observer(tmp_path: Path, mon
     installed = json.loads(hooks_path.read_text(encoding="utf-8"))
     after_shell = installed["hooks"]["afterShellExecution"][-1]
     assert after_shell.get("failClosed") is not True
+    after_mcp = installed["hooks"]["afterMCPExecution"][-1]
+    assert after_mcp.get("failClosed") is not True
     assert (guard_home / "secrets" / "cursor-hook-attestation.key").is_file()
 
 
@@ -783,6 +804,110 @@ def test_cursor_after_shell_rejects_boolean_duration(tmp_path: Path) -> None:
         ),
     )
     assert saved is False
+
+
+def _trusted_cursor_after_observer_env(
+    guard_home: Path,
+    *,
+    conversation_id: str,
+    command: str,
+    observer_event: str,
+    approval_binding: str = "gen-cursor-test",
+) -> dict[str, str]:
+    from codex_plugin_scanner.guard.adapters.cursor_native_approval import (
+        compute_cursor_after_observer_proof,
+        ensure_cursor_hook_attestation_secret,
+    )
+
+    secret = ensure_cursor_hook_attestation_secret(guard_home)
+    proof = compute_cursor_after_observer_proof(
+        secret=secret,
+        conversation_id=conversation_id,
+        command=command,
+        approval_binding=approval_binding,
+        observer_event=observer_event,
+    )
+    return {
+        "HOL_GUARD_MANAGED_CURSOR_HOOK": "1",
+        "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF": proof,
+        "HOL_GUARD_CURSOR_APPROVAL_BINDING": approval_binding,
+        "CURSOR_SESSION_ID": conversation_id,
+        "CURSOR_VERSION": "test",
+    }
+
+
+def test_cursor_shell_command_from_payload_prefers_inner_lean_ctx_command() -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+
+    command = guard_commands_module._cursor_shell_command_from_payload(
+        {
+            "command": "/Users/me/.local/bin/lean-ctx",
+            "tool_input": {"command": "rm -rf ./hol-guard-cursor-native-mcp-marker"},
+        }
+    )
+    assert command == "rm -rf ./hol-guard-cursor-native-mcp-marker"
+
+
+def test_cursor_native_mcp_session_allow_after_trusted_after_mcp(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-native-mcp"
+    inner_command = "rm -rf ./hol-guard-cursor-native-mcp-marker"
+    generation_id = "gen-cursor-native-mcp"
+    before_payload = prepare_cursor_hook_payload(
+        {
+            "conversation_id": conversation_id,
+            "generation_id": generation_id,
+            "hook_event_name": "beforeMCPExecution",
+            "tool_name": "ctx_shell",
+            "tool_input": {"command": inner_command},
+            "command": str(home_dir / ".local" / "bin" / "lean-ctx"),
+        }
+    )
+    guard_commands_module._record_cursor_pending_shell_permission(
+        store=store,
+        guard_home=home_dir,
+        payload=before_payload,
+        reason="Requests a sensitive native tool action.",
+        artifact=_cursor_shell_artifact(workspace_dir=workspace_dir, command=inner_command),
+        artifact_hash="hash-cursor-mcp-shell",
+    )
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "generation_id": generation_id,
+                "hook_event_name": "afterMCPExecution",
+                "tool_name": "ctx_shell",
+                "tool_input": {"command": inner_command},
+                "result_json": "{\"ok\": true}",
+                "duration": 12,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_observer_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=inner_command,
+            observer_event="afterMCPExecution",
+            approval_binding=generation_id,
+        ),
+    )
+    assert saved is True
+    assert guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        before_payload,
+    )
 
 
 def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Record afterMCPExecution observer attestations so Cursor native MCP approvals persist session allow state
- Queue dashboard approval requests for warn and review native Cursor prompts, not only hard blocks
- Prefer inner lean-ctx shell commands for pending fingerprints and fall back to pending artifacts when MCP runtime extraction fails

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_hooks.py -q`
