### PR TITLE
fix(connect): fail first sync when oauth storage is missing

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -187,7 +187,9 @@ def _finalize_guard_connect_payload(
     )
     oauth_health = store.get_oauth_local_credential_health()
     oauth_state = str(oauth_health.get("state") or "")
-    if store.get_cloud_sync_profile() is None and oauth_state == "degraded":
+    if store.get_cloud_sync_profile() is None and (
+        oauth_state == "degraded" or not oauth_health.get("configured")
+    ):
         repair_message = (
             "Guard Cloud authorization did not persist locally. "
             "Run hol-guard connect again to repair local sign-in."

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -864,7 +864,9 @@ def _finalize_daemon_guard_connect_payload(
         }
     )
     oauth_health = store.get_oauth_local_credential_health()
-    if str(oauth_health.get("state") or "") == "degraded":
+    if store.get_cloud_sync_profile() is None and (
+        oauth_health.get("state") == "degraded" or not oauth_health.get("configured")
+    ):
         repair_message = (
             "Guard Cloud authorization did not persist locally. "
             "Start Guard Cloud connect again to repair local sign-in."

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -157,6 +157,48 @@ def test_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(tmp_p
     assert CONNECT_SYNC_AUTH_CONTEXT_KEY not in payload
 
 
+def test_finalize_guard_connect_payload_marks_not_configured_oauth_as_retry_required(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_url = "https://hol.org/guard/connect"
+    now = "2026-06-04T12:00:00+00:00"
+
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "stale-sync-token",
+        "2026-06-04T11:59:00+00:00",
+    )
+    monkeypatch.setattr(store, "get_cloud_sync_profile", lambda: None)
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": False, "state": "not_configured"},
+    )
+
+    payload = guard_commands_module._finalize_guard_connect_payload(
+        store=store,
+        connect_url=connect_url,
+        payload={"status": "connected"},
+        now=now,
+    )
+
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
+    assert payload["sync_succeeded"] is False
+    assert payload["sync_error"] == (
+        "Guard Cloud authorization did not persist locally. "
+        "Run hol-guard connect again to repair local sign-in."
+    )
+    assert payload["repair_message"] == payload["sync_error"]
+    latest_state = payload["latest_connect_state"]
+    assert isinstance(latest_state, dict)
+    assert latest_state["status"] == "retry_required"
+    assert latest_state["milestone"] == "first_sync_failed"
+    assert store.get_cloud_sync_profile() is None
+
+
 def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(
     tmp_path,
     monkeypatch,
@@ -215,6 +257,48 @@ def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_onc
         }
     ]
     assert CONNECT_SYNC_AUTH_CONTEXT_KEY not in payload
+
+
+def test_daemon_finalize_guard_connect_payload_marks_not_configured_oauth_as_retry_required(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    connect_url = "https://hol.org/guard/connect"
+    now = "2026-06-04T12:00:00+00:00"
+
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "stale-sync-token",
+        "2026-06-04T11:59:00+00:00",
+    )
+    monkeypatch.setattr(store, "get_cloud_sync_profile", lambda: None)
+    monkeypatch.setattr(
+        store,
+        "get_oauth_local_credential_health",
+        lambda: {"configured": False, "state": "not_configured"},
+    )
+
+    payload = daemon_server_module._finalize_daemon_guard_connect_payload(
+        store=store,
+        connect_url=connect_url,
+        payload={"status": "connected"},
+        now=now,
+    )
+
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
+    assert payload["sync_succeeded"] is False
+    assert payload["sync_error"] == (
+        "Guard Cloud authorization did not persist locally. "
+        "Start Guard Cloud connect again to repair local sign-in."
+    )
+    assert payload["repair_message"] == payload["sync_error"]
+    latest_state = payload["latest_connect_state"]
+    assert isinstance(latest_state, dict)
+    assert latest_state["status"] == "retry_required"
+    assert latest_state["milestone"] == "first_sync_failed"
+    assert store.get_cloud_sync_profile() is None
 
 
 def test_daemon_finalize_guard_connect_payload_keeps_first_sync_pending_on_sync_lock_timeout(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6652,7 +6652,8 @@ url = http://127.0.0.1:8787/guard-canary
         assert run_rc == 0
         assert connect_rc == 0
         assert opened == ["https://hol.org/guard/oauth/device"]
-        assert connect_output["status"] == "connected"
+        assert connect_output["status"] == "retry_required"
+        assert connect_output["milestone"] == "first_sync_failed"
         assert connect_output["connect_mode"] == "device_code"
         assert connect_output["browser_opened"] is True
         assert connect_output["user_code"] == "ABCD-EFGH"
@@ -7091,7 +7092,8 @@ url = http://127.0.0.1:8787/guard-canary
 
         assert login_rc == 0
         assert opened == ["https://hol.org/guard/oauth/device"]
-        assert login_output["status"] == "connected"
+        assert login_output["status"] == "retry_required"
+        assert login_output["milestone"] == "first_sync_failed"
         assert login_output["connect_mode"] == "device_code"
         assert login_output["browser_opened"] is True
         assert login_output["user_code"] == "ZXCV-BNMQ"

--- a/tests/test_guard_init.py
+++ b/tests/test_guard_init.py
@@ -89,8 +89,9 @@ def test_guard_init_cloud_step_uses_connect_browser_open_and_finalization(tmp_pa
     assert output["cloud"]["browser_opened"] is True
     assert output["cloud"]["wait_timeout_seconds"] == 11
     assert output["cloud"]["announce_copy_present"] is False
-    assert output["cloud"]["milestone"] == "first_sync_pending"
-    assert output["cloud"]["sync_attempted"] is False
+    assert output["cloud"]["status"] == "retry_required"
+    assert output["cloud"]["milestone"] == "first_sync_failed"
+    assert "sync_attempted" not in output["cloud"]
 
 
 def test_guard_init_human_cloud_step_announces_approval_before_waiting(tmp_path, capsys, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- mark Guard connect as repair-required immediately when local OAuth storage is missing after a nominally successful pair
- add first-sync regressions for both CLI and daemon connect finalizers so missing local auth never masquerades as connected

## Testing
- `uv run --no-sync pytest tests/test_guard_auto_first_sync.py -q`
- `uv run --no-sync pytest tests/test_guard_connect_flow.py -q`
