### PR TITLE
feat(guard): bind AIBOM trust attestations to devices

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -47,6 +47,7 @@ def collect_aibom_snapshots(
     *,
     generated_at: str,
     options: AibomCliOptions | None = None,
+    trust_attestation_context: dict[str, object] | None = None,
 ) -> tuple[GuardAgentInventorySnapshot, ...]:
     resolved = options or AibomCliOptions()
     snapshots: list[GuardAgentInventorySnapshot] = []
@@ -70,9 +71,29 @@ def collect_aibom_snapshots(
                 cisco_runs=cisco_runs,
                 include_symlinks=resolved.include_symlinks,
                 follow_unsafe_symlinks=resolved.follow_unsafe_symlinks,
+                trust_attestation_context=trust_attestation_context,
             )
         )
     return tuple(snapshots)
+
+
+def _resolve_trust_attestation_context(store: GuardStore) -> dict[str, object]:
+    from .runtime.trust_attestation import (
+        resolve_guard_oauth_trust_attestation_signing_config,
+        resolve_trust_attestation_signing_config,
+        trust_attestation_v2_enabled,
+    )
+
+    oauth_credentials = store.get_oauth_local_credentials(allow_primary=True)
+    signing_config = resolve_guard_oauth_trust_attestation_signing_config(oauth_credentials)
+    if signing_config is None:
+        signing_config = resolve_trust_attestation_signing_config()
+    enable_v2 = trust_attestation_v2_enabled()
+    return {
+        "deviceId": store.get_or_create_installation_id() if enable_v2 else None,
+        "signingConfig": signing_config,
+        "workspaceId": store.get_cloud_workspace_id() if enable_v2 else None,
+    }
 
 
 def build_inventory_json_payload(
@@ -82,7 +103,12 @@ def build_inventory_json_payload(
     generated_at: str,
     options: AibomCliOptions | None = None,
 ) -> dict[str, object]:
-    snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
+    snapshots = collect_aibom_snapshots(
+        context,
+        generated_at=generated_at,
+        options=options,
+        trust_attestation_context=_resolve_trust_attestation_context(store),
+    )
     metadata_by_artifact = _metadata_lookup_from_snapshots(snapshots)
     items: list[dict[str, object]] = []
     for item in store.list_inventory():
@@ -109,7 +135,12 @@ def build_aibom_status_payload(
     generated_at: str,
     options: AibomCliOptions | None = None,
 ) -> dict[str, object]:
-    snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
+    snapshots = collect_aibom_snapshots(
+        context,
+        generated_at=generated_at,
+        options=options,
+        trust_attestation_context=_resolve_trust_attestation_context(store),
+    )
     sync_summary = _sync_summary(store)
     layer_summary, trust_summary, drift_summary = summarize_aibom_layers(
         snapshots,
@@ -136,7 +167,12 @@ def build_aibom_export_payload(
     options: AibomCliOptions | None = None,
     export_format: AibomExportFormat = "json",
 ) -> dict[str, object]:
-    snapshots = collect_aibom_snapshots(context, generated_at=generated_at, options=options)
+    snapshots = collect_aibom_snapshots(
+        context,
+        generated_at=generated_at,
+        options=options,
+        trust_attestation_context=_resolve_trust_attestation_context(store),
+    )
     serialized_snapshots = [serialize_inventory_snapshot(snapshot) for snapshot in snapshots]
     artifacts = _artifact_rows_from_store(store, snapshots)
     layer_summary, trust_summary, drift_summary = summarize_aibom_layers(
@@ -300,10 +336,12 @@ def sync_aibom_snapshots(
         raise GuardSyncNotConfiguredError("Guard Cloud workspace is not configured. Run `hol-guard connect` first.")
 
     resolved_options = options or _AIBOM_CLOUD_SYNC_OPTIONS
+    trust_attestation_context = _resolve_trust_attestation_context(store)
     snapshots = collect_aibom_snapshots(
         context,
         generated_at=generated_at,
         options=resolved_options,
+        trust_attestation_context=trust_attestation_context,
     )
     if not snapshots:
         synced_at = generated_at
@@ -323,6 +361,11 @@ def sync_aibom_snapshots(
         _inventory_snapshot_event(
             snapshot=snapshot,
             workspace_id=workspace_id,
+            device_id=(
+                str(trust_attestation_context["deviceId"])
+                if isinstance(trust_attestation_context.get("deviceId"), str)
+                else None
+            ),
             generated_at=generated_at,
         )
         for snapshot in snapshots
@@ -575,6 +618,7 @@ def _inventory_snapshot_event(
     *,
     snapshot: GuardAgentInventorySnapshot,
     workspace_id: str,
+    device_id: str | None,
     generated_at: str,
 ) -> dict[str, object]:
     event_id = str(uuid.uuid4())
@@ -585,6 +629,7 @@ def _inventory_snapshot_event(
         "occurredAt": generated_at,
         "source": "edge",
         "workspaceId": workspace_id,
+        "deviceId": device_id,
         "payload": {"snapshot": serialize_inventory_snapshot(snapshot)},
     }
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -6,6 +6,7 @@ import hashlib
 import ipaddress
 import json
 import re
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -368,6 +369,7 @@ def inventory_snapshot_from_detection(
     cisco_runs: tuple[object, ...] = (),
     include_symlinks: bool = True,
     follow_unsafe_symlinks: bool = False,
+    trust_attestation_context: Mapping[str, object] | None = None,
 ) -> GuardAgentInventorySnapshot:
     from .aibom_detection import discover_shared_workspace_aibom_artifacts
 
@@ -395,6 +397,7 @@ def inventory_snapshot_from_detection(
             cisco_runs=cisco_runs,
             include_symlinks=include_symlinks,
             follow_unsafe_symlinks=follow_unsafe_symlinks,
+            trust_attestation_context=trust_attestation_context,
         )
         items.append(item)
         items.extend(
@@ -556,6 +559,7 @@ def _item_from_artifact(
     cisco_runs: tuple[object, ...] = (),
     include_symlinks: bool = True,
     follow_unsafe_symlinks: bool = False,
+    trust_attestation_context: Mapping[str, object] | None = None,
 ) -> GuardAgentInventoryItem:
     artifact_id = str(getattr(artifact, "artifact_id", "artifact"))
     artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
@@ -589,7 +593,22 @@ def _item_from_artifact(
         }
     )
     content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
-    from .runtime.trust_attestation import apply_trust_attestation_metadata
+    from .runtime.trust_attestation import (
+        GuardTrustAttestationSigningConfig,
+        apply_trust_attestation_metadata,
+    )
+
+    workspace_id = None
+    device_id = None
+    signing_config = None
+    if isinstance(trust_attestation_context, Mapping):
+        raw_workspace_id = trust_attestation_context.get("workspaceId")
+        workspace_id = raw_workspace_id if isinstance(raw_workspace_id, str) and raw_workspace_id else None
+        raw_device_id = trust_attestation_context.get("deviceId")
+        device_id = raw_device_id if isinstance(raw_device_id, str) and raw_device_id else None
+        raw_signing_config = trust_attestation_context.get("signingConfig")
+        if isinstance(raw_signing_config, GuardTrustAttestationSigningConfig):
+            signing_config = raw_signing_config
 
     safe_metadata = apply_trust_attestation_metadata(
         safe_metadata,
@@ -597,6 +616,9 @@ def _item_from_artifact(
         item_id=artifact_id,
         item_kind=item_kind,
         content_hash=content_hash,
+        workspace_id=workspace_id,
+        device_id=device_id,
+        signing_config=signing_config,
     )
     publisher = getattr(artifact, "publisher", None)
     publisher_text = publisher if isinstance(publisher, str) else None

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -9,17 +9,23 @@ from dataclasses import dataclass
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric import ec, padding
+from cryptography.hazmat.primitives.asymmetric.ec import EllipticCurvePrivateKey, EllipticCurvePublicKey
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 
 GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION = "guard-aibom-trust-attestation.v1"
+GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION_V2 = "guard-aibom-trust-attestation.v2"
 GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
+GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256 = "ecdsa-p256-sha256"
+_TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
 @dataclass(frozen=True, slots=True)
 class GuardTrustAttestationSigningConfig:
     active_key_id: str
     private_key_pem: str
+    public_jwk_thumbprint: str | None = None
+    signature_algorithm: str = GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM
 
 
 @dataclass(frozen=True, slots=True)
@@ -27,6 +33,7 @@ class GuardTrustAttestationVerificationKey:
     key_id: str
     public_key_pem: str
     fingerprint_sha256: str
+    public_jwk_thumbprint: str | None = None
 
 
 def canonical_trust_attestation_payload(payload: Mapping[str, object]) -> bytes:
@@ -68,7 +75,34 @@ def build_trust_attestation_verification_key(
         key_id=config.active_key_id,
         public_key_pem=public_key_pem,
         fingerprint_sha256=_public_key_fingerprint(public_key_pem),
+        public_jwk_thumbprint=config.public_jwk_thumbprint,
     )
+
+
+def resolve_guard_oauth_trust_attestation_signing_config(
+    credentials: Mapping[str, object] | None,
+) -> GuardTrustAttestationSigningConfig | None:
+    if not isinstance(credentials, Mapping):
+        return None
+    private_key_pem = _normalize_pem(_sanitize_object_string(credentials.get("dpop_private_key_pem")))
+    public_jwk_thumbprint = _sanitize_object_string(credentials.get("dpop_public_jwk_thumbprint")) or None
+    if not private_key_pem or public_jwk_thumbprint is None:
+        return None
+    try:
+        _load_private_key(private_key_pem)
+    except ValueError:
+        return None
+    return GuardTrustAttestationSigningConfig(
+        active_key_id=public_jwk_thumbprint,
+        private_key_pem=private_key_pem,
+        public_jwk_thumbprint=public_jwk_thumbprint,
+        signature_algorithm=GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
+    )
+
+
+def trust_attestation_v2_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    env = environ or os.environ
+    return _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_V2")).lower() in _TRUTHY_ENV_VALUES
 
 
 def build_trust_attestation_payload(
@@ -80,11 +114,18 @@ def build_trust_attestation_payload(
     captured_at: str,
     evidence_hash: str,
     scope: str,
+    workspace_id: str | None = None,
+    device_id: str | None = None,
     layer_id: str | None = None,
     layer_type: str | None = None,
 ) -> dict[str, object]:
+    payload_version = (
+        GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION_V2
+        if workspace_id is not None or device_id is not None
+        else GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION
+    )
     payload: dict[str, object] = {
-        "payloadVersion": GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION,
+        "payloadVersion": payload_version,
         "agentId": agent_id,
         "itemId": item_id,
         "itemKind": item_kind,
@@ -93,6 +134,10 @@ def build_trust_attestation_payload(
         "evidenceHash": evidence_hash,
         "scope": scope,
     }
+    if workspace_id is not None:
+        payload["workspaceId"] = workspace_id
+    if device_id is not None:
+        payload["deviceId"] = device_id
     if layer_id is not None:
         payload["layerId"] = layer_id
     if layer_type is not None:
@@ -107,8 +152,11 @@ def apply_trust_attestation_metadata(
     item_id: str,
     item_kind: str,
     content_hash: str,
+    workspace_id: str | None = None,
+    device_id: str | None = None,
+    signing_config: GuardTrustAttestationSigningConfig | None = None,
 ) -> dict[str, object]:
-    config = resolve_trust_attestation_signing_config()
+    config = signing_config or resolve_trust_attestation_signing_config()
     if config is None:
         return metadata
 
@@ -131,6 +179,8 @@ def apply_trust_attestation_metadata(
                     captured_at=captured_at,
                     evidence_hash=evidence_hash,
                     scope="trust_resolution",
+                    workspace_id=workspace_id,
+                    device_id=device_id,
                 ),
                 config=config,
                 signed_at=captured_at,
@@ -172,6 +222,8 @@ def apply_trust_attestation_metadata(
                         captured_at=captured_at,
                         evidence_hash=evidence_hash,
                         scope="trust_layer",
+                        workspace_id=workspace_id,
+                        device_id=device_id,
                         layer_id=layer_id,
                         layer_type=layer_type,
                     ),
@@ -194,24 +246,30 @@ def sign_trust_attestation(
 ) -> dict[str, object]:
     private_key = _load_private_key(config.private_key_pem)
     canonical_payload = canonical_trust_attestation_payload(_payload_with_signed_at(payload, signed_at))
-    signature = private_key.sign(
-        canonical_payload,
-        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
-        hashes.SHA256(),
+    signature = _sign_payload(
+        private_key=private_key,
+        canonical_payload=canonical_payload,
+        signature_algorithm=config.signature_algorithm,
     )
     verification_key = _verification_key_from_private_key(
         private_key,
         key_id=config.active_key_id,
+        public_jwk_thumbprint=config.public_jwk_thumbprint,
     )
     return {
-        "payloadVersion": GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION,
+        "payloadVersion": str(payload.get("payloadVersion") or GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION),
         "payloadHash": hashlib.sha256(canonical_payload).hexdigest(),
         "signature": base64.b64encode(signature).decode("ascii"),
-        "signatureAlgorithm": GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM,
+        "signatureAlgorithm": config.signature_algorithm,
         "signedAt": signed_at,
         "keyId": verification_key.key_id,
         "publicKeyPem": verification_key.public_key_pem,
         "fingerprintSha256": verification_key.fingerprint_sha256,
+        **(
+            {"publicJwkThumbprint": verification_key.public_jwk_thumbprint}
+            if verification_key.public_jwk_thumbprint is not None
+            else {}
+        ),
     }
 
 
@@ -226,6 +284,7 @@ def verify_trust_attestation(
     raw_key_id = envelope.get("keyId")
     raw_public_key_pem = envelope.get("publicKeyPem")
     raw_fingerprint_sha256 = envelope.get("fingerprintSha256")
+    raw_public_jwk_thumbprint = envelope.get("publicJwkThumbprint")
     raw_signature = envelope.get("signature")
     if not isinstance(raw_payload_hash, str) or not raw_payload_hash:
         raise ValueError("Trust attestation envelope is incomplete")
@@ -244,8 +303,12 @@ def verify_trust_attestation(
     key_id: str = raw_key_id
     public_key_pem: str = raw_public_key_pem
     fingerprint_sha256: str = raw_fingerprint_sha256
+    public_jwk_thumbprint = raw_public_jwk_thumbprint if isinstance(raw_public_jwk_thumbprint, str) else None
     signature: str = raw_signature
-    if signature_algorithm != GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM:
+    if signature_algorithm not in {
+        GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM,
+        GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
+    }:
         raise ValueError("Unsupported trust attestation signature algorithm")
     canonical_payload = canonical_trust_attestation_payload(_payload_with_signed_at(payload, envelope.get("signedAt")))
     if hashlib.sha256(canonical_payload).hexdigest() != payload_hash:
@@ -256,34 +319,36 @@ def verify_trust_attestation(
         trusted_key.key_id == key_id
         and trusted_key.fingerprint_sha256 == fingerprint_sha256
         and _normalize_pem(trusted_key.public_key_pem) == _normalize_pem(public_key_pem)
+        and (public_jwk_thumbprint is None or trusted_key.public_jwk_thumbprint == public_jwk_thumbprint)
         for trusted_key in trusted_keys
     ):
         raise ValueError("Trust attestation key is not trusted")
     public_key = serialization.load_pem_public_key(public_key_pem.encode("utf-8"))
-    if not isinstance(public_key, RSAPublicKey):
-        raise ValueError("Trust attestation public key must be RSA")
+    if not isinstance(public_key, (RSAPublicKey, EllipticCurvePublicKey)):
+        raise ValueError("Trust attestation public key must be RSA or EC")
     try:
-        public_key.verify(
-            base64.b64decode(signature),
-            canonical_payload,
-            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
-            hashes.SHA256(),
+        _verify_signature(
+            public_key=public_key,
+            canonical_payload=canonical_payload,
+            signature=base64.b64decode(signature),
+            signature_algorithm=signature_algorithm,
         )
     except InvalidSignature as exc:
         raise ValueError("Trust attestation signature verification failed") from exc
 
 
-def _load_private_key(private_key_pem: str) -> RSAPrivateKey:
+def _load_private_key(private_key_pem: str) -> RSAPrivateKey | EllipticCurvePrivateKey:
     private_key = serialization.load_pem_private_key(private_key_pem.encode("utf-8"), password=None)
-    if not isinstance(private_key, RSAPrivateKey):
-        raise ValueError("Trust attestation private key must be RSA")
+    if not isinstance(private_key, (RSAPrivateKey, EllipticCurvePrivateKey)):
+        raise ValueError("Trust attestation private key must be RSA or EC")
     return private_key
 
 
 def _verification_key_from_private_key(
-    private_key: RSAPrivateKey,
+    private_key: RSAPrivateKey | EllipticCurvePrivateKey,
     *,
     key_id: str,
+    public_jwk_thumbprint: str | None = None,
 ) -> GuardTrustAttestationVerificationKey:
     public_key_pem = (
         private_key.public_key()
@@ -298,7 +363,58 @@ def _verification_key_from_private_key(
         key_id=key_id,
         public_key_pem=public_key_pem,
         fingerprint_sha256=_public_key_fingerprint(public_key_pem),
+        public_jwk_thumbprint=public_jwk_thumbprint,
     )
+
+
+def _sign_payload(
+    *,
+    private_key: RSAPrivateKey | EllipticCurvePrivateKey,
+    canonical_payload: bytes,
+    signature_algorithm: str,
+) -> bytes:
+    if signature_algorithm == GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM:
+        if not isinstance(private_key, RSAPrivateKey):
+            raise ValueError("Trust attestation private key must be RSA")
+        return private_key.sign(
+            canonical_payload,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+    if signature_algorithm == GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256:
+        if not isinstance(private_key, EllipticCurvePrivateKey):
+            raise ValueError("Trust attestation private key must be EC")
+        if not isinstance(private_key.curve, ec.SECP256R1):
+            raise ValueError("Trust attestation EC private key must use P-256")
+        return private_key.sign(canonical_payload, ec.ECDSA(hashes.SHA256()))
+    raise ValueError("Unsupported trust attestation signature algorithm")
+
+
+def _verify_signature(
+    *,
+    public_key: RSAPublicKey | EllipticCurvePublicKey,
+    canonical_payload: bytes,
+    signature: bytes,
+    signature_algorithm: str,
+) -> None:
+    if signature_algorithm == GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM:
+        if not isinstance(public_key, RSAPublicKey):
+            raise ValueError("Trust attestation public key must be RSA")
+        public_key.verify(
+            signature,
+            canonical_payload,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
+            hashes.SHA256(),
+        )
+        return
+    if signature_algorithm == GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256:
+        if not isinstance(public_key, EllipticCurvePublicKey):
+            raise ValueError("Trust attestation public key must be EC")
+        if not isinstance(public_key.curve, ec.SECP256R1):
+            raise ValueError("Trust attestation EC public key must use P-256")
+        public_key.verify(signature, canonical_payload, ec.ECDSA(hashes.SHA256()))
+        return
+    raise ValueError("Unsupported trust attestation signature algorithm")
 
 
 def _payload_with_signed_at(
@@ -318,6 +434,10 @@ def _public_key_fingerprint(public_key_pem: str) -> str:
 
 def _sanitize_env(value: str | None) -> str:
     return value.replace("\\n", "\n").replace("\r\n", "\n").strip().strip("'\"") if isinstance(value, str) else ""
+
+
+def _sanitize_object_string(value: object) -> str:
+    return value.strip() if isinstance(value, str) else ""
 
 
 def _normalize_pem(value: str) -> str:

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -12,7 +12,7 @@ from codex_plugin_scanner.guard import aibom_cli
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.cli import commands_dispatch_records as dispatch
 from codex_plugin_scanner.guard.inventory_cisco import CiscoInventoryRun
-from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
+from codex_plugin_scanner.guard.inventory_contract import GuardAgentInventorySnapshot, inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -291,6 +291,52 @@ def test_sync_aibom_snapshots_if_due_retries_empty_sync_after_interval(
     assert summary.get("synced") is True
 
 
+def test_inventory_snapshot_event_includes_device_id() -> None:
+    snapshot = GuardAgentInventorySnapshot(
+        snapshot_id='snapshot-aibom-1',
+        agent_id='codex:local',
+        agent_type='codex',
+        generated_at='2026-06-10T12:00:00+00:00',
+        runtime_version='test',
+    )
+
+    event = aibom_cli._inventory_snapshot_event(
+        snapshot=snapshot,
+        workspace_id='workspace-1',
+        device_id='device-1',
+        generated_at='2026-06-10T12:00:00+00:00',
+    )
+
+    assert event['deviceId'] == 'device-1'
+
+
+def test_resolve_trust_attestation_context_defaults_to_v1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / 'guard')
+    monkeypatch.setattr(store, 'get_cloud_workspace_id', lambda: 'workspace-1')
+    monkeypatch.setattr(store, 'get_or_create_installation_id', lambda: 'device-1')
+    monkeypatch.delenv('GUARD_AIBOM_TRUST_ATTESTATION_V2', raising=False)
+
+    context = aibom_cli._resolve_trust_attestation_context(store)
+
+    assert context['workspaceId'] is None
+    assert context['deviceId'] is None
+
+
+def test_resolve_trust_attestation_context_includes_workspace_device_for_v2(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / 'guard')
+    monkeypatch.setattr(store, 'get_cloud_workspace_id', lambda: 'workspace-1')
+    monkeypatch.setattr(store, 'get_or_create_installation_id', lambda: 'device-1')
+    monkeypatch.setenv('GUARD_AIBOM_TRUST_ATTESTATION_V2', '1')
+
+    context = aibom_cli._resolve_trust_attestation_context(store)
+
+    assert context['workspaceId'] == 'workspace-1'
+    assert context['deviceId'] == 'device-1'
+
+
 def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(
     tmp_path: Path,
     monkeypatch,
@@ -474,6 +520,10 @@ def test_sync_aibom_snapshots_uses_cloud_sync_cisco_defaults(
     assert options.cisco_skill_scan == "auto"
     assert options.cisco_mcp_scan == "auto"
     assert options.cisco_timeout_seconds == 30.0
+    trust_attestation_context = collect_kwargs["trust_attestation_context"]
+    assert isinstance(trust_attestation_context, dict)
+    assert trust_attestation_context["deviceId"] is None
+    assert trust_attestation_context["workspaceId"] is None
 
 
 def test_guard_aibom_sync_command_uses_cloud_sync_cisco_defaults(

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -9,15 +9,22 @@ from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
+import pytest
 from cryptography.hazmat.primitives import serialization
-from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
+from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.aibom_trust_metadata import trust_resolution_from_domain
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.runtime.trust_attestation import (
+    GuardTrustAttestationSigningConfig,
     GuardTrustAttestationVerificationKey,
+    GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
     build_trust_attestation_payload,
+    build_trust_attestation_verification_key,
+    resolve_guard_oauth_trust_attestation_signing_config,
+    sign_trust_attestation,
     verify_trust_attestation,
 )
 from codex_plugin_scanner.trust_models import TrustDomainScore
@@ -62,6 +69,7 @@ def _snapshot_for_artifact(
     generated_at: str,
     home_dir: Path,
     workspace_dir: Path,
+    trust_attestation_context: Mapping[str, object] | None = None,
 ) -> Any:
     detection = HarnessDetection(
         harness="codex",
@@ -75,6 +83,7 @@ def _snapshot_for_artifact(
         generated_at=generated_at,
         home_dir=home_dir,
         workspace_dir=workspace_dir,
+        trust_attestation_context=trust_attestation_context,
     )
 
 
@@ -393,6 +402,64 @@ def test_inventory_snapshot_signs_local_trust_metadata_when_configured(monkeypat
         envelope=attestation,
         trusted_keys=(verification_key,),
     )
+
+
+def test_inventory_snapshot_signs_local_trust_metadata_with_workspace_device_binding(
+    tmp_path: Path,
+) -> None:
+    dpop_key_material = generate_dpop_key_pair()
+    signing_config = resolve_guard_oauth_trust_attestation_signing_config(
+        {
+            "dpop_private_key_pem": dpop_key_material.private_key_pem,
+            "dpop_public_jwk_thumbprint": dpop_key_material.public_jwk_thumbprint,
+        }
+    )
+    assert signing_config is not None
+    verification_key = build_trust_attestation_verification_key(signing_config)
+    plugin_dir = tmp_path
+    _write_good_plugin(plugin_dir)
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:plugin:trust-demo",
+            name="trust-demo",
+            harness="codex",
+            artifact_type="plugin",
+            source_scope="project",
+            config_path=str(plugin_dir),
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+        trust_attestation_context={
+            "deviceId": "device-alpha",
+            "signingConfig": signing_config,
+            "workspaceId": "workspace-alpha",
+        },
+    )
+    plugin_item = next(item for item in snapshot.items if item.item_kind == "plugin")
+    trust = plugin_item.metadata.get("trustResolution")
+    assert isinstance(trust, dict)
+    metadata = trust.get("metadata")
+    assert isinstance(metadata, dict)
+    attestation = metadata.get("attestation")
+    assert isinstance(attestation, dict)
+    assert attestation.get("signatureAlgorithm") == GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256
+    assert attestation.get("publicJwkThumbprint") == dpop_key_material.public_jwk_thumbprint
+    verify_trust_attestation(
+        payload=build_trust_attestation_payload(
+            agent_id=snapshot.agent_id,
+            item_id=plugin_item.item_id,
+            item_kind=plugin_item.item_kind,
+            content_hash=plugin_item.content_hash,
+            captured_at=str(trust.get("capturedAt")),
+            evidence_hash=str(metadata.get("evidenceHash")),
+            scope="trust_resolution",
+            workspace_id="workspace-alpha",
+            device_id="device-alpha",
+        ),
+        envelope=attestation,
+        trusted_keys=(verification_key,),
+    )
     trust_layers = plugin_item.metadata.get("trustLayers")
     assert isinstance(trust_layers, list)
     local_layer = next(
@@ -412,11 +479,56 @@ def test_inventory_snapshot_signs_local_trust_metadata_when_configured(monkeypat
             captured_at=str(local_layer.get("capturedAt")),
             evidence_hash=str(layer_metadata.get("evidenceHash")),
             scope="trust_layer",
+            workspace_id="workspace-alpha",
+            device_id="device-alpha",
             layer_id=str(local_layer.get("layerId")),
             layer_type=str(local_layer.get("layerType")),
         ),
         envelope=layer_attestation,
         trusted_keys=(verification_key,),
+    )
+
+
+def test_p384_key_is_rejected_for_p256_attestation() -> None:
+    private_key = ec.generate_private_key(ec.SECP384R1())
+    private_key_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode('ascii')
+
+    with pytest.raises(ValueError, match='P-256'):
+        sign_trust_attestation(
+            payload=build_trust_attestation_payload(
+                agent_id='agent-1',
+                item_id='plugin:trust-demo',
+                item_kind='plugin',
+                content_hash='sha256:plugin-local',
+                captured_at='2026-06-10T12:00:00+00:00',
+                evidence_hash='resolution-hash',
+                scope='trust_resolution',
+                workspace_id='workspace-alpha',
+                device_id='device-alpha',
+            ),
+            config=GuardTrustAttestationSigningConfig(
+                active_key_id='p384-key',
+                private_key_pem=private_key_pem,
+                public_jwk_thumbprint='p384-key',
+                signature_algorithm=GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
+            ),
+            signed_at='2026-06-10T12:00:00+00:00',
+        )
+
+
+def test_invalid_oauth_private_key_disables_attestation_signing_config() -> None:
+    assert (
+        resolve_guard_oauth_trust_attestation_signing_config(
+            {
+                "dpop_private_key_pem": "-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+                "dpop_public_jwk_thumbprint": "thumbprint-123",
+            }
+        )
+        is None
     )
 
 


### PR DESCRIPTION
## Summary
- bind AIBOM trust attestations to workspace and device context during Guard snapshot generation
- sign trust attestations with connected Guard OAuth device keys when available and emit device ids on inventory snapshot events

## Testing
- `uv run pytest -q tests/test_guard_aibom_cli.py tests/test_guard_aibom_trust_metadata.py`
