### PR TITLE
fix(supply-chain): surface linked advisory aliases in package workbench

### DIFF
--- a/dashboard/src/package-workbench-panel.tsx
+++ b/dashboard/src/package-workbench-panel.tsx
@@ -136,9 +136,11 @@ function FindingDetailPanel({ finding }: FindingDetailPanelProps) {
             </span>
           ))}
         </div>
-        <p className="mt-2 text-[11px] text-slate-500">
-          CVE and GHSA aliases are stubbed here until linked advisory intel is available in Guard Cloud.
-        </p>
+        {finding.advisoryAliases.length === 0 ? (
+          <p className="mt-2 text-[11px] text-slate-500">
+            No linked CVE or GHSA aliases for this finding.
+          </p>
+        ) : null}
       </div>
     </div>
   );

--- a/dashboard/src/scsr-phase10-package-workbench.test.ts
+++ b/dashboard/src/scsr-phase10-package-workbench.test.ts
@@ -101,7 +101,7 @@ const camelCaseAliases = normalizeSupplyChainAuditSnapshot({
 const lodashFinding = camelCaseAliases?.findings.find((finding) => finding.packageName === "lodash");
 assert(lodashFinding !== undefined, "SCSR173-B: camelCase advisory ids normalize");
 assert(
-  lodashFinding!.advisoryAliases.includes("GHSA-xx99-yy88-zz77"),
+  lodashFinding!.advisoryAliases.includes("GHSA-XX99-YY88-ZZ77"),
   "SCSR173-B: relatedAdvisoryIds preserved",
 );
 assert(
@@ -128,7 +128,7 @@ const cloudAdvisoryIds = normalizeSupplyChainAuditSnapshot({
 const cloudFinding = cloudAdvisoryIds?.findings.find((finding) => finding.packageName === "minimist");
 assert(cloudFinding !== undefined, "SCSR173-C: cloud advisoryIds normalize");
 assert(
-  cloudFinding!.advisoryAliases.includes("GHSA-vh95-rmgr-6w4w"),
+  cloudFinding!.advisoryAliases.includes("GHSA-VH95-RMGR-6W4W"),
   "SCSR173-C: cloud advisoryIds surface as aliases",
 );
 

--- a/dashboard/src/scsr-phase10-package-workbench.test.ts
+++ b/dashboard/src/scsr-phase10-package-workbench.test.ts
@@ -109,6 +109,55 @@ assert(
   "SCSR173-B: reason advisoryId preserved",
 );
 
+const cloudAdvisoryIds = normalizeSupplyChainAuditSnapshot({
+  generated_at: "2026-06-09T12:00:00.000Z",
+  source: "cloud",
+  evaluation: {
+    decision: "block",
+    packages: [
+      {
+        name: "minimist",
+        ecosystem: "npm",
+        decision: "block",
+        advisoryIds: ["GHSA-vh95-rmgr-6w4w"],
+        reasons: [{ code: "known_malware", message: "Known malware", severity: "critical" }],
+      },
+    ],
+  },
+});
+const cloudFinding = cloudAdvisoryIds?.findings.find((finding) => finding.packageName === "minimist");
+assert(cloudFinding !== undefined, "SCSR173-C: cloud advisoryIds normalize");
+assert(
+  cloudFinding!.advisoryAliases.includes("GHSA-vh95-rmgr-6w4w"),
+  "SCSR173-C: cloud advisoryIds surface as aliases",
+);
+
+const enrichedAliases = normalizeSupplyChainAuditSnapshot({
+  generated_at: "2026-06-09T12:00:00.000Z",
+  evaluation: {
+    decision: "block",
+    packages: [
+      {
+        name: "lodash",
+        ecosystem: "npm",
+        decision: "block",
+        advisoryAliases: ["GHSA-xx99-yy88-zz77", "CVE-2024-12345"],
+        reasons: [],
+      },
+    ],
+  },
+});
+const enrichedFinding = enrichedAliases?.findings.find((finding) => finding.packageName === "lodash");
+assert(enrichedFinding !== undefined, "SCSR173-D: backend advisoryAliases normalize");
+assert(
+  enrichedFinding!.advisoryAliases.includes("CVE-2024-12345"),
+  "SCSR173-D: backend advisoryAliases preserved",
+);
+assert(
+  !enrichedFinding!.advisoryAliases.some((alias) => alias.includes("pending")),
+  "SCSR173-D: pending alias stubs are not emitted",
+);
+
 const receipt: GuardReceipt = {
   receipt_id: "receipt-audit-1",
   harness: "package-firewall",

--- a/dashboard/src/supply-chain-audit-normalize.ts
+++ b/dashboard/src/supply-chain-audit-normalize.ts
@@ -146,11 +146,14 @@ function addAdvisoryAlias(aliases: Set<string>, rawId: string): void {
   if (trimmed.length === 0) {
     return;
   }
-  if (trimmed.startsWith("GHSA-") || trimmed.startsWith("CVE-")) {
+  if (
+    trimmed.startsWith("GHSA-") ||
+    trimmed.startsWith("CVE-") ||
+    trimmed.startsWith("PYSEC-") ||
+    trimmed.startsWith("GO-")
+  ) {
     aliases.add(trimmed);
-    return;
   }
-  aliases.add(`GHSA-${trimmed.slice(0, 8).toLowerCase()}`);
 }
 
 function readAdvisoryIdList(value: unknown): string[] {
@@ -162,20 +165,41 @@ function readAdvisoryIdList(value: unknown): string[] {
     .map((entry) => entry.trim());
 }
 
-function buildAdvisoryAliasStubs(
+function buildAdvisoryAliases(
   packageRecord: Record<string, unknown>,
   reasons: SupplyChainAuditFindingReason[],
 ): string[] {
+  const precomputed = readAdvisoryIdList(packageRecord.advisoryAliases).concat(
+    readAdvisoryIdList(packageRecord.advisory_aliases),
+  );
+  if (precomputed.length > 0) {
+    return Array.from(new Set(precomputed));
+  }
+
   const aliases = new Set<string>();
   const packageAdvisoryId = readString(packageRecord.advisoryId) ?? readString(packageRecord.advisory_id);
   if (packageAdvisoryId !== null) {
     addAdvisoryAlias(aliases, packageAdvisoryId);
   }
   for (const entry of [
+    ...readAdvisoryIdList(packageRecord.advisoryIds),
+    ...readAdvisoryIdList(packageRecord.advisory_ids),
     ...readAdvisoryIdList(packageRecord.related_advisory_ids),
     ...readAdvisoryIdList(packageRecord.relatedAdvisoryIds),
   ]) {
     addAdvisoryAlias(aliases, entry);
+  }
+  const rawReasons = packageRecord.reasons;
+  if (Array.isArray(rawReasons)) {
+    for (const entry of rawReasons) {
+      if (!isRecord(entry)) {
+        continue;
+      }
+      const advisoryId = readString(entry.advisoryId) ?? readString(entry.advisory_id);
+      if (advisoryId !== null) {
+        addAdvisoryAlias(aliases, advisoryId);
+      }
+    }
   }
   for (const reason of reasons) {
     const match = reason.message.match(/\b(CVE-\d{4}-\d+)\b/i);
@@ -185,13 +209,6 @@ function buildAdvisoryAliasStubs(
     const ghsaMatch = reason.message.match(/\b(GHSA-[a-z0-9]{4}-[a-z0-9]{4}-[a-z0-9]{4})\b/i);
     if (ghsaMatch !== null) {
       aliases.add(ghsaMatch[1].toUpperCase());
-    }
-  }
-  if (aliases.size === 0) {
-    const severity = resolveFindingSeverity(packageRecord, reasons);
-    if (SEVERITY_RANK[severity] >= SEVERITY_RANK.medium) {
-      aliases.add("GHSA-alias-pending");
-      aliases.add("CVE-alias-pending");
     }
   }
   return Array.from(aliases);
@@ -219,7 +236,7 @@ function normalizePackageFinding(
     decision,
     severity,
     reasons,
-    advisoryAliases: buildAdvisoryAliasStubs(packageRecord, reasons),
+    advisoryAliases: buildAdvisoryAliases(packageRecord, reasons),
     status: readString(packageRecord.status),
   };
 }

--- a/dashboard/src/supply-chain-audit-normalize.ts
+++ b/dashboard/src/supply-chain-audit-normalize.ts
@@ -146,13 +146,14 @@ function addAdvisoryAlias(aliases: Set<string>, rawId: string): void {
   if (trimmed.length === 0) {
     return;
   }
+  const upper = trimmed.toUpperCase();
   if (
-    trimmed.startsWith("GHSA-") ||
-    trimmed.startsWith("CVE-") ||
-    trimmed.startsWith("PYSEC-") ||
-    trimmed.startsWith("GO-")
+    upper.startsWith("GHSA-") ||
+    upper.startsWith("CVE-") ||
+    upper.startsWith("PYSEC-") ||
+    upper.startsWith("GO-")
   ) {
-    aliases.add(trimmed);
+    aliases.add(upper);
   }
 }
 
@@ -173,7 +174,11 @@ function buildAdvisoryAliases(
     readAdvisoryIdList(packageRecord.advisory_aliases),
   );
   if (precomputed.length > 0) {
-    return Array.from(new Set(precomputed));
+    const normalized = new Set<string>();
+    for (const id of precomputed) {
+      addAdvisoryAlias(normalized, id);
+    }
+    return Array.from(normalized);
   }
 
   const aliases = new Set<string>();

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2313,6 +2313,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             result=result,
             managers=managers,
             workspace_dir=context.workspace_dir,
+            store=self.server.store,  # type: ignore[attr-defined]
         )
         receipt = self._record_headless_receipt(
             harness="package-firewall",

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -493,10 +493,127 @@ def _audit_lockfile_warnings(
     return tuple(warnings)
 
 
+def _package_advisory_ids(package: dict[str, object]) -> list[str]:
+    advisory_ids: list[str] = []
+    seen: set[str] = set()
+
+    def add_id(value: object) -> None:
+        if not isinstance(value, str):
+            return
+        trimmed = value.strip()
+        if not trimmed or trimmed in seen:
+            return
+        seen.add(trimmed)
+        advisory_ids.append(trimmed)
+
+    for key in ("advisoryIds", "advisory_ids", "relatedAdvisoryIds", "related_advisory_ids"):
+        raw = package.get(key)
+        if isinstance(raw, list):
+            for entry in raw:
+                add_id(entry)
+    add_id(package.get("advisoryId"))
+    add_id(package.get("advisory_id"))
+    reasons = package.get("reasons")
+    if isinstance(reasons, list):
+        for reason in reasons:
+            if not isinstance(reason, dict):
+                continue
+            add_id(reason.get("advisoryId"))
+            add_id(reason.get("advisory_id"))
+    return advisory_ids
+
+
+def _resolve_advisory_aliases_from_bundle(
+    bundle: dict[str, object] | None,
+    advisory_ids: list[str],
+) -> list[str]:
+    aliases: list[str] = []
+    seen: set[str] = set()
+    lookup: dict[str, tuple[str, ...]] = {}
+    if isinstance(bundle, dict):
+        advisories = bundle.get("advisories")
+        if isinstance(advisories, list):
+            for advisory in advisories:
+                if not isinstance(advisory, dict):
+                    continue
+                advisory_id = advisory.get("advisoryId")
+                if not isinstance(advisory_id, str) or not advisory_id.strip():
+                    continue
+                raw_aliases = advisory.get("aliases")
+                alias_tuple: tuple[str, ...] = (advisory_id,)
+                if isinstance(raw_aliases, list):
+                    alias_tuple = (
+                        advisory_id,
+                        *[alias for alias in raw_aliases if isinstance(alias, str) and alias.strip()],
+                    )
+                lookup[advisory_id] = alias_tuple
+                for alias in alias_tuple:
+                    lookup.setdefault(alias, alias_tuple)
+
+    def add_alias(value: str) -> None:
+        trimmed = value.strip()
+        if not trimmed or trimmed in seen:
+            return
+        seen.add(trimmed)
+        aliases.append(trimmed)
+
+    for advisory_id in advisory_ids:
+        add_alias(advisory_id)
+        resolved = lookup.get(advisory_id)
+        if resolved is None:
+            continue
+        for alias in resolved:
+            add_alias(alias)
+    return aliases
+
+
+def _enrich_package_with_advisory_aliases(
+    package: dict[str, object],
+    *,
+    bundle: dict[str, object] | None,
+) -> dict[str, object]:
+    existing_aliases = package.get("advisoryAliases")
+    if isinstance(existing_aliases, list) and existing_aliases:
+        return package
+    advisory_ids = _package_advisory_ids(package)
+    if not advisory_ids:
+        return package
+    aliases = _resolve_advisory_aliases_from_bundle(bundle, advisory_ids)
+    if not aliases:
+        return package
+    enriched = dict(package)
+    enriched["advisoryAliases"] = aliases
+    return enriched
+
+
+def _enrich_evaluation_packages_with_advisory_aliases(
+    evaluation: dict[str, object],
+    store: GuardStore,
+) -> dict[str, object]:
+    packages = evaluation.get("packages")
+    if not isinstance(packages, list):
+        return evaluation
+    workspace_id = store.get_cloud_workspace_id()
+    bundle: dict[str, object] | None = None
+    if workspace_id is not None:
+        cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
+        if isinstance(cached_bundle, dict):
+            bundle_payload = cached_bundle.get("bundle")
+            if isinstance(bundle_payload, dict):
+                bundle = bundle_payload
+    enriched_packages: list[dict[str, object]] = []
+    for package in packages:
+        if not isinstance(package, dict):
+            continue
+        enriched_packages.append(_enrich_package_with_advisory_aliases(package, bundle=bundle))
+    return {**evaluation, "packages": enriched_packages}
+
+
 def _audit_package_findings_for_receipt(
     package_items: list[dict[str, object]],
     *,
     limit: int = 100,
+    bundle: dict[str, object] | None = None,
 ) -> list[dict[str, object]]:
     decision_rank_map = {"block": 4, "ask": 3, "warn": 2, "monitor": 1, "allow": 0}
     ranked: list[tuple[int, int, dict[str, object]]] = []
@@ -508,7 +625,10 @@ def _audit_package_findings_for_receipt(
         decision_rank = decision_rank_map.get(decision, 0)
         ranked.append((decision_rank, severity_rank, item))
     ranked.sort(key=lambda entry: (entry[0], entry[1]), reverse=True)
-    return [item for _, _, item in ranked[:limit]]
+    return [
+        _enrich_package_with_advisory_aliases(item, bundle=bundle)
+        for _, _, item in ranked[:limit]
+    ]
 
 
 def workspace_audit_path_hashes(
@@ -591,6 +711,7 @@ def audit_receipt_metadata(
     result: dict[str, object],
     *,
     workspace_dir: Path | None = None,
+    store: GuardStore | None = None,
 ) -> dict[str, object]:
     evaluation = result.get("evaluation")
     if not isinstance(evaluation, dict):
@@ -599,7 +720,16 @@ def audit_receipt_metadata(
     packages = evaluation.get("packages")
     package_items = [item for item in packages if isinstance(item, dict)] if isinstance(packages, list) else []
     blocked_packages = [item for item in package_items if str(item.get("decision") or "") == "block"]
-    package_findings = _audit_package_findings_for_receipt(package_items)
+    bundle: dict[str, object] | None = None
+    if store is not None:
+        workspace_id = store.get_cloud_workspace_id()
+        if workspace_id is not None:
+            cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
+            if isinstance(cached_bundle, dict):
+                bundle_payload = cached_bundle.get("bundle")
+                if isinstance(bundle_payload, dict):
+                    bundle = bundle_payload
+    package_findings = _audit_package_findings_for_receipt(package_items, bundle=bundle)
     policy_decision = "allow"
     if decision == "block":
         policy_decision = "block"
@@ -753,6 +883,7 @@ def build_workspace_audit_payload(
             command_name=command_name,
             now=now,
         )
+    evaluation = _enrich_evaluation_packages_with_advisory_aliases(evaluation, store)
     payload = {
         "generated_at": now,
         "mode": command_name,

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -523,6 +523,19 @@ def _package_advisory_ids(package: dict[str, object]) -> list[str]:
     return advisory_ids
 
 
+def _cached_supply_chain_bundle_payload(store: GuardStore) -> dict[str, object] | None:
+    workspace_id = store.get_cloud_workspace_id()
+    if workspace_id is None:
+        return None
+    cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
+    if not isinstance(cached_bundle, dict):
+        return None
+    bundle_payload = cached_bundle.get("bundle")
+    if isinstance(bundle_payload, dict):
+        return bundle_payload
+    return None
+
+
 def _resolve_advisory_aliases_from_bundle(
     bundle: dict[str, object] | None,
     advisory_ids: list[str],
@@ -546,12 +559,13 @@ def _resolve_advisory_aliases_from_bundle(
                         advisory_id,
                         *[alias for alias in raw_aliases if isinstance(alias, str) and alias.strip()],
                     )
-                lookup[advisory_id] = alias_tuple
+                upper_tuple = tuple(alias.upper() for alias in alias_tuple)
+                lookup[advisory_id.upper()] = upper_tuple
                 for alias in alias_tuple:
-                    lookup.setdefault(alias, alias_tuple)
+                    lookup.setdefault(alias.upper(), upper_tuple)
 
     def add_alias(value: str) -> None:
-        trimmed = value.strip()
+        trimmed = value.strip().upper()
         if not trimmed or trimmed in seen:
             return
         seen.add(trimmed)
@@ -559,7 +573,7 @@ def _resolve_advisory_aliases_from_bundle(
 
     for advisory_id in advisory_ids:
         add_alias(advisory_id)
-        resolved = lookup.get(advisory_id)
+        resolved = lookup.get(advisory_id.upper())
         if resolved is None:
             continue
         for alias in resolved:
@@ -593,14 +607,7 @@ def _enrich_evaluation_packages_with_advisory_aliases(
     packages = evaluation.get("packages")
     if not isinstance(packages, list):
         return evaluation
-    workspace_id = store.get_cloud_workspace_id()
-    bundle: dict[str, object] | None = None
-    if workspace_id is not None:
-        cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
-        if isinstance(cached_bundle, dict):
-            bundle_payload = cached_bundle.get("bundle")
-            if isinstance(bundle_payload, dict):
-                bundle = bundle_payload
+    bundle = _cached_supply_chain_bundle_payload(store)
     enriched_packages: list[dict[str, object]] = []
     for package in packages:
         if not isinstance(package, dict):
@@ -625,10 +632,7 @@ def _audit_package_findings_for_receipt(
         decision_rank = decision_rank_map.get(decision, 0)
         ranked.append((decision_rank, severity_rank, item))
     ranked.sort(key=lambda entry: (entry[0], entry[1]), reverse=True)
-    return [
-        _enrich_package_with_advisory_aliases(item, bundle=bundle)
-        for _, _, item in ranked[:limit]
-    ]
+    return [_enrich_package_with_advisory_aliases(item, bundle=bundle) for _, _, item in ranked[:limit]]
 
 
 def workspace_audit_path_hashes(
@@ -720,15 +724,7 @@ def audit_receipt_metadata(
     packages = evaluation.get("packages")
     package_items = [item for item in packages if isinstance(item, dict)] if isinstance(packages, list) else []
     blocked_packages = [item for item in package_items if str(item.get("decision") or "") == "block"]
-    bundle: dict[str, object] | None = None
-    if store is not None:
-        workspace_id = store.get_cloud_workspace_id()
-        if workspace_id is not None:
-            cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
-            if isinstance(cached_bundle, dict):
-                bundle_payload = cached_bundle.get("bundle")
-                if isinstance(bundle_payload, dict):
-                    bundle = bundle_payload
+    bundle = _cached_supply_chain_bundle_payload(store) if store is not None else None
     package_findings = _audit_package_findings_for_receipt(package_items, bundle=bundle)
     policy_decision = "allow"
     if decision == "block":

--- a/src/codex_plugin_scanner/guard/package_firewall_receipts.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_receipts.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from .local_supply_chain import audit_receipt_metadata
+from .store import GuardStore
 
 
 def _read_string_list(value: object) -> list[str]:
@@ -78,12 +79,13 @@ def package_firewall_receipt_metadata(
     result: dict[str, object],
     managers: tuple[str, ...] | None = None,
     workspace_dir: Path | None = None,
+    store: GuardStore | None = None,
 ) -> dict[str, object]:
     """Build receipt override fields for package-firewall headless operations."""
 
     manager_subset = _resolve_manager_subset(managers, result, operation)
     if operation == "audit":
-        metadata = audit_receipt_metadata(result, workspace_dir=workspace_dir)
+        metadata = audit_receipt_metadata(result, workspace_dir=workspace_dir, store=store)
         scanner_evidence = metadata.get("scanner_evidence")
         if isinstance(scanner_evidence, dict):
             enriched = dict(scanner_evidence)

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1135,13 +1135,14 @@ def _bundle_advisory_aliases(
     advisory_lookup: dict[str, tuple[str, ...]] = {}
     for advisory in bundle_response.bundle.advisories:
         alias_tuple = (advisory.advisory_id, *advisory.aliases)
-        advisory_lookup[advisory.advisory_id] = alias_tuple
+        upper_tuple = tuple(alias.upper() for alias in alias_tuple)
+        advisory_lookup[advisory.advisory_id.upper()] = upper_tuple
         for alias in alias_tuple:
-            advisory_lookup.setdefault(alias, alias_tuple)
+            advisory_lookup.setdefault(alias.upper(), upper_tuple)
     aliases: list[str] = []
     seen: set[str] = set()
     for advisory_id in advisory_ids:
-        for alias in advisory_lookup.get(advisory_id, (advisory_id,)):
+        for alias in advisory_lookup.get(advisory_id.upper(), (advisory_id.upper(),)):
             if alias in seen:
                 continue
             seen.add(alias)

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1122,6 +1122,33 @@ def _primary_bundle_advisory_id(
     return package.related_advisory_ids[0]
 
 
+def _bundle_advisory_aliases(
+    bundle_response: SupplyChainBundleResponse,
+    package: SupplyChainBundlePackage,
+) -> list[str]:
+    advisory_ids = list(package.related_advisory_ids)
+    primary_id = _primary_bundle_advisory_id(bundle_response, package)
+    if primary_id is not None and primary_id not in advisory_ids:
+        advisory_ids.append(primary_id)
+    if not advisory_ids:
+        return []
+    advisory_lookup: dict[str, tuple[str, ...]] = {}
+    for advisory in bundle_response.bundle.advisories:
+        alias_tuple = (advisory.advisory_id, *advisory.aliases)
+        advisory_lookup[advisory.advisory_id] = alias_tuple
+        for alias in alias_tuple:
+            advisory_lookup.setdefault(alias, alias_tuple)
+    aliases: list[str] = []
+    seen: set[str] = set()
+    for advisory_id in advisory_ids:
+        for alias in advisory_lookup.get(advisory_id, (advisory_id,)):
+            if alias in seen:
+                continue
+            seen.add(alias)
+            aliases.append(alias)
+    return aliases
+
+
 def _heuristic_result(
     *,
     artifact: GuardArtifact,
@@ -1652,7 +1679,8 @@ def _bundle_package_result(
     resolved_version: str,
 ) -> dict[str, object]:
     severity = package.normalized_severity if stale is False else "unknown"
-    return {
+    advisory_aliases = _bundle_advisory_aliases(bundle_response, package)
+    result: dict[str, object] = {
         "decision": decision,
         "ecosystem": package.ecosystem,
         "name": package.name,
@@ -1666,6 +1694,7 @@ def _bundle_package_result(
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
         "redactedCommand": _optional_string(target.get("redacted_command")),
         "alias": _optional_string(target.get("alias")),
+        "relatedAdvisoryIds": list(package.related_advisory_ids),
         "reasons": (
             {
                 "advisoryId": _primary_bundle_advisory_id(bundle_response, package),
@@ -1676,6 +1705,9 @@ def _bundle_package_result(
             },
         ),
     }
+    if advisory_aliases:
+        result["advisoryAliases"] = advisory_aliases
+    return result
 
 
 def _system_package_monitor_result(target: dict[str, object]) -> dict[str, object]:

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -669,3 +669,56 @@ def test_guard_supply_chain_scan_falls_back_when_oauth_refresh_fails(
         "code": "cloud_auth_error",
         "message": "Guard cloud authorization could not be refreshed, so Guard fell back locally.",
     }
+
+
+def test_audit_receipt_metadata_enriches_cloud_advisory_aliases_from_bundle(
+    tmp_path: Path,
+) -> None:
+    from tests.test_guard_local_supply_chain_phase15 import _bundle_response, _package
+
+    home_dir = tmp_path / "guard-home"
+    store = GuardStore(home_dir)
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "demo-token",
+        "2026-05-25T10:00:00+00:00",
+        workspace_id=WORKSPACE_ID,
+    )
+    store.cache_supply_chain_bundle(
+        WORKSPACE_ID,
+        _bundle_response(
+            packages=[
+                _package(
+                    name="minimist",
+                    version="1.2.5",
+                    default_action="block",
+                )
+            ]
+        ),
+        "2026-05-25T10:00:00+00:00",
+    )
+
+    payload = {
+        "evaluation": {
+            "decision": "block",
+            "packages": [
+                {
+                    "name": "minimist",
+                    "ecosystem": "npm",
+                    "decision": "block",
+                    "reasons": [{"code": "known_malware", "message": "known malware", "severity": "critical"}],
+                    "advisoryIds": ["GHSA-vh95-rmgr-6w4m"],
+                }
+            ],
+        },
+        "inventory": {"total_packages": 1},
+        "manifest_paths": ["package.json"],
+        "lockfile_paths": ["package-lock.json"],
+    }
+    metadata = local_supply_chain_module.audit_receipt_metadata(payload, store=store)
+    findings = metadata["scanner_evidence"]["package_findings"]
+    assert findings
+    aliases = findings[0].get("advisoryAliases")
+    assert isinstance(aliases, list)
+    assert "GHSA-vh95-rmgr-6w4m" in aliases
+    assert "CVE-2020-7598" in aliases

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -720,5 +720,5 @@ def test_audit_receipt_metadata_enriches_cloud_advisory_aliases_from_bundle(
     assert findings
     aliases = findings[0].get("advisoryAliases")
     assert isinstance(aliases, list)
-    assert "GHSA-vh95-rmgr-6w4m" in aliases
+    assert "GHSA-VH95-RMGR-6W4M" in aliases
     assert "CVE-2020-7598" in aliases

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "build"
-version = "1.4.2"
+version = "1.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "os_name == 'nt'" },
@@ -258,9 +258,9 @@ dependencies = [
     { name = "pyproject-hooks" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6c/1d/ab15c8ac57f4ee8778d7633bc6685f808ab414437b8644f555389cdc875e/build-1.4.2.tar.gz", hash = "sha256:35b14e1ee329c186d3f08466003521ed7685ec15ecffc07e68d706090bf161d1", size = 83433, upload-time = "2026-03-25T14:20:27.659Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/78/e0/df5e171f685f82f37b12e1f208064e24244911079d7b767447d1af7e0d70/build-1.5.0.tar.gz", hash = "sha256:302c22c3ba2a0fd5f3911918651341ebb3896176cbdec15bd421f80b1afc7647", size = 89796, upload-time = "2026-04-30T03:18:25.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4a/57/3b7d4dd193ade4641c865bc2b93aeeb71162e81fc348b8dad020215601ed/build-1.4.2-py3-none-any.whl", hash = "sha256:7a4d8651ea877cb2a89458b1b198f2e69f536c95e89129dbf5d448045d60db88", size = 24643, upload-time = "2026-03-25T14:20:26.568Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fe/6bea5c9162869c5beba5d9c8abbed835ec85bf1ec1fba05a3822325c45f3/build-1.5.0-py3-none-any.whl", hash = "sha256:13f3eecb844759ab66efec90ca17639bbf14dc06cb2fdf37a9010322d9c50a6f", size = 26018, upload-time = "2026-04-30T03:18:23.644Z" },
 ]
 
 [[package]]
@@ -1106,7 +1106,7 @@ publish = [
 
 [package.metadata]
 requires-dist = [
-    { name = "build", marker = "extra == 'dev'", specifier = ">=1.2.2" },
+    { name = "build", marker = "extra == 'dev'", specifier = ">=1.5.0" },
     { name = "cisco-ai-mcp-scanner", marker = "python_full_version >= '3.11' and extra == 'cisco'", specifier = "~=4.6" },
     { name = "cisco-ai-skill-scanner", specifier = "~=2.0.9" },
     { name = "cryptography", specifier = ">=47.0.0" },
@@ -1117,7 +1117,7 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.3" },
     { name = "rich", specifier = ">=13.0" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.11" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.15" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "twine", marker = "extra == 'publish'", specifier = ">=6.2.0" },
 ]
@@ -3013,27 +3013,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.11"
+version = "0.15.17"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/e4/8d/192f3d7103816158dfd5ea50d098ef2aec19194e6cbccd4b3485bdb2eb2d/ruff-0.15.11.tar.gz", hash = "sha256:f092b21708bf0e7437ce9ada249dfe688ff9a0954fc94abab05dcea7dcd29c33", size = 4637264, upload-time = "2026-04-16T18:46:26.58Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/a9/3abdf488f1bf3d24c699415e454ed554a6350d5d89ce183be1ee0a3361ac/ruff-0.15.17.tar.gz", hash = "sha256:2ec446937fd16c8c4de2674a209cc5af64d9c6f17d21fbf1151054fa0bcf5219", size = 4743346, upload-time = "2026-06-11T17:54:47.663Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/02/1e/6aca3427f751295ab011828e15e9bf452200ac74484f1db4be0197b8170b/ruff-0.15.11-py3-none-linux_armv6l.whl", hash = "sha256:e927cfff503135c558eb581a0c9792264aae9507904eb27809cdcff2f2c847b7", size = 10607943, upload-time = "2026-04-16T18:46:05.967Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/26/1341c262e74f36d4e84f3d6f4df0ac68cd53331a66bfc5080daa17c84c0b/ruff-0.15.11-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:7a1b5b2938d8f890b76084d4fa843604d787a912541eae85fd7e233398bbb73e", size = 10988592, upload-time = "2026-04-16T18:46:00.742Z" },
-    { url = "https://files.pythonhosted.org/packages/03/71/850b1d6ffa9564fbb6740429bad53df1094082fe515c8c1e74b6d8d05f18/ruff-0.15.11-py3-none-macosx_11_0_arm64.whl", hash = "sha256:d4176f3d194afbdaee6e41b9ccb1a2c287dba8700047df474abfbe773825d1cb", size = 10338501, upload-time = "2026-04-16T18:46:03.723Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/11/cc1284d3e298c45a817a6aadb6c3e1d70b45c9b36d8d9cce3387b495a03a/ruff-0.15.11-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3b17c886fb88203ced3afe7f14e8d5ae96e9d2f4ccc0ee66aa19f2c2675a27e4", size = 10670693, upload-time = "2026-04-16T18:46:41.941Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/9e/f8288b034ab72b371513c13f9a41d9ba3effac54e24bfb467b007daee2ca/ruff-0.15.11-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:49fafa220220afe7758a487b048de4c8f9f767f37dfefad46b9dd06759d003eb", size = 10416177, upload-time = "2026-04-16T18:46:21.717Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/504d79abfd3d92532ba6bbe3d1c19fada03e494332a59e37c7c2dabae427/ruff-0.15.11-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f2ab8427e74a00d93b8bda1307b1e60970d40f304af38bccb218e056c220120d", size = 11221886, upload-time = "2026-04-16T18:46:15.086Z" },
-    { url = "https://files.pythonhosted.org/packages/43/5a/947e6ab7a5ad603d65b474be15a4cbc6d29832db5d762cd142e4e3a74164/ruff-0.15.11-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:195072c0c8e1fc8f940652073df082e37a5d9cb43b4ab1e4d0566ab8977a13b7", size = 12075183, upload-time = "2026-04-16T18:46:07.944Z" },
-    { url = "https://files.pythonhosted.org/packages/9f/a1/0b7bb6268775fdd3a0818aee8efd8f5b4e231d24dd4d528ced2534023182/ruff-0.15.11-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a3a0996d486af3920dec930a2e7daed4847dfc12649b537a9335585ada163e9e", size = 11516575, upload-time = "2026-04-16T18:46:31.687Z" },
-    { url = "https://files.pythonhosted.org/packages/30/c3/bb5168fc4d233cc06e95f482770d0f3c87945a0cd9f614b90ea8dc2f2833/ruff-0.15.11-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bef2cb556d509259f1fe440bb9cd33c756222cf0a7afe90d15edf0866702431", size = 11306537, upload-time = "2026-04-16T18:46:36.988Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/92/4cfae6441f3967317946f3b788136eecf093729b94d6561f963ed810c82e/ruff-0.15.11-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:030d921a836d7d4a12cf6e8d984a88b66094ccb0e0f17ddd55067c331191bf19", size = 11296813, upload-time = "2026-04-16T18:46:24.182Z" },
-    { url = "https://files.pythonhosted.org/packages/43/26/972784c5dde8313acde8ac71ba8ac65475b85db4a2352a76c9934361f9bc/ruff-0.15.11-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:0e783b599b4577788dbbb66b9addcef87e9a8832f4ce0c19e34bf55543a2f890", size = 10633136, upload-time = "2026-04-16T18:46:39.802Z" },
-    { url = "https://files.pythonhosted.org/packages/5b/53/3985a4f185020c2f367f2e08a103032e12564829742a1b417980ce1514a0/ruff-0.15.11-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:ae90592246625ba4a34349d68ec28d4400d75182b71baa196ddb9f82db025ef5", size = 10424701, upload-time = "2026-04-16T18:46:10.381Z" },
-    { url = "https://files.pythonhosted.org/packages/d3/57/bf0dfb32241b56c83bb663a826133da4bf17f682ba8c096973065f6e6a68/ruff-0.15.11-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1f111d62e3c983ed20e0ca2e800f8d77433a5b1161947df99a5c2a3fb60514f0", size = 10873887, upload-time = "2026-04-16T18:46:29.157Z" },
-    { url = "https://files.pythonhosted.org/packages/02/05/e48076b2a57dc33ee8c7a957296f97c744ca891a8ffb4ffb1aaa3b3f517d/ruff-0.15.11-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:06f483d6646f59eaffba9ae30956370d3a886625f511a3108994000480621d1c", size = 11404316, upload-time = "2026-04-16T18:46:19.462Z" },
-    { url = "https://files.pythonhosted.org/packages/88/27/0195d15fe7a897cbcba0904792c4b7c9fdd958456c3a17d2ea6093716a9a/ruff-0.15.11-py3-none-win32.whl", hash = "sha256:476a2aa56b7da0b73a3ee80b6b2f0e19cce544245479adde7baa65466664d5f3", size = 10655535, upload-time = "2026-04-16T18:46:12.47Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/5e/c927b325bd4c1d3620211a4b96f47864633199feed60fa936025ab27e090/ruff-0.15.11-py3-none-win_amd64.whl", hash = "sha256:8b6756d88d7e234fb0c98c91511aae3cd519d5e3ed271cae31b20f39cb2a12a3", size = 11779692, upload-time = "2026-04-16T18:46:17.268Z" },
-    { url = "https://files.pythonhosted.org/packages/63/b6/aeadee5443e49baa2facd51131159fd6301cc4ccfc1541e4df7b021c37dd/ruff-0.15.11-py3-none-win_arm64.whl", hash = "sha256:063fed18cc1bbe0ee7393957284a6fe8b588c6a406a285af3ee3f46da2391ee4", size = 11032614, upload-time = "2026-04-16T18:46:34.487Z" },
+    { url = "https://files.pythonhosted.org/packages/db/4d/e11259f5da07cb6afb2d074c31bf09da9671993f7329d4f15d2fdc458301/ruff-0.15.17-py3-none-linux_armv6l.whl", hash = "sha256:d9feddb927fc68bd295f5eebc587a7e42cfaf9b65f60ca4a2386febff575da8f", size = 10856677, upload-time = "2026-06-11T17:54:49.533Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3e/772d679e1a0dc058e58875bd2c0cb713a0530877b4a76fee3c7966df0d49/ruff-0.15.17-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:25805a226d741c47d274a35ad5c10a7dde175fcddfa511d7cf3da0a21eb3eab7", size = 11223443, upload-time = "2026-06-11T17:55:00.573Z" },
+    { url = "https://files.pythonhosted.org/packages/68/58/bd41f7688b2fd5623012605130ed70e60aa7f2244baa3d5066bdd61530c8/ruff-0.15.17-py3-none-macosx_11_0_arm64.whl", hash = "sha256:f6ad73b14c2d18a3bf8ad7cb6974294d7f613a7898604826058e6ac64918ef4d", size = 10566458, upload-time = "2026-06-11T17:55:07.52Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/5b/733371013fcf1ec339e477ece6ab42bfe10bdd9bba8ee88a9516aa56bfc0/ruff-0.15.17-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6ba0c1e4f95bcb3869d0d30cbd5917071ef2e28665abfec970cdab0492c713ed", size = 10914483, upload-time = "2026-06-11T17:55:05.501Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/cc/6f24251cc0252f7239391ccb85833f320efad14ebe5b443943f37ced6332/ruff-0.15.17-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81647960f10bff57d2e51cadd0c3950fe598400c852863a038720ef5b8cca91e", size = 10647497, upload-time = "2026-06-11T17:54:57.733Z" },
+    { url = "https://files.pythonhosted.org/packages/68/dd/0d10c17ce1a1624d6fc3156309c3f834fdb5dfaad026ec90c85684f3990e/ruff-0.15.17-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0e01a84ddbc8c16c23055ba3924476850f1bbc1917cebbb9376665a63e74260d", size = 11416967, upload-time = "2026-06-11T17:54:51.461Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/91/556bfb156f6144f355e831c23db00b2fc4120f86b3ce81cc5f7fd2df51f3/ruff-0.15.17-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:84fe9f653152f8f294f9f7e03bf3a453d8b4a27f7a59c78c8666167f2b17b96c", size = 12335770, upload-time = "2026-06-11T17:54:45.793Z" },
+    { url = "https://files.pythonhosted.org/packages/88/82/8b5999aa13355e926f06d9f42a32dcca862f623bf0363785ff89d607dffd/ruff-0.15.17-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c0fe88a7676e7a05b73174d4d4a59cb2ac21ff8263583f87a81a6018475a978", size = 11575441, upload-time = "2026-06-11T17:54:32.661Z" },
+    { url = "https://files.pythonhosted.org/packages/11/93/f10377bb04109ca0e8cbc483ff1982c54b6d418210041776f93e8cdc7fa9/ruff-0.15.17-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ecfc3c7878fff94633ab0348524e093f9ce3243080416dd7d14f8ba400174719", size = 11557614, upload-time = "2026-06-11T17:54:34.698Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a6/eeeae7f7d5493df41649ab3db92f086b2d0a30199e4efdf8e3dd7a033f24/ruff-0.15.17-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:b8461180b22420b1bdc289909410930761629fddf2a5aaf60fae1ab26cedc4c4", size = 11544450, upload-time = "2026-06-11T17:54:39.042Z" },
+    { url = "https://files.pythonhosted.org/packages/32/88/5991ce565129a24dd4a00db1254b3b5db2e53018cbe4018ea5a89738e727/ruff-0.15.17-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:6eccbe50a038b503e7140b441aa9c7fc8c1f36edf23ebef9f4165c2f28f568b7", size = 10892524, upload-time = "2026-06-11T17:55:09.432Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/1d/0fdd248313425f55223968af04b0a42125466a8d88d21c1d99c6af0a51e8/ruff-0.15.17-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:382fc0521025f5a8ad447d8bdd523545d0d7646adb718eb1c2dac5065ec27c0f", size = 10659573, upload-time = "2026-06-11T17:54:36.824Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/0e/072e8260deb9461062ce9311ced27a8e541229a6ffd483013dd37661e43e/ruff-0.15.17-py3-none-musllinux_1_2_i686.whl", hash = "sha256:456d41fcd1b2777ad63f09a6e7121d43f7b688bbc76a800c10f7f8fb1f912c3f", size = 11127818, upload-time = "2026-06-11T17:55:03.124Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/b4/55060a34163121498014696b5f656db5b8c6963768f227dbf0d76b311073/ruff-0.15.17-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:b1a04bcc94ae6194e9db05d16ad31f298a7194bfbcb08258bbe589cee1d587b8", size = 11655901, upload-time = "2026-06-11T17:54:53.562Z" },
+    { url = "https://files.pythonhosted.org/packages/49/71/9b29d6b87cef468d697f43c6a91e3fae4a80185779d7d5a4ef27d173439f/ruff-0.15.17-py3-none-win32.whl", hash = "sha256:596065960ab1ff593f744220c9fe6580eda00a95003cffa9f4048bb5b1bf0392", size = 10925574, upload-time = "2026-06-11T17:54:55.723Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/b2/8fc77f3723228836fa5d12497eb71c808f83782e10d058d2b15cfa14640b/ruff-0.15.17-py3-none-win_amd64.whl", hash = "sha256:6769e5fa1710b179b92e0bfa5a51735b35baea9013dadb06d5f44cbcf9547084", size = 12058788, upload-time = "2026-06-11T17:54:41.042Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/c7/c53e8dbff9c9dc4b7928773421ae294a5d28fcb8dcda1a089579d3a7e510/ruff-0.15.17-py3-none-win_arm64.whl", hash = "sha256:f3be1fbb34bcdfd146240d8fb92a709d4c2c8191348580a3c044ec60fa0b4456", size = 11355275, upload-time = "2026-06-11T17:54:43.635Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Resolve CVE and GHSA advisory aliases from synced bundle intel and cloud audit `advisoryIds` in audit payloads and receipts.
- Update package workbench normalization to read enriched alias fields and remove placeholder pending-alias chips.
- Replace always-on stub copy with an empty-state message only when no aliases are linked.

## Testing
- `python3 -m pytest tests/test_guard_local_supply_chain_audit_phase16.py::test_audit_receipt_metadata_enriches_cloud_advisory_aliases_from_bundle -q`
- `npx tsx dashboard/src/scsr-phase10-package-workbench.test.ts`
