### PR TITLE
fix(command-queue): drop stale pending results

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -133,6 +133,30 @@ def _save_state(store: GuardStore, payload: dict[str, object]) -> None:
     store.set_sync_payload(COMMAND_QUEUE_STATE_KEY, payload, _now())
 
 
+def _parse_iso8601_timestamp(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip()
+    if normalized.endswith(("Z", "z")):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _pending_result_is_stale(job: dict[str, object]) -> bool:
+    now = datetime.now(timezone.utc)
+    for key in ("leaseExpiresAt", "expiresAt"):
+        expires_at = _parse_iso8601_timestamp(job.get(key))
+        if expires_at is not None and expires_at <= now:
+            return True
+    return False
+
+
 def command_queue_status(store: GuardStore) -> dict[str, object]:
     state = _load_state(store)
     profile = store.get_cloud_sync_profile()
@@ -293,6 +317,17 @@ def _retry_pending_result(
     if not isinstance(job, dict) or not isinstance(payload, dict):
         state.pop("pending_result", None)
         state.pop("active_job", None)
+        _save_state(store, state)
+        return False
+    if _pending_result_is_stale(job):
+        _LOGGER.warning(
+            "Guard command dropped stale pending result: job_id=%s",
+            job.get("id", "unknown"),
+        )
+        state.pop("pending_result", None)
+        state.pop("active_job", None)
+        state["state"] = "idle"
+        state["last_error"] = None
         _save_state(store, state)
         return False
     _post_result(auth_context, job, payload)

--- a/tests/test_guard_command_queue_stale_pending_result.py
+++ b/tests/test_guard_command_queue_stale_pending_result.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.runtime import command_queue
+from tests.test_guard_command_queue import FakeStore, _context
+
+
+def test_poll_once_drops_stale_pending_result_before_leasing(tmp_path: Path, monkeypatch) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    stale_job = {
+        "id": "job-3",
+        "leaseId": "lease-3",
+        "leaseExpiresAt": "2000-01-01T00:05:00+00:00",
+        "expiresAt": "2000-01-01T00:15:00+00:00",
+    }
+    store.set_sync_payload(
+        command_queue.COMMAND_QUEUE_STATE_KEY,
+        {
+            "state": "result_pending",
+            "active_job": dict(stale_job),
+            "pending_result": {
+                "job": dict(stale_job),
+                "payload": {
+                    "leaseId": "lease-3",
+                    "idempotencyKey": "job-3:lease-3:succeeded",
+                    "status": "succeeded",
+                    "result": {"data": {}},
+                },
+            },
+        },
+        "2000-01-01T00:00:00+00:00",
+    )
+    calls: list[str] = []
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda current_store: {"sync_url": "https://hol.test/api/guard/receipts/sync", "access_token": "token"},
+    )
+
+    def fake_json_request(
+        auth_context: dict[str, object],
+        *,
+        method: str,
+        path: str,
+        payload: dict[str, object],
+    ) -> dict[str, object]:
+        del auth_context, method, payload
+        calls.append(path)
+        assert path == "/lease"
+        return {"item": None}
+
+    monkeypatch.setattr(command_queue, "_json_request", fake_json_request)
+
+    status = command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    assert status["state"] == "idle"
+    assert calls == ["/lease"]
+    assert status["active_job"] is None
+    assert status["pending_result"] is None


### PR DESCRIPTION
## Summary
- drop expired pending command results before the local poller retries them
- add a regression so stale result state falls through to `/lease` instead of wedging the queue

## Testing
- `uv run --no-sync pytest tests/test_guard_command_queue.py -q`
