### PR TITLE
fix(oauth): auto-repair stale credential fallback

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -4765,10 +4765,12 @@ class GuardStore:
             return health
         secret_hash = payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)
         cached_health = self._get_cached_oauth_health_result(secret_hash)
-        if cached_health is not None:
+        if cached_health is not None and cached_health.get("state") == "healthy":
             health.update(cached_health)
             return health
         secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
+        if secret_payload is None and self.repair_oauth_local_credential_storage_from_primary():
+            secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
         if secret_payload is None:
             health["state"] = "degraded"
             self._remember_oauth_health_result(secret_hash, health)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -4765,7 +4765,7 @@ class GuardStore:
             return health
         secret_hash = payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)
         cached_health = self._get_cached_oauth_health_result(secret_hash)
-        if cached_health is not None and cached_health.get("state") == "healthy":
+        if cached_health is not None:
             health.update(cached_health)
             return health
         secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
@@ -4910,7 +4910,6 @@ class GuardStore:
         cache_key = self._oauth_health_process_cache_key(_string_value(payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)))
         if cache_key is not None:
             _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
-        self._clear_oauth_secret_payload_cache()
         return True
 
     def _load_oauth_secret_payload(

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -1753,7 +1753,7 @@ def test_repair_oauth_local_credential_storage_from_primary_repairs_stale_encryp
 
     monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
 
-    assert store.get_oauth_local_credential_health()["state"] == "degraded"
+    assert store.get_oauth_local_credentials(allow_primary=False) is None
     assert store.repair_oauth_local_credential_storage_from_primary() is True
     health = store.get_oauth_local_credential_health()
     repeated_health = store.get_oauth_local_credential_health()
@@ -1766,6 +1766,57 @@ def test_repair_oauth_local_credential_storage_from_primary_repairs_stale_encryp
     second_store = GuardStore(guard_home)
     assert second_store.repair_oauth_local_credential_storage_from_primary() is False
     assert primary_reads == 1
+
+
+def test_oauth_health_auto_repairs_stale_encrypted_fallback_from_primary(tmp_path, monkeypatch):
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----[REDACTED:Private key block]\\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    secret_id = str(oauth_payload["credentials_ref"])
+    rotated_secret_payload = json.loads(fake_keyring.get_password("hol-guard.oauth", secret_id) or "{}")
+    rotated_secret_payload["refresh_token"] = "refresh-secret-value-rotated"
+    rotated_secret = json.dumps(rotated_secret_payload, sort_keys=True, separators=(",", ":"))
+    fake_keyring.set_password("hol-guard.oauth", secret_id, rotated_secret)
+    oauth_payload["credentials_sha256"] = guard_store_module._secret_fingerprint(rotated_secret)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-01T00:01:00+00:00")
+
+    primary_reads = 0
+    original = store._oauth_secret_store.primary.get_secret_with_timeout
+
+    def count_primary_reads(_secret_id: str, *, timeout_seconds: float) -> str | None:
+        nonlocal primary_reads
+        primary_reads += 1
+        return original(_secret_id, timeout_seconds=timeout_seconds)
+
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", count_primary_reads)
+
+    health = store.get_oauth_local_credential_health()
+    profile = store.get_cloud_sync_profile()
+    repeated_health = store.get_oauth_local_credential_health()
+
+    assert health["state"] == "healthy"
+    assert repeated_health["state"] == "healthy"
+    assert primary_reads == 1
+    assert store._oauth_secret_store.fallback.get_secret(secret_id) == rotated_secret
+    assert profile == {
+        "auth_mode": "oauth",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "workspace_id": "workspace-123",
+    }
 
 
 def test_get_cloud_sync_profile_uses_oauth_metadata_without_primary_keychain_reads(tmp_path, monkeypatch):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -1676,9 +1676,9 @@ def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_pat
 
     for _ in range(10):
         health = store.get_oauth_local_credential_health()
-        assert health["state"] == "degraded"
+        assert health["state"] == "healthy"
 
-    assert primary_reads == 0
+    assert primary_reads == 1
 
 
 def test_oauth_secret_payload_process_cache_is_shared_across_store_instances(tmp_path, monkeypatch):

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -1819,6 +1819,47 @@ def test_oauth_health_auto_repairs_stale_encrypted_fallback_from_primary(tmp_pat
     }
 
 
+def test_oauth_health_caches_degraded_state_between_failed_repair_attempts(tmp_path, monkeypatch):
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----[REDACTED:Private key block]\\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    secret_id = str(oauth_payload["credentials_ref"])
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    store._oauth_secret_store.fallback.delete_secret(secret_id)
+    fake_keyring.delete_password("hol-guard.oauth", secret_id)
+
+    repair_calls = 0
+    original_repair = store.repair_oauth_local_credential_storage_from_primary
+
+    def count_repair_calls() -> bool:
+        nonlocal repair_calls
+        repair_calls += 1
+        return original_repair()
+
+    monkeypatch.setattr(store, "repair_oauth_local_credential_storage_from_primary", count_repair_calls)
+
+    first_health = store.get_oauth_local_credential_health()
+    second_health = store.get_oauth_local_credential_health()
+
+    assert first_health["state"] == "degraded"
+    assert second_health["state"] == "degraded"
+    assert repair_calls == 1
+
+
 def test_get_cloud_sync_profile_uses_oauth_metadata_without_primary_keychain_reads(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
     guard_home = tmp_path / "guard-home"


### PR DESCRIPTION
## Summary
- repair stale Guard Cloud OAuth fallback secrets during normal credential-health checks instead of requiring a separate repair step
- cover stale encrypted-fallback recovery so cloud sync metadata stays available after the primary keychain token rotates

## Testing
- `pytest tests/test_guard_store_migrations.py -q -k 'repair_oauth_local_credential_storage_from_primary or oauth_health_auto_repairs_stale_encrypted_fallback_from_primary or get_cloud_sync_profile_uses_oauth_metadata_without_primary_keychain_reads'`
