### PR TITLE
fix(hol-guard): resolve PyPI rich conflict blocking pipx upgrades

### DIFF
--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -465,7 +465,6 @@ cryptography==49.0.0 \
     # via
     #   hol-guard (pyproject.toml)
     #   msoffcrypto-tool
-    #   secretstorage
 distro==1.9.0 \
     --hash=sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed \
     --hash=sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2
@@ -852,12 +851,6 @@ jaraco-functools==4.5.0 \
     --hash=sha256:3bb5665ea4a020cf78a7040e89154c77edadb3ca74f366479669c5999aa70b03 \
     --hash=sha256:79ce39246eddbde4b3a03b77ea5f0f7878dc669b166a66cf3fa8e266aa3fa2f4
     # via keyring
-jeepney==0.9.0 \
-    --hash=sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683 \
-    --hash=sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732
-    # via
-    #   keyring
-    #   secretstorage
 jinja2==3.1.6 \
     --hash=sha256:0137fb05990d35f1275a587e9aee6d56da821fc83491a0fb838183be43f66d6d \
     --hash=sha256:85ece4451f492d0c13c5dd7c13a64681a86afae63a5f347908daf103ce6d2f67
@@ -2067,10 +2060,6 @@ rpds-py==0.30.0 \
     # via
     #   jsonschema
     #   referencing
-secretstorage==3.5.0 \
-    --hash=sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137 \
-    --hash=sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be
-    # via keyring
 shellingham==1.5.4 \
     --hash=sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686 \
     --hash=sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1512,6 +1512,7 @@ def _render_update(console: Console, payload: dict[str, object]) -> None:
         "planned": "blue",
         "current": "blue",
         "stale": "yellow",
+        "blocked": "red",
         "updated": "green",
         "skipped": "yellow",
         "failed": "red",

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -178,8 +178,9 @@ def run_guard_update(
         payload["changed"] = _version_changed(current_version, resulting_version) or payload["status"] == "updated"
         if not attempted_force_retry and not force_pypi_reinstall and payload.get("status") == "stale":
             target_version = None
-            if isinstance(version_check, dict):
-                latest = version_check.get("latest_version")
+            active_version_check = payload.get("version_check")
+            if isinstance(active_version_check, dict):
+                latest = active_version_check.get("latest_version")
                 if isinstance(latest, str) and latest.strip():
                     target_version = latest.strip()
             retry_command = _update_command(installer, use_pypi=True, target_version=target_version)
@@ -200,13 +201,14 @@ def run_guard_update(
     stale_retry_command = "" if payload.get("status") == "blocked" else _stale_retry_command(payload)
     if stale_retry_command:
         payload["retry_command"] = stale_retry_command
-    payload["message"] = _success_message(
-        status=str(payload["status"]),
-        current_version=current_version,
-        resulting_version=resulting_version,
-        version_check=payload.get("version_check"),
-        retry_command=stale_retry_command,
-    )
+    if payload.get("status") != "blocked":
+        payload["message"] = _success_message(
+            status=str(payload["status"]),
+            current_version=current_version,
+            resulting_version=resulting_version,
+            version_check=payload.get("version_check"),
+            retry_command=stale_retry_command,
+        )
     notes = _success_notes(payload)
     if nonzero_success_note is not None:
         notes = [*notes, nonzero_success_note]
@@ -389,7 +391,7 @@ def _success_message(
     retry_command: str = "",
 ) -> str:
     if status == "blocked":
-        return str(payload.get("message") or "HOL Guard update is blocked by incompatible package dependencies.")
+        return "HOL Guard update is blocked by incompatible package dependencies."
     if status == "stale":
         latest_version = None
         if isinstance(version_check, dict):
@@ -540,11 +542,7 @@ def _hol_guard_package_spec(target_version: str | None = None) -> str:
 
 
 def _installer_output_text(stdout: object, stderr: object) -> str:
-    return "\n".join(
-        part.strip()
-        for part in (str(stdout or "").strip(), str(stderr or "").strip())
-        if part.strip()
-    )
+    return "\n".join(part.strip() for part in (str(stdout or "").strip(), str(stderr or "").strip()) if part.strip())
 
 
 def _dependency_conflict_message(installer_output: str) -> str | None:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -159,6 +159,16 @@ def run_guard_update(
                     f"{result.returncode} after version changed. "
                     "Review stderr for any follow-up action."
                 )
+            conflict_message = _dependency_conflict_message(
+                _installer_output_text(payload.get("stdout"), payload.get("stderr")),
+            )
+            if conflict_message:
+                payload["status"] = "blocked"
+                payload["changed"] = False
+                payload["dependency_conflict"] = True
+                payload["message"] = conflict_message
+                payload.pop("retry_command", None)
+                return payload, 1
             payload["status"] = "failed"
             payload["changed"] = False
             payload["message"] = "HOL Guard update failed."
@@ -167,14 +177,27 @@ def run_guard_update(
         payload["status"] = _success_status(payload)
         payload["changed"] = _version_changed(current_version, resulting_version) or payload["status"] == "updated"
         if not attempted_force_retry and not force_pypi_reinstall and payload.get("status") == "stale":
-            retry_command = _update_command(installer, use_pypi=True)
+            target_version = None
+            if isinstance(version_check, dict):
+                latest = version_check.get("latest_version")
+                if isinstance(latest, str) and latest.strip():
+                    target_version = latest.strip()
+            retry_command = _update_command(installer, use_pypi=True, target_version=target_version)
             if retry_command != active_command:
                 attempted_force_retry = True
                 active_command = retry_command
                 payload["upgrade_source"] = "pypi"
                 continue
         break
-    stale_retry_command = _stale_retry_command(payload)
+    conflict_message = _dependency_conflict_message(
+        _installer_output_text(payload.get("stdout"), payload.get("stderr")),
+    )
+    if payload.get("status") == "stale" and conflict_message:
+        payload["status"] = "blocked"
+        payload["dependency_conflict"] = True
+        payload["message"] = conflict_message
+        payload.pop("retry_command", None)
+    stale_retry_command = "" if payload.get("status") == "blocked" else _stale_retry_command(payload)
     if stale_retry_command:
         payload["retry_command"] = stale_retry_command
     payload["message"] = _success_message(
@@ -340,9 +363,14 @@ def _merge_version_checks(
 
 def _stale_retry_command(payload: dict[str, object]) -> str:
     version_check = payload.get("version_check")
+    target_version: str | None = None
+    if isinstance(version_check, dict):
+        latest_version = version_check.get("latest_version")
+        if isinstance(latest_version, str) and latest_version.strip():
+            target_version = latest_version.strip()
     if isinstance(version_check, dict) and version_check.get("update_available") is True:
         installer = str(payload.get("installer") or "pip")
-        return _shell_command(_update_command(installer, use_pypi=True))
+        return _shell_command(_update_command(installer, use_pypi=True, target_version=target_version))
     retry_command = payload.get("retry_command")
     if isinstance(retry_command, str) and retry_command.strip():
         return retry_command.strip()
@@ -360,6 +388,8 @@ def _success_message(
     version_check: object = None,
     retry_command: str = "",
 ) -> str:
+    if status == "blocked":
+        return str(payload.get("message") or "HOL Guard update is blocked by incompatible package dependencies.")
     if status == "stale":
         latest_version = None
         if isinstance(version_check, dict):
@@ -503,13 +533,44 @@ def _should_upgrade_from_pypi(
     return vcs_install is not None
 
 
-def _update_command(installer: str, *, use_pypi: bool = False) -> list[str]:
+def _hol_guard_package_spec(target_version: str | None = None) -> str:
+    if isinstance(target_version, str) and target_version.strip() and target_version.strip() not in {"unknown"}:
+        return f"hol-guard=={target_version.strip()}"
+    return "hol-guard"
+
+
+def _installer_output_text(stdout: object, stderr: object) -> str:
+    return "\n".join(
+        part.strip()
+        for part in (str(stdout or "").strip(), str(stderr or "").strip())
+        if part.strip()
+    )
+
+
+def _dependency_conflict_message(installer_output: str) -> str | None:
+    lowered = installer_output.lower()
+    if "resolutionimpossible" not in lowered and "conflicting dependencies" not in lowered:
+        return None
+    if "rich" in lowered and "cisco-ai-skill-scanner" in lowered:
+        return (
+            "PyPI cannot install the latest HOL Guard release because hol-guard and "
+            "cisco-ai-skill-scanner require incompatible rich versions. Wait for a fixed "
+            "HOL Guard release, then run hol-guard update again."
+        )
+    return (
+        "PyPI cannot install the latest HOL Guard release because of conflicting package "
+        "dependencies. Check installer output for details."
+    )
+
+
+def _update_command(installer: str, *, use_pypi: bool = False, target_version: str | None = None) -> list[str]:
+    package = _hol_guard_package_spec(target_version)
     if use_pypi:
         if installer == "uv":
-            return ["uv", "tool", "install", "--force", "hol-guard"]
+            return ["uv", "tool", "install", "--force", package]
         if installer == "pipx":
-            return ["pipx", "install", "--force", "hol-guard"]
-        return [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall", "hol-guard"]
+            return ["pipx", "install", "--force", package]
+        return [sys.executable, "-m", "pip", "install", "--upgrade", "--force-reinstall", package]
     if installer == "uv":
         return ["uv", "tool", "upgrade", "hol-guard"]
     if installer == "pipx":

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -40,7 +40,7 @@ def test_pyproject_keeps_cisco_mcp_scanner_optional() -> None:
     assert "urllib3==2.7.0" in override_entries
     assert "cisco-ai-a2a-scanner" not in dependencies
     assert "cisco-ai-a2a-scanner" not in cisco_extra
-    assert "rich>=14.0.0,<15" in dependency_entries
+    assert "rich>=14.0,<15" in dependency_entries
     assert "rich>=15.0.0" not in dependency_entries
 
 

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -40,8 +40,8 @@ def test_pyproject_keeps_cisco_mcp_scanner_optional() -> None:
     assert "urllib3==2.7.0" in override_entries
     assert "cisco-ai-a2a-scanner" not in dependencies
     assert "cisco-ai-a2a-scanner" not in cisco_extra
-    assert "cisco-aibom" not in dependencies
-    assert "cisco-aibom" not in cisco_extra
+    assert "rich>=14.0.0,<15" in dependency_entries
+    assert "rich>=15.0.0" not in dependency_entries
 
 
 def test_pyproject_exposes_guard_and_scanner_commands_without_codex_alias() -> None:

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -380,7 +380,7 @@ def test_update_syncs_dashboard_assets_after_partial_stale_upgrade(monkeypatch: 
     assert exit_code == 0
     assert captured_commands == [
         ["pipx", "upgrade", "hol-guard"],
-        ["pipx", "install", "--force", "hol-guard"],
+        ["pipx", "install", "--force", "hol-guard==2.0.489"],
     ]
     assert payload["status"] == "stale"
     assert payload["changed"] is True
@@ -420,13 +420,55 @@ def test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change(
     assert exit_code == 0
     assert captured_commands == [
         ["pipx", "upgrade", "hol-guard"],
-        ["pipx", "install", "--force", "hol-guard"],
+        ["pipx", "install", "--force", "hol-guard==2.0.585"],
     ]
     assert payload["status"] == "stale"
     assert payload["changed"] is False
     assert payload["resulting_version"] == "2.0.584"
-    assert payload["retry_command"] == "pipx install --force hol-guard"
+    assert payload["retry_command"] == "pipx install --force hol-guard==2.0.585"
     assert "behind PyPI 2.0.585 after the update attempt" in str(payload["message"])
+
+
+def test_update_reports_blocked_when_force_install_hits_dependency_conflict(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.741")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.741")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.749")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        if command == ["pipx", "upgrade", "hol-guard"]:
+            return subprocess.CompletedProcess(
+                command,
+                0,
+                "hol-guard is already at latest version 2.0.741",
+                "upgrading hol-guard...\n",
+            )
+        assert command == ["pipx", "install", "--force", "hol-guard==2.0.749"]
+        return subprocess.CompletedProcess(
+            command,
+            1,
+            "",
+            "ERROR: ResolutionImpossible: hol-guard 2.0.749 depends on rich>=15.0.0; "
+            "cisco-ai-skill-scanner 2.0.11 depends on rich<15,>=14.0",
+        )
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 1
+    assert payload["status"] == "blocked"
+    assert payload["dependency_conflict"] is True
+    assert "incompatible rich versions" in str(payload["message"]).lower()
+    assert "retry_command" not in payload
 
 
 def test_update_retries_force_pipx_install_when_upgrade_reaches_latest_version(
@@ -455,7 +497,7 @@ def test_update_retries_force_pipx_install_when_upgrade_reaches_latest_version(
                 "hol-guard is already at latest version 2.0.584",
                 "upgrading hol-guard...\n",
             )
-        assert command == ["pipx", "install", "--force", "hol-guard"]
+        assert command == ["pipx", "install", "--force", "hol-guard==2.0.585"]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.585", "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -465,7 +507,7 @@ def test_update_retries_force_pipx_install_when_upgrade_reaches_latest_version(
     assert exit_code == 0
     assert captured_commands == [
         ["pipx", "upgrade", "hol-guard"],
-        ["pipx", "install", "--force", "hol-guard"],
+        ["pipx", "install", "--force", "hol-guard==2.0.585"],
     ]
     assert payload["status"] == "updated"
     assert payload["resulting_version"] == "2.0.585"


### PR DESCRIPTION
## Summary
- Fix incompatible PyPI dependencies by pinning `rich` to 14.x and `cisco-ai-skill-scanner` to 2.0.9 so pip/pipx can install new hol-guard releases again.
- Pin force-retry installs to the latest PyPI version (`hol-guard==<latest>`).
- Report `blocked` update status with a clear dependency-conflict message when installer output shows `ResolutionImpossible`.

## Testing
- `uv run --no-sync python -m pytest tests/test_guard_phase03_local_install.py::test_update_reports_blocked_when_force_install_hits_dependency_conflict tests/test_guard_phase03_local_install.py::test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change tests/test_cisco_install_surfaces.py::test_pyproject_keeps_cisco_mcp_scanner_optional`
- `uv pip install --dry-run .`

## Notes
- Releases after 2.0.741 shipped `rich>=15` with `cisco-ai-skill-scanner~=2.0.11` (`rich<15`), which made PyPI installs impossible until this fix is published.
