### PR TITLE
fix(guard): avoid passive policy integrity keychain prompts

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -533,6 +533,9 @@ class SystemKeyringSecretStore:
     def _get_secret_without_macos_ui(self, secret_id: str) -> str | None:
         if not self._supports_native_macos_security_reads():
             return None
+        set_interaction_allowed = None
+        interaction_state = None
+        data = None
         try:
             from ctypes import byref, c_ubyte
 
@@ -573,15 +576,19 @@ class SystemKeyringSecretStore:
         except Exception:
             return None
         finally:
-            if "set_interaction_allowed" in locals() and set_interaction_allowed is not None:
+            if set_interaction_allowed is not None:
                 restore_value = interaction_state.value if interaction_state is not None else 1
                 with suppress(Exception):
                     set_interaction_allowed(restore_value)
         if status == 0:
             try:
-                value = macos_keyring_api.cfstr_to_str(data)
+                value = macos_keyring_api.cfdata_to_str(data)
             except Exception:
-                return None
+                value = None
+            finally:
+                if data is not None:
+                    with suppress(Exception):
+                        macos_keyring_api.CFRelease(data)
             return value if isinstance(value, str) and value else None
         interaction_blocked_statuses = {
             macos_keyring_api.error.item_not_found,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import base64
+import ctypes
 import importlib
 import json
 import logging
@@ -389,6 +390,12 @@ class SystemKeyringSecretStore:
         return importlib.import_module("keyring")
 
     @staticmethod
+    def _load_macos_keyring_api_module():
+        from keyring.backends.macOS import api as macos_keyring_api
+
+        return macos_keyring_api
+
+    @staticmethod
     def _macos_default_keychain_path() -> Path | None:
         result = SystemKeyringSecretStore._run_macos_security_command("default-keychain", "-d", "user")
         if result is None:
@@ -475,7 +482,7 @@ class SystemKeyringSecretStore:
         return result
 
     @classmethod
-    def _is_available(cls) -> bool:
+    def _backend_is_available(cls) -> bool:
         try:
             keyring_module = cls._load_keyring_module()
             backend = keyring_module.get_keyring()
@@ -485,7 +492,11 @@ class SystemKeyringSecretStore:
         if backend_name == "failkeyring":
             return False
         priority = getattr(backend, "priority", None)
-        if isinstance(priority, (int, float)) and priority <= 0:
+        return not (isinstance(priority, (int, float)) and priority <= 0)
+
+    @classmethod
+    def _is_available(cls) -> bool:
+        if not cls._backend_is_available():
             return False
         if sys.platform == "darwin" and not cls._macos_default_keychain_is_usable():
             return False
@@ -519,34 +530,74 @@ class SystemKeyringSecretStore:
         cls._native_macos_security_reads_cache = (loader_id, supported)
         return supported
 
+    def _get_secret_without_macos_ui(self, secret_id: str) -> str | None:
+        if not self._supports_native_macos_security_reads():
+            return None
+        try:
+            from ctypes import byref, c_ubyte
+
+            macos_keyring_api = self._load_macos_keyring_api_module()
+            security_library = getattr(macos_keyring_api, "_sec", None)
+            get_interaction_allowed = (
+                getattr(security_library, "SecKeychainGetUserInteractionAllowed", None)
+                if security_library is not None
+                else None
+            )
+            set_interaction_allowed = (
+                getattr(security_library, "SecKeychainSetUserInteractionAllowed", None)
+                if security_library is not None
+                else None
+            )
+            interaction_state: c_ubyte | None = None
+            if get_interaction_allowed is not None:
+                get_interaction_allowed.restype = macos_keyring_api.OS_status
+                get_interaction_allowed.argtypes = [ctypes.POINTER(c_ubyte)]
+                interaction_state = c_ubyte(1)
+                status = get_interaction_allowed(byref(interaction_state))
+                if status != 0:
+                    interaction_state = None
+            if set_interaction_allowed is not None:
+                set_interaction_allowed.restype = macos_keyring_api.OS_status
+                set_interaction_allowed.argtypes = [c_ubyte]
+                set_interaction_allowed(0)
+            query = macos_keyring_api.create_query(
+                kSecClass=macos_keyring_api.k_("kSecClassGenericPassword"),
+                kSecMatchLimit=macos_keyring_api.k_("kSecMatchLimitOne"),
+                kSecAttrService=self.service_name,
+                kSecAttrAccount=secret_id,
+                kSecReturnData=True,
+                kSecUseAuthenticationUI=macos_keyring_api.k_("kSecUseAuthenticationUIFail"),
+            )
+            data = macos_keyring_api.c_void_p()
+            status = macos_keyring_api.SecItemCopyMatching(query, byref(data))
+        except Exception:
+            return None
+        finally:
+            if "set_interaction_allowed" in locals() and set_interaction_allowed is not None:
+                restore_value = interaction_state.value if interaction_state is not None else 1
+                with suppress(Exception):
+                    set_interaction_allowed(restore_value)
+        if status == 0:
+            try:
+                value = macos_keyring_api.cfstr_to_str(data)
+            except Exception:
+                return None
+            return value if isinstance(value, str) and value else None
+        interaction_blocked_statuses = {
+            macos_keyring_api.error.item_not_found,
+            macos_keyring_api.error.keychain_denied,
+            macos_keyring_api.error.sec_auth_failed,
+            macos_keyring_api.error.plist_missing,
+            macos_keyring_api.error.sec_interaction_not_allowed,
+        }
+        if status in interaction_blocked_statuses:
+            return None
+        return None
+
     def get_secret_with_timeout(self, secret_id: str, *, timeout_seconds: float) -> str | None:
         if not self._supports_native_macos_security_reads():
             return self.get_secret(secret_id)
-        security_path = Path("/usr/bin/security")
-        if not security_path.exists():
-            return None
-        try:
-            result = subprocess.run(
-                [
-                    str(security_path),
-                    "find-generic-password",
-                    "-a",
-                    secret_id,
-                    "-s",
-                    self.service_name,
-                    "-w",
-                ],
-                check=False,
-                capture_output=True,
-                text=True,
-                timeout=timeout_seconds,
-            )
-        except Exception:
-            return None
-        if result.returncode != 0:
-            return None
-        value = result.stdout.rstrip("\r\n")
-        return value if value else None
+        return self._get_secret_without_macos_ui(secret_id)
 
     def delete_secret(self, secret_id: str) -> None:
         keyring_module = self._load_keyring_module()
@@ -796,7 +847,7 @@ def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
 
 
 def _build_policy_integrity_secret_store() -> SystemKeyringSecretStore | None:
-    if SystemKeyringSecretStore._is_available():
+    if SystemKeyringSecretStore._backend_is_available():
         return SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
     return None
 
@@ -938,6 +989,18 @@ class GuardStore:
             )
         return self._get_secret_from_store(secret_store, secret_id)
 
+    @staticmethod
+    def _should_skip_passive_policy_integrity_keychain_read(
+        secret_store: SecretStore,
+        *,
+        create: bool,
+    ) -> bool:
+        return (
+            not create
+            and isinstance(secret_store, SystemKeyringSecretStore)
+            and secret_store._supports_native_macos_security_reads()
+        )
+
     def _clear_policy_integrity_cache(self) -> None:
         self._cached_policy_integrity_secret_material = None
         self._cached_policy_integrity_control_state = None
@@ -1002,7 +1065,13 @@ class GuardStore:
         secret_store = self._policy_integrity_secret_store
         if secret_store is None:
             return None, None
-        encoded_key = self._get_policy_integrity_secret_from_store(self._policy_integrity_key_ref)
+        if self._should_skip_passive_policy_integrity_keychain_read(secret_store, create=create):
+            return None, None
+        encoded_key = (
+            self._get_secret_from_store(secret_store, self._policy_integrity_key_ref)
+            if create
+            else self._get_policy_integrity_secret_from_store(self._policy_integrity_key_ref)
+        )
         if encoded_key is None and create:
             generated_key = base64.urlsafe_b64encode(os.urandom(32)).decode("ascii")
             try:
@@ -1067,7 +1136,13 @@ class GuardStore:
         secret_store = self._policy_integrity_secret_store
         if secret_store is None:
             return None
-        payload_json = self._get_policy_integrity_secret_from_store(self._policy_integrity_control_ref)
+        if self._should_skip_passive_policy_integrity_keychain_read(secret_store, create=create):
+            return None
+        payload_json = (
+            self._get_secret_from_store(secret_store, self._policy_integrity_control_ref)
+            if create
+            else self._get_policy_integrity_secret_from_store(self._policy_integrity_control_ref)
+        )
         payload: dict[str, object] | None = None
         if payload_json is not None:
             try:
@@ -1925,7 +2000,7 @@ class GuardStore:
                 self._record_schema_version(connection, version=2)
             connection.execute("pragma journal_mode=WAL")
             self._repair_store_permissions()
-            self._refresh_policy_integrity_state(connection, now=_now(), create_key=True)
+            self._refresh_policy_integrity_state(connection, now=_now(), create_key=False)
 
     @staticmethod
     def _ensure_policy_column(connection: sqlite3.Connection, column_name: str, column_type: str) -> None:
@@ -3830,9 +3905,11 @@ class GuardStore:
         *,
         now: str,
         harness: str | None = None,
+        create_key: bool,
+        include_items: bool,
     ) -> tuple[dict[str, object], dict[str, int], list[dict[str, object]]]:
-        state = self._refresh_policy_integrity_state(connection, now=now, create_key=True)
-        key, key_id = self._policy_integrity_secret_material(create=True)
+        state = self._refresh_policy_integrity_state(connection, now=now, create_key=create_key)
+        key, key_id = self._policy_integrity_secret_material(create=create_key)
         counts = {status: 0 for status in _POLICY_INTEGRITY_STATUSES}
         items: list[dict[str, object]] = []
         for row in self._load_local_policy_rows(connection, harness=harness):
@@ -3845,6 +3922,8 @@ class GuardStore:
                 trusted_generation=trusted_generation,
             )
             counts[integrity_result.status] += 1
+            if not include_items:
+                continue
             item = self._policy_decision_dict_from_row(connection, row)
             item["integrity_status"] = integrity_result.status
             item["integrity_message"] = integrity_result.message
@@ -3868,7 +3947,13 @@ class GuardStore:
     def get_policy_integrity_status(self, harness: str | None = None) -> dict[str, object]:
         now = _now()
         with self._connect() as connection:
-            state, counts, _items = self._policy_integrity_scan(connection, now=now, harness=harness)
+            state, counts, _items = self._policy_integrity_scan(
+                connection,
+                now=now,
+                harness=harness,
+                create_key=False,
+                include_items=False,
+            )
         return {
             "generated_at": now,
             "harness": harness,
@@ -3886,7 +3971,13 @@ class GuardStore:
     def verify_policy_integrity(self, harness: str | None = None) -> dict[str, object]:
         now = _now()
         with self._connect() as connection:
-            state, counts, items = self._policy_integrity_scan(connection, now=now, harness=harness)
+            state, counts, items = self._policy_integrity_scan(
+                connection,
+                now=now,
+                harness=harness,
+                create_key=False,
+                include_items=True,
+            )
         invalid_items = [item for item in items if item.get("integrity_status") != "valid"]
         return {
             "generated_at": now,
@@ -3916,7 +4007,13 @@ class GuardStore:
             require_policy_clear(self.guard_home, approval_gate_grant=approval_gate_grant, now=current_time)
         next_control_state: dict[str, object] | None = None
         with self._connect() as connection:
-            state, _counts, items = self._policy_integrity_scan(connection, now=current_time, harness=harness)
+            state, _counts, items = self._policy_integrity_scan(
+                connection,
+                now=current_time,
+                harness=harness,
+                create_key=True,
+                include_items=True,
+            )
             invalid_ids = [
                 decision_id
                 for item in items
@@ -3946,7 +4043,13 @@ class GuardStore:
                         connection.commit()
             if next_control_state is not None:
                 self._finalize_policy_integrity_control_state(next_control_state)
-            state, counts, remaining_items = self._policy_integrity_scan(connection, now=current_time, harness=harness)
+            state, counts, remaining_items = self._policy_integrity_scan(
+                connection,
+                now=current_time,
+                harness=harness,
+                create_key=True,
+                include_items=True,
+            )
         return {
             "generated_at": current_time,
             "harness": harness,
@@ -4044,7 +4147,13 @@ class GuardStore:
             connection.commit()
             if next_control_state is not None:
                 self._finalize_policy_integrity_control_state(next_control_state)
-            final_state, counts, items = self._policy_integrity_scan(connection, now=now, harness=harness)
+            final_state, counts, items = self._policy_integrity_scan(
+                connection,
+                now=now,
+                harness=harness,
+                create_key=True,
+                include_items=True,
+            )
         return {
             "generated_at": now,
             "harness": harness,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -540,6 +540,8 @@ class SystemKeyringSecretStore:
             from ctypes import byref, c_ubyte
 
             macos_keyring_api = self._load_macos_keyring_api_module()
+            cfdata_to_str = getattr(macos_keyring_api, "cfdata_to_str", None)
+            cf_release = getattr(macos_keyring_api, "CFRelease", None)
             security_library = getattr(macos_keyring_api, "_sec", None)
             get_interaction_allowed = (
                 getattr(security_library, "SecKeychainGetUserInteractionAllowed", None)
@@ -581,14 +583,16 @@ class SystemKeyringSecretStore:
                 with suppress(Exception):
                     set_interaction_allowed(restore_value)
         if status == 0:
+            if not callable(cfdata_to_str):
+                return None
             try:
-                value = macos_keyring_api.cfdata_to_str(data)
+                value = cfdata_to_str(data)
             except Exception:
                 value = None
             finally:
-                if data is not None:
+                if data is not None and callable(cf_release):
                     with suppress(Exception):
-                        macos_keyring_api.CFRelease(data)
+                        cf_release(data)
             return value if isinstance(value, str) and value else None
         interaction_blocked_statuses = {
             macos_keyring_api.error.item_not_found,
@@ -599,9 +603,12 @@ class SystemKeyringSecretStore:
         }
         if status in interaction_blocked_statuses:
             return None
-        return None
+        return None  # unknown non-zero status
 
-    def get_secret_with_timeout(self, secret_id: str, *, timeout_seconds: float) -> str | None:
+    def get_secret_with_timeout(
+        self, secret_id: str, *, timeout_seconds: float = 0.0
+    ) -> str | None:
+        _ = timeout_seconds
         if not self._supports_native_macos_security_reads():
             return self.get_secret(secret_id)
         return self._get_secret_without_macos_ui(secret_id)

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -24,6 +24,15 @@ def _store(tmp_path: Path) -> GuardStore:
     return GuardStore(tmp_path / "guard-home")
 
 
+def test_guard_store_init_does_not_create_policy_integrity_keyring_material(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    secret_store = store._policy_integrity_secret_store
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+
+    assert secret_store.get_secret(store._policy_integrity_key_ref) is None
+    assert secret_store.get_secret(store._policy_integrity_control_ref) is None
+
+
 def _decision(
     *,
     artifact_id: str = "codex:project:workspace-skill",
@@ -72,6 +81,13 @@ def _delete_policy_integrity_control_state(store: GuardStore) -> None:
     secret_store = store._policy_integrity_secret_store
     assert secret_store is not None
     secret_store.delete_secret(store._policy_integrity_control_ref)
+    store._clear_policy_integrity_cache()
+
+
+def _delete_policy_integrity_key(store: GuardStore) -> None:
+    secret_store = store._policy_integrity_secret_store
+    assert secret_store is not None
+    secret_store.delete_secret(store._policy_integrity_key_ref)
     store._clear_policy_integrity_cache()
 
 
@@ -326,6 +342,91 @@ def test_policy_integrity_status_uses_timed_keychain_reads_once_per_secret(
         store._policy_integrity_control_ref,
         store._policy_integrity_key_ref,
     ]
+
+
+def test_policy_integrity_status_and_verify_do_not_create_keyring_material_on_fresh_store(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    secret_store = store._policy_integrity_secret_store
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+    _delete_policy_integrity_key(store)
+    _delete_policy_integrity_control_state(store)
+    assert secret_store.get_secret(store._policy_integrity_key_ref) is None
+    assert secret_store.get_secret(store._policy_integrity_control_ref) is None
+
+    status = store.get_policy_integrity_status()
+    verify = store.verify_policy_integrity()
+
+    assert status["mode"] == "degraded"
+    assert status["enforcement"] == "warn"
+    assert verify["mode"] == "degraded"
+    assert verify["enforcement"] == "warn"
+    assert verify["local_rows_scanned"] == 0
+    assert secret_store.get_secret(store._policy_integrity_key_ref) is None
+    assert secret_store.get_secret(store._policy_integrity_control_ref) is None
+
+
+def test_policy_integrity_status_skips_passive_macos_keychain_reads(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:passive-skip", artifact_hash="hash-passive-skip"),
+        "2026-06-14T00:00:00Z",
+    )
+    secret_store = store._policy_integrity_secret_store
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+    store._clear_policy_integrity_cache()
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        secret_store,
+        "get_secret_with_timeout",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("passive policy-integrity status should skip macOS keychain reads")
+        ),
+    )
+    monkeypatch.setattr(
+        store,
+        "_get_secret_from_store",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("passive policy-integrity status should not use interactive keychain reads")
+        ),
+    )
+
+    status = store.get_policy_integrity_status()
+    verify = store.verify_policy_integrity()
+
+    assert status["mode"] == "degraded"
+    assert verify["mode"] == "degraded"
+    assert "policy_integrity_key_unavailable" in status["degraded_reasons"]
+    assert "policy_integrity_control_unavailable" in status["degraded_reasons"]
+    assert verify["local_rows_scanned"] == 1
+
+
+def test_policy_integrity_status_skips_item_context_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:status-fast", artifact_hash="hash-status-fast"),
+        "2026-06-14T00:00:00Z",
+    )
+    monkeypatch.setattr(
+        store,
+        "_policy_decision_dict_from_row",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("integrity-status should not build per-row item payloads")
+        ),
+    )
+
+    status = store.get_policy_integrity_status()
+
+    assert status["local_rows_scanned"] == 1
 
 
 def test_tampered_signed_row_is_ignored_and_event_emitted(tmp_path: Path) -> None:
@@ -597,17 +698,27 @@ def test_migrate_local_policy_integrity_reports_rollback_rows(
     assert payload["counts"]["rollback_detected"] == 1
 
 
-def test_policies_cli_verify_status_migrate_and_repair(tmp_path: Path, capsys) -> None:
+def test_policies_cli_verify_status_migrate_and_repair(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
     store.upsert_policy(_decision(artifact_id="codex:project:cli", artifact_hash="hash-cli"), "2026-06-14T00:00:00Z")
     _strip_policy_integrity(home_dir, artifact_id="codex:project:cli")
     _delete_policy_integrity_control_state(store)
+    monkeypatch.setattr(
+        GuardStore,
+        "_backup_policy_database",
+        lambda self, connection, *, now: str(home_dir / "guard.db.pre-integrity-test"),
+    )
 
     verify_rc = main(["guard", "policies", "verify", "--home", str(home_dir), "--json"])
     verify_payload = json.loads(capsys.readouterr().out)
     assert verify_rc == 0
-    assert verify_payload["counts"]["missing_integrity"] == 1
+    assert verify_payload["mode"] == "degraded"
+    assert verify_payload["counts"]["degraded_mode"] == 1
 
     status_rc = main(["guard", "policies", "integrity-status", "--home", str(home_dir), "--json"])
     status_payload = json.loads(capsys.readouterr().out)
@@ -627,7 +738,8 @@ def test_policies_cli_verify_status_migrate_and_repair(tmp_path: Path, capsys) -
     )
     migrate_payload = json.loads(capsys.readouterr().out)
     assert migrate_rc == 0
-    assert migrate_payload["preserved"] == 1
+    assert migrate_payload["preserved"] == 0
+    assert migrate_payload["counts"]["missing_integrity"] == 1
     assert migrate_payload["enforcement"] == "enforce"
 
     _strip_policy_integrity(home_dir, artifact_id="codex:project:cli")

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -24,6 +24,7 @@ from codex_plugin_scanner.guard.store import (
     _build_oauth_secret_store,
     _build_secret_store,
 )
+from codex_plugin_scanner.guard.store_evidence import EvidenceRecord
 
 
 class _FakeSystemKeyringModule:
@@ -73,6 +74,43 @@ def _install_fake_system_keyring(
     return module
 
 
+def test_system_keyring_timeout_uses_noninteractive_macos_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(secret_store, "_get_secret_without_macos_ui", lambda _secret_id: "secret-value")
+    monkeypatch.setattr(
+        guard_store_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("security cli should not run")),
+    )
+
+    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "secret-value"
+
+
+def test_policy_integrity_store_skips_macos_health_probe_when_backend_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    module = _FakeSystemKeyringModule()
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_macos_default_keychain_is_usable",
+        classmethod(
+            lambda cls: (_ for _ in ()).throw(AssertionError("policy integrity builder should skip health probe"))
+        ),
+    )
+
+    secret_store = guard_store_module._build_policy_integrity_secret_store()
+
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+
+
 @pytest.fixture(autouse=True)
 def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
@@ -85,10 +123,6 @@ def _clear_oauth_process_caches() -> None:
     yield
     guard_store_module._OAUTH_SECRET_PAYLOAD_PROCESS_CACHE.clear()
     guard_store_module._OAUTH_HEALTH_RESULT_PROCESS_CACHE.clear()
-
-
-from codex_plugin_scanner.guard.store import GuardStore
-from codex_plugin_scanner.guard.store_evidence import EvidenceRecord
 
 
 def _incomplete_evidence_table(connection: sqlite3.Connection) -> None:


### PR DESCRIPTION
## Summary
- avoid passive policy-integrity keychain reads during store initialization and status checks on macOS
- skip item-context expansion for integrity-status and add regressions for the passive keychain path

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py tests/test_guard_store_migrations.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py tests/test_guard_store_migrations.py`
- `python3 -m pytest tests/test_guard_store_migrations.py -k 'noninteractive_macos_lookup or skips_macos_health_probe' -q`
- `python3 -m pytest tests/test_guard_policy_integrity.py -k 'init_does_not_create_policy_integrity_keyring_material or skips_item_context_expansion or timed_keychain_reads_once_per_secret or do_not_create_keyring_material_on_fresh_store or skips_passive_macos_keychain_reads or policies_cli_verify_status_migrate_and_repair' -q`
