### PR TITLE
feat(guard): add z.ai ZCode harness adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 | If you want to... | Install | Start with |
 | :--- | :--- | :--- |
-| protect Codex, Claude Code, Copilot CLI, Hermes, Cursor, Gemini, or OpenCode before tools run | `hol-guard` | `hol-guard start` |
+| protect Codex, Claude Code, Copilot CLI, Hermes, Cursor, Gemini, OpenCode, or ZCode before tools run | `hol-guard` | `hol-guard start` |
 | lint and verify packages in CI before release | `plugin-scanner` | `plugin-scanner verify .` |
 
 ## Guard Quickstart
@@ -138,6 +138,8 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
   Guard installs managed `PreToolUse` and `UserPromptSubmit` hooks in `~/.kimi-code/config.toml`, blocks with exit code `2` and a JSON `permissionDecision: "deny"` response, and fails open on hook crash or timeout.
 - `grok`
   Guard installs managed Grok hook JSON under `~/.grok/hooks/` plus permission deny rules in `~/.grok/managed_config.toml`, blocks with exit code `2` and a Grok-native `{"decision":"deny"}` response, and never reads `~/.grok/auth`.
+- `zcode`
+  Guard detects `~/.zcode/cli/config.json`, configured MCP servers, enabled plugins, the plugin cache, and plugin manifests; installs managed `PreToolUse` and `UserPromptSubmit` hooks in the config `hooks` section without touching user `mcp` or `plugins`; and blocks with exit code `2` and a `permissionDecision: "deny"` response.
 - `hermes`
   Guard installs a managed Hermes overlay bundle, routes MCP servers through Guard proxies, and prefers native-or-center delivery for blocked requests.
 - `gemini`

--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -90,6 +90,12 @@ Current Guard support in this repo:
   - blocks by returning exit code `2` and Grok-native stdout JSON `{"decision":"deny","reason":"..."}` with approval-center copy in stderr
   - surfaces `--always-approve`, `bypassPermissions`, and sandbox `off` as degraded protection states when detected in Grok config
   - fails open if a hook crashes or times out, so Grok keeps working when Guard is unreachable
+- `zcode`
+  - detects `~/.zcode/cli/config.json`, configured MCP servers, enabled plugins, the plugin cache under `~/.zcode/cli/plugins/cache/`, plugin manifests and provenance seeds, plugin hooks, skills, commands, and marketplace manifests, plus a project `.zcode/cli/config.json` when present
+  - detects a running ZCode app through its non-secret process identity signals when no config file exists yet
+  - installs Guard-managed `PreToolUse` and `UserPromptSubmit` hooks in the `hooks` section of `~/.zcode/cli/config.json` without touching user `mcp`, `plugins`, or pre-existing hooks
+  - blocks by returning exit code `2` and ZCode-native stdout JSON `hookSpecificOutput.permissionDecision: "deny"` with approval-center copy in stderr
+  - fails open if a hook crashes or times out, so ZCode keeps working when Guard is unreachable
 
 Approval tiers:
 
@@ -150,3 +156,4 @@ Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
 | `antigravity` | `antigravity` | ❌ | ✅ | ❌ | mcp_tool, prompt |
 | `kimi` | `kimi`, `kimi-code`, `kimi-cli` | ❌ | ✅ | ❌ | shell, prompt |
 | `grok` | `grok`, `grok-build`, `grok-build-cli`, `xai-grok` | ❌ | ✅ | ❌ | shell, prompt, mcp_tool, file_read |
+| `zcode` | `zcode`, `zai`, `z-code`, `zai-zcode` | ❌ | ✅ | ❌ | shell, prompt, mcp_tool, file_read |

--- a/src/codex_plugin_scanner/guard/adapters/__init__.py
+++ b/src/codex_plugin_scanner/guard/adapters/__init__.py
@@ -19,6 +19,7 @@ _ADAPTER_SPECS: tuple[tuple[str, str], ...] = (
     (".kimi", "KimiHarnessAdapter"),
     (".openclaw", "OpenClawHarnessAdapter"),
     (".opencode", "OpenCodeHarnessAdapter"),
+    (".zcode", "ZCodeHarnessAdapter"),
 )
 
 

--- a/src/codex_plugin_scanner/guard/adapters/contracts.py
+++ b/src/codex_plugin_scanner/guard/adapters/contracts.py
@@ -139,6 +139,7 @@ _DISPLAY_NAMES = {
     "antigravity": "Antigravity",
     "kimi": "Kimi",
     "grok": "Grok",
+    "zcode": "ZCode",
 }
 
 
@@ -313,6 +314,23 @@ HARNESS_CONTRACTS: tuple[HarnessProtectionContract, ...] = (
             "prompt policy but PreToolUse hooks still run when installed."
         ),
         smoke_command="hol-guard install grok --dry-run",
+    ),
+    HarnessProtectionContract(
+        harness="zcode",
+        install_aliases=("zcode", "zai", "z-code", "zai-zcode"),
+        config_paths=(
+            "~/.zcode/cli/config.json",
+            "~/.zcode/cli/plugins/",
+        ),
+        event_surfaces=("shell", "prompt", "mcp_tool", "file_read"),
+        native_approval=False,
+        browser_fallback=True,
+        resume_support=False,
+        known_blind_spots=(
+            "Inline edits applied directly by the model without a tool call are not visible to Guard, "
+            "and background sessions that run without an active terminal do not surface hook events."
+        ),
+        smoke_command="hol-guard install zcode --dry-run",
     ),
 )
 

--- a/src/codex_plugin_scanner/guard/adapters/zcode.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode.py
@@ -417,9 +417,13 @@ def _is_managed_handler(handler: object) -> bool:
 
 
 def _merge_hook_entry(entries: list[object], matcher: str | None, handler: dict[str, object]) -> list[object]:
-    """Add or refresh the Guard handler for a given matcher, preserving user hooks."""
+    """Add or refresh the Guard handler for a given matcher, preserving user hooks.
 
-    normalized: list[object] = [entry for entry in entries if isinstance(entry, dict)]
+    Non-dict entries (kept defensively by ``_prune_managed_entries``) are
+    passed through unchanged so the merge never drops user data.
+    """
+
+    normalized: list[object] = list(entries)
     matcher_key = matcher.strip() if isinstance(matcher, str) and matcher.strip() else None
     for index, entry in enumerate(normalized):
         if not isinstance(entry, dict):

--- a/src/codex_plugin_scanner/guard/adapters/zcode.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode.py
@@ -374,8 +374,16 @@ class ZCodeHarnessAdapter(HarnessAdapter):
         pretool_entries = self._prune_managed_entries(pretool_raw if isinstance(pretool_raw, list) else [])
         prompt_raw = hooks.get("UserPromptSubmit")
         prompt_entries = self._prune_managed_entries(prompt_raw if isinstance(prompt_raw, list) else [])
-        pretool_handler = {"type": "command", "command": managed_command, "timeout": _ZCODE_PRETOOL_TIMEOUT_SECONDS}
-        prompt_handler = {"type": "command", "command": managed_command, "timeout": _ZCODE_PROMPT_TIMEOUT_SECONDS}
+        pretool_handler: dict[str, object] = {
+            "type": "command",
+            "command": managed_command,
+            "timeout": _ZCODE_PRETOOL_TIMEOUT_SECONDS,
+        }
+        prompt_handler: dict[str, object] = {
+            "type": "command",
+            "command": managed_command,
+            "timeout": _ZCODE_PROMPT_TIMEOUT_SECONDS,
+        }
         for matcher in ZCODE_PRETOOL_MATCHERS:
             pretool_entries = _merge_hook_entry(pretool_entries, matcher, pretool_handler)
         prompt_entries = _merge_hook_entry(prompt_entries, None, prompt_handler)

--- a/src/codex_plugin_scanner/guard/adapters/zcode.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode.py
@@ -1,0 +1,453 @@
+"""z.ai ZCode harness adapter for HOL Guard.
+
+ZCode is z.ai's local AI coding harness. Its CLI app config lives under
+``~/.zcode/cli/config.json`` and is Claude-Code-shaped: an ``mcp`` section, a
+``plugins`` section, and an optional ``hooks`` section that follows Claude
+Code's hook group schema. Plugins are cached under
+``~/.zcode/cli/plugins/cache/<marketplace>/<plugin>/<version>/``.
+
+This adapter discovers MCP servers, enabled plugins, plugin manifests and
+provenance, plugin hooks, skills, commands, and marketplaces; installs
+Guard-managed ``PreToolUse`` and ``UserPromptSubmit`` hooks into the CLI
+config ``hooks`` section (idempotently, without touching ``mcp`` or
+``plugins``); and routes ZCode hook events through the shared Guard runtime.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+from ..aibom_detection import extend_detection_with_workspace_aibom
+from ..models import GuardArtifact, HarnessDetection
+from ..shims import install_guard_shim, remove_guard_shim
+from .base import (
+    HarnessAdapter,
+    HarnessContext,
+    _command_available,
+    _ensure_path_within_root,
+    _json_payload,
+    _shell_command,
+)
+from .zcode_config import (
+    GUARD_MANAGED_MARKER,
+    ZCODE_BUNDLE_IDENTIFIER,
+    ZCODE_CLI_CONFIG_FILE,
+    ZCODE_CLI_DIR,
+    ZCODE_DIR,
+    ZCODE_ENV_HINTS,
+    ZCODE_MARKETPLACE_FILE,
+    ZCODE_PLUGIN_CACHE_DIR,
+    ZCODE_PLUGIN_MANIFEST_DIR,
+    ZCODE_PLUGIN_MANIFEST_FILE,
+    ZCODE_PLUGIN_MARKETPLACES_DIR,
+    ZCODE_PRETOOL_MATCHERS,
+    append_cli_config_artifacts,
+    append_found_path,
+    append_marketplace_artifacts,
+    append_plugin_manifest_artifacts,
+    is_guard_managed_hook_command,
+)
+
+_ZCODE_HOME_ENV_VAR = "ZCODE_HOME"
+_ZCODE_PRETOOL_TIMEOUT_SECONDS = 30
+_ZCODE_PROMPT_TIMEOUT_SECONDS = 30
+
+
+class ZCodeHarnessAdapter(HarnessAdapter):
+    """Discover z.ai ZCode settings, plugins, hooks, MCP, and manage Guard protection."""
+
+    harness = "zcode"
+    aliases = ("zcode", "zai", "z-code", "zai-zcode")
+    executable = "zcode"
+    launcher_name = "zcode"
+    approval_tier = "approval-center"
+    approval_summary = (
+        "Guard scans ZCode config, plugins, hooks, skills, and MCP registrations before launch "
+        "and routes blocked actions to the local approval center."
+    )
+    fallback_hint = (
+        "ZCode gets preflight approval through Guard until it exposes a richer native approval surface. "
+        "Use `hol-guard approvals` to resolve pending requests from the terminal."
+    )
+
+    @staticmethod
+    def _zcode_home_dir(context: HarnessContext) -> Path:
+        value = os.environ.get(_ZCODE_HOME_ENV_VAR)
+        if value:
+            return Path(value).expanduser().resolve()
+        return context.home_dir
+
+    @classmethod
+    def _cli_root(cls, context: HarnessContext) -> Path:
+        return cls._zcode_home_dir(context) / ZCODE_CLI_DIR
+
+    @classmethod
+    def _config_path(cls, context: HarnessContext) -> Path:
+        return cls._cli_root(context) / ZCODE_CLI_CONFIG_FILE
+
+    @classmethod
+    def _plugins_root(cls, context: HarnessContext) -> Path:
+        return cls._cli_root(context) / ZCODE_PLUGIN_CACHE_DIR
+
+    @classmethod
+    def _marketplaces_root(cls, context: HarnessContext) -> Path:
+        return cls._cli_root(context) / ZCODE_PLUGIN_MARKETPLACES_DIR
+
+    @classmethod
+    def _project_cli_root(cls, context: HarnessContext) -> Path | None:
+        if context.workspace_dir is None:
+            return None
+        return context.workspace_dir / ZCODE_DIR / "cli"
+
+    def policy_path(self, context: HarnessContext) -> Path:
+        project_cli_root = self._project_cli_root(context)
+        if project_cli_root is not None and (project_cli_root / ZCODE_CLI_CONFIG_FILE).is_file():
+            return project_cli_root / ZCODE_CLI_CONFIG_FILE
+        return self._config_path(context)
+
+    def executable_candidates(self, context: HarnessContext) -> tuple[Path, ...]:
+        del context
+        return ()
+
+    @staticmethod
+    def _detect_runtime_signal() -> bool:
+        """Return True when ZCode runtime env hints or bundle id are present.
+
+        These are non-secret process identifiers (app version, base URL, OAuth
+        origin host). They are read only as a presence signal and never stored.
+        """
+
+        bundle = os.environ.get("__CFBundleIdentifier", "")  # noqa: SIM112 -- macOS sets this exact case-sensitive var
+        if bundle.strip() == ZCODE_BUNDLE_IDENTIFIER:
+            return True
+        return any(os.environ.get(name) for name in ZCODE_ENV_HINTS)
+
+    def detect(self, context: HarnessContext) -> HarnessDetection:
+        artifacts: list[GuardArtifact] = []
+        found_paths: list[str] = []
+
+        for config_path in self._config_candidates(context):
+            if not config_path.is_file():
+                continue
+            append_found_path(found_paths, config_path)
+            payload = _json_payload(config_path)
+            if payload:
+                scope = self._scope_for(context, config_path)
+                append_cli_config_artifacts(
+                    harness=self.harness,
+                    artifacts=artifacts,
+                    payload=payload,
+                    config_path=config_path,
+                    scope=scope,
+                )
+
+        for plugins_root, scope in self._plugins_candidates(context):
+            if not plugins_root.is_dir():
+                continue
+            for marketplace_dir in sorted(entry for entry in plugins_root.iterdir() if entry.is_dir()):
+                for plugin_dir in sorted(entry for entry in marketplace_dir.iterdir() if entry.is_dir()):
+                    for version_dir in sorted(entry for entry in plugin_dir.iterdir() if entry.is_dir()):
+                        manifest_path = version_dir / ZCODE_PLUGIN_MANIFEST_DIR / ZCODE_PLUGIN_MANIFEST_FILE
+                        if not manifest_path.is_file():
+                            continue
+                        append_plugin_manifest_artifacts(
+                            harness=self.harness,
+                            artifacts=artifacts,
+                            found_paths=found_paths,
+                            plugin_root=version_dir,
+                            scope=scope,
+                        )
+
+        for marketplaces_root, scope in self._marketplaces_candidates(context):
+            if not marketplaces_root.is_dir():
+                continue
+            for marketplace_dir in sorted(entry for entry in marketplaces_root.iterdir() if entry.is_dir()):
+                marketplace_file = marketplace_dir / ZCODE_MARKETPLACE_FILE
+                if marketplace_file.is_file():
+                    append_marketplace_artifacts(
+                        harness=self.harness,
+                        artifacts=artifacts,
+                        found_paths=found_paths,
+                        marketplace_file=marketplace_file,
+                        scope=scope,
+                    )
+
+        runtime_signal = self._detect_runtime_signal()
+        command_available = _command_available(self.executable)
+        installed = bool(found_paths) or runtime_signal or command_available
+        warnings: list[str] = []
+        if runtime_signal and not found_paths:
+            warnings.append(
+                "ZCode runtime was detected through process environment signals, but no "
+                "~/.zcode/cli/config.json or plugin cache was found. Run ZCode once so it can "
+                "initialize its local config before Guard install."
+            )
+
+        detection = HarnessDetection(
+            harness=self.harness,
+            installed=installed,
+            command_available=command_available,
+            config_paths=tuple(found_paths),
+            artifacts=tuple(artifacts),
+            warnings=tuple(dict.fromkeys(warnings)),
+        )
+        return extend_detection_with_workspace_aibom(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
+        )
+
+    def _config_candidates(self, context: HarnessContext) -> list[Path]:
+        candidates = [self._config_path(context)]
+        project_cli_root = self._project_cli_root(context)
+        if project_cli_root is not None:
+            candidates.append(project_cli_root / ZCODE_CLI_CONFIG_FILE)
+        return candidates
+
+    def _plugins_candidates(self, context: HarnessContext) -> list[tuple[Path, str]]:
+        candidates: list[tuple[Path, str]] = [(self._plugins_root(context), "global")]
+        project_cli_root = self._project_cli_root(context)
+        if project_cli_root is not None:
+            candidates.append((project_cli_root / ZCODE_PLUGIN_CACHE_DIR, "project"))
+        return candidates
+
+    def _marketplaces_candidates(self, context: HarnessContext) -> list[tuple[Path, str]]:
+        candidates: list[tuple[Path, str]] = [(self._marketplaces_root(context), "global")]
+        project_cli_root = self._project_cli_root(context)
+        if project_cli_root is not None:
+            candidates.append((project_cli_root / ZCODE_PLUGIN_MARKETPLACES_DIR, "project"))
+        return candidates
+
+    @staticmethod
+    def _scope_for(context: HarnessContext, path: Path) -> str:
+        if context.workspace_dir is not None and path.is_relative_to(context.workspace_dir):
+            return "project"
+        return "global"
+
+    # ---- install / uninstall -------------------------------------------------
+
+    def _managed_state_dir(self, context: HarnessContext) -> Path:
+        return context.guard_home / "managed" / "zcode"
+
+    def _state_path(self, context: HarnessContext) -> Path:
+        return self._managed_state_dir(context) / "install.state.json"
+
+    def _backup_path(self, context: HarnessContext) -> Path:
+        return self._managed_state_dir(context) / "config.json.backup"
+
+    @staticmethod
+    def _hook_command_parts(context: HarnessContext) -> tuple[str, ...]:
+        guard_args = [
+            "guard",
+            "hook",
+            "--guard-home",
+            str(context.guard_home),
+            "--harness",
+            "zcode",
+        ]
+        if context.home_dir.resolve() != Path.home().resolve():
+            guard_args.extend(["--home", str(context.home_dir)])
+        if context.workspace_dir is not None:
+            guard_args.extend(["--workspace", str(context.workspace_dir)])
+        package_root = Path(__file__).resolve().parents[3]
+        code = (
+            "import sys;"
+            f"sys.path.insert(0, {str(package_root)!r});"
+            "from codex_plugin_scanner.cli import main;"
+            f"raise SystemExit(main({guard_args!r}))"
+        )
+        return (sys.executable, "-c", code)
+
+    @staticmethod
+    def _managed_command_wrapper(hook_command: str) -> str:
+        """Wrap a hook command so the Guard-managed marker travels with it.
+
+        The marker is appended as a trailing shell comment so ZCode still runs
+        the command verbatim while Guard can later detect and prune only its
+        own managed hook entries.
+        """
+
+        return f"{hook_command} # {GUARD_MANAGED_MARKER}"
+
+    def install(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = install_guard_shim(
+            self.harness,
+            context,
+            launcher_name=self.launcher_name,
+            display_name="zcode",
+        )
+        config_path = self._config_path(context)
+        _ensure_path_within_root(context.home_dir, config_path, label="ZCode")
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+
+        payload = _json_payload(config_path)
+        if not isinstance(payload.get("mcp"), dict):
+            payload["mcp"] = {}
+        if not isinstance(payload.get("plugins"), dict):
+            payload["plugins"] = {}
+
+        state_dir = self._managed_state_dir(context)
+        state_dir.mkdir(parents=True, exist_ok=True)
+        if config_path.is_file() and not self._backup_path(context).exists():
+            import shutil
+
+            shutil.copy2(config_path, self._backup_path(context))
+
+        hook_command = _shell_command(self._hook_command_parts(context))
+        managed_hook_command = self._managed_command_wrapper(hook_command)
+        hooks = payload.get("hooks")
+        if not isinstance(hooks, dict):
+            hooks = {}
+        payload["hooks"] = hooks
+
+        self._sync_managed_hook_groups(hooks, managed_hook_command)
+        config_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+        self._state_path(context).write_text(
+            json.dumps({"managed_config_path": str(config_path)}, indent=2) + "\n",
+            encoding="utf-8",
+        )
+
+        raw_notes = shim_manifest.get("notes")
+        shim_notes = (
+            [str(note) for note in raw_notes if isinstance(note, str)] if isinstance(raw_notes, (list, tuple)) else []
+        )
+        return {
+            "harness": self.harness,
+            "active": True,
+            "config_path": str(config_path),
+            **shim_manifest,
+            "notes": [
+                "Guard hook entries added to ~/.zcode/cli/config.json under the hooks section",
+                "User mcp, plugins, and any pre-existing hooks were preserved",
+                *shim_notes,
+            ],
+        }
+
+    def uninstall(self, context: HarnessContext) -> dict[str, object]:
+        shim_manifest = remove_guard_shim(
+            self.harness,
+            context,
+            launcher_name=self.launcher_name,
+            display_name="zcode",
+        )
+        config_path = self._config_path(context)
+        if config_path.is_file():
+            _ensure_path_within_root(context.home_dir, config_path, label="ZCode")
+            payload = _json_payload(config_path)
+            hooks = payload.get("hooks")
+            if isinstance(hooks, dict):
+                self._prune_managed_hook_groups(hooks)
+                if not hooks:
+                    payload.pop("hooks", None)
+                else:
+                    payload["hooks"] = hooks
+                config_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+        state_path = self._state_path(context)
+        if state_path.is_file():
+            state_path.unlink()
+
+        raw_notes = shim_manifest.get("notes")
+        shim_notes = (
+            [str(note) for note in raw_notes if isinstance(note, str)] if isinstance(raw_notes, (list, tuple)) else []
+        )
+        return {
+            "harness": self.harness,
+            "active": False,
+            "config_path": str(config_path),
+            **shim_manifest,
+            "notes": [
+                "Guard-managed hook entries removed from ~/.zcode/cli/config.json",
+                "User mcp, plugins, and any pre-existing hooks were preserved",
+                *shim_notes,
+            ],
+        }
+
+    def _sync_managed_hook_groups(self, hooks: dict[str, object], managed_command: str) -> None:
+        """Reconcile Guard-managed PreToolUse and UserPromptSubmit hook groups."""
+
+        pretool_raw = hooks.get("PreToolUse")
+        pretool_entries = self._prune_managed_entries(pretool_raw if isinstance(pretool_raw, list) else [])
+        prompt_raw = hooks.get("UserPromptSubmit")
+        prompt_entries = self._prune_managed_entries(prompt_raw if isinstance(prompt_raw, list) else [])
+        pretool_handler = {"type": "command", "command": managed_command, "timeout": _ZCODE_PRETOOL_TIMEOUT_SECONDS}
+        prompt_handler = {"type": "command", "command": managed_command, "timeout": _ZCODE_PROMPT_TIMEOUT_SECONDS}
+        for matcher in ZCODE_PRETOOL_MATCHERS:
+            pretool_entries = _merge_hook_entry(pretool_entries, matcher, pretool_handler)
+        prompt_entries = _merge_hook_entry(prompt_entries, None, prompt_handler)
+        hooks["PreToolUse"] = pretool_entries
+        hooks["UserPromptSubmit"] = prompt_entries
+
+    def _prune_managed_hook_groups(self, hooks: dict[str, object]) -> None:
+        for event_name in ("PreToolUse", "UserPromptSubmit"):
+            entries = hooks.get(event_name)
+            remaining = self._prune_managed_entries(entries if isinstance(entries, list) else [])
+            if remaining:
+                hooks[event_name] = remaining
+            else:
+                hooks.pop(event_name, None)
+
+    @staticmethod
+    def _prune_managed_entries(entries: list[object]) -> list[object]:
+        remaining: list[object] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                remaining.append(entry)
+                continue
+            if is_guard_managed_hook_command(entry.get("command")):
+                continue
+            nested_hooks = entry.get("hooks")
+            if isinstance(nested_hooks, list):
+                filtered = [item for item in nested_hooks if not _is_managed_handler(item)]
+                if filtered:
+                    updated = dict(entry)
+                    updated["hooks"] = filtered
+                    remaining.append(updated)
+                continue
+            remaining.append(entry)
+        return remaining
+
+
+def _is_managed_handler(handler: object) -> bool:
+    return isinstance(handler, dict) and is_guard_managed_hook_command(handler.get("command"))
+
+
+def _merge_hook_entry(entries: list[object], matcher: str | None, handler: dict[str, object]) -> list[object]:
+    """Add or refresh the Guard handler for a given matcher, preserving user hooks."""
+
+    normalized: list[object] = [entry for entry in entries if isinstance(entry, dict)]
+    matcher_key = matcher.strip() if isinstance(matcher, str) and matcher.strip() else None
+    for index, entry in enumerate(normalized):
+        if not isinstance(entry, dict):
+            continue
+        entry_matcher = entry.get("matcher")
+        entry_matcher_key = entry_matcher.strip() if isinstance(entry_matcher, str) and entry_matcher.strip() else None
+        if entry_matcher_key != matcher_key:
+            continue
+        nested_hooks = entry.get("hooks")
+        if not isinstance(nested_hooks, list):
+            nested_hooks = []
+        if any(_is_managed_handler(item) for item in nested_hooks):
+            updated = dict(entry)
+            updated["hooks"] = [
+                handler if isinstance(item, dict) and _is_managed_handler(item) else item for item in nested_hooks
+            ]
+            normalized[index] = updated
+            return normalized
+        merged_hooks = [*nested_hooks, handler]
+        updated = dict(entry)
+        updated["hooks"] = merged_hooks
+        normalized[index] = updated
+        return normalized
+    group: dict[str, object] = {"hooks": [handler]}
+    if matcher_key is not None:
+        group["matcher"] = matcher_key
+    normalized.append(group)
+    return normalized
+
+
+__all__ = ["ZCodeHarnessAdapter"]

--- a/src/codex_plugin_scanner/guard/adapters/zcode_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode_config.py
@@ -1,14 +1,12 @@
 """z.ai ZCode config, hook JSON, and detection helpers for HOL Guard.
 
-ZCode stores its CLI app config under ``~/.zcode/``. The CLI config file
-(``~/.zcode/cli/config.json``) is Claude-Code-shaped: it carries an ``mcp``
-section (``mcp.servers.<name>``), a ``plugins`` section
-(``plugins.enabledPlugins.<name@marketplace>``), and an optional ``hooks``
-section using Claude Code's hook group schema. Plugins are cached under
-``~/.zcode/cli/plugins/cache/<marketplace>/<plugin>/<version>/`` with a
-``.zcode-plugin/plugin.json`` manifest, a ``.zcode-plugin-seed.json``
-provenance file, ``hooks/hooks.json``, ``.mcp.json``, ``skills/`` and
-``commands/`` trees.
+ZCode stores its CLI app config under ``~/.zcode/``. ``~/.zcode/cli/config.json``
+is Claude-Code-shaped: an ``mcp`` section (``mcp.servers.<name>``), a ``plugins``
+section (``plugins.enabledPlugins.<name@marketplace>``), and an optional
+``hooks`` section using Claude Code's hook group schema. Plugins are cached
+under ``~/.zcode/cli/plugins/cache/<marketplace>/<plugin>/<version>/`` with a
+``.zcode-plugin/plugin.json`` manifest, a ``.zcode-plugin-seed.json`` provenance
+file, ``hooks/hooks.json``, ``.mcp.json``, ``skills/`` and ``commands/`` trees.
 """
 
 from __future__ import annotations
@@ -115,14 +113,12 @@ def _mcp_transport(server_config: dict[str, object]) -> str:
     return "stdio"
 
 
-def _server_command(server_config: dict[str, object]) -> str | None:
+def _mcp_endpoint(server_config: dict[str, object]) -> tuple[str | None, str | None]:
+    """Return the (command, url) endpoint for an MCP server config, if any."""
+
     command = server_config.get("command")
-    return command if isinstance(command, str) else None
-
-
-def _server_url(server_config: dict[str, object]) -> str | None:
     url = server_config.get("url")
-    return url if isinstance(url, str) else None
+    return (command if isinstance(command, str) else None, url if isinstance(url, str) else None)
 
 
 def append_cli_config_artifacts(
@@ -142,8 +138,7 @@ def append_cli_config_artifacts(
             for server_name, server_config in servers.items():
                 if not isinstance(server_name, str) or not isinstance(server_config, dict):
                     continue
-                command = _server_command(server_config)
-                url = _server_url(server_config)
+                command, url = _mcp_endpoint(server_config)
                 if command is None and url is None:
                     continue
                 artifacts.append(
@@ -207,48 +202,35 @@ def _append_hook_groups(
             if not isinstance(entry, dict):
                 continue
             matcher = entry.get("matcher")
-            nested_hooks = entry.get("hooks")
+            collected: list[tuple[str, str]] = []
             direct_command = entry.get("command")
             if isinstance(direct_command, str) and direct_command.strip():
-                artifacts.append(
-                    GuardArtifact(
-                        artifact_id=f"{harness}:{scope}:hook:{event_name.lower()}:{index}",
-                        name=_hook_name(event_name, matcher),
-                        harness=harness,
-                        artifact_type="hook",
-                        source_scope=scope,
-                        config_path=str(config_path),
-                        command=direct_command,
-                        metadata={
-                            "event": event_name,
-                            "matcher": matcher,
-                            "managed": is_guard_managed_hook_command(direct_command),
-                        },
-                    )
-                )
+                collected.append((f"{event_name.lower()}:{index}", direct_command))
+            nested_hooks = entry.get("hooks")
             if isinstance(nested_hooks, list):
                 for nested_index, hook_entry in enumerate(nested_hooks):
                     if not isinstance(hook_entry, dict):
                         continue
                     command = hook_entry.get("command")
-                    if not isinstance(command, str) or not command.strip():
-                        continue
-                    artifacts.append(
-                        GuardArtifact(
-                            artifact_id=f"{harness}:{scope}:hook:{event_name.lower()}:{index}:{nested_index}",
-                            name=_hook_name(event_name, matcher),
-                            harness=harness,
-                            artifact_type="hook",
-                            source_scope=scope,
-                            config_path=str(config_path),
-                            command=command,
-                            metadata={
-                                "event": event_name,
-                                "matcher": matcher,
-                                "managed": is_guard_managed_hook_command(command),
-                            },
-                        )
+                    if isinstance(command, str) and command.strip():
+                        collected.append((f"{event_name.lower()}:{index}:{nested_index}", command))
+            for artifact_suffix, command in collected:
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"{harness}:{scope}:hook:{artifact_suffix}",
+                        name=_hook_name(event_name, matcher),
+                        harness=harness,
+                        artifact_type="hook",
+                        source_scope=scope,
+                        config_path=str(config_path),
+                        command=command,
+                        metadata={
+                            "event": event_name,
+                            "matcher": matcher,
+                            "managed": is_guard_managed_hook_command(command),
+                        },
                     )
+                )
 
 
 def _hook_name(event_name: str, matcher: object) -> str:
@@ -354,8 +336,7 @@ def append_plugin_manifest_artifacts(
             for server_name, server_config in servers.items():
                 if not isinstance(server_name, str) or not isinstance(server_config, dict):
                     continue
-                command = _server_command(server_config)
-                url = _server_url(server_config)
+                command, url = _mcp_endpoint(server_config)
                 if command is None and url is None:
                     continue
                 artifacts.append(
@@ -485,50 +466,6 @@ def append_marketplace_artifacts(
     )
 
 
-def build_guard_managed_pretooluse_group(hook_command: str, *, timeout_seconds: int = 30) -> dict[str, object]:
-    """Build the Guard-managed PreToolUse hook group for the ZCode config."""
-
-    entries: list[dict[str, object]] = []
-    for matcher in ZCODE_PRETOOL_MATCHERS:
-        entries.append(
-            {
-                "matcher": matcher,
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": hook_command,
-                        "timeout": timeout_seconds,
-                    }
-                ],
-            }
-        )
-    return {"PreToolUse": entries}
-
-
-def build_guard_managed_userprompt_group(hook_command: str, *, timeout_seconds: int = 30) -> dict[str, object]:
-    """Build the Guard-managed UserPromptSubmit hook group for the ZCode config."""
-
-    return {
-        "UserPromptSubmit": [
-            {
-                "hooks": [
-                    {
-                        "type": "command",
-                        "command": hook_command,
-                        "timeout": timeout_seconds,
-                    }
-                ],
-            }
-        ]
-    }
-
-
-def managed_hook_command(marker_comment: str) -> str:
-    """Return the comment line that tags a managed hook command for ZCode."""
-
-    return marker_comment
-
-
 __all__ = [
     "GUARD_MANAGED_MARKER",
     "ZCODE_BUNDLE_IDENTIFIER",
@@ -556,8 +493,5 @@ __all__ = [
     "append_marketplace_artifacts",
     "append_plugin_manifest_artifacts",
     "append_skill_artifacts",
-    "build_guard_managed_pretooluse_group",
-    "build_guard_managed_userprompt_group",
     "is_guard_managed_hook_command",
-    "managed_hook_command",
 ]

--- a/src/codex_plugin_scanner/guard/adapters/zcode_config.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode_config.py
@@ -1,0 +1,563 @@
+"""z.ai ZCode config, hook JSON, and detection helpers for HOL Guard.
+
+ZCode stores its CLI app config under ``~/.zcode/``. The CLI config file
+(``~/.zcode/cli/config.json``) is Claude-Code-shaped: it carries an ``mcp``
+section (``mcp.servers.<name>``), a ``plugins`` section
+(``plugins.enabledPlugins.<name@marketplace>``), and an optional ``hooks``
+section using Claude Code's hook group schema. Plugins are cached under
+``~/.zcode/cli/plugins/cache/<marketplace>/<plugin>/<version>/`` with a
+``.zcode-plugin/plugin.json`` manifest, a ``.zcode-plugin-seed.json``
+provenance file, ``hooks/hooks.json``, ``.mcp.json``, ``skills/`` and
+``commands/`` trees.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..models import GuardArtifact
+from .base import _json_payload
+
+ZCODE_DIR = ".zcode"
+ZCODE_CLI_DIR = ".zcode/cli"
+ZCODE_CLI_CONFIG_FILE = "config.json"
+ZCODE_PLUGINS_DIR = "plugins"
+ZCODE_PLUGIN_CACHE_DIR = "plugins/cache"
+ZCODE_PLUGIN_MARKETPLACES_DIR = "plugins/marketplaces"
+ZCODE_PLUGIN_MANIFEST_DIR = ".zcode-plugin"
+ZCODE_PLUGIN_MANIFEST_FILE = "plugin.json"
+ZCODE_PLUGIN_SEED_FILE = ".zcode-plugin-seed.json"
+ZCODE_PLUGIN_HOOKS_FILE = "hooks/hooks.json"
+ZCODE_PLUGIN_HOOKS_CURSOR_FILE = "hooks/hooks-cursor.json"
+ZCODE_PLUGIN_MCP_FILE = ".mcp.json"
+ZCODE_PLUGIN_SKILLS_DIR = "skills"
+ZCODE_PLUGIN_COMMANDS_DIR = "commands"
+ZCODE_MARKETPLACE_FILE = "marketplace.json"
+
+GUARD_MANAGED_MARKER = "HOL_GUARD_MANAGED_ZCODE"
+
+# Claude Code tool matchers ZCode surfaces. MCP tools arrive as mcp__<server>__<tool>.
+ZCODE_PRETOOL_MATCHERS = (
+    "Bash",
+    "Read",
+    "Write",
+    "Edit",
+    "MultiEdit",
+    "Grep",
+    "WebFetch",
+    "WebSearch",
+    "run_terminal_command",
+    "run_command",
+    "read_file",
+    "write_file",
+    "search_replace",
+    "multi_edit",
+    "grep",
+    "web_fetch",
+    "web_search",
+)
+
+# z.ai/ZCode process identity and runtime env hints (never secret-bearing).
+ZCODE_BUNDLE_IDENTIFIER = "dev.zcode.app"
+ZCODE_ENV_HINTS = (
+    "ZCODE_BASE_URL",
+    "ZCODE_APP_VERSION",
+    "ZCODE_ENV",
+    "ZCODE_RUNTIME_ENV",
+    "ZCODE_PROCESS_LABEL",
+    "ZCODE_RG_BINARY",
+    "ZAI_OAUTH_ORIGIN",
+    "ZAI_OAUTH_CLIENT_ID",
+)
+
+
+def append_found_path(found_paths: list[str], path: Path) -> None:
+    candidate = str(path)
+    if candidate not in found_paths:
+        found_paths.append(candidate)
+
+
+def is_guard_managed_hook_command(command: object) -> bool:
+    """Return True when a hook command string is owned by HOL Guard for ZCode."""
+
+    if not isinstance(command, str):
+        return False
+    return GUARD_MANAGED_MARKER in command or (
+        "codex_plugin_scanner.cli" in command and "'guard', 'hook'" in command and "--harness', 'zcode'" in command
+    )
+
+
+def _string_args(server_config: dict[str, object]) -> tuple[str, ...]:
+    raw_args = server_config.get("args")
+    if not isinstance(raw_args, list):
+        return ()
+    return tuple(str(value) for value in raw_args if isinstance(value, (str, int, float, bool)))
+
+
+def _mcp_env_keys(server_config: dict[str, object]) -> list[str]:
+    for field in ("env", "environment"):
+        value = server_config.get(field)
+        if isinstance(value, dict):
+            return sorted(key for key in value if isinstance(key, str))
+    return []
+
+
+def _mcp_transport(server_config: dict[str, object]) -> str:
+    url = server_config.get("url")
+    transport = server_config.get("transport")
+    if isinstance(transport, str) and transport.strip():
+        return transport.strip()
+    if isinstance(url, str) and url.strip():
+        return "http"
+    explicit_type = server_config.get("type")
+    if isinstance(explicit_type, str) and explicit_type.strip() == "stdio":
+        return "stdio"
+    return "stdio"
+
+
+def _server_command(server_config: dict[str, object]) -> str | None:
+    command = server_config.get("command")
+    return command if isinstance(command, str) else None
+
+
+def _server_url(server_config: dict[str, object]) -> str | None:
+    url = server_config.get("url")
+    return url if isinstance(url, str) else None
+
+
+def append_cli_config_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    payload: dict[str, object],
+    config_path: Path,
+    scope: str,
+) -> None:
+    """Parse the ZCode CLI config.json into MCP, plugin, and hook artifacts."""
+
+    mcp_section = payload.get("mcp")
+    if isinstance(mcp_section, dict):
+        servers = mcp_section.get("servers")
+        if isinstance(servers, dict):
+            for server_name, server_config in servers.items():
+                if not isinstance(server_name, str) or not isinstance(server_config, dict):
+                    continue
+                command = _server_command(server_config)
+                url = _server_url(server_config)
+                if command is None and url is None:
+                    continue
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"{harness}:{scope}:mcp:{server_name}",
+                        name=server_name,
+                        harness=harness,
+                        artifact_type="mcp_server",
+                        source_scope=scope,
+                        config_path=str(config_path),
+                        command=command,
+                        args=_string_args(server_config),
+                        url=url,
+                        transport=_mcp_transport(server_config),
+                        metadata={"env_keys": _mcp_env_keys(server_config)},
+                    )
+                )
+
+    plugins_section = payload.get("plugins")
+    if isinstance(plugins_section, dict):
+        enabled = plugins_section.get("enabledPlugins")
+        if isinstance(enabled, dict):
+            for plugin_handle, state in enabled.items():
+                if not isinstance(plugin_handle, str):
+                    continue
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"{harness}:{scope}:plugin:{plugin_handle}",
+                        name=plugin_handle,
+                        harness=harness,
+                        artifact_type="plugin",
+                        source_scope=scope,
+                        config_path=str(config_path),
+                        metadata={"enabled": bool(state)},
+                    )
+                )
+
+    hooks_section = payload.get("hooks")
+    if isinstance(hooks_section, dict):
+        _append_hook_groups(
+            harness=harness,
+            artifacts=artifacts,
+            hooks=hooks_section,
+            config_path=config_path,
+            scope=scope,
+        )
+
+
+def _append_hook_groups(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    hooks: dict[str, object],
+    config_path: Path,
+    scope: str,
+) -> None:
+    for event_name, entries in hooks.items():
+        if not isinstance(event_name, str) or not isinstance(entries, list):
+            continue
+        for index, entry in enumerate(entries):
+            if not isinstance(entry, dict):
+                continue
+            matcher = entry.get("matcher")
+            nested_hooks = entry.get("hooks")
+            direct_command = entry.get("command")
+            if isinstance(direct_command, str) and direct_command.strip():
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"{harness}:{scope}:hook:{event_name.lower()}:{index}",
+                        name=_hook_name(event_name, matcher),
+                        harness=harness,
+                        artifact_type="hook",
+                        source_scope=scope,
+                        config_path=str(config_path),
+                        command=direct_command,
+                        metadata={
+                            "event": event_name,
+                            "matcher": matcher,
+                            "managed": is_guard_managed_hook_command(direct_command),
+                        },
+                    )
+                )
+            if isinstance(nested_hooks, list):
+                for nested_index, hook_entry in enumerate(nested_hooks):
+                    if not isinstance(hook_entry, dict):
+                        continue
+                    command = hook_entry.get("command")
+                    if not isinstance(command, str) or not command.strip():
+                        continue
+                    artifacts.append(
+                        GuardArtifact(
+                            artifact_id=f"{harness}:{scope}:hook:{event_name.lower()}:{index}:{nested_index}",
+                            name=_hook_name(event_name, matcher),
+                            harness=harness,
+                            artifact_type="hook",
+                            source_scope=scope,
+                            config_path=str(config_path),
+                            command=command,
+                            metadata={
+                                "event": event_name,
+                                "matcher": matcher,
+                                "managed": is_guard_managed_hook_command(command),
+                            },
+                        )
+                    )
+
+
+def _hook_name(event_name: str, matcher: object) -> str:
+    return f"{event_name}:{matcher}" if isinstance(matcher, str) and matcher else event_name
+
+
+def append_hooks_file_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    found_paths: list[str],
+    hooks_file: Path,
+    scope: str,
+) -> None:
+    """Parse a plugin ``hooks/hooks.json`` (or ``hooks-cursor.json``) file."""
+
+    payload = _json_payload(hooks_file)
+    if not payload:
+        return
+    append_found_path(found_paths, hooks_file)
+    hooks = payload.get("hooks")
+    if isinstance(hooks, dict):
+        _append_hook_groups(
+            harness=harness,
+            artifacts=artifacts,
+            hooks=hooks,
+            config_path=hooks_file,
+            scope=scope,
+        )
+
+
+def append_plugin_manifest_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    found_paths: list[str],
+    plugin_root: Path,
+    scope: str,
+) -> None:
+    """Parse ``.zcode-plugin/plugin.json`` and ``.zcode-plugin-seed.json`` provenance."""
+
+    manifest_path = plugin_root / ZCODE_PLUGIN_MANIFEST_DIR / ZCODE_PLUGIN_MANIFEST_FILE
+    payload = _json_payload(manifest_path)
+    if not payload:
+        return
+    append_found_path(found_paths, manifest_path)
+    raw_name = payload.get("name")
+    plugin_name = raw_name if isinstance(raw_name, str) else plugin_root.name
+    raw_version = payload.get("version")
+    version = raw_version if isinstance(raw_version, str) else None
+    publisher_value = payload.get("author")
+    publisher_name: str | None = None
+    if isinstance(publisher_value, dict):
+        author_name = publisher_value.get("name")
+        publisher_name = author_name if isinstance(author_name, str) else None
+    elif isinstance(publisher_value, str):
+        publisher_name = publisher_value
+
+    seed_path = plugin_root / ZCODE_PLUGIN_SEED_FILE
+    seed_payload = _json_payload(seed_path)
+    metadata: dict[str, object] = {"version": version} if version is not None else {}
+    marketplace_name: str | None = None
+    if seed_payload:
+        append_found_path(found_paths, seed_path)
+        marketplace_value = seed_payload.get("marketplace")
+        if isinstance(marketplace_value, str):
+            marketplace_name = marketplace_value
+            metadata["marketplace"] = marketplace_value
+        source_value = seed_payload.get("source")
+        if isinstance(source_value, str):
+            metadata["source"] = source_value
+        plugin_version_value = seed_payload.get("pluginVersion")
+        if isinstance(plugin_version_value, str):
+            metadata["plugin_version"] = plugin_version_value
+        seed_hash = seed_payload.get("hash")
+        if isinstance(seed_hash, str):
+            metadata["provenance_hash"] = seed_hash
+
+    artifact_id = (
+        f"{harness}:{scope}:plugin:{marketplace_name}:{plugin_name}"
+        if marketplace_name
+        else f"{harness}:{scope}:plugin:{plugin_name}"
+    )
+    artifacts.append(
+        GuardArtifact(
+            artifact_id=artifact_id,
+            name=plugin_name,
+            harness=harness,
+            artifact_type="plugin",
+            source_scope=scope,
+            config_path=str(manifest_path),
+            publisher=publisher_name,
+            metadata=metadata,
+        )
+    )
+
+    plugin_mcp_path = plugin_root / ZCODE_PLUGIN_MCP_FILE
+    plugin_mcp_payload = _json_payload(plugin_mcp_path)
+    if isinstance(plugin_mcp_payload, dict):
+        servers = plugin_mcp_payload.get("mcpServers")
+        if isinstance(servers, dict):
+            append_found_path(found_paths, plugin_mcp_path)
+            for server_name, server_config in servers.items():
+                if not isinstance(server_name, str) or not isinstance(server_config, dict):
+                    continue
+                command = _server_command(server_config)
+                url = _server_url(server_config)
+                if command is None and url is None:
+                    continue
+                artifacts.append(
+                    GuardArtifact(
+                        artifact_id=f"{harness}:{scope}:plugin:{plugin_name}:mcp:{server_name}",
+                        name=server_name,
+                        harness=harness,
+                        artifact_type="mcp_server",
+                        source_scope=scope,
+                        config_path=str(plugin_mcp_path),
+                        command=command,
+                        args=_string_args(server_config),
+                        url=url,
+                        transport=_mcp_transport(server_config),
+                        metadata={
+                            "env_keys": _mcp_env_keys(server_config),
+                            "plugin": plugin_name,
+                        },
+                    )
+                )
+
+    append_hooks_file_artifacts(
+        harness=harness,
+        artifacts=artifacts,
+        found_paths=found_paths,
+        hooks_file=plugin_root / ZCODE_PLUGIN_HOOKS_FILE,
+        scope=scope,
+    )
+    append_hooks_file_artifacts(
+        harness=harness,
+        artifacts=artifacts,
+        found_paths=found_paths,
+        hooks_file=plugin_root / ZCODE_PLUGIN_HOOKS_CURSOR_FILE,
+        scope=scope,
+    )
+    append_skill_artifacts(
+        harness=harness,
+        artifacts=artifacts,
+        found_paths=found_paths,
+        skill_root=plugin_root / ZCODE_PLUGIN_SKILLS_DIR,
+        scope=scope,
+    )
+    append_command_artifacts(
+        harness=harness,
+        artifacts=artifacts,
+        found_paths=found_paths,
+        command_root=plugin_root / ZCODE_PLUGIN_COMMANDS_DIR,
+        scope=scope,
+    )
+
+
+def append_skill_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    found_paths: list[str],
+    skill_root: Path,
+    scope: str,
+) -> None:
+    if not skill_root.is_dir():
+        return
+    for skill_path in sorted(skill_root.rglob("SKILL.md")):
+        append_found_path(found_paths, skill_path)
+        relative = skill_path.parent.relative_to(skill_root).as_posix()
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=f"{harness}:{scope}:skill:{relative}",
+                name=relative,
+                harness=harness,
+                artifact_type="skill",
+                source_scope=scope,
+                config_path=str(skill_path),
+            )
+        )
+
+
+def append_command_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    found_paths: list[str],
+    command_root: Path,
+    scope: str,
+) -> None:
+    if not command_root.is_dir():
+        return
+    for command_path in sorted(command_root.glob("*.md")):
+        append_found_path(found_paths, command_path)
+        artifacts.append(
+            GuardArtifact(
+                artifact_id=f"{harness}:{scope}:command:{command_path.stem}",
+                name=command_path.stem,
+                harness=harness,
+                artifact_type="command",
+                source_scope=scope,
+                config_path=str(command_path),
+            )
+        )
+
+
+def append_marketplace_artifacts(
+    *,
+    harness: str,
+    artifacts: list[GuardArtifact],
+    found_paths: list[str],
+    marketplace_file: Path,
+    scope: str,
+) -> None:
+    payload = _json_payload(marketplace_file)
+    if not payload:
+        return
+    append_found_path(found_paths, marketplace_file)
+    marketplace_name = payload.get("name")
+    name = marketplace_name if isinstance(marketplace_name, str) else marketplace_file.parent.name
+    plugins = payload.get("plugins")
+    entry_count = len(plugins) if isinstance(plugins, list) else 0
+    artifacts.append(
+        GuardArtifact(
+            artifact_id=f"{harness}:{scope}:marketplace:{name}",
+            name=name,
+            harness=harness,
+            artifact_type="marketplace",
+            source_scope=scope,
+            config_path=str(marketplace_file),
+            metadata={"entries": entry_count},
+        )
+    )
+
+
+def build_guard_managed_pretooluse_group(hook_command: str, *, timeout_seconds: int = 30) -> dict[str, object]:
+    """Build the Guard-managed PreToolUse hook group for the ZCode config."""
+
+    entries: list[dict[str, object]] = []
+    for matcher in ZCODE_PRETOOL_MATCHERS:
+        entries.append(
+            {
+                "matcher": matcher,
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": hook_command,
+                        "timeout": timeout_seconds,
+                    }
+                ],
+            }
+        )
+    return {"PreToolUse": entries}
+
+
+def build_guard_managed_userprompt_group(hook_command: str, *, timeout_seconds: int = 30) -> dict[str, object]:
+    """Build the Guard-managed UserPromptSubmit hook group for the ZCode config."""
+
+    return {
+        "UserPromptSubmit": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": hook_command,
+                        "timeout": timeout_seconds,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def managed_hook_command(marker_comment: str) -> str:
+    """Return the comment line that tags a managed hook command for ZCode."""
+
+    return marker_comment
+
+
+__all__ = [
+    "GUARD_MANAGED_MARKER",
+    "ZCODE_BUNDLE_IDENTIFIER",
+    "ZCODE_CLI_CONFIG_FILE",
+    "ZCODE_CLI_DIR",
+    "ZCODE_DIR",
+    "ZCODE_ENV_HINTS",
+    "ZCODE_MARKETPLACE_FILE",
+    "ZCODE_PLUGINS_DIR",
+    "ZCODE_PLUGIN_CACHE_DIR",
+    "ZCODE_PLUGIN_COMMANDS_DIR",
+    "ZCODE_PLUGIN_HOOKS_CURSOR_FILE",
+    "ZCODE_PLUGIN_HOOKS_FILE",
+    "ZCODE_PLUGIN_MANIFEST_DIR",
+    "ZCODE_PLUGIN_MANIFEST_FILE",
+    "ZCODE_PLUGIN_MARKETPLACES_DIR",
+    "ZCODE_PLUGIN_MCP_FILE",
+    "ZCODE_PLUGIN_SEED_FILE",
+    "ZCODE_PLUGIN_SKILLS_DIR",
+    "ZCODE_PRETOOL_MATCHERS",
+    "append_cli_config_artifacts",
+    "append_command_artifacts",
+    "append_found_path",
+    "append_hooks_file_artifacts",
+    "append_marketplace_artifacts",
+    "append_plugin_manifest_artifacts",
+    "append_skill_artifacts",
+    "build_guard_managed_pretooluse_group",
+    "build_guard_managed_userprompt_group",
+    "is_guard_managed_hook_command",
+    "managed_hook_command",
+]

--- a/src/codex_plugin_scanner/guard/adapters/zcode_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode_hooks.py
@@ -1,0 +1,175 @@
+"""z.ai ZCode hook payload and response helpers for HOL Guard.
+
+ZCode speaks the same JSON stdin/stdout wire protocol as Claude Code: hook
+events arrive as a JSON object on stdin, and Guard replies on stdout with a
+``hookSpecificOutput.permissionDecision`` envelope (``allow`` / ``deny``) or,
+for ``UserPromptSubmit`` blocks, a top-level ``decision`` object. Block
+responses are paired with exit code ``2`` and a human-readable reason on
+stderr by the generic hook emitter.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections.abc import Mapping
+from typing import TextIO
+
+# ZCode surfaces tools using Claude Code names (Bash, Read, Write, Edit, ...) and
+# MCP tools as ``mcp__<server>__<tool>``. No alias table is needed because the
+# canonical tool name already matches the Guard runtime contract.
+_ZCODE_TOOL_ALIASES: dict[str, str] = {
+    "run_terminal_command": "Bash",
+    "run_command": "Bash",
+    "read_file": "Read",
+    "write_file": "Write",
+    "search_replace": "Edit",
+    "multi_edit": "MultiEdit",
+    "grep": "Grep",
+    "web_fetch": "WebFetch",
+    "web_search": "WebSearch",
+}
+
+
+def _raw_hook_event_name(payload: Mapping[str, object]) -> str:
+    for key in ("hook_event_name", "hookEventName"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip().lower()
+    return ""
+
+
+def _canonical_zcode_event_name(raw_event: str) -> str:
+    normalized = raw_event.replace("_", "").replace("-", "").lower()
+    mapping = {
+        "pretooluse": "PreToolUse",
+        "userpromptsubmit": "UserPromptSubmit",
+        "posttooluse": "PostToolUse",
+        "sessionstart": "SessionStart",
+        "notification": "Notification",
+        "permissionrequest": "PermissionRequest",
+        "stop": "Stop",
+    }
+    return mapping.get(normalized, raw_event or "PreToolUse")
+
+
+def _canonical_zcode_tool_name(raw_tool: object | None) -> str | None:
+    if not isinstance(raw_tool, str) or not raw_tool.strip():
+        return None
+    stripped = raw_tool.strip()
+    return _ZCODE_TOOL_ALIASES.get(stripped.lower(), stripped)
+
+
+def prepare_zcode_hook_payload(payload: Mapping[str, object]) -> dict[str, object]:
+    """Map a ZCode hook stdin JSON object onto Guard's shared hook shape."""
+
+    normalized = dict(payload)
+    raw_event = _raw_hook_event_name(normalized)
+    if raw_event:
+        normalized["hook_event_name"] = _canonical_zcode_event_name(raw_event)
+
+    tool_name = normalized.get("tool_name")
+    if tool_name is None:
+        tool_name = normalized.get("toolName")
+    canonical_tool = _canonical_zcode_tool_name(tool_name)
+    if canonical_tool is not None:
+        normalized["tool_name"] = canonical_tool
+
+    tool_input = normalized.get("tool_input")
+    if tool_input is None:
+        tool_input = normalized.get("toolInput")
+    if tool_input is None:
+        tool_input = normalized.get("arguments")
+    if tool_input is not None:
+        normalized["tool_input"] = tool_input
+
+    session_id = normalized.get("session_id")
+    if session_id is None and isinstance(normalized.get("sessionId"), str):
+        normalized["session_id"] = normalized["sessionId"]
+
+    workspace_root = normalized.get("workspace_root")
+    if workspace_root is None and isinstance(normalized.get("workspaceRoot"), str):
+        normalized["workspace_root"] = normalized["workspaceRoot"]
+    if workspace_root is None and isinstance(normalized.get("cwd"), str):
+        normalized["workspace_root"] = normalized["cwd"]
+
+    prompt = normalized.get("prompt")
+    if prompt is None and isinstance(normalized.get("userPrompt"), str):
+        normalized["prompt"] = normalized["userPrompt"]
+    return normalized
+
+
+def _event_name_for_response(payload: Mapping[str, object]) -> str:
+    raw_event = _raw_hook_event_name(payload)
+    return _canonical_zcode_event_name(raw_event) if raw_event else "PreToolUse"
+
+
+def zcode_hook_response_from_guard(
+    *,
+    policy_action: str,
+    reason: str,
+    event_name: str | None = None,
+) -> dict[str, object]:
+    """Translate a Guard policy action into a ZCode-native stdout JSON response.
+
+    ZCode understands the Claude Code hook response shape. For blocking policy
+    actions we emit a ``hookSpecificOutput`` envelope with
+    ``permissionDecision: "deny"``; otherwise we emit ``allow`` so ZCode
+    continues normally.
+    """
+
+    resolved_event = event_name or "PreToolUse"
+    if policy_action in {"block", "sandbox-required", "require-reapproval"}:
+        cleaned_reason = (reason.strip() if isinstance(reason, str) else "") or "Blocked by HOL Guard."
+        if resolved_event == "UserPromptSubmit":
+            return {
+                "decision": "block",
+                "reason": cleaned_reason,
+                "hookSpecificOutput": {
+                    "hookEventName": resolved_event,
+                    "additionalContext": cleaned_reason,
+                },
+            }
+        return {
+            "hookSpecificOutput": {
+                "hookEventName": resolved_event,
+                "permissionDecision": "deny",
+                "permissionDecisionReason": cleaned_reason,
+            }
+        }
+    if resolved_event == "UserPromptSubmit":
+        return {"hookSpecificOutput": {"hookEventName": resolved_event}}
+    return {"hookSpecificOutput": {"hookEventName": resolved_event, "permissionDecision": "allow"}}
+
+
+def emit_zcode_hook_response(
+    *,
+    policy_action: str,
+    reason: str,
+    event_name: str | None = None,
+    payload: Mapping[str, object] | None = None,
+    output_stream: TextIO | None = None,
+) -> None:
+    resolved_event = event_name
+    if resolved_event is None and payload is not None:
+        resolved_event = _event_name_for_response(payload)
+    response = zcode_hook_response_from_guard(
+        policy_action=policy_action,
+        reason=reason,
+        event_name=resolved_event,
+    )
+    stream = output_stream if output_stream is not None else sys.stdout
+    stream.write(json.dumps(response, separators=(",", ":")) + "\n")
+    stream.flush()
+
+
+def zcode_hook_should_block(*, policy_action: str) -> bool:
+    return policy_action in {"block", "sandbox-required", "require-reapproval"}
+
+
+__all__ = [
+    "emit_zcode_hook_response",
+    "prepare_zcode_hook_payload",
+    "zcode_hook_response_from_guard",
+    "zcode_hook_should_block",
+]

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -78,6 +78,10 @@ def _run_guard_hook_command(
         from ..adapters.grok_hooks import prepare_grok_hook_payload
 
         payload = _normalize_hook_payload(prepare_grok_hook_payload(payload), harness=args.harness)
+    if _canonical_harness_name(args.harness) == "zcode":
+        from ..adapters.zcode_hooks import prepare_zcode_hook_payload
+
+        payload = _normalize_hook_payload(prepare_zcode_hook_payload(payload), harness=args.harness)
     managed_install = _managed_install_for(store, args.harness)
     workspace_was_explicit = workspace is not None
     runtime_workspace = workspace

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -206,6 +206,16 @@ def _run_hook_generic_payload(
                 reason=block_reason,
                 output_stream=output_stream,
             )
+        elif _canonical_harness_name(args.harness) == "zcode":
+            from ..adapters.zcode_hooks import emit_zcode_hook_response
+
+            emit_zcode_hook_response(
+                policy_action=policy_action,
+                reason=block_reason,
+                event_name=hook_event_name,
+                payload=payload_map,
+                output_stream=output_stream,
+            )
         # Kimi surfaces stderr to the user as the blocking explanation.
         _emit_native_hook_block_stderr(block_reason)
         return 2
@@ -241,6 +251,17 @@ def _run_hook_generic_payload(
             emit_grok_hook_response(
                 policy_action=policy_action,
                 reason=reason,
+                output_stream=output_stream,
+            )
+            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
+        if _canonical_harness_name(args.harness) == "zcode":
+            from ..adapters.zcode_hooks import emit_zcode_hook_response
+
+            emit_zcode_hook_response(
+                policy_action=policy_action,
+                reason=reason,
+                event_name=hook_event_name,
+                payload=payload_map,
                 output_stream=output_stream,
             )
             return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_finish.py
@@ -129,6 +129,16 @@ def _finalize_runtime_artifact_hook(
                 reason=native_block_reason,
                 output_stream=output_stream,
             )
+        elif _canonical_harness_name(args.harness) == "zcode":
+            from ..adapters.zcode_hooks import emit_zcode_hook_response
+
+            emit_zcode_hook_response(
+                policy_action=policy_action,
+                reason=native_block_reason,
+                event_name=event_name,
+                payload=payload,
+                output_stream=output_stream,
+            )
         # Kimi surfaces stderr to the user as the blocking explanation.
         _emit_native_hook_block_stderr(native_block_reason)
         _record_harness_usage_for_hook(
@@ -184,6 +194,23 @@ def _finalize_runtime_artifact_hook(
             emit_grok_hook_response(
                 policy_action=policy_action,
                 reason=runtime_reason,
+                output_stream=output_stream,
+            )
+            _record_harness_usage_for_hook(
+                store=store,
+                action_envelope=action_envelope,
+                payload=payload,
+                policy_action=policy_action,
+            )
+            return 0 if policy_action not in {"block", "sandbox-required", "require-reapproval"} else 2
+        if canonical_harness == "zcode":
+            from ..adapters.zcode_hooks import emit_zcode_hook_response
+
+            emit_zcode_hook_response(
+                policy_action=policy_action,
+                reason=runtime_reason,
+                event_name=event_name,
+                payload=payload,
                 output_stream=output_stream,
             )
             _record_harness_usage_for_hook(

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
@@ -130,7 +130,7 @@ def _native_hook_permission_decision(policy_action: str, *, harness: str) -> str
     if policy_action in {"block", "sandbox-required"}:
         return "deny"
     if policy_action == "require-reapproval":
-        if canonical in {"codex", "kimi", "grok"}:
+        if canonical in {"codex", "kimi", "grok", "zcode"}:
             return "deny"
         return "ask"
     if canonical == "codex":
@@ -397,7 +397,7 @@ def _load_hook_payload(
     return _normalize_hook_payload(payload, harness=harness) if isinstance(payload, dict) else {}
 
 _ACTION_ENVELOPE_HARNESSES = frozenset(
-    {"codex", "claude-code", "opencode", "copilot", "gemini", "hermes", "openclaw", "cursor", "grok"}
+    {"codex", "claude-code", "opencode", "copilot", "gemini", "hermes", "openclaw", "cursor", "grok", "zcode"}
 )
 
 def _hook_action_envelope(

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -284,7 +284,7 @@ def _should_emit_copilot_hook_response(args: argparse.Namespace) -> bool:
 
 def _should_emit_native_hook_response(args: argparse.Namespace) -> bool:
     return (
-        _canonical_harness_name(args.harness) in {"claude-code", "codex", "kimi", "grok"}
+        _canonical_harness_name(args.harness) in {"claude-code", "codex", "kimi", "grok", "zcode"}
         and not getattr(args, "json", False)
     )
 
@@ -324,7 +324,7 @@ def _should_emit_native_hook_exit_block(args: argparse.Namespace, *, event_name:
     # Codex v0.133 logs non-zero PreToolUse hooks as failed but still executes
     # the tool. Blocking must be communicated through the JSON hook response.
     canonical = _canonical_harness_name(args.harness)
-    if canonical in {"kimi", "grok"} and event_name in {"PreToolUse", "UserPromptSubmit"}:
+    if canonical in {"kimi", "grok", "zcode"} and event_name in {"PreToolUse", "UserPromptSubmit"}:
         return policy_action in {"block", "sandbox-required", "require-reapproval"}
     return False
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -68,6 +68,7 @@ AgentInventoryType = Literal[
     "opencode",
     "kimi",
     "grok",
+    "zcode",
 ]
 _AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
     "hermes",
@@ -80,6 +81,7 @@ _AGENT_INVENTORY_TYPES: tuple[AgentInventoryType, ...] = (
     "opencode",
     "kimi",
     "grok",
+    "zcode",
 )
 
 _SENSITIVE_KEY_RE = re.compile(

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -419,6 +419,29 @@ def normalize_grok_hook_payload(
     )
 
 
+def normalize_zcode_hook_payload(
+    payload: Mapping[str, object],
+    *,
+    workspace: Path | str | None = None,
+    home_dir: Path | str | None = None,
+) -> GuardActionEnvelope:
+    """Normalize a z.ai ZCode hook payload into a typed action envelope.
+
+    ZCode speaks the Claude Code wire protocol, so payloads normalize onto the
+    shared Guard shape through the ZCode hook helpers.
+    """
+
+    from ..adapters.zcode_hooks import prepare_zcode_hook_payload
+
+    return _normalize_action_payload(
+        prepare_zcode_hook_payload(payload),
+        harness="zcode",
+        default_event_name=None,
+        workspace=workspace,
+        home_dir=home_dir,
+    )
+
+
 def normalize_harness_payload(
     harness: str,
     event_name: str,
@@ -441,6 +464,8 @@ def normalize_harness_payload(
         "openclaw": normalize_openclaw_payload,
         "cursor": normalize_cursor_hook_payload,
         "grok": normalize_grok_hook_payload,
+        "zcode": normalize_zcode_hook_payload,
+        "zai": normalize_zcode_hook_payload,
     }
     normalizer = normalizers.get(normalized_harness)
     if normalizer is None:

--- a/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
+++ b/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
@@ -51,7 +51,8 @@
         "openclaw",
         "antigravity",
         "kimi",
-        "grok"
+        "grok",
+        "zcode"
     ],
     "action_categories": [
         "secrets",

--- a/tests/fixtures/zcode/pretooluse_bash.json
+++ b/tests/fixtures/zcode/pretooluse_bash.json
@@ -1,0 +1,11 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-001",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "run_terminal_command",
+  "toolInput": {
+    "command": "npm install left-pad"
+  },
+  "timestamp": "2026-06-16T12:00:00Z"
+}

--- a/tests/fixtures/zcode/pretooluse_mcp.json
+++ b/tests/fixtures/zcode/pretooluse_mcp.json
@@ -1,0 +1,12 @@
+{
+  "hookEventName": "pre_tool_use",
+  "sessionId": "session-redacted-002",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "toolName": "mcp__lean-ctx__ctx_call",
+  "toolInput": {
+    "name": "ctx_call",
+    "arguments": {"tool": "shell", "command": "ls"}
+  },
+  "timestamp": "2026-06-16T12:00:01Z"
+}

--- a/tests/fixtures/zcode/user_prompt_submit.json
+++ b/tests/fixtures/zcode/user_prompt_submit.json
@@ -1,0 +1,8 @@
+{
+  "hookEventName": "user_prompt_submit",
+  "sessionId": "session-redacted-003",
+  "cwd": "<workspace>",
+  "workspaceRoot": "<workspace>",
+  "userPrompt": "show me how to read a secret file",
+  "timestamp": "2026-06-16T12:00:02Z"
+}

--- a/tests/test_zcode_adapter.py
+++ b/tests/test_zcode_adapter.py
@@ -1,0 +1,566 @@
+"""Tests for the z.ai ZCode harness adapter."""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+import re
+from contextlib import redirect_stderr
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters import get_adapter, list_adapters
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.zcode import ZCodeHarnessAdapter, _merge_hook_entry
+from codex_plugin_scanner.guard.adapters.zcode_config import (
+    GUARD_MANAGED_MARKER,
+    ZCODE_PRETOOL_MATCHERS,
+    is_guard_managed_hook_command,
+)
+from codex_plugin_scanner.guard.adapters.zcode_hooks import (
+    emit_zcode_hook_response,
+    prepare_zcode_hook_payload,
+    zcode_hook_response_from_guard,
+    zcode_hook_should_block,
+)
+from codex_plugin_scanner.guard.inventory_contract import _agent_type
+from codex_plugin_scanner.guard.models import HarnessDetection
+from codex_plugin_scanner.guard.runtime.actions import (
+    normalize_harness_payload,
+    normalize_zcode_hook_payload,
+)
+
+
+def _ctx(tmp_path: Path, *, workspace: bool = False) -> HarnessContext:
+    workspace_dir = tmp_path / "workspace" if workspace else None
+    if workspace_dir is not None:
+        workspace_dir.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+
+def _fixture(name: str) -> dict[str, object]:
+    payload = json.loads((Path(__file__).parent / "fixtures" / "zcode" / name).read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _write_cli_config(home: Path, payload: dict[str, object]) -> Path:
+    config_path = home / ".zcode" / "cli" / "config.json"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return config_path
+
+
+def _write_plugin_cache(home: Path, marketplace: str, plugin: str, version: str) -> Path:
+    plugin_root = home / ".zcode" / "cli" / "plugins" / "cache" / marketplace / plugin / version
+    plugin_root.mkdir(parents=True, exist_ok=True)
+    (plugin_root / ".zcode-plugin").mkdir(parents=True, exist_ok=True)
+    (plugin_root / ".zcode-plugin" / "plugin.json").write_text(
+        json.dumps({"name": plugin, "version": version, "author": {"name": "Z.ai"}, "skills": "skills"}),
+        encoding="utf-8",
+    )
+    (plugin_root / ".zcode-plugin-seed.json").write_text(
+        json.dumps(
+            {
+                "hash": "abc123def456",
+                "marketplace": marketplace,
+                "plugin": plugin,
+                "pluginVersion": version,
+                "source": "filesystem",
+                "version": 1,
+            }
+        ),
+        encoding="utf-8",
+    )
+    (plugin_root / "hooks").mkdir(parents=True, exist_ok=True)
+    (plugin_root / "hooks" / "hooks.json").write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {
+                            "matcher": "startup|resume|clear|compact",
+                            "hooks": [
+                                {"type": "command", "command": "echo session-start", "async": False},
+                            ],
+                        }
+                    ],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    (plugin_root / "skills" / "demo").mkdir(parents=True, exist_ok=True)
+    (plugin_root / "skills" / "demo" / "SKILL.md").write_text("# Demo skill\n", encoding="utf-8")
+    (plugin_root / "commands").mkdir(parents=True, exist_ok=True)
+    (plugin_root / "commands" / "demo.md").write_text("---\ndescription: demo\n---\n", encoding="utf-8")
+    return plugin_root
+
+
+def _write_marketplace(home: Path, marketplace: str, plugins: list[dict[str, object]]) -> Path:
+    marketplace_file = home / ".zcode" / "cli" / "plugins" / "marketplaces" / marketplace / "marketplace.json"
+    marketplace_file.parent.mkdir(parents=True, exist_ok=True)
+    marketplace_file.write_text(
+        json.dumps({"name": marketplace, "version": 1, "plugins": plugins}),
+        encoding="utf-8",
+    )
+    return marketplace_file
+
+
+class TestZCodeAdapterIdentity:
+    def test_harness_identifier_is_zcode(self) -> None:
+        assert ZCodeHarnessAdapter.harness == "zcode"
+
+    def test_aliases_resolve(self) -> None:
+        for alias in ("zai", "z-code", "zai-zcode"):
+            assert get_adapter(alias).harness == "zcode"
+
+    def test_get_adapter_returns_zcode_instance(self) -> None:
+        assert isinstance(get_adapter("zcode"), ZCodeHarnessAdapter)
+
+    def test_zcode_is_registered_in_adapter_list(self) -> None:
+        assert "zcode" in {item.harness for item in list_adapters()}
+
+    def test_contract_resolve(self) -> None:
+        from codex_plugin_scanner.guard.adapters.contracts import contract_for
+
+        c = contract_for("zcode")
+        assert c is not None
+        assert c.harness == "zcode"
+        assert c.smoke_command == "hol-guard install zcode --dry-run"
+
+    def test_agent_type_attributes_zcode(self) -> None:
+        assert _agent_type("zcode") == "zcode"
+
+
+class TestZCodeDetect:
+    def test_detects_cli_config_mcp_and_plugins(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "mcp": {
+                    "servers": {
+                        "lean-ctx": {
+                            "type": "stdio",
+                            "command": "/usr/local/bin/lean-ctx",
+                            "args": [],
+                            "env": {"LEAN_CTX_DATA_DIR": "/data"},
+                        }
+                    }
+                },
+                "plugins": {"enabledPlugins": {"demo@mp": True}},
+            },
+        )
+        result = ZCodeHarnessAdapter().detect(ctx)
+        assert result.harness == "zcode"
+        assert any(".zcode/cli/config.json" in path for path in result.config_paths)
+        mcp = [a for a in result.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp) == 1
+        assert mcp[0].name == "lean-ctx"
+        assert mcp[0].command == "/usr/local/bin/lean-ctx"
+        assert mcp[0].transport == "stdio"
+        plugins = [a for a in result.artifacts if a.artifact_type == "plugin"]
+        assert any(p.name == "demo@mp" for p in plugins)
+
+    def test_detects_plugin_cache_manifests_hooks_skills_commands(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(ctx.home_dir, {})
+        _write_plugin_cache(ctx.home_dir, "zcode-plugins-official", "demo-plugin", "1.0.0")
+        result = ZCodeHarnessAdapter().detect(ctx)
+        artifacts = result.artifacts
+        plugins = [a for a in artifacts if a.artifact_type == "plugin"]
+        assert any(a.name == "demo-plugin" for a in plugins)
+        plugin_artifact = next(a for a in plugins if a.name == "demo-plugin")
+        assert plugin_artifact.metadata.get("marketplace") == "zcode-plugins-official"
+        assert plugin_artifact.metadata.get("provenance_hash") == "abc123def456"
+        hooks = [a for a in artifacts if a.artifact_type == "hook"]
+        assert any(a.metadata.get("event") == "SessionStart" for a in hooks)
+        skills = [a for a in artifacts if a.artifact_type == "skill"]
+        assert any(a.name == "demo" for a in skills)
+        commands = [a for a in artifacts if a.artifact_type == "command"]
+        assert any(a.name == "demo" for a in commands)
+
+    def test_detects_marketplace_manifest(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(ctx.home_dir, {})
+        _write_marketplace(
+            ctx.home_dir,
+            "zcode-plugins-official",
+            [{"name": "demo", "version": "1.0.0", "source": "filesystem"}],
+        )
+        result = ZCodeHarnessAdapter().detect(ctx)
+        marketplaces = [a for a in result.artifacts if a.artifact_type == "marketplace"]
+        assert len(marketplaces) == 1
+        assert marketplaces[0].name == "zcode-plugins-official"
+        assert marketplaces[0].metadata.get("entries") == 1
+
+    def test_detects_runtime_env_signal_without_config(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        monkeypatch.setenv("__CFBundleIdentifier", "dev.zcode.app")
+        result = ZCodeHarnessAdapter().detect(ctx)
+        assert result.installed is True
+        assert any("runtime was detected through process environment" in w for w in result.warnings)
+
+    def test_detects_http_mcp_transport(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(
+            ctx.home_dir,
+            {"mcp": {"servers": {"remote": {"url": "https://example.com/mcp", "transport": "http"}}}},
+        )
+        result = ZCodeHarnessAdapter().detect(ctx)
+        mcp = [a for a in result.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp) == 1
+        assert mcp[0].transport == "http"
+        assert mcp[0].url == "https://example.com/mcp"
+
+    def test_project_scope_config_is_detected(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path, workspace=True)
+        project_config = ctx.workspace_dir / ".zcode" / "cli" / "config.json"  # type: ignore[union-attr]
+        project_config.parent.mkdir(parents=True, exist_ok=True)
+        project_config.write_text(
+            json.dumps({"mcp": {"servers": {"proj-server": {"command": "node"}}}}),
+            encoding="utf-8",
+        )
+        result = ZCodeHarnessAdapter().detect(ctx)
+        project_mcp = [a for a in result.artifacts if a.artifact_type == "mcp_server" and a.source_scope == "project"]
+        assert any(a.name == "proj-server" for a in project_mcp)
+
+
+class TestZCodeInstallUninstall:
+    def _patch_shims(self, monkeypatch, ctx: HarnessContext) -> None:
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.zcode.install_guard_shim",
+            lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-zcode"), "notes": []},
+        )
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.zcode.remove_guard_shim",
+            lambda *args, **kwargs: {"shim_path": str(ctx.guard_home / "bin" / "guard-zcode"), "notes": []},
+        )
+
+    def test_install_writes_managed_hooks(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        self._patch_shims(monkeypatch, ctx)
+        manifest = ZCodeHarnessAdapter().install(ctx)
+        config_path = ctx.home_dir / ".zcode" / "cli" / "config.json"
+        assert manifest["active"] is True
+        assert config_path.is_file()
+        payload = json.loads(config_path.read_text(encoding="utf-8"))
+        hooks = payload["hooks"]
+        pretool_matchers = {
+            entry["matcher"]
+            for entry in hooks["PreToolUse"]
+            if isinstance(entry, dict) and isinstance(entry.get("matcher"), str)
+        }
+        assert set(ZCODE_PRETOOL_MATCHERS).issubset(pretool_matchers)
+        assert isinstance(hooks["UserPromptSubmit"], list)
+        managed_commands = [
+            handler["command"]
+            for entry in hooks["PreToolUse"]
+            if isinstance(entry, dict)
+            for handler in entry.get("hooks", [])
+            if isinstance(handler, dict) and is_guard_managed_hook_command(handler.get("command"))
+        ]
+        assert managed_commands, "Guard-managed PreToolUse handlers must be present"
+
+    def test_install_preserves_user_mcp_and_plugins(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "mcp": {"servers": {"user-server": {"command": "node"}}},
+                "plugins": {"enabledPlugins": {"user-plugin@mp": True}},
+            },
+        )
+        self._patch_shims(monkeypatch, ctx)
+        ZCodeHarnessAdapter().install(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        assert payload["mcp"]["servers"]["user-server"]["command"] == "node"
+        assert payload["plugins"]["enabledPlugins"]["user-plugin@mp"] is True
+
+    def test_install_preserves_user_hooks(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {"matcher": "startup", "hooks": [{"type": "command", "command": "echo user-start"}]}
+                    ]
+                }
+            },
+        )
+        self._patch_shims(monkeypatch, ctx)
+        ZCodeHarnessAdapter().install(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        session_start = payload["hooks"]["SessionStart"]
+        user_commands = [
+            handler["command"]
+            for entry in session_start
+            if isinstance(entry, dict)
+            for handler in entry.get("hooks", [])
+            if isinstance(handler, dict) and handler.get("command") == "echo user-start"
+        ]
+        assert user_commands == ["echo user-start"]
+
+    def test_repeated_install_is_idempotent(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        self._patch_shims(monkeypatch, ctx)
+        adapter = ZCodeHarnessAdapter()
+        adapter.install(ctx)
+        first = (ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8")
+        adapter.install(ctx)
+        second = (ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8")
+        assert first.count(GUARD_MANAGED_MARKER) == len(ZCODE_PRETOOL_MATCHERS) + 1
+        assert second.count(GUARD_MANAGED_MARKER) == len(ZCODE_PRETOOL_MATCHERS) + 1
+
+    def test_uninstall_removes_only_guard_managed_entries(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(
+            ctx.home_dir,
+            {
+                "mcp": {"servers": {"user-server": {"command": "node"}}},
+                "plugins": {"enabledPlugins": {"user-plugin@mp": True}},
+                "hooks": {
+                    "SessionStart": [
+                        {"matcher": "startup", "hooks": [{"type": "command", "command": "echo user-start"}]}
+                    ],
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "echo user-pretool"}],
+                        }
+                    ],
+                },
+            },
+        )
+        self._patch_shims(monkeypatch, ctx)
+        adapter = ZCodeHarnessAdapter()
+        adapter.install(ctx)
+        adapter.uninstall(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        # User MCP/plugins preserved.
+        assert payload["mcp"]["servers"]["user-server"]["command"] == "node"
+        assert payload["plugins"]["enabledPlugins"]["user-plugin@mp"] is True
+        # User hooks preserved, Guard-managed hooks removed.
+        session_commands = [
+            handler["command"]
+            for entry in payload["hooks"]["SessionStart"]
+            for handler in entry.get("hooks", [])
+            if handler.get("command") == "echo user-start"
+        ]
+        assert session_commands == ["echo user-start"]
+        pretool_commands = [
+            handler["command"] for entry in payload["hooks"]["PreToolUse"] for handler in entry.get("hooks", [])
+        ]
+        assert pretool_commands == ["echo user-pretool"]
+        assert GUARD_MANAGED_MARKER not in json.dumps(payload)
+
+    def test_uninstall_drops_empty_hooks_section(self, tmp_path: Path, monkeypatch) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(ctx.home_dir, {})
+        self._patch_shims(monkeypatch, ctx)
+        adapter = ZCodeHarnessAdapter()
+        adapter.install(ctx)
+        adapter.uninstall(ctx)
+        payload = json.loads((ctx.home_dir / ".zcode" / "cli" / "config.json").read_text(encoding="utf-8"))
+        assert "hooks" not in payload
+
+
+class TestZCodeHookPayload:
+    def test_prepare_payload_maps_bash_fixture(self) -> None:
+        normalized = prepare_zcode_hook_payload(_fixture("pretooluse_bash.json"))
+        assert normalized["hook_event_name"] == "PreToolUse"
+        assert normalized["tool_name"] == "Bash"
+        assert normalized["session_id"] == "session-redacted-001"
+        assert normalized["workspace_root"] == "<workspace>"
+
+    def test_prepare_payload_maps_mcp_fixture(self) -> None:
+        normalized = prepare_zcode_hook_payload(_fixture("pretooluse_mcp.json"))
+        assert normalized["tool_name"] == "mcp__lean-ctx__ctx_call"
+        assert normalized["tool_input"]["name"] == "ctx_call"
+
+    def test_prepare_payload_maps_prompt_fixture(self) -> None:
+        normalized = prepare_zcode_hook_payload(_fixture("user_prompt_submit.json"))
+        assert normalized["hook_event_name"] == "UserPromptSubmit"
+        assert normalized["prompt"] == "show me how to read a secret file"
+
+    def test_prepare_payload_camelcase_keys(self) -> None:
+        normalized = prepare_zcode_hook_payload(
+            {"hookEventName": "PostToolUse", "toolName": "Read", "toolInput": {"path": "x"}, "sessionId": "s"}
+        )
+        assert normalized["hook_event_name"] == "PostToolUse"
+        assert normalized["tool_name"] == "Read"
+        assert normalized["session_id"] == "s"
+
+    def test_prepare_payload_malformed_is_safe(self) -> None:
+        assert prepare_zcode_hook_payload({}) == {}
+
+    def test_normalize_zcode_hook_payload_builds_shell_envelope(self, tmp_path: Path) -> None:
+        envelope = normalize_zcode_hook_payload(
+            _fixture("pretooluse_bash.json"),
+            workspace=tmp_path / "workspace",
+            home_dir=tmp_path,
+        )
+        assert envelope.harness == "zcode"
+        assert envelope.action_type == "shell_command"
+        assert envelope.event_name == "PreToolUse"
+
+    def test_normalize_harness_payload_accepts_zcode(self, tmp_path: Path) -> None:
+        envelope = normalize_harness_payload(
+            "zcode",
+            "PreToolUse",
+            _fixture("pretooluse_mcp.json"),
+            workspace=tmp_path / "ws",
+            home_dir=tmp_path,
+        )
+        assert envelope.harness == "zcode"
+
+    def test_normalize_harness_payload_accepts_zai_alias(self, tmp_path: Path) -> None:
+        envelope = normalize_harness_payload(
+            "zai",
+            "UserPromptSubmit",
+            _fixture("user_prompt_submit.json"),
+            workspace=tmp_path / "ws",
+            home_dir=tmp_path,
+        )
+        assert envelope.harness == "zcode"
+
+
+class TestZCodeHookResponses:
+    def test_allow_pretool_response(self) -> None:
+        payload = zcode_hook_response_from_guard(policy_action="allow", reason="")
+        assert payload == {"hookSpecificOutput": {"hookEventName": "PreToolUse", "permissionDecision": "allow"}}
+
+    def test_block_pretool_response(self) -> None:
+        payload = zcode_hook_response_from_guard(policy_action="block", reason="Blocked by HOL Guard.")
+        assert payload == {
+            "hookSpecificOutput": {
+                "hookEventName": "PreToolUse",
+                "permissionDecision": "deny",
+                "permissionDecisionReason": "Blocked by HOL Guard.",
+            }
+        }
+
+    def test_block_uses_default_reason_when_empty(self) -> None:
+        payload = zcode_hook_response_from_guard(policy_action="block", reason="")
+        reason = payload["hookSpecificOutput"]["permissionDecisionReason"]
+        assert reason == "Blocked by HOL Guard."
+
+    def test_block_userprompt_response(self) -> None:
+        payload = zcode_hook_response_from_guard(
+            policy_action="require-reapproval", reason="needs approval", event_name="UserPromptSubmit"
+        )
+        assert payload["decision"] == "block"
+        assert payload["hookSpecificOutput"]["hookEventName"] == "UserPromptSubmit"
+
+    def test_should_block_flags_blocking_actions(self) -> None:
+        assert zcode_hook_should_block(policy_action="block")
+        assert zcode_hook_should_block(policy_action="sandbox-required")
+        assert zcode_hook_should_block(policy_action="require-reapproval")
+        assert not zcode_hook_should_block(policy_action="allow")
+
+    def test_emit_writes_json_line(self) -> None:
+        stream = io.StringIO()
+        emit_zcode_hook_response(policy_action="allow", reason="", output_stream=stream)
+        assert json.loads(stream.getvalue())["hookSpecificOutput"]["permissionDecision"] == "allow"
+
+
+class TestZCodeManagedHelpers:
+    def test_is_guard_managed_hook_command_detects_marker(self) -> None:
+        assert is_guard_managed_hook_command(f"python -c '...' # {GUARD_MANAGED_MARKER}")
+
+    def test_is_guard_managed_hook_command_rejects_user_command(self) -> None:
+        assert not is_guard_managed_hook_command("echo user-start")
+
+    def test_merge_hook_entry_preserves_user_handlers(self) -> None:
+        handler = {"type": "command", "command": f"x # {GUARD_MANAGED_MARKER}"}
+        user_handler = {"type": "command", "command": "echo user"}
+        entries: list[object] = [{"matcher": "Bash", "hooks": [user_handler]}]
+        result = _merge_hook_entry(entries, "Bash", handler)
+        bash_entry = next(e for e in result if isinstance(e, dict) and e.get("matcher") == "Bash")
+        commands = [h["command"] for h in bash_entry["hooks"]]
+        assert "echo user" in commands
+        assert f"x # {GUARD_MANAGED_MARKER}" in commands
+
+    def test_merge_hook_entry_refreshes_existing_managed_handler(self) -> None:
+        old = {"type": "command", "command": f"old # {GUARD_MANAGED_MARKER}"}
+        new = {"type": "command", "command": f"new # {GUARD_MANAGED_MARKER}"}
+        entries: list[object] = [{"matcher": "Read", "hooks": [old]}]
+        result = _merge_hook_entry(entries, "Read", new)
+        read_entry = next(e for e in result if isinstance(e, dict) and e.get("matcher") == "Read")
+        commands = [h["command"] for h in read_entry["hooks"]]
+        assert commands == [f"new # {GUARD_MANAGED_MARKER}"]
+
+
+class TestZCodeGenericEmitterBlock:
+    def test_block_emits_deny_json_and_exit_two(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.cli.commands_hook_generic import _run_hook_generic_payload
+        from codex_plugin_scanner.guard.config import GuardConfig
+        from codex_plugin_scanner.guard.store import GuardStore
+
+        guard_home = tmp_path / ".hol-guard"
+        store = GuardStore(guard_home)
+        config = GuardConfig(guard_home=guard_home, workspace=tmp_path)
+        args = argparse.Namespace(
+            harness="zcode",
+            json=False,
+            policy_action="block",
+            artifact_id=None,
+            artifact_name=None,
+        )
+        payload = {
+            "hookEventName": "pre_tool_use",
+            "toolName": "run_terminal_command",
+            "toolInput": {"command": "rm -rf /"},
+        }
+        stderr_capture = io.StringIO()
+        stdout_capture = io.StringIO()
+        with redirect_stderr(stderr_capture):
+            rc = _run_hook_generic_payload(
+                args,
+                action_envelope=None,
+                config=config,
+                output_stream=stdout_capture,
+                payload=payload,
+                runtime_workspace=tmp_path,
+                store=store,
+            )
+        assert rc == 2
+        response = json.loads(stdout_capture.getvalue())
+        assert response["hookSpecificOutput"]["permissionDecision"] == "deny"
+
+
+class TestZCodeFixturesAreRedacted:
+    def test_fixtures_do_not_include_real_local_paths_or_tokens(self) -> None:
+        fixture_dir = Path(__file__).parent / "fixtures" / "zcode"
+        home_prefix = "/" + "Users" + "/"
+        unix_home_prefix = "/" + "home" + "/"
+        secret_marker = "ZAI_" + "API_KEY"
+        forbidden = re.compile(
+            rf"({re.escape(home_prefix)}|{re.escape(unix_home_prefix)}|{secret_marker}|sk-[A-Za-z0-9]{{8,}}|Bearer\s+\S+)"
+        )
+        for path in fixture_dir.glob("*.json"):
+            contents = path.read_text(encoding="utf-8")
+            assert forbidden.search(contents) is None, f"fixture {path.name} contains forbidden content"
+
+
+class TestZCodeDetectionModel:
+    def test_detection_to_dict_roundtrip(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_cli_config(ctx.home_dir, {"mcp": {"servers": {"x": {"command": "node"}}}})
+        detection = ZCodeHarnessAdapter().detect(ctx)
+        payload = detection.to_dict()
+        assert payload["harness"] == "zcode"
+        restored = HarnessDetection(
+            harness=payload["harness"],
+            installed=bool(payload["installed"]),
+            command_available=bool(payload["command_available"]),
+            config_paths=tuple(payload["config_paths"]),
+            artifacts=tuple(),
+            warnings=tuple(payload["warnings"]),
+        )
+        assert restored.harness == "zcode"

--- a/tests/test_zcode_adapter.py
+++ b/tests/test_zcode_adapter.py
@@ -495,6 +495,16 @@ class TestZCodeManagedHelpers:
         commands = [h["command"] for h in read_entry["hooks"]]
         assert commands == [f"new # {GUARD_MANAGED_MARKER}"]
 
+    def test_merge_hook_entry_preserves_non_dict_entries(self) -> None:
+        # Non-dict entries (defensively kept by _prune_managed_entries) must
+        # survive the merge so user data is never silently dropped on install.
+        handler = {"type": "command", "command": f"x # {GUARD_MANAGED_MARKER}"}
+        entries: list[object] = ["raw-user-string", 42, {"matcher": "Bash", "hooks": []}]
+        result = _merge_hook_entry(entries, "Bash", handler)
+        assert "raw-user-string" in result
+        assert 42 in result
+        assert any(isinstance(e, dict) and e.get("matcher") == "Bash" for e in result)
+
 
 class TestZCodeGenericEmitterBlock:
     def test_block_emits_deny_json_and_exit_two(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Adds a first-class harness adapter for z.ai ZCode, which stores its CLI config at `~/.zcode/cli/config.json` in a Claude-Code-shaped layout (`mcp.servers`, `plugins.enabledPlugins`, and a Claude-Code-style `hooks` section) and caches plugins under `~/.zcode/cli/plugins/cache/<marketplace>/<plugin>/<version>/`.
- The adapter detects MCP servers, enabled plugins, plugin manifests and provenance seeds, plugin hooks, skills, commands, and marketplace manifests, plus a running ZCode app through its non-secret process identity signals.
- Installs Guard-managed `PreToolUse` and `UserPromptSubmit` hooks into the config `hooks` section idempotently, preserving user `mcp`, `plugins`, and pre-existing hooks; blocks with exit code `2` and a `permissionDecision: "deny"` response.
- Registers the adapter, protection contract, action-envelope normalizer, and inventory agent type, and routes ZCode hook events through the shared Guard runtime and approval center.

## Testing
- `python -m pytest tests/test_zcode_adapter.py -q`
- `python -m pytest tests/test_guard_harness_contracts.py tests/test_guard_phase04_harness_contracts.py tests/test_guard_harness_setup.py tests/test_guard_harness_smoke.py tests/test_guard_runtime_action_harnesses.py -q`
- `python -m ruff check src/ tests/test_zcode_adapter.py`
- `python -m ruff format --check src/`
- `basedpyright --level error src/`

## Notes
- Detection treats `~/.zcode/v2/credentials.json`, certs, and any auth/secret files as off-limits; only the CLI config and plugin cache are read.
- Only Guard-tagged hook entries in the config `hooks` section are managed and reversible; user `mcp` and `plugins` config is never rewritten.
