### PR TITLE
fix(guard): allow safe pytest exit-code echoes

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -6479,9 +6479,13 @@ def _python_module_subcommand(module_root: str, module_args: list[str]) -> str |
 
 
 def _static_shell_segment_is_safe(args: list[str]) -> bool:
-    return all(
-        "$" not in arg and "`" not in arg and "$(" not in arg and "<(" not in arg and ">(" not in arg for arg in args
-    )
+    return all(_static_shell_arg_is_safe(arg) for arg in args)
+
+
+def _static_shell_arg_is_safe(arg: str) -> bool:
+    if "`" in arg or "$(" in arg or "<(" in arg or ">(" in arg:
+        return False
+    return "$" not in arg.replace("$?", "")
 
 
 def _contains_unmodeled_inline_interpreter_eval(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14103,6 +14103,32 @@ def test_guard_hook_codex_does_not_block_safe_pytest_exit_code_echo(tmp_path, ca
     assert "approval_requests" not in output
 
 
+@pytest.mark.parametrize(
+    ("command_suffix",),
+    [
+        ('echo "$HOME"',),
+        ('echo "${VAR}"',),
+        ('printf "$PATH"',),
+    ],
+)
+def test_guard_runtime_keeps_static_shell_expansions_blocked_after_safe_pytest(tmp_path, command_suffix):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {
+            "command": (
+                "cd sub && .venv/bin/python -m pytest "
+                "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                "test_release_checklist_references_smoke_evidence -q 2>&1; "
+                f"{command_suffix}"
+            )
+        },
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.action_class == "destructive shell command"
+
+
 def test_guard_runtime_keeps_mutating_pytest_flags_sensitive(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14054,6 +14054,55 @@ def test_guard_hook_codex_does_not_block_simple_pytest_command(tmp_path, capsys,
     assert "approval_requests" not in output
 
 
+def test_guard_runtime_allows_literal_exit_code_echo_after_safe_pytest(tmp_path):
+    match = extract_sensitive_tool_action_request(
+        "Bash",
+        {
+            "command": (
+                "cd sub && .venv/bin/python -m pytest "
+                "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                'test_release_checklist_references_smoke_evidence -q 2>&1; echo "__EXIT_CODE__:$?"'
+            )
+        },
+        cwd=tmp_path,
+    )
+
+    assert match is None
+
+
+def test_guard_hook_codex_does_not_block_safe_pytest_exit_code_echo(tmp_path, capsys, monkeypatch):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "event": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": (
+                "cd sub && .venv/bin/python -m pytest "
+                "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                'test_release_checklist_references_smoke_evidence -q 2>&1; echo "__EXIT_CODE__:$?"'
+            )
+        },
+        "source_scope": "project",
+    }
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event=event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    assert rc == 0
+    assert output["recorded"] is True
+    assert output["policy_action"] == "warn"
+    assert "approval_requests" not in output
+
+
 def test_guard_runtime_keeps_mutating_pytest_flags_sensitive(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",


### PR DESCRIPTION
## Summary\n- allow literal `0` in otherwise static `echo`/`printf` shell segments\n- keep broader shell expansion blocked so env/command substitution still requires review\n- add Codex pytest regression coverage for chained exit-code reporting\n\n## Testing\n- python3 -m ruff check src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_runtime.py\n- python3 -m pytest tests/test_guard_runtime.py -k 'literal_exit_code_echo_after_safe_pytest or does_not_block_safe_pytest_exit_code_echo or does_not_block_simple_pytest_command or post_tool_use_blocks_credential_looking_output or post_tool_use_blocks_authrc_output' -q