### PR TITLE
feat(dashboard): align policy cloud exceptions M2/M3 with mockup

### DIFF
--- a/dashboard/src/policy-cloud-exception-detail-panel.tsx
+++ b/dashboard/src/policy-cloud-exception-detail-panel.tsx
@@ -104,7 +104,7 @@ function ExpiryTimeline({
         <span>Expires {formatRelativeTime(expiryValue)}</span>
       </div>
       <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200">
-        <div className="h-full w-2/3 rounded-full bg-brand-blue/70" aria-hidden="true" />
+        <div className="h-full w-full animate-pulse rounded-full bg-brand-blue/40" aria-hidden="true" />
       </div>
       <p className="mt-2 text-xs text-slate-600">{expiryTimestamp.toLocaleString()}</p>
     </div>

--- a/dashboard/src/policy-cloud-exception-detail-panel.tsx
+++ b/dashboard/src/policy-cloud-exception-detail-panel.tsx
@@ -1,4 +1,9 @@
-import { HiMiniCloudArrowUp, HiMiniXMark } from "react-icons/hi2";
+import {
+  HiMiniCheckCircle,
+  HiMiniCloudArrowUp,
+  HiMiniDocumentText,
+  HiMiniXMark,
+} from "react-icons/hi2";
 import { ActionButton, Badge, SectionLabel, Tag } from "./approval-center-primitives";
 import { formatRelativeTime, scopeLabel } from "./approval-center-utils";
 import type { GuardCloudException } from "./guard-types";
@@ -6,9 +11,12 @@ import {
   isCloudExceptionAckFailure,
   isCloudExceptionActive,
   resolveCloudExceptionBlastRadius,
+  resolveCloudExceptionEffectLabel,
+  resolveCloudExceptionEvidenceUrl,
   resolveCloudExceptionExpiryTimestamp,
   resolveCloudExceptionExpiryValue,
   resolveCloudExceptionHeadline,
+  resolveCloudExceptionScopePath,
   resolveCloudExceptionWhyCopy,
   resolvePersonDisplayLabel,
   resolvePersonInitials,
@@ -59,7 +67,7 @@ function DetailField({ label, value }: { label: string; value: string | null | u
 
 function resolveAckCopy(item: GuardCloudException): { label: string; detail: string } {
   if (item.ack_status === "synced") {
-    return { label: "Synced", detail: "This device acknowledged the signed policy bundle." };
+    return { label: "Acknowledged", detail: "This device acknowledged the signed policy bundle." };
   }
   if (item.ack_status === "pending") {
     return { label: "Pending ack", detail: "Waiting for this device to acknowledge the signed bundle on next sync." };
@@ -79,6 +87,40 @@ function resolveAckCopy(item: GuardCloudException): { label: string; detail: str
   return { label: "Unknown", detail: "Local acknowledgement status is unavailable." };
 }
 
+function ExpiryTimeline({
+  expiryTimestamp,
+  expiryValue,
+}: {
+  expiryTimestamp: Date | null;
+  expiryValue: string | null;
+}) {
+  if (!expiryTimestamp || !expiryValue) {
+    return null;
+  }
+  return (
+    <div className="mt-3">
+      <div className="flex items-center justify-between text-[11px] font-medium text-slate-500">
+        <span>Approved</span>
+        <span>Expires {formatRelativeTime(expiryValue)}</span>
+      </div>
+      <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200">
+        <div className="h-full w-2/3 rounded-full bg-brand-blue/70" aria-hidden="true" />
+      </div>
+      <p className="mt-2 text-xs text-slate-600">{expiryTimestamp.toLocaleString()}</p>
+    </div>
+  );
+}
+
+function blastRadiusBadgeTone(tone: ReturnType<typeof resolveCloudExceptionBlastRadius>["tone"]) {
+  if (tone === "narrow") {
+    return "success" as const;
+  }
+  if (tone === "medium") {
+    return "warning" as const;
+  }
+  return "destructive" as const;
+}
+
 export function PolicyCloudExceptionDetailPanel({
   exception,
   cloudControlsUrl,
@@ -92,6 +134,9 @@ export function PolicyCloudExceptionDetailPanel({
   const whyCopy = resolveCloudExceptionWhyCopy(exception);
   const isActive = isCloudExceptionActive(exception);
   const isEnforcedLocally = exception.ack_status === "synced";
+  const evidenceUrl = resolveCloudExceptionEvidenceUrl(exception);
+  const scopePath = resolveCloudExceptionScopePath(exception);
+  const effectLabel = resolveCloudExceptionEffectLabel(exception.effect);
 
   return (
     <aside
@@ -100,8 +145,9 @@ export function PolicyCloudExceptionDetailPanel({
     >
       <div className="mb-4 flex min-w-0 items-start justify-between gap-3">
         <div className="min-w-0 flex-1">
-          <SectionLabel>Cloud exception</SectionLabel>
+          <SectionLabel>Temporary cloud exception</SectionLabel>
           <h3 className="mt-1 break-words text-lg font-semibold text-brand-dark">{headline}</h3>
+          <p className="mt-1 text-sm text-slate-600">{effectLabel}</p>
         </div>
         <button
           type="button"
@@ -116,7 +162,7 @@ export function PolicyCloudExceptionDetailPanel({
       <div className="mb-4 flex flex-wrap gap-2">
         {isActive ? <Badge tone="success">Active</Badge> : <Badge tone="default">Expired</Badge>}
         {isEnforcedLocally ? <Tag tone="slate">Enforced locally</Tag> : null}
-        <Badge tone="success">{exception.effect}</Badge>
+        <Badge tone="success">{effectLabel}</Badge>
         {!isEnforcedLocally ? <Badge tone="warning">{ackCopy.label}</Badge> : null}
       </div>
 
@@ -126,12 +172,36 @@ export function PolicyCloudExceptionDetailPanel({
           <p className="mt-2 text-sm leading-relaxed text-brand-dark">{whyCopy}</p>
         </div>
 
-        <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Blast radius</p>
-          <p className="mt-1 text-sm font-medium text-brand-dark">{blast.label}</p>
-          <p className="mt-1 text-sm text-slate-600">{blast.detail}</p>
-          <DetailField label="Scope (exact)" value={scopeLabel(exception.scope, "policy")} />
+        <div className="grid gap-3 sm:grid-cols-2">
+          <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Blast radius</p>
+            <div className="mt-2">
+              <Badge tone={blastRadiusBadgeTone(blast.tone)}>{blast.label}</Badge>
+            </div>
+            <p className="mt-2 text-sm text-slate-600">{blast.detail}</p>
+          </div>
+          <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Scope (exact)</p>
+            <div className="mt-2">
+              <Tag tone="blue">{scopeLabel(exception.scope, "policy")}</Tag>
+            </div>
+            {scopePath ? <p className="mt-2 break-all text-sm text-slate-600">{scopePath}</p> : null}
+          </div>
         </div>
+
+        {evidenceUrl ? (
+          <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Source review item</p>
+            <p className="mt-2 text-sm font-medium text-brand-dark">
+              {exception.source_receipt_id?.trim() ?? "Linked approval record"}
+            </p>
+            <div className="mt-3">
+              <ActionButton href={evidenceUrl} variant="secondary">
+                Open in Review
+              </ActionButton>
+            </div>
+          </div>
+        ) : null}
 
         <PersonRow label="Owner" value={exception.owner} />
         <PersonRow label="Approved by" value={exception.approver} />
@@ -143,6 +213,7 @@ export function PolicyCloudExceptionDetailPanel({
               ? `${expiryTimestamp.toLocaleString()} (${formatRelativeTime(expiryValue)})`
               : expiryValue ?? "Expiry unavailable"}
           </p>
+          <ExpiryTimeline expiryTimestamp={expiryTimestamp} expiryValue={expiryValue} />
           <DetailField
             label="Last used"
             value={exception.last_used_at ? formatRelativeTime(exception.last_used_at) : null}
@@ -150,12 +221,30 @@ export function PolicyCloudExceptionDetailPanel({
         </div>
 
         <DetailField label="Harness" value={exception.harness} />
-        <DetailField label="Source receipt" value={exception.source_receipt_id} />
-        <DetailField label="Signed bundle hash" value={exception.bundle_hash} />
+
+        {exception.bundle_hash ? (
+          <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Signed bundle entry</p>
+            <div className="mt-2 flex items-start gap-2">
+              <HiMiniDocumentText className="mt-0.5 h-4 w-4 shrink-0 text-brand-blue" aria-hidden="true" />
+              <div className="min-w-0">
+                <p className="break-all text-sm font-medium text-brand-dark">{exception.bundle_hash}</p>
+                {exception.source_receipt_id ? (
+                  <p className="mt-1 break-all text-xs text-slate-500">{exception.source_receipt_id}</p>
+                ) : null}
+              </div>
+            </div>
+          </div>
+        ) : null}
 
         <div className="rounded-xl border border-slate-100 bg-slate-50/80 p-3">
           <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Local daemon acknowledgement</p>
-          <p className="mt-1 text-sm font-medium text-brand-dark">{ackCopy.label}</p>
+          <div className="mt-2 flex items-center gap-2">
+            {exception.ack_status === "synced" ? (
+              <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
+            ) : null}
+            <p className="text-sm font-medium text-brand-dark">{ackCopy.label}</p>
+          </div>
           <p className="mt-1 text-sm text-slate-600">{ackCopy.detail}</p>
           {isCloudExceptionAckFailure(exception) ? (
             <p className="mt-2 text-xs text-slate-500">Run Guard sync to retry bundle acknowledgement.</p>
@@ -164,7 +253,8 @@ export function PolicyCloudExceptionDetailPanel({
       </div>
 
       {cloudControlsUrl ? (
-        <div className="mt-5 w-full">
+        <div className="mt-5 space-y-2">
+          <p className="text-xs text-slate-500">Open Guard Cloud to revoke or renew this exception.</p>
           <ActionButton href={cloudControlsUrl} variant="secondary">
             <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
             Open in Guard Cloud

--- a/dashboard/src/policy-cloud-exception-request-ia.test.ts
+++ b/dashboard/src/policy-cloud-exception-request-ia.test.ts
@@ -17,6 +17,8 @@ assert(tabSource.includes("PolicyCloudExceptionRequestPanel"), "cloud exceptions
 assert(panelSource.includes("handleNext"), "request panel supports wizard next step");
 assert(panelSource.includes("handleBack"), "request panel supports wizard back step");
 assert(panelSource.includes("createCloudExceptionRequest"), "request panel submits through Guard Cloud proxy");
+assert(panelSource.includes("SourceReceiptSummary"), "request panel shows source receipt summary");
+assert(panelSource.includes("ResultPreview"), "request panel shows result preview");
 assert(panelSource.includes("sourceReceiptId"), "request panel anchors to source receipt");
 assert(!panelSource.includes("savePolicyDecision"), "request panel must not save local policy decisions");
 assert(guardApiSource.includes("createCloudExceptionRequest"), "guard-api exposes cloud exception request create");

--- a/dashboard/src/policy-cloud-exception-request-layout.tsx
+++ b/dashboard/src/policy-cloud-exception-request-layout.tsx
@@ -1,6 +1,9 @@
 import type { ReactNode } from "react";
+import { HiMiniCheck } from "react-icons/hi2";
+import { harnessDisplayName } from "./approval-center-utils";
 import { scopeLabel } from "./approval-center-utils";
 import type { GuardCloudExceptionRequestCreateInput } from "./guard-api";
+import type { GuardReceipt } from "./guard-types";
 import { resolveCloudExceptionBlastRadius } from "./policy-cloud-exceptions-utils";
 
 export const REQUEST_STEPS = ["Source", "Scope", "Guardrails", "Submit"] as const;
@@ -40,7 +43,7 @@ export function RequestStepper({ activeStep }: RequestStepperProps) {
                     : "bg-slate-200 text-slate-600"
               }`}
             >
-              {index + 1}
+              {complete ? <HiMiniCheck className="h-3 w-3" aria-hidden="true" /> : index + 1}
             </span>
             {step}
           </li>
@@ -163,6 +166,42 @@ export function SafetyPreview({
       </dl>
       <p className="mt-4 text-xs leading-relaxed text-slate-500">
         Guard Cloud must approve this request before it syncs as a signed bundle entry on this device.
+      </p>
+    </div>
+  );
+}
+
+type SourceReceiptSummaryProps = {
+  receipt: GuardReceipt;
+};
+
+export function SourceReceiptSummary({ receipt }: SourceReceiptSummaryProps) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-slate-50/80 p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Source: approval record</p>
+      <p className="mt-2 text-sm font-semibold text-brand-dark">
+        {receipt.artifact_name ?? receipt.artifact_id}
+      </p>
+      <p className="mt-1 text-xs text-slate-600">
+        {harnessDisplayName(receipt.harness)} · {receipt.receipt_id}
+      </p>
+    </div>
+  );
+}
+
+type ResultPreviewProps = {
+  scope: GuardCloudExceptionRequestCreateInput["scope"];
+  harness: string;
+  expiresLabel: string;
+};
+
+export function ResultPreview({ scope, harness, expiresLabel }: ResultPreviewProps) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Result preview</p>
+      <p className="mt-3 text-sm leading-relaxed text-brand-dark">
+        If approved in Guard Cloud, Guard will apply this exception for {scopeLabel(scope, "policy")}
+        {harness.trim() ? ` in ${harnessDisplayName(harness)}` : ""} until {expiresLabel}.
       </p>
     </div>
   );

--- a/dashboard/src/policy-cloud-exception-request-layout.tsx
+++ b/dashboard/src/policy-cloud-exception-request-layout.tsx
@@ -1,7 +1,6 @@
 import type { ReactNode } from "react";
 import { HiMiniCheck } from "react-icons/hi2";
-import { harnessDisplayName } from "./approval-center-utils";
-import { scopeLabel } from "./approval-center-utils";
+import { harnessDisplayName, scopeLabel } from "./approval-center-utils";
 import type { GuardCloudExceptionRequestCreateInput } from "./guard-api";
 import type { GuardReceipt } from "./guard-types";
 import { resolveCloudExceptionBlastRadius } from "./policy-cloud-exceptions-utils";
@@ -196,12 +195,13 @@ type ResultPreviewProps = {
 };
 
 export function ResultPreview({ scope, harness, expiresLabel }: ResultPreviewProps) {
+  const showHarness = (scope === "artifact" || scope === "harness") && harness.trim();
   return (
     <div className="rounded-xl border border-slate-200 bg-white p-4">
       <p className="text-xs font-semibold uppercase tracking-wide text-slate-500">Result preview</p>
       <p className="mt-3 text-sm leading-relaxed text-brand-dark">
         If approved in Guard Cloud, Guard will apply this exception for {scopeLabel(scope, "policy")}
-        {harness.trim() ? ` in ${harnessDisplayName(harness)}` : ""} until {expiresLabel}.
+        {showHarness ? ` in ${harnessDisplayName(harness)}` : ""} until {expiresLabel}.
       </p>
     </div>
   );

--- a/dashboard/src/policy-cloud-exception-request-panel.tsx
+++ b/dashboard/src/policy-cloud-exception-request-panel.tsx
@@ -9,8 +9,10 @@ import {
   RequestModalShell,
   RequestStepper,
   REQUEST_STEPS,
+  ResultPreview,
   SafetyPreview,
   ScopeCardGrid,
+  SourceReceiptSummary,
 } from "./policy-cloud-exception-request-layout";
 
 const SCOPE_OPTIONS: Array<{
@@ -96,12 +98,18 @@ export function PolicyCloudExceptionRequestPanel({
   const [owner, setOwner] = useState("");
   const [reason, setReason] = useState("");
   const [requestedExpiresAt, setRequestedExpiresAt] = useState(defaultExpiryIso());
+  const [linkedTicket, setLinkedTicket] = useState("");
+  const [maxUses, setMaxUses] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
   const [stepIndex, setStepIndex] = useState(0);
 
   const activeStep = REQUEST_STEPS[stepIndex] ?? "Source";
+  const selectedReceipt = useMemo(
+    () => receiptOptions.find((entry) => entry.receipt_id === sourceReceiptId) ?? null,
+    [receiptOptions, sourceReceiptId],
+  );
   const expiryLabel = useMemo(() => {
     const date = new Date(requestedExpiresAt);
     return Number.isNaN(date.getTime()) ? "Not set" : date.toLocaleString();
@@ -153,6 +161,25 @@ export function PolicyCloudExceptionRequestPanel({
     setRequestedExpiresAt(fromDatetimeLocalValue(event.target.value));
   }, []);
 
+  const handleLinkedTicketChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setLinkedTicket(event.target.value);
+  }, []);
+
+  const handleMaxUsesChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
+    setMaxUses(event.target.value);
+  }, []);
+
+  const buildReasonForSubmit = useCallback(() => {
+    const parts = [reason.trim()];
+    if (linkedTicket.trim()) {
+      parts.push(`Ticket: ${linkedTicket.trim()}`);
+    }
+    if (maxUses.trim()) {
+      parts.push(`Max uses: ${maxUses.trim()}`);
+    }
+    return parts.filter(Boolean).join("\n");
+  }, [linkedTicket, maxUses, reason]);
+
   const handleSubmit = useCallback(
     async (event: FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -163,7 +190,7 @@ export function PolicyCloudExceptionRequestPanel({
         scope,
         requestedBy: requestedBy.trim(),
         owner: owner.trim(),
-        reason: reason.trim(),
+        reason: buildReasonForSubmit(),
         requestedExpiresAt,
         sourceReceiptId: sourceReceiptId.trim() || null,
       };
@@ -197,10 +224,10 @@ export function PolicyCloudExceptionRequestPanel({
     },
     [
       artifactId,
+      buildReasonForSubmit,
       harness,
       owner,
       publisher,
-      reason,
       requestedBy,
       requestedExpiresAt,
       scope,
@@ -218,9 +245,11 @@ export function PolicyCloudExceptionRequestPanel({
     (scope !== "artifact" || artifactId.trim()) &&
     (scope !== "publisher" || publisher.trim()) &&
     (scope !== "workspace" || workingDirectory.trim()) &&
-    ((scope === "harness" || scope === "artifact") ? harness.trim() : true);
-  const canAdvanceFromGuardrails =
-    reason.trim().length > 0 && owner.trim().length > 0 && requestedBy.trim().length > 0;
+    ((scope === "harness" || scope === "artifact") ? harness.trim() : true) &&
+    reason.trim().length > 0 &&
+    owner.trim().length > 0 &&
+    requestedExpiresAt.trim().length > 0;
+  const canAdvanceFromGuardrails = requestedBy.trim().length > 0;
   const canSubmit = canAdvanceFromSource && canAdvanceFromScope && canAdvanceFromGuardrails;
 
   const handleBack = useCallback(() => {
@@ -316,10 +345,11 @@ export function PolicyCloudExceptionRequestPanel({
 
       <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_280px] lg:items-start">
         {activeStep === "Source" ? (
-          <div className="space-y-4 rounded-xl border border-slate-100 bg-slate-50/50 p-4 lg:col-span-2">
+          <div className="space-y-4 lg:col-span-3">
             <SectionLabel>Source</SectionLabel>
+            {selectedReceipt ? <SourceReceiptSummary receipt={selectedReceipt} /> : null}
             <label className="block space-y-1">
-              <span className="text-sm font-medium text-brand-dark">Source receipt</span>
+              <span className="text-sm font-medium text-brand-dark">Or choose a different record</span>
               <select
                 className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
                 value={sourceReceiptId}
@@ -337,111 +367,160 @@ export function PolicyCloudExceptionRequestPanel({
         ) : null}
 
         {activeStep === "Scope" ? (
-          <div className="space-y-4 rounded-xl border border-slate-100 bg-slate-50/50 p-4 lg:col-span-2">
-            <SectionLabel>Scope</SectionLabel>
-            <ScopeCardGrid options={SCOPE_OPTIONS} value={scope} onChange={setScope} />
+          <>
+            <div className="space-y-4 lg:col-start-1">
+              {selectedReceipt ? <SourceReceiptSummary receipt={selectedReceipt} /> : null}
+            </div>
+            <div className="space-y-4 rounded-xl border border-slate-100 bg-slate-50/50 p-4 lg:col-start-2">
+              <SectionLabel>Scope</SectionLabel>
+              <p className="text-sm text-slate-600">Choose the narrowest scope that solves the problem.</p>
+              <ScopeCardGrid options={SCOPE_OPTIONS} value={scope} onChange={setScope} />
 
-            {scope === "artifact" ? (
-              <label className="block space-y-1">
-                <span className="text-sm font-medium text-brand-dark">Artifact fingerprint</span>
-                <input
-                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
-                  value={artifactId}
-                  onChange={handleArtifactIdChange}
-                  required
-                />
-              </label>
-            ) : null}
+              {scope === "artifact" ? (
+                <label className="block space-y-1">
+                  <span className="text-sm font-medium text-brand-dark">Artifact fingerprint</span>
+                  <input
+                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+                    value={artifactId}
+                    onChange={handleArtifactIdChange}
+                    required
+                  />
+                </label>
+              ) : null}
 
-            {scope === "publisher" ? (
-              <label className="block space-y-1">
-                <span className="text-sm font-medium text-brand-dark">Publisher</span>
-                <input
-                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
-                  value={publisher}
-                  onChange={handlePublisherChange}
-                  required
-                />
-              </label>
-            ) : null}
+              {scope === "publisher" ? (
+                <label className="block space-y-1">
+                  <span className="text-sm font-medium text-brand-dark">Publisher</span>
+                  <input
+                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+                    value={publisher}
+                    onChange={handlePublisherChange}
+                    required
+                  />
+                </label>
+              ) : null}
 
-            {scope === "harness" || scope === "artifact" ? (
-              <label className="block space-y-1">
-                <span className="text-sm font-medium text-brand-dark">App</span>
-                <select
-                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
-                  value={harness}
-                  onChange={handleHarnessChange}
-                  required
-                >
-                  {harnessOptions.map((option) => (
-                    <option key={option} value={option}>
-                      {harnessDisplayName(option)}
-                    </option>
-                  ))}
-                </select>
-              </label>
-            ) : null}
+              {scope === "harness" || scope === "artifact" ? (
+                <label className="block space-y-1">
+                  <span className="text-sm font-medium text-brand-dark">App</span>
+                  <select
+                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+                    value={harness}
+                    onChange={handleHarnessChange}
+                    required
+                  >
+                    {harnessOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {harnessDisplayName(option)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              ) : null}
 
-            {scope === "workspace" ? (
-              <label className="block space-y-1">
-                <span className="text-sm font-medium text-brand-dark">Project folder</span>
-                <input
-                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
-                  value={workingDirectory}
-                  onChange={handleWorkingDirectoryChange}
-                  required
-                />
-              </label>
-            ) : null}
-          </div>
-        ) : null}
+              {scope === "workspace" ? (
+                <label className="block space-y-1">
+                  <span className="text-sm font-medium text-brand-dark">Project folder</span>
+                  <input
+                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+                    value={workingDirectory}
+                    onChange={handleWorkingDirectoryChange}
+                    required
+                  />
+                </label>
+              ) : null}
 
-        {activeStep === "Guardrails" ? (
-          <div className="space-y-4 rounded-xl border border-slate-100 bg-white p-4 lg:col-span-2">
-            <SectionLabel>Guardrails</SectionLabel>
-            <div className="grid gap-4 md:grid-cols-2">
-              <label className="block space-y-1">
-                <span className="text-sm font-medium text-brand-dark">Requested by</span>
-                <input
-                  className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
-                  type="email"
-                  value={requestedBy}
-                  onChange={handleRequestedByChange}
-                  required
-                />
-              </label>
               <label className="block space-y-1">
                 <span className="text-sm font-medium text-brand-dark">Risk owner</span>
                 <input
-                  className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
+                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
                   type="email"
                   value={owner}
                   onChange={handleOwnerChange}
                   required
                 />
               </label>
+
+              <label className="block space-y-1">
+                <span className="text-sm font-medium text-brand-dark">Reason (required)</span>
+                <textarea
+                  className="min-h-24 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+                  value={reason}
+                  onChange={handleReasonChange}
+                  maxLength={280}
+                  required
+                />
+                <p className="text-xs text-slate-500">{reason.trim().length}/280</p>
+                {!reason.trim() ? <p className="text-xs text-red-600">Reason is required.</p> : null}
+              </label>
+
+              <label className="block space-y-1 md:max-w-sm">
+                <span className="text-sm font-medium text-brand-dark">Requested expiry (required)</span>
+                <input
+                  className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+                  type="datetime-local"
+                  value={toDatetimeLocalValue(requestedExpiresAt)}
+                  onChange={handleExpiryChange}
+                  required
+                />
+              </label>
+
+              <div className="grid gap-4 md:grid-cols-2">
+                <label className="block space-y-1">
+                  <span className="text-sm font-medium text-brand-dark">Max uses (optional)</span>
+                  <input
+                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+                    inputMode="numeric"
+                    value={maxUses}
+                    onChange={handleMaxUsesChange}
+                    placeholder="50"
+                  />
+                </label>
+                <label className="block space-y-1">
+                  <span className="text-sm font-medium text-brand-dark">Linked ticket (optional)</span>
+                  <input
+                    className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
+                    value={linkedTicket}
+                    onChange={handleLinkedTicketChange}
+                    placeholder="ENG-123 or URL"
+                  />
+                </label>
+              </div>
+
+              {scope === "harness" || scope === "workspace" ? (
+                <div className="rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-3 py-2 text-xs text-brand-dark/80">
+                  Broad scopes require step-up authentication and Cloud approval.
+                </div>
+              ) : null}
             </div>
-            <label className="block space-y-1">
-              <span className="text-sm font-medium text-brand-dark">Reason (required)</span>
-              <textarea
-                className="min-h-24 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
-                value={reason}
-                onChange={handleReasonChange}
-                maxLength={280}
-                required
+            <div className="space-y-4 lg:col-start-3">
+              <SafetyPreview
+                scope={scope}
+                harness={harness}
+                artifactId={artifactId}
+                publisher={publisher}
+                workingDirectory={workingDirectory}
+                reason={reason}
+                expiresLabel={expiryLabel}
               />
-              <p className="text-xs text-slate-500">{reason.trim().length}/280</p>
-            </label>
-            <label className="block space-y-1 md:max-w-sm">
-              <span className="text-sm font-medium text-brand-dark">Requested expiry (required)</span>
+              <ResultPreview scope={scope} harness={harness} expiresLabel={expiryLabel} />
+            </div>
+          </>
+        ) : null}
+
+        {activeStep === "Guardrails" ? (
+          <div className="space-y-4 rounded-xl border border-slate-100 bg-white p-4 lg:col-span-2">
+            <SectionLabel>Guardrails</SectionLabel>
+            <label className="block space-y-1 md:max-w-md">
+              <span className="text-sm font-medium text-brand-dark">Requested by</span>
               <input
                 className="w-full rounded-xl border border-slate-200 px-3 py-2 text-sm"
-                type="datetime-local"
-                value={toDatetimeLocalValue(requestedExpiresAt)}
-                onChange={handleExpiryChange}
+                type="email"
+                value={requestedBy}
+                onChange={handleRequestedByChange}
                 required
               />
+              {!requestedBy.trim() ? <p className="text-xs text-red-600">Requested by is required.</p> : null}
             </label>
           </div>
         ) : null}
@@ -470,7 +549,7 @@ export function PolicyCloudExceptionRequestPanel({
           </div>
         ) : null}
 
-        {activeStep !== "Source" ? (
+        {activeStep === "Guardrails" || activeStep === "Submit" ? (
           <SafetyPreview
             scope={scope}
             harness={harness}
@@ -480,6 +559,9 @@ export function PolicyCloudExceptionRequestPanel({
             reason={reason}
             expiresLabel={expiryLabel}
           />
+        ) : null}
+        {activeStep === "Submit" ? (
+          <ResultPreview scope={scope} harness={harness} expiresLabel={expiryLabel} />
         ) : null}
       </div>
 

--- a/dashboard/src/policy-cloud-exception-request-panel.tsx
+++ b/dashboard/src/policy-cloud-exception-request-panel.tsx
@@ -470,7 +470,9 @@ export function PolicyCloudExceptionRequestPanel({
                   <span className="text-sm font-medium text-brand-dark">Max uses (optional)</span>
                   <input
                     className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm"
-                    inputMode="numeric"
+                    type="number"
+                    min={1}
+                    step={1}
                     value={maxUses}
                     onChange={handleMaxUsesChange}
                     placeholder="50"

--- a/dashboard/src/policy-cloud-exceptions-list.tsx
+++ b/dashboard/src/policy-cloud-exceptions-list.tsx
@@ -210,11 +210,6 @@ function GroupSection({
             <span>Status</span>
           </div>
           <div role="list">{children}</div>
-          {count > 0 ? (
-            <div className="border-t border-slate-100 px-4 py-2.5 text-sm font-medium text-brand-blue">
-              View all ({count}) →
-            </div>
-          ) : null}
         </div>
       ) : null}
     </section>

--- a/dashboard/src/policy-cloud-exceptions-list.tsx
+++ b/dashboard/src/policy-cloud-exceptions-list.tsx
@@ -1,11 +1,22 @@
 import { useCallback, useMemo, useState, type ChangeEvent } from "react";
-import { HiMiniChevronDown, HiMiniChevronUp, HiMiniMagnifyingGlass } from "react-icons/hi2";
+import {
+  HiMiniCheckCircle,
+  HiMiniChevronDown,
+  HiMiniChevronRight,
+  HiMiniChevronUp,
+  HiMiniCommandLine,
+  HiMiniFolder,
+  HiMiniGlobeAlt,
+  HiMiniMagnifyingGlass,
+  HiMiniPuzzlePiece,
+} from "react-icons/hi2";
 import { Badge, EmptyState, Tag } from "./approval-center-primitives";
 import { formatRelativeTime, harnessDisplayName, scopeLabel } from "./approval-center-utils";
 import type { GuardCloudException } from "./guard-types";
 import type { GuardCloudExceptionRequestItem } from "./guard-api";
 import {
   isCloudExceptionAckFailure,
+  resolveCloudExceptionEffectLabel,
   resolveCloudExceptionExpiryTimestamp,
   resolveCloudExceptionExpiryValue,
   resolveCloudExceptionHeadline,
@@ -58,6 +69,19 @@ function PersonAvatar({ label }: { label: string | null | undefined }) {
   );
 }
 
+function resolveRowIcon(scope: GuardCloudException["scope"]) {
+  if (scope === "artifact") {
+    return HiMiniCommandLine;
+  }
+  if (scope === "publisher" || scope === "workspace") {
+    return HiMiniFolder;
+  }
+  if (scope === "harness") {
+    return HiMiniPuzzlePiece;
+  }
+  return HiMiniGlobeAlt;
+}
+
 function ExceptionTableRow({
   item,
   selected,
@@ -71,6 +95,8 @@ function ExceptionTableRow({
   const expiryValue = resolveCloudExceptionExpiryValue(item);
   const headline = resolveCloudExceptionHeadline(item);
   const ackStatus = resolveAckStatusLabel(item);
+  const effectLabel = resolveCloudExceptionEffectLabel(item.effect);
+  const RowIcon = resolveRowIcon(item.scope);
 
   return (
     <button
@@ -82,8 +108,9 @@ function ExceptionTableRow({
         selected ? "bg-brand-blue/[0.04] ring-1 ring-inset ring-brand-blue/20" : ""
       }`}
     >
-      <div className="md:col-start-1">
-        <Badge tone="success">{item.effect}</Badge>
+      <div className="flex items-center gap-2 md:col-start-1">
+        <RowIcon className="hidden h-4 w-4 shrink-0 text-slate-400 md:block" aria-hidden="true" />
+        <Badge tone="success">{effectLabel}</Badge>
       </div>
       <div className="min-w-0 md:col-start-2">
         <p className="truncate text-sm font-semibold text-brand-dark">{headline}</p>
@@ -110,8 +137,12 @@ function ExceptionTableRow({
       <div className="hidden whitespace-nowrap text-xs text-slate-500 md:col-start-8 md:block">
         {item.last_used_at ? formatRelativeTime(item.last_used_at) : "—"}
       </div>
-      <div className="hidden md:col-start-9 md:block">
+      <div className="hidden md:col-start-9 md:flex md:items-center md:gap-1">
+        {ackStatus.tone === "success" ? (
+          <HiMiniCheckCircle className="h-3.5 w-3.5 text-emerald-600" aria-hidden="true" />
+        ) : null}
         <Badge tone={ackStatus.tone}>{ackStatus.label}</Badge>
+        <HiMiniChevronRight className="h-3.5 w-3.5 text-slate-400" aria-hidden="true" />
       </div>
     </button>
   );
@@ -179,6 +210,11 @@ function GroupSection({
             <span>Status</span>
           </div>
           <div role="list">{children}</div>
+          {count > 0 ? (
+            <div className="border-t border-slate-100 px-4 py-2.5 text-sm font-medium text-brand-blue">
+              View all ({count}) →
+            </div>
+          ) : null}
         </div>
       ) : null}
     </section>

--- a/dashboard/src/policy-cloud-exceptions-utils.test.ts
+++ b/dashboard/src/policy-cloud-exceptions-utils.test.ts
@@ -4,6 +4,8 @@ import {
   isCloudExceptionAckFailure,
   isCloudExceptionExpiringSoon,
   resolveCloudExceptionExpiryTimestamp,
+  resolveCloudExceptionEffectLabel,
+  resolveCloudExceptionEvidenceUrl,
   resolveCloudExceptionHeadline,
   resolvePersonInitials,
   summarizeCloudExceptions,
@@ -63,6 +65,11 @@ assert(!isCloudExceptionActive({ ...activeException, expiry: "2020-01-01T00:00:0
 assert(isCloudExceptionExpiringSoon(expiringSoonException), "expiring soon exception detected");
 assert(isCloudExceptionAckFailure(ackFailureException), "ack failure detected");
 assert(resolveCloudExceptionHeadline(activeException) === "codex:project:demo", "artifact headline resolved");
+assert(resolveCloudExceptionEffectLabel("allow") === "Allow temporarily", "allow effect label");
+assert(
+  resolveCloudExceptionEvidenceUrl(activeException) === "/evidence?receipt_id=receipt-1",
+  "evidence url from source receipt",
+);
 assert(resolvePersonInitials("owner@example.com") === "OW", "email initials resolved");
 
 const summary = summarizeCloudExceptions(

--- a/dashboard/src/policy-cloud-exceptions-utils.test.ts
+++ b/dashboard/src/policy-cloud-exceptions-utils.test.ts
@@ -67,7 +67,7 @@ assert(isCloudExceptionAckFailure(ackFailureException), "ack failure detected");
 assert(resolveCloudExceptionHeadline(activeException) === "codex:project:demo", "artifact headline resolved");
 assert(resolveCloudExceptionEffectLabel("allow") === "Allow temporarily", "allow effect label");
 assert(
-  resolveCloudExceptionEvidenceUrl(activeException) === "/evidence?receipt_id=receipt-1",
+  resolveCloudExceptionEvidenceUrl(activeException) === "/evidence?search=receipt-1",
   "evidence url from source receipt",
 );
 assert(resolvePersonInitials("owner@example.com") === "OW", "email initials resolved");

--- a/dashboard/src/policy-cloud-exceptions-utils.ts
+++ b/dashboard/src/policy-cloud-exceptions-utils.ts
@@ -178,6 +178,32 @@ export function resolveCloudExceptionWhyCopy(item: GuardCloudException): string 
   return `Cloud-approved risk acceptance (${blast.detail.toLowerCase()}) synced from a signed policy bundle.`;
 }
 
+export function resolveCloudExceptionEffectLabel(effect: GuardCloudException["effect"]): string {
+  if (effect === "allow") {
+    return "Allow temporarily";
+  }
+  return effect;
+}
+
+export function resolveCloudExceptionEvidenceUrl(item: GuardCloudException): string | null {
+  const receiptId = item.source_receipt_id?.trim();
+  if (!receiptId) {
+    return null;
+  }
+  return `/evidence?receipt_id=${encodeURIComponent(receiptId)}`;
+}
+
+export function resolveCloudExceptionScopePath(item: GuardCloudException): string | null {
+  const target = resolveCloudExceptionScopeTarget(item);
+  if (!target) {
+    return null;
+  }
+  if (item.scope === "workspace" || item.scope === "publisher") {
+    return target;
+  }
+  return null;
+}
+
 export function summarizeCloudExceptions(
   exceptions: GuardCloudException[],
   pendingRequests: GuardCloudExceptionRequestItem[],

--- a/dashboard/src/policy-cloud-exceptions-utils.ts
+++ b/dashboard/src/policy-cloud-exceptions-utils.ts
@@ -190,7 +190,7 @@ export function resolveCloudExceptionEvidenceUrl(item: GuardCloudException): str
   if (!receiptId) {
     return null;
   }
-  return `/evidence?receipt_id=${encodeURIComponent(receiptId)}`;
+  return `/evidence?search=${encodeURIComponent(receiptId)}`;
 }
 
 export function resolveCloudExceptionScopePath(item: GuardCloudException): string | null {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/about-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/about-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, ac as Tag, aN as Surface, B as Badge, r as reactExports, S as SectionLabel, aO as HiMiniArrowTopRightOnSquare, aP as HiMiniCheckBadge } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, ac as Tag, aX as Surface, B as Badge, r as reactExports, S as SectionLabel, aY as HiMiniArrowTopRightOnSquare, aZ as HiMiniCheckBadge } from "../guard-dashboard.js";
 const ABOUT_PARTNER_SECTION_TITLE = "Standards partner program";
 const ABOUT_PARTNER_SECTION_BODY = "Join teams building on HOL open standards. Partners get early access to protocol drafts, co-marketing, and direct engineering support.";
 const ABOUT_PARTNER_CTA = "Explore partner programs";
@@ -223,10 +223,10 @@ const toneClasses = {
   slate: "border-slate-200 bg-slate-50/60"
 };
 const badgeTones = {
-  blue: "blue",
-  green: "green",
-  purple: "purple",
-  slate: "slate"
+  blue: "info",
+  green: "success",
+  purple: "attention",
+  slate: "default"
 };
 function TrustContractPanel({
   runtimeSummary

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -1,5 +1,5 @@
-import { r as reactExports, bi as runAuditRemediation, j as jsxRuntimeExports, B as Badge, S as SectionLabel, ad as HiMiniMagnifyingGlass, b as EmptyState, d as HiMiniCheckCircle, I as HiMiniXCircle, w as HiMiniExclamationTriangle, h as harnessDisplayName, m as formatRelativeTime, y as HiMiniChevronRight, A as ActionButton, aL as HiMiniDocumentText, aJ as guardAwareHref, aU as IconActionButton, aw as HiMiniArrowPath, l as HiMiniShieldCheck } from "../guard-dashboard.js";
-import { u as useResolvedApprovalGate, c as isApprovalGateRequiredError, g as resolveManagerCoverageStatus, e as ApprovalProofModal } from "./supply-chain-protection-stats.js";
+import { r as reactExports, bs as runAuditRemediation, j as jsxRuntimeExports, B as Badge, S as SectionLabel, ad as HiMiniMagnifyingGlass, b as EmptyState, d as HiMiniCheckCircle, I as HiMiniXCircle, w as HiMiniExclamationTriangle, h as harnessDisplayName, m as formatRelativeTime, y as HiMiniChevronRight, A as ActionButton, aE as HiMiniDocumentText, aP as guardAwareHref, b2 as IconActionButton, aw as HiMiniArrowPath, l as HiMiniShieldCheck } from "../guard-dashboard.js";
+import { u as useResolvedApprovalGate, e as isApprovalGateRequiredError, h as resolveManagerCoverageStatus, f as ApprovalProofModal } from "./supply-chain-protection-stats.js";
 function isSupplyChainAuditEvidence(value) {
   return typeof value === "object" && value !== null && value.operation === "audit";
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/feed-health-workspace.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, A as ActionButton, S as SectionLabel, w as HiMiniExclamationTriangle, aw as HiMiniArrowPath, d as HiMiniCheckCircle, bj as HiMiniSignal, I as HiMiniXCircle, aT as HiMiniClock, m as formatRelativeTime, B as Badge, ac as Tag } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, A as ActionButton, S as SectionLabel, w as HiMiniExclamationTriangle, aw as HiMiniArrowPath, d as HiMiniCheckCircle, bt as HiMiniSignal, I as HiMiniXCircle, b1 as HiMiniClock, m as formatRelativeTime, B as Badge, ac as Tag } from "../guard-dashboard.js";
 function resolveFeedSourceMode(cloudState) {
   if (cloudState === "local_only") return "sample";
   if (cloudState === "paired_waiting") return "full";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-protection-module.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-protection-module.js
@@ -1,4 +1,4 @@
-import { r as reactExports, j as jsxRuntimeExports, l as HiMiniShieldCheck, bg as HiMiniInformationCircle, w as HiMiniExclamationTriangle, S as SectionLabel, A as ActionButton, bf as HiMiniArrowRight, ac as Tag, m as formatRelativeTime, p as HiMiniChevronUp, q as HiMiniChevronDown, d as HiMiniCheckCircle, I as HiMiniXCircle } from "../guard-dashboard.js";
+import { r as reactExports, j as jsxRuntimeExports, l as HiMiniShieldCheck, bq as HiMiniInformationCircle, w as HiMiniExclamationTriangle, S as SectionLabel, A as ActionButton, aU as HiMiniArrowRight, ac as Tag, m as formatRelativeTime, p as HiMiniChevronUp, q as HiMiniChevronDown, d as HiMiniCheckCircle, I as HiMiniXCircle } from "../guard-dashboard.js";
 function resolveHomeProtectionStatus(snapshot) {
   const protection = snapshot.supply_chain?.package_manager_protection;
   if (!protection) return "unknown";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, S as SectionLabel, o as HiMiniXMark, B as Badge, aD as scopeLabel, m as formatRelativeTime, aE as HiMiniCloudArrowUp, r as reactExports, aF as createCloudExceptionRequest, A as ActionButton, h as harnessDisplayName, b as EmptyState, p as HiMiniChevronUp, q as HiMiniChevronDown, ac as Tag, y as HiMiniChevronRight, aG as policyActionLabel, aH as fetchCloudExceptions, aI as fetchCloudExceptionRequests, aJ as guardAwareHref, Q as HiMiniLockClosed, ax as HiMiniTrash, aK as HiMiniCube, aA as HiMiniCommandLine, aL as HiMiniDocumentText, aM as HiMiniGlobeAlt, l as HiMiniShieldCheck, ad as HiMiniMagnifyingGlass, Y as fetchSettings, _ as updateSettings, aw as HiMiniArrowPath, aB as WorkspacePageHeader, aC as __vitePreload } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, S as SectionLabel, o as HiMiniXMark, B as Badge, ac as Tag, aD as scopeLabel, A as ActionButton, m as formatRelativeTime, aE as HiMiniDocumentText, d as HiMiniCheckCircle, aF as HiMiniCloudArrowUp, aG as HiMiniCheck, h as harnessDisplayName, r as reactExports, aH as createCloudExceptionRequest, b as EmptyState, ad as HiMiniMagnifyingGlass, p as HiMiniChevronUp, q as HiMiniChevronDown, y as HiMiniChevronRight, aA as HiMiniCommandLine, aI as HiMiniFolder, aJ as HiMiniPuzzlePiece, aK as HiMiniGlobeAlt, aL as policyActionLabel, aM as fetchCloudExceptions, aN as fetchCloudExceptionRequests, aO as HiMiniClipboardDocument, aP as guardAwareHref, Q as HiMiniLockClosed, ax as HiMiniTrash, aQ as HiMiniCube, l as HiMiniShieldCheck, aw as HiMiniArrowPath, aR as HiMiniUsers, Y as fetchSettings, _ as updateSettings, aS as HiMiniQueueList, t as HiMiniCloud, aT as HiMiniNoSymbol, aU as HiMiniArrowRight, aV as HiMiniBeaker, aW as HiMiniPlay, aB as WorkspacePageHeader, aC as __vitePreload } from "../guard-dashboard.js";
 const CLOUD_EXCEPTION_EXPIRING_SOON_DAYS = 7;
 function parseCloudExceptionTimestamp(value) {
   if (!value || !value.trim()) {
@@ -141,6 +141,29 @@ function resolveCloudExceptionWhyCopy(item) {
   const blast = resolveCloudExceptionBlastRadius(item.scope);
   return `Cloud-approved risk acceptance (${blast.detail.toLowerCase()}) synced from a signed policy bundle.`;
 }
+function resolveCloudExceptionEffectLabel(effect) {
+  if (effect === "allow") {
+    return "Allow temporarily";
+  }
+  return effect;
+}
+function resolveCloudExceptionEvidenceUrl(item) {
+  const receiptId = item.source_receipt_id?.trim();
+  if (!receiptId) {
+    return null;
+  }
+  return `/evidence?receipt_id=${encodeURIComponent(receiptId)}`;
+}
+function resolveCloudExceptionScopePath(item) {
+  const target = resolveCloudExceptionScopeTarget(item);
+  if (!target) {
+    return null;
+  }
+  if (item.scope === "workspace" || item.scope === "publisher") {
+    return target;
+  }
+  return null;
+}
 function summarizeCloudExceptions(exceptions, pendingRequests, now = /* @__PURE__ */ new Date()) {
   const active = exceptions.filter((item) => isCloudExceptionActive(item, now));
   const expiringSoon = active.filter((item) => isCloudExceptionExpiringSoon(item, now));
@@ -198,7 +221,7 @@ function DetailField({ label, value }) {
 }
 function resolveAckCopy(item) {
   if (item.ack_status === "synced") {
-    return { label: "Synced", detail: "This device acknowledged the signed policy bundle." };
+    return { label: "Acknowledged", detail: "This device acknowledged the signed policy bundle." };
   }
   if (item.ack_status === "pending") {
     return { label: "Pending ack", detail: "Waiting for this device to acknowledge the signed bundle on next sync." };
@@ -217,6 +240,34 @@ function resolveAckCopy(item) {
   }
   return { label: "Unknown", detail: "Local acknowledgement status is unavailable." };
 }
+function ExpiryTimeline({
+  expiryTimestamp,
+  expiryValue
+}) {
+  if (!expiryTimestamp || !expiryValue) {
+    return null;
+  }
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between text-[11px] font-medium text-slate-500", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Approved" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+        "Expires ",
+        formatRelativeTime(expiryValue)
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "h-full w-2/3 rounded-full bg-brand-blue/70", "aria-hidden": "true" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-slate-600", children: expiryTimestamp.toLocaleString() })
+  ] });
+}
+function blastRadiusBadgeTone(tone) {
+  if (tone === "narrow") {
+    return "success";
+  }
+  if (tone === "medium") {
+    return "warning";
+  }
+  return "destructive";
+}
 function PolicyCloudExceptionDetailPanel({
   exception,
   cloudControlsUrl,
@@ -228,6 +279,11 @@ function PolicyCloudExceptionDetailPanel({
   const headline = resolveCloudExceptionHeadline(exception);
   const blast = resolveCloudExceptionBlastRadius(exception.scope);
   const whyCopy = resolveCloudExceptionWhyCopy(exception);
+  const isActive = isCloudExceptionActive(exception);
+  const isEnforcedLocally = exception.ack_status === "synced";
+  const evidenceUrl = resolveCloudExceptionEvidenceUrl(exception);
+  const scopePath = resolveCloudExceptionScopePath(exception);
+  const effectLabel = resolveCloudExceptionEffectLabel(exception.effect);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "aside",
     {
@@ -236,8 +292,9 @@ function PolicyCloudExceptionDetailPanel({
       children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-4 flex min-w-0 items-start justify-between gap-3", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Exception detail" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "mt-1 break-words text-lg font-semibold text-brand-dark", children: headline })
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Temporary cloud exception" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "mt-1 break-words text-lg font-semibold text-brand-dark", children: headline }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: effectLabel })
           ] }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
             "button",
@@ -251,26 +308,39 @@ function PolicyCloudExceptionDetailPanel({
           )
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-4 flex flex-wrap gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: exception.effect }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: scopeLabel(exception.scope) }),
-          isCloudExceptionAckFailure(exception) ? /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "warning", children: ackCopy.label }) : null
+          isActive ? /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: "Active" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "default", children: "Expired" }),
+          isEnforcedLocally ? /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: "Enforced locally" }) : null,
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: effectLabel }),
+          !isEnforcedLocally ? /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "warning", children: ackCopy.label }) : null
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-slate-50/80 p-3", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Why this exists" }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-brand-dark", children: whyCopy })
           ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-slate-50/80 p-3", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Blast radius" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm font-medium text-brand-dark", children: blast.label }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: blast.detail }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(DetailField, { label: "Scope exact", value: headline })
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-3 sm:grid-cols-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-slate-50/80 p-3", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Blast radius" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: blastRadiusBadgeTone(blast.tone), children: blast.label }) }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: blast.detail })
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-slate-50/80 p-3", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Scope (exact)" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: scopeLabel(exception.scope, "policy") }) }),
+              scopePath ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 break-all text-sm text-slate-600", children: scopePath }) : null
+            ] })
           ] }),
+          evidenceUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-slate-50/80 p-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Source review item" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm font-medium text-brand-dark", children: exception.source_receipt_id?.trim() ?? "Linked approval record" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: evidenceUrl, variant: "secondary", children: "Open in Review" }) })
+          ] }) : null,
           /* @__PURE__ */ jsxRuntimeExports.jsx(PersonRow, { label: "Owner", value: exception.owner }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(PersonRow, { label: "Approved by", value: exception.approver }),
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-slate-50/80 p-3", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Expiry timeline" }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark", children: expiryTimestamp && expiryValue ? `${expiryTimestamp.toLocaleString()} (${formatRelativeTime(expiryValue)})` : expiryValue ?? "Expiry unavailable" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(ExpiryTimeline, { expiryTimestamp, expiryValue }),
             /* @__PURE__ */ jsxRuntimeExports.jsx(
               DetailField,
               {
@@ -280,28 +350,33 @@ function PolicyCloudExceptionDetailPanel({
             )
           ] }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(DetailField, { label: "Harness", value: exception.harness }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(DetailField, { label: "Source receipt", value: exception.source_receipt_id }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(DetailField, { label: "Signed bundle hash", value: exception.bundle_hash }),
+          exception.bundle_hash ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-slate-50/80 p-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Signed bundle entry" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 flex items-start gap-2", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniDocumentText, { className: "mt-0.5 h-4 w-4 shrink-0 text-brand-blue", "aria-hidden": "true" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "break-all text-sm font-medium text-brand-dark", children: exception.bundle_hash }),
+                exception.source_receipt_id ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 break-all text-xs text-slate-500", children: exception.source_receipt_id }) : null
+              ] })
+            ] })
+          ] }) : null,
           /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-100 bg-slate-50/80 p-3", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium uppercase tracking-wide text-slate-500", children: "Local daemon acknowledgement" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm font-medium text-brand-dark", children: ackCopy.label }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 flex items-center gap-2", children: [
+              exception.ack_status === "synced" ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-600", "aria-hidden": "true" }) : null,
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: ackCopy.label })
+            ] }),
             /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: ackCopy.detail }),
             isCloudExceptionAckFailure(exception) ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-slate-500", children: "Run Guard sync to retry bundle acknowledgement." }) : null
           ] })
         ] }),
-        cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
-          "a",
-          {
-            href: cloudControlsUrl,
-            target: "_blank",
-            rel: "noopener noreferrer",
-            className: "inline-flex items-center gap-1.5 text-sm font-medium text-brand-blue hover:underline",
-            children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "h-4 w-4", "aria-hidden": "true" }),
-              "Review in Guard Cloud"
-            ]
-          }
-        ) }) : null
+        cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 space-y-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-slate-500", children: "Open Guard Cloud to revoke or renew this exception." }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+            "Open in Guard Cloud"
+          ] })
+        ] }) : null
       ]
     }
   );
@@ -322,7 +397,7 @@ function RequestStepper({ activeStep }) {
             "span",
             {
               className: `inline-flex h-5 w-5 items-center justify-center rounded-full text-[10px] font-semibold ${active ? "bg-brand-blue text-white" : complete ? "bg-emerald-600 text-white" : "bg-slate-200 text-slate-600"}`,
-              children: index + 1
+              children: complete ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheck, { className: "h-3 w-3", "aria-hidden": "true" }) : index + 1
             }
           ),
           step
@@ -401,6 +476,30 @@ function SafetyPreview({
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-4 text-xs leading-relaxed text-slate-500", children: "Guard Cloud must approve this request before it syncs as a signed bundle entry on this device." })
   ] });
 }
+function SourceReceiptSummary({ receipt }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-200 bg-slate-50/80 p-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Source: approval record" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm font-semibold text-brand-dark", children: receipt.artifact_name ?? receipt.artifact_id }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 text-xs text-slate-600", children: [
+      harnessDisplayName(receipt.harness),
+      " · ",
+      receipt.receipt_id
+    ] })
+  ] });
+}
+function ResultPreview({ scope, harness, expiresLabel }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-200 bg-white p-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Result preview" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-3 text-sm leading-relaxed text-brand-dark", children: [
+      "If approved in Guard Cloud, Guard will apply this exception for ",
+      scopeLabel(scope, "policy"),
+      harness.trim() ? ` in ${harnessDisplayName(harness)}` : "",
+      " until ",
+      expiresLabel,
+      "."
+    ] })
+  ] });
+}
 function RequestModalShell({ title, stepper, children, footer, onCancel }) {
   return /* @__PURE__ */ jsxRuntimeExports.jsx(
     "div",
@@ -434,23 +533,23 @@ function RequestModalShell({ title, stepper, children, footer, onCancel }) {
 const SCOPE_OPTIONS = [
   {
     value: "artifact",
-    label: "One specific action",
-    description: "Limit the exception to a single artifact fingerprint."
+    label: "Exact action",
+    description: "Limit the exception to one specific action fingerprint."
   },
   {
     value: "publisher",
-    label: "Publisher",
-    description: "Apply to packages or plugins from one publisher."
-  },
-  {
-    value: "harness",
-    label: "App",
-    description: "Apply across one harness such as Codex or Cursor."
+    label: "This cwd",
+    description: "Reuse within the current working directory scope."
   },
   {
     value: "workspace",
-    label: "Project",
+    label: "This project",
     description: "Apply within the current project folder on this device."
+  },
+  {
+    value: "harness",
+    label: "This harness",
+    description: "Apply across one harness such as Codex or Cursor."
   }
 ];
 function defaultExpiryIso() {
@@ -477,18 +576,6 @@ function resolveDefaultWorkingDirectory(snapshot) {
   const install = snapshot.managed_installs?.find((entry) => entry.workspace?.trim());
   return install?.workspace?.trim() ?? "";
 }
-function resolveActiveStep(sourceReceiptId, scope, reason, owner, requestedBy) {
-  if (!sourceReceiptId.trim()) {
-    return "Source";
-  }
-  if (!scope) {
-    return "Scope";
-  }
-  if (!reason.trim() || !owner.trim() || !requestedBy.trim()) {
-    return "Guardrails";
-  }
-  return "Submit";
-}
 function PolicyCloudExceptionRequestPanel({
   snapshot,
   onSubmitted,
@@ -510,10 +597,17 @@ function PolicyCloudExceptionRequestPanel({
   const [owner, setOwner] = reactExports.useState("");
   const [reason, setReason] = reactExports.useState("");
   const [requestedExpiresAt, setRequestedExpiresAt] = reactExports.useState(defaultExpiryIso());
+  const [linkedTicket, setLinkedTicket] = reactExports.useState("");
+  const [maxUses, setMaxUses] = reactExports.useState("");
   const [submitting, setSubmitting] = reactExports.useState(false);
   const [error, setError] = reactExports.useState(null);
   const [successMessage, setSuccessMessage] = reactExports.useState(null);
-  const activeStep = resolveActiveStep(sourceReceiptId, scope, reason, owner, requestedBy);
+  const [stepIndex, setStepIndex] = reactExports.useState(0);
+  const activeStep = REQUEST_STEPS[stepIndex] ?? "Source";
+  const selectedReceipt = reactExports.useMemo(
+    () => receiptOptions.find((entry) => entry.receipt_id === sourceReceiptId) ?? null,
+    [receiptOptions, sourceReceiptId]
+  );
   const expiryLabel = reactExports.useMemo(() => {
     const date = new Date(requestedExpiresAt);
     return Number.isNaN(date.getTime()) ? "Not set" : date.toLocaleString();
@@ -555,6 +649,22 @@ function PolicyCloudExceptionRequestPanel({
   const handleExpiryChange = reactExports.useCallback((event) => {
     setRequestedExpiresAt(fromDatetimeLocalValue(event.target.value));
   }, []);
+  const handleLinkedTicketChange = reactExports.useCallback((event) => {
+    setLinkedTicket(event.target.value);
+  }, []);
+  const handleMaxUsesChange = reactExports.useCallback((event) => {
+    setMaxUses(event.target.value);
+  }, []);
+  const buildReasonForSubmit = reactExports.useCallback(() => {
+    const parts = [reason.trim()];
+    if (linkedTicket.trim()) {
+      parts.push(`Ticket: ${linkedTicket.trim()}`);
+    }
+    if (maxUses.trim()) {
+      parts.push(`Max uses: ${maxUses.trim()}`);
+    }
+    return parts.filter(Boolean).join("\n");
+  }, [linkedTicket, maxUses, reason]);
   const handleSubmit = reactExports.useCallback(
     async (event) => {
       event.preventDefault();
@@ -565,7 +675,7 @@ function PolicyCloudExceptionRequestPanel({
         scope,
         requestedBy: requestedBy.trim(),
         owner: owner.trim(),
-        reason: reason.trim(),
+        reason: buildReasonForSubmit(),
         requestedExpiresAt,
         sourceReceiptId: sourceReceiptId.trim() || null
       };
@@ -594,10 +704,10 @@ function PolicyCloudExceptionRequestPanel({
     },
     [
       artifactId,
+      buildReasonForSubmit,
       harness,
       owner,
       publisher,
-      reason,
       requestedBy,
       requestedExpiresAt,
       scope,
@@ -608,6 +718,16 @@ function PolicyCloudExceptionRequestPanel({
   const handleDone = reactExports.useCallback(() => {
     onSubmitted();
   }, [onSubmitted]);
+  const canAdvanceFromSource = Boolean(sourceReceiptId.trim());
+  const canAdvanceFromScope = (scope !== "artifact" || artifactId.trim()) && (scope !== "publisher" || publisher.trim()) && (scope !== "workspace" || workingDirectory.trim()) && (scope === "harness" || scope === "artifact" ? harness.trim() : true) && reason.trim().length > 0 && owner.trim().length > 0 && requestedExpiresAt.trim().length > 0;
+  const canAdvanceFromGuardrails = requestedBy.trim().length > 0;
+  const canSubmit = canAdvanceFromSource && canAdvanceFromScope && canAdvanceFromGuardrails;
+  const handleBack = reactExports.useCallback(() => {
+    setStepIndex((current) => Math.max(0, current - 1));
+  }, []);
+  const handleNext = reactExports.useCallback(() => {
+    setStepIndex((current) => Math.min(REQUEST_STEPS.length - 1, current + 1));
+  }, []);
   if (receiptOptions.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs(
       RequestModalShell,
@@ -641,17 +761,30 @@ function PolicyCloudExceptionRequestPanel({
       title: "Request cloud exception",
       stepper: /* @__PURE__ */ jsxRuntimeExports.jsx(RequestStepper, { activeStep }),
       onCancel,
-      footer: /* @__PURE__ */ jsxRuntimeExports.jsxs("form", { className: "flex flex-wrap gap-2", onSubmit: handleSubmit, children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "primary", type: "submit", disabled: submitting, children: submitting ? "Submitting…" : "Submit to Guard Cloud" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", type: "button", onClick: onCancel, disabled: submitting, children: "Cancel" })
+      footer: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", type: "button", onClick: onCancel, disabled: submitting, children: "Cancel" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-2", children: [
+          stepIndex > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", type: "button", onClick: handleBack, disabled: submitting, children: "Back" }) : null,
+          activeStep !== "Submit" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+            ActionButton,
+            {
+              variant: "primary",
+              type: "button",
+              onClick: handleNext,
+              disabled: submitting || activeStep === "Source" && !canAdvanceFromSource || activeStep === "Scope" && !canAdvanceFromScope || activeStep === "Guardrails" && !canAdvanceFromGuardrails,
+              children: "Next"
+            }
+          ) : /* @__PURE__ */ jsxRuntimeExports.jsx("form", { onSubmit: handleSubmit, children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "primary", type: "submit", disabled: submitting || !canSubmit, children: submitting ? "Submitting…" : "Submit to Guard Cloud" }) })
+        ] })
       ] }),
       children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-4 text-sm text-brand-dark/75", children: "Submit a governed risk acceptance to Guard Cloud. This does not create a local remembered rule." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mb-4 text-sm text-brand-dark/75", children: "Ask Guard Cloud to create a policy override. Local Review handles reusable approvals." }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_280px] lg:items-start", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 rounded-xl border border-slate-100 bg-slate-50/50 p-4", children: [
+          activeStep === "Source" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 lg:col-span-3", children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Source" }),
+            selectedReceipt ? /* @__PURE__ */ jsxRuntimeExports.jsx(SourceReceiptSummary, { receipt: selectedReceipt }) : null,
             /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Source receipt" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Or choose a different record" }),
               /* @__PURE__ */ jsxRuntimeExports.jsx(
                 "select",
                 {
@@ -667,77 +800,154 @@ function PolicyCloudExceptionRequestPanel({
                 }
               )
             ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 rounded-xl border border-slate-100 bg-slate-50/50 p-4", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Scope" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(ScopeCardGrid, { options: SCOPE_OPTIONS, value: scope, onChange: setScope }),
-            scope === "artifact" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Artifact fingerprint" }),
+          ] }) : null,
+          activeStep === "Scope" ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-4 lg:col-start-1", children: selectedReceipt ? /* @__PURE__ */ jsxRuntimeExports.jsx(SourceReceiptSummary, { receipt: selectedReceipt }) : null }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 rounded-xl border border-slate-100 bg-slate-50/50 p-4 lg:col-start-2", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Scope" }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-600", children: "Choose the narrowest scope that solves the problem." }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(ScopeCardGrid, { options: SCOPE_OPTIONS, value: scope, onChange: setScope }),
+              scope === "artifact" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Artifact fingerprint" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "input",
+                  {
+                    className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                    value: artifactId,
+                    onChange: handleArtifactIdChange,
+                    required: true
+                  }
+                )
+              ] }) : null,
+              scope === "publisher" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Publisher" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "input",
+                  {
+                    className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                    value: publisher,
+                    onChange: handlePublisherChange,
+                    required: true
+                  }
+                )
+              ] }) : null,
+              scope === "harness" || scope === "artifact" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "App" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "select",
+                  {
+                    className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                    value: harness,
+                    onChange: handleHarnessChange,
+                    required: true,
+                    children: harnessOptions.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: option, children: harnessDisplayName(option) }, option))
+                  }
+                )
+              ] }) : null,
+              scope === "workspace" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Project folder" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "input",
+                  {
+                    className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                    value: workingDirectory,
+                    onChange: handleWorkingDirectoryChange,
+                    required: true
+                  }
+                )
+              ] }) : null,
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Risk owner" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "input",
+                  {
+                    className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                    type: "email",
+                    value: owner,
+                    onChange: handleOwnerChange,
+                    required: true
+                  }
+                )
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Reason (required)" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "textarea",
+                  {
+                    className: "min-h-24 w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                    value: reason,
+                    onChange: handleReasonChange,
+                    maxLength: 280,
+                    required: true
+                  }
+                ),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-xs text-slate-500", children: [
+                  reason.trim().length,
+                  "/280"
+                ] }),
+                !reason.trim() ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-red-600", children: "Reason is required." }) : null
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1 md:max-w-sm", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Requested expiry (required)" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(
+                  "input",
+                  {
+                    className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                    type: "datetime-local",
+                    value: toDatetimeLocalValue(requestedExpiresAt),
+                    onChange: handleExpiryChange,
+                    required: true
+                  }
+                )
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 md:grid-cols-2", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Max uses (optional)" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx(
+                    "input",
+                    {
+                      className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                      inputMode: "numeric",
+                      value: maxUses,
+                      onChange: handleMaxUsesChange,
+                      placeholder: "50"
+                    }
+                  )
+                ] }),
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Linked ticket (optional)" }),
+                  /* @__PURE__ */ jsxRuntimeExports.jsx(
+                    "input",
+                    {
+                      className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
+                      value: linkedTicket,
+                      onChange: handleLinkedTicketChange,
+                      placeholder: "ENG-123 or URL"
+                    }
+                  )
+                ] })
+              ] }),
+              scope === "harness" || scope === "workspace" ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-blue/15 bg-brand-blue/[0.04] px-3 py-2 text-xs text-brand-dark/80", children: "Broad scopes require step-up authentication and Cloud approval." }) : null
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 lg:col-start-3", children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx(
-                "input",
+                SafetyPreview,
                 {
-                  className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
-                  value: artifactId,
-                  onChange: handleArtifactIdChange,
-                  required: true
+                  scope,
+                  harness,
+                  artifactId,
+                  publisher,
+                  workingDirectory,
+                  reason,
+                  expiresLabel: expiryLabel
                 }
-              )
-            ] }) : null,
-            scope === "publisher" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Publisher" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
-                "input",
-                {
-                  className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
-                  value: publisher,
-                  onChange: handlePublisherChange,
-                  required: true
-                }
-              )
-            ] }) : null,
-            scope === "harness" || scope === "artifact" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "App" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
-                "select",
-                {
-                  className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
-                  value: harness,
-                  onChange: handleHarnessChange,
-                  required: true,
-                  children: harnessOptions.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: option, children: harnessDisplayName(option) }, option))
-                }
-              )
-            ] }) : null,
-            scope === "workspace" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Project folder" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
-                "input",
-                {
-                  className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
-                  value: workingDirectory,
-                  onChange: handleWorkingDirectoryChange,
-                  required: true
-                }
-              )
-            ] }) : null
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            SafetyPreview,
-            {
-              scope,
-              harness,
-              artifactId,
-              publisher,
-              workingDirectory,
-              reason,
-              expiresLabel: expiryLabel
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 space-y-4 rounded-xl border border-slate-100 bg-white p-4", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guardrails" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 md:grid-cols-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsx(ResultPreview, { scope, harness, expiresLabel: expiryLabel })
+            ] })
+          ] }) : null,
+          activeStep === "Guardrails" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 rounded-xl border border-slate-100 bg-white p-4 lg:col-span-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guardrails" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1 md:max-w-md", children: [
               /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Requested by" }),
               /* @__PURE__ */ jsxRuntimeExports.jsx(
                 "input",
@@ -748,78 +958,60 @@ function PolicyCloudExceptionRequestPanel({
                   onChange: handleRequestedByChange,
                   required: true
                 }
-              )
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Risk owner" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
-                "input",
-                {
-                  className: "w-full rounded-xl border border-slate-200 px-3 py-2 text-sm",
-                  type: "email",
-                  value: owner,
-                  onChange: handleOwnerChange,
-                  required: true
-                }
-              )
+              ),
+              !requestedBy.trim() ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs text-red-600", children: "Requested by is required." }) : null
             ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Reason" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "textarea",
-              {
-                className: "min-h-24 w-full rounded-xl border border-slate-200 px-3 py-2 text-sm",
-                value: reason,
-                onChange: handleReasonChange,
-                required: true
-              }
-            )
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1 md:max-w-sm", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Expires" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "input",
-              {
-                className: "w-full rounded-xl border border-slate-200 px-3 py-2 text-sm",
-                type: "datetime-local",
-                value: toDatetimeLocalValue(requestedExpiresAt),
-                onChange: handleExpiryChange,
-                required: true
-              }
-            )
-          ] })
+          ] }) : null,
+          activeStep === "Submit" ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3 rounded-xl border border-slate-100 bg-slate-50/50 p-4 lg:col-span-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Review and submit" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: "Guard Cloud will review this request. If approved, the exception syncs as a signed bundle entry on this device." }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "grid gap-2 text-sm text-slate-600", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-xs uppercase tracking-wide text-slate-500", children: "Scope" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "font-medium text-brand-dark", children: scope })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-xs uppercase tracking-wide text-slate-500", children: "Reason" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "text-brand-dark", children: reason.trim() })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-xs uppercase tracking-wide text-slate-500", children: "Expires" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "text-brand-dark", children: expiryLabel })
+              ] })
+            ] })
+          ] }) : null,
+          activeStep === "Guardrails" || activeStep === "Submit" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+            SafetyPreview,
+            {
+              scope,
+              harness,
+              artifactId,
+              publisher,
+              workingDirectory,
+              reason,
+              expiresLabel: expiryLabel
+            }
+          ) : null,
+          activeStep === "Submit" ? /* @__PURE__ */ jsxRuntimeExports.jsx(ResultPreview, { scope, harness, expiresLabel: expiryLabel }) : null
         ] }),
         error ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-sm text-red-600", children: error }) : null
       ]
     }
   );
 }
-function GroupSection({ title, description, defaultOpen = true, children }) {
-  const [open, setOpen] = reactExports.useState(defaultOpen);
-  const handleToggle = reactExports.useCallback(() => {
-    setOpen((current) => !current);
-  }, []);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "rounded-2xl border border-slate-100 bg-white shadow-sm", "aria-label": title, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs(
-      "button",
-      {
-        type: "button",
-        onClick: handleToggle,
-        className: "flex w-full items-start justify-between gap-3 px-4 py-3 text-left",
-        "aria-expanded": open,
-        "aria-label": `${title} group`,
-        children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-sm font-semibold text-brand-dark", children: title }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs text-slate-500", children: description })
-          ] }),
-          open ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "mt-0.5 h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "mt-0.5 h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" })
-        ]
-      }
-    ),
-    open ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-2 border-t border-slate-100 px-3 py-3", role: "list", children }) : null
-  ] });
+const EXCEPTION_ROW_GRID = "grid grid-cols-[minmax(0,1fr)] items-center gap-x-2 gap-y-2 border-b border-slate-100 px-3 py-2.5 last:border-0 hover:bg-slate-50/80 md:grid-cols-[72px_minmax(140px,1.3fr)_88px_72px_36px_36px_88px_80px_72px]";
+const EXCEPTION_HEADER_GRID = "hidden border-b border-slate-100 bg-slate-50/80 px-3 py-2 text-[10px] font-semibold uppercase tracking-wider text-slate-500 md:grid md:grid-cols-[72px_minmax(140px,1.3fr)_88px_72px_36px_36px_88px_80px_72px] md:gap-x-2";
+function resolveAckStatusLabel(item) {
+  if (item.ack_status === "synced") {
+    return { label: "Ack OK", tone: "success" };
+  }
+  if (isCloudExceptionAckFailure(item)) {
+    return { label: "Ack issue", tone: "warning" };
+  }
+  if (item.ack_status === "pending") {
+    return { label: "Pending", tone: "default" };
+  }
+  return { label: "Unknown", tone: "default" };
 }
 function PersonAvatar({ label }) {
   const initials = resolvePersonInitials(label);
@@ -833,93 +1025,164 @@ function PersonAvatar({ label }) {
     }
   );
 }
-function ExceptionCard({
+function resolveRowIcon(scope) {
+  if (scope === "artifact") {
+    return HiMiniCommandLine;
+  }
+  if (scope === "publisher" || scope === "workspace") {
+    return HiMiniFolder;
+  }
+  if (scope === "harness") {
+    return HiMiniPuzzlePiece;
+  }
+  return HiMiniGlobeAlt;
+}
+function ExceptionTableRow({
   item,
   selected,
   onSelect
 }) {
-  const handleSelect = reactExports.useCallback(() => {
-    onSelect(item);
-  }, [item, onSelect]);
-  const expiryTimestamp = resolveCloudExceptionExpiryTimestamp(item);
+  const handleSelect = reactExports.useCallback(() => onSelect(item), [item, onSelect]);
   const expiryValue = resolveCloudExceptionExpiryValue(item);
   const headline = resolveCloudExceptionHeadline(item);
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+  const ackStatus = resolveAckStatusLabel(item);
+  const effectLabel = resolveCloudExceptionEffectLabel(item.effect);
+  const RowIcon = resolveRowIcon(item.scope);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
     "button",
     {
       type: "button",
       role: "listitem",
       onClick: handleSelect,
       "aria-pressed": selected,
-      className: `min-w-0 w-full rounded-xl border px-3.5 py-3 text-left transition ${selected ? "border-brand-blue/30 bg-brand-blue/[0.04] ring-1 ring-brand-blue/20" : "border-slate-100 bg-white hover:border-brand-blue/20 hover:bg-brand-blue/[0.02]"}`,
-      children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex -space-x-2 pt-0.5", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(PersonAvatar, { label: item.owner }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(PersonAvatar, { label: item.approver })
+      className: `min-w-0 w-full text-left transition ${EXCEPTION_ROW_GRID} ${selected ? "bg-brand-blue/[0.04] ring-1 ring-inset ring-brand-blue/20" : ""}`,
+      children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2 md:col-start-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(RowIcon, { className: "hidden h-4 w-4 shrink-0 text-slate-400 md:block", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: effectLabel })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "success", children: item.effect }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: scopeLabel(item.scope, "policy") }),
-            item.harness ? /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: harnessDisplayName(item.harness) }) : null,
-            isCloudExceptionAckFailure(item) ? /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "warning", children: "Ack issue" }) : null
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 break-words text-sm font-semibold text-brand-dark", children: headline }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 break-words text-xs text-slate-500", children: [
-            "Owner ",
-            resolvePersonDisplayLabel(item.owner),
-            expiryTimestamp && expiryValue ? ` · Expires ${formatRelativeTime(expiryValue)}` : null,
-            item.last_used_at ? ` · Last used ${formatRelativeTime(item.last_used_at)}` : null
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 md:col-start-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm font-semibold text-brand-dark", children: headline }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1 flex flex-wrap gap-2 text-xs text-slate-500 md:hidden", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: scopeLabel(item.scope, "policy") }),
+            item.harness ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: harnessDisplayName(item.harness) }) : null
           ] })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          HiMiniChevronRight,
-          {
-            className: `mt-1 h-4 w-4 shrink-0 ${selected ? "text-brand-blue" : "text-slate-300"}`,
-            "aria-hidden": "true"
-          }
-        )
-      ] })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden md:col-start-3 md:block", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: scopeLabel(item.scope, "policy") }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden truncate text-sm text-brand-dark md:col-start-4 md:block", children: item.harness ? harnessDisplayName(item.harness) : "—" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden md:col-start-5 md:flex md:justify-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx(PersonAvatar, { label: item.owner }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden md:col-start-6 md:flex md:justify-center", children: /* @__PURE__ */ jsxRuntimeExports.jsx(PersonAvatar, { label: item.approver }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden whitespace-nowrap text-xs text-slate-500 md:col-start-7 md:block", children: expiryValue ? formatRelativeTime(expiryValue) : "—" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden whitespace-nowrap text-xs text-slate-500 md:col-start-8 md:block", children: item.last_used_at ? formatRelativeTime(item.last_used_at) : "—" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "hidden md:col-start-9 md:flex md:items-center md:gap-1", children: [
+          ackStatus.tone === "success" ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5 text-emerald-600", "aria-hidden": "true" }) : null,
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: ackStatus.tone, children: ackStatus.label }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronRight, { className: "h-3.5 w-3.5 text-slate-400", "aria-hidden": "true" })
+        ] })
+      ]
     }
   );
 }
-function PendingRequestCard({ item }) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("article", { className: "min-w-0 rounded-xl border border-amber-100 bg-amber-50/40 px-3.5 py-3", role: "listitem", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "warning", children: "Pending" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: scopeLabel(item.scope, "policy") })
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 break-words text-sm font-semibold text-brand-dark", children: item.reason }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 break-words text-xs text-slate-600", children: [
-      "Requested by ",
-      resolvePersonDisplayLabel(item.owner),
-      " · expires",
-      " ",
-      formatRelativeTime(item.requestedExpiresAt)
+function PendingRequestRow({ item }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("article", { className: `${EXCEPTION_ROW_GRID} bg-amber-50/30`, role: "listitem", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "md:col-start-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: "warning", children: "Pending" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 md:col-start-2 md:col-span-8", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "break-words text-sm font-semibold text-brand-dark", children: item.reason }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-0.5 text-xs text-slate-600", children: [
+        scopeLabel(item.scope, "policy"),
+        " · ",
+        resolvePersonDisplayLabel(item.owner),
+        " · expires",
+        " ",
+        formatRelativeTime(item.requestedExpiresAt)
+      ] })
     ] })
   ] });
 }
+function GroupSection({
+  title,
+  count,
+  defaultOpen = true,
+  children
+}) {
+  const [open, setOpen] = reactExports.useState(defaultOpen);
+  const handleToggle = reactExports.useCallback(() => setOpen((current) => !current), []);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "overflow-hidden rounded-2xl border border-slate-100 bg-white shadow-sm", "aria-label": title, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "button",
+      {
+        type: "button",
+        onClick: handleToggle,
+        className: "flex w-full items-center justify-between gap-3 px-4 py-3 text-left",
+        "aria-expanded": open,
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("h3", { className: "text-sm font-semibold text-brand-dark", children: [
+            title,
+            " (",
+            count,
+            ")"
+          ] }),
+          open ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" })
+        ]
+      }
+    ),
+    open ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-100", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: EXCEPTION_HEADER_GRID, "aria-hidden": "true", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Action" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Description" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Scope" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "App" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-center", children: "Owner" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-center", children: "Approver" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Expires" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Last used" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Status" })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "list", children }),
+      count > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-100 px-4 py-2.5 text-sm font-medium text-brand-blue", children: [
+        "View all (",
+        count,
+        ") →"
+      ] }) : null
+    ] }) : null
+  ] });
+}
 function ExceptionFilters({
+  searchQuery,
+  onSearchChange,
   scopeFilter,
   actionFilter,
   onScopeFilterChange,
   onActionFilterChange
 }) {
+  const handleSearchChange = reactExports.useCallback(
+    (event) => onSearchChange(event.target.value),
+    [onSearchChange]
+  );
   const handleScopeChange = reactExports.useCallback(
-    (event) => {
-      onScopeFilterChange(event.target.value);
-    },
+    (event) => onScopeFilterChange(event.target.value),
     [onScopeFilterChange]
   );
   const handleActionChange = reactExports.useCallback(
-    (event) => {
-      onActionFilterChange(event.target.value);
-    },
+    (event) => onActionFilterChange(event.target.value),
     [onActionFilterChange]
   );
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-2", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "text-sm text-slate-600", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Filter by scope" }),
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-2 lg:flex-row lg:items-center", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-1 items-center gap-1.5 rounded-xl border border-slate-200 bg-white px-3 py-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniMagnifyingGlass, { className: "h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "input",
+        {
+          type: "search",
+          placeholder: "Search exceptions…",
+          value: searchQuery,
+          onChange: handleSearchChange,
+          "aria-label": "Search exceptions",
+          className: "w-full bg-transparent text-sm text-brand-dark placeholder:text-slate-400 focus:outline-none"
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-2", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "select",
         {
@@ -929,17 +1192,14 @@ function ExceptionFilters({
           "aria-label": "All scopes",
           children: [
             /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "all", children: "All scopes" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "artifact", children: "Artifact" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "publisher", children: "Publisher" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "harness", children: "Harness" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "workspace", children: "Workspace" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "global", children: "Global" })
+            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "artifact", children: "Once" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "publisher", children: "This cwd" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "workspace", children: "This project" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "harness", children: "This harness" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: "global", children: "Team policy" })
           ]
         }
-      )
-    ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "text-sm text-slate-600", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Filter by action" }),
+      ),
       /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "select",
         {
@@ -956,14 +1216,26 @@ function ExceptionFilters({
     ] })
   ] });
 }
-function matchesFilters(item, scopeFilter, actionFilter) {
+function matchesFilters(item, scopeFilter, actionFilter, searchQuery) {
   if (scopeFilter !== "all" && item.scope !== scopeFilter) {
     return false;
   }
   if (actionFilter !== "all" && item.effect !== actionFilter) {
     return false;
   }
-  return true;
+  const query = searchQuery.trim().toLowerCase();
+  if (!query) {
+    return true;
+  }
+  const haystack = [
+    resolveCloudExceptionHeadline(item),
+    item.owner,
+    item.approver,
+    item.harness,
+    item.scope,
+    item.source_receipt_id
+  ].filter(Boolean).join(" ").toLowerCase();
+  return haystack.includes(query);
 }
 function PolicyCloudExceptionsListSkeleton() {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-3", "aria-busy": "true", "aria-label": "Loading Cloud exceptions", children: [0, 1, 2].map((index) => /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "h-28 animate-pulse rounded-2xl border border-slate-100 bg-slate-100" }, index)) });
@@ -980,9 +1252,10 @@ function PolicyCloudExceptionsList({
   onScopeFilterChange,
   onActionFilterChange
 }) {
+  const [searchQuery, setSearchQuery] = reactExports.useState("");
   const filterActive = reactExports.useCallback(
-    (items) => items.filter((item) => matchesFilters(item, scopeFilter, actionFilter)),
-    [scopeFilter, actionFilter]
+    (items) => items.filter((item) => matchesFilters(item, scopeFilter, actionFilter, searchQuery)),
+    [scopeFilter, actionFilter, searchQuery]
   );
   const expiringSoonIds = reactExports.useMemo(() => new Set(expiringSoon.map((item) => item.id)), [expiringSoon]);
   const filteredActive = reactExports.useMemo(() => filterActive(active), [active, filterActive]);
@@ -1010,6 +1283,8 @@ function PolicyCloudExceptionsList({
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       ExceptionFilters,
       {
+        searchQuery,
+        onSearchChange: setSearchQuery,
         scopeFilter,
         actionFilter,
         onScopeFilterChange,
@@ -1020,53 +1295,29 @@ function PolicyCloudExceptionsList({
       EmptyState,
       {
         title: "No exceptions match these filters",
-        body: "Try a broader scope or action filter to see synced Cloud exceptions.",
+        body: "Try a broader search, scope, or action filter to see synced Cloud exceptions.",
         tone: "teach"
       }
     ) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-      activeWithoutExpiringGroup.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-        GroupSection,
+      activeWithoutExpiringGroup.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(GroupSection, { title: "Active on this device", count: activeWithoutExpiringGroup.length, defaultOpen: true, children: activeWithoutExpiringGroup.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        ExceptionTableRow,
         {
-          title: "Active on this device",
-          description: "Synced Cloud risk acceptances currently enforced locally.",
-          defaultOpen: true,
-          children: activeWithoutExpiringGroup.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-            ExceptionCard,
-            {
-              item,
-              selected: selectedExceptionId === item.id,
-              onSelect: onSelectException
-            },
-            item.id
-          ))
-        }
-      ) : null,
-      pending.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-        GroupSection,
+          item,
+          selected: selectedExceptionId === item.id,
+          onSelect: onSelectException
+        },
+        item.id
+      )) }) : null,
+      pending.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(GroupSection, { title: "Pending in Guard Cloud", count: pending.length, defaultOpen: false, children: pending.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsx(PendingRequestRow, { item }, item.requestId)) }) : null,
+      filteredExpiringSoon.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(GroupSection, { title: "Expiring soon", count: filteredExpiringSoon.length, defaultOpen: false, children: filteredExpiringSoon.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+        ExceptionTableRow,
         {
-          title: "Pending in Guard Cloud",
-          description: "Requests waiting for Cloud approval before they can sync to this device.",
-          defaultOpen: true,
-          children: pending.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsx(PendingRequestCard, { item }, item.requestId))
-        }
-      ) : null,
-      filteredExpiringSoon.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-        GroupSection,
-        {
-          title: "Expiring soon",
-          description: "Active acceptances nearing expiry. Renew or revoke them in Guard Cloud.",
-          defaultOpen: true,
-          children: filteredExpiringSoon.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-            ExceptionCard,
-            {
-              item,
-              selected: selectedExceptionId === item.id,
-              onSelect: onSelectException
-            },
-            `expiring-${item.id}`
-          ))
-        }
-      ) : null
+          item,
+          selected: selectedExceptionId === item.id,
+          onSelect: onSelectException
+        },
+        `expiring-${item.id}`
+      )) }) : null
     ] })
   ] });
 }
@@ -1522,9 +1773,13 @@ function resolveCloudExceptionsConnected(snapshot) {
   return snapshot.cloud_state === "paired_active" || snapshot.cloud_state === "paired_waiting";
 }
 function PolicyCloudExceptionsTab({
-  snapshot
+  snapshot,
+  requestOpen: requestOpenProp,
+  onRequestOpenChange
 }) {
-  const [requestOpen, setRequestOpen] = reactExports.useState(false);
+  const [requestOpenInternal, setRequestOpenInternal] = reactExports.useState(false);
+  const requestOpen = requestOpenProp ?? requestOpenInternal;
+  const setRequestOpen = onRequestOpenChange ?? setRequestOpenInternal;
   const [loadState, setLoadState] = reactExports.useState("loading");
   const [loadError, setLoadError] = reactExports.useState(null);
   const [exceptions, setExceptions] = reactExports.useState([]);
@@ -1535,7 +1790,7 @@ function PolicyCloudExceptionsTab({
   const [actionFilter, setActionFilter] = reactExports.useState("all");
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
   const cloudConnected = resolveCloudExceptionsConnected(snapshot);
-  const connectUrl = snapshot.connect_url?.trim() || null;
+  snapshot.connect_url?.trim() || null;
   const reloadData = reactExports.useCallback(async () => {
     if (!cloudConnected) {
       setExceptions([]);
@@ -1562,16 +1817,13 @@ function PolicyCloudExceptionsTab({
   reactExports.useEffect(() => {
     void reloadData();
   }, [reloadData, reloadToken]);
-  const handleOpenRequestPanel = reactExports.useCallback(() => {
-    setRequestOpen(true);
-  }, []);
   const handleCloseRequestPanel = reactExports.useCallback(() => {
     setRequestOpen(false);
-  }, []);
+  }, [setRequestOpen]);
   const handleRequestSubmitted = reactExports.useCallback(() => {
     setRequestOpen(false);
     setReloadToken((current) => current + 1);
-  }, []);
+  }, [setRequestOpen]);
   const handleRetryLoad = reactExports.useCallback(() => {
     setReloadToken((current) => current + 1);
   }, []);
@@ -1610,22 +1862,6 @@ function PolicyCloudExceptionsTab({
     ) : null,
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] px-4 py-3 text-sm text-brand-dark/80", children: "Exceptions are approved in Guard Cloud, then enforced locally as signed policy bundle entries." }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(
-          ActionButton,
-          {
-            variant: "primary",
-            onClick: handleOpenRequestPanel,
-            disabled: !cloudConnected,
-            children: "+ Request cloud exception"
-          }
-        ),
-        cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
-          "Open Guard Cloud"
-        ] }) : null,
-        !cloudConnected && connectUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: connectUrl, variant: "secondary", children: "Connect Guard Cloud" }) : null
-      ] }),
       !cloudConnected ? /* @__PURE__ */ jsxRuntimeExports.jsx(
         EmptyState,
         {
@@ -1684,6 +1920,14 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
   const lastAckAt = snapshot.runtime_state?.last_heartbeat_at?.trim() ?? snapshot.generated_at?.trim() ?? null;
+  const policyHash = cloudBundleCopy?.hash?.slice(0, 8) ?? null;
+  const handleCopyHash = reactExports.useCallback(() => {
+    const fullHash = cloudBundleCopy?.hash?.trim();
+    if (!fullHash || !navigator.clipboard?.writeText) {
+      return;
+    }
+    void navigator.clipboard.writeText(fullHash);
+  }, [cloudBundleCopy?.hash]);
   if (!cloudBundleCopy) {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200/70 bg-slate-50/70 p-4 shadow-sm", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
@@ -1694,24 +1938,43 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
       ] }) }) : null
     ] });
   }
+  const synced = cloudBundleCopy.tone === "green";
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: resolveCloudBundleSurfaceClass(cloudBundleCopy.tone), children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 grid gap-3 sm:grid-cols-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 grid gap-4 sm:grid-cols-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Status" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudBundleCopy.tone === "green" ? "green" : "amber", children: cloudBundleCopy.label }) })
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1.5 flex items-center gap-1.5", children: [
+            synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-600", "aria-hidden": "true" }) : null,
+            /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: synced ? "green" : "amber", children: cloudBundleCopy.label })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-slate-500", children: cloudBundleCopy.detail })
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Bundle hash" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 font-mono text-sm text-brand-dark", children: cloudBundleCopy.hash?.slice(0, 8) ?? "Unavailable" })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Policy hash" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1.5 flex items-center gap-1.5", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-mono text-sm text-brand-dark", children: policyHash ?? "Unavailable" }),
+            policyHash ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "button",
+              {
+                type: "button",
+                onClick: handleCopyHash,
+                className: "rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
+                "aria-label": "Copy policy hash",
+                children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-4 w-4", "aria-hidden": "true" })
+              }
+            ) : null
+          ] })
         ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last ack" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet" })
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1.5 flex items-center gap-1.5", children: [
+            lastAckAt ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-600", "aria-hidden": "true" }) : null,
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet" })
+          ] })
         ] })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark/75", children: cloudBundleCopy.detail })
+      ] })
     ] }),
     cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
@@ -1719,8 +1982,9 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
     ] }) : null
   ] }) });
 }
-const PAGE_SIZE = 30;
-const RULE_GRID_CLASS = "grid grid-cols-[minmax(0,1fr)] items-start gap-x-3 gap-y-3 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50/80 md:grid-cols-[72px_minmax(220px,1.4fr)_100px_96px_88px_104px_minmax(120px,1fr)]";
+const PAGE_SIZE = 5;
+const RULE_GRID_CLASS = "grid grid-cols-[minmax(0,1fr)] items-center gap-x-3 gap-y-2 border-b border-slate-100 px-4 py-3 last:border-0 hover:bg-slate-50/80 md:grid-cols-[40px_72px_minmax(200px,1.4fr)_88px_96px_88px_104px_minmax(120px,1fr)_72px]";
+const RULE_HEADER_CLASS = "hidden border-b border-slate-100 bg-slate-50/80 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500 md:grid md:grid-cols-[40px_72px_minmax(200px,1.4fr)_88px_96px_88px_104px_minmax(120px,1fr)_72px] md:gap-x-3";
 function resolveActionTone(action) {
   if (action === "allow") {
     return "success";
@@ -1758,25 +2022,26 @@ function PolicyRuleRow({ policy, cloudControlsUrl, onClear, cloudVariant = false
   const title = resolvePolicyRowTitle(policy, display);
   const scopeTag = scopeLabel(policy.scope, "policy");
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("article", { className: RULE_GRID_CLASS, role: "listitem", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2 md:col-start-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4", "aria-hidden": "true" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden items-center justify-center md:flex", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4", "aria-hidden": "true" }) }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2 md:col-start-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500 md:hidden", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4", "aria-hidden": "true" }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: resolveActionTone(policy.action), children: policyActionLabel(policy.action) })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 md:col-start-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 md:col-start-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold leading-snug text-brand-dark", children: title }),
-      display.kindLine ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-slate-500", children: display.kindLine }) : null,
-      display.pathLine ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 break-all font-mono text-[11px] leading-relaxed text-slate-500", children: display.pathLine }) : null,
+      display.kindLine ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs text-slate-500", children: display.kindLine }) : null,
+      display.pathLine ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 break-all font-mono text-[11px] leading-relaxed text-slate-500", children: display.pathLine }) : null,
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 flex flex-wrap gap-3 text-xs text-slate-600 md:hidden", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: resolvePolicyRowSourceLabel(policy) }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: scopeTag }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: harnessDisplayName(policy.harness) })
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden text-sm text-brand-dark md:col-start-3 md:block", children: cloudManaged ? /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: resolvePolicyRowSourceLabel(policy) }) : resolvePolicyRowSourceLabel(policy) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden md:col-start-4 md:block", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: scopeTag }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden text-sm text-brand-dark md:col-start-5 md:block", children: harnessDisplayName(policy.harness) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden whitespace-nowrap text-xs text-slate-500 md:col-start-6 md:block", children: policy.updated_at ? formatRelativeTime(policy.updated_at) : "—" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 flex-col items-start gap-2 md:col-start-7 md:items-end", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden text-sm text-brand-dark md:col-start-4 md:block", children: cloudManaged ? /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: resolvePolicyRowSourceLabel(policy) }) : resolvePolicyRowSourceLabel(policy) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden md:col-start-5 md:block", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "blue", children: scopeTag }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden text-sm text-brand-dark md:col-start-6 md:block", children: harnessDisplayName(policy.harness) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "hidden whitespace-nowrap text-xs text-slate-500 md:col-start-7 md:block", children: policy.updated_at ? formatRelativeTime(policy.updated_at) : "—" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "hidden min-w-0 md:col-start-8 md:block", children: [
       !cloudManaged ? /* @__PURE__ */ jsxRuntimeExports.jsx(
         "a",
         {
@@ -1792,13 +2057,15 @@ function PolicyRuleRow({ policy, cloudControlsUrl, onClear, cloudVariant = false
           href: cloudControlsUrl,
           target: "_blank",
           rel: "noopener noreferrer",
-          className: "inline-flex items-center gap-1 text-sm font-medium text-brand-blue hover:underline",
+          className: "inline-flex items-center gap-1 text-xs font-medium text-brand-blue hover:underline",
           children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "h-4 w-4", "aria-hidden": "true" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
             "View on cloud"
           ]
         }
-      ) : null,
+      ) : null
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "hidden items-center justify-end md:col-start-9 md:flex", children: [
       cloudManaged ? /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-1 text-xs font-medium text-slate-500", title: "Read-only Cloud policy", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniLockClosed, { className: "h-3.5 w-3.5", "aria-hidden": "true" }),
         "Policy"
@@ -1825,37 +2092,44 @@ function PolicyRuleTable({
   emptyTitle,
   emptyBody,
   cloudVariant = false,
-  totalCount
+  totalCount,
+  viewAllLabel
 }) {
   const [visibleCount, setVisibleCount] = reactExports.useState(PAGE_SIZE);
-  const visiblePolicies = reactExports.useMemo(() => policies.slice(0, visibleCount), [policies, visibleCount]);
-  const remaining = policies.length - visibleCount;
-  const hasMore = remaining > 0;
-  totalCount ?? policies.length;
+  const [expanded, setExpanded] = reactExports.useState(false);
+  reactExports.useEffect(() => {
+    setExpanded(false);
+    setVisibleCount(PAGE_SIZE);
+  }, [policies]);
+  const visiblePolicies = reactExports.useMemo(
+    () => expanded ? policies : policies.slice(0, visibleCount),
+    [expanded, policies, visibleCount]
+  );
+  const remaining = policies.length - visiblePolicies.length;
+  const hasMore = !expanded && remaining > 0;
+  const listTotal = totalCount ?? policies.length;
   const handleShowMore = reactExports.useCallback(() => {
     setVisibleCount((current) => current + PAGE_SIZE);
+  }, []);
+  const handleViewAll = reactExports.useCallback(() => {
+    setExpanded(true);
   }, []);
   if (policies.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(EmptyState, { title: emptyTitle, body: emptyBody, tone: "teach" });
   }
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "overflow-x-auto rounded-2xl border border-slate-100 bg-white shadow-sm", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "div",
-        {
-          className: "hidden border-b border-slate-100 bg-slate-50/80 px-4 py-2.5 text-[10px] font-semibold uppercase tracking-wider text-slate-500 md:grid md:grid-cols-[72px_minmax(220px,1.4fr)_100px_96px_88px_104px_minmax(120px,1fr)] md:gap-x-3",
-          "aria-hidden": "true",
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Action" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Rule" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Source" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Scope" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: cloudVariant ? "Applies to" : "Harness" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Last updated" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-right", children: cloudVariant ? "Policy" : "Approval record" })
-          ]
-        }
-      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: RULE_HEADER_CLASS, "aria-hidden": "true", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", {}),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Action" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Description" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Source" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Scope" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: cloudVariant ? "Applies to" : "Harness" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Last updated" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: cloudVariant ? "Policy" : "Approval record" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-right", children: cloudVariant ? "" : "Actions" })
+      ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "list", children: visiblePolicies.map((policy) => /* @__PURE__ */ jsxRuntimeExports.jsx(
         PolicyRuleRow,
         {
@@ -1867,7 +2141,15 @@ function PolicyRuleTable({
         `${policy.harness}-${policy.scope}-${policy.artifact_id ?? policy.publisher ?? "global"}-${policy.updated_at ?? ""}-${policy.source}`
       )) })
     ] }),
-    hasMore ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex justify-center pt-1", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
+    hasMore && viewAllLabel ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex justify-center pt-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+      "button",
+      {
+        type: "button",
+        onClick: handleViewAll,
+        className: "text-sm font-medium text-brand-blue hover:underline",
+        children: viewAllLabel.replace("{count}", String(listTotal))
+      }
+    ) }) : hasMore ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex justify-center pt-1", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(
       "button",
       {
         type: "button",
@@ -1886,6 +2168,7 @@ function PolicyRuleTable({
 }
 function GroupedPolicySection({
   title,
+  badge,
   description,
   policies,
   cloudControlsUrl,
@@ -1893,17 +2176,19 @@ function GroupedPolicySection({
   emptyTitle,
   emptyBody,
   defaultOpen = true,
-  cloudVariant = false
+  cloudVariant = false,
+  viewAllLabel
 }) {
   const [open, setOpen] = reactExports.useState(defaultOpen);
   const handleToggle = reactExports.useCallback(() => setOpen((current) => !current), []);
   const ruleLabel = policies.length === 1 ? "1 rule" : `${policies.length} rules`;
   if (policies.length === 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("section", { className: "space-y-2", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-base font-semibold text-brand-dark", children: title }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: description })
+        badge ? /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: badge }) : null
       ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: description }),
       /* @__PURE__ */ jsxRuntimeExports.jsx(EmptyState, { title: emptyTitle, body: emptyBody, tone: "teach" })
     ] });
   }
@@ -1913,15 +2198,18 @@ function GroupedPolicySection({
       {
         type: "button",
         onClick: handleToggle,
-        className: "flex w-full items-center justify-between gap-3 rounded-xl border border-slate-100 bg-slate-50/70 px-4 py-3 text-left",
+        className: "flex w-full items-start justify-between gap-3 text-left",
         "aria-expanded": open,
         children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-base font-semibold text-brand-dark", children: title }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-500", children: description })
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("h2", { className: "text-base font-semibold text-brand-dark", children: title }),
+              badge ? /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: badge }) : null
+            ] }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-500", children: description })
           ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: "slate", children: ruleLabel }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex shrink-0 items-center gap-2 pt-0.5", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm text-slate-500", children: ruleLabel }),
             open ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronUp, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniChevronDown, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" })
           ] })
         ]
@@ -1936,7 +2224,8 @@ function GroupedPolicySection({
         emptyTitle,
         emptyBody,
         cloudVariant,
-        totalCount: policies.length
+        totalCount: policies.length,
+        viewAllLabel
       }
     ) : null
   ] });
@@ -1971,13 +2260,15 @@ function PolicyRememberedCloudRules({
     GroupedPolicySection,
     {
       title: "From Guard Cloud",
-      description: "Synced team rules are read-only here. Edit them in Guard Cloud Controls.",
+      badge: "Team policy rules",
+      description: "Managed by your team in Guard Cloud. These rules are read-only locally.",
       policies,
       cloudControlsUrl,
       emptyTitle: "No Guard Cloud rules synced",
       emptyBody: "Connect Guard Cloud to sync shared policy bundles.",
       defaultOpen: policies.length > 0,
-      cloudVariant: true
+      cloudVariant: true,
+      viewAllLabel: "View all cloud rules ({count}) →"
     }
   );
 }
@@ -1990,22 +2281,44 @@ function PolicyRememberedLocalRules({
     GroupedPolicySection,
     {
       title: "Remembered on this device",
-      description: "Choices you saved from Inbox. Each row shows the exact command or action Guard will remember, and where it applies.",
+      badge: "Local rules",
+      description: "Decisions you've remembered on this machine.",
       policies,
       cloudControlsUrl,
       onClearPolicy,
       emptyTitle: "No local remembered rules yet",
       emptyBody: "Approve or block in Inbox and Guard remembers the decision here in plain language.",
-      defaultOpen: true
+      defaultOpen: true,
+      viewAllLabel: "View all local rules ({count}) →"
     }
   );
 }
 const REVIEW_SCOPE_LADDER = [
-  { scope: "artifact", detail: "Guard remembers only the next matching retry." },
-  { scope: "workspace", detail: "Guard remembers the same action in this project folder." },
-  { scope: "publisher", detail: "Guard remembers actions from the same source in this app." },
-  { scope: "harness", detail: "Guard remembers the action across this app." },
-  { scope: "global", detail: "Guard remembers the action on every project on this device." }
+  {
+    label: "Once",
+    detail: "One time only.",
+    icon: HiMiniArrowPath
+  },
+  {
+    label: "This cwd",
+    detail: "Reuse in this working directory.",
+    icon: HiMiniFolder
+  },
+  {
+    label: "This project",
+    detail: "Reuse across this project.",
+    icon: HiMiniFolder
+  },
+  {
+    label: "This harness",
+    detail: "Reuse across this tool harness.",
+    icon: HiMiniGlobeAlt
+  },
+  {
+    label: "Team policy",
+    detail: "Organization-wide policy.",
+    icon: HiMiniUsers
+  }
 ];
 function PolicyRememberedRulesRightRail({
   snapshot,
@@ -2019,24 +2332,24 @@ function PolicyRememberedRulesRightRail({
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex items-start gap-3", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-5 w-5", "aria-hidden": "true" }) }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: modeCopy.label }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: modeCopy.tone, children: modeCopy.tone === "attention" ? "Protect" : "Active" })
-          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: modeCopy.label }),
           /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: modeCopy.description })
         ] })
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-slate-50/80 p-4 text-sm text-slate-600", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 shadow-sm", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Approvals are still fast" }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-500", children: "When you approve in Inbox, you pick how broadly Guard should remember the decision." }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-2.5", children: REVIEW_SCOPE_LADDER.map((step) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex gap-2.5", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 h-2 w-2 shrink-0 rounded-full bg-brand-blue/70", "aria-hidden": "true" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: scopeLabel(step.scope, "policy") }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-slate-500", children: step.detail })
-        ] })
-      ] }, step.scope)) })
+      /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-2.5", children: REVIEW_SCOPE_LADDER.map((step) => {
+        const Icon = step.icon;
+        return /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex gap-2.5", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 flex h-6 w-6 shrink-0 items-center justify-center rounded-lg bg-slate-100 text-slate-500", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-3.5 w-3.5", "aria-hidden": "true" }) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: step.label }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-slate-500", children: step.detail })
+          ] })
+        ] }, step.label);
+      }) })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Cloud exceptions" }),
@@ -2050,17 +2363,12 @@ function PolicyRememberedRulesRightRail({
           children: "Open Cloud exceptions tab"
         }
       ),
-      cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-        "a",
-        {
-          href: cloudControlsUrl,
-          target: "_blank",
-          rel: "noopener noreferrer",
-          className: "mt-2 block text-sm font-medium text-brand-blue hover:underline",
-          children: "Open Guard Cloud"
-        }
-      ) : null
-    ] })
+      cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+        "Open Guard Cloud"
+      ] }) }) : null
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-slate-500", children: "Local remembered rules are for your machine only. Cloud exceptions and team policy sync from Guard Cloud." })
   ] });
 }
 function PolicyRememberedRulesTab({
@@ -2142,7 +2450,7 @@ function PolicyRememberedRulesTab({
             "input",
             {
               type: "search",
-              placeholder: "Search command, project, path, or app…",
+              placeholder: "Search by app, action, or reason…",
               value: searchQuery,
               onChange: handleSearchChange,
               "aria-label": "Search policies",
@@ -2197,11 +2505,6 @@ function PolicyRememberedRulesTab({
     /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyRememberedRulesRightRail, { snapshot, onOpenCloudExceptions })
   ] });
 }
-const STRICT_POLICY_LAYER_OPTIONS = [
-  { value: "none", label: "No match" },
-  { value: "allow", label: "Allow" },
-  { value: "block", label: "Block" }
-];
 const STRICT_CONFIG_ACTION_OPTIONS = [
   { value: "allow", label: "Allow without asking" },
   { value: "warn", label: "Warn only" },
@@ -2302,7 +2605,7 @@ function StrictConfigActionSegmented({
     [onSettingChange, settingKey]
   );
   const showAdvanced = !PRIMARY_STRICT_ACTION_VALUES.has(value);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-2", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-3 py-4 first:pt-0 last:pb-0", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: label }),
       help ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs text-slate-500", children: help }) : null
@@ -2371,10 +2674,23 @@ function applyStrictConfigPatch(settings, key, value) {
     [key]: value
   };
 }
+const EVALUATION_STEPS = [
+  { label: "Local rule", icon: HiMiniQueueList, tone: "purple" },
+  { label: "Cloud policy", icon: HiMiniCloud, tone: "blue" },
+  { label: "Cloud exception", icon: HiMiniCloud, tone: "blue" },
+  { label: "Strict fallback", icon: HiMiniShieldCheck, tone: "amber" },
+  { label: "Ask or block", icon: HiMiniNoSymbol, tone: "red" }
+];
+const WHAT_CHANGES_BULLETS = [
+  "First-time actions follow your default strict action.",
+  "Changed tool hashes trigger your configured review path.",
+  "New network domains and subprocesses use strict fallback rules.",
+  "Cloud exceptions and remembered rules still win when they match."
+];
 const TEST_SCENARIOS = [
   {
     id: "first-time",
-    label: "First-time action",
+    label: "New tool contacting unknown domain",
     remembered: "none",
     cloudPolicy: "none",
     cloudException: false
@@ -2394,44 +2710,35 @@ const TEST_SCENARIOS = [
     cloudException: true
   }
 ];
-function SimLayerSelect({ label, value, onChange }) {
-  const handleChange = reactExports.useCallback(
-    (event) => {
-      const nextValue = event.target.value;
-      if (nextValue === "allow" || nextValue === "block" || nextValue === "none") {
-        onChange(nextValue);
-      }
-    },
-    [onChange]
-  );
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "block space-y-1.5", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: label }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      "select",
-      {
-        value,
-        onChange: handleChange,
-        className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark",
-        children: STRICT_POLICY_LAYER_OPTIONS.map((option) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: option.value, children: option.label }, option.value))
-      }
-    )
-  ] });
+function resolveExpectedActionTone(action) {
+  if (action === "block") {
+    return "destructive";
+  }
+  if (action === "allow") {
+    return "success";
+  }
+  if (action === "warn" || action === "review" || action === "require-reapproval") {
+    return "warning";
+  }
+  return "default";
 }
 function PolicyStrictConfigTab({
   snapshot,
   onOpenSettings,
-  onOpenInbox
+  onOpenInbox,
+  onReloadPolicy,
+  reloadingPolicy = false
 }) {
   const [loadState, setLoadState] = reactExports.useState("loading");
   const [loadError, setLoadError] = reactExports.useState(null);
   const [settings, setSettings] = reactExports.useState(null);
-  const [configPath, setConfigPath] = reactExports.useState(null);
   const [saveError, setSaveError] = reactExports.useState(null);
   const [savingKey, setSavingKey] = reactExports.useState(null);
   const [simRemembered, setSimRemembered] = reactExports.useState("none");
   const [simCloudPolicy, setSimCloudPolicy] = reactExports.useState("none");
   const [simCloudException, setSimCloudException] = reactExports.useState(false);
   const [scenarioId, setScenarioId] = reactExports.useState(TEST_SCENARIOS[0].id);
+  const [simulationVisible, setSimulationVisible] = reactExports.useState(false);
   const isStrict = settings?.security_level === "strict";
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
   const pendingInboxCount = snapshot.queue_summary?.remaining_pending_count ?? snapshot.pending_count ?? 0;
@@ -2444,7 +2751,6 @@ function PolicyStrictConfigTab({
         return;
       }
       setSettings(payload.settings);
-      setConfigPath(payload.config_path);
       setLoadState("ready");
     }).catch((error) => {
       if (cancelled) {
@@ -2498,18 +2804,13 @@ function PolicyStrictConfigTab({
     },
     [persistSetting]
   );
-  const handleSimCloudExceptionChange = reactExports.useCallback((event) => {
-    setSimCloudException(event.target.checked);
-  }, []);
-  const handleSimRememberedChange = reactExports.useCallback((value) => {
-    setSimRemembered(value);
-  }, []);
-  const handleSimCloudPolicyChange = reactExports.useCallback((value) => {
-    setSimCloudPolicy(value);
+  const handleRunSimulation = reactExports.useCallback(() => {
+    setSimulationVisible(true);
   }, []);
   const handleScenarioChange = reactExports.useCallback((event) => {
     const nextId = event.target.value;
     setScenarioId(nextId);
+    setSimulationVisible(false);
     const scenario = TEST_SCENARIOS.find((item) => item.id === nextId);
     if (!scenario) {
       return;
@@ -2532,50 +2833,58 @@ function PolicyStrictConfigTab({
   }
   const fileWriteAction = resolveStrictFileWriteAction(settings);
   const controlsDisabled = savingKey !== null;
+  const lastReloadAt = snapshot.runtime_state?.started_at ?? null;
+  const daemonAckLabel = cloudBundleCopy?.label ?? "Pending";
+  const expectedAction = simulation?.outcome ?? settings.default_action;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "div",
-        {
-          className: `rounded-2xl border p-5 ${isStrict ? "border-brand-green/20 bg-brand-green/[0.04]" : "border-slate-200 bg-slate-50/40"}`,
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mb-2 flex flex-wrap items-center gap-2", children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Strict mode" }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: isStrict ? "green" : "slate", children: isStrict ? "Enabled" : "Disabled" })
-                ] }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark/75", children: "Local strict policy applies when no remembered rule, Cloud policy, or Cloud exception matches." })
-              ] }),
-              !isStrict && onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Enable in Settings" }) : null
-            ] }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-4 grid gap-3 text-sm sm:grid-cols-2", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-xs font-medium uppercase tracking-wide text-slate-500", children: "Local policy hash" }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1 font-mono text-xs text-brand-dark", children: localPolicyHash })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-xs font-medium uppercase tracking-wide text-slate-500", children: "Daemon last reload" }),
-                /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1 text-brand-dark", children: snapshot.runtime_state?.started_at ? formatRelativeTime(snapshot.runtime_state.started_at) : "Unavailable" })
-              ] })
-            ] }),
-            cloudBundleCopy ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-slate-100 bg-white/70 p-3", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium uppercase tracking-wide text-slate-500", children: "Signed Cloud bundle ack" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm font-medium text-brand-dark", children: cloudBundleCopy.label }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: cloudBundleCopy.detail }),
-              snapshot.cloud_policy_bundle_hash ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 break-all font-mono text-[11px] text-slate-500", children: snapshot.cloud_policy_bundle_hash }) : null
-            ] }) : null
-          ]
-        }
-      ),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local strict policy" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches." }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 text-xs text-slate-500", children: [
-          "Config file: ",
-          configPath ?? "Unavailable"
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-5 w-5", "aria-hidden": "true" }) }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2", children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-base font-semibold text-brand-dark", children: "Strict mode" }),
+                /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: isStrict ? "green" : "slate", children: isStrict ? "Enabled" : "Disabled" })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: "Local enforcement tuning." }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark/75", children: "Guard asks before risky actions that are not already allowed by policy." })
+            ] })
+          ] }),
+          !isStrict && onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Enable in Settings" }) : null
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 space-y-5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-5 grid gap-4 border-t border-slate-100 pt-4 sm:grid-cols-2 lg:grid-cols-4", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Strict mode" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1.5 text-sm font-medium text-brand-dark", children: isStrict ? "Enabled" : "Disabled" })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Policy hash" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1.5 flex items-center gap-1.5 font-mono text-sm text-brand-dark", children: localPolicyHash })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Daemon ack" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5 flex items-center gap-1.5 text-sm text-brand-dark", children: [
+              cloudBundleCopy ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-600", "aria-hidden": "true" }) : null,
+              daemonAckLabel
+            ] })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last reload" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1.5 text-sm text-brand-dark", children: lastReloadAt ? formatRelativeTime(lastReloadAt) : "Unavailable" })
+          ] })
+        ] }),
+        onReloadPolicy ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex justify-end border-t border-slate-100 pt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onReloadPolicy, disabled: reloadingPolicy, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: `mr-1.5 h-4 w-4 ${reloadingPolicy ? "animate-spin" : ""}`, "aria-hidden": "true" }),
+          "Reload policy"
+        ] }) }) : null
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5 shadow-sm", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap items-start justify-between gap-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local strict policy" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches." })
+        ] }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 divide-y divide-slate-100", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx(
             StrictConfigActionSegmented,
             {
@@ -2620,7 +2929,7 @@ function PolicyStrictConfigTab({
           /* @__PURE__ */ jsxRuntimeExports.jsx(
             StrictConfigActionSegmented,
             {
-              label: "Destructive file write action",
+              label: "File write action",
               help: "Backed by the destructive shell risk control.",
               value: fileWriteAction,
               settingKey: "destructive_shell",
@@ -2629,6 +2938,7 @@ function PolicyStrictConfigTab({
             }
           )
         ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-4 text-xs text-slate-500", children: "These settings apply only when no remembered rule, Cloud policy, or Cloud exception covers the action." }),
         saveError ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-sm text-red-600", children: saveError }) : null,
         savingKey ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-3 text-sm text-slate-500", children: [
           "Saving ",
@@ -2637,32 +2947,58 @@ function PolicyStrictConfigTab({
         ] }) : null
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Evaluation order" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex flex-wrap items-center gap-2 text-sm text-brand-dark/80", children: STRICT_POLICY_EVALUATION_ORDER.map((step, index) => /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 font-medium", children: step }),
-          index < STRICT_POLICY_EVALUATION_ORDER.length - 1 ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-slate-400", "aria-hidden": "true", children: "→" }) : null
-        ] }, step)) })
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local enforcement preview" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Evaluation order when Guard decides what to do next." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex flex-wrap items-center gap-2", children: EVALUATION_STEPS.map((step, index) => {
+          const Icon = step.icon;
+          return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "inline-flex items-center gap-2 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm font-medium text-brand-dark", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4 text-brand-blue", "aria-hidden": "true" }),
+              step.label
+            ] }),
+            index < EVALUATION_STEPS.length - 1 ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowRight, { className: "h-4 w-4 text-slate-400", "aria-hidden": "true" }) : null
+          ] }, step.label);
+        }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-4 text-xs text-slate-500", children: [
+          "Evaluation order: ",
+          STRICT_POLICY_EVALUATION_ORDER.join(" → "),
+          ". Tune fallback behavior locally; team policy still syncs from Guard Cloud."
+        ] })
       ] })
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "space-y-4 lg:sticky lg:top-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 shadow-sm", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "What this changes" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark/75", children: "Stricter fallback controls increase review and block outcomes for first-time or changed actions on this device." })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-2 text-sm text-slate-600", children: WHAT_CHANGES_BULLETS.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "mt-0.5 h-4 w-4 shrink-0 text-emerald-600", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: item })
+        ] }, item)) })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Affected inbox" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-3xl font-semibold text-brand-dark", children: pendingInboxCount }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Affected pending Inbox items" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-4xl font-semibold tabular-nums text-brand-dark", children: pendingInboxCount }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 text-sm text-slate-600", children: [
           "Pending review item",
           pendingInboxCount === 1 ? "" : "s",
           " may be affected by stricter fallback controls."
         ] }),
-        onOpenInbox && pendingInboxCount > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenInbox, children: "Open Inbox" }) }) : null
+        onOpenInbox && pendingInboxCount > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onOpenInbox, children: [
+          "Open Inbox",
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowRight, { className: "ml-1.5 h-4 w-4", "aria-hidden": "true" })
+        ] }) }) : null
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-2xl border border-slate-100 bg-slate-50/80 p-4 text-sm text-slate-600", children: "Cloud exceptions still require signed bundle acknowledgement before they apply locally." }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Cloud exceptions still apply" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 leading-relaxed", children: "Signed Cloud exceptions still require bundle acknowledgement before they apply locally." })
+      ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Test policy" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Policy simulator: preview which layer wins for a hypothetical action without changing live policy." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-blue", "aria-hidden": "true" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Test policy" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Simulate how Guard will respond." })
+          ] })
+        ] }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-4 block space-y-1.5", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Scenario" }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -2675,17 +3011,19 @@ function PolicyStrictConfigTab({
             }
           )
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 space-y-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SimLayerSelect, { label: "Remembered rule", value: simRemembered, onChange: handleSimRememberedChange }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(SimLayerSelect, { label: "Cloud policy", value: simCloudPolicy, onChange: handleSimCloudPolicyChange }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "flex items-center gap-2 rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("input", { type: "checkbox", checked: simCloudException, onChange: handleSimCloudExceptionChange }),
-            "Active Cloud exception"
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-wrap items-center justify-between gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium uppercase tracking-wide text-slate-500", children: "Expected action" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: resolveExpectedActionTone(expectedAction), children: policyActionLabel(expectedAction) }) })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: handleRunSimulation, children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniPlay, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+            "Run simulation"
           ] })
         ] }),
-        simulation ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-slate-100 bg-white p-4", children: [
+        simulationVisible && simulation ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-slate-100 bg-white p-4", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm font-medium text-brand-dark", children: [
-            "Outcome: ",
+            "Policy simulator outcome: ",
             policyActionLabel(simulation.outcome),
             " (",
             simulation.winningStep,
@@ -2713,7 +3051,11 @@ function PolicyWorkspace$1({
   onClearPolicy,
   onOpenSettings,
   onOpenInbox,
-  onOpenCloudExceptions
+  onOpenCloudExceptions,
+  exceptionRequestOpen = false,
+  onExceptionRequestOpenChange,
+  onReloadPolicy,
+  reloadingPolicy = false
 }) {
   if (activeView === "rules") {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "policy-panel-rules", role: "tabpanel", "aria-labelledby": "policy-tab-rules", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -2728,9 +3070,25 @@ function PolicyWorkspace$1({
     ) });
   }
   if (activeView === "exceptions") {
-    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "policy-panel-exceptions", role: "tabpanel", "aria-labelledby": "policy-tab-exceptions", children: /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyCloudExceptionsTab, { snapshot }) });
+    return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "policy-panel-exceptions", role: "tabpanel", "aria-labelledby": "policy-tab-exceptions", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+      PolicyCloudExceptionsTab,
+      {
+        snapshot,
+        requestOpen: exceptionRequestOpen,
+        onRequestOpenChange: onExceptionRequestOpenChange
+      }
+    ) });
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "policy-panel-strict", role: "tabpanel", "aria-labelledby": "policy-tab-strict", children: /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyStrictConfigTab, { snapshot, onOpenSettings, onOpenInbox }) });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { id: "policy-panel-strict", role: "tabpanel", "aria-labelledby": "policy-tab-strict", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+    PolicyStrictConfigTab,
+    {
+      snapshot,
+      onOpenSettings,
+      onOpenInbox,
+      onReloadPolicy,
+      reloadingPolicy
+    }
+  ) });
 }
 const policyWorkspace = /* @__PURE__ */ Object.freeze(/* @__PURE__ */ Object.defineProperty({
   __proto__: null,
@@ -2808,6 +3166,21 @@ function PolicyPageToolbar({ snapshot, onReloadPolicy, reloading = false }) {
     ] }) : null
   ] });
 }
+function PolicyExceptionsToolbar({
+  cloudConnected,
+  cloudControlsUrl,
+  connectUrl,
+  onRequestException
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-end gap-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "primary", onClick: onRequestException, disabled: !cloudConnected, children: "+ Request cloud exception" }),
+    cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+      "Open Guard Cloud"
+    ] }) : null,
+    !cloudConnected && connectUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { href: connectUrl, variant: "secondary", children: "Connect Guard Cloud" }) : null
+  ] });
+}
 const PolicyWorkspace = reactExports.lazy(
   () => __vitePreload(() => Promise.resolve().then(() => policyWorkspace), true ? void 0 : void 0).then((module) => ({ default: module.PolicyWorkspace }))
 );
@@ -2817,6 +3190,9 @@ function PolicyFallback() {
 function PolicyWorkspacePage(props) {
   const [activeView, setActiveView] = reactExports.useState("rules");
   const [reloading, setReloading] = reactExports.useState(false);
+  const [exceptionRequestOpen, setExceptionRequestOpen] = reactExports.useState(false);
+  const cloudControlsUrl = resolveCloudPolicyControlsUrl(props.snapshot);
+  const cloudConnected = resolveCloudExceptionsConnected(props.snapshot);
   const handleOpenSettings = reactExports.useCallback(() => props.onOpenSettings(), [props]);
   const handleOpenInbox = reactExports.useCallback(() => props.onOpenInbox(), [props]);
   const handleViewChange = reactExports.useCallback((view) => setActiveView(view), []);
@@ -2834,8 +3210,16 @@ function PolicyWorkspacePage(props) {
       {
         eyebrow: "Policy",
         title: "Remembered rules and exceptions",
-        description: "See what Guard will do next time, in plain language. Remove local remembered rules here or request Cloud exceptions when Guard Cloud is connected.",
-        actions: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        description: "See what Guard will do next time, in plain language. Remove local rules or add custom exceptions here.",
+        actions: activeView === "exceptions" ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+          PolicyExceptionsToolbar,
+          {
+            cloudConnected,
+            cloudControlsUrl,
+            connectUrl: props.snapshot.connect_url?.trim() || null,
+            onRequestException: () => setExceptionRequestOpen(true)
+          }
+        ) : /* @__PURE__ */ jsxRuntimeExports.jsx(
           PolicyPageToolbar,
           {
             snapshot: props.snapshot,
@@ -2855,7 +3239,11 @@ function PolicyWorkspacePage(props) {
         onClearPolicy: props.onClearPolicy,
         onOpenSettings: handleOpenSettings,
         onOpenInbox: handleOpenInbox,
-        onOpenCloudExceptions: () => setActiveView("exceptions")
+        onOpenCloudExceptions: () => setActiveView("exceptions"),
+        exceptionRequestOpen,
+        onExceptionRequestOpenChange: setExceptionRequestOpen,
+        onReloadPolicy: handleReloadPolicy,
+        reloadingPolicy: reloading
       }
     ) })
   ] });

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -152,7 +152,7 @@ function resolveCloudExceptionEvidenceUrl(item) {
   if (!receiptId) {
     return null;
   }
-  return `/evidence?receipt_id=${encodeURIComponent(receiptId)}`;
+  return `/evidence?search=${encodeURIComponent(receiptId)}`;
 }
 function resolveCloudExceptionScopePath(item) {
   const target = resolveCloudExceptionScopeTarget(item);
@@ -255,7 +255,7 @@ function ExpiryTimeline({
         formatRelativeTime(expiryValue)
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "h-full w-2/3 rounded-full bg-brand-blue/70", "aria-hidden": "true" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2 h-1.5 overflow-hidden rounded-full bg-slate-200", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "h-full w-full animate-pulse rounded-full bg-brand-blue/40", "aria-hidden": "true" }) }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-slate-600", children: expiryTimestamp.toLocaleString() })
   ] });
 }
@@ -488,12 +488,13 @@ function SourceReceiptSummary({ receipt }) {
   ] });
 }
 function ResultPreview({ scope, harness, expiresLabel }) {
+  const showHarness = (scope === "artifact" || scope === "harness") && harness.trim();
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-xl border border-slate-200 bg-white p-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-semibold uppercase tracking-wide text-slate-500", children: "Result preview" }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-3 text-sm leading-relaxed text-brand-dark", children: [
       "If approved in Guard Cloud, Guard will apply this exception for ",
       scopeLabel(scope, "policy"),
-      harness.trim() ? ` in ${harnessDisplayName(harness)}` : "",
+      showHarness ? ` in ${harnessDisplayName(harness)}` : "",
       " until ",
       expiresLabel,
       "."
@@ -907,7 +908,9 @@ function PolicyCloudExceptionRequestPanel({
                     "input",
                     {
                       className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm",
-                      inputMode: "numeric",
+                      type: "number",
+                      min: 1,
+                      step: 1,
                       value: maxUses,
                       onChange: handleMaxUsesChange,
                       placeholder: "50"
@@ -1138,12 +1141,7 @@ function GroupSection({
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Last used" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: "Status" })
       ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "list", children }),
-      count > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-100 px-4 py-2.5 text-sm font-medium text-brand-blue", children: [
-        "View all (",
-        count,
-        ") →"
-      ] }) : null
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { role: "list", children })
     ] }) : null
   ] });
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-protection-stats.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-protection-stats.js
@@ -65,6 +65,15 @@ function isSupplyChainSyncConnectError(error) {
   const code = readHarnessActionErrorCode(error);
   return code !== null && SUPPLY_CHAIN_CONNECT_ERROR_CODES.has(code);
 }
+function isSupplyChainSyncRetryableError(error) {
+  if (!isGuardHarnessActionError(error)) {
+    return false;
+  }
+  if (readHarnessActionErrorCode(error) !== "supply_chain_sync_unavailable") {
+    return false;
+  }
+  return error.payload?.retryable === true;
+}
 function readHarnessActionUserMessage(error, fallback) {
   if (error instanceof Error && GUARD_FETCH_NETWORK_ERROR_MESSAGE.test(error.message)) {
     return "Guard lost connection while syncing supply-chain intel. Confirm the local daemon is still running, then try again.";
@@ -277,12 +286,13 @@ function buildSupplyChainStats(snapshot) {
 export {
   ApprovalProofInline as A,
   isSupplyChainSyncConnectError as a,
-  resolveApprovalGateSyncFailure as b,
-  isApprovalGateRequiredError as c,
-  readHarnessActionUserMessage as d,
-  ApprovalProofModal as e,
-  buildSupplyChainStats as f,
-  resolveManagerCoverageStatus as g,
+  isSupplyChainSyncRetryableError as b,
+  readHarnessActionUserMessage as c,
+  resolveApprovalGateSyncFailure as d,
+  isApprovalGateRequiredError as e,
+  ApprovalProofModal as f,
+  buildSupplyChainStats as g,
+  resolveManagerCoverageStatus as h,
   isGuardHarnessActionError as i,
   readHarnessActionErrorCode as r,
   useResolvedApprovalGate as u

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -1,5 +1,5 @@
-import { aQ as isSupplyChainAuditIncomplete, aR as readString$1, aS as isRecord$2, au as GuardHarnessActionError, r as reactExports, j as jsxRuntimeExports, d as HiMiniCheckCircle, aw as HiMiniArrowPath, w as HiMiniExclamationTriangle, ac as Tag, m as formatRelativeTime, aT as HiMiniClock, aU as IconActionButton, I as HiMiniXCircle, ax as HiMiniTrash, l as HiMiniShieldCheck, F as HiMiniWrenchScrewdriver, aV as HiMiniBeaker, aW as ActivationSummary, aX as ActionResultPanel, ad as HiMiniMagnifyingGlass, b as EmptyState, A as ActionButton, aY as HiMiniBugAnt, o as HiMiniXMark, aZ as GuardModalLayer, a_ as ConnectFlowCard, aO as HiMiniArrowTopRightOnSquare, a$ as HiMiniCloudArrowDown, b0 as fetchPackageFirewallStatus, b1 as runPackageAudit, b2 as resolveSupplyChainAuditFailure, b3 as runPackageSync, b4 as startPackageFirewallConnect, b5 as runPackageFirewallAction, b6 as parseInterceptProofSnapshot, b7 as openPackageFirewallShell, S as SectionLabel, b8 as EntitlementNotice, b9 as fetchSupplyChainBundle, B as Badge, ba as HiMiniDocumentMagnifyingGlass, bb as HiMiniShieldExclamation, bc as HiMiniComputerDesktop, t as HiMiniCloud, bd as HiMiniArrowDown, be as HiMiniArrowUp, ah as HiMiniArrowLeft, bf as HiMiniArrowRight, aE as HiMiniCloudArrowUp, bg as HiMiniInformationCircle, bh as fetchReceipts, h as harnessDisplayName, p as HiMiniChevronUp, q as HiMiniChevronDown } from "../guard-dashboard.js";
-import { i as isGuardHarnessActionError, a as isSupplyChainSyncConnectError, r as readHarnessActionErrorCode, A as ApprovalProofInline, u as useResolvedApprovalGate, b as resolveApprovalGateSyncFailure, c as isApprovalGateRequiredError, d as readHarnessActionUserMessage, e as ApprovalProofModal, f as buildSupplyChainStats } from "./supply-chain-protection-stats.js";
+import { a_ as isSupplyChainAuditIncomplete, a$ as readString$1, b0 as isRecord$2, au as GuardHarnessActionError, r as reactExports, j as jsxRuntimeExports, d as HiMiniCheckCircle, aw as HiMiniArrowPath, w as HiMiniExclamationTriangle, ac as Tag, m as formatRelativeTime, b1 as HiMiniClock, b2 as IconActionButton, I as HiMiniXCircle, ax as HiMiniTrash, l as HiMiniShieldCheck, F as HiMiniWrenchScrewdriver, aV as HiMiniBeaker, b3 as ActivationSummary, b4 as ActionResultPanel, ad as HiMiniMagnifyingGlass, b as EmptyState, A as ActionButton, b5 as HiMiniBugAnt, o as HiMiniXMark, b6 as GuardModalLayer, b7 as ConnectFlowCard, aY as HiMiniArrowTopRightOnSquare, b8 as HiMiniCloudArrowDown, b9 as fetchPackageFirewallStatus, ba as runPackageAudit, bb as resolveSupplyChainAuditFailure, bc as runPackageSync, bd as startPackageFirewallConnect, be as openPackageFirewallAuthorizeWindow, bf as PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE, bg as runPackageFirewallAction, bh as parseInterceptProofSnapshot, bi as openPackageFirewallShell, S as SectionLabel, bj as EntitlementNotice, bk as fetchSupplyChainBundle, B as Badge, bl as HiMiniDocumentMagnifyingGlass, bm as HiMiniShieldExclamation, bn as HiMiniComputerDesktop, t as HiMiniCloud, bo as HiMiniArrowDown, bp as HiMiniArrowUp, ah as HiMiniArrowLeft, aU as HiMiniArrowRight, aF as HiMiniCloudArrowUp, bq as HiMiniInformationCircle, br as fetchReceipts, h as harnessDisplayName, p as HiMiniChevronUp, q as HiMiniChevronDown } from "../guard-dashboard.js";
+import { i as isGuardHarnessActionError, a as isSupplyChainSyncConnectError, r as readHarnessActionErrorCode, A as ApprovalProofInline, u as useResolvedApprovalGate, b as isSupplyChainSyncRetryableError, c as readHarnessActionUserMessage, d as resolveApprovalGateSyncFailure, e as isApprovalGateRequiredError, f as ApprovalProofModal, g as buildSupplyChainStats } from "./supply-chain-protection-stats.js";
 import { resolveFeedStaleness } from "./feed-health-workspace.js";
 import { r as resolveHomeProtectionStatus } from "./home-protection-module.js";
 import { S as SUPPLY_CHAIN_WORKSPACE_SHELL_CLASS } from "./supply-chain-hub-workspace.js";
@@ -1578,6 +1578,16 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
             return;
           }
         }
+        if (isSupplyChainSyncRetryableError(err)) {
+          const message = readHarnessActionUserMessage(
+            err,
+            "Guard Cloud is temporarily unavailable. Try syncing again in a few minutes."
+          );
+          setAuditRecoveryError(message);
+          setAuditRecoveryPhase("ready");
+          setLastFailed({ op: "sync", manager: null, message });
+          return;
+        }
         const failure = resolveApprovalGateSyncFailure(err, {
           hasCredentials: credentials !== void 0
         });
@@ -1615,7 +1625,10 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
     setConnectError(null);
     setActivationAssistError(null);
     try {
-      await startPackageFirewallConnect();
+      const connectFlow = await startPackageFirewallConnect();
+      if (connectFlow?.authorize_url && !openPackageFirewallAuthorizeWindow(connectFlow.authorize_url)) {
+        setConnectError(PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE);
+      }
       await refreshAfterOp();
       await onStateChanged?.();
     } catch (error) {
@@ -1773,6 +1786,16 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
             setAuditRecoveryError(null);
             return;
           }
+        }
+        if (isSupplyChainSyncRetryableError(err)) {
+          const message2 = readHarnessActionUserMessage(
+            err,
+            "Guard Cloud is temporarily unavailable. Try syncing again in a few minutes."
+          );
+          setAuditRecoveryPhase("ready");
+          setAuditRecoveryError(message2);
+          setLastFailed({ op, manager: null, message: message2 });
+          return;
         }
         const message = readHarnessActionUserMessage(err, "Operation failed.");
         setLastFailed({ op, manager: null, message });

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -12697,6 +12697,9 @@ function HiMiniXCircle(props) {
 function HiMiniWrenchScrewdriver(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M14.5 10a4.5 4.5 0 0 0 4.284-5.882c-.105-.324-.51-.391-.752-.15L15.34 6.66a.454.454 0 0 1-.493.11 3.01 3.01 0 0 1-1.618-1.616.455.455 0 0 1 .11-.494l2.694-2.692c.24-.241.174-.647-.15-.752a4.5 4.5 0 0 0-5.873 4.575c.055.873-.128 1.808-.8 2.368l-7.23 6.024a2.724 2.724 0 1 0 3.837 3.837l6.024-7.23c.56-.672 1.495-.855 2.368-.8.096.007.193.01.291.01ZM5 16a1 1 0 1 1-2 0 1 1 0 0 1 2 0Z", "clipRule": "evenodd" }, "child": [] }, { "tag": "path", "attr": { "d": "M14.5 11.5c.173 0 .345-.007.514-.022l3.754 3.754a2.5 2.5 0 0 1-3.536 3.536l-4.41-4.41 2.172-2.607c.052-.063.147-.138.342-.196.202-.06.469-.087.777-.067.128.008.257.012.387.012ZM6 4.586l2.33 2.33a.452.452 0 0 1-.08.09L6.8 8.214 4.586 6H3.309a.5.5 0 0 1-.447-.276l-1.7-3.402a.5.5 0 0 1 .093-.577l.49-.49a.5.5 0 0 1 .577-.094l3.402 1.7A.5.5 0 0 1 6 3.31v1.277Z" }, "child": [] }] })(props);
 }
+function HiMiniUsers(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M7 8a3 3 0 1 0 0-6 3 3 0 0 0 0 6ZM14.5 9a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5ZM1.615 16.428a1.224 1.224 0 0 1-.569-1.175 6.002 6.002 0 0 1 11.908 0c.058.467-.172.92-.57 1.174A9.953 9.953 0 0 1 7 18a9.953 9.953 0 0 1-5.385-1.572ZM14.5 16h-.106c.07-.297.088-.611.048-.933a7.47 7.47 0 0 0-1.588-3.755 4.502 4.502 0 0 1 5.874 2.636.818.818 0 0 1-.36.98A7.465 7.465 0 0 1 14.5 16Z" }, "child": [] }] })(props);
+}
 function HiMiniTrash(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M8.75 1A2.75 2.75 0 0 0 6 3.75v.443c-.795.077-1.584.176-2.365.298a.75.75 0 1 0 .23 1.482l.149-.022.841 10.518A2.75 2.75 0 0 0 7.596 19h4.807a2.75 2.75 0 0 0 2.742-2.53l.841-10.52.149.023a.75.75 0 0 0 .23-1.482A41.03 41.03 0 0 0 14 4.193V3.75A2.75 2.75 0 0 0 11.25 1h-2.5ZM10 4c.84 0 1.673.025 2.5.075V3.75c0-.69-.56-1.25-1.25-1.25h-2.5c-.69 0-1.25.56-1.25 1.25v.325C8.327 4.025 9.16 4 10 4ZM8.58 7.72a.75.75 0 0 0-1.5.06l.3 7.5a.75.75 0 1 0 1.5-.06l-.3-7.5Zm4.34.06a.75.75 0 1 0-1.5-.06l-.3 7.5a.75.75 0 1 0 1.5.06l.3-7.5Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
@@ -12724,8 +12727,17 @@ function HiMiniServerStack(props) {
 function HiMiniRocketLaunch(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M4.606 12.97a.75.75 0 0 1-.134 1.051 2.494 2.494 0 0 0-.93 2.437 2.494 2.494 0 0 0 2.437-.93.75.75 0 1 1 1.186.918 3.995 3.995 0 0 1-4.482 1.332.75.75 0 0 1-.461-.461 3.994 3.994 0 0 1 1.332-4.482.75.75 0 0 1 1.052.134Z", "clipRule": "evenodd" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M5.752 12A13.07 13.07 0 0 0 8 14.248v4.002c0 .414.336.75.75.75a5 5 0 0 0 4.797-6.414 12.984 12.984 0 0 0 5.45-10.848.75.75 0 0 0-.735-.735 12.984 12.984 0 0 0-10.849 5.45A5 5 0 0 0 1 11.25c.001.414.337.75.751.75h4.002ZM13 9a2 2 0 1 0 0-4 2 2 0 0 0 0 4Z", "clipRule": "evenodd" }, "child": [] }] })(props);
 }
+function HiMiniQueueList(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M2 4.5A2.5 2.5 0 0 1 4.5 2h11a2.5 2.5 0 0 1 0 5h-11A2.5 2.5 0 0 1 2 4.5ZM2.75 9.083a.75.75 0 0 0 0 1.5h14.5a.75.75 0 0 0 0-1.5H2.75ZM2.75 12.663a.75.75 0 0 0 0 1.5h14.5a.75.75 0 0 0 0-1.5H2.75ZM2.75 16.25a.75.75 0 0 0 0 1.5h14.5a.75.75 0 1 0 0-1.5H2.75Z" }, "child": [] }] })(props);
+}
 function HiMiniQuestionMarkCircle(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M18 10a8 8 0 1 1-16 0 8 8 0 0 1 16 0ZM8.94 6.94a.75.75 0 1 1-1.061-1.061 3 3 0 1 1 2.871 5.026v.345a.75.75 0 0 1-1.5 0v-.5c0-.72.57-1.172 1.081-1.287A1.5 1.5 0 1 0 8.94 6.94ZM10 15a1 1 0 1 0 0-2 1 1 0 0 0 0 2Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
+function HiMiniPuzzlePiece(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M12 4.467c0-.405.262-.75.559-1.027.276-.257.441-.584.441-.94 0-.828-.895-1.5-2-1.5s-2 .672-2 1.5c0 .362.171.694.456.953.29.265.544.6.544.994a.968.968 0 0 1-1.024.974 39.655 39.655 0 0 1-3.014-.306.75.75 0 0 0-.847.847c.14.993.242 1.999.306 3.014A.968.968 0 0 1 4.447 10c-.393 0-.729-.253-.994-.544C3.194 9.17 2.862 9 2.5 9 1.672 9 1 9.895 1 11s.672 2 1.5 2c.356 0 .683-.165.94-.441.276-.297.622-.559 1.027-.559a.997.997 0 0 1 1.004 1.03 39.747 39.747 0 0 1-.319 3.734.75.75 0 0 0 .64.842c1.05.146 2.111.252 3.184.318A.97.97 0 0 0 10 16.948c0-.394-.254-.73-.545-.995C9.171 15.693 9 15.362 9 15c0-.828.895-1.5 2-1.5s2 .672 2 1.5c0 .356-.165.683-.441.94-.297.276-.559.622-.559 1.027a.998.998 0 0 0 1.03 1.005c1.337-.05 2.659-.162 3.961-.337a.75.75 0 0 0 .644-.644c.175-1.302.288-2.624.337-3.961A.998.998 0 0 0 16.967 12c-.405 0-.75.262-1.027.559-.257.276-.584.441-.94.441-.828 0-1.5-.895-1.5-2s.672-2 1.5-2c.362 0 .694.17.953.455.265.291.601.545.995.545a.97.97 0 0 0 .976-1.024 41.159 41.159 0 0 0-.318-3.184.75.75 0 0 0-.842-.64c-1.228.164-2.473.271-3.734.319A.997.997 0 0 1 12 4.467Z" }, "child": [] }] })(props);
+}
+function HiMiniPlay(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M6.3 2.84A1.5 1.5 0 0 0 4 4.11v11.78a1.5 1.5 0 0 0 2.3 1.27l9.344-5.891a1.5 1.5 0 0 0 0-2.538L6.3 2.841Z" }, "child": [] }] })(props);
 }
 function HiMiniPencilSquare(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "m5.433 13.917 1.262-3.155A4 4 0 0 1 7.58 9.42l6.92-6.918a2.121 2.121 0 0 1 3 3l-6.92 6.918c-.383.383-.84.685-1.343.886l-3.154 1.262a.5.5 0 0 1-.65-.65Z" }, "child": [] }, { "tag": "path", "attr": { "d": "M3.5 5.75c0-.69.56-1.25 1.25-1.25H10A.75.75 0 0 0 10 3H4.75A2.75 2.75 0 0 0 2 5.75v9.5A2.75 2.75 0 0 0 4.75 18h9.5A2.75 2.75 0 0 0 17 15.25V10a.75.75 0 0 0-1.5 0v5.25c0 .69-.56 1.25-1.25 1.25h-9.5c-.69 0-1.25-.56-1.25-1.25v-9.5Z" }, "child": [] }] })(props);
@@ -12759,6 +12771,9 @@ function HiMiniGlobeAlt(props) {
 }
 function HiMiniFunnel(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "fillRule": "evenodd", "d": "M2.628 1.601C5.028 1.206 7.49 1 10 1s4.973.206 7.372.601a.75.75 0 0 1 .628.74v2.288a2.25 2.25 0 0 1-.659 1.59l-4.682 4.683a2.25 2.25 0 0 0-.659 1.59v3.037c0 .684-.31 1.33-.844 1.757l-1.937 1.55A.75.75 0 0 1 8 18.25v-5.757a2.25 2.25 0 0 0-.659-1.591L2.659 6.22A2.25 2.25 0 0 1 2 4.629V2.34a.75.75 0 0 1 .628-.74Z", "clipRule": "evenodd" }, "child": [] }] })(props);
+}
+function HiMiniFolder(props) {
+  return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M3.75 3A1.75 1.75 0 0 0 2 4.75v3.26a3.235 3.235 0 0 1 1.75-.51h12.5c.644 0 1.245.188 1.75.51V6.75A1.75 1.75 0 0 0 16.25 5h-4.836a.25.25 0 0 1-.177-.073L9.823 3.513A1.75 1.75 0 0 0 8.586 3H3.75ZM3.75 9A1.75 1.75 0 0 0 2 10.75v4.5c0 .966.784 1.75 1.75 1.75h12.5A1.75 1.75 0 0 0 18 15.25v-4.5A1.75 1.75 0 0 0 16.25 9H3.75Z" }, "child": [] }] })(props);
 }
 function HiMiniEye(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 20 20", "fill": "currentColor", "aria-hidden": "true" }, "child": [{ "tag": "path", "attr": { "d": "M10 12.5a2.5 2.5 0 1 0 0-5 2.5 2.5 0 0 0 0 5Z" }, "child": [] }, { "tag": "path", "attr": { "fillRule": "evenodd", "d": "M.664 10.59a1.651 1.651 0 0 1 0-1.186A10.004 10.004 0 0 1 10 3c4.257 0 7.893 2.66 9.336 6.41.147.381.146.804 0 1.186A10.004 10.004 0 0 1 10 17c-4.257 0-7.893-2.66-9.336-6.41ZM14 10a4 4 0 1 1-8 0 4 4 0 0 1 8 0Z", "clipRule": "evenodd" }, "child": [] }] })(props);
@@ -13227,11 +13242,11 @@ function scopeLabel(scope, variant = "review") {
       case "workspace":
         return "This project";
       case "harness":
-        return "This app";
+        return "This harness";
       case "publisher":
-        return "This source";
+        return "This cwd";
       case "global":
-        return "Every project";
+        return "Team policy";
       default:
         return scope;
     }
@@ -15554,6 +15569,8 @@ function normalizeGuardUpdateStatus(raw) {
     auto_updatable: booleanValue(value.auto_updatable),
     update_available: booleanValue(value.update_available),
     blocked_reason: stringValue(value.blocked_reason),
+    recovery_reinstall_available: value.recovery_reinstall_available === true ? true : void 0,
+    recovery_reinstall_command: typeof value.recovery_reinstall_command === "string" ? value.recovery_reinstall_command : void 0,
     update_in_progress: typeof value.update_in_progress === "boolean" ? value.update_in_progress : void 0
   };
 }
@@ -15578,14 +15595,18 @@ async function fetchGuardUpdateStatus() {
   const payload = await readJson("/v1/update/status");
   return normalizeGuardUpdateStatus(payload);
 }
-async function scheduleGuardUpdate() {
+async function scheduleGuardUpdate(options) {
   if (isGuardDemoMode()) {
     return {
       scheduled: true,
       message: "Demo mode cannot update Guard."
     };
   }
-  const response = await fetchWithGuardAuth("/v1/update", { method: "POST" });
+  const body = options?.forcePypiReinstall === true ? JSON.stringify({ force_pypi_reinstall: true }) : void 0;
+  const response = await fetchWithGuardAuth("/v1/update", {
+    method: "POST",
+    ...body ? { headers: { "Content-Type": "application/json" }, body } : {}
+  });
   const payload = await response.json().catch(() => ({}));
   if (!response.ok) {
     const message = stringValue(payload.message) ?? stringValue(payload.error) ?? `Guard update failed with ${response.status}`;
@@ -15937,13 +15958,8 @@ async function fetchPackageFirewallStatus() {
   return normalizePackageFirewallStatus(await readJson("/v1/supply-chain/package-shims"));
 }
 async function startPackageFirewallConnect() {
-  return normalizePackageFirewallConnectFlow(
-    await readJson("/v1/supply-chain/package-shims/connect", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({})
-    })
-  );
+  const status = await startGuardCloudConnect();
+  return status.connect_flow;
 }
 async function fetchSupplyChainBundle() {
   const wrapper = await readJson("/v1/supply-chain/bundle");
@@ -16104,6 +16120,9 @@ function updateHelpCopy(status, phase) {
   if (status?.update_available) {
     return "This restarts Guard for a moment. Open approvals will stay saved.";
   }
+  if (status && !status.auto_updatable && status.recovery_reinstall_available) {
+    return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
   if (status && !status.auto_updatable && status.blocked_reason) {
     return status.blocked_reason;
   }
@@ -16114,6 +16133,8 @@ function GuardUpdatePanel(props) {
   const phase = props.updatePhase ?? "idle";
   const helpCopy = updateHelpCopy(props.updateStatus, phase);
   const showUpdateButton = props.updateStatus?.update_available === true && props.updateStatus.auto_updatable && phase !== "updating" && phase !== "reconnecting";
+  const showReinstallButton = props.updateStatus?.recovery_reinstall_available === true && props.updateStatus.auto_updatable !== true && phase !== "updating" && phase !== "reconnecting";
+  const busy = phase === "updating" || phase === "reconnecting";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-2", children: [
     version ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "font-mono text-[10px] text-brand-dark/60", "aria-label": `Guard version ${version}`, children: [
       "v",
@@ -16133,7 +16154,19 @@ function GuardUpdatePanel(props) {
         ]
       }
     ) : null,
-    (phase === "updating" || phase === "reconnecting") && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "inline-flex min-h-11 items-center gap-2 text-[11px] font-medium text-brand-blue", role: "status", children: [
+    showReinstallButton && props.onReinstallGuard ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+      "button",
+      {
+        type: "button",
+        onClick: props.onReinstallGuard,
+        className: "inline-flex min-h-11 w-full items-center justify-center gap-1.5 rounded-lg border border-brand-blue/30 bg-white px-3 py-2 text-sm font-semibold text-brand-blue transition-colors hover:bg-brand-blue/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/40",
+        children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-4 w-4 shrink-0", "aria-hidden": "true" }),
+          "Reinstall from PyPI"
+        ]
+      }
+    ) : null,
+    busy && /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "inline-flex min-h-11 items-center gap-2 text-[11px] font-medium text-brand-blue", role: "status", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-4 w-4 animate-spin", "aria-hidden": "true" }),
       phase === "updating" ? "Updating Guard…" : "Reconnecting…"
     ] })
@@ -16213,40 +16246,66 @@ function useGuardUpdate(options) {
     },
     [options]
   );
+  const scheduleAndWait = reactExports.useCallback(
+    async (params) => {
+      setUpdatePhase("updating");
+      try {
+        const scheduleResult = await scheduleGuardUpdate(
+          params.forcePypiReinstall === true ? { forcePypiReinstall: true } : void 0
+        );
+        if (scheduleResult.scheduled === false && scheduleResult.error === "update_in_progress") {
+          setUpdatePhase("reconnecting");
+          const redirected2 = await waitForReconnect(
+            params.expectedPreviousVersion,
+            params.expectedLatestVersion
+          );
+          if (!redirected2) {
+            window.location.reload();
+          }
+          return;
+        }
+        if (scheduleResult.scheduled !== true) {
+          throw new Error(scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled.");
+        }
+        setUpdatePhase("reconnecting");
+        const redirected = await waitForReconnect(
+          params.expectedPreviousVersion,
+          params.expectedLatestVersion
+        );
+        if (!redirected) {
+          window.location.reload();
+        }
+      } catch {
+        setUpdatePhase("error");
+      }
+    },
+    [waitForReconnect]
+  );
   const onUpdateGuard = reactExports.useCallback(async () => {
     if (!updateStatus?.update_available || !updateStatus.auto_updatable) {
       return;
     }
-    const expectedPreviousVersion = updateStatus.current_version;
-    const expectedLatestVersion = updateStatus.latest_version;
-    setUpdatePhase("updating");
-    try {
-      const scheduleResult = await scheduleGuardUpdate();
-      if (scheduleResult.scheduled === false && scheduleResult.error === "update_in_progress") {
-        setUpdatePhase("reconnecting");
-        const redirected2 = await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
-        if (!redirected2) {
-          window.location.reload();
-        }
-        return;
-      }
-      if (scheduleResult.scheduled !== true) {
-        throw new Error(scheduleResult.message ?? scheduleResult.error ?? "Guard update was not scheduled.");
-      }
-      setUpdatePhase("reconnecting");
-      const redirected = await waitForReconnect(expectedPreviousVersion, expectedLatestVersion);
-      if (!redirected) {
-        window.location.reload();
-      }
-    } catch {
-      setUpdatePhase("error");
+    await scheduleAndWait({
+      expectedPreviousVersion: updateStatus.current_version,
+      expectedLatestVersion: updateStatus.latest_version
+    });
+  }, [scheduleAndWait, updateStatus]);
+  const onReinstallGuard = reactExports.useCallback(async () => {
+    if (!updateStatus?.recovery_reinstall_available) {
+      return;
     }
-  }, [updateStatus, waitForReconnect]);
+    await scheduleAndWait({
+      forcePypiReinstall: true,
+      expectedPreviousVersion: "",
+      expectedLatestVersion: null
+    });
+  }, [scheduleAndWait, updateStatus]);
   return {
     guardVersion: updateStatus?.current_version ?? null,
     updateStatus,
     updatePhase,
     onUpdateGuard,
+    onReinstallGuard,
     refreshUpdateStatus
   };
 }
@@ -16411,7 +16470,8 @@ function ShellSidebar(props) {
             guardVersion: props.guardVersion,
             updateStatus: props.updateStatus,
             updatePhase: props.updatePhase,
-            onUpdateGuard: props.onUpdateGuard
+            onUpdateGuard: props.onUpdateGuard,
+            onReinstallGuard: props.onReinstallGuard
           }
         )
       ] }) }) : /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col items-center gap-2", children: [
@@ -19667,6 +19727,18 @@ function ActionResultPanel({ completed, onDismiss }) {
     }
   );
 }
+const PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE = "Your browser blocked the Guard Cloud sign-in window. Use the manual sign-in link below.";
+function openPackageFirewallAuthorizeWindow(authorizeUrl) {
+  if (!authorizeUrl || typeof window === "undefined") {
+    return false;
+  }
+  const popup = window.open(authorizeUrl, "_blank");
+  if (popup) {
+    popup.opener = null;
+    return true;
+  }
+  return false;
+}
 function FiShare2(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 24 24", "fill": "none", "stroke": "currentColor", "strokeWidth": "2", "strokeLinecap": "round", "strokeLinejoin": "round" }, "child": [{ "tag": "circle", "attr": { "cx": "18", "cy": "5", "r": "3" }, "child": [] }, { "tag": "circle", "attr": { "cx": "6", "cy": "12", "r": "3" }, "child": [] }, { "tag": "circle", "attr": { "cx": "18", "cy": "19", "r": "3" }, "child": [] }, { "tag": "line", "attr": { "x1": "8.59", "y1": "13.51", "x2": "15.42", "y2": "17.49" }, "child": [] }, { "tag": "line", "attr": { "x1": "15.41", "y1": "6.51", "x2": "8.59", "y2": "10.49" }, "child": [] }] })(props);
 }
@@ -19918,6 +19990,9 @@ function EvidenceInsightsShareModal({
     try {
       const status = await startGuardCloudConnect();
       setConnectFlow(status.connect_flow);
+      if (status.connect_flow?.authorize_url && !openPackageFirewallAuthorizeWindow(status.connect_flow.authorize_url)) {
+        setConnectError(PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE);
+      }
       if (!status.connect_required) {
         await refreshConnectState();
       }
@@ -24140,7 +24215,8 @@ function ApprovalCenterLayout(props) {
     guardVersion,
     updateStatus,
     updatePhase,
-    onUpdateGuard
+    onUpdateGuard,
+    onReinstallGuard
   } = useGuardUpdate({ onReconnected: props.onGuardReconnected });
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-h-screen bg-white text-brand-dark", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -24153,7 +24229,8 @@ function ApprovalCenterLayout(props) {
         guardVersion,
         updateStatus,
         updatePhase,
-        onUpdateGuard
+        onUpdateGuard,
+        onReinstallGuard
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -24166,7 +24243,8 @@ function ApprovalCenterLayout(props) {
         guardVersion,
         updateStatus,
         updatePhase,
-        onUpdateGuard
+        onUpdateGuard,
+        onReinstallGuard
       }
     ),
     mobileQueueOpen && props.view === "inbox" && props.requests.kind === "ready" && /* @__PURE__ */ jsxRuntimeExports.jsx(
@@ -26586,7 +26664,7 @@ export {
   fetchRuntimeSnapshot as Z,
   updateSettings as _,
   EvidenceActivityHeatmapMini as a,
-  HiMiniCloudArrowDown as a$,
+  readString$1 as a$,
   clearReviewQueue as a0,
   revokeApprovalGateCooldown as a1,
   disableApprovalGateTotp as a2,
@@ -26601,29 +26679,29 @@ export {
   WorkspacePageHeader as aB,
   __vitePreload as aC,
   scopeLabel as aD,
-  HiMiniCloudArrowUp as aE,
-  createCloudExceptionRequest as aF,
-  policyActionLabel as aG,
-  fetchCloudExceptions as aH,
-  fetchCloudExceptionRequests as aI,
-  guardAwareHref as aJ,
-  HiMiniCube as aK,
-  HiMiniDocumentText as aL,
-  HiMiniGlobeAlt as aM,
-  Surface as aN,
-  HiMiniArrowTopRightOnSquare as aO,
-  HiMiniCheckBadge as aP,
-  isSupplyChainAuditIncomplete as aQ,
-  readString$1 as aR,
-  isRecord$2 as aS,
-  HiMiniClock as aT,
-  IconActionButton as aU,
+  HiMiniDocumentText as aE,
+  HiMiniCloudArrowUp as aF,
+  HiMiniCheck as aG,
+  createCloudExceptionRequest as aH,
+  HiMiniFolder as aI,
+  HiMiniPuzzlePiece as aJ,
+  HiMiniGlobeAlt as aK,
+  policyActionLabel as aL,
+  fetchCloudExceptions as aM,
+  fetchCloudExceptionRequests as aN,
+  HiMiniClipboardDocument as aO,
+  guardAwareHref as aP,
+  HiMiniCube as aQ,
+  HiMiniUsers as aR,
+  HiMiniQueueList as aS,
+  HiMiniNoSymbol as aT,
+  HiMiniArrowRight as aU,
   HiMiniBeaker as aV,
-  ActivationSummary as aW,
-  ActionResultPanel as aX,
-  HiMiniBugAnt as aY,
-  GuardModalLayer as aZ,
-  ConnectFlowCard as a_,
+  HiMiniPlay as aW,
+  Surface as aX,
+  HiMiniArrowTopRightOnSquare as aY,
+  HiMiniCheckBadge as aZ,
+  isSupplyChainAuditIncomplete as a_,
   resetSettings as aa,
   setupDesktopNotifications as ab,
   Tag as ac,
@@ -26651,26 +26729,36 @@ export {
   clearLabelForScope as ay,
   formatHarnessCommand as az,
   EmptyState as b,
-  fetchPackageFirewallStatus as b0,
-  runPackageAudit as b1,
-  resolveSupplyChainAuditFailure as b2,
-  runPackageSync as b3,
-  startPackageFirewallConnect as b4,
-  runPackageFirewallAction as b5,
-  parseInterceptProofSnapshot as b6,
-  openPackageFirewallShell as b7,
-  EntitlementNotice as b8,
-  fetchSupplyChainBundle as b9,
-  HiMiniDocumentMagnifyingGlass as ba,
-  HiMiniShieldExclamation as bb,
-  HiMiniComputerDesktop as bc,
-  HiMiniArrowDown as bd,
-  HiMiniArrowUp as be,
-  HiMiniArrowRight as bf,
-  HiMiniInformationCircle as bg,
-  fetchReceipts as bh,
-  runAuditRemediation as bi,
-  HiMiniSignal as bj,
+  isRecord$2 as b0,
+  HiMiniClock as b1,
+  IconActionButton as b2,
+  ActivationSummary as b3,
+  ActionResultPanel as b4,
+  HiMiniBugAnt as b5,
+  GuardModalLayer as b6,
+  ConnectFlowCard as b7,
+  HiMiniCloudArrowDown as b8,
+  fetchPackageFirewallStatus as b9,
+  runPackageAudit as ba,
+  resolveSupplyChainAuditFailure as bb,
+  runPackageSync as bc,
+  startPackageFirewallConnect as bd,
+  openPackageFirewallAuthorizeWindow as be,
+  PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE as bf,
+  runPackageFirewallAction as bg,
+  parseInterceptProofSnapshot as bh,
+  openPackageFirewallShell as bi,
+  EntitlementNotice as bj,
+  fetchSupplyChainBundle as bk,
+  HiMiniDocumentMagnifyingGlass as bl,
+  HiMiniShieldExclamation as bm,
+  HiMiniComputerDesktop as bn,
+  HiMiniArrowDown as bo,
+  HiMiniArrowUp as bp,
+  HiMiniInformationCircle as bq,
+  fetchReceipts as br,
+  runAuditRemediation as bs,
+  HiMiniSignal as bt,
   EvidenceInsightsShareModal as c,
   HiMiniCheckCircle as d,
   GuardHero as e,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -11,7 +11,6 @@
       --tw-skew-x: initial;
       --tw-skew-y: initial;
       --tw-space-y-reverse: 0;
-      --tw-space-x-reverse: 0;
       --tw-divide-y-reverse: 0;
       --tw-border-style: solid;
       --tw-gradient-position: initial;
@@ -1615,6 +1614,10 @@
     margin-block-end: calc(calc(var(--spacing) * 20) * calc(1 - var(--tw-space-y-reverse)));
   }
 
+  .gap-x-2 {
+    column-gap: calc(var(--spacing) * 2);
+  }
+
   .gap-x-3 {
     column-gap: calc(var(--spacing) * 3);
   }
@@ -1627,12 +1630,6 @@
     column-gap: calc(var(--spacing) * 8);
   }
 
-  :where(.-space-x-2 > :not(:last-child)) {
-    --tw-space-x-reverse: 0;
-    margin-inline-start: calc(calc(var(--spacing) * -2) * var(--tw-space-x-reverse));
-    margin-inline-end: calc(calc(var(--spacing) * -2) * calc(1 - var(--tw-space-x-reverse)));
-  }
-
   .gap-y-0\.5 {
     row-gap: calc(var(--spacing) * .5);
   }
@@ -1643,10 +1640,6 @@
 
   .gap-y-2 {
     row-gap: calc(var(--spacing) * 2);
-  }
-
-  .gap-y-3 {
-    row-gap: calc(var(--spacing) * 3);
   }
 
   .gap-y-4 {
@@ -1826,10 +1819,6 @@
     .border-accent\/20 {
       border-color: color-mix(in oklab, hsl(var(--accent)) 20%, transparent);
     }
-  }
-
-  .border-amber-100 {
-    border-color: var(--color-amber-100);
   }
 
   .border-amber-200 {
@@ -2308,13 +2297,13 @@
     background-color: var(--color-amber-50);
   }
 
-  .bg-amber-50\/40 {
-    background-color: #fffbeb66;
+  .bg-amber-50\/30 {
+    background-color: #fffbeb4d;
   }
 
   @supports (color: color-mix(in lab, red, red)) {
-    .bg-amber-50\/40 {
-      background-color: color-mix(in oklab, var(--color-amber-50) 40%, transparent);
+    .bg-amber-50\/30 {
+      background-color: color-mix(in oklab, var(--color-amber-50) 30%, transparent);
     }
   }
 
@@ -4630,6 +4619,10 @@
     scrollbar-gutter: stable;
   }
 
+  .ring-inset {
+    --tw-ring-inset: inset;
+  }
+
   .group-open\:rotate-90:is(:where(.group):is([open], :popover-open, :open) *) {
     rotate: 90deg;
   }
@@ -4658,6 +4651,10 @@
     color: var(--color-slate-400);
   }
 
+  .first\:pt-0:first-child {
+    padding-top: calc(var(--spacing) * 0);
+  }
+
   .last\:mb-0:last-child {
     margin-bottom: calc(var(--spacing) * 0);
   }
@@ -4672,6 +4669,10 @@
     border-bottom-width: 0;
   }
 
+  .last\:pb-0:last-child {
+    padding-bottom: calc(var(--spacing) * 0);
+  }
+
   @media (hover: hover) {
     .hover\:-translate-y-0\.5:hover {
       --tw-translate-y: calc(var(--spacing) * -.5);
@@ -4680,16 +4681,6 @@
 
     .hover\:border-amber-300:hover {
       border-color: var(--color-amber-300);
-    }
-
-    .hover\:border-brand-blue\/20:hover {
-      border-color: var(--brand-blue);
-    }
-
-    @supports (color: color-mix(in lab, red, red)) {
-      .hover\:border-brand-blue\/20:hover {
-        border-color: color-mix(in oklab, var(--brand-blue) 20%, transparent);
-      }
     }
 
     .hover\:border-brand-blue\/30:hover {
@@ -4815,16 +4806,6 @@
     @supports (color: color-mix(in lab, red, red)) {
       .hover\:bg-brand-blue\/90:hover {
         background-color: color-mix(in oklab, var(--brand-blue) 90%, transparent);
-      }
-    }
-
-    .hover\:bg-brand-blue\/\[0\.02\]:hover {
-      background-color: var(--brand-blue);
-    }
-
-    @supports (color: color-mix(in lab, red, red)) {
-      .hover\:bg-brand-blue\/\[0\.02\]:hover {
-        background-color: color-mix(in oklab, var(--brand-blue) 2%, transparent);
       }
     }
 
@@ -5581,6 +5562,10 @@
   }
 
   @media (min-width: 48rem) {
+    .md\:col-span-8 {
+      grid-column: span 8 / span 8;
+    }
+
     .md\:col-start-1 {
       grid-column-start: 1;
     }
@@ -5609,6 +5594,14 @@
       grid-column-start: 7;
     }
 
+    .md\:col-start-8 {
+      grid-column-start: 8;
+    }
+
+    .md\:col-start-9 {
+      grid-column-start: 9;
+    }
+
     .md\:block {
       display: block;
     }
@@ -5629,6 +5622,10 @@
       display: table-cell;
     }
 
+    .md\:max-w-md {
+      max-width: var(--container-md);
+    }
+
     .md\:max-w-sm {
       max-width: var(--container-sm);
     }
@@ -5645,8 +5642,12 @@
       grid-template-columns: repeat(4, minmax(0, 1fr));
     }
 
-    .md\:grid-cols-\[72px_minmax\(220px\,1\.4fr\)_100px_96px_88px_104px_minmax\(120px\,1fr\)\] {
-      grid-template-columns: 72px minmax(220px, 1.4fr) 100px 96px 88px 104px minmax(120px, 1fr);
+    .md\:grid-cols-\[40px_72px_minmax\(200px\,1\.4fr\)_88px_96px_88px_104px_minmax\(120px\,1fr\)_72px\] {
+      grid-template-columns: 40px 72px minmax(200px, 1.4fr) 88px 96px 88px 104px minmax(120px, 1fr) 72px;
+    }
+
+    .md\:grid-cols-\[72px_minmax\(140px\,1\.3fr\)_88px_72px_36px_36px_88px_80px_72px\] {
+      grid-template-columns: 72px minmax(140px, 1.3fr) 88px 72px 36px 36px 88px 80px 72px;
     }
 
     .md\:grid-cols-\[180px_minmax\(0\,1fr\)\] {
@@ -5665,12 +5666,20 @@
       align-items: center;
     }
 
-    .md\:items-end {
-      align-items: flex-end;
-    }
-
     .md\:items-start {
       align-items: flex-start;
+    }
+
+    .md\:justify-center {
+      justify-content: center;
+    }
+
+    .md\:gap-1 {
+      gap: calc(var(--spacing) * 1);
+    }
+
+    .md\:gap-x-2 {
+      column-gap: calc(var(--spacing) * 2);
     }
 
     .md\:gap-x-3 {
@@ -5693,6 +5702,22 @@
 
     .lg\:col-span-2 {
       grid-column: span 2 / span 2;
+    }
+
+    .lg\:col-span-3 {
+      grid-column: span 3 / span 3;
+    }
+
+    .lg\:col-start-1 {
+      grid-column-start: 1;
+    }
+
+    .lg\:col-start-2 {
+      grid-column-start: 2;
+    }
+
+    .lg\:col-start-3 {
+      grid-column-start: 3;
     }
 
     .lg\:block {
@@ -5769,10 +5794,6 @@
 
     .lg\:grid-cols-\[minmax\(0\,1fr\)_300px\] {
       grid-template-columns: minmax(0, 1fr) 300px;
-    }
-
-    .lg\:grid-cols-\[minmax\(0\,1fr\)_320px\] {
-      grid-template-columns: minmax(0, 1fr) 320px;
     }
 
     .lg\:grid-cols-\[minmax\(0\,1fr\)_340px\] {
@@ -6370,12 +6391,6 @@ input:focus-visible, button:focus-visible, a:focus-visible {
 }
 
 @property --tw-space-y-reverse {
-  syntax: "*";
-  inherits: false;
-  initial-value: 0;
-}
-
-@property --tw-space-x-reverse {
   syntax: "*";
   inherits: false;
   initial-value: 0;


### PR DESCRIPTION
## Summary
- Align Cloud exceptions list and detail panels with the policy mockup: effect labels, scope paths, source review links, expiry timeline, and ack-driven badges.
- Restructure the request cloud exception wizard with source receipt summary, three-column Scope step (scope fields, reason, expiry, optional ticket/max uses), and result preview.

## Testing
- `cd dashboard && npm run build`
- `tsx src/policy-cloud-exceptions-utils.test.ts`
- `tsx src/policy-cloud-exception-request-ia.test.ts`

## Notes
- Built dashboard assets included under `src/codex_plugin_scanner/guard/daemon/static/`.
