### PR TITLE
fix(hol-guard): enforce emergency denylist in offline bundle evaluation

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -28,6 +28,7 @@ from .supply_chain_bundle_base import (
 )
 from .supply_chain_bundle_models import (
     SupplyChainBundle,
+    SupplyChainBundleEmergencyDeny,
     SupplyChainBundlePackage,
     SupplyChainBundleResponse,
     SupplyChainVerificationKey,
@@ -225,6 +226,32 @@ def _normalize_package_name(ecosystem: str, package_name: str) -> str:
     return normalized
 
 
+def _emergency_deny_identity_matches(entry: SupplyChainBundleEmergencyDeny, package_name: str) -> bool:
+    normalized_name = _normalize_package_name(entry.ecosystem, package_name)
+    namespace_name = (
+        _normalize_package_name(entry.ecosystem, f"{entry.namespace}/{entry.name}")
+        if entry.namespace is not None
+        else None
+    )
+    entry_leaf_name = _normalize_package_name(entry.ecosystem, entry.name)
+    if normalized_name.startswith("@"):
+        return namespace_name == normalized_name
+    return entry.namespace is None and entry_leaf_name == normalized_name
+
+
+def _matching_emergency_deny_entries(
+    bundle: SupplyChainBundle,
+    *,
+    package_name: str,
+    ecosystem: str | None,
+) -> tuple[SupplyChainBundleEmergencyDeny, ...]:
+    return tuple(
+        item
+        for item in bundle.emergency_denylist
+        if (ecosystem is None or item.ecosystem == ecosystem) and _emergency_deny_identity_matches(item, package_name)
+    )
+
+
 def _is_high_confidence_block(package: SupplyChainBundlePackage) -> bool:
     return package.default_action == "block" and (
         package.known_exploited
@@ -261,6 +288,19 @@ def evaluate_cached_supply_chain_bundle(
         check_supply_chain_bundle_freshness(response.bundle, now=now)
     except SupplyChainBundleExpiredError:
         stale = True
+    deny_entries = _matching_emergency_deny_entries(
+        response.bundle,
+        package_name=package_name,
+        ecosystem=ecosystem,
+    )
+    if deny_entries:
+        return OfflineSupplyChainDecision(
+            action="block",
+            bundle_version=response.bundle.bundle_version,
+            matched_advisory_ids=(),
+            reason=deny_entries[0].reason,
+            stale=stale,
+        )
     matches = [
         item
         for item in response.bundle.packages

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_bundle_runtime.py
@@ -44,6 +44,8 @@ class OfflineSupplyChainDecision:
     matched_advisory_ids: tuple[str, ...]
     reason: str
     stale: bool
+    recommended_fix_version: str | None = None
+    emergency_deny: bool = False
 
 
 def canonical_supply_chain_bundle_payload(bundle: SupplyChainBundle | dict[str, object]) -> bytes:
@@ -203,18 +205,22 @@ def verify_supply_chain_bundle_response(
         raise SupplyChainBundleSignatureError("Supply-chain bundle signature verification failed") from exc
 
 
-def _package_matches(package: SupplyChainBundlePackage, package_name: str, package_version: str | None) -> bool:
-    normalized_name = _normalize_package_name(package.ecosystem, package_name)
-    namespace_name = (
-        _normalize_package_name(package.ecosystem, f"{package.namespace}/{package.name}")
-        if package.namespace is not None
-        else None
-    )
-    package_leaf_name = _normalize_package_name(package.ecosystem, package.name)
+def _package_identity_matches(
+    ecosystem: str,
+    namespace: str | None,
+    name: str,
+    package_name: str,
+) -> bool:
+    normalized_name = _normalize_package_name(ecosystem, package_name)
+    namespace_name = _normalize_package_name(ecosystem, f"{namespace}/{name}") if namespace is not None else None
+    leaf_name = _normalize_package_name(ecosystem, name)
     if normalized_name.startswith("@"):
-        if namespace_name != normalized_name:
-            return False
-    elif package.namespace is not None or package_leaf_name != normalized_name:
+        return namespace_name == normalized_name
+    return namespace is None and leaf_name == normalized_name
+
+
+def _package_matches(package: SupplyChainBundlePackage, package_name: str, package_version: str | None) -> bool:
+    if not _package_identity_matches(package.ecosystem, package.namespace, package.name, package_name):
         return False
     return package_version is None or package.version == package_version
 
@@ -227,16 +233,7 @@ def _normalize_package_name(ecosystem: str, package_name: str) -> str:
 
 
 def _emergency_deny_identity_matches(entry: SupplyChainBundleEmergencyDeny, package_name: str) -> bool:
-    normalized_name = _normalize_package_name(entry.ecosystem, package_name)
-    namespace_name = (
-        _normalize_package_name(entry.ecosystem, f"{entry.namespace}/{entry.name}")
-        if entry.namespace is not None
-        else None
-    )
-    entry_leaf_name = _normalize_package_name(entry.ecosystem, entry.name)
-    if normalized_name.startswith("@"):
-        return namespace_name == normalized_name
-    return entry.namespace is None and entry_leaf_name == normalized_name
+    return _package_identity_matches(entry.ecosystem, entry.namespace, entry.name, package_name)
 
 
 def _matching_emergency_deny_entries(
@@ -294,12 +291,15 @@ def evaluate_cached_supply_chain_bundle(
         ecosystem=ecosystem,
     )
     if deny_entries:
+        deny_entry = deny_entries[0]
         return OfflineSupplyChainDecision(
             action="block",
             bundle_version=response.bundle.bundle_version,
             matched_advisory_ids=(),
-            reason=deny_entries[0].reason,
+            reason=deny_entry.reason,
             stale=stale,
+            recommended_fix_version=deny_entry.recommended_fix_version,
+            emergency_deny=True,
         )
     matches = [
         item

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1038,6 +1038,23 @@ def _evaluate_with_bundle(
             ecosystem=_optional_string(target.get("ecosystem")) or "npm",
             now=now_timestamp,
         )
+        if offline.emergency_deny and offline.action == "block":
+            packages.append(
+                _heuristic_package_result(
+                    target=target,
+                    decision="block",
+                    code=offline.reason,
+                    message=_emergency_deny_bundle_message(
+                        target=target,
+                        resolved_version=resolved_version,
+                        reason=offline.reason,
+                    ),
+                    severity="critical",
+                    resolved_version=resolved_version,
+                    recommended_fix_version=offline.recommended_fix_version,
+                )
+            )
+            continue
         if package_match is None:
             if offline.action == "block":
                 packages.append(
@@ -1051,6 +1068,8 @@ def _evaluate_with_bundle(
                             reason=offline.reason,
                         ),
                         severity="critical",
+                        resolved_version=resolved_version,
+                        recommended_fix_version=offline.recommended_fix_version,
                     )
                 )
                 continue
@@ -1548,46 +1567,56 @@ def _transitive_lockfile_results(
                 package_version=version,
                 ecosystem=lockfile_ecosystem,
             )
-            if package_match is None:
-                offline = evaluate_cached_supply_chain_bundle(
-                    bundle_response,
-                    package_name=package_name,
-                    package_version=version,
-                    ecosystem=lockfile_ecosystem,
-                    now=now_timestamp,
+            offline = evaluate_cached_supply_chain_bundle(
+                bundle_response,
+                package_name=package_name,
+                package_version=version,
+                ecosystem=lockfile_ecosystem,
+                now=now_timestamp,
+            )
+            if offline.emergency_deny and offline.action == "block":
+                results.append(
+                    {
+                        "decision": "block",
+                        "ecosystem": lockfile_ecosystem or "npm",
+                        "name": package_name.rsplit("/", 1)[-1],
+                        "namespace": (
+                            package_name.rsplit("/", 1)[0]
+                            if package_name.startswith("@") and "/" in package_name
+                            else None
+                        ),
+                        "requestedVersion": version,
+                        "resolvedVersion": version,
+                        "recommendedFixVersion": offline.recommended_fix_version,
+                        "riskScore": None,
+                        "direct": False,
+                        "dependencyPath": dependency_path,
+                        "packageManager": str(artifact.metadata.get("package_manager") or "npm"),
+                        "redactedCommand": _optional_string(artifact.metadata.get("redacted_command")),
+                        "reasons": (
+                            {
+                                "code": offline.reason,
+                                "message": _emergency_deny_bundle_message(
+                                    target={
+                                        "name": package_name.rsplit("/", 1)[-1],
+                                        "namespace": (
+                                            package_name.rsplit("/", 1)[0]
+                                            if package_name.startswith("@") and "/" in package_name
+                                            else None
+                                        ),
+                                        "ecosystem": lockfile_ecosystem or "npm",
+                                    },
+                                    resolved_version=version,
+                                    reason=offline.reason,
+                                ),
+                                "severity": "critical",
+                                "source": "bundle",
+                            },
+                        ),
+                    }
                 )
-                if offline.action == "block":
-                    results.append(
-                        {
-                            "decision": "block",
-                            "ecosystem": lockfile_ecosystem or "npm",
-                            "name": package_name.rsplit("/", 1)[-1],
-                            "namespace": (
-                                package_name.rsplit("/", 1)[0]
-                                if package_name.startswith("@") and "/" in package_name
-                                else None
-                            ),
-                            "requestedVersion": version,
-                            "resolvedVersion": version,
-                            "recommendedFixVersion": None,
-                            "riskScore": None,
-                            "direct": False,
-                            "dependencyPath": dependency_path,
-                            "packageManager": str(artifact.metadata.get("package_manager") or "npm"),
-                            "redactedCommand": _optional_string(artifact.metadata.get("redacted_command")),
-                            "reasons": (
-                                {
-                                    "code": offline.reason,
-                                    "message": (
-                                        "Emergency denylist blocked transitive dependency "
-                                        f"{package_name}@{version}."
-                                    ),
-                                    "severity": "critical",
-                                    "source": "bundle",
-                                },
-                            ),
-                        }
-                    )
+                continue
+            if package_match is None:
                 continue
             decision = _transitive_lockfile_decision(package=package_match, stale=bundle_stale)
             if decision not in {"ask", "block", "warn"}:
@@ -2225,6 +2254,8 @@ def _heuristic_package_result(
     code: str,
     message: str,
     severity: str,
+    resolved_version: str | None = None,
+    recommended_fix_version: str | None = None,
 ) -> dict[str, object]:
     return {
         "decision": decision,
@@ -2232,8 +2263,10 @@ def _heuristic_package_result(
         "name": target["name"],
         "namespace": target["namespace"],
         "requestedVersion": _optional_string(target.get("range")) or _optional_string(target.get("version")),
-        "resolvedVersion": _optional_string(target.get("version")),
-        "recommendedFixVersion": None,
+        "resolvedVersion": (
+            resolved_version if resolved_version is not None else _optional_string(target.get("version"))
+        ),
+        "recommendedFixVersion": recommended_fix_version,
         "riskScore": None,
         "direct": True,
         "dependencyPath": None,

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1039,6 +1039,21 @@ def _evaluate_with_bundle(
             now=now_timestamp,
         )
         if package_match is None:
+            if offline.action == "block":
+                packages.append(
+                    _heuristic_package_result(
+                        target=target,
+                        decision="block",
+                        code=offline.reason,
+                        message=_emergency_deny_bundle_message(
+                            target=target,
+                            resolved_version=resolved_version,
+                            reason=offline.reason,
+                        ),
+                        severity="critical",
+                    )
+                )
+                continue
             safe_allow = _recommended_fix_allow_package_result(
                 target=target,
                 resolved_version=resolved_version,
@@ -1534,6 +1549,45 @@ def _transitive_lockfile_results(
                 ecosystem=lockfile_ecosystem,
             )
             if package_match is None:
+                offline = evaluate_cached_supply_chain_bundle(
+                    bundle_response,
+                    package_name=package_name,
+                    package_version=version,
+                    ecosystem=lockfile_ecosystem,
+                    now=now_timestamp,
+                )
+                if offline.action == "block":
+                    results.append(
+                        {
+                            "decision": "block",
+                            "ecosystem": lockfile_ecosystem or "npm",
+                            "name": package_name.rsplit("/", 1)[-1],
+                            "namespace": (
+                                package_name.rsplit("/", 1)[0]
+                                if package_name.startswith("@") and "/" in package_name
+                                else None
+                            ),
+                            "requestedVersion": version,
+                            "resolvedVersion": version,
+                            "recommendedFixVersion": None,
+                            "riskScore": None,
+                            "direct": False,
+                            "dependencyPath": dependency_path,
+                            "packageManager": str(artifact.metadata.get("package_manager") or "npm"),
+                            "redactedCommand": _optional_string(artifact.metadata.get("redacted_command")),
+                            "reasons": (
+                                {
+                                    "code": offline.reason,
+                                    "message": (
+                                        "Emergency denylist blocked transitive dependency "
+                                        f"{package_name}@{version}."
+                                    ),
+                                    "severity": "critical",
+                                    "source": "bundle",
+                                },
+                            ),
+                        }
+                    )
                 continue
             decision = _transitive_lockfile_decision(package=package_match, stale=bundle_stale)
             if decision not in {"ask", "block", "warn"}:
@@ -3725,6 +3779,22 @@ def _cloud_fallback_reason(*, code: str, message: str) -> dict[str, object]:
         "severity": "unknown",
         "source": "guard-cloud",
     }
+
+
+def _emergency_deny_bundle_message(
+    *,
+    target: dict[str, object],
+    resolved_version: str,
+    reason: str,
+) -> str:
+    package_label = f"{_package_display_name(target)}@{resolved_version}"
+    if reason == "known_malware":
+        return f"Emergency denylist blocked {package_label} for known malware."
+    if reason == "known_exploited":
+        return f"Emergency denylist blocked {package_label} because it is a known exploited vulnerability."
+    if reason == "critical_active_exploit":
+        return f"Emergency denylist blocked {package_label} for a critical active exploit."
+    return f"Emergency denylist blocked {package_label}."
 
 
 def _bundle_reason_message(

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -425,6 +425,8 @@ def test_supply_chain_bundle_offline_evaluation_enforces_emergency_deny_without_
     assert decision.action == "block"
     assert decision.reason == "known_malware"
     assert decision.stale is False
+    assert decision.recommended_fix_version == "1.2.9"
+    assert decision.emergency_deny is True
 
 
 def test_supply_chain_bundle_offline_evaluation_enforces_emergency_deny_when_bundle_is_stale() -> None:

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -390,6 +390,81 @@ def test_supply_chain_bundle_verifies_portal_signed_payload_with_emergency_denyl
     assert response.bundle.emergency_denylist[0].reason == "known_malware"
 
 
+def test_supply_chain_bundle_offline_evaluation_enforces_emergency_deny_without_package_entry() -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict(
+        default_action="monitor",
+        exploit_level="none",
+        known_exploited=False,
+        malware_state="none",
+        normalized_severity="low",
+        risk_score=120,
+    )
+    bundle["packages"] = []
+    bundle["emergencyDenylist"] = [
+        {
+            "ecosystem": "npm",
+            "name": "minimist",
+            "namespace": None,
+            "reason": "known_malware",
+            "recommendedFixVersion": "1.2.9",
+        }
+    ]
+    response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key))
+    )
+
+    decision = evaluate_cached_supply_chain_bundle(
+        response,
+        package_name="minimist",
+        package_version="1.2.8",
+        ecosystem="npm",
+        now=response.bundle.generated_at_timestamp + 60,
+    )
+
+    assert decision.action == "block"
+    assert decision.reason == "known_malware"
+    assert decision.stale is False
+
+
+def test_supply_chain_bundle_offline_evaluation_enforces_emergency_deny_when_bundle_is_stale() -> None:
+    private_key, _public_key = _generate_key_pair()
+    bundle = _bundle_dict(
+        default_action="monitor",
+        exploit_level="none",
+        expires_at=datetime(2026, 5, 18, 1, tzinfo=timezone.utc),
+        known_exploited=False,
+        malware_state="none",
+        normalized_severity="low",
+        risk_score=120,
+    )
+    bundle["packages"] = []
+    bundle["emergencyDenylist"] = [
+        {
+            "ecosystem": "npm",
+            "name": "minimist",
+            "namespace": None,
+            "reason": "critical_active_exploit",
+            "recommendedFixVersion": None,
+        }
+    ]
+    response = load_supply_chain_bundle_response(
+        json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key))
+    )
+
+    decision = evaluate_cached_supply_chain_bundle(
+        response,
+        package_name="minimist",
+        package_version="9.9.9",
+        ecosystem="npm",
+        now=datetime(2026, 5, 19, tzinfo=timezone.utc).timestamp(),
+    )
+
+    assert decision.action == "block"
+    assert decision.reason == "critical_active_exploit"
+    assert decision.stale is True
+
+
 def test_supply_chain_bundle_verifies_portal_signed_payload_with_sparse_policy_rules() -> None:
     private_key, _public_key = _generate_key_pair()
     bundle = _bundle_dict()


### PR DESCRIPTION
## Summary
- Emergency denylist entries now block in evaluate_cached_supply_chain_bundle before package lookup
- _evaluate_with_bundle honors offline block when package_match is None
- Transitive deps checked against emergency denylist

## Testing
- pytest tests/test_guard_supply_chain_bundle.py -q
- pytest tests/test_guard_supply_chain_evaluator.py -k bundle -q
