### PR TITLE
fix(dashboard): align Strict config tab with mockup layout

### DIFF
--- a/dashboard/src/policy-strict-config-enforcement-preview.tsx
+++ b/dashboard/src/policy-strict-config-enforcement-preview.tsx
@@ -1,0 +1,63 @@
+import { Fragment } from "react";
+import { HiMiniArrowRight, HiMiniArrowTopRightOnSquare } from "react-icons/hi2";
+import { ActionButton, SectionLabel } from "./approval-center-primitives";
+import {
+  POLICY_PANEL_CARD_CLASS,
+  STRICT_CONFIG_EVALUATION_STEPS,
+} from "./policy-strict-config-surfaces";
+import { STRICT_POLICY_EVALUATION_ORDER } from "./policy-strict-config-utils";
+
+type PolicyEnforcementPreviewCardProps = {
+  cloudControlsUrl: string | null;
+};
+
+export function PolicyEnforcementPreviewCard({ cloudControlsUrl }: PolicyEnforcementPreviewCardProps) {
+  return (
+    <div className={`${POLICY_PANEL_CARD_CLASS} p-5`}>
+      <SectionLabel>Local enforcement preview</SectionLabel>
+      <p className="mt-2 text-sm leading-relaxed text-slate-600">
+        Evaluation order when Guard decides what to do next.
+      </p>
+
+      <div className="mt-5 -mx-1 overflow-x-auto px-1 pb-1">
+        <div className="flex min-w-[52rem] items-stretch">
+          {STRICT_CONFIG_EVALUATION_STEPS.map((step, index) => {
+            const Icon = step.icon;
+            const isLast = index === STRICT_CONFIG_EVALUATION_STEPS.length - 1;
+            return (
+              <Fragment key={step.label}>
+                <div className={`flex min-w-[9.75rem] flex-1 flex-col rounded-xl border p-3 ${step.surfaceClass}`}>
+                  <span className={`flex h-8 w-8 items-center justify-center rounded-lg bg-white/80 ${step.iconClass}`}>
+                    <Icon className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                  <p className="mt-2 text-sm font-semibold text-brand-dark">{step.label}</p>
+                  <p className="mt-1 text-xs leading-relaxed text-slate-600">{step.description}</p>
+                </div>
+                {!isLast ? (
+                  <div className="flex w-7 shrink-0 items-center justify-center" aria-hidden="true">
+                    <HiMiniArrowRight className="h-4 w-4 text-slate-300" />
+                  </div>
+                ) : null}
+              </Fragment>
+            );
+          })}
+        </div>
+      </div>
+
+      <div className="mt-5 flex flex-col gap-3 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
+        <p className="max-w-xl text-xs leading-relaxed text-slate-500">
+          Evaluation order: {STRICT_POLICY_EVALUATION_ORDER.join(" → ")}. Team-wide exceptions are managed in Guard
+          Cloud.
+        </p>
+        {cloudControlsUrl ? (
+          <div className="shrink-0">
+            <ActionButton href={cloudControlsUrl} variant="secondary">
+              Open Guard Cloud
+              <HiMiniArrowTopRightOnSquare className="ml-1.5 h-4 w-4" aria-hidden="true" />
+            </ActionButton>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/src/policy-strict-config-ia.test.ts
+++ b/dashboard/src/policy-strict-config-ia.test.ts
@@ -11,13 +11,19 @@ function assert(condition: boolean, message: string): void {
 const here = dirname(fileURLToPath(import.meta.url));
 const workspaceSource = readFileSync(join(here, "policy-workspace.tsx"), "utf8");
 const tabSource = readFileSync(join(here, "policy-strict-config-tab.tsx"), "utf8");
+const enforcementSource = readFileSync(join(here, "policy-strict-config-enforcement-preview.tsx"), "utf8");
+const rightRailSource = readFileSync(join(here, "policy-strict-config-right-rail.tsx"), "utf8");
 
 assert(workspaceSource.includes("PolicyStrictConfigTab"), "policy workspace mounts strict config tab");
 assert(!workspaceSource.includes("StrictModeView"), "legacy strict mode view removed");
 assert(tabSource.includes("fetchSettings"), "strict config tab loads settings");
-assert(tabSource.includes("Evaluation order"), "strict config tab shows evaluation order");
-assert(tabSource.includes("Policy simulator"), "strict config tab includes simulator");
-assert(tabSource.includes("Local enforcement preview"), "strict config tab shows enforcement preview");
-assert(tabSource.includes("Run simulation"), "strict config tab exposes run simulation");
+assert(enforcementSource.includes("Evaluation order"), "strict config shows evaluation order");
+assert(rightRailSource.includes("Policy simulator outcome"), "strict config includes simulator");
+assert(enforcementSource.includes("Local enforcement preview"), "strict config shows enforcement preview");
+assert(rightRailSource.includes("Run simulation"), "strict config exposes run simulation");
+assert(tabSource.includes("PolicyStrictModeCard"), "strict config tab uses extracted cards");
+assert(enforcementSource.includes("min-w-[52rem]"), "strict config uses horizontal enforcement flow");
+assert(rightRailSource.includes("Learn more"), "strict config links to cloud docs");
+assert(workspaceSource.includes("cloudControlsUrl={resolveCloudPolicyControlsUrl(snapshot)}"), "strict config receives cloud controls url");
 
 console.log("policy-strict-config-ia.test.ts: all assertions passed");

--- a/dashboard/src/policy-strict-config-local-policy-card.tsx
+++ b/dashboard/src/policy-strict-config-local-policy-card.tsx
@@ -1,0 +1,121 @@
+import type { ReactNode } from "react";
+import {
+  HiMiniArrowPath,
+  HiMiniBolt,
+  HiMiniCodeBracket,
+  HiMiniCommandLine,
+  HiMiniDocumentText,
+  HiMiniGlobeAlt,
+  HiMiniInformationCircle,
+} from "react-icons/hi2";
+import { SectionLabel } from "./approval-center-primitives";
+import type { GuardSettings } from "./guard-types";
+import {
+  StrictConfigActionSegmented,
+  type StrictConfigSettingKey,
+} from "./policy-strict-config-segmented";
+import { POLICY_PANEL_CARD_CLASS } from "./policy-strict-config-surfaces";
+import { resolveStrictFileWriteAction } from "./policy-strict-config-utils";
+
+function PolicyInfoBanner({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex items-start gap-2 rounded-xl border border-slate-200/80 bg-slate-50 px-3 py-2.5 text-xs leading-relaxed text-slate-600">
+      <HiMiniInformationCircle className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
+      <span>{children}</span>
+    </div>
+  );
+}
+
+type PolicyLocalStrictPolicyCardProps = {
+  settings: GuardSettings;
+  controlsDisabled: boolean;
+  saveError: string | null;
+  savingKey: string | null;
+  onResetDefaults: () => void;
+  onSettingChange: (key: StrictConfigSettingKey, value: string) => void;
+};
+
+export function PolicyLocalStrictPolicyCard({
+  settings,
+  controlsDisabled,
+  saveError,
+  savingKey,
+  onResetDefaults,
+  onSettingChange,
+}: PolicyLocalStrictPolicyCardProps) {
+  const fileWriteAction = resolveStrictFileWriteAction(settings);
+
+  return (
+    <div className={`${POLICY_PANEL_CARD_CLASS} p-5`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
+        <div className="min-w-0">
+          <SectionLabel>Local strict policy</SectionLabel>
+          <p className="mt-2 text-sm leading-relaxed text-slate-600">
+            Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onResetDefaults}
+          disabled={controlsDisabled}
+          className="inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-brand-blue hover:underline disabled:opacity-50"
+        >
+          <HiMiniArrowPath className="h-4 w-4" aria-hidden="true" />
+          Reset to defaults
+        </button>
+      </div>
+      <div className="mt-4 divide-y divide-slate-100">
+        <StrictConfigActionSegmented
+          label="Default action"
+          help="For any action not explicitly allowed."
+          icon={HiMiniBolt}
+          value={settings.default_action}
+          settingKey="default_action"
+          onSettingChange={onSettingChange}
+          disabled={controlsDisabled}
+        />
+        <StrictConfigActionSegmented
+          label="Changed tool hash action"
+          help="When a tool or script hash is new."
+          icon={HiMiniCodeBracket}
+          value={settings.changed_hash_action}
+          settingKey="changed_hash_action"
+          onSettingChange={onSettingChange}
+          disabled={controlsDisabled}
+        />
+        <StrictConfigActionSegmented
+          label="New network domain action"
+          help="When a process tries to contact a new domain."
+          icon={HiMiniGlobeAlt}
+          value={settings.new_network_domain_action}
+          settingKey="new_network_domain_action"
+          onSettingChange={onSettingChange}
+          disabled={controlsDisabled}
+        />
+        <StrictConfigActionSegmented
+          label="Subprocess action"
+          help="When a process tries to launch another program."
+          icon={HiMiniCommandLine}
+          value={settings.subprocess_action}
+          settingKey="subprocess_action"
+          onSettingChange={onSettingChange}
+          disabled={controlsDisabled}
+        />
+        <StrictConfigActionSegmented
+          label="File write action"
+          help="When a process writes to disk."
+          icon={HiMiniDocumentText}
+          value={fileWriteAction}
+          settingKey="destructive_shell"
+          onSettingChange={onSettingChange}
+          disabled={controlsDisabled}
+        />
+      </div>
+      <div className="mt-4">
+        <PolicyInfoBanner>These settings apply only when no local or Cloud rules cover the action.</PolicyInfoBanner>
+      </div>
+      {saveError ? <p className="mt-3 text-sm text-red-600">{saveError}</p> : null}
+      {savingKey ? <p className="mt-3 text-sm text-slate-500">Saving {savingKey.replace(/_/g, " ")}…</p> : null}
+    </div>
+  );
+}

--- a/dashboard/src/policy-strict-config-right-rail.tsx
+++ b/dashboard/src/policy-strict-config-right-rail.tsx
@@ -1,0 +1,159 @@
+import type { ChangeEvent } from "react";
+import {
+  HiMiniArrowRight,
+  HiMiniBeaker,
+  HiMiniCheckCircle,
+  HiMiniPlay,
+} from "react-icons/hi2";
+import { ActionButton, Badge, SectionLabel } from "./approval-center-primitives";
+import { policyActionLabel } from "./approval-center-utils";
+import { POLICY_PANEL_CARD_CLASS, STRICT_CONFIG_WHAT_CHANGES } from "./policy-strict-config-surfaces";
+import type { StrictPolicySimulationResult, StrictScenarioId } from "./policy-strict-config-utils";
+
+const TEST_SCENARIOS: Array<{
+  id: StrictScenarioId;
+  label: string;
+}> = [
+  { id: "first-time", label: "New tool contacting unknown domain" },
+  { id: "remembered-allow", label: "Remembered allow wins" },
+  { id: "cloud-exception", label: "Active Cloud exception" },
+];
+
+function resolveExpectedActionTone(action: string): "success" | "destructive" | "warning" | "default" {
+  if (action === "block") {
+    return "destructive";
+  }
+  if (action === "allow") {
+    return "success";
+  }
+  if (action === "warn" || action === "review" || action === "require-reapproval") {
+    return "warning";
+  }
+  return "default";
+}
+
+type PolicyStrictConfigRightRailProps = {
+  pendingInboxCount: number;
+  cloudControlsUrl: string | null;
+  scenarioId: StrictScenarioId;
+  expectedAction: string;
+  expectedReasoning: string;
+  simulationVisible: boolean;
+  simulation: StrictPolicySimulationResult | null;
+  onOpenInbox?: () => void;
+  onScenarioChange: (event: ChangeEvent<HTMLSelectElement>) => void;
+  onRunSimulation: () => void;
+};
+
+export function PolicyStrictConfigRightRail({
+  pendingInboxCount,
+  cloudControlsUrl,
+  scenarioId,
+  expectedAction,
+  expectedReasoning,
+  simulationVisible,
+  simulation,
+  onOpenInbox,
+  onScenarioChange,
+  onRunSimulation,
+}: PolicyStrictConfigRightRailProps) {
+  return (
+    <aside className="min-w-0 space-y-4 xl:sticky xl:top-6 xl:self-start">
+      <div className={`${POLICY_PANEL_CARD_CLASS} p-4`}>
+        <SectionLabel>What this changes</SectionLabel>
+        <ul className="mt-3 space-y-2.5 text-sm leading-relaxed text-slate-600">
+          {STRICT_CONFIG_WHAT_CHANGES.map((item) => (
+            <li key={item} className="flex gap-2">
+              <HiMiniCheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
+              <span>{item}</span>
+            </li>
+          ))}
+        </ul>
+      </div>
+
+      <div className={`${POLICY_PANEL_CARD_CLASS} p-4`}>
+        <SectionLabel>Affected pending Inbox items</SectionLabel>
+        <p className="mt-2 text-4xl font-semibold tabular-nums text-brand-blue">
+          {pendingInboxCount}
+          <span className="ml-1.5 text-lg font-medium text-brand-blue/75">items</span>
+        </p>
+        <p className="mt-1 text-sm leading-relaxed text-slate-600">
+          Pending review items may be affected by stricter fallback controls.
+        </p>
+        {onOpenInbox && pendingInboxCount > 0 ? (
+          <div className="mt-3">
+            <ActionButton variant="secondary" onClick={onOpenInbox}>
+              Open Inbox
+              <HiMiniArrowRight className="ml-1.5 h-4 w-4" aria-hidden="true" />
+            </ActionButton>
+          </div>
+        ) : null}
+      </div>
+
+      <div className={`${POLICY_PANEL_CARD_CLASS} p-4 text-sm leading-relaxed text-slate-600`}>
+        <p className="font-medium text-brand-dark">Cloud exceptions still apply</p>
+        <p className="mt-2">
+          Signed Cloud exceptions still require bundle acknowledgement before they apply locally.
+        </p>
+        {cloudControlsUrl ? (
+          <a
+            href={cloudControlsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 inline-flex items-center gap-1 text-sm font-medium text-brand-blue hover:underline"
+          >
+            Learn more
+            <HiMiniArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
+          </a>
+        ) : null}
+      </div>
+
+      <div className={`${POLICY_PANEL_CARD_CLASS} border-brand-blue/15 bg-brand-blue/[0.03] p-4`}>
+        <div className="flex items-start gap-2">
+          <HiMiniBeaker className="mt-0.5 h-5 w-5 shrink-0 text-brand-blue" aria-hidden="true" />
+          <div className="min-w-0 flex-1">
+            <SectionLabel>Test policy</SectionLabel>
+            <p className="mt-2 text-sm leading-relaxed text-slate-600">Simulate how Guard will respond.</p>
+          </div>
+        </div>
+        <label className="mt-4 block space-y-1.5">
+          <span className="text-sm font-medium text-brand-dark">Scenario</span>
+          <select
+            value={scenarioId}
+            onChange={onScenarioChange}
+            className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark"
+          >
+            {TEST_SCENARIOS.map((scenario) => (
+              <option key={scenario.id} value={scenario.id}>
+                {scenario.label}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="mt-4 space-y-2">
+          <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Expected action</p>
+          <Badge tone={resolveExpectedActionTone(expectedAction)}>{policyActionLabel(expectedAction)}</Badge>
+          {expectedReasoning ? <p className="text-sm leading-relaxed text-slate-600">{expectedReasoning}</p> : null}
+        </div>
+        <div className="mt-4">
+          <ActionButton variant="secondary" onClick={onRunSimulation}>
+            <HiMiniPlay className="mr-1.5 h-4 w-4" aria-hidden="true" />
+            Run simulation
+          </ActionButton>
+        </div>
+        {simulationVisible && simulation ? (
+          <div className="mt-4 rounded-xl border border-slate-100 bg-white p-4">
+            <p className="text-sm font-medium text-brand-dark">
+              Policy simulator outcome: {policyActionLabel(simulation.outcome)} ({simulation.winningStep})
+            </p>
+            <ul className="mt-2 space-y-1 text-xs text-slate-600">
+              {simulation.path.map((step) => (
+                <li key={step}>{step}</li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+    </aside>
+  );
+}

--- a/dashboard/src/policy-strict-config-segmented.tsx
+++ b/dashboard/src/policy-strict-config-segmented.tsx
@@ -40,8 +40,8 @@ export function StrictConfigActionSegmented({
   const showAdvanced = !PRIMARY_STRICT_ACTION_VALUES.has(value);
 
   return (
-    <div className="flex flex-col gap-4 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between">
-      <div className="flex min-w-0 items-start gap-3 sm:max-w-[45%]">
+    <div className="grid gap-4 py-5 first:pt-0 last:pb-0 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center lg:gap-6">
+      <div className="flex min-w-0 items-start gap-3">
         {Icon ? (
           <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500">
             <Icon className="h-4 w-4" aria-hidden="true" />
@@ -52,9 +52,9 @@ export function StrictConfigActionSegmented({
           {help ? <p className="mt-0.5 text-xs leading-relaxed text-slate-500">{help}</p> : null}
         </div>
       </div>
-      <div className="sm:shrink-0">
+      <div className="min-w-0 lg:justify-self-end">
         <div
-          className="inline-flex flex-wrap gap-1 rounded-xl border border-slate-200 bg-slate-50/80 p-1"
+          className="inline-flex max-w-full flex-wrap gap-1 rounded-xl border border-slate-200 bg-slate-100/80 p-1"
           role="group"
           aria-label={label}
         >

--- a/dashboard/src/policy-strict-config-strict-mode-card.tsx
+++ b/dashboard/src/policy-strict-config-strict-mode-card.tsx
@@ -1,0 +1,142 @@
+import {
+  HiMiniArrowPath,
+  HiMiniCheckCircle,
+  HiMiniClipboardDocument,
+  HiMiniShieldCheck,
+} from "react-icons/hi2";
+import { ActionButton } from "./approval-center-primitives";
+import { formatRelativeTime } from "./approval-center-utils";
+import { POLICY_PANEL_CARD_CLASS } from "./policy-strict-config-surfaces";
+import { formatPolicyDateTime } from "./policy-workspace-helpers";
+
+type PolicyStrictModeCardProps = {
+  isStrict: boolean;
+  controlsDisabled: boolean;
+  localPolicyHash: string | null;
+  daemonAckSynced: boolean;
+  daemonAckLabel: string;
+  lastAckAt: string | null;
+  lastReloadFormatted: string | null;
+  lastReloadAt: string | null;
+  reloadingPolicy: boolean;
+  onStrictToggle: () => void;
+  onCopyHash: () => void;
+  onOpenSettings?: () => void;
+  onReloadPolicy?: () => void;
+};
+
+export function PolicyStrictModeCard({
+  isStrict,
+  controlsDisabled,
+  localPolicyHash,
+  daemonAckSynced,
+  daemonAckLabel,
+  lastAckAt,
+  lastReloadFormatted,
+  lastReloadAt,
+  reloadingPolicy,
+  onStrictToggle,
+  onCopyHash,
+  onOpenSettings,
+  onReloadPolicy,
+}: PolicyStrictModeCardProps) {
+  return (
+    <div className={`${POLICY_PANEL_CARD_CLASS} p-5`}>
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div className="flex min-w-0 items-start gap-3">
+          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue">
+            <HiMiniShieldCheck className="h-5 w-5" aria-hidden="true" />
+          </span>
+          <div className="min-w-0">
+            <h3 className="text-base font-semibold text-brand-dark">Strict mode</h3>
+            <p className="mt-1 text-sm leading-relaxed text-slate-600">
+              Local enforcement tuning when no remembered rule, Cloud policy, or Cloud exception matches.
+            </p>
+          </div>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          <span className="text-xs font-medium text-slate-500">{isStrict ? "Enabled" : "Disabled"}</span>
+          <button
+            type="button"
+            role="switch"
+            aria-checked={isStrict}
+            aria-label="Toggle strict mode"
+            disabled={controlsDisabled}
+            onClick={onStrictToggle}
+            className={`relative h-7 w-12 shrink-0 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/60 ${
+              isStrict ? "bg-brand-blue" : "bg-slate-200"
+            } ${controlsDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
+          >
+            <span
+              className={`absolute top-0.5 left-0.5 h-6 w-6 rounded-full bg-white shadow-sm transition-transform ${
+                isStrict ? "translate-x-5" : "translate-x-0"
+              }`}
+            />
+          </button>
+        </div>
+      </div>
+
+      <dl className="mt-5 grid gap-4 border-t border-slate-100 pt-4 sm:grid-cols-2 xl:grid-cols-4">
+        <div>
+          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Strict mode</dt>
+          <dd className="mt-1.5 text-sm font-medium text-brand-dark">{isStrict ? "Enabled" : "Disabled"}</dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Policy hash</dt>
+          <dd className="mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-sm text-brand-dark">
+            <span className="truncate" title={localPolicyHash ?? undefined}>
+              {localPolicyHash}
+            </span>
+            <button
+              type="button"
+              onClick={onCopyHash}
+              className="shrink-0 rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark"
+              aria-label="Copy policy hash"
+            >
+              <HiMiniClipboardDocument className="h-4 w-4" aria-hidden="true" />
+            </button>
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Daemon ack</dt>
+          <dd className="mt-1.5 flex items-center gap-1.5 text-sm text-brand-dark">
+            {daemonAckSynced ? (
+              <HiMiniCheckCircle className="h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
+            ) : null}
+            <span>
+              {daemonAckLabel}
+              {lastAckAt ? ` · ${formatRelativeTime(lastAckAt)}` : ""}
+            </span>
+          </dd>
+        </div>
+        <div>
+          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last reload</dt>
+          <dd className="mt-1.5 text-sm text-brand-dark">
+            {lastReloadFormatted ?? (lastReloadAt ? formatRelativeTime(lastReloadAt) : "Unavailable")}
+          </dd>
+          <p className="mt-1 flex items-center gap-1 text-xs text-emerald-700">
+            <HiMiniCheckCircle className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+            Auto-reload on
+          </p>
+        </div>
+      </dl>
+
+      {!isStrict && onOpenSettings ? (
+        <div className="mt-4 border-t border-slate-100 pt-4">
+          <ActionButton variant="secondary" onClick={onOpenSettings}>
+            Enable in Settings
+          </ActionButton>
+        </div>
+      ) : null}
+
+      {onReloadPolicy ? (
+        <div className="mt-4 flex justify-end border-t border-slate-100 pt-4">
+          <ActionButton variant="secondary" onClick={onReloadPolicy} disabled={reloadingPolicy}>
+            <HiMiniArrowPath className={`mr-1.5 h-4 w-4 ${reloadingPolicy ? "animate-spin" : ""}`} aria-hidden="true" />
+            Reload policy
+          </ActionButton>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/dashboard/src/policy-strict-config-surfaces.ts
+++ b/dashboard/src/policy-strict-config-surfaces.ts
@@ -1,0 +1,61 @@
+import type { ComponentType } from "react";
+import {
+  HiMiniCloud,
+  HiMiniNoSymbol,
+  HiMiniQueueList,
+  HiMiniShieldCheck,
+} from "react-icons/hi2";
+
+export const POLICY_PANEL_CARD_CLASS =
+  "rounded-2xl border border-slate-200/80 bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04),0_10px_28px_rgba(15,23,42,0.05)]";
+
+export const STRICT_CONFIG_EVALUATION_STEPS: Array<{
+  label: string;
+  description: string;
+  icon: ComponentType<{ className?: string }>;
+  surfaceClass: string;
+  iconClass: string;
+}> = [
+  {
+    label: "Local rule",
+    description: "If a remembered local rule matches, apply it.",
+    icon: HiMiniQueueList,
+    surfaceClass: "border-violet-200 bg-violet-50",
+    iconClass: "text-violet-600",
+  },
+  {
+    label: "Cloud policy",
+    description: "Then apply the signed Cloud policy bundle.",
+    icon: HiMiniCloud,
+    surfaceClass: "border-sky-200 bg-sky-50",
+    iconClass: "text-sky-600",
+  },
+  {
+    label: "Cloud exception",
+    description: "Matching Cloud exception allows the action.",
+    icon: HiMiniCloud,
+    surfaceClass: "border-cyan-200 bg-cyan-50",
+    iconClass: "text-cyan-700",
+  },
+  {
+    label: "Strict fallback",
+    description: "If nothing allows it, this strict config is used.",
+    icon: HiMiniShieldCheck,
+    surfaceClass: "border-amber-200 bg-amber-50",
+    iconClass: "text-amber-700",
+  },
+  {
+    label: "Ask or block",
+    description: "Guard asks (or blocks) according to your choice.",
+    icon: HiMiniNoSymbol,
+    surfaceClass: "border-rose-200 bg-rose-50",
+    iconClass: "text-rose-600",
+  },
+];
+
+export const STRICT_CONFIG_WHAT_CHANGES = [
+  "First-time actions follow your default strict action.",
+  "Changed tool hashes trigger your configured review path.",
+  "New network domains and subprocesses use strict fallback rules.",
+  "Cloud exceptions and remembered rules still win when they match.",
+] as const;

--- a/dashboard/src/policy-strict-config-tab.tsx
+++ b/dashboard/src/policy-strict-config-tab.tsx
@@ -1,45 +1,29 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import type { ChangeEvent } from "react";
-import {
-  HiMiniArrowPath,
-  HiMiniArrowRight,
-  HiMiniBeaker,
-  HiMiniBolt,
-  HiMiniCheckCircle,
-  HiMiniClipboardDocument,
-  HiMiniCloud,
-  HiMiniCodeBracket,
-  HiMiniDocumentText,
-  HiMiniGlobeAlt,
-  HiMiniNoSymbol,
-  HiMiniPlay,
-  HiMiniQueueList,
-  HiMiniShieldCheck,
-  HiMiniCommandLine,
-} from "react-icons/hi2";
-import { ActionButton, Badge, EmptyState, SectionLabel } from "./approval-center-primitives";
-import { formatRelativeTime, policyActionLabel } from "./approval-center-utils";
+import { EmptyState } from "./approval-center-primitives";
 import { fetchSettings, updateSettings } from "./guard-api";
 import type { GuardRuntimeSnapshot, GuardSettings } from "./guard-types";
-import {
-  fingerprintLocalPolicySettings,
-  resolveStrictFileWriteAction,
-  resolveStrictScenarioOutcome,
-  simulateStrictPolicyOutcome,
-  STRICT_POLICY_DEFAULTS,
-  STRICT_POLICY_EVALUATION_ORDER,
-  type StrictScenarioId,
-} from "./policy-strict-config-utils";
+import { PolicyEnforcementPreviewCard } from "./policy-strict-config-enforcement-preview";
+import { PolicyLocalStrictPolicyCard } from "./policy-strict-config-local-policy-card";
+import { PolicyStrictConfigRightRail } from "./policy-strict-config-right-rail";
 import {
   applyStrictConfigPatch,
   resolveStrictConfigPatch,
-  StrictConfigActionSegmented,
   type StrictConfigSettingKey,
 } from "./policy-strict-config-segmented";
+import { PolicyStrictModeCard } from "./policy-strict-config-strict-mode-card";
+import {
+  fingerprintLocalPolicySettings,
+  resolveStrictScenarioOutcome,
+  simulateStrictPolicyOutcome,
+  STRICT_POLICY_DEFAULTS,
+  type StrictScenarioId,
+} from "./policy-strict-config-utils";
 import { formatPolicyDateTime, resolveCloudPolicyBundleCopy } from "./policy-workspace-helpers";
 
 type PolicyStrictConfigTabProps = {
   snapshot: GuardRuntimeSnapshot;
+  cloudControlsUrl?: string | null;
   onOpenSettings?: () => void;
   onOpenInbox?: () => void;
   onReloadPolicy?: () => void;
@@ -48,91 +32,18 @@ type PolicyStrictConfigTabProps = {
 
 type LoadState = "loading" | "ready" | "error";
 
-const EVALUATION_STEPS = [
-  {
-    label: "Local rule",
-    description: "Remembered decisions on this device.",
-    icon: HiMiniQueueList,
-    surfaceClass: "bg-violet-50 text-violet-700 border-violet-200",
-  },
-  {
-    label: "Cloud policy",
-    description: "Team rules from Guard Cloud.",
-    icon: HiMiniCloud,
-    surfaceClass: "bg-sky-50 text-sky-700 border-sky-200",
-  },
-  {
-    label: "Cloud exception",
-    description: "Signed risk acceptances.",
-    icon: HiMiniCloud,
-    surfaceClass: "bg-sky-50 text-sky-700 border-sky-200",
-  },
-  {
-    label: "Strict fallback",
-    description: "Local strict policy settings.",
-    icon: HiMiniShieldCheck,
-    surfaceClass: "bg-amber-50 text-amber-800 border-amber-200",
-  },
-  {
-    label: "Ask or block",
-    description: "Final prompt or block.",
-    icon: HiMiniNoSymbol,
-    surfaceClass: "bg-rose-50 text-rose-700 border-rose-200",
-  },
-] as const;
-
-const WHAT_CHANGES_BULLETS = [
-  "First-time actions follow your default strict action.",
-  "Changed tool hashes trigger your configured review path.",
-  "New network domains and subprocesses use strict fallback rules.",
-  "Cloud exceptions and remembered rules still win when they match.",
-] as const;
-
-const TEST_SCENARIOS: Array<{
-  id: StrictScenarioId;
-  label: string;
-  remembered: "allow" | "block" | "none";
-  cloudPolicy: "allow" | "block" | "none";
-  cloudException: boolean;
-}> = [
-  {
-    id: "first-time",
-    label: "New tool contacting unknown domain",
-    remembered: "none",
-    cloudPolicy: "none",
-    cloudException: false,
-  },
-  {
-    id: "remembered-allow",
-    label: "Remembered allow wins",
-    remembered: "allow",
-    cloudPolicy: "block",
-    cloudException: false,
-  },
-  {
-    id: "cloud-exception",
-    label: "Active Cloud exception",
-    remembered: "block",
-    cloudPolicy: "block",
-    cloudException: true,
-  },
-];
-
-function resolveExpectedActionTone(action: string): "success" | "destructive" | "warning" | "default" {
-  if (action === "block") {
-    return "destructive";
-  }
-  if (action === "allow") {
-    return "success";
-  }
-  if (action === "warn" || action === "review" || action === "require-reapproval") {
-    return "warning";
-  }
-  return "default";
-}
+const SCENARIO_FIXTURES: Record<
+  StrictScenarioId,
+  { remembered: "allow" | "block" | "none"; cloudPolicy: "allow" | "block" | "none"; cloudException: boolean }
+> = {
+  "first-time": { remembered: "none", cloudPolicy: "none", cloudException: false },
+  "remembered-allow": { remembered: "allow", cloudPolicy: "block", cloudException: false },
+  "cloud-exception": { remembered: "block", cloudPolicy: "block", cloudException: true },
+};
 
 export function PolicyStrictConfigTab({
   snapshot,
+  cloudControlsUrl = null,
   onOpenSettings,
   onOpenInbox,
   onReloadPolicy,
@@ -292,10 +203,7 @@ export function PolicyStrictConfigTab({
     const nextId = event.target.value as StrictScenarioId;
     setScenarioId(nextId);
     setSimulationVisible(false);
-    const scenario = TEST_SCENARIOS.find((item) => item.id === nextId);
-    if (!scenario) {
-      return;
-    }
+    const scenario = SCENARIO_FIXTURES[nextId];
     setSimRemembered(scenario.remembered);
     setSimCloudPolicy(scenario.cloudPolicy);
     setSimCloudException(scenario.cloudException);
@@ -320,299 +228,56 @@ export function PolicyStrictConfigTab({
     );
   }
 
-  const fileWriteAction = resolveStrictFileWriteAction(settings);
   const controlsDisabled = savingKey !== null;
   const lastReloadAt = snapshot.runtime_state?.started_at ?? snapshot.generated_at ?? null;
   const lastReloadFormatted = formatPolicyDateTime(lastReloadAt);
   const lastAckAt = snapshot.cloud_policy_last_ack_at?.trim() ?? null;
-  const daemonAckLabel = cloudBundleCopy?.tone === "green" ? "Acknowledged" : cloudBundleCopy?.label ?? "Pending";
-  const expectedAction = scenarioOutcome?.outcome ?? settings?.new_network_domain_action ?? "review";
+  const daemonAckSynced = cloudBundleCopy?.tone === "green";
+  const daemonAckLabel = daemonAckSynced ? "Acknowledged" : cloudBundleCopy?.label ?? "Needs attention";
+  const expectedAction = scenarioOutcome?.outcome ?? settings.new_network_domain_action ?? "review";
   const expectedReasoning = scenarioOutcome?.reasoning ?? "";
 
   return (
-    <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start">
-      <div className="space-y-4">
-        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div className="flex items-start gap-3">
-              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue">
-                <HiMiniShieldCheck className="h-5 w-5" aria-hidden="true" />
-              </span>
-              <div>
-                <h3 className="text-base font-semibold text-brand-dark">Strict mode</h3>
-                <p className="mt-1 text-sm text-slate-600">Local enforcement tuning when no other rule matches.</p>
-              </div>
-            </div>
-            <div className="flex items-center gap-2">
-              <span className="text-xs font-medium text-slate-500">{isStrict ? "Enabled" : "Disabled"}</span>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={isStrict}
-                aria-label="Toggle strict mode"
-                disabled={controlsDisabled}
-                onClick={handleStrictToggle}
-                className={`relative h-7 w-12 shrink-0 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/60 ${
-                  isStrict ? "bg-brand-blue" : "bg-slate-200"
-                } ${controlsDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`}
-              >
-                <span
-                  className={`absolute top-0.5 left-0.5 h-6 w-6 rounded-full bg-white shadow-sm transition-transform ${
-                    isStrict ? "translate-x-5" : "translate-x-0"
-                  }`}
-                />
-              </button>
-            </div>
-          </div>
-
-          <dl className="mt-5 grid gap-4 border-t border-slate-100 pt-4 sm:grid-cols-2 lg:grid-cols-4">
-            <div>
-              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Strict mode</dt>
-              <dd className="mt-1.5 text-sm font-medium text-brand-dark">{isStrict ? "Enabled" : "Disabled"}</dd>
-            </div>
-            <div>
-              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Policy hash</dt>
-              <dd className="mt-1.5 flex items-center gap-1.5 font-mono text-sm text-brand-dark">
-                {localPolicyHash}
-                <button
-                  type="button"
-                  onClick={handleCopyHash}
-                  className="rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark"
-                  aria-label="Copy policy hash"
-                >
-                  <HiMiniClipboardDocument className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </dd>
-            </div>
-            <div>
-              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Daemon ack</dt>
-              <dd className="mt-1.5 flex items-center gap-1.5 text-sm text-brand-dark">
-                {cloudBundleCopy?.tone === "green" ? (
-                  <HiMiniCheckCircle className="h-4 w-4 text-emerald-600" aria-hidden="true" />
-                ) : null}
-                <span>
-                  {daemonAckLabel}
-                  {lastAckAt ? ` · ${formatRelativeTime(lastAckAt)}` : ""}
-                </span>
-              </dd>
-            </div>
-            <div>
-              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last reload</dt>
-              <dd className="mt-1.5 text-sm text-brand-dark">
-                {lastReloadFormatted ?? (lastReloadAt ? formatRelativeTime(lastReloadAt) : "Unavailable")}
-              </dd>
-              <p className="mt-1 text-xs text-emerald-700">Auto-reload on</p>
-            </div>
-          </dl>
-
-          {!isStrict && onOpenSettings ? (
-            <div className="mt-4 border-t border-slate-100 pt-4">
-              <ActionButton variant="secondary" onClick={onOpenSettings}>
-                Enable in Settings
-              </ActionButton>
-            </div>
-          ) : null}
-
-          {onReloadPolicy ? (
-            <div className="mt-4 flex justify-end border-t border-slate-100 pt-4">
-              <ActionButton variant="secondary" onClick={onReloadPolicy} disabled={reloadingPolicy}>
-                <HiMiniArrowPath className={`mr-1.5 h-4 w-4 ${reloadingPolicy ? "animate-spin" : ""}`} aria-hidden="true" />
-                Reload policy
-              </ActionButton>
-            </div>
-          ) : null}
-        </div>
-
-        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <div className="flex flex-wrap items-start justify-between gap-3">
-            <div>
-              <SectionLabel>Local strict policy</SectionLabel>
-              <p className="mt-2 text-sm text-slate-600">
-                Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches.
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={handleResetDefaults}
-              disabled={controlsDisabled}
-              className="text-sm font-medium text-brand-blue hover:underline disabled:opacity-50"
-            >
-              Reset to defaults
-            </button>
-          </div>
-          <div className="mt-5 divide-y divide-slate-100">
-            <StrictConfigActionSegmented
-              label="Default action"
-              help="For any action not explicitly allowed."
-              icon={HiMiniBolt}
-              value={settings.default_action}
-              settingKey="default_action"
-              onSettingChange={handleStrictConfigChange}
-              disabled={controlsDisabled}
-            />
-            <StrictConfigActionSegmented
-              label="Changed tool hash action"
-              help="When a tool or script hash is new."
-              icon={HiMiniCodeBracket}
-              value={settings.changed_hash_action}
-              settingKey="changed_hash_action"
-              onSettingChange={handleStrictConfigChange}
-              disabled={controlsDisabled}
-            />
-            <StrictConfigActionSegmented
-              label="New network domain action"
-              help="When a process tries to contact a new domain."
-              icon={HiMiniGlobeAlt}
-              value={settings.new_network_domain_action}
-              settingKey="new_network_domain_action"
-              onSettingChange={handleStrictConfigChange}
-              disabled={controlsDisabled}
-            />
-            <StrictConfigActionSegmented
-              label="Subprocess action"
-              help="When a process tries to launch another program."
-              icon={HiMiniCommandLine}
-              value={settings.subprocess_action}
-              settingKey="subprocess_action"
-              onSettingChange={handleStrictConfigChange}
-              disabled={controlsDisabled}
-            />
-            <StrictConfigActionSegmented
-              label="File write action"
-              help="When a process writes to disk."
-              icon={HiMiniDocumentText}
-              value={fileWriteAction}
-              settingKey="destructive_shell"
-              onSettingChange={handleStrictConfigChange}
-              disabled={controlsDisabled}
-            />
-          </div>
-          <p className="mt-4 flex items-start gap-2 text-xs text-slate-500">
-            <HiMiniShieldCheck className="mt-0.5 h-4 w-4 shrink-0 text-slate-400" aria-hidden="true" />
-            These settings apply only when no local or Cloud rules cover the action.
-          </p>
-          {saveError ? <p className="mt-3 text-sm text-red-600">{saveError}</p> : null}
-          {savingKey ? <p className="mt-3 text-sm text-slate-500">Saving {savingKey.replace(/_/g, " ")}…</p> : null}
-        </div>
-
-        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <SectionLabel>Local enforcement preview</SectionLabel>
-          <p className="mt-2 text-sm text-slate-600">Evaluation order when Guard decides what to do next.</p>
-          <div className="mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
-            {EVALUATION_STEPS.map((step, index) => {
-              const Icon = step.icon;
-              return (
-                <div key={step.label} className="relative">
-                  <div className={`rounded-xl border p-3 ${step.surfaceClass}`}>
-                    <span className="flex h-8 w-8 items-center justify-center rounded-lg bg-white/70">
-                      <Icon className="h-4 w-4" aria-hidden="true" />
-                    </span>
-                    <p className="mt-2 text-sm font-semibold text-brand-dark">{step.label}</p>
-                    <p className="mt-1 text-xs leading-relaxed text-slate-600">{step.description}</p>
-                  </div>
-                  {index < EVALUATION_STEPS.length - 1 ? (
-                    <HiMiniArrowRight
-                      className="absolute top-1/2 -right-3 hidden h-4 w-4 -translate-y-1/2 text-slate-300 xl:block"
-                      aria-hidden="true"
-                    />
-                  ) : null}
-                </div>
-              );
-            })}
-          </div>
-          <p className="mt-4 text-xs text-slate-500">
-            Evaluation order: {STRICT_POLICY_EVALUATION_ORDER.join(" → ")}. Team-wide exceptions are managed in Guard
-            Cloud.
-          </p>
-        </div>
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(17rem,20rem)] xl:items-start">
+      <div className="min-w-0 space-y-4">
+        <PolicyStrictModeCard
+          isStrict={isStrict}
+          controlsDisabled={controlsDisabled}
+          localPolicyHash={localPolicyHash}
+          daemonAckSynced={daemonAckSynced}
+          daemonAckLabel={daemonAckLabel}
+          lastAckAt={lastAckAt}
+          lastReloadFormatted={lastReloadFormatted}
+          lastReloadAt={lastReloadAt}
+          reloadingPolicy={reloadingPolicy}
+          onStrictToggle={handleStrictToggle}
+          onCopyHash={handleCopyHash}
+          onOpenSettings={onOpenSettings}
+          onReloadPolicy={onReloadPolicy}
+        />
+        <PolicyLocalStrictPolicyCard
+          settings={settings}
+          controlsDisabled={controlsDisabled}
+          saveError={saveError}
+          savingKey={savingKey}
+          onResetDefaults={handleResetDefaults}
+          onSettingChange={handleStrictConfigChange}
+        />
+        <PolicyEnforcementPreviewCard cloudControlsUrl={cloudControlsUrl} />
       </div>
 
-      <aside className="space-y-4 lg:sticky lg:top-4">
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-          <SectionLabel>What this changes</SectionLabel>
-          <ul className="mt-3 space-y-2 text-sm text-slate-600">
-            {WHAT_CHANGES_BULLETS.map((item) => (
-              <li key={item} className="flex gap-2">
-                <HiMiniCheckCircle className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
-                <span>{item}</span>
-              </li>
-            ))}
-          </ul>
-        </div>
-
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
-          <SectionLabel>Affected pending Inbox items</SectionLabel>
-          <p className="mt-2 text-3xl font-semibold tabular-nums text-brand-dark">
-            {pendingInboxCount}
-            <span className="ml-1 text-base font-medium text-slate-500">items</span>
-          </p>
-          <p className="mt-1 text-sm text-slate-600">
-            Pending review items may be affected by stricter fallback controls.
-          </p>
-          {onOpenInbox && pendingInboxCount > 0 ? (
-            <div className="mt-3">
-              <ActionButton variant="secondary" onClick={onOpenInbox}>
-                Open Inbox
-                <HiMiniArrowRight className="ml-1.5 h-4 w-4" aria-hidden="true" />
-              </ActionButton>
-            </div>
-          ) : null}
-        </div>
-
-        <div className="rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm">
-          <p className="font-medium text-brand-dark">Cloud exceptions still apply</p>
-          <p className="mt-2 leading-relaxed">
-            Signed Cloud exceptions still require bundle acknowledgement before they apply locally.
-          </p>
-        </div>
-
-        <div className="rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4 shadow-sm">
-          <div className="flex items-start gap-2">
-            <HiMiniBeaker className="mt-0.5 h-5 w-5 shrink-0 text-brand-blue" aria-hidden="true" />
-            <div className="min-w-0 flex-1">
-              <SectionLabel>Test policy</SectionLabel>
-              <p className="mt-2 text-sm text-slate-600">Simulate how Guard will respond.</p>
-            </div>
-          </div>
-          <label className="mt-4 block space-y-1.5">
-            <span className="text-sm font-medium text-brand-dark">Scenario</span>
-            <select
-              value={scenarioId}
-              onChange={handleScenarioChange}
-              className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark"
-            >
-              {TEST_SCENARIOS.map((scenario) => (
-                <option key={scenario.id} value={scenario.id}>
-                  {scenario.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <div className="mt-4 space-y-2">
-            <p className="text-xs font-medium uppercase tracking-wide text-slate-500">Expected action</p>
-            <Badge tone={resolveExpectedActionTone(expectedAction)}>{policyActionLabel(expectedAction)}</Badge>
-            {expectedReasoning ? <p className="text-sm text-slate-600">{expectedReasoning}</p> : null}
-          </div>
-          <div className="mt-4">
-            <ActionButton variant="secondary" onClick={handleRunSimulation}>
-              <HiMiniPlay className="mr-1.5 h-4 w-4" aria-hidden="true" />
-              Run simulation
-            </ActionButton>
-          </div>
-          {simulationVisible && simulation ? (
-            <div className="mt-4 rounded-xl border border-slate-100 bg-white p-4">
-              <p className="text-sm font-medium text-brand-dark">
-                Policy simulator outcome: {policyActionLabel(simulation.outcome)} ({simulation.winningStep})
-              </p>
-              <ul className="mt-2 space-y-1 text-xs text-slate-600">
-                {simulation.path.map((step) => (
-                  <li key={step}>{step}</li>
-                ))}
-              </ul>
-            </div>
-          ) : null}
-        </div>
-      </aside>
+      <PolicyStrictConfigRightRail
+        pendingInboxCount={pendingInboxCount}
+        cloudControlsUrl={cloudControlsUrl}
+        scenarioId={scenarioId}
+        expectedAction={expectedAction}
+        expectedReasoning={expectedReasoning}
+        simulationVisible={simulationVisible}
+        simulation={simulation}
+        onOpenInbox={onOpenInbox}
+        onScenarioChange={handleScenarioChange}
+        onRunSimulation={handleRunSimulation}
+      />
     </div>
   );
 }

--- a/dashboard/src/policy-workspace.tsx
+++ b/dashboard/src/policy-workspace.tsx
@@ -82,6 +82,7 @@ export function PolicyWorkspace({
     <div id="policy-panel-strict" role="tabpanel" aria-labelledby="policy-tab-strict">
       <PolicyStrictConfigTab
         snapshot={snapshot}
+        cloudControlsUrl={resolveCloudPolicyControlsUrl(snapshot)}
         onOpenSettings={onOpenSettings}
         onOpenInbox={onOpenInbox}
         onReloadPolicy={onReloadPolicy}

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, S as SectionLabel, o as HiMiniXMark, B as Badge, ac as Tag, aA as HiMiniCommandLine, w as HiMiniExclamationTriangle, b0 as scopeLabel, h as harnessDisplayName, A as ActionButton, b1 as guardAwareHref, m as formatRelativeTime, b2 as HiMiniDocumentText, d as HiMiniCheckCircle, b3 as HiMiniCloudArrowUp, b4 as HiMiniCheck, b5 as HiMiniCodeBracket, b6 as HiMiniClipboardDocument, b7 as HiMiniUsers, aG as HiMiniBeaker, b8 as HiMiniFolder, b9 as HiMiniInformationCircle, Q as HiMiniLockClosed, l as HiMiniShieldCheck, r as reactExports, ba as createCloudExceptionRequest, b as EmptyState, ad as HiMiniMagnifyingGlass, p as HiMiniChevronUp, q as HiMiniChevronDown, y as HiMiniChevronRight, bb as HiMiniPuzzlePiece, bc as HiMiniGlobeAlt, aE as HiMiniClock, bd as policyActionLabel, be as fetchCloudExceptions, bf as fetchCloudExceptionRequests, bg as downloadBlob, bh as PaginationControls, bi as HiMiniNoSymbol, aM as HiMiniArrowTopRightOnSquare, bj as HiMiniCube, aw as HiMiniArrowPath, t as HiMiniCloud, T as HiMiniAdjustmentsHorizontal, bk as HiMiniArrowDownTray, Y as fetchSettings, _ as updateSettings, x as HiMiniBolt, bl as HiMiniQueueList, bm as HiMiniArrowRight, bn as HiMiniPlay, a_ as WorkspacePageHeader, a$ as __vitePreload } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, S as SectionLabel, o as HiMiniXMark, B as Badge, ac as Tag, aA as HiMiniCommandLine, w as HiMiniExclamationTriangle, b0 as scopeLabel, h as harnessDisplayName, A as ActionButton, b1 as guardAwareHref, m as formatRelativeTime, b2 as HiMiniDocumentText, d as HiMiniCheckCircle, b3 as HiMiniCloudArrowUp, b4 as HiMiniCheck, b5 as HiMiniCodeBracket, b6 as HiMiniClipboardDocument, b7 as HiMiniUsers, aG as HiMiniBeaker, b8 as HiMiniFolder, b9 as HiMiniInformationCircle, O as HiMiniLockClosed, l as HiMiniShieldCheck, r as reactExports, ba as createCloudExceptionRequest, b as EmptyState, ad as HiMiniMagnifyingGlass, p as HiMiniChevronUp, q as HiMiniChevronDown, y as HiMiniChevronRight, bb as HiMiniPuzzlePiece, bc as HiMiniGlobeAlt, aE as HiMiniClock, bd as policyActionLabel, be as fetchCloudExceptions, bf as fetchCloudExceptionRequests, bg as downloadBlob, bh as PaginationControls, bi as HiMiniNoSymbol, aM as HiMiniArrowTopRightOnSquare, bj as HiMiniCube, aw as HiMiniArrowPath, t as HiMiniCloud, T as HiMiniAdjustmentsHorizontal, bk as HiMiniArrowDownTray, bl as HiMiniQueueList, bm as HiMiniArrowRight, x as HiMiniBolt, bn as HiMiniPlay, Y as fetchSettings, _ as updateSettings, a_ as WorkspacePageHeader, a$ as __vitePreload } from "../guard-dashboard.js";
 const CLOUD_EXCEPTION_EXPIRING_SOON_DAYS = 7;
 function parseCloudExceptionTimestamp(value) {
   if (!value || !value.trim()) {
@@ -3190,6 +3190,50 @@ function PolicyRememberedRulesTab({
     /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyRememberedRulesRightRail, { onOpenCloudExceptions, snapshot })
   ] });
 }
+const POLICY_PANEL_CARD_CLASS = "rounded-2xl border border-slate-200/80 bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04),0_10px_28px_rgba(15,23,42,0.05)]";
+const STRICT_CONFIG_EVALUATION_STEPS = [
+  {
+    label: "Local rule",
+    description: "If a remembered local rule matches, apply it.",
+    icon: HiMiniQueueList,
+    surfaceClass: "border-violet-200 bg-violet-50",
+    iconClass: "text-violet-600"
+  },
+  {
+    label: "Cloud policy",
+    description: "Then apply the signed Cloud policy bundle.",
+    icon: HiMiniCloud,
+    surfaceClass: "border-sky-200 bg-sky-50",
+    iconClass: "text-sky-600"
+  },
+  {
+    label: "Cloud exception",
+    description: "Matching Cloud exception allows the action.",
+    icon: HiMiniCloud,
+    surfaceClass: "border-cyan-200 bg-cyan-50",
+    iconClass: "text-cyan-700"
+  },
+  {
+    label: "Strict fallback",
+    description: "If nothing allows it, this strict config is used.",
+    icon: HiMiniShieldCheck,
+    surfaceClass: "border-amber-200 bg-amber-50",
+    iconClass: "text-amber-700"
+  },
+  {
+    label: "Ask or block",
+    description: "Guard asks (or blocks) according to your choice.",
+    icon: HiMiniNoSymbol,
+    surfaceClass: "border-rose-200 bg-rose-50",
+    iconClass: "text-rose-600"
+  }
+];
+const STRICT_CONFIG_WHAT_CHANGES = [
+  "First-time actions follow your default strict action.",
+  "Changed tool hashes trigger your configured review path.",
+  "New network domains and subprocesses use strict fallback rules.",
+  "Cloud exceptions and remembered rules still win when they match."
+];
 const STRICT_CONFIG_ACTION_OPTIONS = [
   { value: "allow", label: "Allow without asking" },
   { value: "warn", label: "Warn only" },
@@ -3294,6 +3338,35 @@ function simulateStrictPolicyOutcome(input) {
     path
   };
 }
+function PolicyEnforcementPreviewCard({ cloudControlsUrl }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-5`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local enforcement preview" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-slate-600", children: "Evaluation order when Guard decides what to do next." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 -mx-1 overflow-x-auto px-1 pb-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex min-w-[52rem] items-stretch", children: STRICT_CONFIG_EVALUATION_STEPS.map((step, index) => {
+      const Icon = step.icon;
+      const isLast = index === STRICT_CONFIG_EVALUATION_STEPS.length - 1;
+      return /* @__PURE__ */ jsxRuntimeExports.jsxs(reactExports.Fragment, { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `flex min-w-[9.75rem] flex-1 flex-col rounded-xl border p-3 ${step.surfaceClass}`, children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `flex h-8 w-8 items-center justify-center rounded-lg bg-white/80 ${step.iconClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4", "aria-hidden": "true" }) }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm font-semibold text-brand-dark", children: step.label }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: step.description })
+        ] }),
+        !isLast ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex w-7 shrink-0 items-center justify-center", "aria-hidden": "true", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowRight, { className: "h-4 w-4 text-slate-300" }) }) : null
+      ] }, step.label);
+    }) }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex flex-col gap-3 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-between", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "max-w-xl text-xs leading-relaxed text-slate-500", children: [
+        "Evaluation order: ",
+        STRICT_POLICY_EVALUATION_ORDER.join(" → "),
+        ". Team-wide exceptions are managed in Guard Cloud."
+      ] }),
+      cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "shrink-0", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
+        "Open Guard Cloud",
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowTopRightOnSquare, { className: "ml-1.5 h-4 w-4", "aria-hidden": "true" })
+      ] }) }) : null
+    ] })
+  ] });
+}
 const PRIMARY_STRICT_ACTIONS = [
   { value: "allow", label: "Allow" },
   { value: "warn", label: "Warn" },
@@ -3317,19 +3390,19 @@ function StrictConfigActionSegmented({
     [onSettingChange, settingKey]
   );
   const showAdvanced = !PRIMARY_STRICT_ACTION_VALUES.has(value);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4 py-4 first:pt-0 last:pb-0 sm:flex-row sm:items-center sm:justify-between", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-start gap-3 sm:max-w-[45%]", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 py-5 first:pt-0 last:pb-0 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center lg:gap-6", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-start gap-3", children: [
       Icon ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4", "aria-hidden": "true" }) }) : null,
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-medium text-brand-dark", children: label }),
         help ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs leading-relaxed text-slate-500", children: help }) : null
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "sm:shrink-0", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 lg:justify-self-end", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "div",
         {
-          className: "inline-flex flex-wrap gap-1 rounded-xl border border-slate-200 bg-slate-50/80 p-1",
+          className: "inline-flex max-w-full flex-wrap gap-1 rounded-xl border border-slate-200 bg-slate-100/80 p-1",
           role: "group",
           "aria-label": label,
           children: PRIMARY_STRICT_ACTIONS.map((option) => {
@@ -3391,66 +3464,116 @@ function applyStrictConfigPatch(settings, key, value) {
     [key]: value
   };
 }
-const EVALUATION_STEPS = [
-  {
-    label: "Local rule",
-    description: "Remembered decisions on this device.",
-    icon: HiMiniQueueList,
-    surfaceClass: "bg-violet-50 text-violet-700 border-violet-200"
-  },
-  {
-    label: "Cloud policy",
-    description: "Team rules from Guard Cloud.",
-    icon: HiMiniCloud,
-    surfaceClass: "bg-sky-50 text-sky-700 border-sky-200"
-  },
-  {
-    label: "Cloud exception",
-    description: "Signed risk acceptances.",
-    icon: HiMiniCloud,
-    surfaceClass: "bg-sky-50 text-sky-700 border-sky-200"
-  },
-  {
-    label: "Strict fallback",
-    description: "Local strict policy settings.",
-    icon: HiMiniShieldCheck,
-    surfaceClass: "bg-amber-50 text-amber-800 border-amber-200"
-  },
-  {
-    label: "Ask or block",
-    description: "Final prompt or block.",
-    icon: HiMiniNoSymbol,
-    surfaceClass: "bg-rose-50 text-rose-700 border-rose-200"
-  }
-];
-const WHAT_CHANGES_BULLETS = [
-  "First-time actions follow your default strict action.",
-  "Changed tool hashes trigger your configured review path.",
-  "New network domains and subprocesses use strict fallback rules.",
-  "Cloud exceptions and remembered rules still win when they match."
-];
+function PolicyInfoBanner({ children }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2 rounded-xl border border-slate-200/80 bg-slate-50 px-3 py-2.5 text-xs leading-relaxed text-slate-600", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniInformationCircle, { className: "mt-0.5 h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children })
+  ] });
+}
+function PolicyLocalStrictPolicyCard({
+  settings,
+  controlsDisabled,
+  saveError,
+  savingKey,
+  onResetDefaults,
+  onSettingChange
+}) {
+  const fileWriteAction = resolveStrictFileWriteAction(settings);
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-5`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local strict policy" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-slate-600", children: "Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches." })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "button",
+        {
+          type: "button",
+          onClick: onResetDefaults,
+          disabled: controlsDisabled,
+          className: "inline-flex shrink-0 items-center gap-1.5 text-sm font-medium text-brand-blue hover:underline disabled:opacity-50",
+          children: [
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: "h-4 w-4", "aria-hidden": "true" }),
+            "Reset to defaults"
+          ]
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 divide-y divide-slate-100", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        StrictConfigActionSegmented,
+        {
+          label: "Default action",
+          help: "For any action not explicitly allowed.",
+          icon: HiMiniBolt,
+          value: settings.default_action,
+          settingKey: "default_action",
+          onSettingChange,
+          disabled: controlsDisabled
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        StrictConfigActionSegmented,
+        {
+          label: "Changed tool hash action",
+          help: "When a tool or script hash is new.",
+          icon: HiMiniCodeBracket,
+          value: settings.changed_hash_action,
+          settingKey: "changed_hash_action",
+          onSettingChange,
+          disabled: controlsDisabled
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        StrictConfigActionSegmented,
+        {
+          label: "New network domain action",
+          help: "When a process tries to contact a new domain.",
+          icon: HiMiniGlobeAlt,
+          value: settings.new_network_domain_action,
+          settingKey: "new_network_domain_action",
+          onSettingChange,
+          disabled: controlsDisabled
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        StrictConfigActionSegmented,
+        {
+          label: "Subprocess action",
+          help: "When a process tries to launch another program.",
+          icon: HiMiniCommandLine,
+          value: settings.subprocess_action,
+          settingKey: "subprocess_action",
+          onSettingChange,
+          disabled: controlsDisabled
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        StrictConfigActionSegmented,
+        {
+          label: "File write action",
+          help: "When a process writes to disk.",
+          icon: HiMiniDocumentText,
+          value: fileWriteAction,
+          settingKey: "destructive_shell",
+          onSettingChange,
+          disabled: controlsDisabled
+        }
+      )
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyInfoBanner, { children: "These settings apply only when no local or Cloud rules cover the action." }) }),
+    saveError ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-sm text-red-600", children: saveError }) : null,
+    savingKey ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-3 text-sm text-slate-500", children: [
+      "Saving ",
+      savingKey.replace(/_/g, " "),
+      "…"
+    ] }) : null
+  ] });
+}
 const TEST_SCENARIOS = [
-  {
-    id: "first-time",
-    label: "New tool contacting unknown domain",
-    remembered: "none",
-    cloudPolicy: "none",
-    cloudException: false
-  },
-  {
-    id: "remembered-allow",
-    label: "Remembered allow wins",
-    remembered: "allow",
-    cloudPolicy: "block",
-    cloudException: false
-  },
-  {
-    id: "cloud-exception",
-    label: "Active Cloud exception",
-    remembered: "block",
-    cloudPolicy: "block",
-    cloudException: true
-  }
+  { id: "first-time", label: "New tool contacting unknown domain" },
+  { id: "remembered-allow", label: "Remembered allow wins" },
+  { id: "cloud-exception", label: "Active Cloud exception" }
 ];
 function resolveExpectedActionTone(action) {
   if (action === "block") {
@@ -3464,8 +3587,198 @@ function resolveExpectedActionTone(action) {
   }
   return "default";
 }
+function PolicyStrictConfigRightRail({
+  pendingInboxCount,
+  cloudControlsUrl,
+  scenarioId,
+  expectedAction,
+  expectedReasoning,
+  simulationVisible,
+  simulation,
+  onOpenInbox,
+  onScenarioChange,
+  onRunSimulation
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "min-w-0 space-y-4 xl:sticky xl:top-6 xl:self-start", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-4`, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "What this changes" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-2.5 text-sm leading-relaxed text-slate-600", children: STRICT_CONFIG_WHAT_CHANGES.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "mt-0.5 h-4 w-4 shrink-0 text-emerald-600", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: item })
+      ] }, item)) })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-4`, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Affected pending Inbox items" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-4xl font-semibold tabular-nums text-brand-blue", children: [
+        pendingInboxCount,
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-1.5 text-lg font-medium text-brand-blue/75", children: "items" })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: "Pending review items may be affected by stricter fallback controls." }),
+      onOpenInbox && pendingInboxCount > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onOpenInbox, children: [
+        "Open Inbox",
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowRight, { className: "ml-1.5 h-4 w-4", "aria-hidden": "true" })
+      ] }) }) : null
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-4 text-sm leading-relaxed text-slate-600`, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Cloud exceptions still apply" }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2", children: "Signed Cloud exceptions still require bundle acknowledgement before they apply locally." }),
+      cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs(
+        "a",
+        {
+          href: cloudControlsUrl,
+          target: "_blank",
+          rel: "noopener noreferrer",
+          className: "mt-3 inline-flex items-center gap-1 text-sm font-medium text-brand-blue hover:underline",
+          children: [
+            "Learn more",
+            /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowRight, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
+          ]
+        }
+      ) : null
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} border-brand-blue/15 bg-brand-blue/[0.03] p-4`, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-blue", "aria-hidden": "true" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Test policy" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-slate-600", children: "Simulate how Guard will respond." })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-4 block space-y-1.5", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Scenario" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "select",
+          {
+            value: scenarioId,
+            onChange: onScenarioChange,
+            className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark",
+            children: TEST_SCENARIOS.map((scenario) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: scenario.id, children: scenario.label }, scenario.id))
+          }
+        )
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 space-y-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium uppercase tracking-wide text-slate-500", children: "Expected action" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: resolveExpectedActionTone(expectedAction), children: policyActionLabel(expectedAction) }),
+        expectedReasoning ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm leading-relaxed text-slate-600", children: expectedReasoning }) : null
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onRunSimulation, children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniPlay, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+        "Run simulation"
+      ] }) }),
+      simulationVisible && simulation ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-slate-100 bg-white p-4", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm font-medium text-brand-dark", children: [
+          "Policy simulator outcome: ",
+          policyActionLabel(simulation.outcome),
+          " (",
+          simulation.winningStep,
+          ")"
+        ] }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-2 space-y-1 text-xs text-slate-600", children: simulation.path.map((step) => /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: step }, step)) })
+      ] }) : null
+    ] })
+  ] });
+}
+function PolicyStrictModeCard({
+  isStrict,
+  controlsDisabled,
+  localPolicyHash,
+  daemonAckSynced,
+  daemonAckLabel,
+  lastAckAt,
+  lastReloadFormatted,
+  lastReloadAt,
+  reloadingPolicy,
+  onStrictToggle,
+  onCopyHash,
+  onOpenSettings,
+  onReloadPolicy
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-5`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-start gap-3", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-5 w-5", "aria-hidden": "true" }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-base font-semibold text-brand-dark", children: "Strict mode" }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: "Local enforcement tuning when no remembered rule, Cloud policy, or Cloud exception matches." })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex shrink-0 items-center gap-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-slate-500", children: isStrict ? "Enabled" : "Disabled" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            type: "button",
+            role: "switch",
+            "aria-checked": isStrict,
+            "aria-label": "Toggle strict mode",
+            disabled: controlsDisabled,
+            onClick: onStrictToggle,
+            className: `relative h-7 w-12 shrink-0 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/60 ${isStrict ? "bg-brand-blue" : "bg-slate-200"} ${controlsDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`,
+            children: /* @__PURE__ */ jsxRuntimeExports.jsx(
+              "span",
+              {
+                className: `absolute top-0.5 left-0.5 h-6 w-6 rounded-full bg-white shadow-sm transition-transform ${isStrict ? "translate-x-5" : "translate-x-0"}`
+              }
+            )
+          }
+        )
+      ] })
+    ] }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-5 grid gap-4 border-t border-slate-100 pt-4 sm:grid-cols-2 xl:grid-cols-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Strict mode" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1.5 text-sm font-medium text-brand-dark", children: isStrict ? "Enabled" : "Disabled" })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Policy hash" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5 flex min-w-0 items-center gap-1.5 font-mono text-sm text-brand-dark", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "truncate", title: localPolicyHash ?? void 0, children: localPolicyHash }),
+          /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              type: "button",
+              onClick: onCopyHash,
+              className: "shrink-0 rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
+              "aria-label": "Copy policy hash",
+              children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-4 w-4", "aria-hidden": "true" })
+            }
+          )
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Daemon ack" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5 flex items-center gap-1.5 text-sm text-brand-dark", children: [
+          daemonAckSynced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
+          /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
+            daemonAckLabel,
+            lastAckAt ? ` · ${formatRelativeTime(lastAckAt)}` : ""
+          ] })
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last reload" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1.5 text-sm text-brand-dark", children: lastReloadFormatted ?? (lastReloadAt ? formatRelativeTime(lastReloadAt) : "Unavailable") }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-1 flex items-center gap-1 text-xs text-emerald-700", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5 shrink-0", "aria-hidden": "true" }),
+          "Auto-reload on"
+        ] })
+      ] })
+    ] }),
+    !isStrict && onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 border-t border-slate-100 pt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Enable in Settings" }) }) : null,
+    onReloadPolicy ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex justify-end border-t border-slate-100 pt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onReloadPolicy, disabled: reloadingPolicy, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: `mr-1.5 h-4 w-4 ${reloadingPolicy ? "animate-spin" : ""}`, "aria-hidden": "true" }),
+      "Reload policy"
+    ] }) }) : null
+  ] });
+}
+const SCENARIO_FIXTURES = {
+  "first-time": { remembered: "none", cloudPolicy: "none", cloudException: false },
+  "remembered-allow": { remembered: "allow", cloudPolicy: "block", cloudException: false },
+  "cloud-exception": { remembered: "block", cloudPolicy: "block", cloudException: true }
+};
 function PolicyStrictConfigTab({
   snapshot,
+  cloudControlsUrl = null,
   onOpenSettings,
   onOpenInbox,
   onReloadPolicy,
@@ -3607,10 +3920,7 @@ function PolicyStrictConfigTab({
     const nextId = event.target.value;
     setScenarioId(nextId);
     setSimulationVisible(false);
-    const scenario = TEST_SCENARIOS.find((item) => item.id === nextId);
-    if (!scenario) {
-      return;
-    }
+    const scenario = SCENARIO_FIXTURES[nextId];
     setSimRemembered(scenario.remembered);
     setSimCloudPolicy(scenario.cloudPolicy);
     setSimCloudException(scenario.cloudException);
@@ -3627,272 +3937,62 @@ function PolicyStrictConfigTab({
       }
     );
   }
-  const fileWriteAction = resolveStrictFileWriteAction(settings);
   const controlsDisabled = savingKey !== null;
   const lastReloadAt = snapshot.runtime_state?.started_at ?? snapshot.generated_at ?? null;
   const lastReloadFormatted = formatPolicyDateTime(lastReloadAt);
   const lastAckAt = snapshot.cloud_policy_last_ack_at?.trim() ?? null;
-  const daemonAckLabel = cloudBundleCopy?.tone === "green" ? "Acknowledged" : cloudBundleCopy?.label ?? "Pending";
-  const expectedAction = scenarioOutcome?.outcome ?? settings?.new_network_domain_action ?? "review";
+  const daemonAckSynced = cloudBundleCopy?.tone === "green";
+  const daemonAckLabel = daemonAckSynced ? "Acknowledged" : cloudBundleCopy?.label ?? "Needs attention";
+  const expectedAction = scenarioOutcome?.outcome ?? settings.new_network_domain_action ?? "review";
   const expectedReasoning = scenarioOutcome?.reasoning ?? "";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1fr)_300px] lg:items-start", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-3", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-5 w-5", "aria-hidden": "true" }) }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-base font-semibold text-brand-dark", children: "Strict mode" }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: "Local enforcement tuning when no other rule matches." })
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-2", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-xs font-medium text-slate-500", children: isStrict ? "Enabled" : "Disabled" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx(
-              "button",
-              {
-                type: "button",
-                role: "switch",
-                "aria-checked": isStrict,
-                "aria-label": "Toggle strict mode",
-                disabled: controlsDisabled,
-                onClick: handleStrictToggle,
-                className: `relative h-7 w-12 shrink-0 rounded-full transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue/60 ${isStrict ? "bg-brand-blue" : "bg-slate-200"} ${controlsDisabled ? "cursor-not-allowed opacity-50" : "cursor-pointer"}`,
-                children: /* @__PURE__ */ jsxRuntimeExports.jsx(
-                  "span",
-                  {
-                    className: `absolute top-0.5 left-0.5 h-6 w-6 rounded-full bg-white shadow-sm transition-transform ${isStrict ? "translate-x-5" : "translate-x-0"}`
-                  }
-                )
-              }
-            )
-          ] })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-5 grid gap-4 border-t border-slate-100 pt-4 sm:grid-cols-2 lg:grid-cols-4", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Strict mode" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1.5 text-sm font-medium text-brand-dark", children: isStrict ? "Enabled" : "Disabled" })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Policy hash" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5 flex items-center gap-1.5 font-mono text-sm text-brand-dark", children: [
-              localPolicyHash,
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
-                "button",
-                {
-                  type: "button",
-                  onClick: handleCopyHash,
-                  className: "rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
-                  "aria-label": "Copy policy hash",
-                  children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-4 w-4", "aria-hidden": "true" })
-                }
-              )
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Daemon ack" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5 flex items-center gap-1.5 text-sm text-brand-dark", children: [
-              cloudBundleCopy?.tone === "green" ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 text-emerald-600", "aria-hidden": "true" }) : null,
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("span", { children: [
-                daemonAckLabel,
-                lastAckAt ? ` · ${formatRelativeTime(lastAckAt)}` : ""
-              ] })
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last reload" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1.5 text-sm text-brand-dark", children: lastReloadFormatted ?? (lastReloadAt ? formatRelativeTime(lastReloadAt) : "Unavailable") }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs text-emerald-700", children: "Auto-reload on" })
-          ] })
-        ] }),
-        !isStrict && onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 border-t border-slate-100 pt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Enable in Settings" }) }) : null,
-        onReloadPolicy ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex justify-end border-t border-slate-100 pt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onReloadPolicy, disabled: reloadingPolicy, children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: `mr-1.5 h-4 w-4 ${reloadingPolicy ? "animate-spin" : ""}`, "aria-hidden": "true" }),
-          "Reload policy"
-        ] }) }) : null
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local strict policy" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches." })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              type: "button",
-              onClick: handleResetDefaults,
-              disabled: controlsDisabled,
-              className: "text-sm font-medium text-brand-blue hover:underline disabled:opacity-50",
-              children: "Reset to defaults"
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 divide-y divide-slate-100", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            StrictConfigActionSegmented,
-            {
-              label: "Default action",
-              help: "For any action not explicitly allowed.",
-              icon: HiMiniBolt,
-              value: settings.default_action,
-              settingKey: "default_action",
-              onSettingChange: handleStrictConfigChange,
-              disabled: controlsDisabled
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            StrictConfigActionSegmented,
-            {
-              label: "Changed tool hash action",
-              help: "When a tool or script hash is new.",
-              icon: HiMiniCodeBracket,
-              value: settings.changed_hash_action,
-              settingKey: "changed_hash_action",
-              onSettingChange: handleStrictConfigChange,
-              disabled: controlsDisabled
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            StrictConfigActionSegmented,
-            {
-              label: "New network domain action",
-              help: "When a process tries to contact a new domain.",
-              icon: HiMiniGlobeAlt,
-              value: settings.new_network_domain_action,
-              settingKey: "new_network_domain_action",
-              onSettingChange: handleStrictConfigChange,
-              disabled: controlsDisabled
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            StrictConfigActionSegmented,
-            {
-              label: "Subprocess action",
-              help: "When a process tries to launch another program.",
-              icon: HiMiniCommandLine,
-              value: settings.subprocess_action,
-              settingKey: "subprocess_action",
-              onSettingChange: handleStrictConfigChange,
-              disabled: controlsDisabled
-            }
-          ),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            StrictConfigActionSegmented,
-            {
-              label: "File write action",
-              help: "When a process writes to disk.",
-              icon: HiMiniDocumentText,
-              value: fileWriteAction,
-              settingKey: "destructive_shell",
-              onSettingChange: handleStrictConfigChange,
-              disabled: controlsDisabled
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-4 flex items-start gap-2 text-xs text-slate-500", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "mt-0.5 h-4 w-4 shrink-0 text-slate-400", "aria-hidden": "true" }),
-          "These settings apply only when no local or Cloud rules cover the action."
-        ] }),
-        saveError ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 text-sm text-red-600", children: saveError }) : null,
-        savingKey ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-3 text-sm text-slate-500", children: [
-          "Saving ",
-          savingKey.replace(/_/g, " "),
-          "…"
-        ] }) : null
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-5 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local enforcement preview" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Evaluation order when Guard decides what to do next." }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 grid gap-3 sm:grid-cols-2 xl:grid-cols-5", children: EVALUATION_STEPS.map((step, index) => {
-          const Icon = step.icon;
-          return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "relative", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `rounded-xl border p-3 ${step.surfaceClass}`, children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-8 w-8 items-center justify-center rounded-lg bg-white/70", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4", "aria-hidden": "true" }) }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm font-semibold text-brand-dark", children: step.label }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-600", children: step.description })
-            ] }),
-            index < EVALUATION_STEPS.length - 1 ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-              HiMiniArrowRight,
-              {
-                className: "absolute top-1/2 -right-3 hidden h-4 w-4 -translate-y-1/2 text-slate-300 xl:block",
-                "aria-hidden": "true"
-              }
-            ) : null
-          ] }, step.label);
-        }) }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-4 text-xs text-slate-500", children: [
-          "Evaluation order: ",
-          STRICT_POLICY_EVALUATION_ORDER.join(" → "),
-          ". Team-wide exceptions are managed in Guard Cloud."
-        ] })
-      ] })
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(17rem,20rem)] xl:items-start", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 space-y-4", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        PolicyStrictModeCard,
+        {
+          isStrict,
+          controlsDisabled,
+          localPolicyHash,
+          daemonAckSynced,
+          daemonAckLabel,
+          lastAckAt,
+          lastReloadFormatted,
+          lastReloadAt,
+          reloadingPolicy,
+          onStrictToggle: handleStrictToggle,
+          onCopyHash: handleCopyHash,
+          onOpenSettings,
+          onReloadPolicy
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(
+        PolicyLocalStrictPolicyCard,
+        {
+          settings,
+          controlsDisabled,
+          saveError,
+          savingKey,
+          onResetDefaults: handleResetDefaults,
+          onSettingChange: handleStrictConfigChange
+        }
+      ),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyEnforcementPreviewCard, { cloudControlsUrl })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("aside", { className: "space-y-4 lg:sticky lg:top-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "What this changes" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-3 space-y-2 text-sm text-slate-600", children: WHAT_CHANGES_BULLETS.map((item) => /* @__PURE__ */ jsxRuntimeExports.jsxs("li", { className: "flex gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "mt-0.5 h-4 w-4 shrink-0 text-emerald-600", "aria-hidden": "true" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { children: item })
-        ] }, item)) })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Affected pending Inbox items" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-3xl font-semibold tabular-nums text-brand-dark", children: [
-          pendingInboxCount,
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-1 text-base font-medium text-slate-500", children: "items" })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm text-slate-600", children: "Pending review items may be affected by stricter fallback controls." }),
-        onOpenInbox && pendingInboxCount > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onOpenInbox, children: [
-          "Open Inbox",
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowRight, { className: "ml-1.5 h-4 w-4", "aria-hidden": "true" })
-        ] }) }) : null
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200 bg-white p-4 text-sm text-slate-600 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-medium text-brand-dark", children: "Cloud exceptions still apply" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 leading-relaxed", children: "Signed Cloud exceptions still require bundle acknowledgement before they apply locally." })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-brand-blue/10 bg-brand-blue/[0.03] p-4 shadow-sm", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniBeaker, { className: "mt-0.5 h-5 w-5 shrink-0 text-brand-blue", "aria-hidden": "true" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Test policy" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm text-slate-600", children: "Simulate how Guard will respond." })
-          ] })
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("label", { className: "mt-4 block space-y-1.5", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "text-sm font-medium text-brand-dark", children: "Scenario" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "select",
-            {
-              value: scenarioId,
-              onChange: handleScenarioChange,
-              className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark",
-              children: TEST_SCENARIOS.map((scenario) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: scenario.id, children: scenario.label }, scenario.id))
-            }
-          )
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 space-y-2", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-xs font-medium uppercase tracking-wide text-slate-500", children: "Expected action" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx(Badge, { tone: resolveExpectedActionTone(expectedAction), children: policyActionLabel(expectedAction) }),
-          expectedReasoning ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-slate-600", children: expectedReasoning }) : null
-        ] }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: handleRunSimulation, children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniPlay, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
-          "Run simulation"
-        ] }) }),
-        simulationVisible && simulation ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 rounded-xl border border-slate-100 bg-white p-4", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "text-sm font-medium text-brand-dark", children: [
-            "Policy simulator outcome: ",
-            policyActionLabel(simulation.outcome),
-            " (",
-            simulation.winningStep,
-            ")"
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("ul", { className: "mt-2 space-y-1 text-xs text-slate-600", children: simulation.path.map((step) => /* @__PURE__ */ jsxRuntimeExports.jsx("li", { children: step }, step)) })
-        ] }) : null
-      ] })
-    ] })
+    /* @__PURE__ */ jsxRuntimeExports.jsx(
+      PolicyStrictConfigRightRail,
+      {
+        pendingInboxCount,
+        cloudControlsUrl,
+        scenarioId,
+        expectedAction,
+        expectedReasoning,
+        simulationVisible,
+        simulation,
+        onOpenInbox,
+        onScenarioChange: handleScenarioChange,
+        onRunSimulation: handleRunSimulation
+      }
+    )
   ] });
 }
 function resolvePolicyViewLabel(view) {
@@ -3945,6 +4045,7 @@ function PolicyWorkspace$1({
     PolicyStrictConfigTab,
     {
       snapshot,
+      cloudControlsUrl: resolveCloudPolicyControlsUrl(snapshot),
       onOpenSettings,
       onOpenInbox,
       onReloadPolicy,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1,4 +1,4 @@
-/*! tailwindcss v4.2.2 | MIT License | https://tailwindcss.com */
+/*! tailwindcss v4.3.1 | MIT License | https://tailwindcss.com */
 @layer properties {
   @supports (((-webkit-hyphens: none)) and (not (margin-trim: inline))) or ((-moz-orient: inline) and (not (color: rgb(from red r g b)))) {
     *, :before, :after, ::backdrop {
@@ -108,10 +108,13 @@
     --color-emerald-600: oklch(59.6% .145 163.225);
     --color-emerald-700: oklch(50.8% .118 165.612);
     --color-emerald-800: oklch(43.2% .095 166.913);
+    --color-cyan-50: oklch(98.4% .019 200.873);
+    --color-cyan-200: oklch(91.7% .08 205.041);
+    --color-cyan-700: oklch(52% .105 223.128);
     --color-sky-50: oklch(97.7% .013 236.62);
     --color-sky-200: oklch(90.1% .058 230.902);
     --color-sky-300: oklch(82.8% .111 230.318);
-    --color-sky-700: oklch(50% .134 242.749);
+    --color-sky-600: oklch(58.8% .158 241.966);
     --color-blue-50: oklch(97% .014 254.604);
     --color-blue-100: oklch(93.2% .032 255.585);
     --color-blue-200: oklch(88.2% .059 254.128);
@@ -503,11 +506,11 @@
   }
 
   .inset-0 {
-    inset: calc(var(--spacing) * 0);
+    inset: 0;
   }
 
   .inset-x-0 {
-    inset-inline: calc(var(--spacing) * 0);
+    inset-inline: 0;
   }
 
   .inset-x-2 {
@@ -515,15 +518,7 @@
   }
 
   .inset-y-0 {
-    inset-block: calc(var(--spacing) * 0);
-  }
-
-  .start {
-    inset-inline-start: var(--spacing);
-  }
-
-  .end {
-    inset-inline-end: var(--spacing);
+    inset-block: 0;
   }
 
   .-top-6 {
@@ -531,7 +526,7 @@
   }
 
   .top-0 {
-    top: calc(var(--spacing) * 0);
+    top: 0;
   }
 
   .top-0\.5 {
@@ -567,7 +562,7 @@
   }
 
   .right-0 {
-    right: calc(var(--spacing) * 0);
+    right: 0;
   }
 
   .right-2 {
@@ -587,7 +582,7 @@
   }
 
   .bottom-0 {
-    bottom: calc(var(--spacing) * 0);
+    bottom: 0;
   }
 
   .bottom-4 {
@@ -607,7 +602,7 @@
   }
 
   .left-0 {
-    left: calc(var(--spacing) * 0);
+    left: 0;
   }
 
   .left-0\.5 {
@@ -697,7 +692,7 @@
   }
 
   .mx-1 {
-    margin-inline: calc(var(--spacing) * 1);
+    margin-inline: var(--spacing);
   }
 
   .mx-1\.5 {
@@ -725,7 +720,7 @@
   }
 
   .mt-1 {
-    margin-top: calc(var(--spacing) * 1);
+    margin-top: var(--spacing);
   }
 
   .mt-1\.5 {
@@ -769,7 +764,7 @@
   }
 
   .mr-1 {
-    margin-right: calc(var(--spacing) * 1);
+    margin-right: var(--spacing);
   }
 
   .mr-1\.5 {
@@ -785,7 +780,7 @@
   }
 
   .mb-1 {
-    margin-bottom: calc(var(--spacing) * 1);
+    margin-bottom: var(--spacing);
   }
 
   .mb-1\.5 {
@@ -821,11 +816,11 @@
   }
 
   .ml-0 {
-    margin-left: calc(var(--spacing) * 0);
+    margin-left: 0;
   }
 
   .ml-1 {
-    margin-left: calc(var(--spacing) * 1);
+    margin-left: var(--spacing);
   }
 
   .ml-1\.5 {
@@ -908,7 +903,7 @@
   }
 
   .h-1 {
-    height: calc(var(--spacing) * 1);
+    height: var(--spacing);
   }
 
   .h-1\.5 {
@@ -1052,7 +1047,7 @@
   }
 
   .min-h-0 {
-    min-height: calc(var(--spacing) * 0);
+    min-height: 0;
   }
 
   .min-h-7 {
@@ -1124,7 +1119,7 @@
   }
 
   .w-1 {
-    width: calc(var(--spacing) * 1);
+    width: var(--spacing);
   }
 
   .w-1\.5 {
@@ -1324,7 +1319,7 @@
   }
 
   .min-w-0 {
-    min-width: calc(var(--spacing) * 0);
+    min-width: 0;
   }
 
   .min-w-5 {
@@ -1335,8 +1330,16 @@
     min-width: calc(var(--spacing) * 7);
   }
 
+  .min-w-\[9\.75rem\] {
+    min-width: 9.75rem;
+  }
+
   .min-w-\[44px\] {
     min-width: 44px;
+  }
+
+  .min-w-\[52rem\] {
+    min-width: 52rem;
   }
 
   .min-w-\[120px\] {
@@ -1393,7 +1396,7 @@
   }
 
   .translate-x-0 {
-    --tw-translate-x: calc(var(--spacing) * 0);
+    --tw-translate-x: 0;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
 
@@ -1408,7 +1411,7 @@
   }
 
   .translate-y-0 {
-    --tw-translate-y: calc(var(--spacing) * 0);
+    --tw-translate-y: 0;
     translate: var(--tw-translate-x) var(--tw-translate-y);
   }
 
@@ -1450,6 +1453,10 @@
 
   .resize {
     resize: both;
+  }
+
+  .\[scrollbar-gutter\:stable\] {
+    scrollbar-gutter: stable;
   }
 
   .list-none {
@@ -1520,6 +1527,10 @@
     align-items: flex-start;
   }
 
+  .items-stretch {
+    align-items: stretch;
+  }
+
   .justify-between {
     justify-content: space-between;
   }
@@ -1533,7 +1544,7 @@
   }
 
   .gap-0 {
-    gap: calc(var(--spacing) * 0);
+    gap: 0;
   }
 
   .gap-0\.5 {
@@ -1541,7 +1552,7 @@
   }
 
   .gap-1 {
-    gap: calc(var(--spacing) * 1);
+    gap: var(--spacing);
   }
 
   .gap-1\.5 {
@@ -1582,8 +1593,7 @@
 
   :where(.space-y-0 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 0) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 0) * calc(1 - var(--tw-space-y-reverse)));
+    margin-block: 0;
   }
 
   :where(.space-y-0\.5 > :not(:last-child)) {
@@ -1594,8 +1604,8 @@
 
   :where(.space-y-1 > :not(:last-child)) {
     --tw-space-y-reverse: 0;
-    margin-block-start: calc(calc(var(--spacing) * 1) * var(--tw-space-y-reverse));
-    margin-block-end: calc(calc(var(--spacing) * 1) * calc(1 - var(--tw-space-y-reverse)));
+    margin-block-start: calc(var(--spacing) * var(--tw-space-y-reverse));
+    margin-block-end: calc(var(--spacing) * calc(1 - var(--tw-space-y-reverse)));
   }
 
   :where(.space-y-1\.5 > :not(:last-child)) {
@@ -1673,7 +1683,7 @@
   }
 
   .gap-y-1 {
-    row-gap: calc(var(--spacing) * 1);
+    row-gap: var(--spacing);
   }
 
   .gap-y-2 {
@@ -2113,6 +2123,10 @@
     .border-brand-purple\/30 {
       border-color: color-mix(in oklab, var(--brand-purple) 30%, transparent);
     }
+  }
+
+  .border-cyan-200 {
+    border-color: var(--color-cyan-200);
   }
 
   .border-emerald-200 {
@@ -2843,6 +2857,10 @@
     background-color: hsl(var(--card));
   }
 
+  .bg-cyan-50 {
+    background-color: var(--color-cyan-50);
+  }
+
   .bg-emerald-50 {
     background-color: var(--color-emerald-50);
   }
@@ -3019,6 +3037,16 @@
 
   .bg-slate-100 {
     background-color: var(--color-slate-100);
+  }
+
+  .bg-slate-100\/80 {
+    background-color: #f1f5f9cc;
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .bg-slate-100\/80 {
+      background-color: color-mix(in oklab, var(--color-slate-100) 80%, transparent);
+    }
   }
 
   .bg-slate-200 {
@@ -3524,7 +3552,7 @@
   }
 
   .p-0 {
-    padding: calc(var(--spacing) * 0);
+    padding: 0;
   }
 
   .p-0\.5 {
@@ -3532,7 +3560,7 @@
   }
 
   .p-1 {
-    padding: calc(var(--spacing) * 1);
+    padding: var(--spacing);
   }
 
   .p-1\.5 {
@@ -3564,7 +3592,7 @@
   }
 
   .px-1 {
-    padding-inline: calc(var(--spacing) * 1);
+    padding-inline: var(--spacing);
   }
 
   .px-1\.5 {
@@ -3604,7 +3632,7 @@
   }
 
   .py-1 {
-    padding-block: calc(var(--spacing) * 1);
+    padding-block: var(--spacing);
   }
 
   .py-1\.5 {
@@ -3660,7 +3688,7 @@
   }
 
   .pt-1 {
-    padding-top: calc(var(--spacing) * 1);
+    padding-top: var(--spacing);
   }
 
   .pt-2 {
@@ -3696,7 +3724,7 @@
   }
 
   .pb-1 {
-    padding-bottom: calc(var(--spacing) * 1);
+    padding-bottom: var(--spacing);
   }
 
   .pb-2 {
@@ -4043,6 +4071,16 @@
     }
   }
 
+  .text-brand-blue\/75 {
+    color: var(--brand-blue);
+  }
+
+  @supports (color: color-mix(in lab, red, red)) {
+    .text-brand-blue\/75 {
+      color: color-mix(in oklab, var(--brand-blue) 75%, transparent);
+    }
+  }
+
   .text-brand-blue\/80 {
     color: var(--brand-blue);
   }
@@ -4137,6 +4175,10 @@
     }
   }
 
+  .text-cyan-700 {
+    color: var(--color-cyan-700);
+  }
+
   .text-emerald-300 {
     color: var(--color-emerald-300);
   }
@@ -4217,8 +4259,8 @@
     color: var(--color-sky-300);
   }
 
-  .text-sky-700 {
-    color: var(--color-sky-700);
+  .text-sky-600 {
+    color: var(--color-sky-600);
   }
 
   .text-slate-200 {
@@ -4399,6 +4441,11 @@
 
   .shadow-\[0_-4px_16px_rgba\(63\,65\,116\,0\.08\)\] {
     --tw-shadow: 0 -4px 16px var(--tw-shadow-color, #3f417414);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
+  .shadow-\[0_1px_2px_rgba\(15\,23\,42\,0\.04\)\,0_10px_28px_rgba\(15\,23\,42\,0\.05\)\] {
+    --tw-shadow: 0 1px 2px var(--tw-shadow-color, #0f172a0a), 0 10px 28px var(--tw-shadow-color, #0f172a0d);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 
@@ -4688,10 +4735,6 @@
     user-select: none;
   }
 
-  .\[scrollbar-gutter\:stable\] {
-    scrollbar-gutter: stable;
-  }
-
   .ring-inset {
     --tw-ring-inset: inset;
   }
@@ -4721,11 +4764,11 @@
   }
 
   .first\:pt-0:first-child {
-    padding-top: calc(var(--spacing) * 0);
+    padding-top: 0;
   }
 
   .last\:mb-0:last-child {
-    margin-bottom: calc(var(--spacing) * 0);
+    margin-bottom: 0;
   }
 
   .last\:border-0:last-child {
@@ -4739,7 +4782,7 @@
   }
 
   .last\:pb-0:last-child {
-    padding-bottom: calc(var(--spacing) * 0);
+    padding-bottom: 0;
   }
 
   @media (hover: hover) {
@@ -5414,7 +5457,7 @@
     }
 
     .sm\:mt-0 {
-      margin-top: calc(var(--spacing) * 0);
+      margin-top: 0;
     }
 
     .sm\:flex {
@@ -5453,20 +5496,12 @@
       width: auto;
     }
 
-    .sm\:max-w-\[45\%\] {
-      max-width: 45%;
-    }
-
     .sm\:flex-1 {
       flex: 1;
     }
 
     .sm\:flex-none {
       flex: none;
-    }
-
-    .sm\:shrink-0 {
-      flex-shrink: 0;
     }
 
     .sm\:grid-cols-2 {
@@ -5590,7 +5625,7 @@
     }
 
     .sm\:pl-0 {
-      padding-left: calc(var(--spacing) * 0);
+      padding-left: 0;
     }
 
     .sm\:pl-6 {
@@ -5733,7 +5768,7 @@
     }
 
     .md\:gap-1 {
-      gap: calc(var(--spacing) * 1);
+      gap: var(--spacing);
     }
 
     .md\:gap-x-2 {
@@ -5850,12 +5885,12 @@
       grid-template-columns: minmax(0, 1fr) 280px;
     }
 
-    .lg\:grid-cols-\[minmax\(0\,1fr\)_300px\] {
-      grid-template-columns: minmax(0, 1fr) 300px;
-    }
-
     .lg\:grid-cols-\[minmax\(0\,1fr\)_420px\] {
       grid-template-columns: minmax(0, 1fr) 420px;
+    }
+
+    .lg\:grid-cols-\[minmax\(0\,1fr\)_auto\] {
+      grid-template-columns: minmax(0, 1fr) auto;
     }
 
     .lg\:grid-cols-\[minmax\(0\,1fr\)_minmax\(0\,0\.8fr\)\] {
@@ -5886,6 +5921,10 @@
       justify-content: space-between;
     }
 
+    .lg\:gap-6 {
+      gap: calc(var(--spacing) * 6);
+    }
+
     :where(.lg\:divide-x > :not(:last-child)) {
       --tw-divide-x-reverse: 0;
       border-inline-style: var(--tw-border-style);
@@ -5895,6 +5934,10 @@
 
     :where(.lg\:divide-slate-100 > :not(:last-child)) {
       border-color: var(--color-slate-100);
+    }
+
+    .lg\:justify-self-end {
+      justify-self: flex-end;
     }
 
     .lg\:border-t-0 {
@@ -5950,10 +5993,6 @@
       grid-column: span 1 / span 1;
     }
 
-    .xl\:block {
-      display: block;
-    }
-
     .xl\:grid-cols-1 {
       grid-template-columns: repeat(1, minmax(0, 1fr));
     }
@@ -5964,10 +6003,6 @@
 
     .xl\:grid-cols-4 {
       grid-template-columns: repeat(4, minmax(0, 1fr));
-    }
-
-    .xl\:grid-cols-5 {
-      grid-template-columns: repeat(5, minmax(0, 1fr));
     }
 
     .xl\:grid-cols-\[300px_minmax\(0\,1fr\)\] {
@@ -5982,8 +6017,16 @@
       grid-template-columns: minmax(0, 1fr) 380px;
     }
 
+    .xl\:grid-cols-\[minmax\(0\,1fr\)_minmax\(17rem\,20rem\)\] {
+      grid-template-columns: minmax(0, 1fr) minmax(17rem, 20rem);
+    }
+
     .xl\:items-start {
       align-items: flex-start;
+    }
+
+    .xl\:self-start {
+      align-self: flex-start;
     }
   }
 


### PR DESCRIPTION
## Summary
- Align Strict config tab layout with the policy mockup: shared card surfaces, horizontal enforcement preview flow, and responsive main/right column grid.
- Refresh right-rail copy and styling (inbox count, Cloud exceptions learn-more link, test policy badge).
- Pass Guard Cloud controls URL into the strict tab for footer and sidebar links.

## Testing
- `cd dashboard && npm run build`
- `npx tsx src/policy-strict-config-ia.test.ts`
- `npx tsx src/policy-strict-config-utils.test.ts`
