### PR TITLE
fix(guard): expose cloud policy bundle fields in runtime snapshot

### DIFF
--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -365,6 +365,7 @@ export type GuardRuntimeSnapshot = {
   cloud_policy_bundle_version?: string | null;
   cloud_policy_rollout_state?: string | null;
   cloud_policy_sync_error?: string | null;
+  cloud_policy_last_ack_at?: string | null;
   cloud_pairing_state: GuardCloudPairingState;
   cloud_sync_health: GuardCloudSyncHealth;
   dashboard_url: string;

--- a/dashboard/src/policy-guard-cloud-bundle-card.tsx
+++ b/dashboard/src/policy-guard-cloud-bundle-card.tsx
@@ -5,6 +5,7 @@ import { formatRelativeTime } from "./approval-center-utils";
 import type { GuardRuntimeSnapshot } from "./guard-types";
 import {
   resolveCloudPolicyBundleCopy,
+  resolveCloudExceptionsConnected,
   resolveCloudPolicyControlsUrl,
 } from "./policy-workspace-helpers";
 
@@ -15,8 +16,12 @@ type PolicyGuardCloudBundleCardProps = {
 export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleCardProps) {
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
+  const cloudConnected = resolveCloudExceptionsConnected(snapshot);
   const lastAckAt =
-    snapshot.runtime_state?.last_heartbeat_at?.trim() ?? snapshot.generated_at?.trim() ?? null;
+    snapshot.cloud_policy_last_ack_at?.trim() ??
+    snapshot.runtime_state?.last_heartbeat_at?.trim() ??
+    snapshot.generated_at?.trim() ??
+    null;
   const policyHash = cloudBundleCopy?.hash?.trim() ?? null;
   const policyHashShort = policyHash?.slice(0, 8) ?? null;
   const bundleVersion = snapshot.cloud_policy_bundle_version?.trim() ?? null;
@@ -32,9 +37,21 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
     return (
       <div className="rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm">
         <SectionLabel>Guard Cloud bundle</SectionLabel>
-        <p className="mt-2 text-sm text-brand-dark/75">
-          Not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle.
-        </p>
+        {cloudConnected ? (
+          <>
+            <p className="mt-2 text-sm font-medium text-brand-dark">
+              {snapshot.cloud_state_label?.trim() || "Connected to Guard Cloud"}
+            </p>
+            <p className="mt-1 text-sm text-brand-dark/75">
+              {snapshot.cloud_state_detail?.trim() ||
+                "Guard Cloud is connected. Policy bundle details will appear after the next successful sync."}
+            </p>
+          </>
+        ) : (
+          <p className="mt-2 text-sm text-brand-dark/75">
+            Guard Cloud is not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle.
+          </p>
+        )}
         {cloudControlsUrl ? (
           <div className="mt-3">
             <ActionButton href={cloudControlsUrl} variant="secondary">

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -919,6 +919,14 @@ def _build_runtime_cloud_context(
     remote_policy = store.get_sync_payload("policy") or {}
     team_policy_pack = store.get_sync_payload("team_policy_pack") or {}
     alert_preferences = store.get_sync_payload("alert_preferences") or {}
+    policy_bundle = _sync_payload_dict(store, "policy_bundle")
+    policy_bundle_last_error = _sync_payload_dict(store, "policy_bundle_last_error")
+    acknowledgement = policy_bundle.get("acknowledgement")
+    cloud_policy_last_ack_at = (
+        _optional_string(acknowledgement.get("acknowledgedAt"))
+        if isinstance(acknowledgement, dict)
+        else None
+    )
     remote_payload_active = any((sync_summary, remote_policy, team_policy_pack, alert_preferences))
     cloud_state = _resolve_runtime_cloud_state(
         sync_configured=cloud_profile is not None,
@@ -964,7 +972,18 @@ def _build_runtime_cloud_context(
         "inbox_url": inbox_url,
         "fleet_url": fleet_url,
         "connect_url": connect_url,
+        "cloud_policy_bundle_hash": _optional_string(policy_bundle.get("bundleHash")),
+        "cloud_policy_bundle_version": _optional_string(policy_bundle.get("bundleVersion")),
+        "cloud_policy_rollout_state": _optional_string(policy_bundle.get("rolloutState")),
+        "cloud_policy_sync_error": _optional_string(policy_bundle_last_error.get("reason")),
+        "cloud_policy_last_ack_at": cloud_policy_last_ack_at,
+        "team_policy_active": bool(team_policy_pack),
     }
+
+
+def _sync_payload_dict(store: GuardStore, key: str) -> dict[str, object]:
+    payload = store.get_sync_payload(key) or {}
+    return payload if isinstance(payload, dict) else {}
 
 
 def _build_runtime_device_context(store: GuardStore) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -923,9 +923,7 @@ def _build_runtime_cloud_context(
     policy_bundle_last_error = _sync_payload_dict(store, "policy_bundle_last_error")
     acknowledgement = policy_bundle.get("acknowledgement")
     cloud_policy_last_ack_at = (
-        _optional_string(acknowledgement.get("acknowledgedAt"))
-        if isinstance(acknowledgement, dict)
-        else None
+        _optional_string(acknowledgement.get("acknowledgedAt")) if isinstance(acknowledgement, dict) else None
     )
     remote_payload_active = any((sync_summary, remote_policy, team_policy_pack, alert_preferences))
     cloud_state = _resolve_runtime_cloud_state(

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -2185,7 +2185,8 @@ function PolicyCloudExceptionsTab({
 function PolicyGuardCloudBundleCard({ snapshot }) {
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
-  const lastAckAt = snapshot.runtime_state?.last_heartbeat_at?.trim() ?? snapshot.generated_at?.trim() ?? null;
+  const cloudConnected = resolveCloudExceptionsConnected(snapshot);
+  const lastAckAt = snapshot.cloud_policy_last_ack_at?.trim() ?? snapshot.runtime_state?.last_heartbeat_at?.trim() ?? snapshot.generated_at?.trim() ?? null;
   const policyHash = cloudBundleCopy?.hash?.trim() ?? null;
   const policyHashShort = policyHash?.slice(0, 8) ?? null;
   const bundleVersion = snapshot.cloud_policy_bundle_version?.trim() ?? null;
@@ -2198,7 +2199,10 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
   if (!cloudBundleCopy) {
     return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark/75", children: "Not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle." }),
+      cloudConnected ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm font-medium text-brand-dark", children: snapshot.cloud_state_label?.trim() || "Connected to Guard Cloud" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-brand-dark/75", children: snapshot.cloud_state_detail?.trim() || "Guard Cloud is connected. Policy bundle details will appear after the next successful sync." })
+      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark/75", children: "Guard Cloud is not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle." }),
       cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
         "Open Guard Cloud"

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -490,6 +490,44 @@ def test_runtime_snapshot_exposes_local_device_without_cloud_pairing(tmp_path: P
     }
 
 
+def test_runtime_snapshot_exposes_cloud_policy_bundle_fields(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-06-01T00:00:00+00:00"
+    store.set_sync_credentials(
+        "https://hol.org/api/guard/receipts/sync",
+        "oauth_access_token_fixture",
+        now,
+        workspace_id="workspace-alpha",
+    )
+    store.set_sync_payload(
+        "policy_bundle",
+        {
+            "bundleVersion": "policy-2026-05-01.3",
+            "bundleHash": "sha256:bundle-proof",
+            "rolloutState": "enforcing",
+            "acknowledgement": {
+                "deviceId": "device-alpha",
+                "acknowledgedAt": "2026-06-01T12:00:00+00:00",
+                "status": "synced",
+            },
+        },
+        now,
+    )
+    store.set_sync_payload(
+        "policy_bundle_last_error",
+        {"reason": "sync_failed"},
+        now,
+    )
+
+    snapshot = build_runtime_snapshot(store=store, approval_center_url=None)
+
+    assert snapshot["cloud_policy_bundle_version"] == "policy-2026-05-01.3"
+    assert snapshot["cloud_policy_bundle_hash"] == "sha256:bundle-proof"
+    assert snapshot["cloud_policy_rollout_state"] == "enforcing"
+    assert snapshot["cloud_policy_sync_error"] == "sync_failed"
+    assert snapshot["cloud_policy_last_ack_at"] == "2026-06-01T12:00:00+00:00"
+
+
 def test_runtime_snapshot_exposes_latest_connect_proof_without_pairing_secrets(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     request_id = "connect-imported-state"


### PR DESCRIPTION
## Summary
- Include cloud policy bundle hash, version, rollout state, sync error, and ack timestamp in `/v1/runtime` snapshots.
- Stop labeling paired Guard Cloud devices as "Not connected" in the policy bundle card when bundle metadata is still loading.

## Testing
- `uv run --no-sync pytest tests/test_guard_cloud_local_sync.py::test_runtime_snapshot_exposes_cloud_policy_bundle_fields -q`
- `cd dashboard && npm run build`
