### PR TITLE
fix(hol-guard): verify MCP companion entries before skipping artifact evaluation

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
+++ b/src/codex_plugin_scanner/guard/adapters/mcp_servers.py
@@ -34,6 +34,14 @@ def is_guard_mcp_companion_name(name: str) -> bool:
     return name.startswith(GUARD_MCP_COMPANION_PREFIX)
 
 
+def is_verified_guard_mcp_companion(
+    name: str,
+    command: str | None,
+    args: tuple[str, ...],
+) -> bool:
+    return is_guard_mcp_companion_name(name) and is_guard_proxy_command(command, args)
+
+
 _GUARD_PROXY_COMMANDS = frozenset(
     {
         "codex-mcp-proxy",
@@ -165,7 +173,7 @@ def proxy_process_env(server_env: dict[str, str]) -> dict[str, str]:
 def _managed_stdio_server(artifact: GuardArtifact) -> ManagedMcpServer | None:
     if artifact.artifact_type != "mcp_server":
         return None
-    if is_guard_mcp_companion_name(artifact.name):
+    if is_verified_guard_mcp_companion(artifact.name, artifact.command, artifact.args):
         return None
     if _bool_metadata(artifact.metadata.get("guard_managed_proxy"), default=False):
         return None
@@ -282,6 +290,7 @@ __all__ = [
     "ManagedMcpServer",
     "is_guard_mcp_companion_name",
     "is_guard_proxy_command",
+    "is_verified_guard_mcp_companion",
     "managed_stdio_servers",
     "proxy_cli_args",
     "proxy_process_env",

--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from ..models import GuardArtifact
 from ..runtime.mcp_skill_firewall import enrich_artifact_with_mcp_skill_firewall
 from .base import HarnessContext
-from .mcp_servers import is_guard_mcp_companion_name, is_guard_proxy_command
+from .mcp_servers import is_guard_proxy_command, is_verified_guard_mcp_companion
 
 CONFIG_FILENAMES = ("opencode.json", "opencode.jsonc")
 PLUGIN_SUFFIXES = {".js", ".ts", ".mjs", ".cjs"}
@@ -246,9 +246,9 @@ def _append_mcp_artifacts(
     for name, server_config in mcp_config.items():
         if not isinstance(name, str) or not isinstance(server_config, dict):
             continue
-        if is_guard_mcp_companion_name(name):
-            continue
         command, args = _command_parts(server_config)
+        if is_verified_guard_mcp_companion(name, command, args):
+            continue
         transport = server_config.get("type") if isinstance(server_config.get("type"), str) else None
         url = server_config.get("url") if isinstance(server_config.get("url"), str) else None
         environment = server_config.get("environment")

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -658,7 +658,23 @@ class TestOpenCodeResiliency:
         assert list(first["mcp"]).count("chrome-devtools") == 1
         assert list(first["mcp"]).count("hol-guard::chrome-devtools") == 1
 
-    def test_detect_ignores_guard_companion_mcp_entries(self, tmp_path: Path) -> None:
+    def test_detect_treats_fake_hol_guard_companion_as_mcp_artifact(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
+        _write_mcp_config(
+            config,
+            {
+                "hol-guard::evil": {
+                    "type": "local",
+                    "command": ["bash", "-c", "malicious"],
+                },
+            },
+        )
+        result = OpenCodeHarnessAdapter().detect(ctx)
+        artifact_names = {artifact.name for artifact in result.artifacts}
+        assert "hol-guard::evil" in artifact_names
+
+    def test_detect_still_ignores_verified_guard_companion_mcp_entries(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
         config = ctx.home_dir / ".config" / "opencode" / "opencode.json"
         _write_mcp_config(


### PR DESCRIPTION
## Summary
- Require verified Guard MCP proxy commands before skipping companion-prefixed OpenCode MCP entries during artifact discovery
- Treat fake `hol-guard::` companion names with non-proxy commands as regular MCP servers for evaluation

## Testing
- `python3 -m pytest tests/test_opencode_adapter.py -k "companion" -q`
