### PR TITLE
fix: stop repeated policy-integrity keychain prompts

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -379,6 +379,7 @@ class SystemKeyringSecretStore:
 
     _MACOS_KEYCHAIN_HEALTH_CACHE_TTL_SECONDS = 5.0
     _macos_keychain_health_cache: tuple[float, bool] | None = None
+    _native_macos_security_reads_cache: tuple[int, bool] | None = None
 
     def __init__(self, service_name: str) -> None:
         self.service_name = service_name
@@ -499,8 +500,27 @@ class SystemKeyringSecretStore:
         value = keyring_module.get_password(self.service_name, secret_id)
         return value if isinstance(value, str) and value else None
 
-    def get_secret_with_timeout(self, secret_id: str, *, timeout_seconds: float) -> str | None:
+    @classmethod
+    def _supports_native_macos_security_reads(cls) -> bool:
         if sys.platform != "darwin":
+            return False
+        loader_ref = cls._load_keyring_module
+        loader_id = id(loader_ref)
+        cached = cls._native_macos_security_reads_cache
+        if cached is not None and cached[0] == loader_id:
+            return cached[1]
+        try:
+            keyring_module = loader_ref()
+        except Exception:
+            cls._native_macos_security_reads_cache = (loader_id, False)
+            return False
+        module_name = getattr(keyring_module, "__name__", "")
+        supported = module_name == "keyring"
+        cls._native_macos_security_reads_cache = (loader_id, supported)
+        return supported
+
+    def get_secret_with_timeout(self, secret_id: str, *, timeout_seconds: float) -> str | None:
+        if not self._supports_native_macos_security_reads():
             return self.get_secret(secret_id)
         security_path = Path("/usr/bin/security")
         if not security_path.exists():
@@ -809,6 +829,8 @@ _OAUTH_HEALTH_CACHE_TTL_SECONDS = 60.0
 _OAUTH_HEALTH_DEGRADED_CACHE_TTL_SECONDS = 15.0
 _OAUTH_STORAGE_REPAIR_MIN_INTERVAL_SECONDS = 3600.0
 _OAUTH_KEYCHAIN_ACCESS_STATE_FILE = "oauth-keychain-access.json"
+_POLICY_INTEGRITY_PRIMARY_SECRET_TIMEOUT_SECONDS = 1.0
+_POLICY_INTEGRITY_CACHE_TTL_SECONDS = 60.0
 _store_logger = logging.getLogger(__name__)
 _OAUTH_SECRET_PAYLOAD_PROCESS_CACHE: dict[tuple[str, str, str], str] = {}
 _OAUTH_HEALTH_RESULT_PROCESS_CACHE: dict[tuple[str, str], tuple[float, dict[str, object]]] = {}
@@ -833,6 +855,8 @@ class GuardStore:
         self._oauth_secret_store = _build_oauth_secret_store(self.guard_home)
         self._policy_integrity_secret_store = _build_policy_integrity_secret_store()
         self._cached_oauth_secret_payload: tuple[str, str, str] | None = None
+        self._cached_policy_integrity_secret_material: tuple[str | None, float, tuple[bytes, str]] | None = None
+        self._cached_policy_integrity_control_state: tuple[str | None, float, dict[str, object]] | None = None
         self._sync_token_ref = self._build_scoped_secret_ref(_SYNC_TOKEN_REF)
         self._policy_integrity_key_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_KEY_REF)
         self._policy_integrity_control_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_CONTROL_REF)
@@ -903,6 +927,21 @@ class GuardStore:
             )
         return self._get_secret_from_store(store, secret_id)
 
+    def _get_policy_integrity_secret_from_store(self, secret_id: str) -> str | None:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is None:
+            return None
+        if isinstance(secret_store, SystemKeyringSecretStore):
+            return secret_store.get_secret_with_timeout(
+                secret_id,
+                timeout_seconds=_POLICY_INTEGRITY_PRIMARY_SECRET_TIMEOUT_SECONDS,
+            )
+        return self._get_secret_from_store(secret_store, secret_id)
+
+    def _clear_policy_integrity_cache(self) -> None:
+        self._cached_policy_integrity_secret_material = None
+        self._cached_policy_integrity_control_state = None
+
     def _get_secret_candidates(
         self,
         secret_store: SecretStore,
@@ -955,17 +994,22 @@ class GuardStore:
         return _secret_store_backend_name(self._policy_integrity_secret_store)
 
     def _policy_integrity_secret_material(self, *, create: bool) -> tuple[bytes | None, str | None]:
+        cached = self._cached_policy_integrity_secret_material
+        marker = self._policy_integrity_cache_marker()
+        now = time.monotonic()
+        if cached is not None and cached[0] == marker and (now - cached[1]) < _POLICY_INTEGRITY_CACHE_TTL_SECONDS:
+            return cached[2]
         secret_store = self._policy_integrity_secret_store
         if secret_store is None:
             return None, None
-        encoded_key = self._get_secret_from_store(secret_store, self._policy_integrity_key_ref)
+        encoded_key = self._get_policy_integrity_secret_from_store(self._policy_integrity_key_ref)
         if encoded_key is None and create:
             generated_key = base64.urlsafe_b64encode(os.urandom(32)).decode("ascii")
             try:
                 secret_store.set_secret(self._policy_integrity_key_ref, generated_key)
             except Exception:
                 return None, None
-            encoded_key = self._get_secret_from_store(secret_store, self._policy_integrity_key_ref)
+            encoded_key = self._get_policy_integrity_secret_from_store(self._policy_integrity_key_ref)
         if encoded_key is None:
             return None, None
         try:
@@ -975,6 +1019,7 @@ class GuardStore:
         if len(raw_key) != 32:
             return None, None
         key_id = self._versioned_secret_ref(self._policy_integrity_key_ref, sha256(raw_key).hexdigest())
+        self._cached_policy_integrity_secret_material = (marker, now, (raw_key, key_id))
         return raw_key, key_id
 
     @staticmethod
@@ -1014,16 +1059,23 @@ class GuardStore:
         }
 
     def _load_policy_integrity_control_state(self, *, create: bool) -> dict[str, object] | None:
+        cached = self._cached_policy_integrity_control_state
+        marker = self._policy_integrity_cache_marker()
+        now = time.monotonic()
+        if cached is not None and cached[0] == marker and (now - cached[1]) < _POLICY_INTEGRITY_CACHE_TTL_SECONDS:
+            return dict(cached[2])
         secret_store = self._policy_integrity_secret_store
         if secret_store is None:
             return None
-        payload_json = self._get_secret_from_store(secret_store, self._policy_integrity_control_ref)
+        payload_json = self._get_policy_integrity_secret_from_store(self._policy_integrity_control_ref)
         payload: dict[str, object] | None = None
         if payload_json is not None:
             try:
                 payload = self._normalize_policy_integrity_control_state(json.loads(payload_json))
             except json.JSONDecodeError:
                 payload = None
+        if payload is not None:
+            self._cached_policy_integrity_control_state = (marker, now, dict(payload))
         if payload is not None or not create:
             return payload
         payload = self._default_policy_integrity_control_state()
@@ -1038,6 +1090,7 @@ class GuardStore:
         normalized = self._normalize_policy_integrity_control_state(payload)
         if normalized is None:
             return False
+        self._cached_policy_integrity_control_state = None
         try:
             secret_store.set_secret(
                 self._policy_integrity_control_ref,
@@ -1045,6 +1098,11 @@ class GuardStore:
             )
         except Exception:
             return False
+        self._cached_policy_integrity_control_state = (
+            self._policy_integrity_cache_marker(),
+            time.monotonic(),
+            dict(normalized),
+        )
         return True
 
     def _finalize_policy_integrity_control_state(self, payload: Mapping[str, object]) -> None:
@@ -1085,6 +1143,21 @@ class GuardStore:
         except json.JSONDecodeError:
             return None
         return payload if isinstance(payload, dict) else None
+
+    @staticmethod
+    def _load_policy_integrity_state_cache_marker(connection: sqlite3.Connection) -> str | None:
+        row = connection.execute(
+            "select payload_json from sync_state where state_key = ?",
+            (_POLICY_INTEGRITY_STATE_KEY,),
+        ).fetchone()
+        if row is None:
+            return None
+        payload_json = row["payload_json"]
+        return str(payload_json) if isinstance(payload_json, str) and payload_json else None
+
+    def _policy_integrity_cache_marker(self) -> str | None:
+        with self._connect() as connection:
+            return self._load_policy_integrity_state_cache_marker(connection)
 
     @staticmethod
     def _store_policy_integrity_state(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,13 @@ def install_fake_system_keyring(monkeypatch: pytest.MonkeyPatch) -> Callable[[],
     return _install
 
 
+@pytest.fixture
+def allow_transient_shell_profile_writes(monkeypatch: pytest.MonkeyPatch) -> None:
+    from codex_plugin_scanner.guard import shims as guard_shims_module
+
+    monkeypatch.setattr(guard_shims_module, "_is_transient_path", lambda _path: False)
+
+
 _FAKE_SYSTEM_KEYRING_DISABLED_FILES = {
     "test_guard_store_migrations.py",
 }

--- a/tests/test_cursor_cli.py
+++ b/tests/test_cursor_cli.py
@@ -107,6 +107,7 @@ def test_resolve_cursor_cli_entry_uses_cursor_agent_subcommand(tmp_path: Path, m
 def test_cursor_cli_install_creates_dual_shims_and_shell_profile(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    allow_transient_shell_profile_writes,
 ) -> None:
     bin_dir = tmp_path / "bin"
     _write_fake_cursor_with_agent_subcommand(bin_dir)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -1009,6 +1009,7 @@ def test_supply_chain_package_firewall_open_shell_endpoint_returns_activation_la
 def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    allow_transient_shell_profile_writes,
 ) -> None:
     home_dir = tmp_path / "home"
     home_dir.mkdir()
@@ -1212,6 +1213,7 @@ def test_supply_chain_package_firewall_status_exposes_local_recovery_when_connec
 def test_supply_chain_package_firewall_repair_runs_without_guard_cloud_connect(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    allow_transient_shell_profile_writes,
 ) -> None:
     home_dir = tmp_path / "home"
     home_dir.mkdir()
@@ -1307,6 +1309,7 @@ def test_audit_package_shim_path_remediation_requires_approval_gate_proof(tmp_pa
 def test_audit_package_shim_path_remediation_updates_profile_with_gate_proof(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    allow_transient_shell_profile_writes,
 ) -> None:
     home_dir = tmp_path / "home"
     home_dir.mkdir()

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -292,6 +292,7 @@ def test_package_shims_install_self_heals_retry_required_cloud_auth(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    allow_transient_shell_profile_writes,
 ) -> None:
     home_dir = tmp_path / "home"
     home_dir.mkdir()
@@ -391,6 +392,7 @@ def test_package_shims_repair_runs_without_guard_cloud_connect(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys: pytest.CaptureFixture[str],
+    allow_transient_shell_profile_writes,
 ) -> None:
     home_dir = tmp_path / "home"
     home_dir.mkdir()

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -72,6 +72,7 @@ def _delete_policy_integrity_control_state(store: GuardStore) -> None:
     secret_store = store._policy_integrity_secret_store
     assert secret_store is not None
     secret_store.delete_secret(store._policy_integrity_control_ref)
+    store._clear_policy_integrity_cache()
 
 
 def _strip_policy_integrity(home_dir: Path, *, artifact_id: str) -> None:
@@ -127,6 +128,7 @@ def _rotate_policy_integrity_key(store: GuardStore, *, raw_key: bytes) -> None:
         store._policy_integrity_key_ref,
         base64.urlsafe_b64encode(raw_key).decode("ascii"),
     )
+    store._clear_policy_integrity_cache()
 
 
 def test_upsert_policy_signs_local_row_and_resolve_honors_it(tmp_path: Path) -> None:
@@ -276,6 +278,54 @@ def test_upsert_policy_uses_single_integrity_key_lookup_per_write(
     assert row["integrity_version"] is None
     assert state["mode"] == "degraded"
     assert state["key_id"] is None
+
+
+def test_policy_integrity_status_uses_timed_keychain_reads_once_per_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:keychain-cache", artifact_hash="hash-keychain-cache"),
+        "2026-06-14T00:00:00Z",
+    )
+    secret_store = store._policy_integrity_secret_store
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+    key_value = secret_store.get_secret(store._policy_integrity_key_ref)
+    control_value = secret_store.get_secret(store._policy_integrity_control_ref)
+    assert isinstance(key_value, str) and key_value
+    assert isinstance(control_value, str) and control_value
+    assert store.get_policy_integrity_status()["mode"] == "protected"
+    timed_reads: list[str] = []
+
+    def _count_timed_reads(secret_id: str, *, timeout_seconds: float) -> str | None:
+        assert timeout_seconds > 0
+        timed_reads.append(secret_id)
+        if secret_id == store._policy_integrity_key_ref:
+            return key_value
+        if secret_id == store._policy_integrity_control_ref:
+            return control_value
+        raise AssertionError(f"unexpected policy-integrity secret lookup: {secret_id}")
+
+    monkeypatch.setattr(
+        store,
+        "_get_secret_from_store",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("plain keyring reads should not run for policy integrity")
+        ),
+    )
+    monkeypatch.setattr(secret_store, "get_secret_with_timeout", _count_timed_reads)
+    store._clear_policy_integrity_cache()
+
+    first_status = store.get_policy_integrity_status()
+    second_status = store.get_policy_integrity_status()
+
+    assert first_status["mode"] == "protected"
+    assert second_status["mode"] == "protected"
+    assert timed_reads == [
+        store._policy_integrity_control_ref,
+        store._policy_integrity_key_ref,
+    ]
 
 
 def test_tampered_signed_row_is_ignored_and_event_emitted(tmp_path: Path) -> None:
@@ -482,9 +532,7 @@ def test_signed_rollback_snapshot_is_detected_and_repair_advances_generation(tmp
         )
 
     verify = store.verify_policy_integrity()
-    rollback_item = next(
-        item for item in verify["items"] if item.get("artifact_id") == "codex:project:rollback"
-    )
+    rollback_item = next(item for item in verify["items"] if item.get("artifact_id") == "codex:project:rollback")
     repair = store.repair_policy_integrity(clear_invalid=True, now="2026-06-14T00:02:00Z")
     control = _policy_integrity_control_payload(store)
     resolved = store.resolve_policy("codex", "codex:project:current", "hash-current", now="2026-06-14T00:03:00Z")


### PR DESCRIPTION
## Summary
- stop policy-integrity secret reads from repeatedly going through Python keyring on macOS
- cache policy-integrity key/control lookups inside `GuardStore` so hot status/verify paths do not re-hit secure storage
- keep fake keyring tests on the fake backend while production macOS uses the native `/usr/bin/security` read path

## Testing
- `python3 -m pytest tests/test_guard_policy_integrity.py -q`
- `python3 -m pytest tests/test_guard_store_migrations.py -k 'system_keyring or keychain or timed_primary_lookup or primary_keychain_reads or keyring' -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py`
