### PR TITLE
fix(guard): block pytest secret-looking output

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py
@@ -56,8 +56,19 @@ def _codex_tool_output_request_summary(
     local_secret_source: str | None,
     merged_output_capture: bool = False,
 ) -> str:
+    focused_pytest = _codex_command_is_focused_pytest_verification(command_text)
     if local_secret_source is not None:
         return f"Codex tool `{tool_name}` read local secrets from {local_secret_source} while running `{command_text}`."
+    if focused_pytest and merged_output_capture:
+        return (
+            f"Codex tool `{tool_name}` ran focused pytest, merged stderr into stdout while running "
+            f"`{command_text}`, and the captured output looked credential-like."
+        )
+    if focused_pytest:
+        return (
+            f"Codex tool `{tool_name}` ran focused pytest and produced credential-looking output while "
+            f"running `{command_text}`."
+        )
     if merged_output_capture:
         return (
             f"Codex tool `{tool_name}` merged stderr into stdout while running `{command_text}`, "
@@ -69,10 +80,22 @@ def _codex_tool_output_request_summary(
 def _codex_tool_output_runtime_summary(
     local_secret_source: str | None,
     *,
+    command_text: str = "",
     merged_output_capture: bool = False,
 ) -> str:
+    focused_pytest = bool(command_text) and _codex_command_is_focused_pytest_verification(command_text)
     if local_secret_source is not None:
         return f"Local secrets from {local_secret_source} reached Codex tool output."
+    if focused_pytest and merged_output_capture:
+        return (
+            "Focused pytest merged stderr into stdout and emitted credential-looking output before it reached "
+            "Codex. Pytest can execute repository-controlled code, so this could be a real local secret."
+        )
+    if focused_pytest:
+        return (
+            "Focused pytest emitted credential-looking output before it reached Codex. "
+            "Pytest can execute repository-controlled code, so this could be a real local secret."
+        )
     if merged_output_capture:
         return "Combined stdout/stderr looked credential-like before it reached Codex."
     return "Requests a sensitive native tool action: credential-looking output reached Codex."
@@ -81,12 +104,25 @@ def _codex_tool_output_runtime_summary(
 def _codex_tool_output_runtime_reason(
     local_secret_source: str | None,
     *,
+    command_text: str = "",
     merged_output_capture: bool = False,
 ) -> str:
+    focused_pytest = bool(command_text) and _codex_command_is_focused_pytest_verification(command_text)
     if local_secret_source is not None:
         return (
             "Guard inspects supported Codex tool output before Codex uses it, so accidental secret reads can be "
             "stopped even when the filename was not obviously sensitive."
+        )
+    if focused_pytest and merged_output_capture:
+        return (
+            "Guard stopped this pytest output because pytest executes repository-controlled code, and merging stderr "
+            "into stdout can forward real local secrets to Codex. If you only need the exit status, rerun without "
+            "`2>&1` or keep stderr out of model-visible output."
+        )
+    if focused_pytest:
+        return (
+            "Guard stopped this pytest output because pytest executes repository-controlled code. "
+            "Credential-looking output could be a real local secret printed by the test, not just fixture text."
         )
     if merged_output_capture:
         return (
@@ -325,7 +361,9 @@ def _codex_focused_pytest_can_skip_secret_output(
         return all(match.classifier == "pem-private-key" for match in non_medium_matches) and (
             _codex_output_uses_placeholder_private_key_fixture(response_text)
         )
-    return True
+    from .commands_support_codex_commands import _codex_output_is_only_benign_secret_fixture
+
+    return _codex_output_is_only_benign_secret_fixture(response_text)
 
 
 def _codex_command_is_focused_pytest_verification(command_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py
@@ -47,93 +47,14 @@ _CODEX_PYTEST_SAFE_FLAG_PREFIXES = (
     "--durations=",
 )
 _CODEX_SAFE_SHELL_REDIRECTION_TOKENS = frozenset({"1>&2", "2>&1", ">/dev/null", "1>/dev/null", "2>/dev/null"})
-
-
-def _codex_tool_output_request_summary(
-    *,
-    tool_name: str,
-    command_text: str,
-    local_secret_source: str | None,
-    merged_output_capture: bool = False,
-) -> str:
-    focused_pytest = _codex_command_is_focused_pytest_verification(command_text)
-    if local_secret_source is not None:
-        return f"Codex tool `{tool_name}` read local secrets from {local_secret_source} while running `{command_text}`."
-    if focused_pytest and merged_output_capture:
-        return (
-            f"Codex tool `{tool_name}` ran focused pytest, merged stderr into stdout while running "
-            f"`{command_text}`, and the captured output looked credential-like."
-        )
-    if focused_pytest:
-        return (
-            f"Codex tool `{tool_name}` ran focused pytest and produced credential-looking output while "
-            f"running `{command_text}`."
-        )
-    if merged_output_capture:
-        return (
-            f"Codex tool `{tool_name}` merged stderr into stdout while running `{command_text}`, "
-            "and the captured output looked credential-like."
-        )
-    return f"Codex tool `{tool_name}` produced credential-looking output while running `{command_text}`."
-
-
-def _codex_tool_output_runtime_summary(
-    local_secret_source: str | None,
-    *,
-    command_text: str = "",
-    merged_output_capture: bool = False,
-) -> str:
-    focused_pytest = bool(command_text) and _codex_command_is_focused_pytest_verification(command_text)
-    if local_secret_source is not None:
-        return f"Local secrets from {local_secret_source} reached Codex tool output."
-    if focused_pytest and merged_output_capture:
-        return (
-            "Focused pytest merged stderr into stdout and emitted credential-looking output before it reached "
-            "Codex. Pytest can execute repository-controlled code, so this could be a real local secret."
-        )
-    if focused_pytest:
-        return (
-            "Focused pytest emitted credential-looking output before it reached Codex. "
-            "Pytest can execute repository-controlled code, so this could be a real local secret."
-        )
-    if merged_output_capture:
-        return "Combined stdout/stderr looked credential-like before it reached Codex."
-    return "Requests a sensitive native tool action: credential-looking output reached Codex."
-
-
-def _codex_tool_output_runtime_reason(
-    local_secret_source: str | None,
-    *,
-    command_text: str = "",
-    merged_output_capture: bool = False,
-) -> str:
-    focused_pytest = bool(command_text) and _codex_command_is_focused_pytest_verification(command_text)
-    if local_secret_source is not None:
-        return (
-            "Guard inspects supported Codex tool output before Codex uses it, so accidental secret reads can be "
-            "stopped even when the filename was not obviously sensitive."
-        )
-    if focused_pytest and merged_output_capture:
-        return (
-            "Guard stopped this pytest output because pytest executes repository-controlled code, and merging stderr "
-            "into stdout can forward real local secrets to Codex. If you only need the exit status, rerun without "
-            "`2>&1` or keep stderr out of model-visible output."
-        )
-    if focused_pytest:
-        return (
-            "Guard stopped this pytest output because pytest executes repository-controlled code. "
-            "Credential-looking output could be a real local secret printed by the test, not just fixture text."
-        )
-    if merged_output_capture:
-        return (
-            "Guard stopped this command shape because merging stderr into stdout can send credential-looking failure "
-            "output to Codex. If you only need the exit status, rerun without `2>&1` or keep stderr out of the "
-            "model-visible output."
-        )
-    return (
-        "Guard inspects supported Codex tool output before Codex uses it, so accidental secret reads can be stopped "
-        "even when the filename was not obviously sensitive."
-    )
+_CODEX_PYTEST_PROGRESS_LINE_PATTERN = re.compile(r"^[.FEsxXrR]+$")
+_CODEX_PYTEST_SUMMARY_LINE_PATTERN = re.compile(
+    r"(?ix)^"
+    r"(?:=+\s.*\s=+"
+    r"|collected\s+\d+\s+items(?:\s*/\s*\d+\s+deselected)?"
+    r"|(?:\d+\s+\w+(?:,\s*\d+\s+\w+)*)\s+in\s+\d+(?:\.\d+)?s"
+    r"|.+::.+\s+(?:PASSED|FAILED|ERROR|SKIPPED|XFAIL|XPASS))$"
+)
 
 
 def _codex_command_start_indexes(parts: list[str]) -> list[int]:
@@ -361,9 +282,31 @@ def _codex_focused_pytest_can_skip_secret_output(
         return all(match.classifier == "pem-private-key" for match in non_medium_matches) and (
             _codex_output_uses_placeholder_private_key_fixture(response_text)
         )
+    return _codex_focused_pytest_output_is_only_benign_fixture(response_text)
+
+
+def _codex_focused_pytest_output_is_only_benign_fixture(response_text: str) -> bool:
     from .commands_support_codex_commands import _codex_output_is_only_benign_secret_fixture
 
-    return _codex_output_is_only_benign_secret_fixture(response_text)
+    saw_fixture = False
+    for raw_line in response_text.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        if _codex_output_is_only_benign_secret_fixture(line):
+            saw_fixture = True
+            continue
+        if _codex_focused_pytest_status_line_is_benign(line):
+            continue
+        return False
+    return saw_fixture
+
+
+def _codex_focused_pytest_status_line_is_benign(line: str) -> bool:
+    return bool(
+        _CODEX_PYTEST_PROGRESS_LINE_PATTERN.fullmatch(line)
+        or _CODEX_PYTEST_SUMMARY_LINE_PATTERN.fullmatch(line)
+    )
 
 
 def _codex_command_is_focused_pytest_verification(command_text: str) -> bool:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output_messages.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output_messages.py
@@ -1,0 +1,95 @@
+"""Codex tool-output risk copy helpers."""
+
+from __future__ import annotations
+
+
+def _codex_tool_output_request_summary(
+    *,
+    tool_name: str,
+    command_text: str,
+    local_secret_source: str | None,
+    merged_output_capture: bool = False,
+    focused_pytest: bool = False,
+) -> str:
+    if local_secret_source is not None:
+        return f"Codex tool `{tool_name}` read local secrets from {local_secret_source} while running `{command_text}`."
+    if focused_pytest and merged_output_capture:
+        return (
+            f"Codex tool `{tool_name}` ran focused pytest, merged stderr into stdout while running "
+            f"`{command_text}`, and the captured output looked credential-like."
+        )
+    if focused_pytest:
+        return (
+            f"Codex tool `{tool_name}` ran focused pytest and produced credential-looking output while "
+            f"running `{command_text}`."
+        )
+    if merged_output_capture:
+        return (
+            f"Codex tool `{tool_name}` merged stderr into stdout while running `{command_text}`, "
+            "and the captured output looked credential-like."
+        )
+    return f"Codex tool `{tool_name}` produced credential-looking output while running `{command_text}`."
+
+
+def _codex_tool_output_runtime_summary(
+    local_secret_source: str | None,
+    *,
+    merged_output_capture: bool = False,
+    focused_pytest: bool = False,
+) -> str:
+    if local_secret_source is not None:
+        return f"Local secrets from {local_secret_source} reached Codex tool output."
+    if focused_pytest and merged_output_capture:
+        return (
+            "Focused pytest merged stderr into stdout and emitted credential-looking output before it reached "
+            "Codex. Pytest can execute repository-controlled code, so this could be a real local secret."
+        )
+    if focused_pytest:
+        return (
+            "Focused pytest emitted credential-looking output before it reached Codex. "
+            "Pytest can execute repository-controlled code, so this could be a real local secret."
+        )
+    if merged_output_capture:
+        return "Combined stdout/stderr looked credential-like before it reached Codex."
+    return "Requests a sensitive native tool action: credential-looking output reached Codex."
+
+
+def _codex_tool_output_runtime_reason(
+    local_secret_source: str | None,
+    *,
+    merged_output_capture: bool = False,
+    focused_pytest: bool = False,
+) -> str:
+    if local_secret_source is not None:
+        return (
+            "Guard inspects supported Codex tool output before Codex uses it, so accidental secret reads can be "
+            "stopped even when the filename was not obviously sensitive."
+        )
+    if focused_pytest and merged_output_capture:
+        return (
+            "Guard stopped this pytest output because pytest executes repository-controlled code, and merging stderr "
+            "into stdout can forward real local secrets to Codex. If you only need the exit status, rerun without "
+            "`2>&1` or keep stderr out of model-visible output."
+        )
+    if focused_pytest:
+        return (
+            "Guard stopped this pytest output because pytest executes repository-controlled code. "
+            "Credential-looking output could be a real local secret printed by the test, not just fixture text."
+        )
+    if merged_output_capture:
+        return (
+            "Guard stopped this command shape because merging stderr into stdout can send credential-looking failure "
+            "output to Codex. If you only need the exit status, rerun without `2>&1` or keep stderr out of the "
+            "model-visible output."
+        )
+    return (
+        "Guard inspects supported Codex tool output before Codex uses it, so accidental secret reads can be stopped "
+        "even when the filename was not obviously sensitive."
+    )
+
+
+__all__ = [
+    "_codex_tool_output_request_summary",
+    "_codex_tool_output_runtime_reason",
+    "_codex_tool_output_runtime_summary",
+]

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -19,6 +19,7 @@ from .commands_support_codex_commands import (
 )
 from .commands_support_codex_reads import _split_codex_safe_read_only_pipeline
 from .commands_support_codex_tool_output import (
+    _codex_command_is_focused_pytest_verification,
     _codex_command_captures_combined_shell_output,
     _codex_command_references_sensitive_local_source,
     _codex_existing_local_path_match,
@@ -28,11 +29,13 @@ from .commands_support_codex_tool_output import (
     _codex_sensitive_path_matches_in_text,
     _codex_token_is_url,
     _codex_token_prefix_is_url_scheme,
+    _codex_url_like_local_path_tokens,
+    _dedupe_codex_secret_path_matches,
+)
+from .commands_support_codex_tool_output_messages import (
     _codex_tool_output_request_summary,
     _codex_tool_output_runtime_reason,
     _codex_tool_output_runtime_summary,
-    _codex_url_like_local_path_tokens,
-    _dedupe_codex_secret_path_matches,
 )
 
 def _optional_string(value: object | None) -> str | None:
@@ -325,6 +328,7 @@ def _codex_post_tool_output_artifact(
     ):
         return None
     merged_output_capture = _codex_command_captures_combined_shell_output(command_text)
+    focused_pytest = _codex_command_is_focused_pytest_verification(command_text)
     fingerprint = hashlib.sha256(
         json.dumps(
             {
@@ -350,11 +354,12 @@ def _codex_post_tool_output_artifact(
         tool_name=tool_name,
         command_text=command_text,
         local_secret_source=local_secret_source,
+        focused_pytest=focused_pytest,
         merged_output_capture=merged_output_capture,
     )
     runtime_request_summary = _codex_tool_output_runtime_summary(
         local_secret_source,
-        command_text=command_text,
+        focused_pytest=focused_pytest,
         merged_output_capture=merged_output_capture,
     )
     metadata: dict[str, object] = {
@@ -371,7 +376,7 @@ def _codex_post_tool_output_artifact(
         "runtime_request_summary": runtime_request_summary,
         "runtime_request_reason": _codex_tool_output_runtime_reason(
             local_secret_source,
-            command_text=command_text,
+            focused_pytest=focused_pytest,
             merged_output_capture=merged_output_capture,
         ),
     }

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -354,6 +354,7 @@ def _codex_post_tool_output_artifact(
     )
     runtime_request_summary = _codex_tool_output_runtime_summary(
         local_secret_source,
+        command_text=command_text,
         merged_output_capture=merged_output_capture,
     )
     metadata: dict[str, object] = {
@@ -370,6 +371,7 @@ def _codex_post_tool_output_artifact(
         "runtime_request_summary": runtime_request_summary,
         "runtime_request_reason": _codex_tool_output_runtime_reason(
             local_secret_source,
+            command_text=command_text,
             merged_output_capture=merged_output_capture,
         ),
     }

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -29,6 +29,9 @@ from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import render as guard_render_module
+from codex_plugin_scanner.guard.cli.commands_support_runtime_artifacts import (
+    _codex_post_tool_output_artifact,
+)
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config
@@ -14879,6 +14882,78 @@ def test_guard_hook_codex_post_tool_use_explains_merged_stderr_capture(
     assert rc == 0
     assert payload["continue"] is False
     assert "Combined stdout/stderr looked credential-like before it reached Codex." in payload["stopReason"]
+    assert payload["stopReason"].count("Open HOL Guard to approve or keep this blocked") == 1
+    assert "http://127.0.0.1:4455/requests/" in payload["stopReason"]
+
+
+def test_codex_post_tool_output_allows_focused_pytest_fake_credential_fixture(tmp_path):
+    artifact = _codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    "python3 -m pytest "
+                    "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                    "test_release_checklist_references_smoke_evidence -q"
+                )
+            },
+            "tool_response": {"stdout": "fake_credential=fixture-only\n"},
+        },
+        config_path="codex.json",
+        source_scope="project",
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert artifact is None
+
+
+def test_guard_hook_codex_post_tool_use_blocks_focused_pytest_medium_secret_output(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    event = {
+        "hook_event_name": "PostToolUse",
+        "tool_name": "Bash",
+        "tool_input": {
+            "command": (
+                "python3 -m pytest "
+                "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                "test_release_checklist_references_smoke_evidence -q"
+            )
+        },
+        "tool_response": {"stdout": "Authorization: Bearer guardfixturetoken123456\n"},
+        "source_scope": "project",
+    }
+    monkeypatch.setenv("CODEX_HOME", str(home_dir / ".codex"))
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--harness",
+            "codex",
+            "--policy-action",
+            "block",
+        ]
+    )
+    captured = capsys.readouterr()
+    payload = json.loads(captured.out)
+
+    assert rc == 0
+    assert payload["continue"] is False
+    assert "Focused pytest emitted credential-looking output before it reached Codex." in payload["stopReason"]
+    assert "Pytest can execute repository-controlled code" in payload["stopReason"]
     assert payload["stopReason"].count("Open HOL Guard to approve or keep this blocked") == 1
     assert "http://127.0.0.1:4455/requests/" in payload["stopReason"]
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14908,6 +14908,30 @@ def test_codex_post_tool_output_allows_focused_pytest_fake_credential_fixture(tm
     assert artifact is None
 
 
+def test_codex_post_tool_output_allows_focused_pytest_fixture_with_status_noise(tmp_path):
+    artifact = _codex_post_tool_output_artifact(
+        payload={
+            "tool_name": "Bash",
+            "tool_input": {
+                "command": (
+                    "python3 -m pytest "
+                    "tests/test_guard_harness_smoke.py::TestSmokeEvidenceTemplate::"
+                    "test_release_checklist_references_smoke_evidence -q -s"
+                )
+            },
+            "tool_response": {
+                "stdout": "fake_credential=fixture-only\n.\n1 passed in 0.02s\n",
+            },
+        },
+        config_path="codex.json",
+        source_scope="project",
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert artifact is None
+
+
 def test_guard_hook_codex_post_tool_use_blocks_focused_pytest_medium_secret_output(
     tmp_path,
     capsys,


### PR DESCRIPTION
## Summary
- block focused pytest output when it contains credential-looking content unless the output is a clearly fake fixture
- preserve the safe exit-code pytest path and allow benign fake fixture output even when pytest adds normal status noise

## Testing
- `python3 -m pytest tests/test_guard_runtime.py -k 'post_tool_use_explains_merged_stderr_capture or codex_post_tool_output_allows_focused_pytest_fake_credential_fixture or codex_post_tool_output_allows_focused_pytest_fixture_with_status_noise or post_tool_use_blocks_focused_pytest_medium_secret_output or literal_exit_code_echo_after_safe_pytest or does_not_block_safe_pytest_exit_code_echo or keeps_static_shell_expansions_blocked_after_safe_pytest' -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output.py src/codex_plugin_scanner/guard/cli/commands_support_codex_tool_output_messages.py src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py tests/test_guard_runtime.py`
