### PR TITLE
feat(guard): add AIBOM attestation freshness bindings

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -7,7 +7,7 @@ import os
 import urllib.error
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Literal
 
@@ -77,7 +77,7 @@ def collect_aibom_snapshots(
     return tuple(snapshots)
 
 
-def _resolve_trust_attestation_context(store: GuardStore) -> dict[str, object]:
+def _resolve_trust_attestation_context(store: GuardStore, *, generated_at: str) -> dict[str, object]:
     from .runtime.trust_attestation import (
         resolve_guard_oauth_trust_attestation_signing_config,
         resolve_trust_attestation_signing_config,
@@ -89,9 +89,21 @@ def _resolve_trust_attestation_context(store: GuardStore) -> dict[str, object]:
     if signing_config is None:
         signing_config = resolve_trust_attestation_signing_config()
     enable_v2 = trust_attestation_v2_enabled()
+    installation_id = store.get_or_create_installation_id() if enable_v2 else None
+    expires_at = (
+        (_aware_utc_timestamp(generated_at) + timedelta(minutes=15)).isoformat().replace("+00:00", "Z")
+        if enable_v2
+        else None
+    )
     return {
-        "deviceId": store.get_or_create_installation_id() if enable_v2 else None,
+        "challengeId": f"guard-aibom-challenge-{uuid.uuid4().hex}" if enable_v2 else None,
+        "deviceId": installation_id,
+        "expiresAt": expires_at,
+        "installationId": installation_id,
+        "nonce": uuid.uuid4().hex if enable_v2 else None,
+        "sequence": store.next_aibom_trust_attestation_sequence(generated_at) if enable_v2 else None,
         "signingConfig": signing_config,
+        "uploadId": f"guard-aibom-upload-{uuid.uuid4().hex}" if enable_v2 else None,
         "workspaceId": store.get_cloud_workspace_id() if enable_v2 else None,
     }
 
@@ -107,7 +119,7 @@ def build_inventory_json_payload(
         context,
         generated_at=generated_at,
         options=options,
-        trust_attestation_context=_resolve_trust_attestation_context(store),
+        trust_attestation_context=_resolve_trust_attestation_context(store, generated_at=generated_at),
     )
     metadata_by_artifact = _metadata_lookup_from_snapshots(snapshots)
     items: list[dict[str, object]] = []
@@ -139,7 +151,7 @@ def build_aibom_status_payload(
         context,
         generated_at=generated_at,
         options=options,
-        trust_attestation_context=_resolve_trust_attestation_context(store),
+        trust_attestation_context=_resolve_trust_attestation_context(store, generated_at=generated_at),
     )
     sync_summary = _sync_summary(store)
     layer_summary, trust_summary, drift_summary = summarize_aibom_layers(
@@ -171,7 +183,7 @@ def build_aibom_export_payload(
         context,
         generated_at=generated_at,
         options=options,
-        trust_attestation_context=_resolve_trust_attestation_context(store),
+        trust_attestation_context=_resolve_trust_attestation_context(store, generated_at=generated_at),
     )
     serialized_snapshots = [serialize_inventory_snapshot(snapshot) for snapshot in snapshots]
     artifacts = _artifact_rows_from_store(store, snapshots)
@@ -336,7 +348,7 @@ def sync_aibom_snapshots(
         raise GuardSyncNotConfiguredError("Guard Cloud workspace is not configured. Run `hol-guard connect` first.")
 
     resolved_options = options or _AIBOM_CLOUD_SYNC_OPTIONS
-    trust_attestation_context = _resolve_trust_attestation_context(store)
+    trust_attestation_context = _resolve_trust_attestation_context(store, generated_at=generated_at)
     snapshots = collect_aibom_snapshots(
         context,
         generated_at=generated_at,

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -77,7 +77,12 @@ def collect_aibom_snapshots(
     return tuple(snapshots)
 
 
-def _resolve_trust_attestation_context(store: GuardStore, *, generated_at: str) -> dict[str, object]:
+def _resolve_trust_attestation_context(
+    store: GuardStore,
+    *,
+    generated_at: str,
+    include_upload_session_bindings: bool = False,
+) -> dict[str, object]:
     from .runtime.trust_attestation import (
         resolve_guard_oauth_trust_attestation_signing_config,
         resolve_trust_attestation_signing_config,
@@ -90,22 +95,33 @@ def _resolve_trust_attestation_context(store: GuardStore, *, generated_at: str) 
         signing_config = resolve_trust_attestation_signing_config()
     enable_v2 = trust_attestation_v2_enabled()
     installation_id = store.get_or_create_installation_id() if enable_v2 else None
-    expires_at = (
-        (_aware_utc_timestamp(generated_at) + timedelta(minutes=15)).isoformat().replace("+00:00", "Z")
-        if enable_v2
-        else None
-    )
-    return {
-        "challengeId": f"guard-aibom-challenge-{uuid.uuid4().hex}" if enable_v2 else None,
+    context: dict[str, object] = {
+        "challengeId": None,
         "deviceId": installation_id,
-        "expiresAt": expires_at,
+        "expiresAt": None,
         "installationId": installation_id,
-        "nonce": uuid.uuid4().hex if enable_v2 else None,
-        "sequence": store.next_aibom_trust_attestation_sequence(generated_at) if enable_v2 else None,
+        "nonce": None,
+        "sequence": None,
         "signingConfig": signing_config,
-        "uploadId": f"guard-aibom-upload-{uuid.uuid4().hex}" if enable_v2 else None,
+        "uploadId": None,
         "workspaceId": store.get_cloud_workspace_id() if enable_v2 else None,
     }
+    if not enable_v2 or not include_upload_session_bindings:
+        return context
+    try:
+        expires_at = (_aware_utc_timestamp(generated_at) + timedelta(minutes=15)).isoformat().replace("+00:00", "Z")
+    except (OverflowError, TypeError, ValueError):
+        expires_at = None
+    context.update(
+        {
+            "challengeId": f"guard-aibom-challenge-{uuid.uuid4().hex}",
+            "expiresAt": expires_at,
+            "nonce": uuid.uuid4().hex,
+            "sequence": store.next_aibom_trust_attestation_sequence(generated_at),
+            "uploadId": f"guard-aibom-upload-{uuid.uuid4().hex}",
+        }
+    )
+    return context
 
 
 def build_inventory_json_payload(
@@ -348,7 +364,11 @@ def sync_aibom_snapshots(
         raise GuardSyncNotConfiguredError("Guard Cloud workspace is not configured. Run `hol-guard connect` first.")
 
     resolved_options = options or _AIBOM_CLOUD_SYNC_OPTIONS
-    trust_attestation_context = _resolve_trust_attestation_context(store, generated_at=generated_at)
+    trust_attestation_context = _resolve_trust_attestation_context(
+        store,
+        generated_at=generated_at,
+        include_upload_session_bindings=True,
+    )
     snapshots = collect_aibom_snapshots(
         context,
         generated_at=generated_at,

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -613,9 +613,7 @@ def _item_from_artifact(
         raw_device_id = trust_attestation_context.get("deviceId")
         device_id = raw_device_id if isinstance(raw_device_id, str) and raw_device_id else None
         raw_installation_id = trust_attestation_context.get("installationId")
-        installation_id = (
-            raw_installation_id if isinstance(raw_installation_id, str) and raw_installation_id else None
-        )
+        installation_id = raw_installation_id if isinstance(raw_installation_id, str) and raw_installation_id else None
         raw_upload_id = trust_attestation_context.get("uploadId")
         upload_id = raw_upload_id if isinstance(raw_upload_id, str) and raw_upload_id else None
         raw_challenge_id = trust_attestation_context.get("challengeId")

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -600,12 +600,33 @@ def _item_from_artifact(
 
     workspace_id = None
     device_id = None
+    installation_id = None
+    upload_id = None
+    challenge_id = None
+    nonce = None
+    sequence = None
+    expires_at = None
     signing_config = None
     if isinstance(trust_attestation_context, Mapping):
         raw_workspace_id = trust_attestation_context.get("workspaceId")
         workspace_id = raw_workspace_id if isinstance(raw_workspace_id, str) and raw_workspace_id else None
         raw_device_id = trust_attestation_context.get("deviceId")
         device_id = raw_device_id if isinstance(raw_device_id, str) and raw_device_id else None
+        raw_installation_id = trust_attestation_context.get("installationId")
+        installation_id = (
+            raw_installation_id if isinstance(raw_installation_id, str) and raw_installation_id else None
+        )
+        raw_upload_id = trust_attestation_context.get("uploadId")
+        upload_id = raw_upload_id if isinstance(raw_upload_id, str) and raw_upload_id else None
+        raw_challenge_id = trust_attestation_context.get("challengeId")
+        challenge_id = raw_challenge_id if isinstance(raw_challenge_id, str) and raw_challenge_id else None
+        raw_nonce = trust_attestation_context.get("nonce")
+        nonce = raw_nonce if isinstance(raw_nonce, str) and raw_nonce else None
+        raw_sequence = trust_attestation_context.get("sequence")
+        if isinstance(raw_sequence, int):
+            sequence = raw_sequence
+        raw_expires_at = trust_attestation_context.get("expiresAt")
+        expires_at = raw_expires_at if isinstance(raw_expires_at, str) and raw_expires_at else None
         raw_signing_config = trust_attestation_context.get("signingConfig")
         if isinstance(raw_signing_config, GuardTrustAttestationSigningConfig):
             signing_config = raw_signing_config
@@ -616,6 +637,12 @@ def _item_from_artifact(
         item_id=artifact_id,
         item_kind=item_kind,
         content_hash=content_hash,
+        challenge_id=challenge_id,
+        expires_at=expires_at,
+        installation_id=installation_id,
+        nonce=nonce,
+        sequence=sequence,
+        upload_id=upload_id,
         workspace_id=workspace_id,
         device_id=device_id,
         signing_config=signing_config,

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -114,6 +114,12 @@ def build_trust_attestation_payload(
     captured_at: str,
     evidence_hash: str,
     scope: str,
+    challenge_id: str | None = None,
+    expires_at: str | None = None,
+    installation_id: str | None = None,
+    nonce: str | None = None,
+    sequence: int | None = None,
+    upload_id: str | None = None,
     workspace_id: str | None = None,
     device_id: str | None = None,
     layer_id: str | None = None,
@@ -138,6 +144,18 @@ def build_trust_attestation_payload(
         payload["workspaceId"] = workspace_id
     if device_id is not None:
         payload["deviceId"] = device_id
+    if installation_id is not None:
+        payload["installationId"] = installation_id
+    if upload_id is not None:
+        payload["uploadId"] = upload_id
+    if challenge_id is not None:
+        payload["challengeId"] = challenge_id
+    if nonce is not None:
+        payload["nonce"] = nonce
+    if sequence is not None:
+        payload["sequence"] = sequence
+    if expires_at is not None:
+        payload["expiresAt"] = expires_at
     if layer_id is not None:
         payload["layerId"] = layer_id
     if layer_type is not None:
@@ -152,6 +170,12 @@ def apply_trust_attestation_metadata(
     item_id: str,
     item_kind: str,
     content_hash: str,
+    challenge_id: str | None = None,
+    expires_at: str | None = None,
+    installation_id: str | None = None,
+    nonce: str | None = None,
+    sequence: int | None = None,
+    upload_id: str | None = None,
     workspace_id: str | None = None,
     device_id: str | None = None,
     signing_config: GuardTrustAttestationSigningConfig | None = None,
@@ -161,6 +185,20 @@ def apply_trust_attestation_metadata(
         return metadata
 
     enriched = dict(metadata)
+    attestation_bindings = {
+        key: value
+        for key, value in {
+            "challengeId": challenge_id,
+            "deviceId": device_id,
+            "expiresAt": expires_at,
+            "installationId": installation_id,
+            "nonce": nonce,
+            "sequence": sequence,
+            "uploadId": upload_id,
+            "workspaceId": workspace_id,
+        }.items()
+        if value is not None
+    }
 
     raw_trust_resolution = enriched.get("trustResolution")
     if isinstance(raw_trust_resolution, dict):
@@ -177,8 +215,14 @@ def apply_trust_attestation_metadata(
                     item_kind=item_kind,
                     content_hash=content_hash,
                     captured_at=captured_at,
+                    challenge_id=challenge_id,
+                    expires_at=expires_at,
                     evidence_hash=evidence_hash,
+                    installation_id=installation_id,
+                    nonce=nonce,
+                    sequence=sequence,
                     scope="trust_resolution",
+                    upload_id=upload_id,
                     workspace_id=workspace_id,
                     device_id=device_id,
                 ),
@@ -186,6 +230,8 @@ def apply_trust_attestation_metadata(
                 signed_at=captured_at,
             )
             resolution_metadata["attestationStatus"] = "signed"
+            if attestation_bindings:
+                resolution_metadata["attestationBindings"] = dict(attestation_bindings)
             trust_resolution["metadata"] = resolution_metadata
             enriched["trustResolution"] = trust_resolution
 
@@ -220,8 +266,14 @@ def apply_trust_attestation_metadata(
                         item_kind=item_kind,
                         content_hash=content_hash,
                         captured_at=captured_at,
+                        challenge_id=challenge_id,
+                        expires_at=expires_at,
                         evidence_hash=evidence_hash,
+                        installation_id=installation_id,
+                        nonce=nonce,
+                        sequence=sequence,
                         scope="trust_layer",
+                        upload_id=upload_id,
                         workspace_id=workspace_id,
                         device_id=device_id,
                         layer_id=layer_id,
@@ -231,6 +283,8 @@ def apply_trust_attestation_metadata(
                     signed_at=captured_at,
                 )
                 layer_metadata["attestationStatus"] = "signed"
+                if attestation_bindings:
+                    layer_metadata["attestationBindings"] = dict(attestation_bindings)
                 layer["metadata"] = layer_metadata
             signed_layers.append(layer)
         enriched["trustLayers"] = signed_layers

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2438,6 +2438,38 @@ class GuardStore:
         with self._connect() as connection:
             return self._cloud_workspace_id_from_connection(connection)
 
+    def next_aibom_trust_attestation_sequence(self, now: str) -> int:
+        state_key = "aibom_trust_attestation_sequence"
+        with self._connect() as connection:
+            row = connection.execute(
+                "select payload_json from sync_state where state_key = ?",
+                (state_key,),
+            ).fetchone()
+            current_sequence = 0
+            if row is not None:
+                try:
+                    payload = json.loads(str(row["payload_json"]))
+                except json.JSONDecodeError:
+                    payload = None
+                if isinstance(payload, dict):
+                    raw_sequence = payload.get("sequence")
+                    if isinstance(raw_sequence, int) and raw_sequence >= 0:
+                        current_sequence = raw_sequence
+                    elif isinstance(raw_sequence, str) and raw_sequence.isdigit():
+                        current_sequence = int(raw_sequence)
+            next_sequence = current_sequence + 1
+            connection.execute(
+                """
+                insert into sync_state (state_key, payload_json, updated_at)
+                values (?, ?, ?)
+                on conflict(state_key) do update set
+                  payload_json = excluded.payload_json,
+                  updated_at = excluded.updated_at
+                """,
+                (state_key, json.dumps({"sequence": next_sequence}), now),
+            )
+        return next_sequence
+
     def upsert_policy(
         self,
         decision: PolicyDecision,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2441,6 +2441,7 @@ class GuardStore:
     def next_aibom_trust_attestation_sequence(self, now: str) -> int:
         state_key = "aibom_trust_attestation_sequence"
         with self._connect() as connection:
+            connection.execute("begin immediate")
             row = connection.execute(
                 "select payload_json from sync_state where state_key = ?",
                 (state_key,),

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -342,6 +342,28 @@ def test_resolve_trust_attestation_context_includes_workspace_device_for_v2(
     assert context["workspaceId"] == "workspace-1"
     assert context["deviceId"] == "device-1"
     assert context["installationId"] == "device-1"
+    assert context["uploadId"] is None
+    assert context["challengeId"] is None
+    assert context["nonce"] is None
+    assert context["sequence"] is None
+    assert context["expiresAt"] is None
+
+
+def test_resolve_trust_attestation_context_includes_upload_session_bindings_for_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    monkeypatch.setattr(store, "get_or_create_installation_id", lambda: "device-1")
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "1")
+
+    context = aibom_cli._resolve_trust_attestation_context(
+        store,
+        generated_at="2026-06-10T12:00:00+00:00",
+        include_upload_session_bindings=True,
+    )
+
     assert isinstance(context["uploadId"], str) and context["uploadId"].startswith("guard-aibom-upload-")
     assert isinstance(context["challengeId"], str) and context["challengeId"].startswith("guard-aibom-challenge-")
     assert isinstance(context["nonce"], str) and context["nonce"]
@@ -351,9 +373,29 @@ def test_resolve_trust_attestation_context_includes_workspace_device_for_v2(
     second_context = aibom_cli._resolve_trust_attestation_context(
         store,
         generated_at="2026-06-10T12:05:00+00:00",
+        include_upload_session_bindings=True,
     )
 
     assert second_context["sequence"] == 2
+
+
+def test_resolve_trust_attestation_context_tolerates_invalid_generated_at_for_sync(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    monkeypatch.setattr(store, "get_or_create_installation_id", lambda: "device-1")
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "1")
+
+    context = aibom_cli._resolve_trust_attestation_context(
+        store,
+        generated_at="not-a-timestamp",
+        include_upload_session_bindings=True,
+    )
+
+    assert context["expiresAt"] is None
+    assert context["sequence"] == 1
 
 
 def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -316,7 +316,10 @@ def test_resolve_trust_attestation_context_defaults_to_v1(monkeypatch: pytest.Mo
     monkeypatch.setattr(store, 'get_or_create_installation_id', lambda: 'device-1')
     monkeypatch.delenv('GUARD_AIBOM_TRUST_ATTESTATION_V2', raising=False)
 
-    context = aibom_cli._resolve_trust_attestation_context(store)
+    context = aibom_cli._resolve_trust_attestation_context(
+        store,
+        generated_at='2026-06-10T12:00:00+00:00',
+    )
 
     assert context['workspaceId'] is None
     assert context['deviceId'] is None
@@ -331,10 +334,19 @@ def test_resolve_trust_attestation_context_includes_workspace_device_for_v2(
     monkeypatch.setattr(store, 'get_or_create_installation_id', lambda: 'device-1')
     monkeypatch.setenv('GUARD_AIBOM_TRUST_ATTESTATION_V2', '1')
 
-    context = aibom_cli._resolve_trust_attestation_context(store)
+    context = aibom_cli._resolve_trust_attestation_context(
+        store,
+        generated_at='2026-06-10T12:00:00+00:00',
+    )
 
     assert context['workspaceId'] == 'workspace-1'
     assert context['deviceId'] == 'device-1'
+    assert context['installationId'] == 'device-1'
+    assert isinstance(context['uploadId'], str) and context['uploadId'].startswith('guard-aibom-upload-')
+    assert isinstance(context['challengeId'], str) and context['challengeId'].startswith('guard-aibom-challenge-')
+    assert isinstance(context['nonce'], str) and context['nonce']
+    assert context['sequence'] == 1
+    assert context['expiresAt'] == '2026-06-10T12:15:00Z'
 
 
 def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -293,60 +293,67 @@ def test_sync_aibom_snapshots_if_due_retries_empty_sync_after_interval(
 
 def test_inventory_snapshot_event_includes_device_id() -> None:
     snapshot = GuardAgentInventorySnapshot(
-        snapshot_id='snapshot-aibom-1',
-        agent_id='codex:local',
-        agent_type='codex',
-        generated_at='2026-06-10T12:00:00+00:00',
-        runtime_version='test',
+        snapshot_id="snapshot-aibom-1",
+        agent_id="codex:local",
+        agent_type="codex",
+        generated_at="2026-06-10T12:00:00+00:00",
+        runtime_version="test",
     )
 
     event = aibom_cli._inventory_snapshot_event(
         snapshot=snapshot,
-        workspace_id='workspace-1',
-        device_id='device-1',
-        generated_at='2026-06-10T12:00:00+00:00',
+        workspace_id="workspace-1",
+        device_id="device-1",
+        generated_at="2026-06-10T12:00:00+00:00",
     )
 
-    assert event['deviceId'] == 'device-1'
+    assert event["deviceId"] == "device-1"
 
 
 def test_resolve_trust_attestation_context_defaults_to_v1(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
-    store = GuardStore(tmp_path / 'guard')
-    monkeypatch.setattr(store, 'get_cloud_workspace_id', lambda: 'workspace-1')
-    monkeypatch.setattr(store, 'get_or_create_installation_id', lambda: 'device-1')
-    monkeypatch.delenv('GUARD_AIBOM_TRUST_ATTESTATION_V2', raising=False)
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    monkeypatch.setattr(store, "get_or_create_installation_id", lambda: "device-1")
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", raising=False)
 
     context = aibom_cli._resolve_trust_attestation_context(
         store,
-        generated_at='2026-06-10T12:00:00+00:00',
+        generated_at="2026-06-10T12:00:00+00:00",
     )
 
-    assert context['workspaceId'] is None
-    assert context['deviceId'] is None
+    assert context["workspaceId"] is None
+    assert context["deviceId"] is None
 
 
 def test_resolve_trust_attestation_context_includes_workspace_device_for_v2(
     monkeypatch: pytest.MonkeyPatch,
     tmp_path: Path,
 ) -> None:
-    store = GuardStore(tmp_path / 'guard')
-    monkeypatch.setattr(store, 'get_cloud_workspace_id', lambda: 'workspace-1')
-    monkeypatch.setattr(store, 'get_or_create_installation_id', lambda: 'device-1')
-    monkeypatch.setenv('GUARD_AIBOM_TRUST_ATTESTATION_V2', '1')
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    monkeypatch.setattr(store, "get_or_create_installation_id", lambda: "device-1")
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "1")
 
     context = aibom_cli._resolve_trust_attestation_context(
         store,
-        generated_at='2026-06-10T12:00:00+00:00',
+        generated_at="2026-06-10T12:00:00+00:00",
     )
 
-    assert context['workspaceId'] == 'workspace-1'
-    assert context['deviceId'] == 'device-1'
-    assert context['installationId'] == 'device-1'
-    assert isinstance(context['uploadId'], str) and context['uploadId'].startswith('guard-aibom-upload-')
-    assert isinstance(context['challengeId'], str) and context['challengeId'].startswith('guard-aibom-challenge-')
-    assert isinstance(context['nonce'], str) and context['nonce']
-    assert context['sequence'] == 1
-    assert context['expiresAt'] == '2026-06-10T12:15:00Z'
+    assert context["workspaceId"] == "workspace-1"
+    assert context["deviceId"] == "device-1"
+    assert context["installationId"] == "device-1"
+    assert isinstance(context["uploadId"], str) and context["uploadId"].startswith("guard-aibom-upload-")
+    assert isinstance(context["challengeId"], str) and context["challengeId"].startswith("guard-aibom-challenge-")
+    assert isinstance(context["nonce"], str) and context["nonce"]
+    assert context["sequence"] == 1
+    assert context["expiresAt"] == "2026-06-10T12:15:00Z"
+
+    second_context = aibom_cli._resolve_trust_attestation_context(
+        store,
+        generated_at="2026-06-10T12:05:00+00:00",
+    )
+
+    assert second_context["sequence"] == 2
 
 
 def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(
@@ -410,9 +417,7 @@ def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(
     assert aibom_backoff.get("sync_reason") == "guard_events_endpoint_unavailable"
 
 
-def test_collect_aibom_snapshots_passes_cisco_runs(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_collect_aibom_snapshots_passes_cisco_runs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from codex_plugin_scanner.guard import aibom_cli
     from codex_plugin_scanner.guard.adapters.base import HarnessContext
 
@@ -492,9 +497,7 @@ def test_collect_aibom_snapshots_passes_cisco_runs(
     assert snapshot_kwargs["cisco_runs"] == cisco_runs
 
 
-def test_sync_aibom_snapshots_uses_cloud_sync_cisco_defaults(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_sync_aibom_snapshots_uses_cloud_sync_cisco_defaults(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from codex_plugin_scanner.guard import aibom_cli
     from codex_plugin_scanner.guard.adapters.base import HarnessContext
     from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots
@@ -539,7 +542,8 @@ def test_sync_aibom_snapshots_uses_cloud_sync_cisco_defaults(
 
 
 def test_guard_aibom_sync_command_uses_cloud_sync_cisco_defaults(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard")
     context = HarnessContext(

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -431,8 +431,14 @@ def test_inventory_snapshot_signs_local_trust_metadata_with_workspace_device_bin
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
         trust_attestation_context={
+            "challengeId": "guard-aibom-challenge-1",
             "deviceId": "device-alpha",
+            "expiresAt": "2026-06-10T12:15:00Z",
+            "installationId": "device-alpha",
+            "nonce": "nonce-alpha",
+            "sequence": 7,
             "signingConfig": signing_config,
+            "uploadId": "guard-aibom-upload-1",
             "workspaceId": "workspace-alpha",
         },
     )
@@ -445,15 +451,31 @@ def test_inventory_snapshot_signs_local_trust_metadata_with_workspace_device_bin
     assert isinstance(attestation, dict)
     assert attestation.get("signatureAlgorithm") == GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256
     assert attestation.get("publicJwkThumbprint") == dpop_key_material.public_jwk_thumbprint
+    assert metadata.get("attestationBindings") == {
+        "challengeId": "guard-aibom-challenge-1",
+        "deviceId": "device-alpha",
+        "expiresAt": "2026-06-10T12:15:00Z",
+        "installationId": "device-alpha",
+        "nonce": "nonce-alpha",
+        "sequence": 7,
+        "uploadId": "guard-aibom-upload-1",
+        "workspaceId": "workspace-alpha",
+    }
     verify_trust_attestation(
         payload=build_trust_attestation_payload(
             agent_id=snapshot.agent_id,
+            challenge_id="guard-aibom-challenge-1",
             item_id=plugin_item.item_id,
             item_kind=plugin_item.item_kind,
             content_hash=plugin_item.content_hash,
             captured_at=str(trust.get("capturedAt")),
+            expires_at="2026-06-10T12:15:00Z",
             evidence_hash=str(metadata.get("evidenceHash")),
+            installation_id="device-alpha",
+            nonce="nonce-alpha",
+            sequence=7,
             scope="trust_resolution",
+            upload_id="guard-aibom-upload-1",
             workspace_id="workspace-alpha",
             device_id="device-alpha",
         ),
@@ -473,12 +495,18 @@ def test_inventory_snapshot_signs_local_trust_metadata_with_workspace_device_bin
     verify_trust_attestation(
         payload=build_trust_attestation_payload(
             agent_id=snapshot.agent_id,
+            challenge_id="guard-aibom-challenge-1",
             item_id=plugin_item.item_id,
             item_kind=plugin_item.item_kind,
             content_hash=plugin_item.content_hash,
             captured_at=str(local_layer.get("capturedAt")),
+            expires_at="2026-06-10T12:15:00Z",
             evidence_hash=str(layer_metadata.get("evidenceHash")),
+            installation_id="device-alpha",
+            nonce="nonce-alpha",
+            sequence=7,
             scope="trust_layer",
+            upload_id="guard-aibom-upload-1",
             workspace_id="workspace-alpha",
             device_id="device-alpha",
             layer_id=str(local_layer.get("layerId")),


### PR DESCRIPTION
## Summary
- add workspace/device-bound freshness fields to Guard AIBOM trust attestations when v2 is enabled
- persist monotonic local attestation sequence state for device-bound trust uploads
- fail safe when malformed stored OAuth key material is present

## Testing
- `uv run pytest -q tests/test_guard_aibom_cli.py tests/test_guard_aibom_trust_metadata.py`
