### PR TITLE
refactor(dashboard): use shared guard cloud connect route

### DIFF
--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -1035,7 +1035,7 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   const url = input instanceof Request ? input.url : String(input);
   connectCalls.push({ url, init });
   const path = new URL(url, "http://127.0.0.1:4174").pathname;
-  if (path === "/v1/supply-chain/package-shims/connect") {
+  if (path === "/v1/cloud/connect") {
     return new Response(JSON.stringify({ error: "unauthorized", message: "Guard session missing." }), {
       status: 401,
       headers: { "Content-Type": "application/json" }
@@ -1052,8 +1052,8 @@ try {
 }
 assert(connectCalls.length === 1, "L079dc: connect flow does not mint local session from unauthenticated initialize");
 assert(
-  new URL(connectCalls[0].url).pathname === "/v1/supply-chain/package-shims/connect",
-  "L079dc: connect flow posts to daemon connect route"
+  new URL(connectCalls[0].url).pathname === "/v1/cloud/connect",
+  "L079dc: connect flow posts to shared Guard Cloud connect route"
 );
 assert(
   connectFlowError instanceof Error && connectFlowError.message.includes("Guard session missing"),

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2583,7 +2583,7 @@ export async function fetchPackageFirewallStatus(): Promise<PackageFirewallStatu
 
 export async function startPackageFirewallConnect(): Promise<PackageFirewallStatusResponse["connect_flow"]> {
   const status = await startGuardCloudConnect();
-  return normalizePackageFirewallConnectFlow(status.connect_flow);
+  return status.connect_flow;
 }
 
 export async function fetchSupplyChainBundle(): Promise<SupplyChainBundle | null> {

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2582,13 +2582,8 @@ export async function fetchPackageFirewallStatus(): Promise<PackageFirewallStatu
 }
 
 export async function startPackageFirewallConnect(): Promise<PackageFirewallStatusResponse["connect_flow"]> {
-  return normalizePackageFirewallConnectFlow(
-    await readJson<unknown>("/v1/supply-chain/package-shims/connect", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({}),
-    }),
-  );
+  const status = await startGuardCloudConnect();
+  return normalizePackageFirewallConnectFlow(status.connect_flow);
 }
 
 export async function fetchSupplyChainBundle(): Promise<SupplyChainBundle | null> {

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -707,6 +707,8 @@ def _resolve_package_firewall_connect_flow(
         return None
     current = _copy_package_firewall_connect_state(server)
     if current is None:
+        current = _copy_guard_cloud_connect_state(server)
+    if current is None:
         return _default_package_firewall_connect_flow(store=server.store, reason=reason)
     state = str(current.get("state") or "idle")
     flow = {

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -373,14 +373,26 @@ def test_supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_pa
         status, payload = _read_json_response(
             _request(
                 daemon.port,
-                "/v1/supply-chain/package-shims/connect",
+                "/v1/cloud/connect",
                 token=token,
                 payload={},
             ),
         )
         assert status == 202
-        assert payload["state"] == "running"
-        assert payload["authorize_url"] == "https://hol.org/mock-authorize"
+        assert payload["connect_required"] is True
+        assert payload["connect_flow"]["state"] == "running"
+        assert payload["connect_flow"]["authorize_url"] == "https://hol.org/mock-authorize"
+        status, running = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims",
+                method="GET",
+                token=token,
+            ),
+        )
+        assert status == 200
+        assert running["connect_flow"]["state"] == "running"
+        assert running["connect_flow"]["authorize_url"] == "https://hol.org/mock-authorize"
         for _ in range(20):
             status, refreshed = _read_json_response(
                 _request(


### PR DESCRIPTION
## Summary
- route package-firewall connect start through the shared `/v1/cloud/connect` API instead of the legacy package-specific connect endpoint
- mirror shared Guard Cloud connect state into package-firewall status so the local dashboard still shows package-firewall progress while the shared auth flow runs

## Testing
- `./node_modules/.bin/tsx src/guard-api.test.ts`
- `./node_modules/.bin/tsx src/package-firewall-connect.test.tsx`
- `uv run --no-sync pytest tests/test_guard_headless_daemon_api.py -k 'supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_paid_access' -q`
