### PR TITLE
fix(dashboard): Guard Cloud bundle card layout overlap

### DIFF
--- a/dashboard/src/policy-guard-cloud-bundle-card.test.ts
+++ b/dashboard/src/policy-guard-cloud-bundle-card.test.ts
@@ -1,0 +1,44 @@
+import {
+  formatCloudBundleHashDisplay,
+  resolveCloudBundleStatusSubtitle,
+  resolveCloudPolicyBundleCopy,
+} from "./policy-workspace-helpers";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+assert(
+  formatCloudBundleHashDisplay("sha256:abcdef1234567890") === "sha256:abcd…",
+  "bundle hash display truncates sha256 hashes",
+);
+assert(formatCloudBundleHashDisplay(null) === "Unavailable", "missing hash shows unavailable");
+
+const attentionCopy = resolveCloudPolicyBundleCopy({
+  cloud_policy_bundle_version: "policy-1781231113830",
+  cloud_policy_sync_error: "auth_expired",
+  cloud_policy_bundle_hash: "sha256:abcdef1234567890",
+});
+assert(attentionCopy?.label === "Needs attention", "sync error surfaces attention label");
+assert(
+  resolveCloudBundleStatusSubtitle(attentionCopy!) === "Latest sync needs attention",
+  "status subtitle stays short when sync needs attention",
+);
+assert(
+  attentionCopy!.detail.includes("auth_expired"),
+  "full sync detail remains available for detail row",
+);
+
+const syncedCopy = resolveCloudPolicyBundleCopy({
+  cloud_policy_bundle_version: "v2026.05.23.1",
+  cloud_policy_rollout_state: "active",
+  cloud_policy_bundle_hash: "a1b2c3d4e5f6",
+});
+assert(
+  resolveCloudBundleStatusSubtitle(syncedCopy!) === "All policies up to date",
+  "synced subtitle matches mockup copy",
+);
+
+console.log("policy-guard-cloud-bundle-card.test.ts: all assertions passed");

--- a/dashboard/src/policy-guard-cloud-bundle-card.test.ts
+++ b/dashboard/src/policy-guard-cloud-bundle-card.test.ts
@@ -1,8 +1,8 @@
 import {
   formatCloudBundleHashDisplay,
   resolveCloudBundleStatusSubtitle,
-  resolveCloudPolicyBundleCopy,
-} from "./policy-workspace-helpers";
+} from "./policy-guard-cloud-bundle-helpers";
+import { resolveCloudPolicyBundleCopy } from "./policy-workspace-helpers";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -13,6 +13,10 @@ function assert(condition: boolean, message: string): void {
 assert(
   formatCloudBundleHashDisplay("sha256:abcdef1234567890") === "sha256:abcd…",
   "bundle hash display truncates sha256 hashes",
+);
+assert(
+  formatCloudBundleHashDisplay("sha256:abc") === "sha256:abc",
+  "bundle hash display preserves prefix for short hashes",
 );
 assert(formatCloudBundleHashDisplay(null) === "Unavailable", "missing hash shows unavailable");
 

--- a/dashboard/src/policy-guard-cloud-bundle-card.tsx
+++ b/dashboard/src/policy-guard-cloud-bundle-card.tsx
@@ -6,6 +6,8 @@ import type { GuardRuntimeSnapshot } from "./guard-types";
 import {
   formatCloudBundleHashDisplay,
   resolveCloudBundleStatusSubtitle,
+} from "./policy-guard-cloud-bundle-helpers";
+import {
   resolveCloudPolicyBundleCopy,
   resolveCloudExceptionsConnected,
   resolveCloudPolicyControlsUrl,
@@ -68,7 +70,7 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
 
   const synced = cloudBundleCopy.tone === "green";
   const statusSubtitle = resolveCloudBundleStatusSubtitle(cloudBundleCopy);
-  const showDetail = !synced || cloudBundleCopy.detail !== statusSubtitle;
+  const showDetail = !synced;
 
   return (
     <div className="rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm">

--- a/dashboard/src/policy-guard-cloud-bundle-card.tsx
+++ b/dashboard/src/policy-guard-cloud-bundle-card.tsx
@@ -4,6 +4,8 @@ import { ActionButton, SectionLabel, Tag } from "./approval-center-primitives";
 import { formatRelativeTime } from "./approval-center-utils";
 import type { GuardRuntimeSnapshot } from "./guard-types";
 import {
+  formatCloudBundleHashDisplay,
+  resolveCloudBundleStatusSubtitle,
   resolveCloudPolicyBundleCopy,
   resolveCloudExceptionsConnected,
   resolveCloudPolicyControlsUrl,
@@ -23,7 +25,7 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
     snapshot.generated_at?.trim() ??
     null;
   const policyHash = cloudBundleCopy?.hash?.trim() ?? null;
-  const policyHashShort = policyHash?.slice(0, 8) ?? null;
+  const policyHashDisplay = formatCloudBundleHashDisplay(policyHash);
   const bundleVersion = snapshot.cloud_policy_bundle_version?.trim() ?? null;
 
   const handleCopyHash = useCallback(() => {
@@ -42,13 +44,13 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
             <p className="mt-2 text-sm font-medium text-brand-dark">
               {snapshot.cloud_state_label?.trim() || "Connected to Guard Cloud"}
             </p>
-            <p className="mt-1 text-sm text-brand-dark/75">
+            <p className="mt-1 text-sm leading-relaxed text-brand-dark/75">
               {snapshot.cloud_state_detail?.trim() ||
                 "Guard Cloud is connected. Policy bundle details will appear after the next successful sync."}
             </p>
           </>
         ) : (
-          <p className="mt-2 text-sm text-brand-dark/75">
+          <p className="mt-2 text-sm leading-relaxed text-brand-dark/75">
             Guard Cloud is not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle.
           </p>
         )}
@@ -65,56 +67,80 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
   }
 
   const synced = cloudBundleCopy.tone === "green";
+  const statusSubtitle = resolveCloudBundleStatusSubtitle(cloudBundleCopy);
+  const showDetail = !synced || cloudBundleCopy.detail !== statusSubtitle;
 
   return (
     <div className="rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm">
       <SectionLabel>Guard Cloud bundle</SectionLabel>
-      <div className="mt-3 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between">
-        <div className="grid flex-1 gap-4 sm:grid-cols-3">
-          <div>
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Status</p>
-            <div className="mt-1.5 flex items-center gap-1.5">
-              {synced ? (
-                <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
-              ) : null}
-              <Tag tone={synced ? "green" : "amber"}>{synced ? "Synced" : cloudBundleCopy.label}</Tag>
+
+      <div className="mt-3 space-y-3">
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <dl className="grid min-w-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
+            <div className="min-w-0">
+              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Status</dt>
+              <dd className="mt-1.5">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  {synced ? (
+                    <HiMiniCheckCircle className="h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
+                  ) : null}
+                  <Tag tone={synced ? "green" : "amber"}>{synced ? "Synced" : cloudBundleCopy.label}</Tag>
+                </div>
+                <p className="mt-1 text-xs leading-relaxed text-slate-500">{statusSubtitle}</p>
+              </dd>
             </div>
-            <p className="mt-1 text-xs text-slate-500">
-              {synced ? "All policies up to date" : cloudBundleCopy.detail}
-            </p>
-          </div>
-          <div>
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Bundle hash</p>
-            <div className="mt-1.5 flex items-center gap-1.5">
-              <p className="font-mono text-sm text-brand-dark">{policyHashShort ?? "Unavailable"}</p>
-              {policyHashShort ? (
-                <button
-                  type="button"
-                  onClick={handleCopyHash}
-                  className="rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark"
-                  aria-label="Copy bundle hash"
-                >
-                  <HiMiniClipboardDocument className="h-4 w-4" aria-hidden="true" />
-                </button>
-              ) : null}
+
+            <div className="min-w-0">
+              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Bundle hash</dt>
+              <dd className="mt-1.5 flex min-w-0 items-center gap-1.5">
+                <p className="truncate font-mono text-sm text-brand-dark" title={policyHash ?? undefined}>
+                  {policyHashDisplay}
+                </p>
+                {policyHash ? (
+                  <button
+                    type="button"
+                    onClick={handleCopyHash}
+                    className="shrink-0 rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark"
+                    aria-label="Copy bundle hash"
+                  >
+                    <HiMiniClipboardDocument className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                ) : null}
+              </dd>
             </div>
-          </div>
-          <div>
-            <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last ack</p>
-            <div className="mt-1.5 flex items-center gap-1.5">
-              {lastAckAt ? (
-                <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
-              ) : null}
-              <p className="text-sm text-brand-dark">{lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}</p>
+
+            <div className="min-w-0 sm:col-span-2 xl:col-span-1">
+              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last ack</dt>
+              <dd className="mt-1.5">
+                <div className="flex min-w-0 items-center gap-1.5">
+                  {lastAckAt && synced ? (
+                    <HiMiniCheckCircle className="h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
+                  ) : null}
+                  <p className="text-sm text-brand-dark">{lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}</p>
+                </div>
+                {bundleVersion ? (
+                  <p className="mt-1 truncate text-xs text-slate-500" title={bundleVersion}>
+                    {bundleVersion}
+                  </p>
+                ) : null}
+              </dd>
             </div>
-            {bundleVersion ? <p className="mt-1 text-xs text-slate-500">{bundleVersion}</p> : null}
-          </div>
+          </dl>
+
+          {cloudControlsUrl ? (
+            <div className="w-full shrink-0 sm:w-auto lg:pt-5">
+              <ActionButton href={cloudControlsUrl} variant="secondary">
+                <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
+                Open Guard Cloud
+              </ActionButton>
+            </div>
+          ) : null}
         </div>
-        {cloudControlsUrl ? (
-          <ActionButton href={cloudControlsUrl} variant="secondary">
-            <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
-            Open Guard Cloud
-          </ActionButton>
+
+        {showDetail ? (
+          <p className="rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-relaxed text-slate-700">
+            {cloudBundleCopy.detail}
+          </p>
         ) : null}
       </div>
     </div>

--- a/dashboard/src/policy-guard-cloud-bundle-helpers.ts
+++ b/dashboard/src/policy-guard-cloud-bundle-helpers.ts
@@ -1,0 +1,27 @@
+export function formatCloudBundleHashDisplay(hash: string | null | undefined): string {
+  if (!hash?.trim()) {
+    return "Unavailable";
+  }
+  const value = hash.trim();
+  const isSha256 = value.toLowerCase().startsWith("sha256:");
+  const normalized = isSha256 ? value.slice(7) : value;
+
+  if (isSha256) {
+    return normalized.length <= 4 ? value : `sha256:${normalized.slice(0, 4)}…`;
+  }
+  return normalized.length <= 8 ? normalized : `${normalized.slice(0, 8)}…`;
+}
+
+export function resolveCloudBundleStatusSubtitle(copy: {
+  label: string;
+  detail: string;
+  tone: "green" | "attention" | "slate";
+}): string {
+  if (copy.tone === "green") {
+    return "All policies up to date";
+  }
+  if (copy.tone === "attention") {
+    return "Latest sync needs attention";
+  }
+  return copy.label;
+}

--- a/dashboard/src/policy-workspace-helpers.ts
+++ b/dashboard/src/policy-workspace-helpers.ts
@@ -573,6 +573,35 @@ export function resolveSecurityModeCopy(
   };
 }
 
+export function formatCloudBundleHashDisplay(hash: string | null | undefined): string {
+  if (!hash?.trim()) {
+    return "Unavailable";
+  }
+  const value = hash.trim();
+  const normalized = value.replace(/^sha256:/i, "");
+  if (normalized.length <= 8) {
+    return normalized;
+  }
+  if (value.toLowerCase().startsWith("sha256:")) {
+    return `sha256:${normalized.slice(0, 4)}…`;
+  }
+  return `${normalized.slice(0, 8)}…`;
+}
+
+export function resolveCloudBundleStatusSubtitle(copy: {
+  label: string;
+  detail: string;
+  tone: "green" | "attention" | "slate";
+}): string {
+  if (copy.tone === "green") {
+    return "All policies up to date";
+  }
+  if (copy.tone === "attention") {
+    return "Latest sync needs attention";
+  }
+  return copy.label;
+}
+
 export function resolveCloudPolicyBundleCopy(snapshot: {
   cloud_policy_bundle_version?: string | null;
   cloud_policy_rollout_state?: string | null;

--- a/dashboard/src/policy-workspace-helpers.ts
+++ b/dashboard/src/policy-workspace-helpers.ts
@@ -573,35 +573,6 @@ export function resolveSecurityModeCopy(
   };
 }
 
-export function formatCloudBundleHashDisplay(hash: string | null | undefined): string {
-  if (!hash?.trim()) {
-    return "Unavailable";
-  }
-  const value = hash.trim();
-  const normalized = value.replace(/^sha256:/i, "");
-  if (normalized.length <= 8) {
-    return normalized;
-  }
-  if (value.toLowerCase().startsWith("sha256:")) {
-    return `sha256:${normalized.slice(0, 4)}…`;
-  }
-  return `${normalized.slice(0, 8)}…`;
-}
-
-export function resolveCloudBundleStatusSubtitle(copy: {
-  label: string;
-  detail: string;
-  tone: "green" | "attention" | "slate";
-}): string {
-  if (copy.tone === "green") {
-    return "All policies up to date";
-  }
-  if (copy.tone === "attention") {
-    return "Latest sync needs attention";
-  }
-  return copy.label;
-}
-
 export function resolveCloudPolicyBundleCopy(snapshot: {
   cloud_policy_bundle_version?: string | null;
   cloud_policy_rollout_state?: string | null;

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -2110,29 +2110,6 @@ function resolveSecurityModeCopy(level) {
     tone: "slate"
   };
 }
-function formatCloudBundleHashDisplay(hash) {
-  if (!hash?.trim()) {
-    return "Unavailable";
-  }
-  const value = hash.trim();
-  const normalized = value.replace(/^sha256:/i, "");
-  if (normalized.length <= 8) {
-    return normalized;
-  }
-  if (value.toLowerCase().startsWith("sha256:")) {
-    return `sha256:${normalized.slice(0, 4)}…`;
-  }
-  return `${normalized.slice(0, 8)}…`;
-}
-function resolveCloudBundleStatusSubtitle(copy) {
-  if (copy.tone === "green") {
-    return "All policies up to date";
-  }
-  if (copy.tone === "attention") {
-    return "Latest sync needs attention";
-  }
-  return copy.label;
-}
 function resolveCloudPolicyBundleCopy(snapshot) {
   const bundleVersion = snapshot.cloud_policy_bundle_version?.trim();
   if (!bundleVersion) {
@@ -2393,6 +2370,27 @@ function downloadPolicies(format, policies) {
   const result = format === "csv" ? exportPoliciesCsv(policies) : exportPoliciesJson(policies);
   downloadBlob(result.blob, result.filename);
 }
+function formatCloudBundleHashDisplay(hash) {
+  if (!hash?.trim()) {
+    return "Unavailable";
+  }
+  const value = hash.trim();
+  const isSha256 = value.toLowerCase().startsWith("sha256:");
+  const normalized = isSha256 ? value.slice(7) : value;
+  if (isSha256) {
+    return normalized.length <= 4 ? value : `sha256:${normalized.slice(0, 4)}…`;
+  }
+  return normalized.length <= 8 ? normalized : `${normalized.slice(0, 8)}…`;
+}
+function resolveCloudBundleStatusSubtitle(copy) {
+  if (copy.tone === "green") {
+    return "All policies up to date";
+  }
+  if (copy.tone === "attention") {
+    return "Latest sync needs attention";
+  }
+  return copy.label;
+}
 function PolicyGuardCloudBundleCard({ snapshot }) {
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
@@ -2422,7 +2420,7 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
   }
   const synced = cloudBundleCopy.tone === "green";
   const statusSubtitle = resolveCloudBundleStatusSubtitle(cloudBundleCopy);
-  const showDetail = !synced || cloudBundleCopy.detail !== statusSubtitle;
+  const showDetail = !synced;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 space-y-3", children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -2110,6 +2110,29 @@ function resolveSecurityModeCopy(level) {
     tone: "slate"
   };
 }
+function formatCloudBundleHashDisplay(hash) {
+  if (!hash?.trim()) {
+    return "Unavailable";
+  }
+  const value = hash.trim();
+  const normalized = value.replace(/^sha256:/i, "");
+  if (normalized.length <= 8) {
+    return normalized;
+  }
+  if (value.toLowerCase().startsWith("sha256:")) {
+    return `sha256:${normalized.slice(0, 4)}…`;
+  }
+  return `${normalized.slice(0, 8)}…`;
+}
+function resolveCloudBundleStatusSubtitle(copy) {
+  if (copy.tone === "green") {
+    return "All policies up to date";
+  }
+  if (copy.tone === "attention") {
+    return "Latest sync needs attention";
+  }
+  return copy.label;
+}
 function resolveCloudPolicyBundleCopy(snapshot) {
   const bundleVersion = snapshot.cloud_policy_bundle_version?.trim();
   if (!bundleVersion) {
@@ -2376,7 +2399,7 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
   const cloudConnected = resolveCloudExceptionsConnected(snapshot);
   const lastAckAt = snapshot.cloud_policy_last_ack_at?.trim() ?? snapshot.runtime_state?.last_heartbeat_at?.trim() ?? snapshot.generated_at?.trim() ?? null;
   const policyHash = cloudBundleCopy?.hash?.trim() ?? null;
-  const policyHashShort = policyHash?.slice(0, 8) ?? null;
+  const policyHashDisplay = formatCloudBundleHashDisplay(policyHash);
   const bundleVersion = snapshot.cloud_policy_bundle_version?.trim() ?? null;
   const handleCopyHash = reactExports.useCallback(() => {
     if (!policyHash || !navigator.clipboard?.writeText) {
@@ -2389,8 +2412,8 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
       cloudConnected ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm font-medium text-brand-dark", children: snapshot.cloud_state_label?.trim() || "Connected to Guard Cloud" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-brand-dark/75", children: snapshot.cloud_state_detail?.trim() || "Guard Cloud is connected. Policy bundle details will appear after the next successful sync." })
-      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-brand-dark/75", children: "Guard Cloud is not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle." }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-brand-dark/75", children: snapshot.cloud_state_detail?.trim() || "Guard Cloud is connected. Policy bundle details will appear after the next successful sync." })
+      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-brand-dark/75", children: "Guard Cloud is not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle." }),
       cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
         "Open Guard Cloud"
@@ -2398,47 +2421,56 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
     ] });
   }
   const synced = cloudBundleCopy.tone === "green";
+  const statusSubtitle = resolveCloudBundleStatusSubtitle(cloudBundleCopy);
+  const showDetail = !synced || cloudBundleCopy.detail !== statusSubtitle;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex flex-col gap-4 lg:flex-row lg:items-center lg:justify-between", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid flex-1 gap-4 sm:grid-cols-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Status" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1.5 flex items-center gap-1.5", children: [
-            synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-600", "aria-hidden": "true" }) : null,
-            /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: synced ? "green" : "amber", children: synced ? "Synced" : cloudBundleCopy.label })
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 space-y-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "grid min-w-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Status" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-1.5", children: [
+                synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
+                /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: synced ? "green" : "amber", children: synced ? "Synced" : cloudBundleCopy.label })
+              ] }),
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-500", children: statusSubtitle })
+            ] })
           ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-slate-500", children: synced ? "All policies up to date" : cloudBundleCopy.detail })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Bundle hash" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1.5 flex items-center gap-1.5", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-mono text-sm text-brand-dark", children: policyHashShort ?? "Unavailable" }),
-            policyHashShort ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "button",
-              {
-                type: "button",
-                onClick: handleCopyHash,
-                className: "rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
-                "aria-label": "Copy bundle hash",
-                children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-4 w-4", "aria-hidden": "true" })
-              }
-            ) : null
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Bundle hash" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5 flex min-w-0 items-center gap-1.5", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate font-mono text-sm text-brand-dark", title: policyHash ?? void 0, children: policyHashDisplay }),
+              policyHash ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+                "button",
+                {
+                  type: "button",
+                  onClick: handleCopyHash,
+                  className: "shrink-0 rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
+                  "aria-label": "Copy bundle hash",
+                  children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-4 w-4", "aria-hidden": "true" })
+                }
+              ) : null
+            ] })
+          ] }),
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 sm:col-span-2 xl:col-span-1", children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last ack" }),
+            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5", children: [
+              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-1.5", children: [
+                lastAckAt && synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
+                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet" })
+              ] }),
+              bundleVersion ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 truncate text-xs text-slate-500", title: bundleVersion, children: bundleVersion }) : null
+            ] })
           ] })
         ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last ack" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-1.5 flex items-center gap-1.5", children: [
-            lastAckAt ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-600", "aria-hidden": "true" }) : null,
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet" })
-          ] }),
-          bundleVersion ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-slate-500", children: bundleVersion }) : null
-        ] })
+        cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full shrink-0 sm:w-auto lg:pt-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+          "Open Guard Cloud"
+        ] }) }) : null
       ] }),
-      cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
-        "Open Guard Cloud"
-      ] }) : null
+      showDetail ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-relaxed text-slate-700", children: cloudBundleCopy.detail }) : null
     ] })
   ] });
 }

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1882,6 +1882,16 @@
     }
   }
 
+  .border-amber-200\/80 {
+    border-color: #fee685cc;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .border-amber-200\/80 {
+      border-color: color-mix(in oklab, var(--color-amber-200) 80%, transparent);
+    }
+  }
+
   .border-amber-300 {
     border-color: var(--color-amber-300);
   }
@@ -5900,6 +5910,10 @@
       padding-inline: calc(var(--spacing) * 8);
     }
 
+    .lg\:pt-5 {
+      padding-top: calc(var(--spacing) * 5);
+    }
+
     .lg\:pl-20 {
       padding-left: calc(var(--spacing) * 20);
     }
@@ -5921,6 +5935,10 @@
 
     .xl\:top-6 {
       top: calc(var(--spacing) * 6);
+    }
+
+    .xl\:col-span-1 {
+      grid-column: span 1 / span 1;
     }
 
     .xl\:block {


### PR DESCRIPTION
## Summary
- Fix Guard Cloud bundle card overlap by keeping stat columns short and moving long sync detail into a full-width callout below.
- Truncate bundle hash display and add responsive grid breakpoints for half-width Policy layout.

## Testing
- `cd dashboard && npm run build`
- `npx tsx src/policy-guard-cloud-bundle-card.test.ts`
- `npx tsx src/policy-workspace-helpers.test.ts`
