### PR TITLE
fix(connect): normalize missing oauth state

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -217,6 +217,7 @@ from .connect_flow import (
     DEFAULT_GUARD_SYNC_URL,
     build_connect_status_payload,
     connect_recovery_command,
+    normalize_connect_state_for_missing_oauth,
     resolve_connect_url,
     run_guard_browser_connect_command,
     run_guard_connect_repair_command,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -34,9 +34,14 @@ def _resolve_policy_expiry(args: argparse.Namespace) -> str | None:
     return (datetime.now(timezone.utc) + timedelta(hours=float(hours))).isoformat()
 
 def _guard_doctor_connect_health_payload(store: GuardStore) -> dict[str, object]:
-    latest_state = store.get_effective_guard_connect_state(now=_now())
+    oauth_storage_health = store.get_oauth_local_credential_health()
+    latest_state = normalize_connect_state_for_missing_oauth(
+        latest_state=store.get_effective_guard_connect_state(now=_now()),
+        cloud_profile=store.get_cloud_sync_profile(),
+        oauth_storage_health=oauth_storage_health,
+    )
     payload: dict[str, object] = {
-        "oauth_storage_health": _guard_doctor_oauth_storage_health_payload(store),
+        "oauth_storage_health": _guard_doctor_oauth_storage_health_payload_from_health(oauth_storage_health),
         "connect_recovery_command": connect_recovery_command(latest_state),
     }
     if isinstance(latest_state, dict):
@@ -44,7 +49,11 @@ def _guard_doctor_connect_health_payload(store: GuardStore) -> dict[str, object]
     return payload
 
 def _guard_doctor_oauth_storage_health_payload(store: GuardStore) -> dict[str, str]:
-    oauth_storage_health = store.get_oauth_local_credential_health()
+    return _guard_doctor_oauth_storage_health_payload_from_health(
+        store.get_oauth_local_credential_health(),
+    )
+
+def _guard_doctor_oauth_storage_health_payload_from_health(oauth_storage_health: dict[str, object]) -> dict[str, str]:
     state = "unknown"
     if isinstance(oauth_storage_health, dict):
         raw_state = oauth_storage_health.get("state")

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -37,7 +37,6 @@ def _guard_doctor_connect_health_payload(store: GuardStore) -> dict[str, object]
     oauth_storage_health = store.get_oauth_local_credential_health()
     latest_state = normalize_connect_state_for_missing_oauth(
         latest_state=store.get_effective_guard_connect_state(now=_now()),
-        cloud_profile=store.get_cloud_sync_profile(),
         oauth_storage_health=oauth_storage_health,
     )
     payload: dict[str, object] = {

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -22,6 +22,7 @@ from ...version import __version__
 from ..package_firewall_entitlement import build_oauth_package_firewall_entitlement
 from ..runtime.runner import prepare_guard_cloud_connect_authorization
 from ..store import GuardStore
+from ..store_connect import build_connect_state_response
 from .oauth_client import (
     GuardDpopKeyMaterial,
     GuardOAuthClientConfig,
@@ -1143,6 +1144,11 @@ def build_connect_status_payload(
     latest_state = store.get_effective_guard_connect_state(now=datetime.now(timezone.utc).isoformat())
     cloud_profile = store.get_cloud_sync_profile()
     oauth_storage_health = store.get_oauth_local_credential_health()
+    latest_state = normalize_connect_state_for_missing_oauth(
+        latest_state=latest_state,
+        cloud_profile=cloud_profile,
+        oauth_storage_health=oauth_storage_health,
+    )
     oauth_repair_required = (
         bool(oauth_storage_health.get("configured")) and oauth_storage_health.get("state") == "degraded"
     )
@@ -1192,6 +1198,32 @@ def build_connect_status_payload(
     ):
         payload["repair_message"] = "Run hol-guard connect again to repair local Guard Cloud authorization."
     return payload
+
+
+def normalize_connect_state_for_missing_oauth(
+    *,
+    latest_state: dict[str, object] | None,
+    cloud_profile: dict[str, str] | None,
+    oauth_storage_health: dict[str, object],
+) -> dict[str, object] | None:
+    if latest_state is None or cloud_profile is not None:
+        return latest_state
+    oauth_state = str(oauth_storage_health.get("state") or "")
+    oauth_configured = bool(oauth_storage_health.get("configured"))
+    if oauth_state != "degraded" and oauth_configured:
+        return latest_state
+    status = str(latest_state.get("status") or "")
+    if status != "connected":
+        return latest_state
+    normalized = dict(latest_state)
+    normalized["status"] = "retry_required"
+    normalized["milestone"] = "first_sync_failed"
+    normalized["reason"] = "Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again."
+    poll_after_ms = latest_state.get("poll_after_ms")
+    return build_connect_state_response(
+        normalized,
+        poll_after_ms=poll_after_ms if isinstance(poll_after_ms, int) else None,
+    )
 
 
 def connect_recovery_command(latest_state: dict[str, object] | None) -> str:

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -1146,7 +1146,6 @@ def build_connect_status_payload(
     oauth_storage_health = store.get_oauth_local_credential_health()
     latest_state = normalize_connect_state_for_missing_oauth(
         latest_state=latest_state,
-        cloud_profile=cloud_profile,
         oauth_storage_health=oauth_storage_health,
     )
     oauth_repair_required = (
@@ -1203,10 +1202,9 @@ def build_connect_status_payload(
 def normalize_connect_state_for_missing_oauth(
     *,
     latest_state: dict[str, object] | None,
-    cloud_profile: dict[str, str] | None,
     oauth_storage_health: dict[str, object],
 ) -> dict[str, object] | None:
-    if latest_state is None or cloud_profile is not None:
+    if latest_state is None:
         return latest_state
     oauth_state = str(oauth_storage_health.get("state") or "")
     oauth_configured = bool(oauth_storage_health.get("configured"))

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -16,7 +16,13 @@ from ..daemon import load_guard_daemon_url
 from ..models import GuardArtifact, HarnessDetection
 from ..redaction import redact_local_path
 from ..store import GuardStore
-from .connect_flow import CONNECT_COMMAND, CONNECT_REPAIR_COMMAND, CONNECT_STATUS_COMMAND, connect_recovery_command
+from .connect_flow import (
+    CONNECT_COMMAND,
+    CONNECT_REPAIR_COMMAND,
+    CONNECT_STATUS_COMMAND,
+    connect_recovery_command,
+    normalize_connect_state_for_missing_oauth,
+)
 
 HARNESS_PRIORITY = ("codex", "claude-code", "copilot", "hermes", "cursor", "antigravity", "gemini", "opencode")
 GUARD_COMMAND = "hol-guard"
@@ -248,7 +254,11 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
     team_policy_pack = _coerce_payload_dict(store.get_sync_payload("team_policy_pack"))
     sync_summary = _coerce_payload_dict(store.get_sync_payload("sync_summary"))
     last_sync_at = _optional_string(sync_summary.get("synced_at"))
-    latest_connect_state = store.get_effective_guard_connect_state(now=_now())
+    latest_connect_state = normalize_connect_state_for_missing_oauth(
+        latest_state=store.get_effective_guard_connect_state(now=_now()),
+        cloud_profile=cloud_profile,
+        oauth_storage_health=oauth_storage_health,
+    )
     connect_retry_required = _connect_retry_required(latest_connect_state)
     connect_retry_refresh_race = _connect_retry_refresh_race(latest_connect_state)
     remote_payload_active = bool(advisories or alert_preferences or remote_policy or team_policy_pack)

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -256,7 +256,6 @@ def _build_cloud_context(store: GuardStore) -> dict[str, object]:
     last_sync_at = _optional_string(sync_summary.get("synced_at"))
     latest_connect_state = normalize_connect_state_for_missing_oauth(
         latest_state=store.get_effective_guard_connect_state(now=_now()),
-        cloud_profile=cloud_profile,
         oauth_storage_health=oauth_storage_health,
     )
     connect_retry_required = _connect_retry_required(latest_connect_state)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -5073,9 +5073,11 @@ class GuardStore:
         latest_state = self.get_latest_guard_connect_state(now=now)
         cloud_profile = self.get_cloud_sync_profile()
         sync_summary = self.get_sync_payload("sync_summary")
+        oauth_storage_health = self.get_oauth_local_credential_health()
         return self._normalize_guard_connect_state(
             latest_state=latest_state,
             cloud_profile=cloud_profile,
+            oauth_storage_health=oauth_storage_health,
             sync_summary=sync_summary if isinstance(sync_summary, dict) else None,
             now=now,
         )
@@ -5185,10 +5187,29 @@ class GuardStore:
         *,
         latest_state: dict[str, object] | None,
         cloud_profile: dict[str, str] | None,
+        oauth_storage_health: dict[str, object],
         sync_summary: dict[str, object] | None,
         now: str,
     ) -> dict[str, object] | None:
         if cloud_profile is None:
+            if latest_state is None:
+                return None
+            oauth_state = str(oauth_storage_health.get("state") or "")
+            oauth_configured = bool(oauth_storage_health.get("configured"))
+            latest_status = str(latest_state.get("status") or "")
+            latest_milestone = str(latest_state.get("milestone") or "")
+            if (
+                (oauth_state == "degraded" or not oauth_configured)
+                and (latest_status == "connected" or latest_milestone in {"first_sync_pending", "sync_not_available"})
+            ):
+                return self._coerce_guard_connect_state_status(
+                    state=latest_state,
+                    status="retry_required",
+                    milestone="first_sync_failed",
+                    reason="Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again.",
+                    sync_summary=sync_summary,
+                    now=now,
+                )
             return latest_state
         normalized = self._hydrate_guard_connect_state_from_cloud_profile(
             latest_state=latest_state,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -5198,9 +5198,8 @@ class GuardStore:
             oauth_configured = bool(oauth_storage_health.get("configured"))
             latest_status = str(latest_state.get("status") or "")
             latest_milestone = str(latest_state.get("milestone") or "")
-            if (
-                (oauth_state == "degraded" or not oauth_configured)
-                and (latest_status == "connected" or latest_milestone in {"first_sync_pending", "sync_not_available"})
+            if (oauth_state == "degraded" or not oauth_configured) and (
+                latest_status == "connected" or latest_milestone in {"first_sync_pending", "sync_not_available"}
             ):
                 return self._coerce_guard_connect_state_status(
                     state=latest_state,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -5073,11 +5073,9 @@ class GuardStore:
         latest_state = self.get_latest_guard_connect_state(now=now)
         cloud_profile = self.get_cloud_sync_profile()
         sync_summary = self.get_sync_payload("sync_summary")
-        oauth_storage_health = self.get_oauth_local_credential_health()
         return self._normalize_guard_connect_state(
             latest_state=latest_state,
             cloud_profile=cloud_profile,
-            oauth_storage_health=oauth_storage_health,
             sync_summary=sync_summary if isinstance(sync_summary, dict) else None,
             now=now,
         )
@@ -5187,28 +5185,10 @@ class GuardStore:
         *,
         latest_state: dict[str, object] | None,
         cloud_profile: dict[str, str] | None,
-        oauth_storage_health: dict[str, object],
         sync_summary: dict[str, object] | None,
         now: str,
     ) -> dict[str, object] | None:
         if cloud_profile is None:
-            if latest_state is None:
-                return None
-            oauth_state = str(oauth_storage_health.get("state") or "")
-            oauth_configured = bool(oauth_storage_health.get("configured"))
-            latest_status = str(latest_state.get("status") or "")
-            latest_milestone = str(latest_state.get("milestone") or "")
-            if (oauth_state == "degraded" or not oauth_configured) and (
-                latest_status == "connected" or latest_milestone in {"first_sync_pending", "sync_not_available"}
-            ):
-                return self._coerce_guard_connect_state_status(
-                    state=latest_state,
-                    status="retry_required",
-                    milestone="first_sync_failed",
-                    reason="Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again.",
-                    sync_summary=sync_summary,
-                    now=now,
-                )
             return latest_state
         normalized = self._hydrate_guard_connect_state_from_cloud_profile(
             latest_state=latest_state,

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6960,6 +6960,45 @@ url = http://127.0.0.1:8787/guard-canary
         assert "sign-in on this machine is incomplete" in output["cloud_state_detail"]
         assert output["oauth_storage_health"]["state"] == "degraded"
 
+    def test_guard_status_marks_stale_connected_state_retry_required_when_oauth_is_missing(
+        self,
+        tmp_path,
+        capsys,
+    ):
+        del capsys
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        store = GuardStore(home_dir)
+        store.record_guard_connect_pairing_completed(
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            allowed_origin="https://hol.org",
+            now="2026-06-11T22:11:11+00:00",
+            request_id="connect-401",
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="connected",
+            milestone="first_sync_pending",
+            now="2026-06-11T22:11:11+00:00",
+            reason="Guard Cloud is unavailable. Local Guard keeps protecting this machine.",
+        )
+
+        output = guard_product_module.build_guard_status_payload(
+            HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+            store,
+            load_guard_config(home_dir),
+        )
+
+        latest_state = output["latest_connect_state"]
+        assert isinstance(latest_state, dict)
+        assert latest_state["status"] == "retry_required"
+        assert latest_state["milestone"] == "first_sync_failed"
+        assert latest_state["reason"] == (
+            "Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again."
+        )
+        assert output["cloud_state"] == "local_only"
+        assert "needs repair before the first shared proof can land" in output["cloud_state_detail"]
+
     def test_guard_disconnect_revokes_cloud_grant_through_oauth_disconnect_helper(
         self,
         tmp_path,

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -2672,10 +2672,7 @@ args = ["workspace-skill.js", "--changed"]
                 guard_home=home_dir,
             )
         )
-        assert (
-            guard_pretool_entry["matcher"]
-            == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
-        )
+        assert guard_pretool_entry["matcher"] == "Bash|Read|Write|Edit|MultiEdit|WebFetch|WebSearch|mcp__.*"
         assert (
             install_settings_payload["hooks"]["SessionStart"][0]["hooks"][0]["command"]
             == expected_session_start_command
@@ -6999,6 +6996,69 @@ url = http://127.0.0.1:8787/guard-canary
         assert output["cloud_state"] == "local_only"
         assert "needs repair before the first shared proof can land" in output["cloud_state_detail"]
 
+    def test_guard_status_marks_stale_connected_state_retry_required_when_oauth_is_degraded(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        del capsys
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+        monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
+        store = GuardStore(home_dir)
+        store.record_guard_connect_pairing_completed(
+            sync_url="https://hol.org/api/guard/receipts/sync",
+            allowed_origin="https://hol.org",
+            now="2026-06-11T22:11:11+00:00",
+            request_id="connect-403",
+        )
+        store.record_latest_guard_connect_sync_result(
+            status="connected",
+            milestone="first_sync_pending",
+            now="2026-06-11T22:11:11+00:00",
+            reason="Guard Cloud is unavailable. Local Guard keeps protecting this machine.",
+        )
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            workspace_id="workspace-123",
+            now="2026-06-11T22:12:00+00:00",
+        )
+        oauth_payload = store.get_sync_payload("oauth_local_credentials")
+        assert isinstance(oauth_payload, dict)
+        oauth_payload["credentials_sha256"] = "pbkdf2-sha256$invalid"
+        store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-11T22:12:30+00:00")
+
+        output = guard_product_module.build_guard_status_payload(
+            HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+            store,
+            load_guard_config(home_dir),
+        )
+
+        latest_state = output["latest_connect_state"]
+        assert isinstance(latest_state, dict)
+        assert latest_state["status"] == "retry_required"
+        assert latest_state["milestone"] == "first_sync_failed"
+        assert latest_state["reason"] == (
+            "Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again."
+        )
+        assert output["oauth_storage_health"]["state"] == "degraded"
+
     def test_guard_disconnect_revokes_cloud_grant_through_oauth_disconnect_helper(
         self,
         tmp_path,
@@ -8865,9 +8925,7 @@ url = http://127.0.0.1:8787/guard-canary
             "reason": "bundle_version_downgrade",
         }
 
-    def test_refresh_cloud_policy_bundle_clears_non_bundle_errors_after_success(
-        self, tmp_path, monkeypatch
-    ):
+    def test_refresh_cloud_policy_bundle_clears_non_bundle_errors_after_success(self, tmp_path, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         store.set_sync_credentials(

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -158,6 +158,43 @@ def test_connect_status_requires_retry_when_oauth_not_configured(tmp_path: Path)
     )
 
 
+def test_connect_status_requires_retry_when_legacy_sync_profile_exists_but_oauth_is_missing(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-11T22:11:11+00:00",
+        request_id="connect-402",
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="connected",
+        milestone="first_sync_pending",
+        now="2026-06-11T22:11:11+00:00",
+        reason="Guard Cloud is unavailable. Local Guard keeps protecting this machine.",
+    )
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "legacy-sync-token",
+        "2026-06-11T22:12:00+00:00",
+    )
+
+    payload = build_connect_status_payload(
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+        action="status",
+    )
+
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
+    latest_state = payload["latest_connect_state"]
+    assert isinstance(latest_state, dict)
+    assert latest_state["status"] == "retry_required"
+    assert latest_state["milestone"] == "first_sync_failed"
+
+
 def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
 

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -146,8 +146,16 @@ def test_connect_status_requires_retry_when_oauth_not_configured(tmp_path: Path)
 
     assert payload["status"] == "retry_required"
     assert payload["milestone"] == "first_sync_failed"
+    assert payload["reason"] == "Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again."
     assert payload["recovery_command"] == "hol-guard connect"
     assert payload["repair_message"] == "Run hol-guard connect again to repair local Guard Cloud authorization."
+    latest_state = payload["latest_connect_state"]
+    assert isinstance(latest_state, dict)
+    assert latest_state["status"] == "retry_required"
+    assert latest_state["milestone"] == "first_sync_failed"
+    assert latest_state["reason"] == (
+        "Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again."
+    )
 
 
 def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- normalize Guard connect state when pairing metadata exists but OAuth storage is missing or degraded
- add focused regressions for `hol-guard connect status` and `hol-guard status` so nested `latest_connect_state` no longer stays stale

## Testing
- `uv run --no-sync pytest tests/test_guard_connect_flow.py -k 'connect_status_requires_retry_when_oauth_not_configured' -q`
- `uv run --no-sync pytest tests/test_guard_cli.py -k 'stale_connected_state_retry_required_when_oauth_is_missing or degraded_oauth_does_not_fall_back_to_legacy_sync' -q`
