### PR TITLE
fix(guard): recover sync after team workspace connect

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -255,6 +255,7 @@ def _finalize_guard_connect_payload(
         sync_payload = sync_local_guard_cloud_proof(
             store,
             auth_context=resolved_sync_auth_context,
+            now=now,
         )
     except GuardSyncNotAvailableError as error:
         store.record_latest_guard_connect_sync_result(

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -19,7 +19,10 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 from ...version import __version__
-from ..package_firewall_entitlement import build_oauth_package_firewall_entitlement
+from ..package_firewall_entitlement import (
+    build_oauth_package_firewall_entitlement,
+    reconcile_connect_state_with_oauth_entitlement,
+)
 from ..runtime.runner import prepare_guard_cloud_connect_authorization
 from ..store import GuardStore
 from ..store_connect import build_connect_state_response
@@ -866,6 +869,7 @@ def _persist_oauth_local_credentials(
         runtime_label=runtime_label,
         now=now,
     )
+    reconcile_connect_state_with_oauth_entitlement(store, now=now)
 
 
 def run_guard_disconnect_command(

--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -203,6 +203,33 @@ def _requires_guard_cloud_connect(
     return not (bundle is not None and bool(bundle.get("allowed")))
 
 
+def reconcile_connect_state_with_oauth_entitlement(
+    store: GuardStore,
+    *,
+    now: str,
+) -> dict[str, object] | None:
+    """Clear stale sync_not_available when OAuth credentials reflect a paid plan."""
+    latest_state = store.get_effective_guard_connect_state(now=now)
+    if not isinstance(latest_state, dict):
+        return None
+    milestone = _optional_string(latest_state.get("milestone"))
+    if milestone != "sync_not_available":
+        return None
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    oauth_fields = _oauth_entitlement_fields_from_sync_payload(oauth_payload)
+    if not isinstance(oauth_fields, dict):
+        return None
+    plan_id = _optional_string(oauth_fields.get("supply_chain_plan_id"))
+    if plan_id is None or plan_id.lower() not in PACKAGE_FIREWALL_PAID_TIERS:
+        return None
+    return store.record_latest_guard_connect_sync_result(
+        status="connected",
+        milestone="first_sync_pending",
+        now=now,
+        reason=None,
+    )
+
+
 def resolve_package_firewall_entitlement(
     store: GuardStore,
     *,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -46,7 +46,10 @@ from ..config import GuardConfig
 from ..consumer import detect_harness, evaluate_detection
 from ..edge_events import build_runtime_session_event
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
-from ..package_firewall_entitlement import build_oauth_package_firewall_entitlement
+from ..package_firewall_entitlement import (
+    build_oauth_package_firewall_entitlement,
+    reconcile_connect_state_with_oauth_entitlement,
+)
 from ..policy_bundle_parser import (
     POLICY_BUNDLE_DEFAULT_ENVIRONMENTS,
     POLICY_BUNDLE_RULE_ACTIONS,
@@ -1986,6 +1989,7 @@ def sync_local_guard_cloud_proof(
     auth_context: dict[str, object] | None = None,
 ) -> dict[str, object]:
     """Publish the local Guard runtime session before syncing receipts."""
+    reconcile_connect_state_with_oauth_entitlement(store, now=_now())
     with store.hold_cloud_sync_lock():
         resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
         runtime_summary = sync_runtime_session(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1987,10 +1987,12 @@ def sync_local_guard_cloud_proof(
     store: GuardStore,
     *,
     auth_context: dict[str, object] | None = None,
+    now: str | None = None,
 ) -> dict[str, object]:
     """Publish the local Guard runtime session before syncing receipts."""
-    reconcile_connect_state_with_oauth_entitlement(store, now=_now())
+    resolved_now = now or _now()
     with store.hold_cloud_sync_lock():
+        reconcile_connect_state_with_oauth_entitlement(store, now=resolved_now)
         resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
         runtime_summary = sync_runtime_session(
             store,

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -32,6 +32,7 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sy
         _store: GuardStore,
         *,
         auth_context: dict[str, object] | None = None,
+        now: str | None = None,
     ) -> dict[str, object]:
         assert auth_context is None
         raise RuntimeError("temporary receipt sync failure")
@@ -80,6 +81,7 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_sync_lock_ti
         _store: GuardStore,
         *,
         auth_context: dict[str, object] | None = None,
+        now: str | None = None,
     ) -> dict[str, object]:
         assert auth_context is None
         raise TimeoutError("Timed out waiting for Guard Cloud sync lock.")
@@ -121,6 +123,7 @@ def test_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(tmp_p
         _store: GuardStore,
         *,
         auth_context: dict[str, object] | None = None,
+        now: str | None = None,
     ) -> dict[str, object]:
         sync_calls.append(auth_context)
         return {
@@ -223,6 +226,7 @@ def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_onc
         _store: GuardStore,
         *,
         auth_context: dict[str, object] | None = None,
+        now: str | None = None,
     ) -> dict[str, object]:
         sync_calls.append(auth_context)
         return {
@@ -324,6 +328,7 @@ def test_daemon_finalize_guard_connect_payload_keeps_first_sync_pending_on_sync_
         _store: GuardStore,
         *,
         auth_context: dict[str, object] | None = None,
+        now: str | None = None,
     ) -> dict[str, object]:
         assert auth_context is None
         raise TimeoutError("Timed out waiting for Guard Cloud sync lock.")
@@ -457,6 +462,7 @@ def test_finalize_guard_connect_payload_keeps_reauth_failures_in_retry_required_
         _store: GuardStore,
         *,
         auth_context: dict[str, object] | None = None,
+        now: str | None = None,
     ) -> dict[str, object]:
         assert auth_context is None
         raise guard_commands_module.GuardSyncAuthorizationExpiredError("reauth required")
@@ -498,7 +504,12 @@ def test_headless_first_sync_auth_expiry_marks_connect_state_for_repair(tmp_path
         lambda: {"configured": True, "state": "healthy"},
     )
 
-    def _raise_auth_expired(_store: GuardStore) -> dict[str, object]:
+    def _raise_auth_expired(
+        _store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+        now: str | None = None,
+    ) -> dict[str, object]:
         raise guard_commands_module.GuardSyncAuthorizationExpiredError("reauth required")
 
     def _record_queue(*, store: GuardStore) -> dict[str, object]:

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6712,6 +6712,7 @@ url = http://127.0.0.1:8787/guard-canary
             store: GuardStore,
             *,
             auth_context: dict[str, object] | None = None,
+            now: str | None = None,
         ) -> dict[str, object]:
             del store
             assert auth_context is None

--- a/tests/test_guard_package_firewall_entitlement.py
+++ b/tests/test_guard_package_firewall_entitlement.py
@@ -1,0 +1,72 @@
+"""Tests for package-firewall entitlement helpers."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+
+from codex_plugin_scanner.guard.package_firewall_entitlement import (
+    build_oauth_package_firewall_entitlement,
+    reconcile_connect_state_with_oauth_entitlement,
+)
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def test_build_oauth_package_firewall_entitlement_preserves_team_tier() -> None:
+    entitlement = build_oauth_package_firewall_entitlement(
+        {
+            "guard_local_entitlement": {
+                "plan_id": "team",
+                "tier": "team",
+                "supply_chain_firewall": True,
+                "expires_at": "2026-06-30T00:00:00.000Z",
+            }
+        },
+        now=datetime(2026, 5, 31, tzinfo=timezone.utc),
+    )
+
+    assert entitlement == {
+        "plan_id": "team",
+        "supply_chain_entitlement_expires_at": "2026-06-30T00:00:00.000Z",
+        "supply_chain_firewall": True,
+        "supply_chain_plan_id": "team",
+    }
+
+
+def test_reconcile_connect_state_clears_stale_sync_not_available_for_paid_oauth(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-05-31T09:00:00.000Z"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="connected",
+        milestone="sync_not_available",
+        now=now,
+        reason="Guard sync requires a Pro or Team plan.",
+    )
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VuBCIEIA==\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "OKP", "crv": "Ed25519", "x": "test"},
+        dpop_public_jwk_thumbprint="thumbprint-1",
+        supply_chain_plan_id="team",
+        supply_chain_firewall=True,
+        supply_chain_entitlement_expires_at="2026-06-30T00:00:00.000Z",
+        workspace_id="workspace-1",
+        now=now,
+    )
+
+    reconciled = reconcile_connect_state_with_oauth_entitlement(store, now=now)
+
+    assert reconciled is not None
+    assert reconciled.get("milestone") == "first_sync_pending"
+    effective = store.get_effective_guard_connect_state(now=now)
+    assert isinstance(effective, dict)
+    assert effective.get("milestone") == "first_sync_pending"

--- a/tests/test_guard_package_firewall_entitlement.py
+++ b/tests/test_guard_package_firewall_entitlement.py
@@ -70,3 +70,66 @@ def test_reconcile_connect_state_clears_stale_sync_not_available_for_paid_oauth(
     effective = store.get_effective_guard_connect_state(now=now)
     assert isinstance(effective, dict)
     assert effective.get("milestone") == "first_sync_pending"
+
+
+def test_reconcile_connect_state_ignores_non_sync_not_available_milestones(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-05-31T09:00:00.000Z"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+
+    assert reconcile_connect_state_with_oauth_entitlement(store, now=now) is None
+
+
+def test_reconcile_connect_state_ignores_missing_oauth_credentials(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-05-31T09:00:00.000Z"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="connected",
+        milestone="sync_not_available",
+        now=now,
+        reason="Guard sync requires a Pro or Team plan.",
+    )
+
+    assert reconcile_connect_state_with_oauth_entitlement(store, now=now) is None
+
+
+def test_reconcile_connect_state_ignores_free_oauth_plan(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-05-31T09:00:00.000Z"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="connected",
+        milestone="sync_not_available",
+        now=now,
+        reason="Guard sync requires a Pro or Team plan.",
+    )
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nMC4CAQAwBQYDK2VuBCIEIA==\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "OKP", "crv": "Ed25519", "x": "test"},
+        dpop_public_jwk_thumbprint="thumbprint-1",
+        supply_chain_plan_id="free",
+        supply_chain_firewall=False,
+        supply_chain_entitlement_expires_at="2026-06-30T00:00:00.000Z",
+        workspace_id="workspace-1",
+        now=now,
+    )
+
+    assert reconcile_connect_state_with_oauth_entitlement(store, now=now) is None


### PR DESCRIPTION
## Summary
- Clear stale `sync_not_available` connect state when OAuth credentials reflect a paid team or pro plan.
- Reconcile connect milestones before sync retries and after credential persistence.

## Testing
- `python3 -m pytest tests/test_guard_package_firewall_entitlement.py -q`
