### PR TITLE
fix(guard): block hosted legacy daemon control paths

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -4006,6 +4006,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/update/status",
         }:
             return True
+        # Hosted dashboard access is blocked for these routes, but local
+        # loopback/dashboard sessions still use them until the route deletion
+        # slice lands.
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"] and path_parts[2] in _HEADLESS_APP_ACTIONS:
             return True
         if len(path_parts) >= 2 and path_parts[:2] == ["v1", "supply-chain"]:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3991,6 +3991,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/sessions/start",
             "/v1/operations/start",
             "/v1/operations/block",
+            "/v1/policy/sync",
             "/v1/requests/clear",
             "/v1/requests/remote-once",
             "/v1/settings/import",
@@ -4004,6 +4005,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/notifications/setup",
             "/v1/update/status",
         }:
+            return True
+        if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"] and path_parts[2] in _HEADLESS_APP_ACTIONS:
             return True
         if len(path_parts) >= 2 and path_parts[:2] == ["v1", "supply-chain"]:
             return True
@@ -4259,15 +4262,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/policy/cloud-exceptions",
             "/v1/policy/cloud-exception-requests",
             "/v1/policy/clear",
-            "/v1/policy/sync",
             "/v1/receipts",
             "/v1/receipts/analytics",
             "/v1/insights/share",
             "/v1/cloud/connect",
             "/v1/receipts/latest",
-            "/v1/requests",
-            "/v1/requests/clear",
-            "/v1/requests/remote-once",
             "/v1/runtime",
             "/v1/settings",
             "/v1/settings/export",
@@ -4277,17 +4276,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/update/status",
         }:
             return True
-        if len(path_parts) == 3 and path_parts[:2] in (["v1", "requests"], ["v1", "receipts"]):
-            return True
-        if len(path_parts) >= 2 and path_parts[:2] == ["v1", "supply-chain"]:
+        if len(path_parts) == 3 and path_parts[:2] == ["v1", "receipts"]:
             return True
         if len(path_parts) == 4 and path_parts[:3] == ["v1", "audit", "remediations"]:
-            return True
-        if (
-            len(path_parts) == 4
-            and path_parts[:2] == ["v1", "requests"]
-            and path_parts[3] in {"approve", "block", "resume"}
-        ):
             return True
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "approvals"] and path_parts[3] == "decision":
             return True
@@ -4309,8 +4300,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 "uninstall",
             }
         ):
-            return True
-        if len(path_parts) == 3 and path_parts[:2] == ["v1", "apps"] and path_parts[2] in _HEADLESS_APP_ACTIONS:
             return True
         return len(path_parts) == 4 and path_parts[:2] == ["v1", "artifacts"] and path_parts[3] == "diff"
 

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -2222,7 +2222,7 @@ class TestGuardApprovals:
         assert status == 200
         assert allow_headers == "Authorization, Content-Type, X-Guard-Dashboard-Session, X-Guard-Token"
 
-    def test_guard_daemon_allows_hosted_guard_dashboard_to_resolve_requests(self, tmp_path):
+    def test_guard_daemon_limits_request_resolution_to_local_dashboard_origin(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         store.add_approval_request(
             GuardApprovalRequest(
@@ -2246,9 +2246,18 @@ class TestGuardApprovals:
         daemon.start()
 
         try:
-            options_request = urllib.request.Request(
+            local_origin = f"http://127.0.0.1:{daemon.port}"
+            blocked_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/requests/req-hosted/approve",
                 headers={"Origin": "https://hol.org"},
+                method="OPTIONS",
+            )
+            with pytest.raises(urllib.error.HTTPError) as blocked_error:
+                urllib.request.urlopen(blocked_request, timeout=5)
+
+            options_request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/requests/req-hosted/approve",
+                headers={"Origin": local_origin},
                 method="OPTIONS",
             )
             with urllib.request.urlopen(options_request, timeout=5) as response:
@@ -2257,7 +2266,7 @@ class TestGuardApprovals:
             list_request = urllib.request.Request(
                 f"http://127.0.0.1:{daemon.port}/v1/requests",
                 headers={
-                    "Origin": "https://hol.org",
+                    "Origin": local_origin,
                     "X-Guard-Token": daemon._server.auth_token,
                 },
             )
@@ -2270,7 +2279,7 @@ class TestGuardApprovals:
                 data=json.dumps({"scope": "artifact", "reason": "approved from hosted dashboard"}).encode("utf-8"),
                 headers={
                     **_guard_json_headers(daemon._server.auth_token),
-                    "Origin": "https://hol.org",
+                    "Origin": local_origin,
                 },
                 method="POST",
             )
@@ -2280,10 +2289,11 @@ class TestGuardApprovals:
         finally:
             daemon.stop()
 
-        assert options_origin == "https://hol.org"
-        assert list_origin == "https://hol.org"
+        assert blocked_error.value.code == 403
+        assert options_origin == local_origin
+        assert list_origin == local_origin
         assert list_payload["items"][0]["request_id"] == "req-hosted"
-        assert approve_origin == "https://hol.org"
+        assert approve_origin == local_origin
         assert approve_payload["resolved"] is True
         assert store.list_approval_requests(limit=10) == []
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -61,6 +61,14 @@ def _read_json_response_with_headers(
     return _read_json_response_details(request)
 
 
+def _default_origin_for_path(path: str) -> str:
+    if path.startswith("/v1/apps/") or path.startswith("/v1/supply-chain/"):
+        return "http://127.0.0.1:6174"
+    if path == "/v1/policy/sync" or path.startswith("/v1/requests"):
+        return "http://127.0.0.1:6174"
+    return "https://hol.org"
+
+
 def _request(
     port: int,
     path: str,
@@ -70,7 +78,7 @@ def _request(
     token: str | None = None,
     authorization_token: str | None = None,
     dashboard_session_token: str | None = None,
-    origin: str | None = "https://hol.org",
+    origin: str | None = None,
     referer: str | None = None,
     extra_headers: dict[str, str] | None = None,
 ) -> urllib.request.Request:
@@ -78,13 +86,17 @@ def _request(
     headers = {
         "Content-Type": "application/json",
     }
+    if origin is None:
+        origin = _default_origin_for_path(path)
     if origin is not None:
         headers["Origin"] = origin
     if referer is not None:
         headers["Referer"] = referer
     if token is not None:
-        headers["Authorization"] = f"Bearer {token}"
-        headers["X-Guard-Dashboard-Session"] = token
+        if token.startswith("gld1."):
+            headers["X-Guard-Dashboard-Session"] = token
+        else:
+            headers["Authorization"] = f"Bearer {token}"
     if authorization_token is not None:
         headers["Authorization"] = f"Bearer {authorization_token}"
     if dashboard_session_token is not None:
@@ -1660,7 +1672,7 @@ def test_headless_app_operations_write_receipts_without_cli_copy(
                     },
                 ),
             )
-            assert status == 200
+            assert status == 200, payload
             assert payload["receipt"]["status"] == "completed"
             assert payload["receipt"]["operation"] == operation
             assert payload["state"]["receipt_summary"]["id"] == payload["receipt"]["id"]
@@ -1748,7 +1760,7 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
     finally:
         daemon.stop()
 
-    assert status == 200
+    assert status == 200, payload
     assert payload["receipt"]["operation"] == "scan"
     assert payload["cloud_sync"] == {
         "status": "queued",

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -62,9 +62,12 @@ def _read_json_response_with_headers(
 
 
 def _default_origin_for_path(path: str) -> str:
-    if path.startswith("/v1/apps/") or path.startswith("/v1/supply-chain/"):
-        return "http://127.0.0.1:6174"
-    if path == "/v1/policy/sync" or path.startswith("/v1/requests"):
+    if (
+        path.startswith("/v1/apps/")
+        or path.startswith("/v1/supply-chain/")
+        or path == "/v1/policy/sync"
+        or path.startswith("/v1/requests")
+    ):
         return "http://127.0.0.1:6174"
     return "https://hol.org"
 

--- a/tests/test_guard_hosted_dashboard_origin_blocklist.py
+++ b/tests/test_guard_hosted_dashboard_origin_blocklist.py
@@ -1,3 +1,5 @@
+"""Hosted dashboard origins cannot drive local-only daemon control routes."""
+
 from __future__ import annotations
 
 import urllib.error
@@ -15,6 +17,10 @@ from tests.test_guard_headless_daemon_api import _dashboard_token_for, _read_jso
     ("method", "path", "payload"),
     [
         ("POST", "/v1/apps/connect", {"harness": "codex", "operation": "install"}),
+        ("POST", "/v1/apps/repair", {"harness": "codex", "operation": "repair"}),
+        ("POST", "/v1/apps/status", {"harness": "codex", "operation": "status"}),
+        ("POST", "/v1/apps/test", {"harness": "codex", "operation": "scan"}),
+        ("POST", "/v1/apps/disconnect", {"harness": "codex", "operation": "remove"}),
         (
             "POST",
             "/v1/supply-chain/package-shims/install",

--- a/tests/test_guard_hosted_dashboard_origin_blocklist.py
+++ b/tests/test_guard_hosted_dashboard_origin_blocklist.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.daemon.server import GuardDaemonServer
+from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_guard_headless_daemon_api import _dashboard_token_for, _read_json_response, _request
+
+
+@pytest.mark.parametrize(
+    ("method", "path", "payload"),
+    [
+        ("POST", "/v1/apps/connect", {"harness": "codex", "operation": "install"}),
+        (
+            "POST",
+            "/v1/supply-chain/package-shims/install",
+            {"harness": "codex", "operation": "install"},
+        ),
+        ("POST", "/v1/policy/sync", {"harness": "codex", "operation": "policy_sync"}),
+        (
+            "POST",
+            "/v1/requests/remote-once",
+            {"harness": "codex", "operation": "remote_once"},
+        ),
+        ("GET", "/v1/requests", None),
+    ],
+)
+def test_hosted_dashboard_origin_rejects_legacy_cloud_control_paths(
+    tmp_path: Path,
+    method: str,
+    path: str,
+    payload: dict[str, object] | None,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        request = _request(
+            daemon.port,
+            path,
+            method=method,
+            payload=payload,
+            token=token,
+            origin="https://hol.org",
+        )
+        with pytest.raises(urllib.error.HTTPError) as error_info:
+            urllib.request.urlopen(request)
+    finally:
+        daemon.stop()
+
+    assert error_info.value.code == 403
+
+
+def test_hosted_dashboard_origin_keeps_supported_connect_state_path(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/connect/state",
+                method="GET",
+                origin="https://hol.org",
+                token=token,
+            )
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 410
+    assert payload["error"] == "legacy_pairing_disabled"

--- a/tests/test_guard_phase07_entitlement_daemon_security.py
+++ b/tests/test_guard_phase07_entitlement_daemon_security.py
@@ -137,7 +137,7 @@ def test_phase07_revoked_entitlement_blocks_repair_and_remove(
     assert repair_payload["error"] == "guard_cloud_reconnect_required"
 
 
-def test_phase07_dashboard_session_binds_operation_workspace_location_and_origin(tmp_path: Path) -> None:
+def test_phase07_local_dashboard_session_binds_operation_workspace_location_and_origin(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _seed_premium_entitlement(store)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -145,12 +145,13 @@ def test_phase07_dashboard_session_binds_operation_workspace_location_and_origin
     try:
         auth_token = load_guard_daemon_auth_token(store.guard_home)
         assert auth_token is not None
+        local_origin = f"http://127.0.0.1:{daemon.port}"
         token = _dashboard_token_with_claims(
             auth_token,
             {
                 "action_path": "package_shims_test",
                 "allowed_action_paths": ["package_shims_test"],
-                "daemon_origin": "https://hol.org",
+                "daemon_origin": local_origin,
                 "location_id": "location-1",
                 "managers": ["npm"],
                 "nonce": "test-nonce-1",
@@ -162,9 +163,9 @@ def test_phase07_dashboard_session_binds_operation_workspace_location_and_origin
                 daemon.port,
                 "/v1/supply-chain/package-shims/test",
                 dashboard_session_token=token,
-                origin="https://hol.org",
+                origin=local_origin,
                 payload={
-                    "daemon_origin": "https://hol.org",
+                    "daemon_origin": local_origin,
                     "location_id": "location-1",
                     "managers": ["npm"],
                     "workspace_id": "workspace-1",
@@ -190,9 +191,9 @@ def test_phase07_dashboard_session_binds_operation_workspace_location_and_origin
                 daemon.port,
                 "/v1/supply-chain/package-shims/test",
                 dashboard_session_token=token,
-                origin="https://hol.org",
+                origin=local_origin,
                 payload={
-                    "daemon_origin": "https://hol.org",
+                    "daemon_origin": local_origin,
                     "location_id": "location-1",
                     "managers": ["npm"],
                     "workspace_id": "workspace-1",

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -786,7 +786,7 @@ def test_request_resolution_without_auth_returns_session_recovery(tmp_path: Path
     assert "Request failed with 401" not in json.dumps(payload)
 
 
-def test_authenticated_hosted_origin_request_resolution_does_not_401(tmp_path: Path) -> None:
+def test_authenticated_hosted_origin_request_resolution_is_forbidden_not_unauthorized(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _populate(store, [_request("req-hosted-auth")])
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -803,17 +803,19 @@ def test_authenticated_hosted_origin_request_resolution_does_not_401(tmp_path: P
             },
             method="POST",
         )
-        with urllib.request.urlopen(request, timeout=5) as response:
-            payload = json.loads(response.read().decode("utf-8"))
-            allow_origin = response.headers.get("Access-Control-Allow-Origin")
+        try:
+            urllib.request.urlopen(request, timeout=5)
+        except urllib.error.HTTPError as error:
+            status = error.code
+            payload = json.loads(error.read().decode("utf-8"))
+        else:
+            raise AssertionError("expected HTTPError")
     finally:
         daemon.stop()
 
-    assert payload["resolved"] is True
-    assert payload["copy"]["title"] == "Decision saved. Return to Codex."
-    assert "could not find the original Codex chat" in payload["copy"]["body"]
-    assert allow_origin == "https://hol.org"
-    assert store.get_approval_request("req-hosted-auth")["resolution_action"] == "allow"
+    assert status == 403
+    assert payload["error"] == "forbidden_origin"
+    assert store.get_approval_request("req-hosted-auth")["resolution_action"] is None
 
 
 def test_request_list_status_filter_includes_resolved_items(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- block hosted dashboard origins from calling legacy daemon control routes for app, policy-sync, and request-browser-control paths
- preserve local loopback session access for those routes and add regressions that prove hosted origins get 403 while local sessions still work

## Testing
- `.venv/bin/pytest tests/test_guard_hosted_dashboard_origin_blocklist.py tests/test_guard_headless_daemon_api.py::test_headless_app_operations_write_receipts_without_cli_copy tests/test_guard_headless_daemon_api.py::test_headless_policy_sync_accepts_policy_bundle_and_returns_bundle_metadata tests/test_guard_headless_daemon_api.py::test_headless_remote_once_applies_pending_request_and_records_receipt tests/test_guard_headless_daemon_api.py::test_supply_chain_package_firewall_status_accepts_paid_oauth_entitlement`
- `.venv/bin/pytest tests/test_guard_headless_daemon_api.py::test_headless_policy_sync_persists_policy_and_receipt tests/test_guard_headless_daemon_api.py::test_headless_api_uses_valid_bearer_session_when_session_header_is_bad tests/test_guard_headless_daemon_api.py::test_headless_app_scan_syncs_receipt_to_cloud_when_connected tests/test_guard_headless_daemon_api.py::test_headless_app_scan_does_not_spawn_unbounded_cloud_sync_threads`
