### PR TITLE
feat(hol-guard): require approval gate for inbox bulk approve once

### DIFF
--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -619,6 +619,7 @@ export function App() {
         requestIds: ids,
         approval_password: gateCredentials.approval_password,
         approval_totp_code: gateCredentials.approval_totp_code,
+        approval_gate_use_cooldown: gateCredentials.approval_gate_use_cooldown,
       });
       await refreshStateAfterAction();
       if (result.failed.length > 0) {

--- a/dashboard/src/app.tsx
+++ b/dashboard/src/app.tsx
@@ -15,6 +15,7 @@ import {
   fetchSettings,
   fetchGuardUpdateStatus,
   guardAwareHref,
+  bulkAllowReadOnce,
   repairApprovalCenter,
   resolveRequestWithQueueResult,
   retryResume,
@@ -609,24 +610,27 @@ export function App() {
     if (bulkApproveInFlight.current) {
       return;
     }
+    if (!gateCredentials?.approval_password?.trim()) {
+      throw new Error("Bulk approval requires an approval password.");
+    }
     bulkApproveInFlight.current = true;
     try {
-      const results = await Promise.allSettled(
-        ids.map((id) =>
-          resolveRequestWithQueueResult({ requestId: id, action: "allow", scope: "artifact", reason: "", ...gateCredentials })
-        )
-      );
-      const succeeded = results.filter((r) => r.status === "fulfilled").length;
-      const failed = results.length - succeeded;
+      const result = await bulkAllowReadOnce({
+        requestIds: ids,
+        approval_password: gateCredentials.approval_password,
+        approval_totp_code: gateCredentials.approval_totp_code,
+      });
       await refreshStateAfterAction();
-      if (failed > 0) {
+      if (result.failed.length > 0) {
+        const succeeded = result.resolved_count;
+        const failed = result.failed.length;
         throw new Error(
-          failed === results.length
+          failed === ids.length
             ? "Bulk approval failed. Retry the selected items manually."
             : `${succeeded} approved, ${failed} failed. Retry the failed items manually.`
         );
       }
-      const label = `${succeeded} item${succeeded !== 1 ? "s" : ""} approved.`;
+      const label = `${result.resolved_count} item${result.resolved_count !== 1 ? "s" : ""} approved.`;
       setResolutionMessage(label);
     } finally {
       bulkApproveInFlight.current = false;

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -90,8 +90,10 @@ import {
 } from "./queue-state";
 import {
   buildBulkGateCredentials,
+  isBulkApproveGateReady,
   QueueBulkApproveFlow,
   type BulkApproveFlowStep,
+  validateBulkApproveCredentials,
 } from "./queue-bulk-approve-flow";
 import {
   buildDecisionPayload,
@@ -630,7 +632,6 @@ function QueueBrowser(props: {
   const [selectedBulkIds, setSelectedBulkIds] = useState<Set<string>>(() => new Set());
   const [bulkApprovePassword, setBulkApprovePassword] = useState("");
   const [bulkApproveTotpCode, setBulkApproveTotpCode] = useState("");
-  const [bulkApproveUseCooldown, setBulkApproveUseCooldown] = useState(false);
   const [bulkApproveError, setBulkApproveError] = useState<string | null>(null);
   const [bulkCompletedActionCount, setBulkCompletedActionCount] = useState<number | null>(null);
   const harnesses = Array.from(new Set(props.items.map((item) => item.harness).filter(isDisplayableHarness))).sort();
@@ -707,10 +708,7 @@ function QueueBrowser(props: {
     props.onBulkApprove !== undefined &&
     (bulkEligibleGroups.length >= 2 || bulkFlowStep === "completed");
 
-  const showBulkGateFields =
-    showBulkApprove &&
-    props.approvalGate?.enabled === true &&
-    props.approvalGate.configured === true;
+  const bulkGateReady = isBulkApproveGateReady(props.approvalGate);
 
   const selectedBulkGroups = useMemo(
     () => bulkEligibleGroups.filter((group) => selectedBulkIds.has(group.primary.request_id)),
@@ -722,17 +720,19 @@ function QueueBrowser(props: {
     setSelectedBulkIds(new Set());
     setBulkApprovePassword("");
     setBulkApproveTotpCode("");
-    setBulkApproveUseCooldown(false);
     setBulkApproveError(null);
     setBulkCompletedActionCount(null);
   }, []);
 
   const handleBulkFlowStart = useCallback(() => {
+    if (!bulkGateReady) {
+      return;
+    }
     setBulkFlowStep("select");
     setSelectedBulkIds(new Set());
     setBulkApproveError(null);
     setBulkCompletedActionCount(null);
-  }, []);
+  }, [bulkGateReady]);
 
   const handleBulkSelectAll = useCallback(() => {
     setSelectedBulkIds(new Set(bulkApprovePrimaryIds(bulkEligibleGroups)));
@@ -777,21 +777,24 @@ function QueueBrowser(props: {
     setBulkApproveTotpCode(event.target.value);
   }, []);
 
-  const handleBulkApproveUseCooldownChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
-    setBulkApproveUseCooldown(event.target.checked);
-  }, []);
-
   const handleBulkConfirmApprove = useCallback(async () => {
     if (bulkFlowStep === "submitting" || bulkFlowStep === "completed" || selectedBulkGroups.length === 0) {
       return;
     }
     const ids = bulkApprovePrimaryIds(selectedBulkGroups);
     const approvedActionCount = bulkApproveActionCount(selectedBulkGroups);
+    const credentialError = validateBulkApproveCredentials(props.approvalGate, {
+      password: bulkApprovePassword,
+      totpCode: bulkApproveTotpCode,
+    });
+    if (credentialError !== null) {
+      setBulkApproveError(credentialError);
+      return;
+    }
     const gateCredentials = buildBulkGateCredentials(
-      showBulkGateFields,
+      props.approvalGate,
       bulkApprovePassword,
       bulkApproveTotpCode,
-      bulkApproveUseCooldown
     );
     setBulkFlowStep("submitting");
     setBulkApproveError(null);
@@ -801,7 +804,6 @@ function QueueBrowser(props: {
       setBulkFlowStep("completed");
       setBulkApprovePassword("");
       setBulkApproveTotpCode("");
-      setBulkApproveUseCooldown(false);
     } catch (error) {
       setBulkFlowStep("review");
       setBulkApproveError(error instanceof Error ? error.message : "Bulk approval failed.");
@@ -809,11 +811,10 @@ function QueueBrowser(props: {
   }, [
     bulkApprovePassword,
     bulkApproveTotpCode,
-    bulkApproveUseCooldown,
     bulkFlowStep,
+    props.approvalGate,
     props.onBulkApprove,
     selectedBulkGroups,
-    showBulkGateFields,
   ]);
 
   const blockEligibleGroups = useMemo(() => bulkBlockEligibleGroups(groups), [groups]);
@@ -840,9 +841,9 @@ function QueueBrowser(props: {
           completedActionCount={bulkCompletedActionCount}
           sensitiveFileReadCount={sensitiveFileReadCount}
           approvalGate={props.approvalGate ?? null}
+          settingsHref={guardAwareHref("/settings")}
           bulkApprovePassword={bulkApprovePassword}
           bulkApproveTotpCode={bulkApproveTotpCode}
-          bulkApproveUseCooldown={bulkApproveUseCooldown}
           errorMessage={bulkApproveError}
           onStart={handleBulkFlowStart}
           onSelectAll={handleBulkSelectAll}
@@ -853,7 +854,6 @@ function QueueBrowser(props: {
           onConfirmApprove={handleBulkConfirmApprove}
           onBulkApprovePasswordChange={handleBulkApprovePasswordChange}
           onBulkApproveTotpCodeChange={handleBulkApproveTotpCodeChange}
-          onBulkApproveUseCooldownChange={handleBulkApproveUseCooldownChange}
         />
       )}
       {!showBulkApprove && sensitiveFileReadCount > 0 && (

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -719,9 +719,9 @@ export function buildBulkApproveConsequenceCopy(actionCount: number): string {
     return "No read-only file reads are selected.";
   }
   if (actionCount === 1) {
-    return "Guard will allow one read-only file access and remember this retry only.";
+    return "Guard will approve once for one read-only file access. This applies to the current retry only and does not remember future reads.";
   }
-  return `Guard will allow ${actionCount} read-only file accesses. Each decision applies to this retry only, not future edits, writes, or different paths.`;
+  return `Guard will approve once for ${actionCount} read-only file accesses. Mass approval is risky: you are allowing many paths in one step without reviewing each file individually. Each decision applies to this retry only, not future edits, writes, or different paths.`;
 }
 
 export function buildCodexResumeUx(resume: GuardCodexResumeResult): CodexResumeUx {

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2020,6 +2020,44 @@ export async function resolveRequestWithQueueResult(input: {
   return normalizeQueueResolution(payload);
 }
 
+export type BulkAllowReadOnceResult = {
+  resolved_count: number;
+  failed: Array<{ request_id: string; error: string }>;
+  resolution_summary: string;
+};
+
+export async function bulkAllowReadOnce(input: {
+  requestIds: string[];
+  approval_password?: string;
+  approval_totp_code?: string;
+}): Promise<BulkAllowReadOnceResult> {
+  if (isGuardDemoMode()) {
+    return {
+      resolved_count: input.requestIds.length,
+      failed: [],
+      resolution_summary: `${input.requestIds.length} read-only file reads approved once.`,
+    };
+  }
+  const payload = await readJson<BulkAllowReadOnceResult>("/v1/requests/bulk-allow-once", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...guardAuthHeaders(),
+    },
+    body: JSON.stringify({
+      request_ids: input.requestIds,
+      ...(input.approval_password !== undefined ? { approval_password: input.approval_password } : {}),
+      ...(input.approval_totp_code !== undefined ? { approval_totp_code: input.approval_totp_code } : {}),
+      approval_gate_use_cooldown: false,
+    }),
+  });
+  return {
+    resolved_count: payload.resolved_count ?? 0,
+    failed: Array.isArray(payload.failed) ? payload.failed : [],
+    resolution_summary: payload.resolution_summary ?? "",
+  };
+}
+
 export async function clearEvidence(): Promise<void> {
   if (isGuardDemoMode()) {
     return;

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2030,6 +2030,7 @@ export async function bulkAllowReadOnce(input: {
   requestIds: string[];
   approval_password?: string;
   approval_totp_code?: string;
+  approval_gate_use_cooldown?: boolean;
 }): Promise<BulkAllowReadOnceResult> {
   if (isGuardDemoMode()) {
     return {
@@ -2048,7 +2049,7 @@ export async function bulkAllowReadOnce(input: {
       request_ids: input.requestIds,
       ...(input.approval_password !== undefined ? { approval_password: input.approval_password } : {}),
       ...(input.approval_totp_code !== undefined ? { approval_totp_code: input.approval_totp_code } : {}),
-      approval_gate_use_cooldown: false,
+      approval_gate_use_cooldown: input.approval_gate_use_cooldown ?? false,
     }),
   });
   return {

--- a/dashboard/src/queue-bulk-approve-flow.tsx
+++ b/dashboard/src/queue-bulk-approve-flow.tsx
@@ -10,6 +10,28 @@ import { bulkApproveActionCount, type QueueGroup } from "./queue-state";
 
 export type BulkApproveFlowStep = "collapsed" | "select" | "review" | "submitting" | "completed";
 
+export function isBulkApproveGateReady(
+  gate: GuardApprovalGatePublicConfig | null | undefined,
+): boolean {
+  return gate?.enabled === true && gate?.configured === true;
+}
+
+export function validateBulkApproveCredentials(
+  gate: GuardApprovalGatePublicConfig | null | undefined,
+  credentials: { password: string; totpCode: string },
+): string | null {
+  if (!isBulkApproveGateReady(gate)) {
+    return "Set up an approval password in Settings before bulk approval.";
+  }
+  if (!credentials.password.trim()) {
+    return "Enter your approval password to continue.";
+  }
+  if (gate?.totp_enabled === true && !credentials.totpCode.trim()) {
+    return "Enter your authenticator code to continue.";
+  }
+  return null;
+}
+
 export type QueueBulkApproveFlowProps = {
   step: BulkApproveFlowStep;
   eligibleGroups: QueueGroup[];
@@ -17,9 +39,9 @@ export type QueueBulkApproveFlowProps = {
   completedActionCount: number | null;
   sensitiveFileReadCount: number;
   approvalGate?: GuardApprovalGatePublicConfig | null;
+  settingsHref: string;
   bulkApprovePassword: string;
   bulkApproveTotpCode: string;
-  bulkApproveUseCooldown: boolean;
   errorMessage: string | null;
   onStart: () => void;
   onSelectAll: () => void;
@@ -30,7 +52,6 @@ export type QueueBulkApproveFlowProps = {
   onConfirmApprove: () => void;
   onBulkApprovePasswordChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onBulkApproveTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
-  onBulkApproveUseCooldownChange: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 
 export function QueueBulkApproveFlow(props: QueueBulkApproveFlowProps) {
@@ -55,10 +76,33 @@ export function QueueBulkApproveFlow(props: QueueBulkApproveFlowProps) {
 
   const selectedActionCount = bulkApproveActionCount(props.selectedGroups);
   const riskLines = summarizeBulkApproveSelection(props.selectedGroups);
-  const showBulkGateFields =
-    props.approvalGate?.enabled === true && props.approvalGate?.configured === true;
+  const gateReady = isBulkApproveGateReady(props.approvalGate);
+  const credentialError = validateBulkApproveCredentials(props.approvalGate, {
+    password: props.bulkApprovePassword,
+    totpCode: props.bulkApproveTotpCode,
+  });
+  const confirmDisabled =
+    props.step === "submitting" ||
+    (props.step === "review" && credentialError !== null);
 
   if (props.step === "collapsed") {
+    if (!gateReady) {
+      return (
+        <div className="mb-4 rounded-xl border border-brand-attention/20 bg-brand-attention/[0.04] px-4 py-3">
+          <p className="text-sm font-semibold text-brand-dark">Bulk approve once requires an approval password</p>
+          <p className="mt-1 text-xs leading-5 text-brand-dark/70">
+            Set up your local approval gate before allowing multiple read-only file reads in one pass.
+            Bulk approval always uses approve once and cannot remember future reads.
+          </p>
+          <a
+            href={props.settingsHref}
+            className="mt-3 inline-flex rounded-full border border-brand-blue/30 bg-white px-4 py-2 text-sm font-medium text-brand-blue no-underline transition-colors hover:bg-brand-blue/5"
+          >
+            Open Settings
+          </a>
+        </div>
+      );
+    }
     return (
       <div className="mb-4 space-y-2">
         <button
@@ -66,7 +110,7 @@ export function QueueBulkApproveFlow(props: QueueBulkApproveFlowProps) {
           onClick={props.onStart}
           className="rounded-full border border-brand-blue/30 bg-white px-4 py-2 text-sm font-medium text-brand-blue shadow-sm transition-colors hover:bg-brand-blue/5"
         >
-          Approve multiple read-only reads
+          Approve once for multiple read-only reads
         </button>
         {props.sensitiveFileReadCount > 0 && (
           <p className="text-xs text-brand-attention">
@@ -90,7 +134,7 @@ export function QueueBulkApproveFlow(props: QueueBulkApproveFlowProps) {
   const confirmLabel =
     props.step === "submitting"
       ? "Approving..."
-      : `Approve ${selectedActionCount} read-only ${selectedUnit}`;
+      : `Approve once (${selectedActionCount} ${selectedUnit})`;
 
   return (
     <div className="mb-4 space-y-3 rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
@@ -181,8 +225,16 @@ export function QueueBulkApproveFlow(props: QueueBulkApproveFlowProps) {
               </p>
             </div>
           )}
-          {showBulkGateFields && (
+          <div className="flex items-start gap-2 rounded-lg border border-brand-attention/20 bg-brand-attention/[0.04] px-3 py-2">
+            <HiMiniExclamationTriangle className="mt-0.5 h-4 w-4 shrink-0 text-brand-attention" aria-hidden="true" />
+            <p className="text-xs leading-5 text-brand-dark/80">
+              Mass approval is risky. You are allowing multiple file reads without opening each request. Bulk approval
+              only supports approve once and never remembers future reads.
+            </p>
+          </div>
+          {gateReady && (
             <div className="space-y-2 rounded-lg border border-slate-200 bg-slate-50 px-3 py-2">
+              <p className="text-xs font-medium text-brand-dark">Confirm with your approval password</p>
               <label className="block">
                 <span className="sr-only">Approval password</span>
                 <input
@@ -210,18 +262,6 @@ export function QueueBulkApproveFlow(props: QueueBulkApproveFlowProps) {
                   />
                 </label>
               )}
-              {(props.approvalGate?.cooldown_seconds ?? 0) > 0 && props.approvalGate?.totp_enabled !== true && (
-                <label className="flex items-center gap-2 text-xs text-slate-600">
-                  <input
-                    type="checkbox"
-                    checked={props.bulkApproveUseCooldown}
-                    onChange={props.onBulkApproveUseCooldownChange}
-                    disabled={props.step === "submitting"}
-                    className="rounded"
-                  />
-                  Skip password for next approvals (use cooldown)
-                </label>
-              )}
             </div>
           )}
           {props.errorMessage !== null && (
@@ -233,7 +273,7 @@ export function QueueBulkApproveFlow(props: QueueBulkApproveFlowProps) {
             <button
               type="button"
               onClick={props.onConfirmApprove}
-              disabled={props.step === "submitting"}
+              disabled={confirmDisabled}
               className="rounded-full bg-brand-blue px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-brand-blue/90 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {confirmLabel}
@@ -262,17 +302,16 @@ export function QueueBulkApproveFlow(props: QueueBulkApproveFlowProps) {
 }
 
 export function buildBulkGateCredentials(
-  showGateFields: boolean,
+  gate: GuardApprovalGatePublicConfig | null | undefined,
   password: string,
   totpCode: string,
-  useCooldown: boolean
 ): BulkGateCredentials | undefined {
-  if (!showGateFields) {
+  if (!isBulkApproveGateReady(gate)) {
     return undefined;
   }
   return {
-    approval_password: password,
-    approval_totp_code: totpCode,
-    approval_gate_use_cooldown: useCooldown,
+    approval_password: password.trim(),
+    approval_totp_code: totpCode.trim(),
+    approval_gate_use_cooldown: false,
   };
 }

--- a/dashboard/src/queue-bulk-approve.test.ts
+++ b/dashboard/src/queue-bulk-approve.test.ts
@@ -3,7 +3,12 @@ import {
   buildBulkApproveConsequenceCopy,
   summarizeBulkApproveSelection,
 } from "./approval-center-utils";
-import { buildBulkGateCredentials } from "./queue-bulk-approve-flow";
+import type { GuardApprovalGatePublicConfig } from "./guard-types";
+import {
+  buildBulkGateCredentials,
+  isBulkApproveGateReady,
+  validateBulkApproveCredentials,
+} from "./queue-bulk-approve-flow";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -73,19 +78,39 @@ assert(summary[0].path === "src/index.ts", "T-BULK-02: summarizeBulkApproveSelec
 assert(summary[1].duplicateCount === 1, "T-BULK-03: summarizeBulkApproveSelection preserves duplicate count");
 
 assert(
-  buildBulkApproveConsequenceCopy(2).includes("2 read-only file accesses"),
-  "T-BULK-04: buildBulkApproveConsequenceCopy pluralizes selected action count"
+  buildBulkApproveConsequenceCopy(2).includes("Mass approval is risky"),
+  "T-BULK-04: buildBulkApproveConsequenceCopy warns about mass approval"
 );
 
 assert(
-  buildBulkApproveConsequenceCopy(1).includes("one read-only file access"),
-  "T-BULK-05: buildBulkApproveConsequenceCopy handles single selection"
+  buildBulkApproveConsequenceCopy(1).includes("approve once"),
+  "T-BULK-05: buildBulkApproveConsequenceCopy handles single selection with approve once copy"
 );
 
-const gateCredentials = buildBulkGateCredentials(true, "secret", "123456", true);
-assert(gateCredentials?.approval_password === "secret", "T-BULK-06: buildBulkGateCredentials includes password when gate fields are shown");
-assert(gateCredentials?.approval_gate_use_cooldown === true, "T-BULK-07: buildBulkGateCredentials includes cooldown preference");
+const readyGate: GuardApprovalGatePublicConfig = {
+  enabled: true,
+  configured: true,
+  cooldown_seconds: 900,
+  cooldown_active: false,
+  cooldown_expires_at: null,
+  locked_until: null,
+  fail_closed: false,
+  strict_all_decisions: false,
+  totp_enabled: false,
+  totp_pending: false,
+};
 
-assert(buildBulkGateCredentials(false, "secret", "", false) === undefined, "T-BULK-08: buildBulkGateCredentials omits credentials when gate fields are hidden");
+assert(isBulkApproveGateReady(readyGate) === true, "T-BULK-06: gate ready when enabled and configured");
+assert(isBulkApproveGateReady({ ...readyGate, configured: false }) === false, "T-BULK-07: gate not ready without password");
+assert(
+  validateBulkApproveCredentials(readyGate, { password: "", totpCode: "" }) !== null,
+  "T-BULK-08: validateBulkApproveCredentials rejects empty password",
+);
+
+const gateCredentials = buildBulkGateCredentials(readyGate, "secret", "123456");
+assert(gateCredentials?.approval_password === "secret", "T-BULK-09: buildBulkGateCredentials includes password when gate is ready");
+assert(gateCredentials?.approval_gate_use_cooldown === false, "T-BULK-10: buildBulkGateCredentials never enables cooldown for bulk");
+
+assert(buildBulkGateCredentials(null, "secret", "") === undefined, "T-BULK-11: buildBulkGateCredentials omits credentials when gate is not ready");
 
 console.log("queue-bulk-approve.test.ts: all tests passed");

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1385,6 +1385,220 @@ def _runtime_headline_detail(headline_state: str) -> str:
     return details.get(headline_state, "This machine is protected locally.")
 
 
+_BULK_SECRET_TEXT_HINTS = (
+    "credential",
+    "secret",
+    ".env",
+    "token",
+    "api key",
+    "apikey",
+    "password",
+    "private key",
+    "ssh key",
+    "aws_access_key",
+    "github_token",
+)
+
+
+def _bulk_queue_category_text(request: Mapping[str, object]) -> str:
+    envelope = request.get("action_envelope_json")
+    envelope_fields: list[str] = []
+    if isinstance(envelope, dict):
+        for key in (
+            "action_type",
+            "command",
+            "tool_name",
+            "prompt_excerpt",
+            "mcp_server",
+            "mcp_tool",
+            "package_manager",
+            "package_name",
+            "script_name",
+        ):
+            value = envelope.get(key)
+            if isinstance(value, str) and value:
+                envelope_fields.append(value)
+        target_paths = envelope.get("target_paths")
+        if isinstance(target_paths, list):
+            envelope_fields.extend(str(path) for path in target_paths if isinstance(path, str))
+        decision_signals = envelope.get("signals")
+        if isinstance(decision_signals, list):
+            for signal in decision_signals:
+                if isinstance(signal, dict):
+                    for key in ("category", "title", "plain_reason"):
+                        value = signal.get(key)
+                        if isinstance(value, str) and value:
+                            envelope_fields.append(value)
+    return " ".join(
+        [
+            str(request.get("artifact_name") or ""),
+            str(request.get("artifact_type") or ""),
+            str(request.get("risk_headline") or ""),
+            str(request.get("risk_summary") or ""),
+            str(request.get("trigger_summary") or ""),
+            str(request.get("launch_summary") or ""),
+            str(request.get("why_now") or ""),
+            str(request.get("launch_target") or ""),
+            *_string_list(request.get("risk_signals")),
+            *envelope_fields,
+        ]
+    )
+
+
+def _bulk_decision_v2_categories(request: Mapping[str, object]) -> tuple[str, ...]:
+    decision_v2 = request.get("decision_v2_json")
+    if not isinstance(decision_v2, dict):
+        return ()
+    signals = decision_v2.get("signals")
+    if not isinstance(signals, list):
+        return ()
+    categories: list[str] = []
+    for signal in signals:
+        if isinstance(signal, dict):
+            category = signal.get("category")
+            if isinstance(category, str) and category:
+                categories.append(category)
+    return tuple(categories)
+
+
+def _bulk_has_secret_signal(request: Mapping[str, object]) -> bool:
+    categories = _bulk_decision_v2_categories(request)
+    if "secret" in categories:
+        return True
+    lowered = _bulk_queue_category_text(request).lower()
+    return any(hint in lowered for hint in _BULK_SECRET_TEXT_HINTS)
+
+
+def _bulk_read_command(command: str) -> bool:
+    import re
+
+    return re.search(r"\b(?:cat|grep|rg|sed\s+-n|awk|less|more|head|tail)\b", command.lower()) is not None
+
+
+def _bulk_has_secret_path_text(text: str) -> bool:
+    lowered = text.lower()
+    return any(
+        hint in lowered
+        for hint in (".env", "token", "secret", "credential", "password", "private key", "api key")
+    )
+
+
+def _bulk_is_file_read_request(request: Mapping[str, object]) -> bool:
+    envelope = request.get("action_envelope_json")
+    artifact_type = str(request.get("artifact_type") or "")
+    if isinstance(envelope, dict) and envelope.get("action_type") == "file_read":
+        return True
+    if artifact_type == "file_read_request":
+        return True
+    command = ""
+    if isinstance(envelope, dict):
+        command = str(envelope.get("command") or "")
+    command = command or str(request.get("launch_target") or "")
+    return _bulk_read_command(command) and _bulk_has_secret_path_text(_bulk_queue_category_text(request))
+
+
+def _bulk_target_paths_are_secret(request: Mapping[str, object]) -> bool:
+    from .runtime.secret_sensitivity import classify_secret_path
+
+    envelope = request.get("action_envelope_json")
+    if not isinstance(envelope, dict):
+        return False
+    target_paths = envelope.get("target_paths")
+    if not isinstance(target_paths, list):
+        return False
+    for path in target_paths:
+        if isinstance(path, str) and classify_secret_path(path) is not None:
+            return True
+    return False
+
+
+def _is_sensitive_file_read_request(request: Mapping[str, object]) -> bool:
+    if not _bulk_is_file_read_request(request):
+        return False
+    if _bulk_target_paths_are_secret(request):
+        return True
+    envelope = request.get("action_envelope_json")
+    command = ""
+    if isinstance(envelope, dict):
+        command = str(envelope.get("command") or "")
+    command = command or str(request.get("launch_target") or "")
+    text = _bulk_queue_category_text(request)
+    secret_read_action = (
+        (isinstance(envelope, dict) and envelope.get("action_type") == "file_read")
+        or str(request.get("artifact_type") or "") == "file_read_request"
+        or (_bulk_read_command(command) and _bulk_has_secret_path_text(text))
+    )
+    return secret_read_action and _bulk_has_secret_signal(request)
+
+
+def is_bulk_allow_once_eligible(request: Mapping[str, object]) -> bool:
+    if str(request.get("status") or "") != "pending":
+        return False
+    if str(request.get("policy_action") or "") == "block":
+        return False
+    envelope = request.get("action_envelope_json")
+    artifact_type = str(request.get("artifact_type") or "")
+    is_file_read = (
+        isinstance(envelope, dict) and envelope.get("action_type") == "file_read"
+    ) or artifact_type == "file_read_request"
+    if not is_file_read:
+        return False
+    return not _is_sensitive_file_read_request(request)
+
+
+def bulk_allow_read_only_once(
+    *,
+    store: GuardStore,
+    request_ids: Sequence[str],
+    approval_gate_input: ApprovalGateInput | None,
+    now: str | None = None,
+) -> dict[str, object]:
+    from .approval_gate import public_config
+
+    resolved_at = now or _now()
+    gate = public_config(store.guard_home, now=resolved_at)
+    if not gate.enabled or not gate.configured:
+        raise ValueError("bulk_approve_gate_required")
+
+    resolved_count = 0
+    failed: list[dict[str, str]] = []
+    gate_input_for_request = approval_gate_input
+
+    for request_id in request_ids:
+        if not isinstance(request_id, str) or not request_id.strip():
+            failed.append({"request_id": str(request_id), "error": "invalid_request_id"})
+            continue
+        normalized_id = request_id.strip()
+        request = store.get_approval_request(normalized_id)
+        if request is None or not is_bulk_allow_once_eligible(request):
+            failed.append({"request_id": normalized_id, "error": "ineligible"})
+            continue
+        try:
+            apply_approval_resolution(
+                store=store,
+                request_id=normalized_id,
+                action="allow",
+                scope="artifact",
+                workspace=None,
+                reason="bulk approve once",
+                now=resolved_at,
+                return_queue_result=False,
+                resolve_scope_matches=True,
+                approval_gate_input=gate_input_for_request,
+                persist_policy=False,
+            )
+            resolved_count += 1
+            gate_input_for_request = None
+        except (ApprovalRequestNotFoundError, ApprovalRequestAlreadyResolvedError, ValueError) as error:
+            failed.append({"request_id": normalized_id, "error": str(error)})
+
+    return {
+        "resolved_count": resolved_count,
+        "failed": failed,
+        "resolution_summary": f"{resolved_count} read-only file reads approved once.",
+    }
+
+
 def _optional_string(value: object) -> str | None:
     return value if isinstance(value, str) and value else None
 

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1517,18 +1517,7 @@ def _is_sensitive_file_read_request(request: Mapping[str, object]) -> bool:
         return False
     if _bulk_target_paths_are_secret(request):
         return True
-    envelope = request.get("action_envelope_json")
-    command = ""
-    if isinstance(envelope, dict):
-        command = str(envelope.get("command") or "")
-    command = command or str(request.get("launch_target") or "")
-    text = _bulk_queue_category_text(request)
-    secret_read_action = (
-        (isinstance(envelope, dict) and envelope.get("action_type") == "file_read")
-        or str(request.get("artifact_type") or "") == "file_read_request"
-        or (_bulk_read_command(command) and _bulk_has_secret_path_text(text))
-    )
-    return secret_read_action and _bulk_has_secret_signal(request)
+    return _bulk_has_secret_signal(request)
 
 
 def is_bulk_allow_once_eligible(request: Mapping[str, object]) -> bool:
@@ -1562,7 +1551,6 @@ def bulk_allow_read_only_once(
 
     resolved_count = 0
     failed: list[dict[str, str]] = []
-    gate_input_for_request = approval_gate_input
 
     for request_id in request_ids:
         if not isinstance(request_id, str) or not request_id.strip():
@@ -1584,11 +1572,10 @@ def bulk_allow_read_only_once(
                 now=resolved_at,
                 return_queue_result=False,
                 resolve_scope_matches=True,
-                approval_gate_input=gate_input_for_request,
+                approval_gate_input=approval_gate_input,
                 persist_policy=False,
             )
             resolved_count += 1
-            gate_input_for_request = None
         except (ApprovalRequestNotFoundError, ApprovalRequestAlreadyResolvedError, ValueError) as error:
             failed.append({"request_id": normalized_id, "error": str(error)})
 

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1506,10 +1506,12 @@ def _bulk_target_paths_are_secret(request: Mapping[str, object]) -> bool:
     target_paths = envelope.get("target_paths")
     if not isinstance(target_paths, list):
         return False
-    for path in target_paths:
-        if isinstance(path, str) and classify_secret_path(path) is not None:
-            return True
-    return False
+    workspace = envelope.get("workspace")
+    workspace_dir = Path(str(workspace)).expanduser() if isinstance(workspace, str) and workspace else None
+    path_context = {"cwd": workspace_dir}
+    return any(
+        isinstance(path, str) and classify_secret_path(path, **path_context) is not None for path in target_paths
+    )
 
 
 def _is_sensitive_file_read_request(request: Mapping[str, object]) -> bool:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1478,8 +1478,7 @@ def _bulk_read_command(command: str) -> bool:
 def _bulk_has_secret_path_text(text: str) -> bool:
     lowered = text.lower()
     return any(
-        hint in lowered
-        for hint in (".env", "token", "secret", "credential", "password", "private key", "api key")
+        hint in lowered for hint in (".env", "token", "secret", "credential", "password", "private key", "api key")
     )
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3057,11 +3057,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not isinstance(request_ids, list) or len(request_ids) == 0:
             self._write_json({"error": "missing_request_ids", "resolved_count": 0, "failed": []}, status=400)
             return
-        normalized_ids = [
-            str(item).strip()
-            for item in request_ids
-            if isinstance(item, str) and str(item).strip()
-        ]
+        normalized_ids = [str(item).strip() for item in request_ids if isinstance(item, str) and str(item).strip()]
         if len(normalized_ids) == 0:
             self._write_json({"error": "missing_request_ids", "resolved_count": 0, "failed": []}, status=400)
             return

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -53,8 +53,8 @@ from ..approvals import (
     ApprovalRequestAlreadyResolvedError,
     ApprovalRequestNotFoundError,
     apply_approval_resolution,
-    bulk_allow_read_only_once,
     build_runtime_snapshot,
+    bulk_allow_read_only_once,
 )
 from ..cli.connect_flow import (
     CONNECT_SYNC_AUTH_CONTEXT_KEY,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -53,6 +53,7 @@ from ..approvals import (
     ApprovalRequestAlreadyResolvedError,
     ApprovalRequestNotFoundError,
     apply_approval_resolution,
+    bulk_allow_read_only_once,
     build_runtime_snapshot,
 )
 from ..cli.connect_flow import (
@@ -1392,6 +1393,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/requests/clear":
             self._handle_requests_clear(payload)
+            return
+        if parsed.path == "/v1/requests/bulk-allow-once":
+            self._handle_bulk_allow_read_once(payload)
             return
         if parsed.path == "/v1/policy/sync":
             self._handle_headless_policy_sync(payload)
@@ -3048,6 +3052,45 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         self._write_json({"cleared": cleared, "status": status, "harness": harness})
 
+    def _handle_bulk_allow_read_once(self, payload: dict[str, object]) -> None:
+        request_ids = payload.get("request_ids")
+        if not isinstance(request_ids, list) or len(request_ids) == 0:
+            self._write_json({"error": "missing_request_ids", "resolved_count": 0, "failed": []}, status=400)
+            return
+        normalized_ids = [
+            str(item).strip()
+            for item in request_ids
+            if isinstance(item, str) and str(item).strip()
+        ]
+        if len(normalized_ids) == 0:
+            self._write_json({"error": "missing_request_ids", "resolved_count": 0, "failed": []}, status=400)
+            return
+        try:
+            result = bulk_allow_read_only_once(
+                store=self.server.store,  # type: ignore[attr-defined]
+                request_ids=normalized_ids,
+                approval_gate_input=approval_gate_input_from_mapping(payload),
+            )
+        except ValueError as error:
+            if str(error) == "bulk_approve_gate_required":
+                self._write_json(
+                    {"error": str(error), "resolved_count": 0, "failed": []},
+                    status=403,
+                )
+                return
+            self._write_json(
+                {"error": str(error), "resolved_count": 0, "failed": []},
+                status=400,
+            )
+            return
+        except ApprovalGateError as error:
+            error_payload = error.to_payload()
+            error_payload.setdefault("resolved_count", 0)
+            error_payload.setdefault("failed", [])
+            self._write_json(error_payload, status=error.status)
+            return
+        self._write_json(result)
+
     def _harness_context(self, payload: dict[str, object]) -> HarnessContext:
         del payload
         return HarnessContext(
@@ -3982,6 +4025,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/operations/block",
             "/v1/policy/sync",
             "/v1/requests/clear",
+            "/v1/requests/bulk-allow-once",
             "/v1/requests/remote-once",
             "/v1/settings/import",
             "/v1/settings/reset",
@@ -4625,6 +4669,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/policy/clear",
             "/v1/policy/sync",
             "/v1/requests/clear",
+            "/v1/requests/bulk-allow-once",
             "/v1/requests/remote-once",
             "/v1/settings",
             "/v1/settings/import",

--- a/tests/test_guard_bulk_allow_once.py
+++ b/tests/test_guard_bulk_allow_once.py
@@ -244,6 +244,29 @@ def test_bulk_allow_read_only_once_resolves_plain_reads_only(tmp_path: Path) -> 
     assert store.get_approval_request("req-secret")["status"] == "pending"
 
 
+def test_bulk_allow_read_only_once_resolves_multiple_plain_reads(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    plain1 = _file_read_request("req-plain-1")
+    plain2 = _file_read_request("req-plain-2")
+    store.add_approval_request(plain1, "2026-06-16T00:00:00+00:00")
+    store.add_approval_request(plain2, "2026-06-16T00:00:00+00:00")
+
+    result = bulk_allow_read_only_once(
+        store=store,
+        request_ids=["req-plain-1", "req-plain-2"],
+        approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        now="2026-06-16T00:01:00+00:00",
+    )
+
+    assert result["resolved_count"] == 2
+    failed = result["failed"]
+    assert isinstance(failed, list)
+    assert len(failed) == 0
+    assert store.get_approval_request("req-plain-1")["status"] == "resolved"
+    assert store.get_approval_request("req-plain-2")["status"] == "resolved"
+
+
 def test_bulk_allow_read_once_daemon_route(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store)

--- a/tests/test_guard_bulk_allow_once.py
+++ b/tests/test_guard_bulk_allow_once.py
@@ -1,0 +1,275 @@
+"""Bulk allow-once eligibility and resolution behavior."""
+
+from __future__ import annotations
+
+import json
+import urllib.request
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.approval_gate import ApprovalGateInput, update_settings as update_approval_gate_settings
+from codex_plugin_scanner.guard.approvals import (
+    bulk_allow_read_only_once,
+    is_bulk_allow_once_eligible,
+)
+from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.store import GuardStore
+
+PASSWORD = "bulk-approve-password"
+
+
+def _store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard-home")
+
+
+def _enable_gate(store: GuardStore) -> None:
+    update_approval_gate_settings(
+        store.guard_home,
+        {
+            "enabled": True,
+            "new_password": PASSWORD,
+            "confirm_password": PASSWORD,
+            "cooldown_seconds": 0,
+        },
+    )
+
+
+def _file_read_request(
+    request_id: str,
+    *,
+    target_path: str = "src/index.ts",
+    artifact_type: str = "command",
+    policy_action: str = "require-reapproval",
+    risk_summary: str | None = None,
+    decision_v2_json: dict[str, object] | None = None,
+) -> GuardApprovalRequest:
+    return GuardApprovalRequest(
+        request_id=request_id,
+        harness="cursor",
+        artifact_id=f"cursor:project:{request_id}",
+        artifact_name="file read",
+        artifact_type=artifact_type,
+        artifact_hash=f"hash-{request_id}",
+        policy_action=policy_action,
+        recommended_scope="artifact",
+        changed_fields=("file_read",),
+        source_scope="project",
+        config_path="/repo/.cursor/config.toml",
+        review_command=f"hol-guard approvals approve {request_id}",
+        approval_url=f"http://127.0.0.1:5474/requests/{request_id}",
+        risk_summary=risk_summary,
+        decision_v2_json=decision_v2_json,
+        action_envelope_json={
+            "schema_version": 1,
+            "action_id": request_id,
+            "harness": "cursor",
+            "event_name": "tool_call",
+            "action_type": "file_read",
+            "workspace": "/repo",
+            "workspace_hash": "workspace-hash",
+            "tool_name": "Read",
+            "command": None,
+            "prompt_excerpt": None,
+            "target_paths": [target_path],
+            "network_hosts": [],
+            "mcp_server": None,
+            "mcp_tool": None,
+            "package_manager": None,
+            "package_name": None,
+            "script_name": None,
+            "raw_payload_redacted": {},
+        },
+    )
+
+
+def store_request_dict(request: GuardApprovalRequest) -> dict[str, object]:
+    payload = request.to_dict()
+    return {str(key): value for key, value in payload.items()}
+
+
+def test_is_bulk_allow_once_eligible_plain_file_read(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    plain = _file_read_request("req-plain")
+    store.add_approval_request(plain, "2026-06-16T00:00:00+00:00")
+    stored = store.get_approval_request("req-plain")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is True
+
+
+def test_is_bulk_allow_once_eligible_file_read_request_artifact_type(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    request = _file_read_request("req-artifact-type", artifact_type="file_read_request")
+    store.add_approval_request(request, "2026-06-16T00:00:00+00:00")
+    stored = store.get_approval_request("req-artifact-type")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is True
+
+
+def test_is_bulk_allow_once_eligible_rejects_secret_file_read(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    secret = _file_read_request(
+        "req-secret",
+        target_path=".env",
+        risk_summary="reads .env file containing credentials",
+        decision_v2_json={
+            "action": "ask",
+            "reason": "secret read",
+            "signals": [
+                {
+                    "signal_id": "sec-001",
+                    "category": "secret",
+                    "severity": "high",
+                    "confidence": "strong",
+                    "detector": "secret.read",
+                    "title": "Secret file read",
+                    "plain_reason": "reads .env file",
+                }
+            ],
+        },
+    )
+    store.add_approval_request(secret, "2026-06-16T00:00:00+00:00")
+    stored = store.get_approval_request("req-secret")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is False
+
+
+def test_is_bulk_allow_once_eligible_rejects_secret_path_without_signal(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    secret_path = _file_read_request("req-secret-path", target_path=".env")
+    store.add_approval_request(secret_path, "2026-06-16T00:00:00+00:00")
+    stored = store.get_approval_request("req-secret-path")
+    assert stored is not None
+    assert is_bulk_allow_once_eligible(stored) is False
+
+
+def test_is_bulk_allow_once_eligible_rejects_blocked_and_shell(tmp_path: Path) -> None:
+    blocked = store_request_dict(_file_read_request("req-blocked", policy_action="block"))
+    shell = store_request_dict(
+        GuardApprovalRequest(
+            request_id="req-shell",
+            harness="cursor",
+            artifact_id="cursor:project:shell",
+            artifact_name="Shell command",
+            artifact_type="command",
+            artifact_hash="hash-shell",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("shell_command",),
+            source_scope="project",
+            config_path="/repo/.cursor/config.toml",
+            review_command="hol-guard approvals approve req-shell",
+            approval_url="http://127.0.0.1:5474/requests/req-shell",
+            action_envelope_json={
+                "schema_version": 1,
+                "action_id": "req-shell",
+                "harness": "cursor",
+                "event_name": "tool_call",
+                "action_type": "shell_command",
+                "workspace": "/repo",
+                "workspace_hash": "workspace-hash",
+                "tool_name": "Bash",
+                "command": "ls -la",
+                "prompt_excerpt": None,
+                "target_paths": [],
+                "network_hosts": [],
+                "mcp_server": None,
+                "mcp_tool": None,
+                "package_manager": None,
+                "package_name": None,
+                "script_name": None,
+                "raw_payload_redacted": {},
+            },
+        )
+    )
+    assert is_bulk_allow_once_eligible(blocked) is False
+    assert is_bulk_allow_once_eligible(shell) is False
+
+
+def test_bulk_allow_read_only_once_requires_gate(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    plain = _file_read_request("req-plain")
+    store.add_approval_request(plain, "2026-06-16T00:00:00+00:00")
+
+    with pytest.raises(ValueError, match="bulk_approve_gate_required"):
+        bulk_allow_read_only_once(
+            store=store,
+            request_ids=["req-plain"],
+            approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        )
+
+
+def test_bulk_allow_read_only_once_resolves_plain_reads_only(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    plain = _file_read_request("req-plain")
+    secret = _file_read_request(
+        "req-secret",
+        target_path=".env",
+        risk_summary="reads .env file containing credentials",
+        decision_v2_json={
+            "action": "ask",
+            "reason": "secret read",
+            "signals": [
+                {
+                    "signal_id": "sec-001",
+                    "category": "secret",
+                    "severity": "high",
+                    "confidence": "strong",
+                    "detector": "secret.read",
+                    "title": "Secret file read",
+                    "plain_reason": "reads .env file",
+                }
+            ],
+        },
+    )
+    store.add_approval_request(plain, "2026-06-16T00:00:00+00:00")
+    store.add_approval_request(secret, "2026-06-16T00:00:00+00:00")
+
+    result = bulk_allow_read_only_once(
+        store=store,
+        request_ids=["req-plain", "req-secret"],
+        approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        now="2026-06-16T00:01:00+00:00",
+    )
+
+    assert result["resolved_count"] == 1
+    failed = result["failed"]
+    assert isinstance(failed, list)
+    assert len(failed) == 1
+    assert failed[0]["request_id"] == "req-secret"
+    assert failed[0]["error"] == "ineligible"
+    assert store.get_approval_request("req-plain")["status"] == "resolved"
+    assert store.get_approval_request("req-secret")["status"] == "pending"
+
+
+def test_bulk_allow_read_once_daemon_route(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    plain = _file_read_request("req-plain")
+    store.add_approval_request(plain, "2026-06-16T00:00:00+00:00")
+    daemon = GuardDaemonServer(store=store)
+    daemon.start()
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/requests/bulk-allow-once",
+            data=json.dumps(
+                {
+                    "request_ids": ["req-plain"],
+                    "approval_password": PASSWORD,
+                }
+            ).encode("utf-8"),
+            headers={
+                "Content-Type": "application/json",
+                "X-Guard-Token": daemon._server.auth_token,
+            },
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=5) as response:
+            payload = json.loads(response.read().decode("utf-8"))
+        assert payload["resolved_count"] == 1
+        assert payload["failed"] == []
+        assert store.get_approval_request("req-plain")["status"] == "resolved"
+    finally:
+        daemon.stop()


### PR DESCRIPTION
## Summary
- Route inbox bulk approve once through `/v1/requests/bulk-allow-once` with approval gate verification.
- Align bulk eligibility with dashboard read-only queue rules, excluding sensitive or secret file reads.
- Add dashboard API helper and regression tests for bulk allow-once behavior.

## Testing
- `python3 -m pytest tests/test_guard_bulk_allow_once.py -q`
- `cd dashboard && pnpm test -- queue-bulk-approve.test.ts`
- `cd dashboard && pnpm run build`
