### PR TITLE
fix(guard): fail closed on macos policy keychain reads

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -607,13 +607,13 @@ class SystemKeyringSecretStore:
             return None
         return None  # unknown non-zero status
 
-    def get_secret_with_timeout(
-        self, secret_id: str, *, timeout_seconds: float = 0.0
-    ) -> str | None:
+    def get_secret_with_timeout(self, secret_id: str, *, timeout_seconds: float = 0.0) -> str | None:
         _ = timeout_seconds
-        if not self._supports_native_macos_security_reads():
-            return self.get_secret(secret_id)
-        return self._get_secret_without_macos_ui(secret_id)
+        if self._supports_native_macos_security_reads():
+            return self._get_secret_without_macos_ui(secret_id)
+        if sys.platform == "darwin":
+            return None
+        return self.get_secret(secret_id)
 
     def delete_secret(self, secret_id: str) -> None:
         keyring_module = self._load_keyring_module()
@@ -1069,10 +1069,14 @@ class GuardStore:
         *,
         create: bool,
     ) -> bool:
+        return not create and GuardStore._should_skip_policy_integrity_keychain_access(secret_store)
+
+    @staticmethod
+    def _should_skip_policy_integrity_keychain_access(secret_store: SecretStore) -> bool:
         return (
-            not create
-            and isinstance(secret_store, SystemKeyringSecretStore)
-            and secret_store._supports_native_macos_security_reads()
+            isinstance(secret_store, SystemKeyringSecretStore)
+            and sys.platform == "darwin"
+            and not secret_store._supports_native_macos_security_reads()
         )
 
     def _clear_policy_integrity_cache(self) -> None:
@@ -1139,13 +1143,11 @@ class GuardStore:
         secret_store = self._policy_integrity_secret_store
         if secret_store is None:
             return None, None
+        if self._should_skip_policy_integrity_keychain_access(secret_store):
+            return None, None
         if self._should_skip_passive_policy_integrity_keychain_read(secret_store, create=create):
             return None, None
-        encoded_key = (
-            self._get_secret_from_store(secret_store, self._policy_integrity_key_ref)
-            if create
-            else self._get_policy_integrity_secret_from_store(self._policy_integrity_key_ref)
-        )
+        encoded_key = self._get_policy_integrity_secret_from_store(self._policy_integrity_key_ref)
         if encoded_key is None and create:
             generated_key = base64.urlsafe_b64encode(os.urandom(32)).decode("ascii")
             try:
@@ -1210,13 +1212,11 @@ class GuardStore:
         secret_store = self._policy_integrity_secret_store
         if secret_store is None:
             return None
+        if self._should_skip_policy_integrity_keychain_access(secret_store):
+            return None
         if self._should_skip_passive_policy_integrity_keychain_read(secret_store, create=create):
             return None
-        payload_json = (
-            self._get_secret_from_store(secret_store, self._policy_integrity_control_ref)
-            if create
-            else self._get_policy_integrity_secret_from_store(self._policy_integrity_control_ref)
-        )
+        payload_json = self._get_policy_integrity_secret_from_store(self._policy_integrity_control_ref)
         payload: dict[str, object] | None = None
         if payload_json is not None:
             try:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1064,14 +1064,6 @@ class GuardStore:
         return self._get_secret_from_store(secret_store, secret_id)
 
     @staticmethod
-    def _should_skip_passive_policy_integrity_keychain_read(
-        secret_store: SecretStore,
-        *,
-        create: bool,
-    ) -> bool:
-        return not create and GuardStore._should_skip_policy_integrity_keychain_access(secret_store)
-
-    @staticmethod
     def _should_skip_policy_integrity_keychain_access(secret_store: SecretStore) -> bool:
         return (
             isinstance(secret_store, SystemKeyringSecretStore)
@@ -1145,8 +1137,6 @@ class GuardStore:
             return None, None
         if self._should_skip_policy_integrity_keychain_access(secret_store):
             return None, None
-        if self._should_skip_passive_policy_integrity_keychain_read(secret_store, create=create):
-            return None, None
         encoded_key = self._get_policy_integrity_secret_from_store(self._policy_integrity_key_ref)
         if encoded_key is None and create:
             generated_key = base64.urlsafe_b64encode(os.urandom(32)).decode("ascii")
@@ -1213,8 +1203,6 @@ class GuardStore:
         if secret_store is None:
             return None
         if self._should_skip_policy_integrity_keychain_access(secret_store):
-            return None
-        if self._should_skip_passive_policy_integrity_keychain_read(secret_store, create=create):
             return None
         payload_json = self._get_policy_integrity_secret_from_store(self._policy_integrity_control_ref)
         payload: dict[str, object] | None = None

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -11,6 +11,7 @@ from typing import cast
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore, SystemKeyringSecretStore
 
@@ -300,6 +301,7 @@ def test_policy_integrity_status_uses_timed_keychain_reads_once_per_secret(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
     store = _store(tmp_path)
     store.upsert_policy(
         _decision(artifact_id="codex:project:keychain-cache", artifact_hash="hash-keychain-cache"),
@@ -369,6 +371,7 @@ def test_policy_integrity_status_skips_passive_macos_keychain_reads(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
     store = _store(tmp_path)
     store.upsert_policy(
         _decision(artifact_id="codex:project:passive-skip", artifact_hash="hash-passive-skip"),
@@ -380,13 +383,20 @@ def test_policy_integrity_status_skips_passive_macos_keychain_reads(
     monkeypatch.setattr(
         SystemKeyringSecretStore,
         "_supports_native_macos_security_reads",
-        classmethod(lambda cls: True),
+        classmethod(lambda cls: False),
     )
     monkeypatch.setattr(
         secret_store,
         "get_secret_with_timeout",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(
             AssertionError("passive policy-integrity status should skip macOS keychain reads")
+        ),
+    )
+    monkeypatch.setattr(
+        secret_store,
+        "get_secret",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("passive policy-integrity status should never prompt through get_secret")
         ),
     )
     monkeypatch.setattr(
@@ -404,6 +414,95 @@ def test_policy_integrity_status_skips_passive_macos_keychain_reads(
     assert verify["mode"] == "degraded"
     assert "policy_integrity_key_unavailable" in status["degraded_reasons"]
     assert "policy_integrity_control_unavailable" in status["degraded_reasons"]
+    assert verify["local_rows_scanned"] == 1
+
+
+def test_policy_integrity_create_skips_macos_keychain_when_native_reads_are_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    store = _store(tmp_path)
+    secret_store = store._policy_integrity_secret_store
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        secret_store,
+        "get_secret",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("policy-integrity create should not prompt through get_secret")
+        ),
+    )
+    monkeypatch.setattr(
+        secret_store,
+        "set_secret",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("policy-integrity create should not write unusable keychain material")
+        ),
+    )
+
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:no-native-create", artifact_hash="hash-no-native-create"),
+        "2026-06-14T00:00:00Z",
+    )
+    status = store.get_policy_integrity_status()
+
+    assert status["mode"] == "degraded"
+    assert "policy_integrity_key_unavailable" in status["degraded_reasons"]
+    assert "policy_integrity_control_unavailable" in status["degraded_reasons"]
+
+
+def test_policy_integrity_status_uses_native_macos_reads_without_degrading(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:native-passive", artifact_hash="hash-native-passive"),
+        "2026-06-14T00:00:00Z",
+    )
+    secret_store = store._policy_integrity_secret_store
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+    key_value = secret_store.get_secret(store._policy_integrity_key_ref)
+    control_value = secret_store.get_secret(store._policy_integrity_control_ref)
+    assert isinstance(key_value, str) and key_value
+    assert isinstance(control_value, str) and control_value
+    store._clear_policy_integrity_cache()
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        store,
+        "_get_secret_from_store",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("passive policy-integrity status should not use interactive keychain reads")
+        ),
+    )
+
+    def _native_read(secret_id: str, *, timeout_seconds: float) -> str | None:
+        assert timeout_seconds > 0
+        if secret_id == store._policy_integrity_key_ref:
+            return key_value
+        if secret_id == store._policy_integrity_control_ref:
+            return control_value
+        raise AssertionError(f"unexpected policy-integrity secret lookup: {secret_id}")
+
+    monkeypatch.setattr(secret_store, "get_secret_with_timeout", _native_read)
+
+    status = store.get_policy_integrity_status()
+    verify = store.verify_policy_integrity()
+
+    assert status["mode"] == "protected"
+    assert status["degraded_reasons"] == []
+    assert verify["mode"] == "protected"
     assert verify["local_rows_scanned"] == 1
 
 

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -92,6 +92,25 @@ def test_system_keyring_timeout_uses_noninteractive_macos_lookup(monkeypatch: py
     assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "secret-value"
 
 
+def test_system_keyring_timeout_fails_closed_on_macos_without_native_reads(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: False),
+    )
+    monkeypatch.setattr(
+        secret_store,
+        "get_secret",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("macOS timed reads should not fall back to interactive get_secret")
+        ),
+    )
+
+    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) is None
+
+
 def test_policy_integrity_store_skips_macos_health_probe_when_backend_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- prevent macOS timed keychain reads from falling back to interactive get_secret
- skip policy-integrity keychain access entirely when native no-UI Security reads are unavailable
- keep protected status when native macOS no-UI reads can read policy-integrity material

## Testing
- python3 -m ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py tests/test_guard_store_migrations.py
- python3 -m ruff format --check src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py tests/test_guard_store_migrations.py
- python3 -m pytest tests/test_guard_store_migrations.py -k "system_keyring_timeout" -q
- python3 -m pytest tests/test_guard_policy_integrity.py -k "passive_macos_keychain_reads or native_macos_reads_without_degrading or timed_keychain_reads_once_per_secret" -q
- python3 -m pytest tests/test_guard_policy_integrity.py::test_policy_integrity_create_skips_macos_keychain_when_native_reads_are_unavailable -q
- PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard policies integrity-status --json