### PR TITLE
fix(cursor): make MCP native approvals tool-agnostic

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -853,20 +853,63 @@ def _normalize_cursor_shell_command(command: str) -> str:
     return stripped
 
 
+def _cursor_hook_payload_is_mcp_execution(payload: Mapping[str, object]) -> bool:
+    source_event = payload.get("cursor_source_hook_event")
+    if isinstance(source_event, str) and source_event.strip().lower() == "beforemcpexecution":
+        return True
+    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"beforemcpexecution", "aftermcpexecution"}:
+                return True
+    return False
+
+
+def _is_shell_wrapper_command(command: str) -> bool:
+    stripped = command.strip()
+    if not stripped:
+        return False
+    try:
+        parts = shlex.split(stripped, posix=True, comments=False)
+    except ValueError:
+        return False
+    if not parts:
+        return False
+    binary = Path(parts[0]).name.lower()
+    if binary == "lean-ctx":
+        return True
+    if binary not in {"ash", "bash", "dash", "fish", "sh", "zsh"}:
+        return False
+    return len(parts) > 1 and parts[1] == "-c"
+
+
+def _nested_cursor_shell_command(tool_input: Mapping[str, object]) -> str | None:
+    for key in ("command", "cmd", "shell_command", "shellCommand"):
+        value = tool_input.get(key)
+        if isinstance(value, str) and value.strip():
+            return _normalize_cursor_shell_command(value)
+    return None
+
+
 def _cursor_shell_command(payload: Mapping[str, object]) -> str | None:
     tool_input = payload.get("tool_input")
     nested_command: str | None = None
     if isinstance(tool_input, dict):
-        nested = tool_input.get("command")
-        if isinstance(nested, str) and nested.strip():
-            nested_command = _normalize_cursor_shell_command(nested)
+        nested_command = _nested_cursor_shell_command(tool_input)
     command = payload.get("command")
+    top_level: str | None = None
     if isinstance(command, str) and command.strip():
         top_level = _normalize_cursor_shell_command(command)
+    if _cursor_hook_payload_is_mcp_execution(payload):
         if nested_command is not None:
-            first_token = command.strip().split(maxsplit=1)[0]
-            if Path(first_token).name.lower() == "lean-ctx":
-                return nested_command
+            return nested_command
+        return top_level
+    if nested_command is not None and (
+        top_level is None or (isinstance(command, str) and _is_shell_wrapper_command(command))
+    ):
+        return nested_command
+    if top_level is not None:
         return top_level
     return nested_command
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -853,6 +853,9 @@ def _normalize_cursor_shell_command(command: str) -> str:
     return stripped
 
 
+# Installed hook helpers below mirror cursor_native_approval.py; keep both copies in sync.
+
+
 def _cursor_hook_payload_is_mcp_execution(payload: Mapping[str, object]) -> bool:
     source_event = payload.get("cursor_source_hook_event")
     if isinstance(source_event, str) and source_event.strip().lower() == "beforemcpexecution":

--- a/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py
@@ -24,6 +24,17 @@ _CURSOR_BLOCKING_OBSERVER_EVENTS = {
 }
 _MAX_CURSOR_SHELL_NORMALIZE_BYTES = 8192
 _LEAN_CTX_COMMAND_MARKER = "lean-ctx"
+_SHELL_WRAPPER_BINARIES = frozenset(
+    {
+        _LEAN_CTX_COMMAND_MARKER,
+        "ash",
+        "bash",
+        "dash",
+        "fish",
+        "sh",
+        "zsh",
+    }
+)
 
 
 def _split_posix_single_quoted_argument(text: str) -> tuple[str, str] | None:
@@ -117,6 +128,41 @@ def is_lean_ctx_wrapper_command(command: str) -> bool:
         return False
     first_token = stripped.split(maxsplit=1)[0]
     return Path(first_token).name.lower() == _LEAN_CTX_COMMAND_MARKER
+
+
+def is_shell_wrapper_command(command: str) -> bool:
+    """Return True when a top-level command is wrapping an inner shell invocation."""
+
+    stripped = command.strip()
+    if not stripped:
+        return False
+    if is_lean_ctx_wrapper_command(stripped):
+        return True
+    try:
+        parts = shlex.split(stripped, posix=True, comments=False)
+    except ValueError:
+        return False
+    if not parts:
+        return False
+    binary = Path(parts[0]).name.lower()
+    if binary not in _SHELL_WRAPPER_BINARIES:
+        return False
+    return len(parts) > 1 and parts[1] == "-c"
+
+
+def cursor_hook_payload_is_mcp_execution(payload: Mapping[str, object]) -> bool:
+    """Return True when the payload came from Cursor MCP before/after hooks."""
+
+    source_event = payload.get("cursor_source_hook_event")
+    if isinstance(source_event, str) and source_event.strip().lower() == "beforemcpexecution":
+        return True
+    for key in ("hook_event_name", "hookEventName", "hook_name", "hookName", "event", "eventName"):
+        value = payload.get(key)
+        if isinstance(value, str):
+            lowered = value.strip().lower()
+            if lowered in {"beforemcpexecution", "aftermcpexecution"}:
+                return True
+    return False
 
 
 def cursor_observer_event_for_blocking(blocking_event: str) -> str | None:
@@ -450,12 +496,14 @@ __all__ = [
     "cursor_after_shell_trusted",
     "cursor_generation_id",
     "cursor_hook_attestation_secret_path",
+    "cursor_hook_payload_is_mcp_execution",
     "cursor_observer_event_for_blocking",
     "cursor_observer_event_for_payload",
     "cursor_shell_binding_path",
     "ensure_cursor_approval_binding",
     "ensure_cursor_hook_attestation_secret",
     "is_lean_ctx_wrapper_command",
+    "is_shell_wrapper_command",
     "managed_cursor_hook_invocation",
     "normalize_cursor_shell_command",
     "read_cursor_shell_binding_file",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
@@ -309,9 +309,8 @@ def _cursor_shell_command_from_payload(payload: Mapping[str, object]) -> str | N
         return normalize_cursor_shell_command(tool_input_command)
     if top_level is not None:
         return normalize_cursor_shell_command(top_level)
-    if tool_input_command is not None:
-        return normalize_cursor_shell_command(tool_input_command)
     return None
+
 
 def _cursor_shell_command_fingerprint(command: str) -> str:
     from ..adapters.cursor_native_approval import normalize_cursor_shell_command

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
@@ -290,18 +290,27 @@ def _cursor_conversation_id(payload: dict[str, object]) -> str | None:
 
 def _cursor_shell_command_from_payload(payload: Mapping[str, object]) -> str | None:
     from ..adapters.cursor_native_approval import (
-        is_lean_ctx_wrapper_command,
+        cursor_hook_payload_is_mcp_execution,
+        is_shell_wrapper_command,
         normalize_cursor_shell_command,
     )
 
     tool_input_command = _hook_command_text(payload)
     top_level = _optional_string(payload.get("command"))
+    if cursor_hook_payload_is_mcp_execution(payload):
+        if tool_input_command is not None:
+            return normalize_cursor_shell_command(tool_input_command)
+        if top_level is not None:
+            return normalize_cursor_shell_command(top_level)
+        return None
     if tool_input_command is not None and (
-        top_level is None or is_lean_ctx_wrapper_command(top_level)
+        top_level is None or is_shell_wrapper_command(top_level)
     ):
         return normalize_cursor_shell_command(tool_input_command)
     if top_level is not None:
         return normalize_cursor_shell_command(top_level)
+    if tool_input_command is not None:
+        return normalize_cursor_shell_command(tool_input_command)
     return None
 
 def _cursor_shell_command_fingerprint(command: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -305,27 +305,25 @@ def _persist_cursor_native_permission_after_shell(
         env=hook_env,
     ):
         return False
-    action_envelope = _hook_action_envelope(
-        harness=harness,
-        payload=prepared,
-        home_dir=home_dir,
-        workspace=workspace,
-    )
-    runtime_artifact = _hook_runtime_artifact(
-        harness=harness,
-        payload=prepared,
-        action_envelope=action_envelope,
-        home_dir=home_dir,
-        guard_home=guard_home,
-        workspace=workspace,
-    )
-    runtime_artifact_hash: str | None = None
-    if runtime_artifact is not None:
-        runtime_artifact_hash = artifact_hash(runtime_artifact)
-    else:
-        runtime_artifact = _cursor_runtime_artifact_from_pending(pending)
+    runtime_artifact = _cursor_runtime_artifact_from_pending(pending)
+    runtime_artifact_hash = _optional_string(pending.get("artifact_hash"))
+    if runtime_artifact is None:
+        action_envelope = _hook_action_envelope(
+            harness=harness,
+            payload=prepared,
+            home_dir=home_dir,
+            workspace=workspace,
+        )
+        runtime_artifact = _hook_runtime_artifact(
+            harness=harness,
+            payload=prepared,
+            action_envelope=action_envelope,
+            home_dir=home_dir,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
         if runtime_artifact is not None:
-            runtime_artifact_hash = _optional_string(pending.get("artifact_hash"))
+            runtime_artifact_hash = artifact_hash(runtime_artifact)
     if runtime_artifact is None or runtime_artifact_hash is None:
         return False
     session_saved = _record_cursor_native_shell_allow_state(

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -307,6 +307,8 @@ def _persist_cursor_native_permission_after_shell(
         return False
     runtime_artifact = _cursor_runtime_artifact_from_pending(pending)
     runtime_artifact_hash = _optional_string(pending.get("artifact_hash"))
+    if runtime_artifact is not None and runtime_artifact_hash is None:
+        runtime_artifact_hash = artifact_hash(runtime_artifact)
     if runtime_artifact is None:
         action_envelope = _hook_action_envelope(
             harness=harness,

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -166,7 +166,6 @@ _SHELL_TOOL_NAMES = frozenset(
         "ash",
         "bash",
         "cmd",
-        "ctx_shell",
         "dash",
         "powershell",
         "pwsh",
@@ -665,6 +664,18 @@ def build_file_read_request_artifact(
     )
 
 
+def _shell_normalized_tool_name(
+    *,
+    normalized_tool_name: str | None,
+    arguments: object,
+) -> str | None:
+    if normalized_tool_name in _SHELL_TOOL_NAMES:
+        return normalized_tool_name
+    if _candidate_command_texts(arguments):
+        return "shell"
+    return normalized_tool_name
+
+
 def extract_sensitive_tool_action_request(
     tool_name: object,
     arguments: object,
@@ -675,20 +686,26 @@ def extract_sensitive_tool_action_request(
     """Extract a sensitive native tool action from arguments."""
 
     normalized_tool_name = _normalize_tool_name(tool_name)
-    if normalized_tool_name is None:
+    if normalized_tool_name is None and not _candidate_command_texts(arguments):
         return None
-    requested_tool_name = str(tool_name).strip()
+    requested_tool_name = str(tool_name).strip() if isinstance(tool_name, str) and str(tool_name).strip() else "Shell"
+    effective_tool_name = _shell_normalized_tool_name(
+        normalized_tool_name=normalized_tool_name,
+        arguments=arguments,
+    )
+    if effective_tool_name is None:
+        return None
     for command_text in _candidate_command_texts(arguments):
         docker_sensitive_request = _docker_sensitive_tool_action_request(
             tool_name=requested_tool_name,
-            normalized_tool_name=normalized_tool_name,
+            normalized_tool_name=effective_tool_name,
             command_text=command_text,
         )
         if docker_sensitive_request is not None:
             return docker_sensitive_request
         docker_config_request = _docker_config_tool_action_request(
             tool_name=requested_tool_name,
-            normalized_tool_name=normalized_tool_name,
+            normalized_tool_name=effective_tool_name,
             command_text=command_text,
             cwd=cwd,
             home_dir=home_dir,
@@ -697,7 +714,7 @@ def extract_sensitive_tool_action_request(
             return docker_config_request
         destructive_shell_request = _destructive_shell_tool_action_request(
             tool_name=requested_tool_name,
-            normalized_tool_name=normalized_tool_name,
+            normalized_tool_name=effective_tool_name,
             command_text=command_text,
             cwd=cwd,
             home_dir=home_dir,

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -848,6 +848,107 @@ def test_cursor_shell_command_from_payload_prefers_inner_lean_ctx_command() -> N
     assert command == "rm -rf ./hol-guard-cursor-native-mcp-marker"
 
 
+def test_cursor_shell_command_from_payload_prefers_mcp_tool_input_command() -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+
+    command = guard_commands_module._cursor_shell_command_from_payload(
+        {
+            "hook_event_name": "beforeMCPExecution",
+            "tool_name": "run_terminal_cmd",
+            "tool_input": {"command": "rm -rf ./hol-guard-cursor-native-mcp-marker"},
+            "command": "/usr/bin/unrelated-mcp-bridge",
+        }
+    )
+    assert command == "rm -rf ./hol-guard-cursor-native-mcp-marker"
+
+
+def test_cursor_shell_command_from_payload_prefers_bash_wrapper_inner_command() -> None:
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+
+    command = guard_commands_module._cursor_shell_command_from_payload(
+        {
+            "hook_event_name": "beforeShellExecution",
+            "command": "bash -c 'rm -rf ./hol-guard-cursor-native-mcp-marker'",
+            "tool_input": {"command": "rm -rf ./hol-guard-cursor-native-mcp-marker"},
+        }
+    )
+    assert command == "rm -rf ./hol-guard-cursor-native-mcp-marker"
+
+
+def test_cursor_native_mcp_session_allow_generic_tool_name(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
+    from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    store = GuardStore(home_dir)
+    conversation_id = "conv-cursor-generic-mcp"
+    inner_command = "rm -rf ./hol-guard-cursor-native-mcp-marker"
+    generation_id = "gen-cursor-generic-mcp"
+    before_payload = prepare_cursor_hook_payload(
+        {
+            "conversation_id": conversation_id,
+            "generation_id": generation_id,
+            "hook_event_name": "beforeMCPExecution",
+            "tool_name": "run_terminal_cmd",
+            "tool_input": {"command": inner_command},
+        }
+    )
+    guard_commands_module._record_cursor_pending_shell_permission(
+        store=store,
+        guard_home=home_dir,
+        payload=before_payload,
+        reason="Requests a sensitive native tool action.",
+        artifact=_cursor_shell_artifact(workspace_dir=workspace_dir, command=inner_command),
+        artifact_hash="hash-cursor-generic-mcp-shell",
+    )
+    saved = guard_commands_module._persist_cursor_native_permission_after_shell(
+        store=store,
+        payload=prepare_cursor_hook_payload(
+            {
+                "conversation_id": conversation_id,
+                "generation_id": generation_id,
+                "hook_event_name": "afterMCPExecution",
+                "tool_name": "run_terminal_cmd",
+                "tool_input": {"command": inner_command},
+                "result_json": "{\"ok\": true}",
+                "duration": 12,
+            }
+        ),
+        harness="cursor",
+        home_dir=home_dir,
+        guard_home=home_dir,
+        workspace=workspace_dir,
+        hook_env=_trusted_cursor_after_observer_env(
+            home_dir,
+            conversation_id=conversation_id,
+            command=inner_command,
+            observer_event="afterMCPExecution",
+            approval_binding=generation_id,
+        ),
+    )
+    assert saved is True
+    assert guard_commands_module._cursor_native_shell_is_approved(
+        store,
+        before_payload,
+    )
+
+
+def test_extract_sensitive_tool_action_request_accepts_generic_mcp_tool_command() -> None:
+    from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+        extract_sensitive_tool_action_request,
+    )
+
+    match = extract_sensitive_tool_action_request(
+        "custom_mcp_shell_gateway",
+        {"command": "rm -rf ./hol-guard-cursor-native-mcp-marker"},
+    )
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_cursor_native_mcp_session_allow_after_trusted_after_mcp(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.adapters.cursor_hooks import prepare_cursor_hook_payload
     from codex_plugin_scanner.guard.cli import commands as guard_commands_module


### PR DESCRIPTION
## Summary
- Resolve Cursor MCP approval fingerprints from tool_input shell commands for any MCP tool name, not only lean-ctx ctx_shell
- Detect bash/sh/zsh wrapper commands and lean-ctx bridges when unwrapping pending approval keys
- Treat any tool arguments that include shell command text as sensitive for runtime review
- Complete after-observer native approvals from pending before-hook state instead of re-parsing runtime artifacts

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_cursor_hooks.py -q`
- `uv run python -m ruff check src/codex_plugin_scanner/guard/adapters/cursor_native_approval.py src/codex_plugin_scanner/guard/adapters/cursor_hooks.py src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py`
