### PR TITLE
fix(opencode): fall back to node child_process without Bun

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -44,6 +44,54 @@ function normalizeCommand(command: unknown): string | null {
   return null;
 }
 
+async function spawnGuardProcess(options: {
+  command: string[];
+  cwd: string;
+  env: Record<string, string>;
+  stdin: string;
+}): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+  const bun = (globalThis as { Bun?: { spawn?: Function } }).Bun;
+  if (typeof bun?.spawn === "function") {
+    const proc = bun.spawn(options.command, {
+      cwd: options.cwd,
+      env: options.env,
+      stdin: new Blob([options.stdin]),
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const stdoutPromise = new Response(proc.stdout).text();
+    const stderrPromise = new Response(proc.stderr).text();
+    const exitCode = await proc.exited;
+    return {
+      exitCode,
+      stdout: await stdoutPromise,
+      stderr: await stderrPromise,
+    };
+  }
+
+  const { spawn } = await import("node:child_process");
+  return await new Promise((resolve, reject) => {
+    const proc = spawn(options.command[0], options.command.slice(1), {
+      cwd: options.cwd,
+      env: options.env,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    proc.stdout?.on("data", (chunk: Buffer | string) => {
+      stdout += String(chunk);
+    });
+    proc.stderr?.on("data", (chunk: Buffer | string) => {
+      stderr += String(chunk);
+    });
+    proc.on("error", reject);
+    proc.on("close", (code: number | null) => {
+      resolve({ exitCode: code ?? 1, stdout, stderr });
+    });
+    proc.stdin?.end(options.stdin);
+  });
+}
+
 async function runGuardHook(directory: string, payload: Record<string, unknown>) {
   const workspace = directory?.trim() || process.cwd();
   const guardArgv = [
@@ -57,19 +105,12 @@ async function runGuardHook(directory: string, payload: Record<string, unknown>)
     workspace,
     "--json",
   ];
-  const proc = Bun.spawn([GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER], {
+  return spawnGuardProcess({
+    command: [GUARD_PYTHON, "-c", GUARD_HOOK_LAUNCHER],
     cwd: GUARD_HOME,
     env: hookProcessEnv(guardArgv),
-    stdin: new Blob([JSON.stringify(payload)]),
-    stdout: "pipe",
-    stderr: "pipe",
+    stdin: JSON.stringify(payload),
   });
-  const stdoutPromise = new Response(proc.stdout).text();
-  const stderrPromise = new Response(proc.stderr).text();
-  const exitCode = await proc.exited;
-  const stdout = await stdoutPromise;
-  const stderr = await stderrPromise;
-  return { exitCode, stdout, stderr };
 }
 
 function parseGuardPayload(stdout: string): Record<string, unknown> | null {

--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -70,7 +70,7 @@ async function spawnGuardProcess(options: {
   }
 
   const { spawn } = await import("node:child_process");
-  return await new Promise((resolve, reject) => {
+  return new Promise((resolve, reject) => {
     const proc = spawn(options.command[0], options.command.slice(1), {
       cwd: options.cwd,
       env: options.env,
@@ -78,16 +78,19 @@ async function spawnGuardProcess(options: {
     });
     let stdout = "";
     let stderr = "";
-    proc.stdout?.on("data", (chunk: Buffer | string) => {
-      stdout += String(chunk);
+    proc.stdout?.setEncoding("utf8");
+    proc.stderr?.setEncoding("utf8");
+    proc.stdout?.on("data", (chunk: string) => {
+      stdout += chunk;
     });
-    proc.stderr?.on("data", (chunk: Buffer | string) => {
-      stderr += String(chunk);
+    proc.stderr?.on("data", (chunk: string) => {
+      stderr += chunk;
     });
     proc.on("error", reject);
     proc.on("close", (code: number | null) => {
       resolve({ exitCode: code ?? 1, stdout, stderr });
     });
+    proc.stdin?.on("error", () => {});
     proc.stdin?.end(options.stdin);
   });
 }

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -73,10 +73,14 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     source = pretool_plugin_source(ctx)
     assert str(ctx.guard_home.resolve()) in source
     assert "tool.execute.before" in source
-    assert "stdin: new Blob([JSON.stringify(payload)])" in source
+    assert "spawnGuardProcess" in source
+    assert "node:child_process" in source
     assert "normalizeCommand" in source
-    assert '.stream()' not in source.split("Bun.spawn", 1)[1].split("});", 1)[0]
-    assert "stdoutPromise" in source
+    spawn_block = source.split("async function spawnGuardProcess", 1)[1].split("async function runGuardHook", 1)[0]
+    assert "globalThis" in spawn_block
+    assert "Bun" in spawn_block
+    assert "stdin: new Blob([options.stdin])" in spawn_block
+    assert '.stream()' not in spawn_block
     assert "try {" in source
     assert 'source_scope: directory?.trim() ? "project" : "global"' in source
     assert "GUARD_HOOK_LAUNCHER" in source
@@ -84,8 +88,8 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     assert "GUARD_INHERIT_ENV_KEYS" in source
     assert "HOL_GUARD_HOOK_ARGV" in source
     assert "cwd: GUARD_HOME" in source
-    spawn_block = source.split("Bun.spawn(", 1)[1].split("});", 1)[0]
-    assert "cwd: workspace" not in spawn_block
+    run_block = source.split("async function runGuardHook", 1)[1].split("function parseGuardPayload", 1)[0]
+    assert "cwd: workspace" not in run_block
     assert '"-m",' not in source
     assert '-m",' not in source
 
@@ -175,10 +179,20 @@ def test_pretool_hook_env_blocks_workspace_import_shadowing(tmp_path: Path) -> N
 
 def test_pretool_plugin_source_does_not_spawn_python_m_module(tmp_path: Path) -> None:
     source = pretool_plugin_source(_ctx(tmp_path))
-    spawn_block = source.split("Bun.spawn(", 1)[1].split("});", 1)[0]
-    assert "codex_plugin_scanner.cli" not in spawn_block
-    assert '"-c"' in spawn_block or "'-c'" in spawn_block or "-c" in spawn_block
-    assert "GUARD_HOOK_LAUNCHER" in spawn_block
+    run_block = source.split("return spawnGuardProcess({", 1)[1].split("});", 1)[0]
+    assert "codex_plugin_scanner.cli" not in run_block
+    assert '"-c"' in run_block or "'-c'" in run_block or "-c" in run_block
+    assert "GUARD_HOOK_LAUNCHER" in run_block
+
+
+def test_pretool_plugin_source_includes_node_spawn_fallback(tmp_path: Path) -> None:
+    spawn_block = pretool_plugin_source(_ctx(tmp_path)).split("async function spawnGuardProcess", 1)[1].split(
+        "async function runGuardHook",
+        1,
+    )[0]
+    assert "typeof bun?.spawn === \"function\"" in spawn_block
+    assert 'await import("node:child_process")' in spawn_block
+    assert "proc.stdin?.end(options.stdin)" in spawn_block
 
 
 def test_install_pretool_plugin_writes_managed_and_global_copies(tmp_path: Path) -> None:

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -192,6 +192,8 @@ def test_pretool_plugin_source_includes_node_spawn_fallback(tmp_path: Path) -> N
     )[0]
     assert "typeof bun?.spawn === \"function\"" in spawn_block
     assert 'await import("node:child_process")' in spawn_block
+    assert 'proc.stdout?.setEncoding("utf8")' in spawn_block
+    assert 'proc.stdin?.on("error", () => {})' in spawn_block
     assert "proc.stdin?.end(options.stdin)" in spawn_block
 
 


### PR DESCRIPTION
## Summary
- Fix OpenCode pretool plugin failing with `Bun is not defined` in Node-based agent runtimes
- Spawn the Guard hook with `node:child_process` when `Bun.spawn` is unavailable

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_opencode_pretool.py -q`
