### PR TITLE
fix(opencode): prevent install from wiping invalid MCP config

### DIFF
--- a/src/codex_plugin_scanner/ecosystems/opencode.py
+++ b/src/codex_plugin_scanner/ecosystems/opencode.py
@@ -87,12 +87,13 @@ def _load_json_or_jsonc(path: Path) -> tuple[dict[str, object], bool, str | None
         return {}, True, "permission-denied"
     except OSError:
         return {}, True, "read-error"
-    if path.suffix == ".jsonc":
+    has_comments = "//" in text or "/*" in text
+    if path.suffix == ".jsonc" and has_comments:
         text = _strip_jsonc(text)
     parsed = _parse_opencode_config_text(text)
     if parsed is not None:
         return parsed, False, None
-    if path.suffix != ".jsonc":
+    if path.suffix != ".jsonc" and has_comments:
         stripped = _strip_jsonc(text)
         if stripped != text:
             parsed = _parse_opencode_config_text(stripped)

--- a/src/codex_plugin_scanner/ecosystems/opencode.py
+++ b/src/codex_plugin_scanner/ecosystems/opencode.py
@@ -70,6 +70,14 @@ def _strip_jsonc(text: str) -> str:
     return "".join(output)
 
 
+def _parse_opencode_config_text(text: str) -> dict[str, object] | None:
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
 def _load_json_or_jsonc(path: Path) -> tuple[dict[str, object], bool, str | None]:
     try:
         text = path.read_text(encoding="utf-8")
@@ -81,13 +89,16 @@ def _load_json_or_jsonc(path: Path) -> tuple[dict[str, object], bool, str | None
         return {}, True, "read-error"
     if path.suffix == ".jsonc":
         text = _strip_jsonc(text)
-    try:
-        payload = json.loads(text)
-        if isinstance(payload, dict):
-            return payload, False, None
-    except json.JSONDecodeError:
-        return {}, True, "invalid-json"
-    return {}, True, "not-object"
+    parsed = _parse_opencode_config_text(text)
+    if parsed is not None:
+        return parsed, False, None
+    if path.suffix != ".jsonc":
+        stripped = _strip_jsonc(text)
+        if stripped != text:
+            parsed = _parse_opencode_config_text(stripped)
+            if parsed is not None:
+                return parsed, False, None
+    return {}, True, "invalid-json"
 
 
 class OpenCodeAdapter:

--- a/src/codex_plugin_scanner/ecosystems/opencode.py
+++ b/src/codex_plugin_scanner/ecosystems/opencode.py
@@ -70,12 +70,14 @@ def _strip_jsonc(text: str) -> str:
     return "".join(output)
 
 
-def _parse_opencode_config_text(text: str) -> dict[str, object] | None:
+def _parse_opencode_config_text(text: str) -> tuple[dict[str, object] | None, str | None]:
     try:
         payload = json.loads(text)
     except json.JSONDecodeError:
-        return None
-    return payload if isinstance(payload, dict) else None
+        return None, "invalid-json"
+    if isinstance(payload, dict):
+        return payload, None
+    return None, "not-object"
 
 
 def _load_json_or_jsonc(path: Path) -> tuple[dict[str, object], bool, str | None]:
@@ -90,16 +92,16 @@ def _load_json_or_jsonc(path: Path) -> tuple[dict[str, object], bool, str | None
     has_comments = "//" in text or "/*" in text
     if path.suffix == ".jsonc" and has_comments:
         text = _strip_jsonc(text)
-    parsed = _parse_opencode_config_text(text)
+    parsed, parse_reason = _parse_opencode_config_text(text)
     if parsed is not None:
         return parsed, False, None
     if path.suffix != ".jsonc" and has_comments:
         stripped = _strip_jsonc(text)
         if stripped != text:
-            parsed = _parse_opencode_config_text(stripped)
+            parsed, parse_reason = _parse_opencode_config_text(stripped)
             if parsed is not None:
                 return parsed, False, None
-    return {}, True, "invalid-json"
+    return {}, True, parse_reason or "invalid-json"
 
 
 class OpenCodeAdapter:

--- a/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
+++ b/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
@@ -258,10 +258,19 @@ def _bool_metadata(value: object, *, default: bool) -> bool:
     return default
 
 
+def _hol_guard_command_name(command: str) -> str | None:
+    cmd_name = PurePath(command.replace("\\", "/")).name.lower()
+    for suffix in (".exe", ".cmd", ".bat"):
+        if cmd_name.endswith(suffix):
+            cmd_name = cmd_name[: -len(suffix)]
+            break
+    return cmd_name if cmd_name == "hol-guard" else None
+
+
 def is_guard_proxy_command(command: str | None, args: tuple[str, ...]) -> bool:
     if not isinstance(command, str):
         return False
-    if command == "hol-guard":
+    if _hol_guard_command_name(command) is not None:
         return "guard" in args and any(value in _GUARD_PROXY_COMMANDS for value in args)
     if "codex_plugin_scanner.cli" not in args or "guard" not in args:
         return False

--- a/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
+++ b/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
@@ -27,6 +27,13 @@ class ManagedMcpServer:
     identity: McpServerIdentity | None = None
 
 
+GUARD_MCP_COMPANION_PREFIX = "hol-guard::"
+
+
+def is_guard_mcp_companion_name(name: str) -> bool:
+    return name.startswith(GUARD_MCP_COMPANION_PREFIX)
+
+
 _GUARD_PROXY_COMMANDS = frozenset(
     {
         "codex-mcp-proxy",
@@ -158,6 +165,8 @@ def proxy_process_env(server_env: dict[str, str]) -> dict[str, str]:
 def _managed_stdio_server(artifact: GuardArtifact) -> ManagedMcpServer | None:
     if artifact.artifact_type != "mcp_server":
         return None
+    if is_guard_mcp_companion_name(artifact.name):
+        return None
     if _bool_metadata(artifact.metadata.get("guard_managed_proxy"), default=False):
         return None
     if artifact.command is None or not artifact.name.strip():
@@ -252,13 +261,17 @@ def _bool_metadata(value: object, *, default: bool) -> bool:
 def is_guard_proxy_command(command: str | None, args: tuple[str, ...]) -> bool:
     if not isinstance(command, str):
         return False
+    if command == "hol-guard":
+        return "guard" in args and any(value in _GUARD_PROXY_COMMANDS for value in args)
     if "codex_plugin_scanner.cli" not in args or "guard" not in args:
         return False
     return any(value in _GUARD_PROXY_COMMANDS for value in args)
 
 
 __all__ = [
+    "GUARD_MCP_COMPANION_PREFIX",
     "ManagedMcpServer",
+    "is_guard_mcp_companion_name",
     "is_guard_proxy_command",
     "managed_stdio_servers",
     "proxy_cli_args",

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -176,6 +176,14 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         managed_servers = managed_stdio_servers(detection)
         skipped_servers = skipped_stdio_server_names(detection)
         target_config_path = self._managed_install_config_path(context)
+        target_payload, parse_error, _parse_reason = _load_json_or_jsonc(target_config_path)
+        if target_config_path.is_file() and (parse_error or not isinstance(target_payload, dict)):
+            raise OpenCodeInstallConfigError(
+                "Refusing to modify an invalid OpenCode root config. "
+                "Fix opencode.json (or opencode.jsonc) syntax and retry install."
+            )
+        if not isinstance(target_payload, dict):
+            target_payload = {}
         original_text = None
         if target_config_path.is_file():
             original_text = target_config_path.read_text(encoding="utf-8")
@@ -201,14 +209,6 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             + "\n",
             encoding="utf-8",
         )
-        target_payload, parse_error, _parse_reason = _load_json_or_jsonc(target_config_path)
-        if target_config_path.is_file() and (parse_error or not isinstance(target_payload, dict)):
-            raise OpenCodeInstallConfigError(
-                "Refusing to modify an invalid OpenCode root config. "
-                "Fix opencode.json (or opencode.jsonc) syntax and retry install."
-            )
-        if not isinstance(target_payload, dict):
-            target_payload = {}
         existing_workspace_server_names = self._workspace_server_names(context)
         _apply_install_baseline(target_payload)
         target_payload["permission"] = self._managed_permission_payload(

--- a/src/codex_plugin_scanner/guard/adapters/opencode.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode.py
@@ -15,7 +15,9 @@ from ..shims import install_guard_shim, remove_guard_shim
 from .base import HarnessAdapter, HarnessContext, _command_available, _run_command_probe
 from .hook_python import resolve_guard_hook_python
 from .mcp_servers import (
+    GUARD_MCP_COMPANION_PREFIX,
     ManagedMcpServer,
+    is_guard_mcp_companion_name,
     is_guard_proxy_command,
     managed_stdio_servers,
     proxy_cli_args,
@@ -36,7 +38,7 @@ from .opencode_artifacts import (
 from .opencode_pretool import install_pretool_plugin, remove_pretool_plugin
 
 _OPENCODE_SCHEMA = "https://opencode.ai/config.json"
-_GUARD_MCP_COMPANION_PREFIX = "hol-guard::"
+_GUARD_MCP_COMPANION_PREFIX = GUARD_MCP_COMPANION_PREFIX
 _DEFAULT_BASH_PERMISSION: dict[str, object] = {
     "*": "allow",
     "git checkout *": "deny",
@@ -50,6 +52,10 @@ _DEFAULT_BASH_PERMISSION: dict[str, object] = {
     "rm -rf *": "deny",
     "rm -r *": "deny",
 }
+
+
+class OpenCodeInstallConfigError(RuntimeError):
+    """Raised when Guard cannot safely update an existing OpenCode config file."""
 
 
 class OpenCodeHarnessAdapter(HarnessAdapter):
@@ -196,7 +202,12 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             encoding="utf-8",
         )
         target_payload, parse_error, _parse_reason = _load_json_or_jsonc(target_config_path)
-        if parse_error or not isinstance(target_payload, dict):
+        if target_config_path.is_file() and (parse_error or not isinstance(target_payload, dict)):
+            raise OpenCodeInstallConfigError(
+                "Refusing to modify an invalid OpenCode root config. "
+                "Fix opencode.json (or opencode.jsonc) syntax and retry install."
+            )
+        if not isinstance(target_payload, dict):
             target_payload = {}
         existing_workspace_server_names = self._workspace_server_names(context)
         _apply_install_baseline(target_payload)
@@ -432,8 +443,11 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
             if not isinstance(mcp, dict):
                 continue
             for name, value in mcp.items():
-                if isinstance(name, str) and isinstance(value, dict):
-                    workspace_server_names.add(name)
+                if not isinstance(name, str) or not isinstance(value, dict):
+                    continue
+                if is_guard_mcp_companion_name(name):
+                    continue
+                workspace_server_names.add(name)
         return workspace_server_names
 
     @staticmethod
@@ -628,7 +642,7 @@ class OpenCodeHarnessAdapter(HarnessAdapter):
         return {}
 
 
-__all__ = ["OpenCodeHarnessAdapter"]
+__all__ = ["OpenCodeHarnessAdapter", "OpenCodeInstallConfigError"]
 
 
 def _apply_install_baseline(payload: dict[str, object]) -> None:
@@ -759,6 +773,11 @@ def _persisted_mcp_with_guard_companions(
         if environment:
             entry["environment"] = environment
         persisted[companion_name] = entry
+        native_entry = persisted.get(server.name)
+        if isinstance(native_entry, dict):
+            disabled_native = dict(native_entry)
+            disabled_native["enabled"] = False
+            persisted[server.name] = disabled_native
     return persisted
 
 

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from ..models import GuardArtifact
 from ..runtime.mcp_skill_firewall import enrich_artifact_with_mcp_skill_firewall
 from .base import HarnessContext
+from .mcp_servers import is_guard_mcp_companion_name, is_guard_proxy_command
 
 CONFIG_FILENAMES = ("opencode.json", "opencode.jsonc")
 PLUGIN_SUFFIXES = {".js", ".ts", ".mjs", ".cjs"}
@@ -245,6 +246,8 @@ def _append_mcp_artifacts(
     for name, server_config in mcp_config.items():
         if not isinstance(name, str) or not isinstance(server_config, dict):
             continue
+        if is_guard_mcp_companion_name(name):
+            continue
         command, args = _command_parts(server_config)
         transport = server_config.get("type") if isinstance(server_config.get("type"), str) else None
         url = server_config.get("url") if isinstance(server_config.get("url"), str) else None
@@ -262,6 +265,7 @@ def _append_mcp_artifacts(
             transport=transport or ("remote" if url is not None else "stdio"),
             metadata={
                 "enabled": bool(server_config.get("enabled", True)),
+                "guard_managed_proxy": is_guard_proxy_command(command, args),
                 "env": {
                     str(key): str(value)
                     for key, value in environment.items()

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -665,7 +665,7 @@ class TestOpenCodeResiliency:
                 "chrome-devtools": {"type": "local", "command": ["npx", "-y", "chrome-devtools-mcp@latest"]},
                 "hol-guard::chrome-devtools": {
                     "type": "local",
-                    "command": ["hol-guard", "guard", "opencode-mcp-proxy"],
+                    "command": ["/usr/local/bin/hol-guard", "guard", "opencode-mcp-proxy"],
                 },
             },
         )

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -614,6 +614,8 @@ class TestOpenCodeResiliency:
         with pytest.raises(OpenCodeInstallConfigError):
             OpenCodeHarnessAdapter().install(ctx)
         assert config.read_text(encoding="utf-8") == original + ","
+        assert not OpenCodeHarnessAdapter._backup_path(ctx).exists()
+        assert not OpenCodeHarnessAdapter._state_path(ctx, config).exists()
 
     def test_install_parses_json_with_comments(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter, OpenCodeInstallConfigError
 from codex_plugin_scanner.guard.adapters.opencode_artifacts import (
     CONFIG_FILENAMES,
     runtime_config_path,
@@ -340,6 +342,7 @@ class TestOpenCodeInstall:
         managed_config = json.loads(target.read_text(encoding="utf-8"))
         chrome = managed_config["mcp"]["chrome-devtools"]
         assert chrome["command"] == ["npx", "-y", "chrome-devtools-mcp@latest"]
+        assert chrome["enabled"] is False
         assert "opencode-mcp-proxy" not in json.dumps(chrome)
         assert managed_config["mcp"]["my-remote"]["url"] == "https://example.com/mcp"
         companion = managed_config["mcp"]["hol-guard::chrome-devtools"]
@@ -601,6 +604,74 @@ class TestOpenCodeResiliency:
         config.write_text("{invalid json!", encoding="utf-8")
         result = OpenCodeHarnessAdapter().detect(ctx)
         assert result.artifacts == ()
+
+    def test_install_refuses_malformed_existing_config(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        original = '{"model": "gpt-4", "mcp": {"lab": {"type": "local", "command": ["node", "lab.js"]}}}'
+        config.write_text(original + ",", encoding="utf-8")
+        with pytest.raises(OpenCodeInstallConfigError):
+            OpenCodeHarnessAdapter().install(ctx)
+        assert config.read_text(encoding="utf-8") == original + ","
+
+    def test_install_parses_json_with_comments(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(
+            """
+            {
+              // workspace model
+              "model": "gpt-4",
+              "mcp": {
+                "lab": {
+                  "type": "local",
+                  "command": ["node", "lab.js"]
+                }
+              }
+            }
+            """,
+            encoding="utf-8",
+        )
+        OpenCodeHarnessAdapter().install(ctx)
+        managed_config = json.loads(config.read_text(encoding="utf-8"))
+        assert managed_config["model"] == "gpt-4"
+        assert managed_config["mcp"]["lab"]["command"] == ["node", "lab.js"]
+        assert managed_config["mcp"]["lab"]["enabled"] is False
+        assert "hol-guard::lab" in managed_config["mcp"]
+
+    def test_install_is_idempotent_for_managed_mcp_entries(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        _write_mcp_config(
+            config,
+            {"chrome-devtools": {"type": "local", "command": ["npx", "-y", "chrome-devtools-mcp@latest"]}},
+        )
+        OpenCodeHarnessAdapter().install(ctx)
+        first = json.loads(config.read_text(encoding="utf-8"))
+        OpenCodeHarnessAdapter().install(ctx)
+        second = json.loads(config.read_text(encoding="utf-8"))
+        assert set(first["mcp"]) == set(second["mcp"])
+        assert list(first["mcp"]).count("chrome-devtools") == 1
+        assert list(first["mcp"]).count("hol-guard::chrome-devtools") == 1
+
+    def test_detect_ignores_guard_companion_mcp_entries(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        _write_mcp_config(
+            config,
+            {
+                "chrome-devtools": {"type": "local", "command": ["npx", "-y", "chrome-devtools-mcp@latest"]},
+                "hol-guard::chrome-devtools": {
+                    "type": "local",
+                    "command": ["hol-guard", "guard", "opencode-mcp-proxy"],
+                },
+            },
+        )
+        result = OpenCodeHarnessAdapter().detect(ctx)
+        artifact_names = {artifact.name for artifact in result.artifacts}
+        assert artifact_names == {"chrome-devtools"}
 
     def test_detect_skips_empty_config_file(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)


### PR DESCRIPTION
## Summary
- Refuse OpenCode hook install when the existing root config is invalid instead of resetting it to Guard defaults
- Parse JSON-with-comments in opencode.json so minor syntax issues do not trigger a wipe
- Ignore hol-guard companion MCP entries during detection and disable native servers when a companion is installed to prevent duplicate MCP tools

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_opencode_adapter.py tests/test_opencode_pretool.py tests/test_guard_cli.py -k opencode -q`
