### PR TITLE
fix(opencode): handle RuntimeError during pretool plugin refresh

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -623,7 +623,10 @@ def _refresh_opencode_pretool_plugin(
     repair_context, _ = _repair_context_from_managed_install(context, managed_install)
     global_path = global_plugin_path(repair_context)
     managed_path = managed_plugin_path(repair_context)
-    expected_source = pretool_plugin_source(repair_context)
+    try:
+        expected_source = pretool_plugin_source(repair_context)
+    except (OSError, RuntimeError) as error:
+        return f"Could not inspect OpenCode pretool plugin during update: {error}"
     try:
         global_source = global_path.read_text(encoding="utf-8") if global_path.is_file() else ""
         managed_source = managed_path.read_text(encoding="utf-8") if managed_path.is_file() else ""
@@ -633,7 +636,7 @@ def _refresh_opencode_pretool_plugin(
         return None
     try:
         install_pretool_plugin(repair_context)
-    except OSError as error:
+    except (OSError, RuntimeError) as error:
         return f"Could not refresh OpenCode pretool plugin during update: {error}"
     return "Refreshed the OpenCode pretool plugin during update. Restart OpenCode to load it."
 

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -431,6 +431,30 @@ def test_refresh_opencode_pretool_plugin_handles_runtime_error(
     assert "Could not inspect OpenCode pretool plugin during update" in note
 
 
+def test_refresh_opencode_pretool_plugin_handles_install_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.cli import update_commands
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    ctx = _ctx(tmp_path)
+    store = GuardStore(ctx.guard_home)
+    store.set_managed_install("opencode", True, None, {}, "2026-06-04T00:00:00+00:00")
+    install_pretool_plugin(ctx)
+    global_plugin_path(ctx).write_text("// stale plugin\n", encoding="utf-8")
+
+    def _raise_runtime_error(_context: HarnessContext) -> dict[str, object]:
+        raise RuntimeError("write failed")
+
+    monkeypatch.setattr(update_commands, "install_pretool_plugin", _raise_runtime_error)
+
+    note = update_commands._refresh_opencode_pretool_plugin(context=ctx, store=store)
+
+    assert note is not None
+    assert "Could not refresh OpenCode pretool plugin during update" in note
+
+
 def test_opencode_verification_reports_missing_plugin(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.store import GuardStore
 

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -409,6 +409,28 @@ def test_refresh_opencode_pretool_plugin_rewrites_stale_plugin(tmp_path: Path) -
     assert 'import { spawn as nodeSpawn } from "node:child_process"' in refreshed_managed
 
 
+def test_refresh_opencode_pretool_plugin_handles_runtime_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.cli import update_commands
+    from codex_plugin_scanner.guard.store import GuardStore
+
+    ctx = _ctx(tmp_path)
+    store = GuardStore(ctx.guard_home)
+    store.set_managed_install("opencode", True, None, {}, "2026-06-04T00:00:00+00:00")
+
+    def _raise_runtime_error(_context: HarnessContext) -> str:
+        raise RuntimeError("no guard python")
+
+    monkeypatch.setattr(update_commands, "pretool_plugin_source", _raise_runtime_error)
+
+    note = update_commands._refresh_opencode_pretool_plugin(context=ctx, store=store)
+
+    assert note is not None
+    assert "Could not inspect OpenCode pretool plugin during update" in note
+
+
 def test_opencode_verification_reports_missing_plugin(tmp_path: Path) -> None:
     from codex_plugin_scanner.guard.store import GuardStore
 


### PR DESCRIPTION
## Summary
- Catch RuntimeError from pretool plugin generation during hol-guard update

## Testing
- python3 -m pytest tests/test_opencode_pretool.py::test_refresh_opencode_pretool_plugin_handles_runtime_error -q