### PR TITLE
fix(runtime): preserve oauth sign-in until explicit repair

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2420,12 +2420,13 @@ def clear_revoked_guard_oauth_sign_in(store: GuardStore) -> bool:
             credentials = store.get_oauth_local_credentials(allow_primary=True)
             if credentials is None:
                 return False
-            _resolve_guard_sync_auth_context_from_oauth_credentials(store, credentials)
-    except GuardSyncAuthorizationExpiredError as error:
-        if _oauth_authorization_error_requires_fresh_sign_in(error):
-            store.clear_oauth_local_credentials()
-            return True
-        return False
+            try:
+                _resolve_guard_sync_auth_context_from_oauth_credentials(store, credentials)
+            except GuardSyncAuthorizationExpiredError as error:
+                if _oauth_authorization_error_requires_fresh_sign_in(error):
+                    store.clear_oauth_local_credentials()
+                    return True
+                return False
     except (RuntimeError, OSError, TimeoutError):
         return False
     return False
@@ -2619,15 +2620,12 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
         oauth_client = resolve_guard_oauth_client_config(issuer)
     except ValueError as error:
         raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
-    try:
-        refreshed = _refresh_guard_oauth_access_token(
-            token_endpoint=oauth_client.token_endpoint,
-            client_id=client_id,
-            refresh_token=refresh_token,
-            dpop_key_material=dpop_key_material,
-        )
-    except GuardSyncAuthorizationExpiredError as error:
-        raise
+    refreshed = _refresh_guard_oauth_access_token(
+        token_endpoint=oauth_client.token_endpoint,
+        client_id=client_id,
+        refresh_token=refresh_token,
+        dpop_key_material=dpop_key_material,
+    )
     rotated_refresh_token = str(refreshed["refresh_token"])
     package_firewall_entitlement = (
         refreshed["package_firewall_entitlement"]

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2423,7 +2423,8 @@ def clear_revoked_guard_oauth_sign_in(store: GuardStore) -> bool:
             _resolve_guard_sync_auth_context_from_oauth_credentials(store, credentials)
     except GuardSyncAuthorizationExpiredError as error:
         if _oauth_authorization_error_requires_fresh_sign_in(error):
-            return store.get_oauth_local_credentials(allow_primary=True) is None
+            store.clear_oauth_local_credentials()
+            return True
         return False
     except (RuntimeError, OSError, TimeoutError):
         return False
@@ -2626,8 +2627,6 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
             dpop_key_material=dpop_key_material,
         )
     except GuardSyncAuthorizationExpiredError as error:
-        if _oauth_authorization_error_requires_fresh_sign_in(error):
-            store.clear_oauth_local_credentials()
         raise
     rotated_refresh_token = str(refreshed["refresh_token"])
     package_firewall_entitlement = (

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -88,7 +88,7 @@ def test_connect_repair_clears_revoked_sign_in_and_points_to_connect(tmp_path, m
     assert "Cleared expired Guard Cloud sign-in" in str(payload["repair_message"])
 
 
-def test_invalid_grant_refresh_uses_disconnect_reconnect_message(tmp_path, monkeypatch) -> None:
+def test_invalid_grant_refresh_preserves_sign_in_until_explicit_repair(tmp_path, monkeypatch) -> None:
     store = _store_with_oauth_credentials(tmp_path)
 
     def _fake_urlopen(request, timeout):
@@ -100,7 +100,7 @@ def test_invalid_grant_refresh_uses_disconnect_reconnect_message(tmp_path, monke
         guard_runner_module._resolve_guard_sync_auth_context(store)
 
     assert "hol-guard disconnect" in str(error.value)
-    assert store.get_oauth_local_credentials(allow_primary=True) is None
+    assert store.get_oauth_local_credentials(allow_primary=True) is not None
 
 
 def test_prepare_guard_cloud_connect_authorization_tolerates_network_errors(tmp_path, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- preserve local Guard OAuth sign-in state when background refresh hits an expired or revoked grant
- keep explicit connect-repair flows responsible for clearing stale OAuth state before reconnect

## Testing
- `uv run --no-sync pytest tests/test_guard_oauth_reconnect.py -q`
- `uv run --no-sync pytest tests/test_guard_connect_flow.py -q`
- `uv run --no-sync pytest tests/test_guard_auto_first_sync.py -q`
- `uv run --no-sync pytest tests/test_guard_package_shims_cli.py -q`
- `uv run --no-sync pytest tests/test_guard_supply_chain_daemon.py -q`
