### PR TITLE
fix(dashboard): eliminate all TypeScript typecheck errors

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,6 +17,7 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.50.0",
+    "@types/node": "^24.0.0",
     "@tailwindcss/vite": "^4.1.4",
     "@types/react": "^19.2.2",
     "@types/react-dom": "^19.2.2",

--- a/dashboard/pnpm-lock.yaml
+++ b/dashboard/pnpm-lock.yaml
@@ -26,7 +26,10 @@ importers:
         version: 1.60.0
       '@tailwindcss/vite':
         specifier: ^4.1.4
-        version: 4.2.2(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 4.2.2(vite@7.3.2(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.2
       '@types/react':
         specifier: ^19.2.2
         version: 19.2.14
@@ -35,7 +38,7 @@ importers:
         version: 19.2.3(@types/react@19.2.14)
       '@vitejs/plugin-react':
         specifier: ^5.0.4
-        version: 5.2.0(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
+        version: 5.2.0(vite@7.3.2(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))
       tailwindcss:
         specifier: ^4.1.4
         version: 4.2.2
@@ -47,7 +50,7 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.1.10
-        version: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+        version: 7.3.2(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
 packages:
 
@@ -561,6 +564,9 @@ packages:
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
+  '@types/node@24.13.2':
+    resolution: {integrity: sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -860,6 +866,9 @@ packages:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
     engines: {node: '>=14.17'}
     hasBin: true
+
+  undici-types@7.18.2:
+    resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
@@ -1263,12 +1272,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
       '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
 
-  '@tailwindcss/vite@4.2.2(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@tailwindcss/vite@4.2.2(vite@7.3.2(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@tailwindcss/node': 4.2.2
       '@tailwindcss/oxide': 4.2.2
       tailwindcss: 4.2.2
-      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
 
   '@types/babel__core@7.20.5':
     dependencies:
@@ -1293,6 +1302,10 @@ snapshots:
 
   '@types/estree@1.0.8': {}
 
+  '@types/node@24.13.2':
+    dependencies:
+      undici-types: 7.18.2
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -1301,7 +1314,7 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -1309,7 +1322,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+      vite: 7.3.2(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -1572,13 +1585,15 @@ snapshots:
 
   typescript@5.9.3: {}
 
+  undici-types@7.18.2: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.2):
     dependencies:
       browserslist: 4.28.2
       escalade: 3.2.0
       picocolors: 1.1.1
 
-  vite@7.3.2(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
+  vite@7.3.2(@types/node@24.13.2)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1587,6 +1602,7 @@ snapshots:
       rollup: 4.60.1
       tinyglobby: 0.2.16
     optionalDependencies:
+      '@types/node': 24.13.2
       fsevents: 2.3.3
       jiti: 2.6.1
       lightningcss: 1.32.0

--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode, MouseEvent, KeyboardEvent } from "react";
+import type { ReactNode, MouseEvent, KeyboardEvent as ReactKeyboardEvent } from "react";
 import { useState, useEffect, useCallback, useMemo, useRef, type ChangeEvent } from "react";
 import {
   HiMiniChevronDown,
@@ -1052,7 +1052,7 @@ function QueueCard(props: {
   const isBlocked = props.item.policy_action === "block";
   const statusDotClass = queueCardStatusDotClass(props.active, isBlocked);
   const handleKeyDown = useCallback(
-    (event: KeyboardEvent<HTMLDivElement>) => {
+    (event: ReactKeyboardEvent<HTMLDivElement>) => {
       if (event.key === "Enter" || event.key === " ") {
         event.preventDefault();
         props.onClick();
@@ -1522,7 +1522,7 @@ function DecisionWorkspace(props: {
 
   useEffect(() => {
     if (props.detail.kind !== "ready") return;
-    const onKeyDown = (event: KeyboardEvent) => {
+    const onKeyDown = (event: globalThis.KeyboardEvent) => {
       if (submitting !== null || pendingAction !== null) return;
       const target = event.target as HTMLElement;
       if (

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -328,9 +328,22 @@ export function Badge(props: {
   );
 }
 
+type TagTone =
+  | "blue"
+  | "green"
+  | "purple"
+  | "slate"
+  | "red"
+  | "amber"
+  | "attention"
+  | "default"
+  | "info"
+  | "warning"
+  | "destructive";
+
 export function Tag(props: {
   children: ReactNode;
-  tone?: "blue" | "green" | "purple" | "slate" | "red" | "attention";
+  tone?: TagTone;
 }) {
   const toneClass = tagToneClass(props.tone);
   return (
@@ -381,11 +394,13 @@ type ActionButtonProps = {
   href?: string;
   variant?: "primary" | "secondary" | "danger" | "outline" | "ghost" | "success" | "quiet";
   disabled?: boolean;
+  className?: string;
+  type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "className" | "onClick" | "type">;
 
 export const ActionButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, ActionButtonProps>(
-  ({ children, href, variant, disabled, onClick, ...buttonProps }, ref) => {
-    const className = actionButtonClass(variant);
+  ({ children, href, variant, disabled, onClick, className: customClassName, type, ...buttonProps }, ref) => {
+    const className = `${actionButtonClass(variant)}${customClassName ? ` ${customClassName}` : ""}`;
     if (href) {
       return (
         <a
@@ -393,6 +408,7 @@ export const ActionButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Ac
           href={guardAwareHref(href)}
           target={href.startsWith("https://") ? "_blank" : undefined}
           rel={href.startsWith("https://") ? "noreferrer" : undefined}
+          onClick={onClick}
           className={className}
         >
           {children}
@@ -400,7 +416,7 @@ export const ActionButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Ac
       );
     }
     return (
-      <button ref={ref as Ref<HTMLButtonElement>} type="button" className={className} onClick={onClick} disabled={disabled} {...buttonProps}>
+      <button ref={ref as Ref<HTMLButtonElement>} type={type ?? "button"} className={className} onClick={onClick} disabled={disabled} {...buttonProps}>
         {children}
       </button>
     );
@@ -592,10 +608,15 @@ function badgeToneClass(tone: "default" | "success" | "warning" | "info" | "dest
   return "border-transparent bg-gray-100 text-gray-600 border-gray-200";
 }
 
-function tagToneClass(tone: "blue" | "green" | "purple" | "slate" | "red" | "attention" | undefined): string {
+function tagToneClass(tone: TagTone | undefined): string {
   if (tone === "green") return "border-transparent bg-brand-green-bg/60 text-brand-green-text";
   if (tone === "purple") return "border-transparent bg-brand-purple/10 text-brand-purple";
+  if (tone === "destructive") return "border-transparent bg-brand-purple/10 text-brand-purple";
   if (tone === "red") return "border-transparent bg-brand-purple/10 text-brand-purple";
+  if (tone === "amber") return "border-transparent bg-amber-50 text-amber-700";
+  if (tone === "warning") return "border-transparent bg-amber-50 text-amber-700";
+  if (tone === "info") return "border-transparent bg-blue-500/10 text-blue-700";
+  if (tone === "default") return "border-gray-200 bg-gray-100 text-gray-500";
   if (tone === "slate") return "border-gray-200 bg-gray-100 text-gray-500";
   if (tone === "attention") return "border-transparent bg-brand-attention-bg text-brand-attention";
   return "border-transparent bg-blue-500/10 text-blue-700";

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -1,5 +1,5 @@
 import { forwardRef } from "react";
-import type { ButtonHTMLAttributes, ChangeEvent, ReactNode, Ref } from "react";
+import type { ButtonHTMLAttributes, AnchorHTMLAttributes, ChangeEvent, ReactNode, Ref } from "react";
 import {
   HiMiniArrowTopRightOnSquare,
   HiMiniCloud,
@@ -398,6 +398,25 @@ type ActionButtonProps = {
   type?: ButtonHTMLAttributes<HTMLButtonElement>["type"];
 } & Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "className" | "onClick" | "type">;
 
+function anchorPropsFromButtonProps(
+  props: Omit<ButtonHTMLAttributes<HTMLButtonElement>, "children" | "className" | "onClick" | "type">,
+): AnchorHTMLAttributes<HTMLAnchorElement> {
+  const {
+    disabled: _disabled,
+    form: _form,
+    formAction: _formAction,
+    formEncType: _formEncType,
+    formMethod: _formMethod,
+    formNoValidate: _formNoValidate,
+    formTarget: _formTarget,
+    name: _name,
+    value: _value,
+    type: _type,
+    ...rest
+  } = props;
+  return rest;
+}
+
 export const ActionButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, ActionButtonProps>(
   ({ children, href, variant, disabled, onClick, className: customClassName, type, ...buttonProps }, ref) => {
     const className = `${actionButtonClass(variant)}${customClassName ? ` ${customClassName}` : ""}`;
@@ -410,6 +429,7 @@ export const ActionButton = forwardRef<HTMLButtonElement | HTMLAnchorElement, Ac
           rel={href.startsWith("https://") ? "noreferrer" : undefined}
           onClick={onClick}
           className={className}
+          {...anchorPropsFromButtonProps(buttonProps)}
         >
           {children}
         </a>

--- a/dashboard/src/approval-scopes.test.ts
+++ b/dashboard/src/approval-scopes.test.ts
@@ -66,7 +66,7 @@ for (const scope of ["artifact", "publisher", "harness", "global"] as const) {
 
 const fullScopeValues = scopeChoicesForRequest(BASE_REQUEST).map((choice) => choice.value);
 assert(
-  ["artifact", "workspace", "publisher", "harness", "global"].every((scope) => fullScopeValues.includes(scope)),
+  (["artifact", "workspace", "publisher", "harness", "global"] as const).every((scope) => fullScopeValues.includes(scope)),
   "T-AS-03: requests with workspace and publisher expose all approval scope kinds"
 );
 

--- a/dashboard/src/apps/app-detail-workspace.tsx
+++ b/dashboard/src/apps/app-detail-workspace.tsx
@@ -1023,7 +1023,7 @@ function PolicyDecisionRow(props: {
   onRequestClear: (key: string) => void;
   onConfirmClear: () => void;
   onCancelClear: () => void;
-  rowConfirmRef?: RefObject<HTMLDivElement>;
+  rowConfirmRef?: RefObject<HTMLDivElement | null>;
 }) {
   const { policy, rowKey, isConfirming, inFlight, showClearButton } = props;
   const label = clearLabelForScope(policy.scope);

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -21,7 +21,12 @@ import { formatRelativeTime, harnessDisplayName } from "./approval-center-utils"
 import { runAuditRemediation, guardAwareHref } from "./guard-api";
 import { isApprovalGateRequiredError } from "./harness-action-errors";
 import type { AuditRemediationAction } from "./guard-api";
-import type { GuardApprovalGatePublicConfig, GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
+import type {
+  GuardApprovalGatePublicConfig,
+  GuardReceipt,
+  GuardRuntimeSnapshot,
+  GuardSupplyChainScannerEvidence,
+} from "./guard-types";
 import { useResolvedApprovalGate } from "./use-resolved-approval-gate";
 import { resolveManagerCoverageStatus } from "./supply-chain-protection-stats";
 import { PackageWorkbenchPanel } from "./package-workbench-panel";
@@ -49,8 +54,12 @@ export type AuditRemediationRequest = {
   label: string;
 };
 
-function isSupplyChainAuditEvidence(value: unknown): value is Record<string, unknown> & { operation: "audit" } {
-  return typeof value === "object" && value !== null && (value as Record<string, unknown>).operation === "audit";
+type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
+
+function isSupplyChainAuditEvidence(
+  value: ReceiptScannerEvidence,
+): value is GuardSupplyChainScannerEvidence & { operation: "audit" } {
+  return "operation" in value && value.operation === "audit";
 }
 
 function auditSeverityForDecision(decision: string, blockedCount: number): AuditSeverity {

--- a/dashboard/src/audit-workspace.tsx
+++ b/dashboard/src/audit-workspace.tsx
@@ -27,6 +27,7 @@ import type {
   GuardRuntimeSnapshot,
   GuardSupplyChainScannerEvidence,
 } from "./guard-types";
+import { isSupplyChainAuditEvidence } from "./guard-types";
 import { useResolvedApprovalGate } from "./use-resolved-approval-gate";
 import { resolveManagerCoverageStatus } from "./supply-chain-protection-stats";
 import { PackageWorkbenchPanel } from "./package-workbench-panel";
@@ -53,14 +54,6 @@ export type AuditRemediationRequest = {
   manager: string;
   label: string;
 };
-
-type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
-
-function isSupplyChainAuditEvidence(
-  value: ReceiptScannerEvidence,
-): value is GuardSupplyChainScannerEvidence & { operation: "audit" } {
-  return "operation" in value && value.operation === "audit";
-}
 
 function auditSeverityForDecision(decision: string, blockedCount: number): AuditSeverity {
   if (decision === "block" || blockedCount > 0) {

--- a/dashboard/src/evidence/app-tab.tsx
+++ b/dashboard/src/evidence/app-tab.tsx
@@ -11,10 +11,13 @@ import { detectCategory, getCategoryInfo } from "./categories";
 import { guardAwareHref } from "../guard-api";
 import { Sparkline } from "./sparkline";
 import { ScopedEvidenceTable } from "./scoped-evidence-table";
+import type { EvidenceDecision } from "./evidence-types";
 
 interface AppTabProps {
   receipts: GuardReceipt[];
 }
+
+type AppDecisionFilter = Extract<EvidenceDecision, "all" | "allow" | "block">;
 
 function hashString(str: string): number {
   let hash = 0;
@@ -77,7 +80,7 @@ function AppListCard({ harness, items, onSelect }: AppListCardProps) {
 function AppTabRaw({ receipts }: AppTabProps) {
   const [selectedApp, setSelectedApp] = useState<string | null>(null);
   const [searchTerm, setSearchTerm] = useState("");
-  const [decisionFilter, setDecisionFilter] = useState<string>("all");
+  const [decisionFilter, setDecisionFilter] = useState<AppDecisionFilter>("all");
   const [categoryFilter, setCategoryFilter] = useState<string>("");
 
   const appReceipts = useMemo(
@@ -133,6 +136,13 @@ function AppTabRaw({ receipts }: AppTabProps) {
 
   const handleCategoryFilter = useCallback((category: string) => {
     setCategoryFilter(category);
+  }, []);
+
+  const handleDecisionFilterChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+    const nextValue = event.target.value;
+    if (nextValue === "all" || nextValue === "allow" || nextValue === "block") {
+      setDecisionFilter(nextValue);
+    }
   }, []);
 
   const categories = useMemo(() => {
@@ -203,7 +213,7 @@ function AppTabRaw({ receipts }: AppTabProps) {
           </div>
           <select
             value={decisionFilter}
-            onChange={(e) => setDecisionFilter(e.target.value)}
+            onChange={handleDecisionFilterChange}
             className="min-h-7 rounded-lg border border-slate-200 bg-white px-2 text-xs font-medium text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-1 focus:ring-brand-blue/20"
           >
             <option value="all">All decisions</option>

--- a/dashboard/src/evidence/evidence-action-detail.tsx
+++ b/dashboard/src/evidence/evidence-action-detail.tsx
@@ -13,7 +13,8 @@ import {
   HiMiniDocumentText,
 } from "react-icons/hi2";
 import { useState } from "react";
-import type { GuardReceipt, RiskSignalV2 } from "../guard-types";
+import type { GuardReceipt } from "../guard-types";
+import { isRiskSignalEvidence } from "../guard-types";
 import { harnessDisplayName, formatRelativeTime } from "../approval-center-utils";
 import { plainEnglishDescription, resolveActionTitle, resolveActionType, resolveActionSubtitle, resolveActionDetail } from "./plain-english";
 import { detectCategory, getCategoryInfo } from "./categories";
@@ -23,12 +24,6 @@ import { DecisionBadge } from "./decision-badge";
 interface EvidenceActionDetailProps {
   receipt: GuardReceipt | null;
   onClose: () => void;
-}
-
-type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
-
-function isRiskSignalEvidence(signal: ReceiptScannerEvidence): signal is RiskSignalV2 {
-  return "signal_id" in signal && typeof signal.signal_id === "string";
 }
 
 function SeverityIcon({ severity }: { severity: string }) {

--- a/dashboard/src/evidence/evidence-action-detail.tsx
+++ b/dashboard/src/evidence/evidence-action-detail.tsx
@@ -25,6 +25,12 @@ interface EvidenceActionDetailProps {
   onClose: () => void;
 }
 
+type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
+
+function isRiskSignalEvidence(signal: ReceiptScannerEvidence): signal is RiskSignalV2 {
+  return "signal_id" in signal && typeof signal.signal_id === "string";
+}
+
 function SeverityIcon({ severity }: { severity: string }) {
   if (severity === "critical" || severity === "high") {
     return <HiMiniExclamationTriangle className="h-4 w-4 text-amber-500" aria-hidden="true" />;
@@ -296,7 +302,7 @@ export function EvidenceActionDetail({
   const actionType = resolveActionType(receipt);
   const actionSubtitle = resolveActionSubtitle(receipt);
   const actionDetail = resolveActionDetail(receipt);
-  const signals = receipt.scanner_evidence ?? [];
+  const signals = (receipt.scanner_evidence ?? []).filter(isRiskSignalEvidence);
   const primarySignal = signals[0];
   let copyLabel = "Copy receipt ID";
   if (copied) {

--- a/dashboard/src/evidence/evidence-insights-share-modal.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-modal.tsx
@@ -1,5 +1,10 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import type { GuardCloudConnectFlow, GuardReceiptAnalytics, GuardRuntimeSnapshot } from "../guard-types";
+import type {
+  GuardCloudConnectFlow,
+  GuardInsightsShareResult,
+  GuardReceiptAnalytics,
+  GuardRuntimeSnapshot,
+} from "../guard-types";
 import { ActionButton } from "../approval-center-primitives";
 import { GuardModalLayer } from "../guard-modal-layer";
 import {
@@ -7,7 +12,6 @@ import {
   fetchRuntimeSnapshot,
   publishInsightsShare,
   startGuardCloudConnect,
-  type GuardInsightsShareResult,
 } from "../guard-api";
 import { ConnectFlowCard } from "../supply-chain-firewall-views";
 import {

--- a/dashboard/src/evidence/evidence-table.tsx
+++ b/dashboard/src/evidence/evidence-table.tsx
@@ -33,7 +33,7 @@ export function EvidenceTableHead({ children }: EvidenceTableHeadProps) {
 }
 
 interface EvidenceTableHeaderProps {
-  children: ReactNode;
+  children?: ReactNode;
   className?: string;
 }
 

--- a/dashboard/src/evidence/evidence-types.ts
+++ b/dashboard/src/evidence/evidence-types.ts
@@ -2,7 +2,7 @@ export type EvidenceDecision = "allow" | "block" | "ask" | "all";
 export type EvidenceTimeFilter = "all" | "today" | "yesterday" | "week" | "last7d" | "last30d";
 export type EvidenceSortKey = "newest" | "oldest" | "app" | "decision" | "category" | "artifact";
 export type EvidenceExportFormat = "csv" | "json";
-export type EvidenceView = "actions" | "insights" | "apps" | "export" | "categories";
+export type EvidenceView = "actions" | "insights" | "apps" | "export" | "story" | "categories";
 
 export interface EvidenceFilterState {
   search: string;

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -2,16 +2,10 @@ import type {
   GuardReceipt,
   GuardApprovalRequest,
   GuardActionEnvelope,
-  RiskSignalV2,
 } from "../guard-types";
+import { isRiskSignalEvidence } from "../guard-types";
 import { harnessDisplayName } from "../approval-center-utils";
 import { detectCategory, type ReceiptCategory } from "./categories";
-
-type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
-
-function isRiskSignalEvidence(signal: ReceiptScannerEvidence): signal is RiskSignalV2 {
-  return "signal_id" in signal && typeof signal.signal_id === "string";
-}
 
 function getArtifactType(receipt: GuardReceipt): string {
   return (receipt.artifact_type ?? "").toLowerCase();

--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -1,6 +1,17 @@
-import type { GuardReceipt, GuardApprovalRequest, GuardActionEnvelope } from "../guard-types";
+import type {
+  GuardReceipt,
+  GuardApprovalRequest,
+  GuardActionEnvelope,
+  RiskSignalV2,
+} from "../guard-types";
 import { harnessDisplayName } from "../approval-center-utils";
 import { detectCategory, type ReceiptCategory } from "./categories";
+
+type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
+
+function isRiskSignalEvidence(signal: ReceiptScannerEvidence): signal is RiskSignalV2 {
+  return "signal_id" in signal && typeof signal.signal_id === "string";
+}
 
 function getArtifactType(receipt: GuardReceipt): string {
   return (receipt.artifact_type ?? "").toLowerCase();
@@ -93,7 +104,7 @@ export function resolveActionTitle(receipt: GuardReceipt): string {
   }
 
   // Scanner evidence title is usually more descriptive than raw artifact_name
-  const signals = receipt.scanner_evidence ?? [];
+  const signals = (receipt.scanner_evidence ?? []).filter(isRiskSignalEvidence);
   if (signals.length > 0 && signals[0]?.title) {
     return signals[0].title;
   }
@@ -134,7 +145,7 @@ export function resolveActionTitle(receipt: GuardReceipt): string {
 }
 
 export function resolveActionSubtitle(receipt: GuardReceipt): string | null {
-  const signals = receipt.scanner_evidence ?? [];
+  const signals = (receipt.scanner_evidence ?? []).filter(isRiskSignalEvidence);
   const firstSignal = signals[0];
 
   // Highest priority: scanner plain_reason explains the actual risk

--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -29,7 +29,7 @@ import {
 } from "./approval-center-utils";
 import type { GuardActionEnvelope, GuardApprovalRequest, GuardDecisionV2, RiskSignalV2 } from "./guard-types";
 
-function assert(condition: boolean, message: string): void {
+function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }
@@ -1423,6 +1423,7 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
 
 const retriedResume = await retryResume("req-retry-resume");
 assert(retryResumeCalls.length === 3, "L080: retryResume refreshes and retries once");
+assert(retriedResume !== null, "L080: retryResume returns a resume payload after refresh");
 assert(retriedResume.status === "sent", "L080: retryResume returns retried resume status");
 assert(
   headerValue(retryResumeCalls[1].init, "X-Guard-Dashboard-Session") === "stale-retry-resume-token",

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -49,6 +49,7 @@ import type {
   GuardReceiptHarnessStat,
   GuardRuntimeSnapshot,
   GuardCloudConnectStatusResponse,
+  SupplyChainBundle,
   SupplyChainSnapshot,
   GuardSettingsPayload,
   GuardSettingsExport,
@@ -96,10 +97,14 @@ type ApprovalRequestListPayload = {
   status?: unknown;
 };
 
-type RuntimeSnapshotPayload = Omit<GuardRuntimeSnapshot, "items" | "supply_chain"> & {
+type RuntimeSnapshotPayload = Omit<
+  GuardRuntimeSnapshot,
+  "items" | "queue_summary" | "supply_chain" | "managed_installs"
+> & {
   items?: RawGuardApprovalRequest[] | null;
   queue_summary?: unknown;
   supply_chain?: unknown;
+  managed_installs?: unknown;
 };
 
 type QueueResolutionPayload = Omit<
@@ -2723,7 +2728,7 @@ export type AuditRemediationInput = {
 export async function runAuditRemediation(input: AuditRemediationInput): Promise<PackageFirewallActionResponse> {
   if (isGuardDemoMode()) {
     return {
-      entitlement: { allowed: true, tier: "demo" },
+      entitlement: { allowed: true, reason: "demo", tier: "demo", upgrade_cta: null, upgrade_url: null },
       operation: input.action,
       receipt: null,
       result: `${input.action} completed for ${input.manager}.`,

--- a/dashboard/src/guard-demo.ts
+++ b/dashboard/src/guard-demo.ts
@@ -99,6 +99,7 @@ const demoPolicy: GuardPolicyDecision = {
   publisher: demoRequests[1].publisher,
   action: "allow",
   reason: "approved locally after diff review",
+  source: "local",
   updated_at: "2026-04-10T18:42:00Z"
 };
 

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -415,6 +415,28 @@ export type GuardReceipt = {
   action_envelope_json?: GuardActionEnvelope | null;
 };
 
+export type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
+
+function isScannerEvidenceRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+export function isRiskSignalEvidence(signal: ReceiptScannerEvidence): signal is RiskSignalV2 {
+  return isScannerEvidenceRecord(signal) && typeof signal.signal_id === "string";
+}
+
+export function isSupplyChainScannerEvidence(
+  value: ReceiptScannerEvidence,
+): value is GuardSupplyChainScannerEvidence {
+  return isScannerEvidenceRecord(value) && typeof value.operation === "string";
+}
+
+export function isSupplyChainAuditEvidence(
+  value: ReceiptScannerEvidence,
+): value is GuardSupplyChainScannerEvidence & { operation: "audit" } {
+  return isSupplyChainScannerEvidence(value) && value.operation === "audit";
+}
+
 export type GuardReceiptAnalyticsBucket = {
   date_key: string;
   label: string;

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -58,6 +58,21 @@ export type RiskSignalV2 = {
   advisory_id: string | null;
 };
 
+export type GuardSupplyChainScannerEvidence = {
+  operation: string;
+  status?: string;
+  audit_status?: string;
+  audit_decision?: string;
+  blocked_package_count?: number;
+  total_packages?: number;
+  manifest_paths?: string[];
+  lockfile_paths?: string[];
+  package_inventory?: unknown;
+  package_findings?: unknown;
+};
+
+export type GuardScannerEvidence = RiskSignalV2 | GuardSupplyChainScannerEvidence;
+
 export type GuardDecisionV2 = {
   action: GuardDecisionV2Action;
   reason: string;
@@ -391,12 +406,12 @@ export type GuardReceipt = {
   changed_capabilities: string[];
   provenance_summary: string;
   user_override: string | null;
-  artifact_name: string | null;
+  artifact_name?: string | null;
   artifact_type?: string | null;
   source_scope: string | null;
   timestamp: string;
   diff_summary?: string | null;
-  scanner_evidence?: RiskSignalV2[];
+  scanner_evidence?: GuardScannerEvidence[];
   action_envelope_json?: GuardActionEnvelope | null;
 };
 
@@ -592,6 +607,7 @@ export type GuardHarnessActionErrorPayload = {
   error: string;
   message?: string;
   harness?: string;
+  operation?: string;
   confirmation_phrase?: string;
   confirm_command?: string;
   retryable?: boolean;

--- a/dashboard/src/harness-action-errors.test.ts
+++ b/dashboard/src/harness-action-errors.test.ts
@@ -16,14 +16,14 @@ function assert(condition: boolean, message: string): void {
 
 function makeHarnessError(
   status: number,
-  payload: { error: string; message?: string } | null,
+  payload: ConstructorParameters<typeof GuardHarnessActionError>[1],
 ): GuardHarnessActionError {
   return new GuardHarnessActionError(status, payload);
 }
 
 function makeDuckTypedHarnessError(
   status: number,
-  payload: { error: string; message?: string } | null,
+  payload: ConstructorParameters<typeof GuardHarnessActionError>[1],
 ): GuardHarnessActionError {
   const error = makeHarnessError(status, payload);
   return Object.assign(Object.create(GuardHarnessActionError.prototype), error);

--- a/dashboard/src/home-dashboard.tsx
+++ b/dashboard/src/home-dashboard.tsx
@@ -86,8 +86,8 @@ export function buildDaemonErrorCopy(): { title: string; body: string; primaryCt
   };
 }
 
-export function redactHomeArtifactLabel(value: string | null): string {
-  if (value === null || value.trim().length === 0) {
+export function redactHomeArtifactLabel(value: string | null | undefined): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
     return "a local action";
   }
   const trimmed = value.trim();

--- a/dashboard/src/policy-workspace-helpers.test.ts
+++ b/dashboard/src/policy-workspace-helpers.test.ts
@@ -15,7 +15,7 @@ import {
 } from "./policy-workspace-helpers";
 import { scopeLabel } from "./approval-center-utils";
 
-function assert(condition: boolean, message: string): void {
+function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -261,7 +261,7 @@ export function DeviceProofCard(props: DeviceProofCardProps) {
 export type PackageManagerProtectionCopy = {
   pathLabel: string;
   pathDetail: string;
-  pathTone: "green" | "attention" | "slate";
+  pathTone: "green" | "attention" | "blue" | "slate";
   protectedList: string[];
   unprotectedList: string[];
 };

--- a/dashboard/src/scrg159-170.test.ts
+++ b/dashboard/src/scrg159-170.test.ts
@@ -5,7 +5,7 @@ import { groupPoliciesByHarness, resolveSecurityModeCopy } from "./policy-worksp
 import { resolveFeedSourceMode, resolveFeedStaleness } from "./feed-health-workspace";
 import type { GuardRuntimeSnapshot, GuardManagedInstall, GuardReceipt, GuardPolicyDecision, PackageManagerProtection } from "./guard-types";
 
-function assert(condition: boolean, message: string): void {
+function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }
@@ -244,7 +244,7 @@ const auditWithUnprotected = deriveFrontendAuditResults(
 const pipIssue = auditWithUnprotected.find((r) => r.id === "unprotected-pip");
 assert(pipIssue !== undefined, "SCRG162-D: unprotected pip should be flagged");
 assert(pipIssue!.severity === "high", "SCRG162-E: unprotected manager should be high severity");
-assert(pipIssue!.remediation.includes("Guard"), "SCRG162-F: remediation should point back to Guard action");
+assert(pipIssue!.remediation !== null && pipIssue.remediation.includes("Guard"), "SCRG162-F: remediation should point back to Guard action");
 
 const auditWithInstalledUnprotected = deriveFrontendAuditResults(
   [],

--- a/dashboard/src/scsr-phase09c-evidence-rail.test.ts
+++ b/dashboard/src/scsr-phase09c-evidence-rail.test.ts
@@ -14,7 +14,7 @@ function assert(condition: boolean, message: string): void {
 const baseSnapshot: GuardRuntimeSnapshot = {
   generated_at: new Date().toISOString(),
   approval_center_url: null,
-  runtime_state: {},
+  runtime_state: null,
   device: {
     installation_id: "install-1",
     device_label: "Test Machine",

--- a/dashboard/src/scsr-phase09e-posture-banners.test.ts
+++ b/dashboard/src/scsr-phase09e-posture-banners.test.ts
@@ -28,7 +28,7 @@ const makeProtection = (
 const baseSnapshot: GuardRuntimeSnapshot = {
   generated_at: new Date().toISOString(),
   approval_center_url: null,
-  runtime_state: {},
+  runtime_state: null,
   device: {
     installation_id: "install-1",
     device_label: "Test Machine",

--- a/dashboard/src/scsr-phase09f-mobile-polish.test.ts
+++ b/dashboard/src/scsr-phase09f-mobile-polish.test.ts
@@ -4,7 +4,7 @@ import {
   SUPPLY_CHAIN_WORKSPACE_SHELL_CLASS,
 } from "./supply-chain-workspace-layout";
 
-function assert(condition: boolean, message: string): void {
+function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }
@@ -36,7 +36,7 @@ assert(repairStat.label === "Needs path fix", "SCSR165: repair stat avoids PATH 
 const partialAlerts = resolveSupplyChainPostureAlerts({
   generated_at: new Date().toISOString(),
   approval_center_url: null,
-  runtime_state: {},
+  runtime_state: null,
   device: {
     installation_id: "install-1",
     device_label: "Test Machine",

--- a/dashboard/src/scsr-phase09g-cloud-capabilities.test.ts
+++ b/dashboard/src/scsr-phase09g-cloud-capabilities.test.ts
@@ -10,7 +10,7 @@ function assert(condition: boolean, message: string): void {
 const baseSnapshot: GuardRuntimeSnapshot = {
   generated_at: new Date().toISOString(),
   approval_center_url: null,
-  runtime_state: {},
+  runtime_state: null,
   device: {
     installation_id: "install-1",
     device_label: "Test Machine",

--- a/dashboard/src/scsr-phase09h-hero-cards.test.ts
+++ b/dashboard/src/scsr-phase09h-hero-cards.test.ts
@@ -11,7 +11,7 @@ function assert(condition: boolean, message: string): void {
 const baseSnapshot: GuardRuntimeSnapshot = {
   generated_at: new Date().toISOString(),
   approval_center_url: null,
-  runtime_state: {},
+  runtime_state: null,
   device: {
     installation_id: "install-1",
     device_label: "Test Machine",

--- a/dashboard/src/settings-workspace.test.ts
+++ b/dashboard/src/settings-workspace.test.ts
@@ -100,7 +100,7 @@ assert(isFineTuningEditable("relaxed") === false, "fine-tuning: relaxed level is
 
 assert(resolveTotpSetupStep(null) === "confirm", "totp-setup: fresh setup starts at password confirmation");
 assert(
-  resolveTotpSetupStep({ provisioning_uri: "otpauth://totp/test", manual_key: "abcd", expires_at: "2026-01-01T00:00:00Z" }) === "scan",
+  resolveTotpSetupStep({ otpauth_uri: "otpauth://totp/test", manual_key: "abcd", expires_at: "2026-01-01T00:00:00Z" }) === "scan",
   "totp-setup: pending enrollment resumes at QR scan step",
 );
 

--- a/dashboard/src/shell-footer.test.ts
+++ b/dashboard/src/shell-footer.test.ts
@@ -20,7 +20,7 @@ assert(
   "footer keeps a compact set of resource links for the workspace shell"
 );
 
-const labels = SHELL_FOOTER_RESOURCE_LINKS.map((link) => link.label);
+const labels: string[] = SHELL_FOOTER_RESOURCE_LINKS.map((link) => link.label);
 
 assert(labels.includes("Docs"), "footer includes Docs");
 assert(labels.includes("Guard Cloud"), "footer includes Guard Cloud");

--- a/dashboard/src/supply-chain-audit-connect.test.tsx
+++ b/dashboard/src/supply-chain-audit-connect.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "./supply-chain-audit-connect";
 import type { PackageFirewallStatusResponse } from "./guard-types";
 
-function assert(condition: boolean, message: string): void {
+function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }

--- a/dashboard/src/supply-chain-audit-normalize.ts
+++ b/dashboard/src/supply-chain-audit-normalize.ts
@@ -1,5 +1,6 @@
 import type {
   GuardReceipt,
+  GuardSupplyChainScannerEvidence,
   PackageWorkbenchFilters,
   PackageWorkbenchSortKey,
   SupplyChainAuditDecision,
@@ -294,8 +295,12 @@ function packageRecordsFromEvaluation(evaluation: Record<string, unknown> | null
   return normalizePackageFindings(evaluation.package_findings);
 }
 
-function isAuditEvidence(value: unknown): value is Record<string, unknown> & { operation: "audit" } {
-  return isRecord(value) && value.operation === "audit";
+type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
+
+function isAuditEvidence(
+  value: ReceiptScannerEvidence,
+): value is GuardSupplyChainScannerEvidence & { operation: "audit" } {
+  return "operation" in value && value.operation === "audit";
 }
 
 export function normalizeSupplyChainAuditSnapshot(
@@ -358,13 +363,11 @@ export function normalizeSupplyChainAuditSnapshot(
 export function derivePackageWorkbenchFromReceipts(receipts: GuardReceipt[]): SupplyChainAuditSnapshot | null {
   const auditReceipts = receipts
     .filter((receipt) => receipt.harness === "package-firewall")
-    .filter((receipt) =>
-      (receipt.scanner_evidence ?? []).some((entry) => isAuditEvidence(entry as unknown)),
-    )
+    .filter((receipt) => (receipt.scanner_evidence ?? []).some((entry) => isAuditEvidence(entry)))
     .sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp));
   for (const receipt of auditReceipts) {
-    const evidenceRaw = (receipt.scanner_evidence ?? []).find((entry) => isAuditEvidence(entry as unknown));
-    if (evidenceRaw === undefined || !isRecord(evidenceRaw)) {
+    const evidenceRaw = (receipt.scanner_evidence ?? []).find((entry) => isAuditEvidence(entry));
+    if (evidenceRaw === undefined) {
       continue;
     }
     const snapshot = normalizeSupplyChainAuditSnapshot(

--- a/dashboard/src/supply-chain-audit-normalize.ts
+++ b/dashboard/src/supply-chain-audit-normalize.ts
@@ -1,6 +1,5 @@
 import type {
   GuardReceipt,
-  GuardSupplyChainScannerEvidence,
   PackageWorkbenchFilters,
   PackageWorkbenchSortKey,
   SupplyChainAuditDecision,
@@ -10,6 +9,7 @@ import type {
   SupplyChainAuditSeverity,
   SupplyChainAuditSnapshot,
 } from "./guard-types";
+import { isSupplyChainAuditEvidence } from "./guard-types";
 import { isSupplyChainAuditIncomplete } from "./supply-chain-audit-result";
 
 const SEVERITY_RANK: Record<SupplyChainAuditSeverity, number> = {
@@ -295,14 +295,6 @@ function packageRecordsFromEvaluation(evaluation: Record<string, unknown> | null
   return normalizePackageFindings(evaluation.package_findings);
 }
 
-type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
-
-function isAuditEvidence(
-  value: ReceiptScannerEvidence,
-): value is GuardSupplyChainScannerEvidence & { operation: "audit" } {
-  return "operation" in value && value.operation === "audit";
-}
-
 export function normalizeSupplyChainAuditSnapshot(
   raw: unknown,
   receiptId: string | null = null,
@@ -363,10 +355,10 @@ export function normalizeSupplyChainAuditSnapshot(
 export function derivePackageWorkbenchFromReceipts(receipts: GuardReceipt[]): SupplyChainAuditSnapshot | null {
   const auditReceipts = receipts
     .filter((receipt) => receipt.harness === "package-firewall")
-    .filter((receipt) => (receipt.scanner_evidence ?? []).some((entry) => isAuditEvidence(entry)))
+    .filter((receipt) => (receipt.scanner_evidence ?? []).some((entry) => isSupplyChainAuditEvidence(entry)))
     .sort((left, right) => Date.parse(right.timestamp) - Date.parse(left.timestamp));
   for (const receipt of auditReceipts) {
-    const evidenceRaw = (receipt.scanner_evidence ?? []).find((entry) => isAuditEvidence(entry));
+    const evidenceRaw = (receipt.scanner_evidence ?? []).find((entry) => isSupplyChainAuditEvidence(entry));
     if (evidenceRaw === undefined) {
       continue;
     }

--- a/dashboard/src/supply-chain-audit-result.test.ts
+++ b/dashboard/src/supply-chain-audit-result.test.ts
@@ -4,7 +4,7 @@ import {
 } from "./supply-chain-audit-result";
 import { normalizeSupplyChainAuditSnapshot } from "./supply-chain-audit-normalize";
 
-function assert(condition: boolean, message: string): void {
+function assert(condition: unknown, message: string): asserts condition {
   if (!condition) {
     throw new Error(message);
   }

--- a/dashboard/src/supply-chain-audit-result.ts
+++ b/dashboard/src/supply-chain-audit-result.ts
@@ -1,3 +1,7 @@
+type SupplyChainAuditIncompletePayload = Record<string, unknown> & {
+  audit_status: "incomplete";
+};
+
 export function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
@@ -10,7 +14,9 @@ export function readString(value: unknown): string | null {
   return trimmed.length > 0 ? trimmed : null;
 }
 
-export function isSupplyChainAuditIncomplete(detail: unknown): boolean {
+export function isSupplyChainAuditIncomplete(
+  detail: unknown,
+): detail is SupplyChainAuditIncompletePayload {
   if (!isRecord(detail)) {
     return false;
   }

--- a/dashboard/src/supply-chain-bundle-panel.tsx
+++ b/dashboard/src/supply-chain-bundle-panel.tsx
@@ -134,7 +134,6 @@ export function SupplyChainBundlePanel() {
           <EmptyState
             title="Could not load intel"
             body={error}
-            tone="error"
           />
         </div>
       </div>

--- a/dashboard/src/supply-chain-evidence-rail.ts
+++ b/dashboard/src/supply-chain-evidence-rail.ts
@@ -1,8 +1,8 @@
 import type {
   GuardReceipt,
   GuardRuntimeSnapshot,
-  GuardSupplyChainScannerEvidence,
 } from "./guard-types";
+import { isSupplyChainScannerEvidence } from "./guard-types";
 
 export type SupplyChainEvidenceRailKind = "block" | "audit" | "sync";
 
@@ -28,16 +28,8 @@ export type SupplyChainCloudDegradedState = {
   detail: string;
 };
 
-type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
-
-function isSupplyChainEvidence(
-  value: ReceiptScannerEvidence,
-): value is GuardSupplyChainScannerEvidence {
-  return "operation" in value && typeof value.operation === "string";
-}
-
-function readOperation(value: ReceiptScannerEvidence): string | null {
-  if (!isSupplyChainEvidence(value)) {
+function readOperation(value: NonNullable<GuardReceipt["scanner_evidence"]>[number]): string | null {
+  if (!isSupplyChainScannerEvidence(value)) {
     return null;
   }
   const trimmed = value.operation.trim();

--- a/dashboard/src/supply-chain-evidence-rail.ts
+++ b/dashboard/src/supply-chain-evidence-rail.ts
@@ -1,4 +1,8 @@
-import type { GuardReceipt, GuardRuntimeSnapshot } from "./guard-types";
+import type {
+  GuardReceipt,
+  GuardRuntimeSnapshot,
+  GuardSupplyChainScannerEvidence,
+} from "./guard-types";
 
 export type SupplyChainEvidenceRailKind = "block" | "audit" | "sync";
 
@@ -24,12 +28,16 @@ export type SupplyChainCloudDegradedState = {
   detail: string;
 };
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null && !Array.isArray(value);
+type ReceiptScannerEvidence = NonNullable<GuardReceipt["scanner_evidence"]>[number];
+
+function isSupplyChainEvidence(
+  value: ReceiptScannerEvidence,
+): value is GuardSupplyChainScannerEvidence {
+  return "operation" in value && typeof value.operation === "string";
 }
 
-function readOperation(value: unknown): string | null {
-  if (!isRecord(value) || typeof value.operation !== "string") {
+function readOperation(value: ReceiptScannerEvidence): string | null {
+  if (!isSupplyChainEvidence(value)) {
     return null;
   }
   const trimmed = value.operation.trim();
@@ -113,10 +121,10 @@ function blockRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
 
 function auditRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
   const evidence = (receipt.scanner_evidence ?? []).find(
-    (entry) => readOperation(entry) === "audit",
+    (entry): entry is GuardSupplyChainScannerEvidence => readOperation(entry) === "audit",
   );
   const auditStatus =
-    isRecord(evidence) && typeof evidence.audit_status === "string"
+    evidence !== undefined && typeof evidence.audit_status === "string"
       ? evidence.audit_status
       : null;
   if (auditStatus === "incomplete") {
@@ -134,15 +142,15 @@ function auditRailItem(receipt: GuardReceipt): SupplyChainEvidenceRailItem {
     };
   }
   const decision =
-    isRecord(evidence) && typeof evidence.audit_decision === "string"
+    evidence !== undefined && typeof evidence.audit_decision === "string"
       ? evidence.audit_decision
       : receipt.policy_decision;
   const blockedCount =
-    isRecord(evidence) && typeof evidence.blocked_package_count === "number"
+    evidence !== undefined && typeof evidence.blocked_package_count === "number"
       ? evidence.blocked_package_count
       : 0;
   const totalPackages =
-    isRecord(evidence) && typeof evidence.total_packages === "number"
+    evidence !== undefined && typeof evidence.total_packages === "number"
       ? evidence.total_packages
       : blockedCount;
   const detail =

--- a/dashboard/src/supply-chain-issues.test.ts
+++ b/dashboard/src/supply-chain-issues.test.ts
@@ -29,7 +29,7 @@ const makeProtection = (
 const baseSnapshot: GuardRuntimeSnapshot = {
   generated_at: new Date().toISOString(),
   approval_center_url: null,
-  runtime_state: {},
+  runtime_state: null,
   device: {
     installation_id: "install-1",
     device_label: "Test Machine",


### PR DESCRIPTION
This PR eliminates all TypeScript typecheck errors in the React dashboard app under `dashboard/` and keeps the diff focused to dashboard/type-safety work.

All 90+ remaining errors have been fixed across runtime, evidence, policy, and supply-chain areas. `cd dashboard && pnpm exec tsc --noEmit` now passes cleanly.

Changes are grouped by area:

**Test infrastructure**
- Add `@types/node` to provide Node typings for `node:*` imports and `process`
- Loosen test helpers to accept `unknown` assertions and pre-normalized API shapes
- Fix test fixtures to use `null` runtime state instead of empty `{}`
- Correct TOTP enrollment field name (`otpauth_uri` vs `provisioning_uri`)

**Component type mismatches**
- Fix window keydown listener to use DOM `KeyboardEvent` instead of React `KeyboardEvent`
- Add `className` and `type` support to `ActionButton` props
- Extend `Tag` tone union to include `"amber"`, `"destructive"`, `"warning"`, `"info"`, `"default"`
- Make `EvidenceTableHeaderProps.children` and `pathTone` unions nullable or widened
- Fix ref nullability in `app-detail-workspace` (`RefObject<HTMLDivElement | null>`)

**Shared type drift against guard-types**
- Add `GuardSupplyChainScannerEvidence` type for supply-chain audit evidence
- Change `scanner_evidence` from `RiskSignalV2[]` to `GuardScannerEvidence[]` union
- Add `isRiskSignalEvidence` guard for filtering scanner evidence
- Make `artifact_name` optional on `GuardReceipt` (was required but sometimes missing)
- Add `operation?` to `GuardHarnessActionErrorPayload`
- Add `"story"` to `EvidenceView` union
- Add `source` to demo `GuardPolicyDecision`

**Normalization and runtime**
- Add `managed_installs` to `RuntimeSnapshotPayload` Omit list
- Fix demo entitlement shape to require all PackageFirewallEntitlement fields
- Use type guards for supply-chain evidence field access instead of `isRecord`

## Testing
- `cd dashboard && pnpm exec tsc --noEmit` — all errors resolved
- `cd dashboard && pnpm test` — all tests passing

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b259de13-c7a7-4faa-95ee-6bfe66724093/thread/a2b8f92d-b51f-4a31-9f9b-a9edf12c0ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open POINT-003" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b259de13-c7a7-4faa-95ee-6bfe66724093/thread/a2b8f92d-b51f-4a31-9f9b-a9edf12c0ff3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=POINT-003&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=POINT-003"><img alt="POINT-003" src="https://capy.ai/api/badge/thread.svg?label=POINT-003"></picture></a>
<!-- capy-pr-badge:end -->