### PR TITLE
fix(guard): stop shell-profile PATH pollution from transient shim dirs

### DIFF
--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -64,14 +64,14 @@ _PACKAGE_PROFILE_MARKER = "# HOL Guard package manager shims"
 # Path fragments that indicate a shim dir lives in an ephemeral location (a test
 # temp dir, the system temp root, etc.). Such paths must never be written into a
 # long-lived shell profile: they vanish and leave broken PATH entries behind.
+# Kept POSIX-only because the profile writers short-circuit on Windows
+# (os.name == "nt") before the transient check can run.
 _TRANSIENT_PATH_FRAGMENTS = (
     "/var/folders/",
     "/private/var/folders/",
     "/tmp/",
     "/private/tmp/",
     "/temp/",
-    "\\temp\\",
-    "\\tmp\\",
     "pytest-of-",
 )
 _TRUSTED_CLI_LAUNCHER = (
@@ -839,28 +839,43 @@ def _upsert_managed_profile_block(
 def _strip_managed_marker_blocks(content: str, marker: str) -> str:
     """Remove every Guard-managed block tagged with *marker* from *content*.
 
-    A block is the marker line plus the single line that follows it. Trailing
-    blank lines left behind are collapsed.
+    A block is the marker line plus the single line that follows it. To avoid
+    leaving a gap where a block sat, a single blank line immediately preceding
+    or following a removed block is also dropped. Blank-line runs elsewhere in
+    the file (user content) are left untouched.
     """
 
     if not content:
         return ""
     marker_stripped = marker.strip()
     lines = content.splitlines()
+    # First pass: locate index ranges [i, i+1] of each marker block.
+    drop_indices: set[int] = set()
+    for index, line in enumerate(lines):
+        if line.strip() == marker_stripped and index + 1 < len(lines):
+            drop_indices.add(index)
+            drop_indices.add(index + 1)
+    if not drop_indices:
+        return content if content.endswith("\n") else content + "\n"
+    # Second pass: keep lines, swallowing one blank line adjacent to a dropped
+    # block so the removal does not leave a stale blank gap.
     keep: list[str] = []
-    skip_next = False
-    for line in lines:
-        if skip_next:
-            skip_next = False
+    for index, line in enumerate(lines):
+        if index in drop_indices:
             continue
-        if line.strip() == marker_stripped:
-            # Drop the marker line and the export line that follows it.
-            skip_next = True
-            continue
+        is_blank = line.strip() == ""
+        if is_blank:
+            prev_kept_blank_gap = keep and keep[-1].strip() == ""
+            # Drop this blank only if both neighbors were removed (i.e. the blank
+            # was sandwiched between two removed block lines or sits at the edge
+            # of a removal zone).
+            prev_dropped = (index - 1) in drop_indices
+            next_dropped = (index + 1) in drop_indices
+            edge_of_removal = prev_dropped or next_dropped
+            if edge_of_removal and not prev_kept_blank_gap:
+                continue
         keep.append(line)
     cleaned = "\n".join(keep)
-    while "\n\n\n" in cleaned:
-        cleaned = cleaned.replace("\n\n\n", "\n\n")
     if cleaned and not cleaned.endswith("\n"):
         cleaned += "\n"
     return cleaned
@@ -909,10 +924,24 @@ def _is_transient_path(path: Path) -> bool:
 
     Such paths must not be persisted into a user shell profile because they are
     cleaned up, leaving broken PATH entries that shadow the real binaries.
+    Besides the known static temp roots, any path under the process's own
+    ``TMPDIR``/``TEMP``/``TMP`` is treated as transient so non-standard temp
+    roots on Linux or CI cannot bypass the guard.
     """
 
     text = str(path)
-    return any(fragment in text for fragment in _TRANSIENT_PATH_FRAGMENTS)
+    if any(fragment in text for fragment in _TRANSIENT_PATH_FRAGMENTS):
+        return True
+    for env_name in ("TMPDIR", "TEMP", "TMP"):
+        env_value = os.environ.get(env_name, "").strip()
+        if env_value:
+            try:
+                if path.resolve().is_relative_to(Path(env_value).expanduser().resolve()):
+                    return True
+            except (OSError, ValueError):
+                if text.startswith(env_value):
+                    return True
+    return False
 
 
 def _profile_already_references_path(content: str, shim_dir: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -59,6 +59,21 @@ _PACKAGE_SHIM_COMMANDS = {
     "yarn": "yarn",
 }
 _PACKAGE_SHIM_MANIFEST = "manifest.json"
+_GUARD_PROFILE_MARKER = "# HOL Guard harness launchers"
+_PACKAGE_PROFILE_MARKER = "# HOL Guard package manager shims"
+# Path fragments that indicate a shim dir lives in an ephemeral location (a test
+# temp dir, the system temp root, etc.). Such paths must never be written into a
+# long-lived shell profile: they vanish and leave broken PATH entries behind.
+_TRANSIENT_PATH_FRAGMENTS = (
+    "/var/folders/",
+    "/private/var/folders/",
+    "/tmp/",
+    "/private/tmp/",
+    "/temp/",
+    "\\temp\\",
+    "\\tmp\\",
+    "pytest-of-",
+)
 _TRUSTED_CLI_LAUNCHER = (
     "import importlib.util, os, sys; "
     "trusted_root = os.path.realpath(sys.argv.pop(1)); "
@@ -745,20 +760,18 @@ def ensure_guard_shim_path_in_shell_profile(context: HarnessContext) -> dict[str
             "restart_shell_required": False,
             "manual_path_required": True,
         }
-    profile_path, export_line = _guard_shim_profile_target(context.home_dir, shim_dir)
-    profile_path.parent.mkdir(parents=True, exist_ok=True)
-    existing = profile_path.read_text(encoding="utf-8") if profile_path.exists() else ""
-    if _profile_already_references_path(existing, shim_dir):
+    if _is_transient_path(shim_dir):
         return {
             "changed": False,
-            "profile_path": str(profile_path),
+            "profile_path": None,
             "shim_dir": str(shim_dir),
-            "restart_shell_required": True,
+            "restart_shell_required": False,
+            "manual_path_required": True,
         }
-    prefix = "" if existing == "" or existing.endswith("\n") else "\n"
-    profile_path.write_text(f"{existing}{prefix}{export_line}\n", encoding="utf-8")
+    profile_path, export_line = _guard_shim_profile_target(context.home_dir, shim_dir)
+    result = _upsert_managed_profile_block(profile_path, export_line, _GUARD_PROFILE_MARKER)
     return {
-        "changed": True,
+        "changed": result["changed"],
         "profile_path": str(profile_path),
         "shim_dir": str(shim_dir),
         "restart_shell_required": True,
@@ -769,29 +782,93 @@ def ensure_package_shim_path_in_shell_profile(context: HarnessContext) -> dict[s
     """Prepend the package shim dir in the user's normal shell profile."""
 
     shim_dir = context.guard_home / "package-shims" / "bin"
-    profile_path, export_line = _package_shim_profile_target(context.home_dir, shim_dir)
-    profile_path.parent.mkdir(parents=True, exist_ok=True)
-    existing = profile_path.read_text(encoding="utf-8") if profile_path.exists() else ""
-    if _profile_already_references_path(existing, shim_dir):
+    if _is_transient_path(shim_dir):
         return {
             "changed": False,
-            "profile_path": str(profile_path),
+            "profile_path": None,
             "shim_dir": str(shim_dir),
-            "restart_shell_required": True,
+            "restart_shell_required": False,
+            "manual_path_required": True,
         }
-    prefix = "" if existing == "" or existing.endswith("\n") else "\n"
-    profile_path.write_text(f"{existing}{prefix}{export_line}\n", encoding="utf-8")
+    profile_path, export_line = _package_shim_profile_target(context.home_dir, shim_dir)
+    result = _upsert_managed_profile_block(profile_path, export_line, _PACKAGE_PROFILE_MARKER)
     return {
-        "changed": True,
+        "changed": result["changed"],
         "profile_path": str(profile_path),
         "shim_dir": str(shim_dir),
         "restart_shell_required": True,
     }
 
 
+def _upsert_managed_profile_block(
+    profile_path: Path,
+    export_line: str,
+    marker: str,
+) -> dict[str, object]:
+    """Idempotently write a single Guard-managed block to a shell profile.
+
+    Replaces any existing block tagged with *marker* instead of appending a new
+    one each time, so the profile never accumulates stale Guard PATH entries
+    (for example, one per pytest temp shim dir). Keeps all other profile
+    content untouched. A managed block is exactly two lines: the marker comment
+    followed by the export/fish_add_path line.
+    """
+
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    existing = profile_path.read_text(encoding="utf-8") if profile_path.exists() else ""
+    export_line = export_line.rstrip("\n")
+    marker_line = export_line.split("\n", 1)[0]
+    if marker_line.strip() != marker.strip():
+        # Defensive: caller always passes a block whose first line is the marker.
+        export_line = f"{marker}\n{export_line}"
+    desired = f"{export_line}\n"
+    if existing == desired:
+        return {"changed": False}
+    cleaned = _strip_managed_marker_blocks(existing, marker)
+    if cleaned == "":
+        new_content = desired
+    else:
+        prefix = "" if cleaned.endswith("\n") else "\n"
+        new_content = f"{cleaned}{prefix}{desired}"
+    if new_content == existing:
+        return {"changed": False}
+    profile_path.write_text(new_content, encoding="utf-8")
+    return {"changed": True}
+
+
+def _strip_managed_marker_blocks(content: str, marker: str) -> str:
+    """Remove every Guard-managed block tagged with *marker* from *content*.
+
+    A block is the marker line plus the single line that follows it. Trailing
+    blank lines left behind are collapsed.
+    """
+
+    if not content:
+        return ""
+    marker_stripped = marker.strip()
+    lines = content.splitlines()
+    keep: list[str] = []
+    skip_next = False
+    for line in lines:
+        if skip_next:
+            skip_next = False
+            continue
+        if line.strip() == marker_stripped:
+            # Drop the marker line and the export line that follows it.
+            skip_next = True
+            continue
+        keep.append(line)
+    cleaned = "\n".join(keep)
+    while "\n\n\n" in cleaned:
+        cleaned = cleaned.replace("\n\n\n", "\n\n")
+    if cleaned and not cleaned.endswith("\n"):
+        cleaned += "\n"
+    return cleaned
+
+
 def _guard_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, str]:
     shell = Path(os.environ.get("SHELL", "")).name
-    marker = "# HOL Guard harness launchers"
+    marker = _GUARD_PROFILE_MARKER
     if shell == "fish":
         return (
             home_dir / ".config" / "fish" / "config.fish",
@@ -810,7 +887,7 @@ def _guard_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, st
 
 def _package_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, str]:
     shell = Path(os.environ.get("SHELL", "")).name
-    marker = "# HOL Guard package manager shims"
+    marker = _PACKAGE_PROFILE_MARKER
     if shell == "fish":
         return (
             home_dir / ".config" / "fish" / "config.fish",
@@ -825,6 +902,17 @@ def _package_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, 
         home_dir / ".zshrc",
         f'{marker}\nexport PATH="{shim_dir}:$PATH"',
     )
+
+
+def _is_transient_path(path: Path) -> bool:
+    """Return True when *path* lives in an ephemeral temp/test location.
+
+    Such paths must not be persisted into a user shell profile because they are
+    cleaned up, leaving broken PATH entries that shadow the real binaries.
+    """
+
+    text = str(path)
+    return any(fragment in text for fragment in _TRANSIENT_PATH_FRAGMENTS)
 
 
 def _profile_already_references_path(content: str, shim_dir: Path) -> bool:

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -782,6 +782,14 @@ def ensure_package_shim_path_in_shell_profile(context: HarnessContext) -> dict[s
     """Prepend the package shim dir in the user's normal shell profile."""
 
     shim_dir = context.guard_home / "package-shims" / "bin"
+    if os.name == "nt":
+        return {
+            "changed": False,
+            "profile_path": None,
+            "shim_dir": str(shim_dir),
+            "restart_shell_required": False,
+            "manual_path_required": True,
+        }
     if _is_transient_path(shim_dir):
         return {
             "changed": False,

--- a/tests/test_guard_shim_profile.py
+++ b/tests/test_guard_shim_profile.py
@@ -1,0 +1,161 @@
+"""Tests for Guard-managed shell profile PATH writes.
+
+Regression coverage for two defects:
+
+1. The profile writers only de-duplicated on an exact ``shim_dir`` match, so
+   each distinct shim dir (one per pytest temp run) appended a fresh line to the
+   shell profile. The profile accumulated dozens of stale PATH entries pointing
+   at deleted temp dirs, which shadowed the real package-manager binaries.
+2. Transient (temp / pytest) shim dirs were written into the long-lived shell
+   profile, leaving broken entries behind after cleanup.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from codex_plugin_scanner.guard.shims import (
+    _PACKAGE_PROFILE_MARKER,
+    _is_transient_path,
+    _strip_managed_marker_blocks,
+    _upsert_managed_profile_block,
+    ensure_guard_shim_path_in_shell_profile,
+    ensure_package_shim_path_in_shell_profile,
+)
+
+
+def _context(home: Path, guard_home: Path) -> MagicMock:
+    ctx = MagicMock()
+    ctx.home_dir = home
+    ctx.guard_home = guard_home
+    ctx.workspace_dir = None
+    return ctx
+
+
+@pytest.fixture(autouse=True)
+def _force_zsh(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SHELL", "/bin/zsh")
+
+
+class TestTransientPathDetection:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "/var/folders/xx/pytest-1/guard-home/package-shims/bin",
+            "/private/var/folders/yy/T/abc/guard-home/bin",
+            "/tmp/guard-shims/bin",
+            "/private/tmp/guard/bin",
+            "/some/where/pytest-of-user/pytest-5/guard-home/package-shims/bin",
+        ],
+    )
+    def test_transient_paths_detected(self, path: str) -> None:
+        assert _is_transient_path(Path(path)) is True
+
+    @pytest.mark.parametrize(
+        "path",
+        [
+            str(Path.home() / ".hol-guard" / "package-shims" / "bin"),
+            "/usr/local/guard/package-shims/bin",
+            "/home/user/.hol-guard/bin",
+        ],
+    )
+    def test_stable_paths_not_transient(self, path: str) -> None:
+        assert _is_transient_path(Path(path)) is False
+
+
+class TestEnsureSkipsTransientShimDir:
+    def test_package_shim_transient_dir_not_written(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+        # guard_home under tmp_path -> transient on macOS (/var/folders/...).
+        ctx = _context(home, tmp_path / "guard-home")
+        ctx.guard_home.mkdir(parents=True)
+        result = ensure_package_shim_path_in_shell_profile(ctx)
+        assert result["changed"] is False
+        assert result["manual_path_required"] is True
+        assert not (home / ".zshrc").exists()
+
+    def test_guard_shim_transient_dir_not_written(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+        ctx = _context(home, tmp_path / "guard-home")
+        ctx.guard_home.mkdir(parents=True)
+        result = ensure_guard_shim_path_in_shell_profile(ctx)
+        assert result["changed"] is False
+        assert result["manual_path_required"] is True
+        assert not (home / ".zshrc").exists()
+
+
+class TestUpsertIsIdempotent:
+    def test_repeat_write_does_not_accumulate_blocks(self, tmp_path: Path) -> None:
+        profile = tmp_path / ".zshrc"
+        export = f'{_PACKAGE_PROFILE_MARKER}\nexport PATH="/stable/shims/bin:$PATH"'
+        assert _upsert_managed_profile_block(profile, export, _PACKAGE_PROFILE_MARKER)["changed"] is True
+        assert _upsert_managed_profile_block(profile, export, _PACKAGE_PROFILE_MARKER)["changed"] is False
+        assert profile.read_text(encoding="utf-8").count(_PACKAGE_PROFILE_MARKER) == 1
+
+    def test_stale_block_is_replaced_not_duplicated(self, tmp_path: Path) -> None:
+        profile = tmp_path / ".zshrc"
+        stale = (
+            f"user_alias=keep\n"
+            f"{_PACKAGE_PROFILE_MARKER}\n"
+            f'export PATH="/var/folders/STALE/guard-home/package-shims/bin:$PATH"\n'
+            f"other_setting=1\n"
+        )
+        profile.write_text(stale, encoding="utf-8")
+        fresh = f'{_PACKAGE_PROFILE_MARKER}\nexport PATH="/stable/shims/bin:$PATH"'
+        assert _upsert_managed_profile_block(profile, fresh, _PACKAGE_PROFILE_MARKER)["changed"] is True
+        text = profile.read_text(encoding="utf-8")
+        assert text.count(_PACKAGE_PROFILE_MARKER) == 1
+        assert "STALE" not in text
+        assert "/stable/shims/bin" in text
+        # User content outside the managed block is preserved.
+        assert "user_alias=keep" in text
+        assert "other_setting=1" in text
+
+    def test_multiple_stale_blocks_collapsed_to_one(self, tmp_path: Path) -> None:
+        profile = tmp_path / ".zshrc"
+        polluted = (
+            "\n".join(
+                f'{_PACKAGE_PROFILE_MARKER}\nexport PATH="/var/folders/pytest-{i}/guard-home/package-shims/bin:$PATH"'
+                for i in range(5)
+            )
+            + "\n"
+        )
+        profile.write_text(polluted, encoding="utf-8")
+        fresh = f'{_PACKAGE_PROFILE_MARKER}\nexport PATH="/stable/shims/bin:$PATH"'
+        _upsert_managed_profile_block(profile, fresh, _PACKAGE_PROFILE_MARKER)
+        text = profile.read_text(encoding="utf-8")
+        assert text.count(_PACKAGE_PROFILE_MARKER) == 1
+        assert "pytest-" not in text
+
+
+class TestStripManagedMarkerBlocks:
+    def test_preserves_unrelated_marker_free_content(self) -> None:
+        content = "a=1\nb=2\n"
+        assert _strip_managed_marker_blocks(content, _PACKAGE_PROFILE_MARKER) == content
+
+    def test_empty_content_stays_empty(self) -> None:
+        assert _strip_managed_marker_blocks("", _PACKAGE_PROFILE_MARKER) == ""
+
+
+class TestEnsureWritesStablePath:
+    def test_package_shim_writes_single_stable_entry(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+        guard_home = tmp_path / "guard-home"
+        (guard_home / "package-shims" / "bin").mkdir(parents=True)
+        ctx = _context(home, guard_home)
+        # Force the shim dir to look stable so the writer proceeds under a temp home.
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.shims._is_transient_path",
+            lambda path: False,
+        )
+        ensure_package_shim_path_in_shell_profile(ctx)
+        ensure_package_shim_path_in_shell_profile(ctx)
+        text = (home / ".zshrc").read_text(encoding="utf-8")
+        assert text.count(_PACKAGE_PROFILE_MARKER) == 1
+        assert "package-shims/bin" in text

--- a/tests/test_guard_shim_profile.py
+++ b/tests/test_guard_shim_profile.py
@@ -65,6 +65,21 @@ class TestTransientPathDetection:
     def test_stable_paths_not_transient(self, path: str) -> None:
         assert _is_transient_path(Path(path)) is False
 
+    def test_custom_tmpdir_is_transient(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """A caller-pointed TMPDIR (not under /var/folders) must still be treated as transient."""
+        custom = tmp_path / "scratch-tmp"
+        custom.mkdir()
+        monkeypatch.setenv("TMPDIR", str(custom))
+        shim = custom / "guard-home" / "package-shims" / "bin"
+        shim.mkdir(parents=True)
+        assert _is_transient_path(shim) is True
+
+    def test_no_windows_backslash_fragments_in_list(self) -> None:
+        """The transient-fragment list is POSIX-only; backslash fragments are dead code on POSIX."""
+        from codex_plugin_scanner.guard.shims import _TRANSIENT_PATH_FRAGMENTS
+
+        assert not any("\\" in fragment for fragment in _TRANSIENT_PATH_FRAGMENTS)
+
 
 class TestEnsureSkipsTransientShimDir:
     def test_package_shim_transient_dir_not_written(self, tmp_path: Path) -> None:
@@ -140,6 +155,11 @@ class TestStripManagedMarkerBlocks:
 
     def test_empty_content_stays_empty(self) -> None:
         assert _strip_managed_marker_blocks("", _PACKAGE_PROFILE_MARKER) == ""
+
+    def test_user_triple_blank_lines_preserved(self) -> None:
+        """Stripping must only drop blank lines adjacent to a removed block; user blanks stay intact."""
+        content = "a=1\n\n\n\nb=2\n"  # 3 blank lines between user content
+        assert _strip_managed_marker_blocks(content, _PACKAGE_PROFILE_MARKER) == content
 
 
 class TestEnsureWritesStablePath:

--- a/tests/test_guard_shim_profile.py
+++ b/tests/test_guard_shim_profile.py
@@ -179,3 +179,39 @@ class TestEnsureWritesStablePath:
         text = (home / ".zshrc").read_text(encoding="utf-8")
         assert text.count(_PACKAGE_PROFILE_MARKER) == 1
         assert "package-shims/bin" in text
+
+
+class TestEnsureSkipsOnWindows:
+    """Both profile writers must short-circuit on Windows before touching .zshrc."""
+
+    def _stable_ctx(self, tmp_path: Path) -> MagicMock:
+        home = tmp_path / "home"
+        home.mkdir()
+        guard_home = home / ".hol-guard"
+        (guard_home / "bin").mkdir(parents=True)
+        (guard_home / "package-shims" / "bin").mkdir(parents=True)
+        return _context(home, guard_home)
+
+    def test_package_shim_skipped_on_windows(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = self._stable_ctx(tmp_path)
+        monkeypatch.setattr("codex_plugin_scanner.guard.shims.os.name", "nt")
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.shims._is_transient_path",
+            lambda path: False,
+        )
+        result = ensure_package_shim_path_in_shell_profile(ctx)
+        assert result["changed"] is False
+        assert result["manual_path_required"] is True
+        assert not (ctx.home_dir / ".zshrc").exists()
+
+    def test_guard_shim_skipped_on_windows(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        ctx = self._stable_ctx(tmp_path)
+        monkeypatch.setattr("codex_plugin_scanner.guard.shims.os.name", "nt")
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.shims._is_transient_path",
+            lambda path: False,
+        )
+        result = ensure_guard_shim_path_in_shell_profile(ctx)
+        assert result["changed"] is False
+        assert result["manual_path_required"] is True
+        assert not (ctx.home_dir / ".zshrc").exists()


### PR DESCRIPTION
## Summary
- Makes the harness-launcher and package-shim shell-profile PATH writes idempotent per marker, replacing the existing Guard-managed block instead of appending a new line each time.
- Refuses to write shim dirs that live in transient locations (`/var/folders`, `/tmp`, pytest temp trees) into the long-lived shell profile, so ephemeral runs can never leave broken PATH entries behind.
- Previously each distinct shim dir (one per temp/pytest guard home) appended a fresh PATH line, accumulating dozens of stale entries that pointed at deleted paths and shadowed the real package-manager binaries.

## Testing
- `python -m pytest tests/test_guard_shim_profile.py -q`
- `python -m pytest tests/test_guard_phase05_manager_coverage.py -q`
- `python -m ruff check src/ tests/test_guard_shim_profile.py`
- `python -m ruff format --check src/`
- `basedpyright --level error src/codex_plugin_scanner/guard/shims.py`

## Notes
- Regression tests cover transient-path detection, the no-write skip for temp dirs, idempotent upsert (no accumulation), stale-block replacement with user content preserved, and multi-block collapse.
- User content outside the Guard-managed marker block is preserved untouched.
