### PR TITLE
fix(dashboard): trim footer links and use HOL copy

### DIFF
--- a/dashboard/src/shell-footer.test.ts
+++ b/dashboard/src/shell-footer.test.ts
@@ -26,6 +26,8 @@ assert(labels.includes("Docs"), "footer includes Docs");
 assert(labels.includes("Guard Cloud"), "footer includes Guard Cloud");
 assert(labels.includes("GitHub"), "footer includes GitHub");
 assert(labels.includes(GITHUB_ISSUE_BUTTON_LABEL), "footer includes report bug link");
+assert(!labels.includes("Privacy"), "footer does not include Privacy link");
+assert(!labels.includes("Terms"), "footer does not include Terms link");
 
 const bugLink = SHELL_FOOTER_RESOURCE_LINKS.find((link) => link.href === GITHUB_ISSUE_LINK);
 assert(bugLink !== undefined, "footer bug link uses the shared GitHub issue URL");

--- a/dashboard/src/shell-footer.tsx
+++ b/dashboard/src/shell-footer.tsx
@@ -24,6 +24,7 @@ export function ShellFooter() {
           >
             Apache-2.0
           </a>
+          .
         </p>
         <nav aria-label="Guard resources" className="flex flex-wrap gap-x-4 gap-y-1">
           {SHELL_FOOTER_RESOURCE_LINKS.map((link) => (

--- a/dashboard/src/shell-footer.tsx
+++ b/dashboard/src/shell-footer.tsx
@@ -8,8 +8,6 @@ export const SHELL_FOOTER_RESOURCE_LINKS = [
   { href: "https://hol.org/guard", label: "Guard Cloud" },
   { href: "https://github.com/hashgraph-online/hol-guard", label: "GitHub" },
   { href: GITHUB_ISSUE_LINK, label: GITHUB_ISSUE_BUTTON_LABEL },
-  { href: "https://hol.org/points/legal/privacy", label: "Privacy" },
-  { href: "https://hol.org/points/legal/terms", label: "Terms" },
 ] as const;
 
 export function ShellFooter() {
@@ -26,7 +24,6 @@ export function ShellFooter() {
           >
             Apache-2.0
           </a>
-          . Built by Hashgraph Online.
         </p>
         <nav aria-label="Guard resources" className="flex flex-wrap gap-x-4 gap-y-1">
           {SHELL_FOOTER_RESOURCE_LINKS.map((link) => (

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16165,7 +16165,8 @@ function ShellFooter() {
           className: "rounded-sm text-slate-500 no-underline transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/30",
           children: "Apache-2.0"
         }
-      )
+      ),
+      "."
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("nav", { "aria-label": "Guard resources", className: "flex flex-wrap gap-x-4 gap-y-1", children: SHELL_FOOTER_RESOURCE_LINKS.map((link) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       "a",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16149,9 +16149,7 @@ const SHELL_FOOTER_RESOURCE_LINKS = [
   { href: "https://hol.org/guard/docs", label: "Docs" },
   { href: "https://hol.org/guard", label: "Guard Cloud" },
   { href: "https://github.com/hashgraph-online/hol-guard", label: "GitHub" },
-  { href: GITHUB_ISSUE_LINK, label: GITHUB_ISSUE_BUTTON_LABEL },
-  { href: "https://hol.org/points/legal/privacy", label: "Privacy" },
-  { href: "https://hol.org/points/legal/terms", label: "Terms" }
+  { href: GITHUB_ISSUE_LINK, label: GITHUB_ISSUE_BUTTON_LABEL }
 ];
 function ShellFooter() {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("footer", { className: "mt-auto border-t border-slate-200 bg-[#f8fafc]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mx-auto flex max-w-6xl flex-col gap-3 px-4 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6 lg:px-8", children: [
@@ -16167,8 +16165,7 @@ function ShellFooter() {
           className: "rounded-sm text-slate-500 no-underline transition-colors hover:text-brand-blue focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/30",
           children: "Apache-2.0"
         }
-      ),
-      ". Built by Hashgraph Online."
+      )
     ] }),
     /* @__PURE__ */ jsxRuntimeExports.jsx("nav", { "aria-label": "Guard resources", className: "flex flex-wrap gap-x-4 gap-y-1", children: SHELL_FOOTER_RESOURCE_LINKS.map((link) => /* @__PURE__ */ jsxRuntimeExports.jsx(
       "a",


### PR DESCRIPTION
## Summary
- Remove `Privacy` and `Terms` links from the Guard dashboard shell footer
- Update the footer copy to say `HOL` only, removing "Hashgraph Online" wording

## Testing
- `cd dashboard && pnpm test`
- `cd dashboard && pnpm run build`
