### PR TITLE
fix(dashboard): replace LLC copyright with Apache-2.0 attribution

### DIFF
--- a/dashboard/src/shell-footer.test.ts
+++ b/dashboard/src/shell-footer.test.ts
@@ -2,13 +2,18 @@ import {
   GITHUB_ISSUE_BUTTON_LABEL,
   GITHUB_ISSUE_LINK,
 } from "./github-issue-link";
-import { SHELL_FOOTER_RESOURCE_LINKS } from "./shell-footer";
+import { SHELL_FOOTER_LICENSE_HREF, SHELL_FOOTER_RESOURCE_LINKS } from "./shell-footer";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
     throw new Error(message);
   }
 }
+
+assert(
+  SHELL_FOOTER_LICENSE_HREF.endsWith("/hol-guard/blob/main/LICENSE"),
+  "footer license link points at the repository LICENSE file"
+);
 
 assert(
   SHELL_FOOTER_RESOURCE_LINKS.length >= 4,

--- a/dashboard/src/shell-footer.tsx
+++ b/dashboard/src/shell-footer.tsx
@@ -1,5 +1,8 @@
 import { GITHUB_ISSUE_BUTTON_LABEL, GITHUB_ISSUE_LINK } from "./github-issue-link";
 
+export const SHELL_FOOTER_LICENSE_HREF =
+  "https://github.com/hashgraph-online/hol-guard/blob/main/LICENSE";
+
 export const SHELL_FOOTER_RESOURCE_LINKS = [
   { href: "https://hol.org/guard/docs", label: "Docs" },
   { href: "https://hol.org/guard", label: "Guard Cloud" },
@@ -14,7 +17,16 @@ export function ShellFooter() {
     <footer className="mt-auto border-t border-slate-200 bg-[#f8fafc]">
       <div className="mx-auto flex max-w-6xl flex-col gap-3 px-4 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8">
         <p className="text-[11px] font-medium text-slate-400">
-          © {new Date().getFullYear()} HOL DAO LLC
+          HOL Guard is open source under{" "}
+          <a
+            href={SHELL_FOOTER_LICENSE_HREF}
+            target="_blank"
+            rel="noreferrer"
+            className="rounded-sm text-slate-500 no-underline transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/30"
+          >
+            Apache-2.0
+          </a>
+          . Built by Hashgraph Online.
         </p>
         <nav aria-label="Guard resources" className="flex flex-wrap gap-x-4 gap-y-1">
           {SHELL_FOOTER_RESOURCE_LINKS.map((link) => (

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16144,6 +16144,7 @@ function buildGitHubIssueUrl(options) {
   return url.toString();
 }
 const GITHUB_ISSUE_LINK = buildGitHubIssueUrl();
+const SHELL_FOOTER_LICENSE_HREF = "https://github.com/hashgraph-online/hol-guard/blob/main/LICENSE";
 const SHELL_FOOTER_RESOURCE_LINKS = [
   { href: "https://hol.org/guard/docs", label: "Docs" },
   { href: "https://hol.org/guard", label: "Guard Cloud" },
@@ -16155,9 +16156,19 @@ const SHELL_FOOTER_RESOURCE_LINKS = [
 function ShellFooter() {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("footer", { className: "mt-auto border-t border-slate-200 bg-[#f8fafc]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mx-auto flex max-w-6xl flex-col gap-3 px-4 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-[11px] font-medium text-slate-400", children: [
-      "© ",
-      (/* @__PURE__ */ new Date()).getFullYear(),
-      " HOL DAO LLC"
+      "HOL Guard is open source under",
+      " ",
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        "a",
+        {
+          href: SHELL_FOOTER_LICENSE_HREF,
+          target: "_blank",
+          rel: "noreferrer",
+          className: "rounded-sm text-slate-500 no-underline transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/30",
+          children: "Apache-2.0"
+        }
+      ),
+      ". Built by Hashgraph Online."
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("nav", { "aria-label": "Guard resources", className: "flex flex-wrap gap-x-4 gap-y-1", children: SHELL_FOOTER_RESOURCE_LINKS.map((link) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       "a",


### PR DESCRIPTION
## Summary
- Replace the shell footer LLC copyright line with Apache-2.0 open-source attribution
- Link the license label to the repository LICENSE file and match About page maintainer copy

## Testing
- `cd dashboard && pnpm test`
- `cd dashboard && pnpm run build`
