### PR TITLE
fix(guard): explain codex post-tool blocks

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_prompts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_prompts.py
@@ -291,11 +291,11 @@ def _decision_v2_has_data_flow_signal(response_payload: dict[str, object]) -> bo
 def _should_use_decision_v2_harness_message(response_payload: dict[str, object], message: str) -> bool:
     if _decision_v2_has_data_flow_signal(response_payload):
         return True
-    generic_messages = {
+    generic_prefixes = (
         "HOL Guard blocked this action.",
         "HOL Guard wants this action reviewed and run in a sandboxed path.",
-    }
-    if message in generic_messages:
+    )
+    if any(message.startswith(prefix) for prefix in generic_prefixes):
         return False
     return not message.startswith("HOL Guard needs a fresh approval because this action changed.")
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14834,6 +14834,55 @@ def test_guard_hook_codex_post_tool_use_blocks_authrc_output(
     assert "credential-looking output" in payload["stopReason"]
 
 
+def test_guard_hook_codex_post_tool_use_explains_merged_stderr_capture(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": (
+                "cd sub && .venv/bin/python -m pytest "
+                "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                'test_release_checklist_references_smoke_evidence -q 2>&1; echo "__EXIT_CODE__:$?"'
+            )
+        },
+        "tool_response": {"stdout": "HOL_GUARD_FAKE_CREDENTIAL=fixture-only\n"},
+        "source_scope": "project",
+    }
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+            "--policy-action",
+            "block",
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["continue"] is False
+    assert "Combined stdout/stderr looked credential-like before it reached Codex." in payload["stopReason"]
+    assert payload["stopReason"].count("Open HOL Guard to approve or keep this blocked") == 1
+    assert "http://127.0.0.1:4455/requests/" in payload["stopReason"]
+
+
 def test_guard_hook_codex_post_tool_use_browser_approval_resumes_result(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary

prefer artifact-native risk summaries over generic approval-center copy for Codex post-tool blocks\n- keep the approval link in the stop reason, but avoid collapsing the explanation into duplicated generic text
 add regression coverage for merged stdout/stderr credential-output blocks

## Testing
python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_support_prompts.py tests/test_guard_runtime.py\n- python3 -m pytest tests/test_guard_runtime.py -k 'post_tool_use_blocks_credential_looking_output or post_tool_use_blocks_authrc_output or post_tool_use_explains_merged_stderr_capture or does_not_block_safe_pytest_exit_code_echo or keeps_static_shell_expansions_blocked_after_safe_pytest' -q