### PR TITLE
fix(opencode): spawn pretool hooks with node child_process only

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_pretool.py
@@ -15,6 +15,8 @@ _HOOK_ARGV_ENV = "HOL_GUARD_HOOK_ARGV"
 _INHERIT_ENV_KEYS = ("PATH", "HOME", "USER", "TMPDIR", "TEMP", "TMP", "LANG", "LC_ALL", "SYSTEMROOT")
 
 _PLUGIN_TEMPLATE = """// Managed by HOL Guard. Re-run `hol-guard install opencode` after moving Guard home.
+import { spawn as nodeSpawn } from "node:child_process";
+
 const GUARD_HOME = __GUARD_HOME__;
 const GUARD_PYTHON = __GUARD_PYTHON__;
 const GUARD_HOOK_LAUNCHER = __GUARD_HOOK_LAUNCHER__;
@@ -50,28 +52,8 @@ async function spawnGuardProcess(options: {
   env: Record<string, string>;
   stdin: string;
 }): Promise<{ exitCode: number; stdout: string; stderr: string }> {
-  const bun = (globalThis as { Bun?: { spawn?: Function } }).Bun;
-  if (typeof bun?.spawn === "function") {
-    const proc = bun.spawn(options.command, {
-      cwd: options.cwd,
-      env: options.env,
-      stdin: new Blob([options.stdin]),
-      stdout: "pipe",
-      stderr: "pipe",
-    });
-    const stdoutPromise = new Response(proc.stdout).text();
-    const stderrPromise = new Response(proc.stderr).text();
-    const exitCode = await proc.exited;
-    return {
-      exitCode,
-      stdout: await stdoutPromise,
-      stderr: await stderrPromise,
-    };
-  }
-
-  const { spawn } = await import("node:child_process");
   return new Promise((resolve, reject) => {
-    const proc = spawn(options.command[0], options.command.slice(1), {
+    const proc = nodeSpawn(options.command[0], options.command.slice(1), {
       cwd: options.cwd,
       env: options.env,
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -22,7 +22,12 @@ from packaging.version import InvalidVersion, Version
 
 from ..adapters.base import HarnessContext
 from ..adapters.codex import CodexHarnessAdapter, codex_native_hook_state
-from ..adapters.opencode_pretool import global_plugin_path, install_pretool_plugin, pretool_plugin_source
+from ..adapters.opencode_pretool import (
+    global_plugin_path,
+    install_pretool_plugin,
+    managed_plugin_path,
+    pretool_plugin_source,
+)
 from ..redaction import redact_sensitive_text
 from ..store import GuardStore
 from .dashboard_sync import sync_dashboard_assets as _sync_dashboard_assets
@@ -615,14 +620,16 @@ def _refresh_opencode_pretool_plugin(
         return None
     if managed_install is None or not bool(managed_install.get("active")):
         return None
-    repair_context = _opencode_repair_context(context, managed_install)
-    plugin_path = global_plugin_path(repair_context)
+    repair_context, _ = _repair_context_from_managed_install(context, managed_install)
+    global_path = global_plugin_path(repair_context)
+    managed_path = managed_plugin_path(repair_context)
     expected_source = pretool_plugin_source(repair_context)
     try:
-        current_source = plugin_path.read_text(encoding="utf-8") if plugin_path.is_file() else ""
+        global_source = global_path.read_text(encoding="utf-8") if global_path.is_file() else ""
+        managed_source = managed_path.read_text(encoding="utf-8") if managed_path.is_file() else ""
     except OSError as error:
         return f"Could not inspect OpenCode pretool plugin during update: {error}"
-    if current_source == expected_source:
+    if global_source == expected_source and managed_source == expected_source:
         return None
     try:
         install_pretool_plugin(repair_context)
@@ -631,16 +638,22 @@ def _refresh_opencode_pretool_plugin(
     return "Refreshed the OpenCode pretool plugin during update. Restart OpenCode to load it."
 
 
-def _opencode_repair_context(context: HarnessContext, managed_install: dict[str, object]) -> HarnessContext:
+def _repair_context_from_managed_install(
+    context: HarnessContext,
+    managed_install: dict[str, object],
+) -> tuple[HarnessContext, str | None]:
     managed_workspace = managed_install.get("workspace")
     if isinstance(managed_workspace, str) and managed_workspace.strip():
         workspace_path = Path(managed_workspace).expanduser().resolve()
-        return HarnessContext(
-            home_dir=context.home_dir,
-            workspace_dir=workspace_path,
-            guard_home=context.guard_home,
+        return (
+            HarnessContext(
+                home_dir=context.home_dir,
+                workspace_dir=workspace_path,
+                guard_home=context.guard_home,
+            ),
+            str(workspace_path),
         )
-    return HarnessContext(context.home_dir, None, context.guard_home)
+    return HarnessContext(context.home_dir, None, context.guard_home), None
 
 
 def _repair_codex_install(
@@ -682,18 +695,7 @@ def _codex_repair_target(context: HarnessContext, store: GuardStore) -> tuple[Ha
     except (json.JSONDecodeError, sqlite3.Error):
         return _codex_backup_repair_target(context)
     if managed_install is not None and bool(managed_install.get("active")):
-        managed_workspace = managed_install.get("workspace")
-        if isinstance(managed_workspace, str) and managed_workspace.strip():
-            workspace_path = Path(managed_workspace).expanduser().resolve()
-            return (
-                HarnessContext(
-                    home_dir=context.home_dir,
-                    workspace_dir=workspace_path,
-                    guard_home=context.guard_home,
-                ),
-                str(workspace_path),
-            )
-        return HarnessContext(context.home_dir, None, context.guard_home), None
+        return _repair_context_from_managed_install(context, managed_install)
     return _codex_backup_repair_target(context)
 
 

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -22,6 +22,7 @@ from packaging.version import InvalidVersion, Version
 
 from ..adapters.base import HarnessContext
 from ..adapters.codex import CodexHarnessAdapter, codex_native_hook_state
+from ..adapters.opencode_pretool import global_plugin_path, install_pretool_plugin, pretool_plugin_source
 from ..redaction import redact_sensitive_text
 from ..store import GuardStore
 from .dashboard_sync import sync_dashboard_assets as _sync_dashboard_assets
@@ -597,7 +598,49 @@ def _repair_supported_harnesses(
     )
     repaired_installs = [repaired_codex] if repaired_codex is not None else []
     repair_notes = [codex_warning] if codex_warning is not None else []
+    opencode_note = _refresh_opencode_pretool_plugin(context=context, store=store)
+    if opencode_note is not None:
+        repair_notes.append(opencode_note)
     return repaired_installs, repair_notes
+
+
+def _refresh_opencode_pretool_plugin(
+    *,
+    context: HarnessContext,
+    store: GuardStore,
+) -> str | None:
+    try:
+        managed_install = store.get_managed_install("opencode")
+    except (json.JSONDecodeError, sqlite3.Error):
+        return None
+    if managed_install is None or not bool(managed_install.get("active")):
+        return None
+    repair_context = _opencode_repair_context(context, managed_install)
+    plugin_path = global_plugin_path(repair_context)
+    expected_source = pretool_plugin_source(repair_context)
+    try:
+        current_source = plugin_path.read_text(encoding="utf-8") if plugin_path.is_file() else ""
+    except OSError as error:
+        return f"Could not inspect OpenCode pretool plugin during update: {error}"
+    if current_source == expected_source:
+        return None
+    try:
+        install_pretool_plugin(repair_context)
+    except OSError as error:
+        return f"Could not refresh OpenCode pretool plugin during update: {error}"
+    return "Refreshed the OpenCode pretool plugin during update. Restart OpenCode to load it."
+
+
+def _opencode_repair_context(context: HarnessContext, managed_install: dict[str, object]) -> HarnessContext:
+    managed_workspace = managed_install.get("workspace")
+    if isinstance(managed_workspace, str) and managed_workspace.strip():
+        workspace_path = Path(managed_workspace).expanduser().resolve()
+        return HarnessContext(
+            home_dir=context.home_dir,
+            workspace_dir=workspace_path,
+            guard_home=context.guard_home,
+        )
+    return HarnessContext(context.home_dir, None, context.guard_home)
 
 
 def _repair_codex_install(

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -404,6 +404,9 @@ def test_refresh_opencode_pretool_plugin_rewrites_stale_plugin(tmp_path: Path) -
     refreshed = stale_path.read_text(encoding="utf-8")
     assert "Bun" not in refreshed
     assert 'import { spawn as nodeSpawn } from "node:child_process"' in refreshed
+    refreshed_managed = managed_plugin_path(ctx).read_text(encoding="utf-8")
+    assert "Bun" not in refreshed_managed
+    assert 'import { spawn as nodeSpawn } from "node:child_process"' in refreshed_managed
 
 
 def test_opencode_verification_reports_missing_plugin(tmp_path: Path) -> None:

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -74,12 +74,12 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     assert str(ctx.guard_home.resolve()) in source
     assert "tool.execute.before" in source
     assert "spawnGuardProcess" in source
-    assert "node:child_process" in source
+    assert 'import { spawn as nodeSpawn } from "node:child_process"' in source
     assert "normalizeCommand" in source
     spawn_block = source.split("async function spawnGuardProcess", 1)[1].split("async function runGuardHook", 1)[0]
-    assert "globalThis" in spawn_block
-    assert "Bun" in spawn_block
-    assert "stdin: new Blob([options.stdin])" in spawn_block
+    assert "nodeSpawn" in spawn_block
+    assert "globalThis" not in spawn_block
+    assert "Bun" not in spawn_block
     assert '.stream()' not in spawn_block
     assert "try {" in source
     assert 'source_scope: directory?.trim() ? "project" : "global"' in source
@@ -190,11 +190,17 @@ def test_pretool_plugin_source_includes_node_spawn_fallback(tmp_path: Path) -> N
         "async function runGuardHook",
         1,
     )[0]
-    assert "typeof bun?.spawn === \"function\"" in spawn_block
-    assert 'await import("node:child_process")' in spawn_block
+    assert "nodeSpawn" in spawn_block
+    assert "await import(" not in spawn_block
+    assert "Bun" not in spawn_block
     assert 'proc.stdout?.setEncoding("utf8")' in spawn_block
     assert 'proc.stdin?.on("error", () => {})' in spawn_block
     assert "proc.stdin?.end(options.stdin)" in spawn_block
+
+
+def test_pretool_plugin_source_has_no_bun_identifier(tmp_path: Path) -> None:
+    source = pretool_plugin_source(_ctx(tmp_path))
+    assert "Bun" not in source
 
 
 def test_install_pretool_plugin_writes_managed_and_global_copies(tmp_path: Path) -> None:
@@ -378,6 +384,26 @@ def test_opencode_verification_ready_with_guard_companion_servers(tmp_path: Path
     assert verification["mcp_proxy_configured"] is True
     assert verification["ready"] is True
     assert not verification["warnings"]
+
+
+def test_refresh_opencode_pretool_plugin_rewrites_stale_plugin(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.cli import update_commands
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    ctx = _ctx(tmp_path)
+    store = GuardStore(ctx.guard_home)
+    store.set_managed_install("opencode", True, None, {}, "2026-06-04T00:00:00+00:00")
+    install_pretool_plugin(ctx)
+    stale_path = global_plugin_path(ctx)
+    stale_path.write_text("// stale plugin\n", encoding="utf-8")
+
+    note = update_commands._refresh_opencode_pretool_plugin(context=ctx, store=store)
+
+    assert note is not None
+    assert "Refreshed the OpenCode pretool plugin" in note
+    refreshed = stale_path.read_text(encoding="utf-8")
+    assert "Bun" not in refreshed
+    assert 'import { spawn as nodeSpawn } from "node:child_process"' in refreshed
 
 
 def test_opencode_verification_reports_missing_plugin(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Generate the OpenCode pretool plugin with a static `node:child_process` spawn path and no Bun references
- Refresh stale OpenCode pretool plugin files during `hol-guard update` when OpenCode is actively managed

## Testing
- `python3 -m pytest tests/test_opencode_pretool.py -q`
