### PR TITLE
fix(dashboard): unify audit panel with full package inventory

### DIFF
--- a/dashboard/src/audit-run-progress.tsx
+++ b/dashboard/src/audit-run-progress.tsx
@@ -1,7 +1,7 @@
 import { HiMiniArrowPath, HiMiniCheckCircle } from "react-icons/hi2";
 import type { AuditRunPhase } from "./use-supply-chain-audit-session";
 
-type AuditRunProgressProps = {
+type AuditProgressProps = {
   phase: AuditRunPhase;
   running: boolean;
 };
@@ -11,8 +11,8 @@ type StepState = "pending" | "active" | "done";
 const STEPS: Array<{ id: AuditRunPhase; label: string }> = [
   { id: "preparing", label: "Prepare workspace" },
   { id: "scanning", label: "Scan manifests and lockfiles" },
-  { id: "evaluating", label: "Evaluate packages" },
-  { id: "finalizing", label: "Build findings" },
+  { id: "evaluating", label: "Evaluate packages against Guard intel" },
+  { id: "finalizing", label: "Prepare results" },
 ];
 
 function stepState(stepId: AuditRunPhase, phase: AuditRunPhase, running: boolean): StepState {
@@ -54,18 +54,38 @@ function stepBubbleClass(state: StepState): string {
   return "border border-slate-200 bg-white text-slate-400";
 }
 
-export function AuditRunProgress({ phase, running }: AuditRunProgressProps) {
-  if (!running && phase === "idle") {
+export function AuditProgressStepList({ phase, running }: AuditProgressProps) {
+  return (
+    <ol className="space-y-2" aria-live="polite" aria-busy={running} data-testid="audit-run-progress">
+      {STEPS.map((step, index) => {
+        const state = stepState(step.id, phase, running);
+        return (
+          <li key={step.id} className={`flex items-center gap-2 text-sm ${stepTextClass(state)}`}>
+            <span
+              className={`inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${stepBubbleClass(state)}`}
+              aria-hidden="true"
+            >
+              {state === "done" ? "✓" : index + 1}
+            </span>
+            {step.label}
+          </li>
+        );
+      })}
+    </ol>
+  );
+}
+
+export function auditProgressActive(phase: AuditRunPhase, running: boolean): boolean {
+  return running || phase !== "idle";
+}
+
+export function AuditRunProgress({ phase, running }: AuditProgressProps) {
+  if (!auditProgressActive(phase, running)) {
     return null;
   }
 
   return (
-    <section
-      className="rounded-2xl border border-brand-blue/15 bg-brand-blue/[0.03] px-4 py-4"
-      aria-live="polite"
-      aria-busy={running}
-      data-testid="audit-run-progress"
-    >
+    <section className="rounded-2xl border border-brand-blue/15 bg-brand-blue/[0.03] px-4 py-4">
       <div className="flex items-center gap-2">
         {running ? (
           <HiMiniArrowPath className="h-4 w-4 shrink-0 animate-spin text-brand-blue" aria-hidden="true" />
@@ -76,25 +96,9 @@ export function AuditRunProgress({ phase, running }: AuditRunProgressProps) {
           {running ? "Workspace audit in progress" : "Workspace audit complete"}
         </p>
       </div>
-      <ol className="mt-4 space-y-2">
-        {STEPS.map((step, index) => {
-          const state = stepState(step.id, phase, running);
-          return (
-            <li
-              key={step.id}
-              className={`flex items-center gap-2 text-sm ${stepTextClass(state)}`}
-            >
-              <span
-                className={`inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${stepBubbleClass(state)}`}
-                aria-hidden="true"
-              >
-                {state === "done" ? "✓" : index + 1}
-              </span>
-              {step.label}
-            </li>
-          );
-        })}
-      </ol>
+      <div className="mt-4">
+        <AuditProgressStepList phase={phase} running={running} />
+      </div>
     </section>
   );
 }

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -25,7 +25,6 @@ import type { GuardApprovalGatePublicConfig, GuardReceipt, GuardRuntimeSnapshot 
 import { useResolvedApprovalGate } from "./use-resolved-approval-gate";
 import { resolveManagerCoverageStatus } from "./supply-chain-protection-stats";
 import { PackageWorkbenchPanel } from "./package-workbench-panel";
-import { AuditRunProgress } from "./audit-run-progress";
 import type { SupplyChainAuditSession } from "./use-supply-chain-audit-session";
 
 export type AuditSeverity = "critical" | "high" | "medium" | "low" | "info";
@@ -559,13 +558,13 @@ export function AuditWorkspace({ snapshot, receipts, approvalGate, auditSession 
 
   return (
     <div className="space-y-6">
-      <AuditRunProgress phase={auditSession.auditPhase} running={auditSession.auditRunning} />
-
       <PackageWorkbenchPanel
         auditConnectGate={auditSession.auditConnectGate}
         auditError={auditSession.auditError}
         auditSnapshot={auditSession.auditSnapshot}
         auditRunning={auditSession.auditRunning}
+        auditPhase={auditSession.auditPhase}
+        cloudState={snapshot.cloud_state}
         onRunAudit={auditSession.handleRunAudit}
       />
 

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -803,6 +803,7 @@ export type SupplyChainAuditSnapshot = {
   source: string | null;
   decision: SupplyChainAuditDecision;
   inventory: SupplyChainAuditInventory;
+  packages: SupplyChainAuditFinding[];
   findings: SupplyChainAuditFinding[];
   manifestPaths: string[];
   lockfilePaths: string[];

--- a/dashboard/src/package-workbench-panel.tsx
+++ b/dashboard/src/package-workbench-panel.tsx
@@ -471,7 +471,6 @@ function EcosystemChip({ ecosystem, active, onSelect }: EcosystemChipProps) {
 
 type WorkbenchEmptyStateProps = {
   auditConnectGate?: AuditConnectGateViewState | null;
-  auditError?: string | null;
 };
 
 function WorkbenchAuditErrorBanner({ message }: { message: string }) {
@@ -491,7 +490,7 @@ function WorkbenchAuditErrorBanner({ message }: { message: string }) {
   );
 }
 
-function WorkbenchEmptyState({ auditConnectGate, auditError }: WorkbenchEmptyStateProps) {
+function WorkbenchEmptyState({ auditConnectGate }: WorkbenchEmptyStateProps) {
   if (auditConnectGate !== null && auditConnectGate !== undefined) {
     return (
       <ConnectFlowCard
@@ -509,25 +508,12 @@ function WorkbenchEmptyState({ auditConnectGate, auditError }: WorkbenchEmptySta
   }
 
   return (
-    <>
-      {auditError ? <WorkbenchAuditErrorBanner message={auditError} /> : null}
-      <EmptyState
-        title="No workspace audit yet"
-        body="Run a workspace audit to index dependencies across npm, pnpm, PyPI, and other ecosystems found in this project."
-        tone="teach"
-      />
-    </>
+    <EmptyState
+      title="No workspace audit yet"
+      body="Run a workspace audit to index dependencies across npm, pnpm, PyPI, and other ecosystems found in this project."
+      tone="teach"
+    />
   );
-}
-
-type ViewModeChipProps = {
-  label: string;
-  active: boolean;
-  onSelect: () => void;
-};
-
-function ViewModeChip({ label, active, onSelect }: ViewModeChipProps) {
-  return <FilterChip label={label} active={active} onSelect={onSelect} />;
 }
 
 function ecosystemSummary(packages: SupplyChainAuditFinding[]): Array<{ ecosystem: string; count: number }> {
@@ -702,7 +688,7 @@ export function PackageWorkbenchPanel({
 
       <div className="px-4 py-4 space-y-4">
         {auditConnectGate !== null && auditConnectGate !== undefined ? (
-          <WorkbenchEmptyState auditConnectGate={auditConnectGate} auditError={auditError} />
+          <WorkbenchEmptyState auditConnectGate={auditConnectGate} />
         ) : (
           <>
             {auditError ? <WorkbenchAuditErrorBanner message={auditError} /> : null}
@@ -714,13 +700,21 @@ export function PackageWorkbenchPanel({
             ) : null}
 
             {auditSnapshot === null && !progressActive ? (
-              <WorkbenchEmptyState auditConnectGate={null} auditError={auditError} />
+              <WorkbenchEmptyState auditConnectGate={null} />
             ) : null}
 
         {showResults && auditSnapshot !== null && packages.length === 0 && auditSnapshot.inventory.totalPackages > 0 ? (
           <EmptyState
             title="Package list not loaded"
             body="This audit indexed packages, but the detailed list was not stored yet. Run audit again to load the full inventory table."
+            tone="teach"
+          />
+        ) : null}
+
+        {showResults && auditSnapshot !== null && packages.length === 0 && auditSnapshot.inventory.totalPackages === 0 ? (
+          <EmptyState
+            title="No packages indexed"
+            body="The latest workspace audit completed, but no supported package manifests or lockfiles were found."
             tone="teach"
           />
         ) : null}
@@ -735,8 +729,8 @@ export function PackageWorkbenchPanel({
               ))}
             </div>
             <div className="flex flex-wrap gap-2">
-              <ViewModeChip label={`All packages (${packages.length})`} active={viewMode === "all"} onSelect={handleViewAll} />
-              <ViewModeChip
+              <FilterChip label={`All packages (${packages.length})`} active={viewMode === "all"} onSelect={handleViewAll} />
+              <FilterChip
                 label={`Needs review (${findings.length})`}
                 active={viewMode === "review"}
                 onSelect={handleViewReview}
@@ -766,7 +760,7 @@ export function PackageWorkbenchPanel({
             />
             {sortedFindings.length === 0 ? (
               <p className="py-6 text-center text-sm text-slate-500">
-                {viewMode === "review"
+                {viewMode === "review" && findings.length === 0
                   ? "No packages need review in this audit."
                   : "No packages match the current filters."}
               </p>

--- a/dashboard/src/package-workbench-panel.tsx
+++ b/dashboard/src/package-workbench-panel.tsx
@@ -3,6 +3,7 @@ import type { ChangeEvent, ReactNode } from "react";
 import {
   HiMiniArrowDown,
   HiMiniArrowUp,
+  HiMiniArrowPath,
   HiMiniBugAnt,
   HiMiniChevronLeft,
   HiMiniChevronRight,
@@ -13,6 +14,8 @@ import {
 import { SectionLabel, Tag, ActionButton, EmptyState, IconActionButton } from "./approval-center-primitives";
 import { formatRelativeTime } from "./approval-center-utils";
 import { GuardModalLayer } from "./guard-modal-layer";
+import { AuditProgressStepList, auditProgressActive } from "./audit-run-progress";
+import type { AuditRunPhase } from "./use-supply-chain-audit-session";
 import type {
   PackageWorkbenchFilters,
   PackageWorkbenchSortKey,
@@ -31,12 +34,16 @@ import type { AuditConnectGateViewState } from "./supply-chain-firewall-panel";
 
 const WORKBENCH_PAGE_SIZE = 25;
 
+type PackageViewMode = "all" | "review";
+
 type PackageWorkbenchPanelProps = {
   auditConnectGate?: AuditConnectGateViewState | null;
   auditError?: string | null;
   auditSnapshot: SupplyChainAuditSnapshot | null;
   onRunAudit?: () => void;
   auditRunning?: boolean;
+  auditPhase?: AuditRunPhase;
+  cloudState?: string | null;
 };
 
 const decisionTone = (
@@ -91,9 +98,36 @@ function humanizeReasonMessage(code: string, message: string): string {
 type WorkbenchHeaderProps = {
   auditSnapshot: SupplyChainAuditSnapshot;
   flaggedCount: number;
+  packageCount: number;
+  cloudState?: string | null;
 };
 
-function WorkbenchHeader({ auditSnapshot, flaggedCount }: WorkbenchHeaderProps) {
+function cloudIntelLabel(cloudState: string | null | undefined, source: string | null): string {
+  if (cloudState === "local_only") {
+    return "Local intel only";
+  }
+  if (source !== null && source.length > 0) {
+    return `${source} intel`;
+  }
+  return "Guard Cloud";
+}
+
+function cloudIntelTone(cloudState: string | null | undefined): "attention" | "green" | "info" {
+  if (cloudState === "local_only") {
+    return "attention";
+  }
+  if (cloudState === "paired_active") {
+    return "green";
+  }
+  return "info";
+}
+
+function WorkbenchHeader({
+  auditSnapshot,
+  flaggedCount,
+  packageCount,
+  cloudState,
+}: WorkbenchHeaderProps) {
   const manifestSummary =
     auditSnapshot.manifestPaths.length > 0
       ? `${auditSnapshot.manifestPaths.length} manifest${auditSnapshot.manifestPaths.length === 1 ? "" : "s"}`
@@ -108,9 +142,14 @@ function WorkbenchHeader({ auditSnapshot, flaggedCount }: WorkbenchHeaderProps) 
     <div className="space-y-1">
       <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
         <Tag tone={decisionTone(auditSnapshot.decision)}>{auditSnapshot.decision}</Tag>
+        <Tag tone={cloudIntelTone(cloudState)}>{cloudIntelLabel(cloudState, auditSnapshot.source)}</Tag>
         <span>
           {auditSnapshot.inventory.totalPackages} package
           {auditSnapshot.inventory.totalPackages === 1 ? "" : "s"} indexed
+        </span>
+        <span aria-hidden="true">·</span>
+        <span>
+          {packageCount} in table
         </span>
         <span aria-hidden="true">·</span>
         <span>
@@ -118,12 +157,6 @@ function WorkbenchHeader({ auditSnapshot, flaggedCount }: WorkbenchHeaderProps) 
         </span>
         <span aria-hidden="true">·</span>
         <span>Last audit {formatRelativeTime(auditSnapshot.generatedAt)}</span>
-        {auditSnapshot.source !== null && (
-          <>
-            <span aria-hidden="true">·</span>
-            <span className="capitalize">{auditSnapshot.source} intel</span>
-          </>
-        )}
       </div>
       {scanSummary.length > 0 ? (
         <p className="text-[11px] text-slate-400">Scanned {scanSummary} across this workspace.</p>
@@ -439,8 +472,6 @@ function EcosystemChip({ ecosystem, active, onSelect }: EcosystemChipProps) {
 type WorkbenchEmptyStateProps = {
   auditConnectGate?: AuditConnectGateViewState | null;
   auditError?: string | null;
-  onRunAudit?: () => void;
-  auditRunning?: boolean;
 };
 
 function WorkbenchAuditErrorBanner({ message }: { message: string }) {
@@ -460,7 +491,7 @@ function WorkbenchAuditErrorBanner({ message }: { message: string }) {
   );
 }
 
-function WorkbenchEmptyState({ auditConnectGate, auditError, onRunAudit, auditRunning }: WorkbenchEmptyStateProps) {
+function WorkbenchEmptyState({ auditConnectGate, auditError }: WorkbenchEmptyStateProps) {
   if (auditConnectGate !== null && auditConnectGate !== undefined) {
     return (
       <ConnectFlowCard
@@ -482,19 +513,31 @@ function WorkbenchEmptyState({ auditConnectGate, auditError, onRunAudit, auditRu
       {auditError ? <WorkbenchAuditErrorBanner message={auditError} /> : null}
       <EmptyState
         title="No workspace audit yet"
-        body="Run a package audit to index dependencies and surface flagged packages here."
+        body="Run a workspace audit to index dependencies across npm, pnpm, PyPI, and other ecosystems found in this project."
         tone="teach"
-        action={
-          onRunAudit !== undefined ? (
-            <ActionButton variant="outline" onClick={onRunAudit} disabled={auditRunning} aria-busy={auditRunning}>
-              <HiMiniBugAnt className="mr-1.5 h-4 w-4" aria-hidden="true" />
-              Run audit
-            </ActionButton>
-          ) : undefined
-        }
       />
     </>
   );
+}
+
+type ViewModeChipProps = {
+  label: string;
+  active: boolean;
+  onSelect: () => void;
+};
+
+function ViewModeChip({ label, active, onSelect }: ViewModeChipProps) {
+  return <FilterChip label={label} active={active} onSelect={onSelect} />;
+}
+
+function ecosystemSummary(packages: SupplyChainAuditFinding[]): Array<{ ecosystem: string; count: number }> {
+  const counts = new Map<string, number>();
+  for (const pkg of packages) {
+    counts.set(pkg.ecosystem, (counts.get(pkg.ecosystem) ?? 0) + 1);
+  }
+  return [...counts.entries()]
+    .map(([ecosystem, count]) => ({ ecosystem, count }))
+    .sort((left, right) => right.count - left.count || left.ecosystem.localeCompare(right.ecosystem));
 }
 
 export function PackageWorkbenchPanel({
@@ -503,7 +546,10 @@ export function PackageWorkbenchPanel({
   auditSnapshot,
   onRunAudit,
   auditRunning = false,
+  auditPhase = "idle",
+  cloudState = null,
 }: PackageWorkbenchPanelProps) {
+  const [viewMode, setViewMode] = useState<PackageViewMode>("all");
   const [filters, setFilters] = useState<PackageWorkbenchFilters>({
     ecosystem: "all",
     decision: "all",
@@ -519,10 +565,15 @@ export function PackageWorkbenchPanel({
   const [page, setPage] = useState(0);
 
   const findings = auditSnapshot?.findings ?? [];
-  const ecosystems = useMemo(() => packageWorkbenchEcosystems(findings), [findings]);
+  const packages = auditSnapshot?.packages ?? [];
+  const tableSource = viewMode === "review" ? findings : packages;
+  const progressActive = auditProgressActive(auditPhase, auditRunning);
+  const showResults = auditSnapshot !== null && !progressActive && (auditConnectGate === null || auditConnectGate === undefined);
+  const ecosystems = useMemo(() => packageWorkbenchEcosystems(tableSource), [tableSource]);
+  const ecosystemBreakdown = useMemo(() => ecosystemSummary(packages), [packages]);
   const filteredFindings = useMemo(
-    () => filterPackageWorkbenchFindings(findings, filters),
-    [findings, filters],
+    () => filterPackageWorkbenchFindings(tableSource, filters),
+    [tableSource, filters],
   );
   const sortedFindings = useMemo(() => {
     const sorted = sortPackageWorkbenchFindings(filteredFindings, sortKey);
@@ -592,91 +643,167 @@ export function PackageWorkbenchPanel({
     setSelectedId("");
   }, []);
 
+  const handleViewAll = useCallback(() => {
+    setViewMode("all");
+    setPage(0);
+    setSelectedId("");
+  }, []);
+
+  const handleViewReview = useCallback(() => {
+    setViewMode("review");
+    setPage(0);
+    setSelectedId("");
+  }, []);
+
+  const handleRunAudit = useCallback(() => {
+    onRunAudit?.();
+  }, [onRunAudit]);
+
+  const headerTitle = progressActive ? "Auditing workspace" : "Workspace audit";
+  const headerBody = progressActive
+    ? "Guard is scanning manifests, lockfiles, and package intel for this workspace."
+    : "Browse indexed packages, filter by ecosystem, and open any row for advisory detail.";
+
   return (
-    <div className="rounded-2xl border border-slate-100 bg-white shadow-sm">
+    <div className="rounded-2xl border border-slate-100 bg-white shadow-sm" data-testid="workspace-audit-panel">
       <div className="border-b border-slate-100 px-4 py-3">
-        <SectionLabel>Audit findings</SectionLabel>
-        <p className="mt-0.5 text-sm text-slate-500">
-          Packages that need review from the latest workspace audit. Filter, sort, and open a finding for detail.
-        </p>
-        {auditSnapshot !== null && (
-          <div className="mt-2">
-            <WorkbenchHeader auditSnapshot={auditSnapshot} flaggedCount={findings.length} />
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0">
+            <SectionLabel>{headerTitle}</SectionLabel>
+            <p className="mt-0.5 text-sm text-slate-500">{headerBody}</p>
           </div>
-        )}
+          {onRunAudit !== undefined ? (
+            <ActionButton
+              variant="outline"
+              onClick={handleRunAudit}
+              disabled={auditRunning}
+              aria-busy={auditRunning}
+            >
+              {auditRunning ? (
+                <HiMiniArrowPath className="mr-1.5 h-4 w-4 animate-spin" aria-hidden="true" />
+              ) : (
+                <HiMiniBugAnt className="mr-1.5 h-4 w-4" aria-hidden="true" />
+              )}
+              {auditSnapshot === null ? "Run audit" : "Run audit again"}
+            </ActionButton>
+          ) : null}
+        </div>
+        {auditSnapshot !== null && showResults ? (
+          <div className="mt-2">
+            <WorkbenchHeader
+              auditSnapshot={auditSnapshot}
+              flaggedCount={findings.length}
+              packageCount={packages.length}
+              cloudState={cloudState}
+            />
+          </div>
+        ) : null}
       </div>
 
-      {auditSnapshot === null && (
-        <div className="px-4 py-6">
-          <WorkbenchEmptyState
-            auditConnectGate={auditConnectGate}
-            auditError={auditError}
-            onRunAudit={onRunAudit}
-            auditRunning={auditRunning}
-          />
-        </div>
-      )}
-      {auditSnapshot !== null && findings.length === 0 && (
-        <div className="px-4 py-6">
+      <div className="px-4 py-4 space-y-4">
+        {auditConnectGate !== null && auditConnectGate !== undefined ? (
+          <WorkbenchEmptyState auditConnectGate={auditConnectGate} auditError={auditError} />
+        ) : (
+          <>
+            {auditError ? <WorkbenchAuditErrorBanner message={auditError} /> : null}
+
+            {progressActive ? (
+              <div className="rounded-xl border border-brand-blue/15 bg-brand-blue/[0.03] px-4 py-4">
+                <AuditProgressStepList phase={auditPhase} running={auditRunning} />
+              </div>
+            ) : null}
+
+            {auditSnapshot === null && !progressActive ? (
+              <WorkbenchEmptyState auditConnectGate={null} auditError={auditError} />
+            ) : null}
+
+        {showResults && auditSnapshot !== null && packages.length === 0 && auditSnapshot.inventory.totalPackages > 0 ? (
           <EmptyState
-            title="No flagged packages"
-            body="The latest workspace audit completed without packages that need review."
+            title="Package list not loaded"
+            body="This audit indexed packages, but the detailed list was not stored yet. Run audit again to load the full inventory table."
             tone="teach"
           />
-        </div>
-      )}
-      {auditSnapshot !== null && findings.length > 0 && (
-        <div className="space-y-4 px-4 py-4">
-          <WorkbenchControls
-            filters={filters}
-            ecosystems={ecosystems}
-            sortKey={sortKey}
-            sortDirection={sortDirection}
-            onSearchChange={handleSearchChange}
-            onEcosystemChange={handleEcosystemChange}
-            onDecisionChange={handleDecisionChange}
-            onSeverityChange={handleSeverityChange}
-            onSortChange={handleSortChange}
-          />
-          <WorkbenchPagination
-            page={safePage}
-            pageCount={pageCount}
-            total={sortedFindings.length}
-            onPageChange={handlePageChange}
-          />
-          {sortedFindings.length === 0 ? (
-            <p className="py-6 text-center text-sm text-slate-500">No packages match the current filters.</p>
-          ) : (
-            <div
-              className="overflow-hidden rounded-xl border border-slate-100"
-              role="table"
-              aria-label="Package audit findings"
-            >
-              <div
-                className="sticky top-0 z-[1] hidden border-b border-slate-100 bg-slate-50 px-4 py-2 sm:grid sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3"
-                role="row"
-              >
-                <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400" role="columnheader">
-                  Package
-                </span>
-                <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400" role="columnheader">
-                  Decision · Severity
-                </span>
-              </div>
-              <div className="max-h-[min(60vh,32rem)] overflow-y-auto overscroll-y-contain" role="rowgroup">
-                {pagedFindings.map((finding) => (
-                  <FindingRow
-                    key={finding.id}
-                    finding={finding}
-                    selected={selectedId === finding.id}
-                    onSelect={handleSelectFinding}
-                  />
-                ))}
-              </div>
+        ) : null}
+
+        {showResults && packages.length > 0 ? (
+          <>
+            <div className="flex flex-wrap gap-2">
+              {ecosystemBreakdown.map((entry) => (
+                <Tag key={entry.ecosystem} tone="default">
+                  {entry.ecosystem} · {entry.count}
+                </Tag>
+              ))}
             </div>
-          )}
-        </div>
-      )}
+            <div className="flex flex-wrap gap-2">
+              <ViewModeChip label={`All packages (${packages.length})`} active={viewMode === "all"} onSelect={handleViewAll} />
+              <ViewModeChip
+                label={`Needs review (${findings.length})`}
+                active={viewMode === "review"}
+                onSelect={handleViewReview}
+              />
+            </div>
+            {cloudState === "local_only" ? (
+              <p className="text-xs leading-relaxed text-slate-500">
+                This device is using local intel only. Connect Guard Cloud and sync supply-chain intel for live CVE and malware coverage.
+              </p>
+            ) : null}
+            <WorkbenchControls
+              filters={filters}
+              ecosystems={ecosystems}
+              sortKey={sortKey}
+              sortDirection={sortDirection}
+              onSearchChange={handleSearchChange}
+              onEcosystemChange={handleEcosystemChange}
+              onDecisionChange={handleDecisionChange}
+              onSeverityChange={handleSeverityChange}
+              onSortChange={handleSortChange}
+            />
+            <WorkbenchPagination
+              page={safePage}
+              pageCount={pageCount}
+              total={sortedFindings.length}
+              onPageChange={handlePageChange}
+            />
+            {sortedFindings.length === 0 ? (
+              <p className="py-6 text-center text-sm text-slate-500">
+                {viewMode === "review"
+                  ? "No packages need review in this audit."
+                  : "No packages match the current filters."}
+              </p>
+            ) : (
+              <div
+                className="overflow-hidden rounded-xl border border-slate-100"
+                role="table"
+                aria-label={viewMode === "review" ? "Packages needing review" : "Indexed packages"}
+              >
+                <div
+                  className="sticky top-0 z-[1] hidden border-b border-slate-100 bg-slate-50 px-4 py-2 sm:grid sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3"
+                  role="row"
+                >
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400" role="columnheader">
+                    Package
+                  </span>
+                  <span className="text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400" role="columnheader">
+                    Decision · Severity
+                  </span>
+                </div>
+                <div className="max-h-[min(60vh,32rem)] overflow-y-auto overscroll-y-contain" role="rowgroup">
+                  {pagedFindings.map((finding) => (
+                    <FindingRow
+                      key={finding.id}
+                      finding={finding}
+                      selected={selectedId === finding.id}
+                      onSelect={handleSelectFinding}
+                    />
+                  ))}
+                </div>
+              </div>
+            )}
+          </>
+        ) : null}
+          </>
+        )}
+      </div>
       {selectedFinding !== null ? (
         <GuardModalLayer
           ariaLabel={`Finding detail for ${selectedFinding.packageName}`}

--- a/dashboard/src/scsr-phase10-package-workbench.test.ts
+++ b/dashboard/src/scsr-phase10-package-workbench.test.ts
@@ -58,7 +58,8 @@ const auditPayload = {
 
 const snapshot = normalizeSupplyChainAuditSnapshot(auditPayload, "receipt-audit-1");
 assert(snapshot !== null, "SCSR166: audit payload normalizes into workbench snapshot");
-assert(snapshot!.findings.length === 3, "SCSR167: all evaluated packages surface as findings");
+assert(snapshot!.packages.length === 3, "SCSR167: all evaluated packages surface in inventory");
+assert(snapshot!.findings.length === 2, "SCSR167-B: actionable findings exclude clean monitor packages");
 assert(snapshot!.inventory.totalPackages === 3, "SCSR168: inventory totals normalize");
 
 const sorted = sortPackageWorkbenchFindings(snapshot!.findings, "severity");
@@ -186,7 +187,8 @@ const receipt: GuardReceipt = {
 
 const derived = derivePackageWorkbenchFromReceipts([receipt]);
 assert(derived !== null, "SCSR174: latest audit receipt hydrates workbench snapshot");
-assert(derived!.findings.length === 3, "SCSR175: receipt package_findings hydrate findings table");
+assert(derived!.packages.length === 3, "SCSR175: receipt package_findings hydrate full inventory");
+assert(derived!.findings.length === 2, "SCSR175-B: receipt findings stay actionable-only");
 
 assert(
   normalizeSupplyChainAuditSnapshot({ generated_at: "2026-06-09T12:00:00.000Z" }) === null,

--- a/dashboard/src/supply-chain-audit-normalize.ts
+++ b/dashboard/src/supply-chain-audit-normalize.ts
@@ -311,19 +311,23 @@ export function normalizeSupplyChainAuditSnapshot(
   const evaluation = isRecord(raw.evaluation) ? raw.evaluation : null;
   const inventoryPackages = normalizePackageFindings(raw.package_inventory);
   const evaluationPackages = packageRecordsFromEvaluation(evaluation);
-  const packages =
-    evaluationPackages.length > 0
-      ? evaluationPackages
-      : inventoryPackages.length > 0
-        ? inventoryPackages
-        : normalizePackageFindings(raw.package_findings);
+  let packages: SupplyChainAuditFinding[];
+  if (evaluationPackages.length > 0) {
+    packages = evaluationPackages;
+  } else if (inventoryPackages.length > 0) {
+    packages = inventoryPackages;
+  } else {
+    packages = normalizePackageFindings(raw.package_findings);
+  }
   const findingsFromEvidence = normalizePackageFindings(raw.package_findings);
-  const findings =
-    packages.length > 0
-      ? deriveActionableFindings(packages)
-      : findingsFromEvidence.length > 0
-        ? findingsFromEvidence
-        : [];
+  let findings: SupplyChainAuditFinding[];
+  if (packages.length > 0) {
+    findings = deriveActionableFindings(packages);
+  } else if (findingsFromEvidence.length > 0) {
+    findings = findingsFromEvidence;
+  } else {
+    findings = [];
+  }
   const generatedAt =
     readString(raw.generated_at) ?? readString(raw.generatedAt) ?? new Date(0).toISOString();
   const inventory = normalizeInventory(isRecord(raw.inventory) ? raw.inventory : null);

--- a/dashboard/src/supply-chain-audit-normalize.ts
+++ b/dashboard/src/supply-chain-audit-normalize.ts
@@ -265,6 +265,24 @@ function normalizePackageFindings(value: unknown): SupplyChainAuditFinding[] {
   return findings;
 }
 
+const INFORMATIONAL_REASON_CODES = new Set(["unknown_package", "no_cached_match"]);
+
+export function isActionablePackageFinding(finding: SupplyChainAuditFinding): boolean {
+  if (finding.decision === "block" || finding.decision === "ask" || finding.decision === "warn") {
+    return true;
+  }
+  if (finding.reasons.length === 0) {
+    return finding.decision !== "allow" && finding.decision !== "monitor";
+  }
+  return finding.reasons.some((reason) => !INFORMATIONAL_REASON_CODES.has(reason.code));
+}
+
+export function deriveActionableFindings(
+  packages: SupplyChainAuditFinding[],
+): SupplyChainAuditFinding[] {
+  return packages.filter(isActionablePackageFinding);
+}
+
 function packageRecordsFromEvaluation(evaluation: Record<string, unknown> | null): SupplyChainAuditFinding[] {
   if (evaluation === null) {
     return [];
@@ -291,9 +309,21 @@ export function normalizeSupplyChainAuditSnapshot(
     return null;
   }
   const evaluation = isRecord(raw.evaluation) ? raw.evaluation : null;
+  const inventoryPackages = normalizePackageFindings(raw.package_inventory);
+  const evaluationPackages = packageRecordsFromEvaluation(evaluation);
+  const packages =
+    evaluationPackages.length > 0
+      ? evaluationPackages
+      : inventoryPackages.length > 0
+        ? inventoryPackages
+        : normalizePackageFindings(raw.package_findings);
   const findingsFromEvidence = normalizePackageFindings(raw.package_findings);
   const findings =
-    findingsFromEvidence.length > 0 ? findingsFromEvidence : packageRecordsFromEvaluation(evaluation);
+    packages.length > 0
+      ? deriveActionableFindings(packages)
+      : findingsFromEvidence.length > 0
+        ? findingsFromEvidence
+        : [];
   const generatedAt =
     readString(raw.generated_at) ?? readString(raw.generatedAt) ?? new Date(0).toISOString();
   const inventory = normalizeInventory(isRecord(raw.inventory) ? raw.inventory : null);
@@ -301,6 +331,7 @@ export function normalizeSupplyChainAuditSnapshot(
   const manifestPaths = readStringArray(raw.manifest_paths);
   const lockfilePaths = readStringArray(raw.lockfile_paths);
   const hasAuditContext =
+    packages.length > 0 ||
     findings.length > 0 ||
     inventory.totalPackages > 0 ||
     evaluation !== null;
@@ -312,6 +343,7 @@ export function normalizeSupplyChainAuditSnapshot(
     source: readString(raw.source),
     decision,
     inventory,
+    packages,
     findings,
     manifestPaths,
     lockfilePaths,
@@ -337,7 +369,8 @@ export function derivePackageWorkbenchFromReceipts(receipts: GuardReceipt[]): Su
         audit_status: evidenceRaw.audit_status,
         evaluation: {
           decision: evidenceRaw.audit_decision,
-          packages: evidenceRaw.package_findings,
+          packages:
+            evidenceRaw.package_inventory ?? evidenceRaw.package_findings,
         },
         inventory: {
           total_packages: evidenceRaw.total_packages,

--- a/dashboard/src/supply-chain-ux-consolidation.test.ts
+++ b/dashboard/src/supply-chain-ux-consolidation.test.ts
@@ -39,8 +39,20 @@ assert(
   "audit tab hosts package workbench",
 );
 assert(
-  auditSource.includes("AuditRunProgress"),
-  "audit tab shows progressive audit steps",
+  !auditSource.includes("AuditRunProgress"),
+  "audit tab does not mount a separate progress card",
+);
+assert(
+  workbenchSource.includes("AuditProgressStepList"),
+  "workbench embeds progressive audit steps in one panel",
+);
+assert(
+  workbenchSource.includes("Run audit again"),
+  "workbench keeps re-run audit action after completion",
+);
+assert(
+  workbenchSource.includes('viewMode === "all"'),
+  "workbench exposes full package inventory view",
 );
 assert(
   hubSource.includes("useSupplyChainAuditSession"),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -1,6 +1,67 @@
-import { r as reactExports, j as jsxRuntimeExports, S as SectionLabel, b as EmptyState, aK as GuardModalLayer, ac as Tag, m as formatRelativeTime, aL as ConnectFlowCard, A as ActionButton, aJ as HiMiniBugAnt, ad as HiMiniMagnifyingGlass, br as HiMiniChevronLeft, y as HiMiniChevronRight, aF as IconActionButton, o as HiMiniXMark, w as HiMiniExclamationTriangle, bs as HiMiniArrowDown, bt as HiMiniArrowUp, aw as HiMiniArrowPath, d as HiMiniCheckCircle, bu as runAuditRemediation, B as Badge, I as HiMiniXCircle, h as harnessDisplayName, b2 as HiMiniDocumentText, b1 as guardAwareHref, l as HiMiniShieldCheck } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, r as reactExports, S as SectionLabel, A as ActionButton, aw as HiMiniArrowPath, aJ as HiMiniBugAnt, b as EmptyState, ac as Tag, aK as GuardModalLayer, m as formatRelativeTime, aL as ConnectFlowCard, w as HiMiniExclamationTriangle, ad as HiMiniMagnifyingGlass, br as HiMiniChevronLeft, y as HiMiniChevronRight, aF as IconActionButton, o as HiMiniXMark, bs as HiMiniArrowDown, bt as HiMiniArrowUp, bu as runAuditRemediation, B as Badge, d as HiMiniCheckCircle, I as HiMiniXCircle, h as harnessDisplayName, b2 as HiMiniDocumentText, b1 as guardAwareHref, l as HiMiniShieldCheck } from "../guard-dashboard.js";
 import { p as packageWorkbenchEcosystems, f as filterPackageWorkbenchFindings, s as sortPackageWorkbenchFindings, u as useResolvedApprovalGate, i as isApprovalGateRequiredError, A as ApprovalProofModal } from "./supply-chain-hub-workspace.js";
 import { r as resolveManagerCoverageStatus } from "./supply-chain-protection-stats.js";
+const STEPS = [
+  { id: "preparing", label: "Prepare workspace" },
+  { id: "scanning", label: "Scan manifests and lockfiles" },
+  { id: "evaluating", label: "Evaluate packages against Guard intel" },
+  { id: "finalizing", label: "Prepare results" }
+];
+function stepState(stepId, phase, running) {
+  const order = STEPS.map((step) => step.id);
+  const stepIndex = order.indexOf(stepId);
+  const phaseIndex = order.indexOf(phase);
+  if (!running && phase === "idle") {
+    return "pending";
+  }
+  if (phase === "finalizing" && stepId !== "finalizing") {
+    return "done";
+  }
+  if (stepIndex < phaseIndex) {
+    return "done";
+  }
+  if (stepIndex === phaseIndex) {
+    return "active";
+  }
+  return "pending";
+}
+function stepTextClass(state) {
+  if (state === "active") {
+    return "font-medium text-brand-dark";
+  }
+  if (state === "done") {
+    return "text-slate-600";
+  }
+  return "text-slate-400";
+}
+function stepBubbleClass(state) {
+  if (state === "active") {
+    return "bg-brand-blue text-white";
+  }
+  if (state === "done") {
+    return "bg-brand-green/15 text-brand-green-text";
+  }
+  return "border border-slate-200 bg-white text-slate-400";
+}
+function AuditProgressStepList({ phase, running }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx("ol", { className: "space-y-2", "aria-live": "polite", "aria-busy": running, "data-testid": "audit-run-progress", children: STEPS.map((step, index) => {
+    const state = stepState(step.id, phase, running);
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: `flex items-center gap-2 text-sm ${stepTextClass(state)}`, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "span",
+        {
+          className: `inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${stepBubbleClass(state)}`,
+          "aria-hidden": "true",
+          children: state === "done" ? "✓" : index + 1
+        }
+      ),
+      step.label
+    ] }, step.id);
+  }) });
+}
+function auditProgressActive(phase, running) {
+  return running || phase !== "idle";
+}
 const WORKBENCH_PAGE_SIZE = 25;
 const decisionTone = (decision) => {
   if (decision === "block") {
@@ -44,18 +105,47 @@ function humanizeReasonMessage(code, message) {
   }
   return message;
 }
-function WorkbenchHeader({ auditSnapshot, flaggedCount }) {
+function cloudIntelLabel(cloudState, source) {
+  if (cloudState === "local_only") {
+    return "Local intel only";
+  }
+  if (source !== null && source.length > 0) {
+    return `${source} intel`;
+  }
+  return "Guard Cloud";
+}
+function cloudIntelTone(cloudState) {
+  if (cloudState === "local_only") {
+    return "attention";
+  }
+  if (cloudState === "paired_active") {
+    return "green";
+  }
+  return "info";
+}
+function WorkbenchHeader({
+  auditSnapshot,
+  flaggedCount,
+  packageCount,
+  cloudState
+}) {
   const manifestSummary = auditSnapshot.manifestPaths.length > 0 ? `${auditSnapshot.manifestPaths.length} manifest${auditSnapshot.manifestPaths.length === 1 ? "" : "s"}` : null;
   const lockfileSummary = auditSnapshot.lockfilePaths.length > 0 ? `${auditSnapshot.lockfilePaths.length} lockfile${auditSnapshot.lockfilePaths.length === 1 ? "" : "s"}` : null;
   const scanSummary = [manifestSummary, lockfileSummary].filter((entry) => entry !== null).join(" · ");
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-1", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center gap-2 text-xs text-slate-500", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: decisionTone(auditSnapshot.decision), children: auditSnapshot.decision }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: cloudIntelTone(cloudState), children: cloudIntelLabel(cloudState, auditSnapshot.source) }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
         auditSnapshot.inventory.totalPackages,
         " package",
         auditSnapshot.inventory.totalPackages === 1 ? "" : "s",
         " indexed"
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { "aria-hidden": "true", children: "·" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+        packageCount,
+        " in table"
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("span", { "aria-hidden": "true", children: "·" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
@@ -66,13 +156,6 @@ function WorkbenchHeader({ auditSnapshot, flaggedCount }) {
       /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
         "Last audit ",
         formatRelativeTime(auditSnapshot.generatedAt)
-      ] }),
-      auditSnapshot.source !== null && /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { "aria-hidden": "true", children: "·" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { className: "capitalize", children: [
-          auditSnapshot.source,
-          " intel"
-        ] })
       ] })
     ] }),
     scanSummary.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-[11px] text-slate-400", children: [
@@ -328,7 +411,7 @@ function WorkbenchAuditErrorBanner({ message }) {
     }
   );
 }
-function WorkbenchEmptyState({ auditConnectGate, auditError, onRunAudit, auditRunning }) {
+function WorkbenchEmptyState({ auditConnectGate, auditError }) {
   if (auditConnectGate !== null && auditConnectGate !== void 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(
       ConnectFlowCard,
@@ -351,23 +434,32 @@ function WorkbenchEmptyState({ auditConnectGate, auditError, onRunAudit, auditRu
       EmptyState,
       {
         title: "No workspace audit yet",
-        body: "Run a package audit to index dependencies and surface flagged packages here.",
-        tone: "teach",
-        action: onRunAudit !== void 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "outline", onClick: onRunAudit, disabled: auditRunning, "aria-busy": auditRunning, children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBugAnt, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
-          "Run audit"
-        ] }) : void 0
+        body: "Run a workspace audit to index dependencies across npm, pnpm, PyPI, and other ecosystems found in this project.",
+        tone: "teach"
       }
     )
   ] });
+}
+function ViewModeChip({ label, active, onSelect }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(FilterChip, { label, active, onSelect });
+}
+function ecosystemSummary(packages) {
+  const counts = /* @__PURE__ */ new Map();
+  for (const pkg of packages) {
+    counts.set(pkg.ecosystem, (counts.get(pkg.ecosystem) ?? 0) + 1);
+  }
+  return [...counts.entries()].map(([ecosystem, count]) => ({ ecosystem, count })).sort((left, right) => right.count - left.count || left.ecosystem.localeCompare(right.ecosystem));
 }
 function PackageWorkbenchPanel({
   auditConnectGate = null,
   auditError = null,
   auditSnapshot,
   onRunAudit,
-  auditRunning = false
+  auditRunning = false,
+  auditPhase = "idle",
+  cloudState = null
 }) {
+  const [viewMode, setViewMode] = reactExports.useState("all");
   const [filters, setFilters] = reactExports.useState({
     ecosystem: "all",
     decision: "all",
@@ -379,10 +471,15 @@ function PackageWorkbenchPanel({
   const [selectedId, setSelectedId] = reactExports.useState("");
   const [page, setPage] = reactExports.useState(0);
   const findings = auditSnapshot?.findings ?? [];
-  const ecosystems = reactExports.useMemo(() => packageWorkbenchEcosystems(findings), [findings]);
+  const packages = auditSnapshot?.packages ?? [];
+  const tableSource = viewMode === "review" ? findings : packages;
+  const progressActive = auditProgressActive(auditPhase, auditRunning);
+  const showResults = auditSnapshot !== null && !progressActive && (auditConnectGate === null || auditConnectGate === void 0);
+  const ecosystems = reactExports.useMemo(() => packageWorkbenchEcosystems(tableSource), [tableSource]);
+  const ecosystemBreakdown = reactExports.useMemo(() => ecosystemSummary(packages), [packages]);
   const filteredFindings = reactExports.useMemo(
-    () => filterPackageWorkbenchFindings(findings, filters),
-    [findings, filters]
+    () => filterPackageWorkbenchFindings(tableSource, filters),
+    [tableSource, filters]
   );
   const sortedFindings = reactExports.useMemo(() => {
     const sorted = sortPackageWorkbenchFindings(filteredFindings, sortKey);
@@ -443,84 +540,137 @@ function PackageWorkbenchPanel({
     setPage(nextPage);
     setSelectedId("");
   }, []);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-100 bg-white shadow-sm", children: [
+  const handleViewAll = reactExports.useCallback(() => {
+    setViewMode("all");
+    setPage(0);
+    setSelectedId("");
+  }, []);
+  const handleViewReview = reactExports.useCallback(() => {
+    setViewMode("review");
+    setPage(0);
+    setSelectedId("");
+  }, []);
+  const handleRunAudit = reactExports.useCallback(() => {
+    onRunAudit?.();
+  }, [onRunAudit]);
+  const headerTitle = progressActive ? "Auditing workspace" : "Workspace audit";
+  const headerBody = progressActive ? "Guard is scanning manifests, lockfiles, and package intel for this workspace." : "Browse indexed packages, filter by ecosystem, and open any row for advisory detail.";
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-100 bg-white shadow-sm", "data-testid": "workspace-audit-panel", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-b border-slate-100 px-4 py-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Audit findings" }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-sm text-slate-500", children: "Packages that need review from the latest workspace audit. Filter, sort, and open a finding for detail." }),
-      auditSnapshot !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchHeader, { auditSnapshot, flaggedCount: findings.length }) })
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: headerTitle }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-sm text-slate-500", children: headerBody })
+        ] }),
+        onRunAudit !== void 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          ActionButton,
+          {
+            variant: "outline",
+            onClick: handleRunAudit,
+            disabled: auditRunning,
+            "aria-busy": auditRunning,
+            children: [
+              auditRunning ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "mr-1.5 h-4 w-4 animate-spin", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBugAnt, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+              auditSnapshot === null ? "Run audit" : "Run audit again"
+            ]
+          }
+        ) : null
+      ] }),
+      auditSnapshot !== null && showResults ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-2", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+        WorkbenchHeader,
+        {
+          auditSnapshot,
+          flaggedCount: findings.length,
+          packageCount: packages.length,
+          cloudState
+        }
+      ) }) : null
     ] }),
-    auditSnapshot === null && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4 py-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-      WorkbenchEmptyState,
-      {
-        auditConnectGate,
-        auditError,
-        onRunAudit,
-        auditRunning
-      }
-    ) }),
-    auditSnapshot !== null && findings.length === 0 && /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4 py-6", children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-      EmptyState,
-      {
-        title: "No flagged packages",
-        body: "The latest workspace audit completed without packages that need review.",
-        tone: "teach"
-      }
-    ) }),
-    auditSnapshot !== null && findings.length > 0 && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4 px-4 py-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        WorkbenchControls,
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4 py-4 space-y-4", children: auditConnectGate !== null && auditConnectGate !== void 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchEmptyState, { auditConnectGate, auditError }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+      auditError ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchAuditErrorBanner, { message: auditError }) : null,
+      progressActive ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-blue/15 bg-brand-blue/[0.03] px-4 py-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(AuditProgressStepList, { phase: auditPhase, running: auditRunning }) }) : null,
+      auditSnapshot === null && !progressActive ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchEmptyState, { auditConnectGate: null, auditError }) : null,
+      showResults && auditSnapshot !== null && packages.length === 0 && auditSnapshot.inventory.totalPackages > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+        EmptyState,
         {
-          filters,
-          ecosystems,
-          sortKey,
-          sortDirection,
-          onSearchChange: handleSearchChange,
-          onEcosystemChange: handleEcosystemChange,
-          onDecisionChange: handleDecisionChange,
-          onSeverityChange: handleSeverityChange,
-          onSortChange: handleSortChange
+          title: "Package list not loaded",
+          body: "This audit indexed packages, but the detailed list was not stored yet. Run audit again to load the full inventory table.",
+          tone: "teach"
         }
-      ),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(
-        WorkbenchPagination,
-        {
-          page: safePage,
-          pageCount,
-          total: sortedFindings.length,
-          onPageChange: handlePageChange
-        }
-      ),
-      sortedFindings.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "py-6 text-center text-sm text-slate-500", children: "No packages match the current filters." }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(
-        "div",
-        {
-          className: "overflow-hidden rounded-xl border border-slate-100",
-          role: "table",
-          "aria-label": "Package audit findings",
-          children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs(
-              "div",
-              {
-                className: "sticky top-0 z-[1] hidden border-b border-slate-100 bg-slate-50 px-4 py-2 sm:grid sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3",
-                role: "row",
-                children: [
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400", role: "columnheader", children: "Package" }),
-                  /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400", role: "columnheader", children: "Decision · Severity" })
-                ]
-              }
-            ),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "max-h-[min(60vh,32rem)] overflow-y-auto overscroll-y-contain", role: "rowgroup", children: pagedFindings.map((finding) => /* @__PURE__ */ jsxRuntimeExports.jsx(
-              FindingRow,
-              {
-                finding,
-                selected: selectedId === finding.id,
-                onSelect: handleSelectFinding
-              },
-              finding.id
-            )) })
-          ]
-        }
-      )
-    ] }),
+      ) : null,
+      showResults && packages.length > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex flex-wrap gap-2", children: ecosystemBreakdown.map((entry) => /* @__PURE__ */ jsxRuntimeExports.jsxs(Tag, { tone: "default", children: [
+          entry.ecosystem,
+          " · ",
+          entry.count
+        ] }, entry.ecosystem)) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-2", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(ViewModeChip, { label: `All packages (${packages.length})`, active: viewMode === "all", onSelect: handleViewAll }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            ViewModeChip,
+            {
+              label: `Needs review (${findings.length})`,
+              active: viewMode === "review",
+              onSelect: handleViewReview
+            }
+          )
+        ] }),
+        cloudState === "local_only" ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs leading-relaxed text-slate-500", children: "This device is using local intel only. Connect Guard Cloud and sync supply-chain intel for live CVE and malware coverage." }) : null,
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          WorkbenchControls,
+          {
+            filters,
+            ecosystems,
+            sortKey,
+            sortDirection,
+            onSearchChange: handleSearchChange,
+            onEcosystemChange: handleEcosystemChange,
+            onDecisionChange: handleDecisionChange,
+            onSeverityChange: handleSeverityChange,
+            onSortChange: handleSortChange
+          }
+        ),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          WorkbenchPagination,
+          {
+            page: safePage,
+            pageCount,
+            total: sortedFindings.length,
+            onPageChange: handlePageChange
+          }
+        ),
+        sortedFindings.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "py-6 text-center text-sm text-slate-500", children: viewMode === "review" ? "No packages need review in this audit." : "No packages match the current filters." }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(
+          "div",
+          {
+            className: "overflow-hidden rounded-xl border border-slate-100",
+            role: "table",
+            "aria-label": viewMode === "review" ? "Packages needing review" : "Indexed packages",
+            children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs(
+                "div",
+                {
+                  className: "sticky top-0 z-[1] hidden border-b border-slate-100 bg-slate-50 px-4 py-2 sm:grid sm:grid-cols-[minmax(0,1fr)_auto] sm:gap-3",
+                  role: "row",
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400", role: "columnheader", children: "Package" }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-[10px] font-semibold uppercase tracking-[0.18em] text-slate-400", role: "columnheader", children: "Decision · Severity" })
+                  ]
+                }
+              ),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "max-h-[min(60vh,32rem)] overflow-y-auto overscroll-y-contain", role: "rowgroup", children: pagedFindings.map((finding) => /* @__PURE__ */ jsxRuntimeExports.jsx(
+                FindingRow,
+                {
+                  finding,
+                  selected: selectedId === finding.id,
+                  onSelect: handleSelectFinding
+                },
+                finding.id
+              )) })
+            ]
+          }
+        )
+      ] }) : null
+    ] }) }),
     selectedFinding !== null ? /* @__PURE__ */ jsxRuntimeExports.jsx(
       GuardModalLayer,
       {
@@ -531,89 +681,6 @@ function PackageWorkbenchPanel({
       }
     ) : null
   ] });
-}
-const STEPS = [
-  { id: "preparing", label: "Prepare workspace" },
-  { id: "scanning", label: "Scan manifests and lockfiles" },
-  { id: "evaluating", label: "Evaluate packages" },
-  { id: "finalizing", label: "Build findings" }
-];
-function stepState(stepId, phase, running) {
-  const order = STEPS.map((step) => step.id);
-  const stepIndex = order.indexOf(stepId);
-  const phaseIndex = order.indexOf(phase);
-  if (!running && phase === "idle") {
-    return "pending";
-  }
-  if (phase === "finalizing" && stepId !== "finalizing") {
-    return "done";
-  }
-  if (stepIndex < phaseIndex) {
-    return "done";
-  }
-  if (stepIndex === phaseIndex) {
-    return "active";
-  }
-  return "pending";
-}
-function stepTextClass(state) {
-  if (state === "active") {
-    return "font-medium text-brand-dark";
-  }
-  if (state === "done") {
-    return "text-slate-600";
-  }
-  return "text-slate-400";
-}
-function stepBubbleClass(state) {
-  if (state === "active") {
-    return "bg-brand-blue text-white";
-  }
-  if (state === "done") {
-    return "bg-brand-green/15 text-brand-green-text";
-  }
-  return "border border-slate-200 bg-white text-slate-400";
-}
-function AuditRunProgress({ phase, running }) {
-  if (!running && phase === "idle") {
-    return null;
-  }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-    "section",
-    {
-      className: "rounded-2xl border border-brand-blue/15 bg-brand-blue/[0.03] px-4 py-4",
-      "aria-live": "polite",
-      "aria-busy": running,
-      "data-testid": "audit-run-progress",
-      children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-          running ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-4 w-4 shrink-0 animate-spin text-brand-blue", "aria-hidden": "true" }) : /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-brand-green", "aria-hidden": "true" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: running ? "Workspace audit in progress" : "Workspace audit complete" })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("ol", { className: "mt-4 space-y-2", children: STEPS.map((step, index) => {
-          const state = stepState(step.id, phase, running);
-          return /* @__PURE__ */ jsxRuntimeExports.jsxs(
-            "li",
-            {
-              className: `flex items-center gap-2 text-sm ${stepTextClass(state)}`,
-              children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsx(
-                  "span",
-                  {
-                    className: `inline-flex h-5 w-5 shrink-0 items-center justify-center rounded-full text-[10px] font-semibold ${stepBubbleClass(state)}`,
-                    "aria-hidden": "true",
-                    children: state === "done" ? "✓" : index + 1
-                  }
-                ),
-                step.label
-              ]
-            },
-            step.id
-          );
-        }) })
-      ]
-    }
-  );
 }
 function isSupplyChainAuditEvidence(value) {
   return typeof value === "object" && value !== null && value.operation === "audit";
@@ -1011,7 +1078,6 @@ function AuditWorkspace({ snapshot, receipts, approvalGate, auditSession }) {
     [baseResults, resolvedIds]
   );
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-6", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(AuditRunProgress, { phase: auditSession.auditPhase, running: auditSession.auditRunning }),
     /* @__PURE__ */ jsxRuntimeExports.jsx(
       PackageWorkbenchPanel,
       {
@@ -1019,6 +1085,8 @@ function AuditWorkspace({ snapshot, receipts, approvalGate, auditSession }) {
         auditError: auditSession.auditError,
         auditSnapshot: auditSession.auditSnapshot,
         auditRunning: auditSession.auditRunning,
+        auditPhase: auditSession.auditPhase,
+        cloudState: snapshot.cloud_state,
         onRunAudit: auditSession.handleRunAudit
       }
     ),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/audit-workspace.js
@@ -411,7 +411,7 @@ function WorkbenchAuditErrorBanner({ message }) {
     }
   );
 }
-function WorkbenchEmptyState({ auditConnectGate, auditError }) {
+function WorkbenchEmptyState({ auditConnectGate }) {
   if (auditConnectGate !== null && auditConnectGate !== void 0) {
     return /* @__PURE__ */ jsxRuntimeExports.jsx(
       ConnectFlowCard,
@@ -428,20 +428,14 @@ function WorkbenchEmptyState({ auditConnectGate, auditError }) {
       }
     );
   }
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
-    auditError ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchAuditErrorBanner, { message: auditError }) : null,
-    /* @__PURE__ */ jsxRuntimeExports.jsx(
-      EmptyState,
-      {
-        title: "No workspace audit yet",
-        body: "Run a workspace audit to index dependencies across npm, pnpm, PyPI, and other ecosystems found in this project.",
-        tone: "teach"
-      }
-    )
-  ] });
-}
-function ViewModeChip({ label, active, onSelect }) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsx(FilterChip, { label, active, onSelect });
+  return /* @__PURE__ */ jsxRuntimeExports.jsx(
+    EmptyState,
+    {
+      title: "No workspace audit yet",
+      body: "Run a workspace audit to index dependencies across npm, pnpm, PyPI, and other ecosystems found in this project.",
+      tone: "teach"
+    }
+  );
 }
 function ecosystemSummary(packages) {
   const counts = /* @__PURE__ */ new Map();
@@ -586,15 +580,23 @@ function PackageWorkbenchPanel({
         }
       ) }) : null
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4 py-4 space-y-4", children: auditConnectGate !== null && auditConnectGate !== void 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchEmptyState, { auditConnectGate, auditError }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "px-4 py-4 space-y-4", children: auditConnectGate !== null && auditConnectGate !== void 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchEmptyState, { auditConnectGate }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
       auditError ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchAuditErrorBanner, { message: auditError }) : null,
       progressActive ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "rounded-xl border border-brand-blue/15 bg-brand-blue/[0.03] px-4 py-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(AuditProgressStepList, { phase: auditPhase, running: auditRunning }) }) : null,
-      auditSnapshot === null && !progressActive ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchEmptyState, { auditConnectGate: null, auditError }) : null,
+      auditSnapshot === null && !progressActive ? /* @__PURE__ */ jsxRuntimeExports.jsx(WorkbenchEmptyState, { auditConnectGate: null }) : null,
       showResults && auditSnapshot !== null && packages.length === 0 && auditSnapshot.inventory.totalPackages > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
         EmptyState,
         {
           title: "Package list not loaded",
           body: "This audit indexed packages, but the detailed list was not stored yet. Run audit again to load the full inventory table.",
+          tone: "teach"
+        }
+      ) : null,
+      showResults && auditSnapshot !== null && packages.length === 0 && auditSnapshot.inventory.totalPackages === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+        EmptyState,
+        {
+          title: "No packages indexed",
+          body: "The latest workspace audit completed, but no supported package manifests or lockfiles were found.",
           tone: "teach"
         }
       ) : null,
@@ -605,9 +607,9 @@ function PackageWorkbenchPanel({
           entry.count
         ] }, entry.ecosystem)) }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(ViewModeChip, { label: `All packages (${packages.length})`, active: viewMode === "all", onSelect: handleViewAll }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(FilterChip, { label: `All packages (${packages.length})`, active: viewMode === "all", onSelect: handleViewAll }),
           /* @__PURE__ */ jsxRuntimeExports.jsx(
-            ViewModeChip,
+            FilterChip,
             {
               label: `Needs review (${findings.length})`,
               active: viewMode === "review",
@@ -639,7 +641,7 @@ function PackageWorkbenchPanel({
             onPageChange: handlePageChange
           }
         ),
-        sortedFindings.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "py-6 text-center text-sm text-slate-500", children: viewMode === "review" ? "No packages need review in this audit." : "No packages match the current filters." }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        sortedFindings.length === 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "py-6 text-center text-sm text-slate-500", children: viewMode === "review" && findings.length === 0 ? "No packages need review in this audit." : "No packages match the current filters." }) : /* @__PURE__ */ jsxRuntimeExports.jsxs(
           "div",
           {
             className: "overflow-hidden rounded-xl border border-slate-100",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -254,9 +254,23 @@ function normalizeSupplyChainAuditSnapshot(raw, receiptId = null) {
   const evaluation = isRecord(raw.evaluation) ? raw.evaluation : null;
   const inventoryPackages = normalizePackageFindings(raw.package_inventory);
   const evaluationPackages = packageRecordsFromEvaluation(evaluation);
-  const packages = evaluationPackages.length > 0 ? evaluationPackages : inventoryPackages.length > 0 ? inventoryPackages : normalizePackageFindings(raw.package_findings);
+  let packages;
+  if (evaluationPackages.length > 0) {
+    packages = evaluationPackages;
+  } else if (inventoryPackages.length > 0) {
+    packages = inventoryPackages;
+  } else {
+    packages = normalizePackageFindings(raw.package_findings);
+  }
   const findingsFromEvidence = normalizePackageFindings(raw.package_findings);
-  const findings = packages.length > 0 ? deriveActionableFindings(packages) : findingsFromEvidence.length > 0 ? findingsFromEvidence : [];
+  let findings;
+  if (packages.length > 0) {
+    findings = deriveActionableFindings(packages);
+  } else if (findingsFromEvidence.length > 0) {
+    findings = findingsFromEvidence;
+  } else {
+    findings = [];
+  }
   const generatedAt = readString(raw.generated_at) ?? readString(raw.generatedAt) ?? (/* @__PURE__ */ new Date(0)).toISOString();
   const inventory = normalizeInventory(isRecord(raw.inventory) ? raw.inventory : null);
   const decision = normalizeDecision(evaluation?.decision ?? raw.audit_decision);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -218,6 +218,19 @@ function normalizePackageFindings(value) {
   }
   return findings;
 }
+const INFORMATIONAL_REASON_CODES = /* @__PURE__ */ new Set(["unknown_package", "no_cached_match"]);
+function isActionablePackageFinding(finding) {
+  if (finding.decision === "block" || finding.decision === "ask" || finding.decision === "warn") {
+    return true;
+  }
+  if (finding.reasons.length === 0) {
+    return finding.decision !== "allow" && finding.decision !== "monitor";
+  }
+  return finding.reasons.some((reason) => !INFORMATIONAL_REASON_CODES.has(reason.code));
+}
+function deriveActionableFindings(packages) {
+  return packages.filter(isActionablePackageFinding);
+}
 function packageRecordsFromEvaluation(evaluation) {
   if (evaluation === null) {
     return [];
@@ -239,14 +252,17 @@ function normalizeSupplyChainAuditSnapshot(raw, receiptId = null) {
     return null;
   }
   const evaluation = isRecord(raw.evaluation) ? raw.evaluation : null;
+  const inventoryPackages = normalizePackageFindings(raw.package_inventory);
+  const evaluationPackages = packageRecordsFromEvaluation(evaluation);
+  const packages = evaluationPackages.length > 0 ? evaluationPackages : inventoryPackages.length > 0 ? inventoryPackages : normalizePackageFindings(raw.package_findings);
   const findingsFromEvidence = normalizePackageFindings(raw.package_findings);
-  const findings = findingsFromEvidence.length > 0 ? findingsFromEvidence : packageRecordsFromEvaluation(evaluation);
+  const findings = packages.length > 0 ? deriveActionableFindings(packages) : findingsFromEvidence.length > 0 ? findingsFromEvidence : [];
   const generatedAt = readString(raw.generated_at) ?? readString(raw.generatedAt) ?? (/* @__PURE__ */ new Date(0)).toISOString();
   const inventory = normalizeInventory(isRecord(raw.inventory) ? raw.inventory : null);
   const decision = normalizeDecision(evaluation?.decision ?? raw.audit_decision);
   const manifestPaths = readStringArray(raw.manifest_paths);
   const lockfilePaths = readStringArray(raw.lockfile_paths);
-  const hasAuditContext = findings.length > 0 || inventory.totalPackages > 0 || evaluation !== null;
+  const hasAuditContext = packages.length > 0 || findings.length > 0 || inventory.totalPackages > 0 || evaluation !== null;
   if (!hasAuditContext) {
     return null;
   }
@@ -255,6 +271,7 @@ function normalizeSupplyChainAuditSnapshot(raw, receiptId = null) {
     source: readString(raw.source),
     decision,
     inventory,
+    packages,
     findings,
     manifestPaths,
     lockfilePaths,
@@ -276,7 +293,7 @@ function derivePackageWorkbenchFromReceipts(receipts) {
         audit_status: evidenceRaw.audit_status,
         evaluation: {
           decision: evidenceRaw.audit_decision,
-          packages: evidenceRaw.package_findings
+          packages: evidenceRaw.package_inventory ?? evidenceRaw.package_findings
         },
         inventory: {
           total_packages: evidenceRaw.total_packages

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -663,6 +663,22 @@ def _is_actionable_package_finding(item: dict[str, object]) -> bool:
     return not reason_codes.issubset(_INFORMATIONAL_REASON_CODES)
 
 
+def _audit_package_inventory_for_receipt(
+    package_items: list[dict[str, object]],
+    *,
+    limit: int = 500,
+    bundle: dict[str, object] | None = None,
+) -> list[dict[str, object]]:
+    ranked = sorted(
+        package_items,
+        key=lambda item: (
+            str(item.get("ecosystem") or ""),
+            str(item.get("name") or ""),
+        ),
+    )
+    return [_enrich_package_with_advisory_aliases(item, bundle=bundle) for item in ranked[:limit]]
+
+
 def _audit_package_findings_for_receipt(
     package_items: list[dict[str, object]],
     *,
@@ -773,6 +789,7 @@ def audit_receipt_metadata(
     blocked_packages = [item for item in package_items if str(item.get("decision") or "") == "block"]
     bundle = _cached_supply_chain_bundle_payload(store) if store is not None else None
     package_findings = _audit_package_findings_for_receipt(package_items, bundle=bundle)
+    package_inventory = _audit_package_inventory_for_receipt(package_items, bundle=bundle)
     policy_decision = "allow"
     if decision == "block":
         policy_decision = "block"
@@ -799,6 +816,7 @@ def audit_receipt_metadata(
             "manifest_hashes": path_hashes["manifest_hashes"],
             "lockfile_hashes": path_hashes["lockfile_hashes"],
             "total_packages": inventory_summary.get("total_packages", len(package_items)),
+            "package_inventory": package_inventory,
             "package_findings": package_findings,
         },
     }

--- a/tests/test_guard_phase06_workspace_audit.py
+++ b/tests/test_guard_phase06_workspace_audit.py
@@ -697,6 +697,49 @@ def test_audit_receipt_metadata_skips_informational_unknown_packages() -> None:
     assert findings[0]["name"] == "risky-lib"
 
 
+def test_audit_receipt_metadata_includes_full_package_inventory() -> None:
+    metadata = audit_receipt_metadata(
+        {
+            "lockfile_paths": ["package-lock.json"],
+            "manifest_paths": ["package.json"],
+            "inventory": {"total_packages": 3},
+            "evaluation": {
+                "decision": "warn",
+                "packages": [
+                    {
+                        "name": "clean-lib",
+                        "ecosystem": "npm",
+                        "decision": "monitor",
+                        "reasons": [],
+                    },
+                    {
+                        "name": "risky-lib",
+                        "ecosystem": "npm",
+                        "decision": "block",
+                        "reasons": [{"code": "known_malware", "message": "known malware", "severity": "critical"}],
+                    },
+                    {
+                        "name": "requests",
+                        "ecosystem": "pypi",
+                        "decision": "monitor",
+                        "reasons": [{"code": "unknown_package", "message": "not indexed", "severity": "low"}],
+                    },
+                ],
+            },
+        }
+    )
+
+    evidence = metadata["scanner_evidence"]
+    inventory = evidence.get("package_inventory")
+    findings = evidence.get("package_findings")
+    assert isinstance(inventory, list)
+    assert len(inventory) == 3
+    assert {item["ecosystem"] for item in inventory} == {"npm", "pypi"}
+    assert isinstance(findings, list)
+    assert len(findings) == 1
+    assert findings[0]["name"] == "risky-lib"
+
+
 def test_workspace_files_discovers_nested_manifests(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     nested = workspace_dir / "dashboard"


### PR DESCRIPTION
## Summary
- Merge audit progress into the workspace audit panel so one surface progresses from scan to results.
- Persist full `package_inventory` on audit receipts and show all indexed packages with ecosystem breakdown and review filter.
- Keep Run audit again in the panel header and surface Guard Cloud vs local-only intel state.

## Testing
- `npx tsx dashboard/src/scsr-phase10-package-workbench.test.ts`
- `npx tsx dashboard/src/supply-chain-ux-consolidation.test.ts`
- `python3 -m pytest tests/test_guard_phase06_workspace_audit.py::test_audit_receipt_metadata_includes_full_package_inventory tests/test_guard_phase06_workspace_audit.py::test_audit_receipt_metadata_includes_prioritized_package_findings -q`
- `cd dashboard && pnpm run build`
