### PR TITLE
chore(guard): remove legacy cloud sync token path

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_service.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_service.py
@@ -69,13 +69,13 @@ def _guard_service_sync_failure_message(error: GuardSyncNotConfiguredError) -> s
     return _guard_service_sync_prerequisite_message()
 
 def _guard_service_status_payload(store: GuardStore) -> dict[str, object]:
-    credentials = store.get_sync_credentials()
+    cloud_profile = store.get_cloud_sync_profile()
     service_profile = _guard_service_runtime_profile(store)
     return {
-        "configured": credentials is not None and service_profile is not None,
+        "configured": cloud_profile is not None and service_profile is not None,
         "connection": {
-            "configured": credentials is not None,
-            "sync_url": credentials["sync_url"] if credentials is not None else None,
+            "configured": cloud_profile is not None,
+            "sync_url": cloud_profile["sync_url"] if cloud_profile is not None else None,
         },
         "service": service_profile,
         "runtime": store.get_sync_payload("runtime_session_summary") or {},

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -1241,8 +1241,6 @@ def connect_state_requires_oauth(
     if isinstance(request_id, str) and bool(request_id.strip()):
         return True
     auth_mode = cloud_profile.get("auth_mode") if isinstance(cloud_profile, dict) else None
-    if auth_mode == "legacy":
-        return False
     return auth_mode == "oauth"
 
 

--- a/src/codex_plugin_scanner/guard/cli/product.py
+++ b/src/codex_plugin_scanner/guard/cli/product.py
@@ -100,7 +100,6 @@ def _build_guard_product_payload(
         "guard_home": _redacted_path(context.guard_home, context.home_dir),
         "workspace": _redacted_path(context.workspace_dir, context.home_dir),
         "sync_configured": store.get_cloud_sync_profile() is not None,
-        "sync_storage_health": store.get_sync_credential_health(),
         "oauth_storage_health": store.get_oauth_local_credential_health(),
         "receipt_count": receipt_count,
         "pending_approvals": store.count_approval_requests(),

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2695,11 +2695,20 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
     }
 
 
+# Test-only override: when set, _resolve_guard_sync_auth_context returns this dict
+# directly instead of resolving OAuth credentials (which would refresh tokens over
+# the network). Tests seed OAuth credentials for status/connect-state checks and set
+# this override to keep sync-path exercises hermetic.
+_test_sync_auth_context_override: dict[str, object] | None = None
+
+
 def _resolve_guard_sync_auth_context(
     store: GuardStore,
     *,
     allow_primary_repair: bool = True,
 ) -> dict[str, object]:
+    if _test_sync_auth_context_override is not None:
+        return dict(_test_sync_auth_context_override)
     with _guard_sync_auth_lock(store):
         oauth_health = store.get_oauth_local_credential_health()
         oauth_credentials = store.get_oauth_local_credentials(allow_primary=allow_primary_repair)
@@ -2714,14 +2723,7 @@ def _resolve_guard_sync_auth_context(
                     persist_recovered_secret=allow_primary_repair,
                 )
             raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-        credentials = store.get_sync_credentials()
-        if credentials is None:
-            raise GuardSyncNotConfiguredError("Guard is not logged in.")
-        return {
-            "sync_url": _validate_guard_sync_url(str(credentials["sync_url"])),
-            "access_token": str(credentials["token"]),
-            "dpop_key_material": None,
-        }
+        raise GuardSyncNotConfiguredError("Guard is not logged in.")
 
 
 def _guard_sync_headers(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -24,7 +24,7 @@ from uuid import uuid4
 from cryptography.fernet import Fernet, InvalidToken
 
 from .approval_gate import ApprovalGateGrant, require_policy_clear, require_policy_write, require_request_resolution
-from .cli.oauth_client import resolve_guard_oauth_client_config, validate_guard_sync_endpoint
+from .cli.oauth_client import resolve_guard_oauth_client_config
 from .edge_events import build_receipt_event
 from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
 from .policy_integrity import (
@@ -160,17 +160,14 @@ from .store_threat_intel import (
 )
 from .types import CapabilitySet, TransportKind
 
-_SYNC_TOKEN_REF = "guard-cloud-token"
 _POLICY_INTEGRITY_KEY_REF = "guard-policy-integrity-key"
 _POLICY_INTEGRITY_CONTROL_REF = "guard-policy-integrity-control"
 _OAUTH_LOCAL_CREDENTIALS_REF = "guard-oauth-local-credentials"
-_SYNC_TOKEN_HASH_KEY = "token_sha256"
 _OAUTH_LOCAL_CREDENTIALS_STATE_KEY = "oauth_local_credentials"
 _OAUTH_LOCAL_CREDENTIALS_HASH_KEY = "credentials_sha256"
 _OAUTH_LOCAL_CREDENTIALS_REF_KEY = "credentials_ref"
 _OAUTH_PRIMARY_SECRET_TIMEOUT_SECONDS = 2.0
 _GUARD_CLOUD_RESET_STATE_KEYS = (
-    "credentials",
     "sync_summary",
     "receipt_sync_cursor",
     "policy",
@@ -320,61 +317,6 @@ class SecretStore(Protocol):
 
     def delete_secret(self, secret_id: str) -> None:
         """Delete a secret value if it exists."""
-
-
-class KeychainSecretStore:
-    """macOS keychain-backed secret store."""
-
-    def __init__(self, service_name: str) -> None:
-        self.service_name = service_name
-
-    @staticmethod
-    def _is_available() -> bool:
-        return os.name == "posix" and Path("/usr/bin/security").exists()
-
-    def set_secret(self, secret_id: str, value: str) -> None:
-        if not self._is_available():
-            raise RuntimeError("macOS keychain command is not available")
-        raise RuntimeError("macOS security CLI does not support noninteractive secret writes without argv exposure")
-
-    def get_secret(self, secret_id: str) -> str | None:
-        if not self._is_available():
-            return None
-        result = subprocess.run(
-            [
-                "/usr/bin/security",
-                "find-generic-password",
-                "-a",
-                secret_id,
-                "-s",
-                self.service_name,
-                "-w",
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
-        if result.returncode != 0:
-            return None
-        value = result.stdout.rstrip("\r\n")
-        return value if value else None
-
-    def delete_secret(self, secret_id: str) -> None:
-        if not self._is_available():
-            return
-        subprocess.run(
-            [
-                "/usr/bin/security",
-                "delete-generic-password",
-                "-a",
-                secret_id,
-                "-s",
-                self.service_name,
-            ],
-            check=False,
-            capture_output=True,
-            text=True,
-        )
 
 
 class SystemKeyringSecretStore:
@@ -900,16 +842,6 @@ def _system_keyring_is_available(guard_home: Path) -> bool:
     return available
 
 
-def _build_secret_store(guard_home: Path) -> SecretStore:
-    fallback_store = EncryptedFileSecretStore(guard_home)
-    if KeychainSecretStore._is_available():
-        keychain_store = KeychainSecretStore(service_name="hol-guard.sync")
-        if sys.platform == "darwin":
-            return FallbackSecretStore(keychain_store, fallback_store)
-        return FallbackSecretStore(fallback_store, keychain_store)
-    return fallback_store
-
-
 def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
     fallback_store = EncryptedFileSecretStore(guard_home)
     if _system_keyring_is_available(guard_home):
@@ -932,8 +864,6 @@ def _build_policy_integrity_secret_store() -> SystemKeyringSecretStore | None:
 def _secret_store_backend_name(secret_store: SecretStore) -> str:
     if isinstance(secret_store, SystemKeyringSecretStore):
         return "system-keyring"
-    if isinstance(secret_store, KeychainSecretStore):
-        return "keychain"
     if isinstance(secret_store, EncryptedFileSecretStore):
         return "encrypted-file"
     if isinstance(secret_store, FallbackSecretStore):
@@ -979,13 +909,11 @@ class GuardStore:
         self.guard_home = guard_home
         self.guard_home.mkdir(parents=True, exist_ok=True)
         _set_private_mode(self.guard_home, _GUARD_STORE_PRIVATE_DIR_MODE)
-        self._secret_store = _build_secret_store(self.guard_home)
         self._oauth_secret_store = _build_oauth_secret_store(self.guard_home)
         self._policy_integrity_secret_store = _build_policy_integrity_secret_store()
         self._cached_oauth_secret_payload: tuple[str, str, str] | None = None
         self._cached_policy_integrity_secret_material: tuple[str | None, float, tuple[bytes, str]] | None = None
         self._cached_policy_integrity_control_state: tuple[str | None, float, dict[str, object]] | None = None
-        self._sync_token_ref = self._build_scoped_secret_ref(_SYNC_TOKEN_REF)
         self._policy_integrity_key_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_KEY_REF)
         self._policy_integrity_control_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_CONTROL_REF)
         self._oauth_local_credentials_ref = self._build_scoped_secret_ref(_OAUTH_LOCAL_CREDENTIALS_REF)
@@ -1001,10 +929,6 @@ class GuardStore:
     @staticmethod
     def _versioned_secret_ref(base_ref: str, value_hash: str) -> str:
         return f"{base_ref}:{value_hash[:16]}"
-
-    def _promote_secret_to_primary(self, secret_store: SecretStore, secret_id: str, value: str) -> None:
-        if isinstance(secret_store, FallbackSecretStore):
-            secret_store.promote_secret(secret_id, value)
 
     def _mirror_oauth_secret_to_fallback(self, secret_id: str, value: str) -> None:
         secret_store = self._oauth_secret_store
@@ -4523,10 +4447,6 @@ class GuardStore:
                 bundle_version=bundle_version,
             )
 
-    def set_sync_credentials(self, sync_url: str, token: str, now: str, workspace_id: str | None = None) -> None:
-        with self._connect() as connection:
-            self._set_sync_credentials_in_connection(connection, sync_url, token, now, workspace_id=workspace_id)
-
     def set_sync_payload(self, state_key: str, payload: Mapping[str, object] | Sequence[object], now: str) -> None:
         with self._connect() as connection:
             connection.execute(
@@ -4822,32 +4742,6 @@ class GuardStore:
             )
         return items
 
-    def get_sync_credentials(self) -> dict[str, str] | None:
-        with self._connect() as connection:
-            row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
-        if row is None:
-            return None
-        payload = json.loads(str(row["payload_json"]))
-        if not isinstance(payload, dict):
-            return None
-        sync_url = payload.get("sync_url")
-        if not isinstance(sync_url, str):
-            return None
-        token_reference = payload.get("token_ref")
-        if isinstance(token_reference, str) and token_reference:
-            if token_reference != self._sync_token_ref:
-                return None
-            expected_hash = payload.get(_SYNC_TOKEN_HASH_KEY)
-            expected_hash_value = expected_hash if isinstance(expected_hash, str) and expected_hash else None
-
-            for token in self._get_secret_candidates(self._secret_store, self._sync_token_ref, expected_hash_value):
-                if expected_hash_value is not None and not _secret_matches_hash(token, expected_hash_value):
-                    continue
-                self._promote_secret_to_primary(self._secret_store, self._sync_token_ref, token)
-                return {"sync_url": sync_url, "token": token}
-            return None
-        return None
-
     def get_cloud_sync_profile(self) -> dict[str, str] | None:
         oauth_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if isinstance(oauth_payload, dict):
@@ -4867,24 +4761,9 @@ class GuardStore:
                 if isinstance(workspace_id, str) and workspace_id.strip():
                     profile["workspace_id"] = workspace_id.strip()
                 return profile
-        credentials = self.get_sync_credentials()
-        if credentials is None:
-            return None
-        profile = {
-            "auth_mode": "legacy",
-            "sync_url": str(credentials["sync_url"]),
-        }
-        workspace_id = self.get_cloud_workspace_id()
-        if isinstance(workspace_id, str) and workspace_id.strip():
-            profile["workspace_id"] = workspace_id.strip()
-        return profile
-
-    def clear_sync_credentials(self) -> None:
-        self._secret_store.delete_secret(self._sync_token_ref)
-        self.delete_sync_payload("credentials")
+        return None
 
     def clear_cloud_sync_state_for_reconnect(self) -> None:
-        self.clear_sync_credentials()
         self.delete_sync_payloads(list(_GUARD_CLOUD_RESET_STATE_KEYS))
 
     def set_oauth_local_credentials(
@@ -5032,44 +4911,6 @@ class GuardStore:
             if isinstance(value, str) and value:
                 health[key] = value
         self._remember_oauth_health_result(secret_hash, health)
-        return health
-
-    def get_sync_credential_health(self) -> dict[str, object]:
-        payload = self.get_sync_payload("credentials")
-        health: dict[str, object] = {
-            "configured": isinstance(payload, dict),
-            "state": "not_configured",
-            "backend": _secret_store_backend_name(self._secret_store),
-            "fallback_backend": _secret_store_fallback_backend_name(self._secret_store),
-        }
-        if not isinstance(payload, dict):
-            return health
-        sync_url = payload.get("sync_url")
-        token_reference = payload.get("token_ref")
-        if not isinstance(sync_url, str) or not sync_url:
-            health["state"] = "degraded"
-            return health
-        if not isinstance(token_reference, str) or not token_reference or token_reference != self._sync_token_ref:
-            health["state"] = "degraded"
-            return health
-        expected_hash = payload.get(_SYNC_TOKEN_HASH_KEY)
-        expected_hash_value = expected_hash if isinstance(expected_hash, str) and expected_hash else None
-        secret_candidates = self._get_secret_candidates(
-            self._secret_store,
-            self._sync_token_ref,
-            expected_hash_value,
-        )
-        if not any(
-            expected_hash_value is None or _secret_matches_hash(candidate, expected_hash_value)
-            for candidate in secret_candidates
-        ):
-            health["state"] = "degraded"
-            return health
-        health["state"] = "healthy"
-        health["sync_url"] = sync_url
-        workspace_id = payload.get("workspace_id")
-        if isinstance(workspace_id, str) and workspace_id:
-            health["workspace_id"] = workspace_id
         return health
 
     @staticmethod
@@ -5629,101 +5470,6 @@ class GuardStore:
         }
         return build_connect_state_response(payload, poll_after_ms=0)
 
-    def _credential_payload_token_hash(self, payload: dict[str, object]) -> str | None:
-        token_hash = payload.get(_SYNC_TOKEN_HASH_KEY)
-        if isinstance(token_hash, str) and token_hash:
-            return token_hash
-        legacy_token = payload.get("token")
-        if isinstance(legacy_token, str) and legacy_token:
-            return _secret_fingerprint(legacy_token)
-        token_reference = payload.get("token_ref")
-        if isinstance(token_reference, str) and token_reference:
-            token = self._secret_store.get_secret(token_reference)
-            if isinstance(token, str) and token:
-                return _secret_fingerprint(token)
-        return None
-
-    def _set_sync_credentials_in_connection(
-        self,
-        connection: sqlite3.Connection,
-        sync_url: str,
-        token: str,
-        now: str,
-        *,
-        workspace_id: str | None = None,
-    ) -> None:
-        validated_sync_url = validate_guard_sync_endpoint(sync_url)
-        token_hash = _secret_fingerprint(token)
-        normalized_workspace_id = (
-            workspace_id.strip() if isinstance(workspace_id, str) and workspace_id.strip() else None
-        )
-        previous_payload: dict[str, object] | None = None
-        previous_row = connection.execute(
-            "select payload_json from sync_state where state_key = 'credentials'"
-        ).fetchone()
-        if previous_row is not None:
-            previous_payload_candidate = json.loads(str(previous_row["payload_json"]))
-            if isinstance(previous_payload_candidate, dict):
-                previous_payload = previous_payload_candidate
-        previous_sync_url = previous_payload.get("sync_url") if previous_payload is not None else None
-        previous_token_hash = (
-            self._credential_payload_token_hash(previous_payload) if previous_payload is not None else None
-        )
-        previous_workspace_id = (
-            _string_value(previous_payload.get("workspace_id")) if previous_payload is not None else None
-        )
-        previous_workspace = previous_workspace_id.strip() if previous_workspace_id is not None else None
-        effective_workspace_id = normalized_workspace_id
-        can_preserve_workspace = (
-            previous_sync_url == validated_sync_url
-            and previous_token_hash is not None
-            and previous_token_hash == token_hash
-            and previous_workspace_id is not None
-            and previous_workspace_id.strip()
-        )
-        if effective_workspace_id is None and can_preserve_workspace:
-            effective_workspace_id = previous_workspace
-        workspace_changed = (
-            previous_workspace is not None
-            and effective_workspace_id is not None
-            and previous_workspace != effective_workspace_id
-        )
-        payload = {
-            "sync_url": validated_sync_url,
-            "token_ref": self._sync_token_ref,
-            _SYNC_TOKEN_HASH_KEY: token_hash,
-        }
-        if effective_workspace_id is not None:
-            payload["workspace_id"] = effective_workspace_id
-        if previous_row is None or previous_payload is None:
-            credentials_changed = True
-        else:
-            credentials_changed = (
-                previous_sync_url != validated_sync_url
-                or previous_token_hash is None
-                or previous_token_hash != token_hash
-                or workspace_changed
-            )
-        self._secret_store.set_secret(self._sync_token_ref, token)
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('credentials', ?, ?)
-            on conflict(state_key) do update set
-              payload_json = excluded.payload_json,
-              updated_at = excluded.updated_at
-            """,
-            (json.dumps(payload), now),
-        )
-        if credentials_changed:
-            connection.execute("delete from sync_state where state_key != 'credentials'")
-            connection.execute("delete from guard_supply_chain_bundle_cache")
-            connection.execute("delete from guard_supply_chain_eval_cache")
-            connection.execute("delete from publisher_cache")
-            connection.execute(
-                "delete from policy_decisions where source in ('cloud-sync', 'team-policy', 'policy-bundle')"
-            )
-
     @staticmethod
     def _cloud_workspace_id_from_connection(connection: sqlite3.Connection) -> str | None:
         oauth_row = connection.execute(
@@ -5735,15 +5481,6 @@ class GuardStore:
                 workspace_id = oauth_payload.get("workspace_id")
                 if isinstance(workspace_id, str) and workspace_id.strip():
                     return workspace_id
-        row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
-        if row is None:
-            return None
-        payload = json.loads(str(row["payload_json"]))
-        if not isinstance(payload, dict):
-            return None
-        workspace_id = payload.get("workspace_id")
-        if isinstance(workspace_id, str) and workspace_id.strip():
-            return workspace_id
         return None
 
     def upsert_guard_session(

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.345"
+__version__ = "2.0.764"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,10 +24,16 @@ if pythonpath_prefix:
 
 
 @pytest.fixture(autouse=True)
-def _disable_real_macos_keychain(monkeypatch: pytest.MonkeyPatch) -> None:
-    from codex_plugin_scanner.guard.store import KeychainSecretStore
+def _reset_guard_sync_resolver_override(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Undo any _resolve_guard_sync_auth_context override leaked by _seed_guard_cloud."""
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_resolve_guard_sync_auth_context",
+        guard_runner_module._resolve_guard_sync_auth_context,
+    )
+    guard_runner_module._test_sync_auth_context_override = None
 
 
 class _FakeSystemKeyringModule:

--- a/tests/e2e_droid_exec.py
+++ b/tests/e2e_droid_exec.py
@@ -1,19 +1,21 @@
 #!/usr/bin/env python3
 """Headless droid exec e2e test script for hol-guard."""
+
 from __future__ import annotations
 
 import json
 import os
-import shutil
 import subprocess
 import sys
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parent.parent
 
+
 def _scan_cmd(fixture_path: Path, fmt: str) -> list[str]:
     """Build scanner invocation, bypassing guard preflight by using direct python module."""
     return ["python3", "-m", "codex_plugin_scanner.cli", "scan", str(fixture_path), "--format", fmt]
+
 
 def run(cmd: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
     env = dict(os.environ)
@@ -22,13 +24,14 @@ def run(cmd: list[str], cwd: Path | None = None) -> tuple[int, str, str]:
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=120, env=env, cwd=cwd)
     return result.returncode, result.stdout, result.stderr
 
+
 def test_scanner():
     fixtures_dir = Path(__file__).resolve().parent.parent / "tests" / "fixtures"
     test_cases = [
         (fixtures_dir / "good-plugin", 0, "json", False),
         (fixtures_dir / "good-plugin", 0, "text", False),
         (fixtures_dir / "good-plugin", 0, "sarif", False),
-        (fixtures_dir / "bad-plugin", 0, "json", True),   # expect low score
+        (fixtures_dir / "bad-plugin", 0, "json", True),  # expect low score
         (fixtures_dir / "malicious-skill-plugin", 0, "json", False),  # can score high w/few findings
         (fixtures_dir / "multi-plugin-repo" / "plugins" / "alpha-plugin", 0, "json", False),
     ]
@@ -64,9 +67,7 @@ def test_scanner():
             passed = False  # Bad plugin should score poorly
 
         if not passed:
-            failures.append(
-                f"{fixture_path.name} fmt={fmt} code={code} expected={expected_code} score={score}"
-            )
+            failures.append(f"{fixture_path.name} fmt={fmt} code={code} expected={expected_code} score={score}")
 
         status = "PASS" if passed else "FAIL"
         label = fixture_path.name.split("/")[-1]
@@ -78,6 +79,7 @@ def test_scanner():
             print(f"  DEBUG stderr: {stderr[:300]}")
 
     return failures
+
 
 def test_guard():
     guard_cases = [
@@ -97,15 +99,16 @@ def test_guard():
             failures.append(f"guard: {' '.join(cmd[3:])} exit={code}")
     return failures
 
+
 def test_droid_exec():
-    prompt = (
-        "Run hol-guard scan against tests/fixtures/good-plugin with --json"
-        " and report only the score."
-    )
+    prompt = "Run hol-guard scan against tests/fixtures/good-plugin with --json and report only the score."
     cmd = [
-        "droid", "exec",
-        "--cwd", str(PROJECT_ROOT),
-        "--auto", "medium",
+        "droid",
+        "exec",
+        "--cwd",
+        str(PROJECT_ROOT),
+        "--auto",
+        "medium",
         prompt,
     ]
     code, stdout, stderr = run(cmd)
@@ -117,6 +120,7 @@ def test_droid_exec():
         print(f"  DEBUG stdout: {stdout[:500]}")
         print(f"  DEBUG stderr: {stderr[:500]}")
     return [] if passed else ["droid exec headless run failed"]
+
 
 if __name__ == "__main__":
     all_failures: list[str] = []

--- a/tests/fixtures/guard-red-team/benign-docs-fake-token.py
+++ b/tests/fixtures/guard-red-team/benign-docs-fake-token.py
@@ -7,7 +7,6 @@ that only mention tokens in explanatory context.
 The tokens below are clearly fake and used only for illustrative purposes.
 """
 
-
 DOCS = """
 # API Authentication Guide
 

--- a/tests/shim_execution_helpers.py
+++ b/tests/shim_execution_helpers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 from pathlib import Path
 
 from codex_plugin_scanner.guard.shim_probe import (

--- a/tests/test_action_bundle.py
+++ b/tests/test_action_bundle.py
@@ -104,9 +104,7 @@ def test_python_safe_path_blocks_workspace_module_shadowing(tmp_path: Path) -> N
         encoding="utf-8",
     )
     hijacked_env = {
-        key: value
-        for key, value in os.environ.items()
-        if key not in {"PYTHONSAFEPATH", "PYTHONNOUSERSITE"}
+        key: value for key, value in os.environ.items() if key not in {"PYTHONSAFEPATH", "PYTHONNOUSERSITE"}
     }
     hijacked_env["PYTHONPATH"] = str(trusted_root)
 
@@ -135,9 +133,7 @@ def test_python_safe_path_blocks_workspace_module_shadowing(tmp_path: Path) -> N
 
 
 def test_publish_action_repo_workflow_syncs_action_repository() -> None:
-    workflow_text = (
-        ROOT / ".github" / "workflows" / "publish-action-repo.yml"
-    ).read_text(encoding="utf-8")
+    workflow_text = (ROOT / ".github" / "workflows" / "publish-action-repo.yml").read_text(encoding="utf-8")
 
     assert "Publish GitHub Action Repository" in workflow_text
     assert "ACTION_REPO_TOKEN" in workflow_text

--- a/tests/test_action_runner.py
+++ b/tests/test_action_runner.py
@@ -514,7 +514,7 @@ def test_action_runner_verify_mode_ignores_invalid_repo_pr_comment_config(
     event_path = tmp_path / "event.json"
     plugin_dir = tmp_path / "repo"
     shutil.copytree(FIXTURES / "good-plugin", plugin_dir)
-    (plugin_dir / ".plugin-scanner.toml").write_text("[github\npr_comment = \"off\"\n", encoding="utf-8")
+    (plugin_dir / ".plugin-scanner.toml").write_text('[github\npr_comment = "off"\n', encoding="utf-8")
     event_path.write_text(json.dumps({"pull_request": {"number": 12}}), encoding="utf-8")
 
     monkeypatch.setenv("MODE", "verify")

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -89,7 +89,9 @@ def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     assert "apt-get clean" in dockerfile
     requirements_copy_index = dockerfile.index("COPY docker-requirements.txt LICENSE README.md /app/")
     build_deps_index = dockerfile.index("apt-get install -y --no-install-recommends gcc libc6-dev")
-    pip_install_index = dockerfile.index("python3 -m pip install --no-deps --require-hashes -r /app/docker-requirements.txt")
+    pip_install_index = dockerfile.index(
+        "python3 -m pip install --no-deps --require-hashes -r /app/docker-requirements.txt"
+    )
     purge_index = dockerfile.index("apt-get purge -y --auto-remove gcc libc6-dev")
     source_copy_index = dockerfile.index("COPY src /app/src")
     assert requirements_copy_index < pip_install_index

--- a/tests/test_cloud_exception_sync_proof.py
+++ b/tests/test_cloud_exception_sync_proof.py
@@ -21,6 +21,37 @@ from tests.cloud_exception_bundle_fixtures import (
 from tests.test_policy_bundle_parser import computed_policy_bundle_hash
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 class _JsonResponse:
     def __init__(self, payload: dict[str, object]) -> None:
         self._payload = payload
@@ -79,12 +110,7 @@ def test_hglp140_wrong_workspace_bundle_is_rejected(tmp_path: Path, monkeypatch:
     from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-06-14T12:00:00+00:00",
-        workspace_id="workspace-a",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-a")
     bundle = build_cloud_exception_policy_bundle(workspace_id="workspace-b")
     bundle["bundleHash"] = computed_policy_bundle_hash(bundle)
 
@@ -114,11 +140,7 @@ def test_hglp141_bundle_ack_metadata_is_available_for_sync_upload(
     from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-06-14T12:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     bundle = build_cloud_exception_policy_bundle()
     bundle["bundleHash"] = computed_policy_bundle_hash(bundle)
     requests: list[dict[str, object]] = []

--- a/tests/test_codex_skill_config.py
+++ b/tests/test_codex_skill_config.py
@@ -76,9 +76,7 @@ def test_resolve_codex_skill_enabled_matches_path_and_name(tmp_path: Path) -> No
 
     from codex_plugin_scanner.guard.codex_skill_config import CodexSkillConfigRule
 
-    disabled_by_name = (
-        CodexSkillConfigRule(enabled=False, name="lint"),
-    )
+    disabled_by_name = (CodexSkillConfigRule(enabled=False, name="lint"),)
     assert not resolve_codex_skill_enabled(
         config_path=str(skill_md),
         display_name="lint",

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -282,7 +282,7 @@ def test_prepare_cursor_hook_payload_maps_after_mcp_execution() -> None:
             "hook_event_name": "afterMCPExecution",
             "tool_name": "ctx_shell",
             "tool_input": {"command": "pnpm test"},
-            "result_json": "{\"ok\": true}",
+            "result_json": '{"ok": true}',
             "duration": 42,
         }
     )
@@ -913,7 +913,7 @@ def test_cursor_native_mcp_session_allow_generic_tool_name(tmp_path: Path) -> No
                 "hook_event_name": "afterMCPExecution",
                 "tool_name": "run_terminal_cmd",
                 "tool_input": {"command": inner_command},
-                "result_json": "{\"ok\": true}",
+                "result_json": '{"ok": true}',
                 "duration": 12,
             }
         ),
@@ -988,7 +988,7 @@ def test_cursor_native_mcp_session_allow_after_trusted_after_mcp(tmp_path: Path)
                 "hook_event_name": "afterMCPExecution",
                 "tool_name": "ctx_shell",
                 "tool_input": {"command": inner_command},
-                "result_json": "{\"ok\": true}",
+                "result_json": '{"ok": true}',
                 "duration": 12,
             }
         ),

--- a/tests/test_dashboard_sync_security.py
+++ b/tests/test_dashboard_sync_security.py
@@ -144,9 +144,7 @@ def test_export_committed_static_files_rejects_traversal_paths(
     )
     monkeypatch.setattr(
         "codex_plugin_scanner.guard.cli.dashboard_sync._read_committed_file",
-        lambda _checkout, path: (
-            b"<html>safe</html>" if path == safe_path else b"malicious"
-        ),
+        lambda _checkout, path: b"<html>safe</html>" if path == safe_path else b"malicious",
     )
 
     installed_static = tmp_path / "installed-static"

--- a/tests/test_dashboard_update.py
+++ b/tests/test_dashboard_update.py
@@ -62,9 +62,7 @@ def _post_json(daemon: GuardDaemonServer, path: str) -> tuple[int, dict[str, obj
         return error.code, payload
 
 
-def _post_json_body(
-    daemon: GuardDaemonServer, path: str, body: dict[str, object]
-) -> tuple[int, dict[str, object]]:
+def _post_json_body(daemon: GuardDaemonServer, path: str, body: dict[str, object]) -> tuple[int, dict[str, object]]:
     request = urllib.request.Request(
         f"http://127.0.0.1:{daemon.port}{path}",
         data=json.dumps(body).encode("utf-8"),

--- a/tests/test_gemini_adapter.py
+++ b/tests/test_gemini_adapter.py
@@ -134,13 +134,7 @@ class TestGeminiHookDetection:
         ctx = _ctx(tmp_path)
         _write_json(
             ctx.home_dir / ".gemini" / "settings.json",
-            {
-                "hooks": {
-                    "PreToolUse": [
-                        {"hooks": [{"type": "command", "command": "python hook.py"}]}
-                    ]
-                }
-            },
+            {"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "python hook.py"}]}]}},
         )
         result = GeminiHarnessAdapter().detect(ctx)
         hook_artifacts = [a for a in result.artifacts if a.artifact_type == "hook"]
@@ -151,13 +145,7 @@ class TestGeminiHookDetection:
         ctx = _ctx(tmp_path)
         _write_json(
             ctx.home_dir / ".gemini" / "settings.json",
-            {
-                "hooks": {
-                    "PreToolUse": [
-                        {"hooks": [{"type": "command", "command": "guard-hook.sh"}]}
-                    ]
-                }
-            },
+            {"hooks": {"PreToolUse": [{"hooks": [{"type": "command", "command": "guard-hook.sh"}]}]}},
         )
         result = GeminiHarnessAdapter().detect(ctx)
         hook = next(a for a in result.artifacts if a.artifact_type == "hook")
@@ -236,9 +224,7 @@ class TestGeminiExtensionDetection:
             manifest,
             {
                 "name": "ext-with-mcp",
-                "mcpServers": {
-                    "embedded-server": {"command": "node", "args": ["server.js"]}
-                },
+                "mcpServers": {"embedded-server": {"command": "node", "args": ["server.js"]}},
             },
         )
         result = GeminiHarnessAdapter().detect(ctx)

--- a/tests/test_grok_adapter.py
+++ b/tests/test_grok_adapter.py
@@ -62,7 +62,7 @@ class TestGrokDetect:
         grok_root = ctx.home_dir / ".grok"
         hooks_dir = grok_root / "hooks"
         hooks_dir.mkdir(parents=True)
-        (grok_root / "managed_config.toml").write_text("[permission]\nallow = [\"Read\"]\n", encoding="utf-8")
+        (grok_root / "managed_config.toml").write_text('[permission]\nallow = ["Read"]\n', encoding="utf-8")
         (hooks_dir / "custom.json").write_text(
             json.dumps(
                 {
@@ -210,7 +210,11 @@ class TestGrokHookResponses:
             artifact_id=None,
             artifact_name=None,
         )
-        payload = {"hookEventName": "pre_tool_use", "toolName": "run_terminal_command", "toolInput": {"command": "rm -rf /"}}
+        payload = {
+            "hookEventName": "pre_tool_use",
+            "toolName": "run_terminal_command",
+            "toolInput": {"command": "rm -rf /"},
+        }
         stderr_capture = io.StringIO()
         stdout_capture = io.StringIO()
         with redirect_stderr(stderr_capture):
@@ -439,7 +443,9 @@ GITHUB_TOKEN = "redacted"
             + "\n",
             encoding="utf-8",
         )
-        artifact = next(artifact for artifact in GrokHarnessAdapter().detect(ctx).artifacts if artifact.name == "github")
+        artifact = next(
+            artifact for artifact in GrokHarnessAdapter().detect(ctx).artifacts if artifact.name == "github"
+        )
         signal_ids = {signal.signal_id for signal in artifact_risk_signals_typed(artifact)}
         assert "secret:env-keys" in signal_ids
         assert "secret:env-semantic" in signal_ids

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -17,7 +17,10 @@ from codex_plugin_scanner.guard.aibom_detection import (
     instruction_role_for_path,
 )
 from codex_plugin_scanner.guard.consumer.service import artifact_hash, diff_artifact
-from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection, serialize_inventory_snapshot
+from codex_plugin_scanner.guard.inventory_contract import (
+    inventory_snapshot_from_detection,
+    serialize_inventory_snapshot,
+)
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 
 
@@ -60,11 +63,7 @@ def test_discover_agents_md_and_cursor_rules(tmp_path: Path) -> None:
         workspace_dir=workspace,
     )
     kinds = {artifact.artifact_type for artifact in artifacts}
-    roles = {
-        artifact.metadata.get("instructionRole")
-        for artifact in artifacts
-        if isinstance(artifact.metadata, dict)
-    }
+    roles = {artifact.metadata.get("instructionRole") for artifact in artifacts if isinstance(artifact.metadata, dict)}
 
     assert "instruction" in kinds
     assert "agents_md" in roles
@@ -103,11 +102,7 @@ def test_discover_standards_context_files_in_root_and_fallback_dirs(tmp_path: Pa
         for artifact in artifacts
         if artifact.artifact_type == "instruction" and isinstance(artifact.metadata, dict)
     }
-    names = {
-        artifact.name
-        for artifact in artifacts
-        if artifact.artifact_type == "instruction"
-    }
+    names = {artifact.name for artifact in artifacts if artifact.artifact_type == "instruction"}
 
     assert roles == {"product_md", "design_md", "claude_md"}
     assert "PRODUCT.md (.agents/context)" in names
@@ -338,11 +333,7 @@ def test_discover_named_instruction_docs(tmp_path: Path) -> None:
         home_dir=tmp_path,
         workspace_dir=workspace,
     )
-    roles = {
-        artifact.metadata.get("instructionRole")
-        for artifact in artifacts
-        if isinstance(artifact.metadata, dict)
-    }
+    roles = {artifact.metadata.get("instructionRole") for artifact in artifacts if isinstance(artifact.metadata, dict)}
 
     assert "design_md" in roles
     assert "security_md" in roles
@@ -499,7 +490,4 @@ def test_cursor_detect_extends_workspace_aibom(tmp_path: Path) -> None:
         workspace_dir=context.workspace_dir,
     )
 
-    assert any(
-        artifact.artifact_type == "instruction"
-        for artifact in extended.artifacts
-    )
+    assert any(artifact.artifact_type == "instruction" for artifact in extended.artifacts)

--- a/tests/test_guard_aibom_symlink.py
+++ b/tests/test_guard_aibom_symlink.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 
 import pytest
@@ -15,6 +14,8 @@ from codex_plugin_scanner.guard.aibom_symlink import (
 )
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+
+
 def test_fingerprint_redacted_path_never_emits_raw_home(tmp_path: Path) -> None:
     workspace = tmp_path / "repo"
     workspace.mkdir()
@@ -112,10 +113,7 @@ def test_classify_workspace_relative_path(tmp_path: Path) -> None:
     agents_md = workspace / "AGENTS.md"
     agents_md.write_text("policy\n", encoding="utf-8")
 
-    assert (
-        classify_path_class(agents_md, home_dir=tmp_path / "home", workspace_dir=workspace)
-        == "workspace_relative"
-    )
+    assert classify_path_class(agents_md, home_dir=tmp_path / "home", workspace_dir=workspace) == "workspace_relative"
 
 
 def test_inspection_serializes_without_raw_paths(tmp_path: Path) -> None:

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -13,17 +13,18 @@ import pytest
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ec, rsa
 
-from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.aibom_trust_metadata import trust_resolution_from_domain
+from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.runtime.trust_attestation import (
+    GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
     GuardTrustAttestationSigningConfig,
     GuardTrustAttestationVerificationKey,
-    GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
     build_trust_attestation_payload,
     build_trust_attestation_verification_key,
     resolve_guard_oauth_trust_attestation_signing_config,
+    resolve_trust_attestation_signing_config,
     sign_trust_attestation,
     verify_trust_attestation,
 )
@@ -542,28 +543,28 @@ def test_p384_key_is_rejected_for_p256_attestation() -> None:
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
-    ).decode('ascii')
+    ).decode("ascii")
 
-    with pytest.raises(ValueError, match='P-256'):
+    with pytest.raises(ValueError, match="P-256"):
         sign_trust_attestation(
             payload=build_trust_attestation_payload(
-                agent_id='agent-1',
-                item_id='plugin:trust-demo',
-                item_kind='plugin',
-                content_hash='sha256:plugin-local',
-                captured_at='2026-06-10T12:00:00+00:00',
-                evidence_hash='resolution-hash',
-                scope='trust_resolution',
-                workspace_id='workspace-alpha',
-                device_id='device-alpha',
+                agent_id="agent-1",
+                item_id="plugin:trust-demo",
+                item_kind="plugin",
+                content_hash="sha256:plugin-local",
+                captured_at="2026-06-10T12:00:00+00:00",
+                evidence_hash="resolution-hash",
+                scope="trust_resolution",
+                workspace_id="workspace-alpha",
+                device_id="device-alpha",
             ),
             config=GuardTrustAttestationSigningConfig(
-                active_key_id='p384-key',
+                active_key_id="p384-key",
                 private_key_pem=private_key_pem,
-                public_jwk_thumbprint='p384-key',
+                public_jwk_thumbprint="p384-key",
                 signature_algorithm=GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
             ),
-            signed_at='2026-06-10T12:00:00+00:00',
+            signed_at="2026-06-10T12:00:00+00:00",
         )
 
 
@@ -577,6 +578,24 @@ def test_invalid_oauth_private_key_disables_attestation_signing_config() -> None
         )
         is None
     )
+
+
+def test_headless_short_lived_attestation_generates_ephemeral_ec_key(monkeypatch) -> None:
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", raising=False)
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_HEADLESS_SHORT_LIVED", "1")
+
+    config = resolve_trust_attestation_signing_config(
+        {
+            "GUARD_AIBOM_TRUST_ATTESTATION_HEADLESS_SHORT_LIVED": "1",
+            "GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID": "ci-short-lived",
+        }
+    )
+
+    assert config is not None
+    assert config.active_key_id == "ci-short-lived"
+    assert config.signature_algorithm == GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256
+    verification_key = build_trust_attestation_verification_key(config)
+    assert verification_key.public_jwk_thumbprint is not None
 
 
 def test_registry_identified_skill_still_gets_local_baseline(tmp_path: Path) -> None:

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -47,6 +47,38 @@ from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.guard.totp import TotpSecretStore, _temporary_atomic_path, totp_code_at_counter
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 PASSWORD = "correct-password"
 WRONG_PASSWORD = "wrong-password"
 
@@ -1251,11 +1283,7 @@ def test_approval_gate_background_remote_policy_sync_fails_closed_without_crashi
 ) -> None:
     store = _store(tmp_path)
     _enable_gate(store)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store, workspace_id=None)
     monkeypatch.setattr(
         guard_runner_module,
         "_guard_device_metadata",
@@ -1291,7 +1319,12 @@ def test_approval_gate_background_remote_policy_sync_fails_closed_without_crashi
 
     monkeypatch.setattr(guard_runner_module.urllib.request, "urlopen", _urlopen)
 
-    payload = guard_runner_module.sync_receipts(store)
+    auth_context = {
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "access_token": "demo-token",
+        "dpop_key_material": None,
+    }
+    payload = guard_runner_module.sync_receipts(store, auth_context=auth_context)
 
     assert payload["remote_policies_stored"] == 0
     assert payload["remote_policy_sync_blocked"] is True

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -14,7 +14,11 @@ import pytest
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import bridge as guard_bridge_module
-from codex_plugin_scanner.guard.approvals import build_runtime_snapshot, apply_approval_resolution, queue_blocked_approvals
+from codex_plugin_scanner.guard.approvals import (
+    apply_approval_resolution,
+    build_runtime_snapshot,
+    queue_blocked_approvals,
+)
 from codex_plugin_scanner.guard.bridge import BridgeConfig, GuardBridge
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash, evaluate_detection

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -9,6 +9,37 @@ from codex_plugin_scanner.guard.store import GuardStore
 from tests.test_guard_headless_daemon_api import _dashboard_token, _read_json_response, _request
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sync_error(
     tmp_path,
     monkeypatch,
@@ -168,11 +199,7 @@ def test_finalize_guard_connect_payload_marks_not_configured_oauth_as_retry_requ
     connect_url = "https://hol.org/guard/connect"
     now = "2026-06-04T12:00:00+00:00"
 
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "stale-sync-token",
-        "2026-06-04T11:59:00+00:00",
-    )
+    _seed_guard_cloud(store)
     monkeypatch.setattr(store, "get_cloud_sync_profile", lambda: None)
     monkeypatch.setattr(
         store,
@@ -191,8 +218,7 @@ def test_finalize_guard_connect_payload_marks_not_configured_oauth_as_retry_requ
     assert payload["milestone"] == "first_sync_failed"
     assert payload["sync_succeeded"] is False
     assert payload["sync_error"] == (
-        "Guard Cloud authorization did not persist locally. "
-        "Run hol-guard connect again to repair local sign-in."
+        "Guard Cloud authorization did not persist locally. Run hol-guard connect again to repair local sign-in."
     )
     assert payload["repair_message"] == payload["sync_error"]
     latest_state = payload["latest_connect_state"]
@@ -271,11 +297,7 @@ def test_daemon_finalize_guard_connect_payload_marks_not_configured_oauth_as_ret
     connect_url = "https://hol.org/guard/connect"
     now = "2026-06-04T12:00:00+00:00"
 
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "stale-sync-token",
-        "2026-06-04T11:59:00+00:00",
-    )
+    _seed_guard_cloud(store)
     monkeypatch.setattr(store, "get_cloud_sync_profile", lambda: None)
     monkeypatch.setattr(
         store,
@@ -294,8 +316,7 @@ def test_daemon_finalize_guard_connect_payload_marks_not_configured_oauth_as_ret
     assert payload["milestone"] == "first_sync_failed"
     assert payload["sync_succeeded"] is False
     assert payload["sync_error"] == (
-        "Guard Cloud authorization did not persist locally. "
-        "Start Guard Cloud connect again to repair local sign-in."
+        "Guard Cloud authorization did not persist locally. Start Guard Cloud connect again to repair local sign-in."
     )
     assert payload["repair_message"] == payload["sync_error"]
     latest_state = payload["latest_connect_state"]

--- a/tests/test_guard_bulk_allow_once.py
+++ b/tests/test_guard_bulk_allow_once.py
@@ -8,7 +8,8 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.guard.approval_gate import ApprovalGateInput, update_settings as update_approval_gate_settings
+from codex_plugin_scanner.guard.approval_gate import ApprovalGateInput
+from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.approvals import (
     bulk_allow_read_only_once,
     is_bulk_allow_once_eligible,

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -25,9 +25,9 @@ except ModuleNotFoundError:
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters import claude_code as claude_adapter_module
 from codex_plugin_scanner.guard.adapters import cursor as cursor_adapter_module
-from codex_plugin_scanner.guard.adapters.cursor_cli import CursorCliLaunchEntry
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.adapters.claude_code import CLAUDE_GUARD_DAEMON_HOOK_MARKER, ClaudeCodeHarnessAdapter
+from codex_plugin_scanner.guard.adapters.cursor_cli import CursorCliLaunchEntry
 from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.cli import product as guard_product_module
@@ -37,7 +37,41 @@ from codex_plugin_scanner.guard.cli.render import emit_guard_payload
 from codex_plugin_scanner.guard.config import GuardConfig, load_guard_config, resolve_risk_action
 from codex_plugin_scanner.guard.desktop_notifications import DesktopNotificationSetupResult
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
-from codex_plugin_scanner.guard.store import GuardStore, KeychainSecretStore
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _seed_guard_cloud(
+    store, *, workspace_id="workspace-1", sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"
+):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding)."""
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    if sync_url is not None:
+        from _pytest.monkeypatch import MonkeyPatch
+        from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+        captured_sync_url = sync_url
+        captured_token = token
+
+        def _fake_resolve(store, *, allow_primary_repair=True):
+            return {"sync_url": captured_sync_url, "access_token": captured_token, "dpop_key_material": None}
+
+        _mp = MonkeyPatch()
+        _mp.setattr(guard_runner_module, "_resolve_guard_sync_auth_context", _fake_resolve)
+
 
 FIXTURES = Path(__file__).parent / "fixtures"
 
@@ -64,7 +98,26 @@ def _read_codex_config(path: Path) -> dict[str, object]:
 
 
 def _seed_sync_credentials(home_dir: Path, sync_url: str, token: str = "demo-token") -> None:
-    GuardStore(home_dir).set_sync_credentials(sync_url, token, "2026-04-09T00:00:00Z")
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    GuardStore(home_dir).set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        now="2026-04-09T00:00:00Z",
+    )
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
 
 
 def _read_codex_hooks(config_path: Path) -> dict[str, object]:
@@ -2994,8 +3047,6 @@ args = ["workspace-skill.js", "--changed"]
         runtime_config_path = Path(str(manifest["runtime_config_path"]))
         runtime_payload = json.loads(runtime_config_path.read_text(encoding="utf-8"))
         managed_config_path = Path(str(manifest["managed_config_path"]))
-        managed_payload = json.loads(managed_config_path.read_text(encoding="utf-8"))
-
         assert rc == 0
         assert output["managed_install"]["active"] is True
         assert manifest["shim_command"] == "guard-opencode"
@@ -4474,11 +4525,7 @@ args = ["-lc", "echo hi"]
             },
         )
         store = GuardStore(guard_home)
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "access-secret-value",
-            "2026-06-01T00:00:00+00:00",
-        )
+        _seed_guard_cloud(store)
         store.set_oauth_local_credentials(
             issuer="https://hol.org",
             client_id="guard-local-daemon",
@@ -6545,7 +6592,7 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         now = "2026-05-01T00:00:00Z"
-        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "oauth_access_token_fixture", now)
+        _seed_guard_cloud(store)
         store.set_sync_payload(
             "policy_bundle",
             {
@@ -6661,7 +6708,7 @@ url = http://127.0.0.1:8787/guard-canary
         assert connect_output["workspace_id"] == "workspace-123"
         assert "guardPairSecret" not in json.dumps(connect_output)
         assert "guardPairRequest" not in json.dumps(connect_output)
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
 
     def test_guard_connect_runs_first_sync_and_surfaces_cloud_urls(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
@@ -6788,14 +6835,8 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
         store = GuardStore(home_dir)
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "legacy-token",
-            "2026-06-04T18:31:00+00:00",
-            workspace_id="workspace-123",
-        )
+        _seed_guard_cloud(store, workspace_id="workspace-123")
         store.set_oauth_local_credentials(
             issuer="https://hol.org",
             client_id="guard-local-daemon",
@@ -6820,14 +6861,6 @@ url = http://127.0.0.1:8787/guard-canary
         status_output = json.loads(capsys.readouterr().out)
 
         assert status_rc == 0
-        assert status_output["sync_storage_health"] == {
-            "configured": True,
-            "state": "healthy",
-            "backend": "encrypted-file",
-            "fallback_backend": None,
-            "sync_url": "https://hol.org/api/guard/receipts/sync",
-            "workspace_id": "workspace-123",
-        }
         assert status_output["oauth_storage_health"] == {
             "configured": True,
             "state": "healthy",
@@ -6844,7 +6877,6 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
         store = GuardStore(home_dir)
         store.set_oauth_local_credentials(
             issuer="https://hol.org",
@@ -6921,7 +6953,6 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
         store = GuardStore(home_dir)
         store.set_oauth_local_credentials(
             issuer="https://hol.org",
@@ -7007,7 +7038,6 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
-        monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
         store = GuardStore(home_dir)
         store.record_guard_connect_pairing_completed(
             sync_url="https://hol.org/api/guard/receipts/sync",
@@ -7202,7 +7232,7 @@ url = http://127.0.0.1:8787/guard-canary
         assert login_output["grant_id"] == "grant-456"
         assert login_output["machine_id"] == "machine-456"
         assert login_output["workspace_id"] == "workspace-456"
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
 
     def test_guard_login_rejects_manual_token_mode_and_redirects_to_connect(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -7225,7 +7255,7 @@ url = http://127.0.0.1:8787/guard-canary
         assert login_rc == 2
         assert "Manual token login is retired." in stderr
         assert "Run `hol-guard connect`" in stderr
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
         assert store.list_events(event_name="sign_in") == []
 
     def test_guard_service_login_rejects_pasted_token_and_redirects_to_connect(self, tmp_path, capsys):
@@ -7268,7 +7298,7 @@ url = http://127.0.0.1:8787/guard-canary
                 "workspace": "workspace_ops",
             },
         }
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
         assert store.get_sync_payload("service_runtime_profile") is None
         assert store.get_device_metadata() == original_device_metadata
 
@@ -7299,7 +7329,7 @@ url = http://127.0.0.1:8787/guard-canary
             payload["next_action"]["command"]
             == "hol-guard connect --headless --ci-safe --workspace workspace_ops --label 'Hermes Telegram agent'"
         )
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
 
     def test_guard_service_login_rejects_blank_token(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -7340,7 +7370,7 @@ url = http://127.0.0.1:8787/guard-canary
                 "workspace": "workspace_ops",
             },
         }
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
 
     def test_guard_service_sync_prerequisite_points_to_guard_connect(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
@@ -7367,7 +7397,7 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         now = "2026-05-01T00:00:00Z"
-        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "oauth_access_token_fixture", now)
+        _seed_guard_cloud(store)
         store.set_sync_payload(
             "service_runtime_profile",
             {
@@ -7428,7 +7458,7 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         now = "2026-05-01T00:00:00Z"
-        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "oauth_access_token_fixture", now)
+        _seed_guard_cloud(store)
         store.set_sync_payload(
             "service_runtime_profile",
             {
@@ -7478,7 +7508,7 @@ url = http://127.0.0.1:8787/guard-canary
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         now = "2026-05-01T00:00:00Z"
-        store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "oauth_access_token_fixture", now)
+        _seed_guard_cloud(store)
         store.set_sync_payload(
             "service_runtime_profile",
             {
@@ -7599,7 +7629,7 @@ url = http://127.0.0.1:8787/guard-canary
         assert connect_rc == 1
         assert "Guard authorization failed: device_code_unreachable" in captured.err
         assert "Traceback" not in captured.err
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
 
     def test_guard_connect_never_exposes_legacy_pairing_fields(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
@@ -8800,12 +8830,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_guard_cloud_sync_intel_emits_bundle_summary(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
-            workspace_id="workspace-alpha",
-        )
+        _seed_guard_cloud(store, workspace_id="workspace-alpha")
 
         def _fake_sync_intel(_store: GuardStore) -> dict[str, object]:
             return {
@@ -8880,11 +8905,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_refresh_cloud_policy_bundle_records_auth_expired_reason(self, tmp_path, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "oauth_access_token_fixture",
-            "2026-04-09T00:00:00Z",
-        )
+        _seed_guard_cloud(store)
 
         def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             raise guard_commands_module.GuardSyncAuthorizationExpiredError(
@@ -8903,11 +8924,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_refresh_cloud_policy_bundle_preserves_bundle_rejection_reason(self, tmp_path, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "oauth_access_token_fixture",
-            "2026-04-09T00:00:00Z",
-        )
+        _seed_guard_cloud(store)
 
         def _bundle_rejected(current_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             current_store.set_sync_payload(
@@ -8929,11 +8946,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_refresh_cloud_policy_bundle_preserves_bundle_hash_mismatch_reason(self, tmp_path, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "oauth_access_token_fixture",
-            "2026-04-09T00:00:00Z",
-        )
+        _seed_guard_cloud(store)
 
         def _bundle_rejected(current_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             current_store.set_sync_payload(
@@ -8955,11 +8968,7 @@ url = http://127.0.0.1:8787/guard-canary
     def test_refresh_cloud_policy_bundle_clears_non_bundle_errors_after_success(self, tmp_path, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "oauth_access_token_fixture",
-            "2026-04-09T00:00:00Z",
-        )
+        _seed_guard_cloud(store)
         store.set_sync_payload(
             "policy_bundle_last_error",
             {"reason": "sync_failed", "message": "stale error"},

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -15,10 +15,41 @@ from codex_plugin_scanner.guard.approvals import build_runtime_snapshot
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import evaluate_detection
 from codex_plugin_scanner.guard.edge_events import build_runtime_session_event
-from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection, PolicyDecision
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
 
 
 def _artifact(tmp_path: Path) -> GuardArtifact:
@@ -49,123 +80,23 @@ def test_sync_credentials_preserve_installation_id_when_cloud_workspace_changes(
     store = GuardStore(tmp_path / "guard-home")
     installation_id = store.get_or_create_installation_id()
 
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-two",
-        "2026-04-24T00:01:00+00:00",
-        workspace_id="workspace-beta",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    _seed_guard_cloud(store, workspace_id="workspace-beta")
 
     assert store.get_or_create_installation_id() == installation_id
     assert store.get_cloud_workspace_id() == "workspace-beta"
-
-
-def test_sync_credentials_refresh_preserves_existing_cloud_workspace_id(tmp_path: Path) -> None:
-    store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store)
     store.set_sync_payload("policy", {"policy": "team"}, "2026-04-24T00:00:00+00:00")
 
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:01:00+00:00",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
 
     assert store.get_cloud_workspace_id() == "workspace-alpha"
     assert store.get_sync_payload("policy") == {"policy": "team"}
-
-
-def test_sync_credentials_token_rotation_clears_stale_cloud_workspace_id(tmp_path: Path) -> None:
-    store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
-    store.set_sync_payload("policy", {"policy": "team"}, "2026-04-24T00:00:00+00:00")
-
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-two",
-        "2026-04-24T00:01:00+00:00",
-    )
-
-    assert store.get_cloud_workspace_id() is None
-    assert store.get_sync_payload("policy") is None
-
-
-def test_sync_credentials_workspace_metadata_update_preserves_cached_policy(tmp_path: Path) -> None:
-    store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-    )
-    store.set_sync_payload("policy", {"policy": "team"}, "2026-04-24T00:00:00+00:00")
-
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:01:00+00:00",
-        workspace_id="workspace-alpha",
-    )
-
-    assert store.get_cloud_workspace_id() == "workspace-alpha"
-    assert store.get_sync_payload("policy") == {"policy": "team"}
-
-
-def test_sync_credentials_workspace_switch_clears_stale_cloud_policy_allows(tmp_path: Path) -> None:
-    store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
-    store.set_sync_payload("policy", {"policy": "workspace-alpha"}, "2026-04-24T00:00:00+00:00")
-    store.upsert_policy(
-        PolicyDecision(
-            harness="codex",
-            scope="harness",
-            action="allow",
-            source="cloud-sync",
-            reason="workspace alpha cloud allow",
-        ),
-        "2026-04-24T00:00:00+00:00",
-    )
-
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:01:00+00:00",
-        workspace_id="workspace-beta",
-    )
-
-    assert store.get_cloud_workspace_id() == "workspace-beta"
-    assert store.get_sync_payload("policy") is None
-    assert not any(item["source"] in {"cloud-sync", "team-policy"} for item in store.list_policy_decisions())
 
 
 def test_evaluate_detection_queues_access_graph_snapshot_without_syncing(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     artifact = _artifact(tmp_path)
     config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=None)
 
@@ -184,11 +115,7 @@ def test_evaluate_detection_queues_access_graph_snapshot_without_syncing(tmp_pat
 
 def test_evaluate_detection_queues_access_graph_snapshot_without_cloud_workspace(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     artifact = _artifact(tmp_path)
     config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=None)
 
@@ -213,12 +140,7 @@ class _FailingAccessGraphEventStore(GuardStore):
 
 def test_access_graph_queue_failure_does_not_block_local_approval_decision(tmp_path: Path) -> None:
     store = _FailingAccessGraphEventStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     artifact = _artifact(tmp_path)
     config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=None)
 
@@ -257,12 +179,7 @@ def test_sync_guard_events_records_failed_backoff_without_dropping_pending_event
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     store.add_guard_event_v1(
         build_runtime_session_event(
             session_id="session-1",
@@ -328,12 +245,7 @@ def test_sync_guard_events_drains_all_pending_events_when_v1_endpoint_is_unavail
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home", guard_event_queue_limit=400)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     for index in range(250):
         store.add_guard_event_v1(
             build_runtime_session_event(
@@ -370,12 +282,7 @@ def test_sync_guard_events_drains_all_pending_events_when_v1_endpoint_is_unavail
 
 def test_sync_guard_events_preserves_unavailable_summary_when_no_events_pending(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     store.set_sync_payload(
         "guard_events_v1_summary",
         {
@@ -413,12 +320,7 @@ def test_build_runtime_snapshot_calls_oauth_health_once(tmp_path: Path, monkeypa
 
 def test_runtime_snapshot_treats_naive_sync_timestamps_as_utc(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     store.set_sync_payload(
         "guard_events_v1_summary",
         {"synced_at": "2000-01-01T00:00:00"},
@@ -433,12 +335,7 @@ def test_runtime_snapshot_treats_naive_sync_timestamps_as_utc(tmp_path: Path) ->
 
 def test_runtime_snapshot_reports_endpoint_unavailable_sync_as_degraded(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     store.set_sync_payload(
         "sync_summary",
         {"synced_at": datetime.now(timezone.utc).isoformat()},
@@ -493,12 +390,7 @@ def test_runtime_snapshot_exposes_local_device_without_cloud_pairing(tmp_path: P
 def test_runtime_snapshot_exposes_cloud_policy_bundle_fields(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     now = "2026-06-01T00:00:00+00:00"
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "oauth_access_token_fixture",
-        now,
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     store.set_sync_payload(
         "policy_bundle",
         {
@@ -747,12 +639,7 @@ def test_runtime_session_sync_skips_v1_event_when_ingest_was_recently_unavailabl
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     store.set_sync_payload(
         "guard_events_v1_summary",
         {
@@ -790,12 +677,7 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir(parents=True, exist_ok=True)
     context = HarnessContext(
@@ -868,12 +750,7 @@ def test_sync_runtime_session_prefers_ipv6_private_identity_when_ipv4_unavailabl
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-ipv6",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     monkeypatch.setattr(guard_runner_module, "_safe_private_ip", lambda: None)
     monkeypatch.setattr(guard_runner_module, "_safe_private_ipv6", lambda: "fd00::42")
     captured_body: dict[str, object] = {}
@@ -912,12 +789,7 @@ def test_sync_runtime_session_keeps_local_identity_when_package_coverage_missing
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-no-coverage",
-        "2026-04-24T00:00:00+00:00",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     monkeypatch.setattr(
         guard_runner_module,
         "package_shim_cloud_coverage",

--- a/tests/test_guard_codex_app_server.py
+++ b/tests/test_guard_codex_app_server.py
@@ -36,10 +36,7 @@ def test_read_websocket_frame_rejects_oversized_payload_before_reading() -> None
 
 def test_send_websocket_handshake_rejects_oversized_headers_before_marker() -> None:
     oversized_header_bytes = 128_000
-    mock_socket = _OversizedHandshakeSocket(
-        b"HTTP/1.1 101 Switching Protocols\r\n"
-        + (b"A" * oversized_header_bytes)
-    )
+    mock_socket = _OversizedHandshakeSocket(b"HTTP/1.1 101 Switching Protocols\r\n" + (b"A" * oversized_header_bytes))
 
     with pytest.raises(ValueError, match="websocket_headers_too_large"):
         codex_app_server_module._send_websocket_handshake(mock_socket)

--- a/tests/test_guard_codex_resume_commands.py
+++ b/tests/test_guard_codex_resume_commands.py
@@ -183,9 +183,7 @@ def test_default_codex_app_server_socket_probe_uses_codex_home(
         codex_app_server_module.default_codex_app_server_socket_path(environ={"CODEX_HOME": str(codex_home)})
         == socket_path
     )
-    assert codex_app_server_module.default_codex_app_server_socket_available(
-        environ={"CODEX_HOME": str(codex_home)}
-    )
+    assert codex_app_server_module.default_codex_app_server_socket_available(environ={"CODEX_HOME": str(codex_home)})
     assert connect_paths == [str(socket_path)]
 
 

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -21,6 +21,37 @@ from codex_plugin_scanner.guard.config import (
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
@@ -369,14 +400,14 @@ def test_resolve_guard_home_does_not_migrate_retired_legacy_credentials(tmp_path
     legacy_home = home_dir / ".ai-plugin-scanner-guard"
     GuardStore(canonical_home)
     legacy_store = GuardStore(legacy_home)
-    legacy_store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "legacy-token", "2026-04-15T00:00:00Z")
+    _seed_guard_cloud(legacy_store)
     monkeypatch.setattr(Path, "home", lambda: home_dir)
 
     resolved_home = resolve_guard_home()
 
     assert resolved_home == canonical_home
     canonical_store = GuardStore(canonical_home)
-    assert canonical_store.get_sync_credentials() is None
+    assert canonical_store.get_cloud_sync_profile() is None
 
 
 def test_migrate_guard_home_state_merges_nested_legacy_directories(tmp_path):
@@ -531,7 +562,7 @@ def test_resolve_guard_home_keeps_canonical_state_when_legacy_only_has_credentia
     legacy_home = home_dir / ".ai-plugin-scanner-guard"
     _write_text(canonical_home / "guard.db", "sqlite placeholder")
     legacy_store = GuardStore(legacy_home)
-    legacy_store.set_sync_credentials("https://hol.org/api/guard/receipts/sync", "legacy-token", "2026-04-15T00:00:00Z")
+    _seed_guard_cloud(legacy_store)
     monkeypatch.setattr(Path, "home", lambda: home_dir)
 
     assert resolve_guard_home() == canonical_home

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -22,6 +22,37 @@ from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _initialize_daemon(daemon: GuardDaemonServer) -> dict[str, object]:
     request = urllib.request.Request(
         f"http://127.0.0.1:{daemon.port}/v1/initialize",
@@ -173,11 +204,6 @@ def test_connect_status_requires_retry_when_legacy_sync_profile_exists_but_oauth
         milestone="first_sync_pending",
         now="2026-06-11T22:11:11+00:00",
         reason="Guard Cloud is unavailable. Local Guard keeps protecting this machine.",
-    )
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "legacy-sync-token",
-        "2026-06-11T22:12:00+00:00",
     )
 
     payload = build_connect_status_payload(

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -176,10 +176,7 @@ def test_guard_daemon_url_port_rejects_invalid_port_text() -> None:
 
 
 def test_guard_daemon_port_from_command_supports_equals_syntax() -> None:
-    command = (
-        "python -m codex_plugin_scanner.cli guard daemon --serve "
-        "--guard-home /tmp/guard-home --port=5474"
-    )
+    command = "python -m codex_plugin_scanner.cli guard daemon --serve --guard-home /tmp/guard-home --port=5474"
     assert daemon_manager_module._guard_daemon_port_from_command(command) == 5474
 
 
@@ -245,7 +242,9 @@ def test_ensure_guard_daemon_adopts_running_guard_daemon_before_respawning(tmp_p
         "Popen",
         lambda *_args, **_kwargs: (_ for _ in ()).throw(AssertionError("should not spawn a new daemon")),
     )
-    monkeypatch.setattr(daemon_manager_module, "_running_guard_daemon_processes_for_guard_home", lambda _guard_home, **kwargs: [])
+    monkeypatch.setattr(
+        daemon_manager_module, "_running_guard_daemon_processes_for_guard_home", lambda _guard_home, **kwargs: []
+    )
 
     url = daemon_manager_module.ensure_guard_daemon(guard_home)
 
@@ -276,7 +275,9 @@ def test_ensure_guard_daemon_retires_duplicate_ports_for_same_guard_home(tmp_pat
     killed: list[int] = []
 
     monkeypatch.setattr(daemon_manager_module, "_reap_stale_ephemeral_guard_daemons", lambda **_kwargs: None)
-    monkeypatch.setattr(daemon_manager_module, "load_guard_daemon_url", lambda _guard_home, **kwargs: "http://127.0.0.1:5474")
+    monkeypatch.setattr(
+        daemon_manager_module, "load_guard_daemon_url", lambda _guard_home, **kwargs: "http://127.0.0.1:5474"
+    )
     monkeypatch.setattr(
         daemon_manager_module,
         "_running_guard_daemon_processes_for_guard_home",
@@ -394,6 +395,7 @@ def test_ensure_guard_daemon_retires_stale_daemon_from_different_source_root(tmp
 
     _disable_daemon_adoption(monkeypatch)
     _disable_duplicate_retire(monkeypatch)
+
     def fake_load_guard_daemon_url(_guard_home):
         if launched_commands:
             return "http://127.0.0.1:5412"
@@ -440,6 +442,7 @@ def test_ensure_guard_daemon_spawns_with_current_package_import_path(tmp_path, m
 
     _disable_daemon_adoption(monkeypatch)
     _disable_duplicate_retire(monkeypatch)
+
     def fake_load_guard_daemon_url(_guard_home):
         return next(responses, "http://127.0.0.1:5412")
 

--- a/tests/test_guard_daemon_perf.py
+++ b/tests/test_guard_daemon_perf.py
@@ -245,6 +245,7 @@ class TestMemoryBenchmark:
         )
         assert result.returncode == 0, f"Subprocess failed: {result.stderr}"
         import ast
+
         leaked = ast.literal_eval(result.stdout.strip())
         assert not leaked, f"Guard import leaked heavy dependencies: {leaked}"
 

--- a/tests/test_guard_event_schema_v1.py
+++ b/tests/test_guard_event_schema_v1.py
@@ -20,6 +20,37 @@ from codex_plugin_scanner.guard.schemas.guard_event_v1 import GuardEventV1
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _receipt() -> GuardReceipt:
     return GuardReceipt(
         receipt_id="receipt-1",
@@ -207,10 +238,10 @@ def test_sync_guard_events_posts_to_v1_ingest(tmp_path) -> None:
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "token-1",
-            "2026-04-24T00:00:00+00:00",
+        _seed_guard_cloud(
+            store,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="token-1",
         )
 
         result = sync_guard_events(store)
@@ -233,11 +264,7 @@ def test_sync_guard_events_normalizes_registry_base_url(tmp_path) -> None:
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/registry/api/v1",
-            "token-1",
-            "2026-04-24T00:00:00+00:00",
-        )
+        _seed_guard_cloud(store, sync_url=f"http://127.0.0.1:{server.server_port}/registry/api/v1", token="token-1")
 
         result = sync_guard_events(store)
     finally:
@@ -256,10 +283,10 @@ def test_sync_receipts_uploads_pending_guard_events(tmp_path) -> None:
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "token-1",
-            "2026-04-24T00:00:00+00:00",
+        _seed_guard_cloud(
+            store,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="token-1",
         )
 
         result = sync_receipts(store)
@@ -284,10 +311,10 @@ def test_sync_receipts_keeps_receipt_success_when_v1_events_endpoint_is_missing(
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "token-1",
-            "2026-04-24T00:00:00+00:00",
+        _seed_guard_cloud(
+            store,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="token-1",
         )
 
         result = sync_receipts(store)
@@ -309,10 +336,10 @@ def test_sync_guard_events_marks_rejected_events_processed(tmp_path) -> None:
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "token-1",
-            "2026-04-24T00:00:00+00:00",
+        _seed_guard_cloud(
+            store,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="token-1",
         )
 
         result = sync_guard_events(store)

--- a/tests/test_guard_events.py
+++ b/tests/test_guard_events.py
@@ -19,13 +19,44 @@ from codex_plugin_scanner.guard.runtime.runner import (
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")
 
 
 def _seed_sync_credentials(home_dir: Path, sync_url: str, token: str = "local-test-token") -> None:
-    GuardStore(home_dir).set_sync_credentials(sync_url, token, "2026-04-09T00:00:00Z")
+    _seed_guard_cloud(GuardStore(home_dir), sync_url=sync_url, token=token)
 
 
 class _SyncRequestHandler(BaseHTTPRequestHandler):

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -101,9 +101,7 @@ def test_daemon_lists_harness_setup_contracts(tmp_path: Path) -> None:
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
-        status, payload = _read_json_response(
-            _request(daemon.port, "/v1/harnesses", token=daemon._server.auth_token)
-        )
+        status, payload = _read_json_response(_request(daemon.port, "/v1/harnesses", token=daemon._server.auth_token))
     finally:
         daemon.stop()
 

--- a/tests/test_guard_harness_smoke.py
+++ b/tests/test_guard_harness_smoke.py
@@ -46,9 +46,7 @@ class TestCodexCliSmoke:
         npmrc_prompt = _fixture_text(PROMPT_NPMRC_READ)
         requests = extract_prompt_requests(npmrc_prompt)
         classes = {r.request_class for r in requests}
-        assert "secret_read" in classes, (
-            "Guard did not classify .npmrc read as a secret_read request"
-        )
+        assert "secret_read" in classes, "Guard did not classify .npmrc read as a secret_read request"
 
     def test_canary_exfil_script_contains_fake_key_only(self) -> None:
         source = _fixture_text(CANARY_SCRIPT)
@@ -58,27 +56,19 @@ class TestCodexCliSmoke:
         real_gh_fine_grained_re = re.compile(r"github_pat_[A-Za-z0-9_]{82}")
         real_aws_key_re = re.compile(r"AKIA[0-9A-Z]{16}")
         real_npm_token_re = re.compile(r"npm_[A-Za-z0-9]{36}")
-        assert real_gh_token_re.search(source) is None, (
-            "Canary fixture must not contain real-looking GitHub tokens"
-        )
+        assert real_gh_token_re.search(source) is None, "Canary fixture must not contain real-looking GitHub tokens"
         assert real_gh_fine_grained_re.search(source) is None, (
             "Canary fixture must not contain real-looking GitHub fine-grained PATs"
         )
-        assert real_aws_key_re.search(source) is None, (
-            "Canary fixture must not contain real-looking AWS access keys"
-        )
-        assert real_npm_token_re.search(source) is None, (
-            "Canary fixture must not contain real-looking npm tokens"
-        )
+        assert real_aws_key_re.search(source) is None, "Canary fixture must not contain real-looking AWS access keys"
+        assert real_npm_token_re.search(source) is None, "Canary fixture must not contain real-looking npm tokens"
 
     def test_canary_exfil_script_triggers_exfil_detection(self) -> None:
         """Verify canary exfil patterns trigger data-flow detection via a simulated shell action."""
         source = _fixture_text(CANARY_SCRIPT)
         fake_key_re = re.compile(r"hol-fake-key-[0-9a-f]+")
         canary_url_re = re.compile(r"https://evil\.hol\.org/")
-        assert fake_key_re.search(source) is not None, (
-            "Canary exfil script must contain fake key material"
-        )
+        assert fake_key_re.search(source) is not None, "Canary exfil script must contain fake key material"
         canary_url_match = canary_url_re.search(source)
         assert canary_url_match is not None, (
             "Canary exfil script must reference canary endpoint with a complete URL path"
@@ -121,8 +111,20 @@ class TestCodexCliSmoke:
         env_file.write_text("//registry.npmjs.org/:_authToken=hol-fake-npm-token\n")
 
         result = subprocess.run(
-            [sys.executable, "-m", "codex_plugin_scanner.cli", "guard", "run", "codex",
-             "--dry-run", "--json", "--workspace", str(tmp_path), "--home", str(tmp_path / "home")],
+            [
+                sys.executable,
+                "-m",
+                "codex_plugin_scanner.cli",
+                "guard",
+                "run",
+                "codex",
+                "--dry-run",
+                "--json",
+                "--workspace",
+                str(tmp_path),
+                "--home",
+                str(tmp_path / "home"),
+            ],
             capture_output=True,
             text=True,
             check=False,
@@ -130,9 +132,7 @@ class TestCodexCliSmoke:
         )
         if not result.stdout:
             pytest.fail(f"Guard produced no output. Stderr: {result.stderr}")
-        assert result.returncode == 0, (
-            f"Guard run exited with code {result.returncode}. Stderr: {result.stderr}"
-        )
+        assert result.returncode == 0, f"Guard run exited with code {result.returncode}. Stderr: {result.stderr}"
         try:
             payload = json.loads(result.stdout)
             assert payload.get("dry_run") is True or payload.get("harness") == "codex", (
@@ -162,9 +162,7 @@ class TestClaudeCodeSmoke:
         env_prompt = _fixture_text(PROMPT_ENV_READ)
         requests = extract_prompt_requests(env_prompt)
         classes = {r.request_class for r in requests}
-        assert "secret_read" in classes, (
-            "Guard must classify .env read prompt as secret_read"
-        )
+        assert "secret_read" in classes, "Guard must classify .env read prompt as secret_read"
 
     def test_guard_bypass_prompt_classified_as_high_risk(self) -> None:
         bypass_prompt = _fixture_text(PROMPT_GUARD_BYPASS)
@@ -225,9 +223,7 @@ class TestOpenCodeSmoke:
             redaction_settings={},
         )
         signals = SecretPathDetector().detect(action, ctx)
-        assert len(signals) > 0, (
-            "SecretPathDetector must flag ~/.aws/credentials as a high-risk file read"
-        )
+        assert len(signals) > 0, "SecretPathDetector must flag ~/.aws/credentials as a high-risk file read"
 
     @pytest.mark.skipif(not _has_harness("opencode"), reason="opencode CLI not installed")
     def test_live_opencode_mcp_dangerous_tool_shows_guard_attribution(self) -> None:
@@ -242,9 +238,7 @@ class TestCopilotSmoke:
         source = _fixture_text(CANARY_ENCODED_SCRIPT)
         requests = extract_prompt_requests(source)
         classes = {r.request_class for r in requests}
-        assert "subprocess_intent" in classes, (
-            "Encoded canary script must trigger subprocess_intent detection"
-        )
+        assert "subprocess_intent" in classes, "Encoded canary script must trigger subprocess_intent detection"
         action = GuardActionEnvelope(
             schema_version=1,
             action_id="",

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -36,6 +36,37 @@ from codex_plugin_scanner.guard.store import GuardStore
 from tests.test_guard_supply_chain_evaluator import WORKSPACE_ID, _bundle_response, _package
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _read_json_response_details(
     request: urllib.request.Request,
 ) -> tuple[int, dict[str, object], dict[str, str]]:
@@ -1016,12 +1047,7 @@ def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(
     monkeypatch.setenv("HOME", str(home_dir))
     monkeypatch.setenv("SHELL", "/bin/zsh")
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "cloud-token",
-        "2026-05-27T16:00:00.000Z",
-        workspace_id="workspace-1",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-1")
     store.set_sync_payload(
         "supply_chain_bundle_entitlement",
         {"tier": "premium", "workspace_id": "workspace-1"},
@@ -1118,12 +1144,7 @@ def test_supply_chain_audit_scans_workspace_manifests(tmp_path: Path) -> None:
         encoding="utf-8",
     )
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "cloud-token",
-        audit_now,
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     bundle_response = _bundle_response(
         packages=[
             _package(
@@ -1385,12 +1406,7 @@ def test_supply_chain_package_firewall_rejects_duplicate_managers(tmp_path: Path
 
 def test_supply_chain_dashboard_session_claims_scope_action_and_managers(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "cloud-token",
-        "2026-05-27T16:00:00.000Z",
-        workspace_id="workspace-1",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-1")
     store.set_sync_payload(
         "supply_chain_bundle_entitlement",
         {"tier": "premium", "workspace_id": "workspace-1"},
@@ -1602,7 +1618,7 @@ def test_cloud_app_handoff_start_does_not_save_raw_sync_credentials(tmp_path: Pa
     assert status == 410
     assert payload["error"] == "legacy_cloud_handoff_disabled"
     assert "guard-runtime-token" not in json.dumps(payload)
-    assert store.get_sync_credentials() is None
+    assert store.get_cloud_sync_profile() is None
 
 
 def test_cloud_app_handoff_navigation_requires_auth_before_legacy_sync_query_handling(tmp_path: Path) -> None:
@@ -1634,7 +1650,7 @@ def test_cloud_app_handoff_navigation_requires_auth_before_legacy_sync_query_han
     assert status == 401
     assert payload["error"] == "unauthorized"
     assert "guard-runtime-token" not in json.dumps(payload)
-    assert store.get_sync_credentials() is None
+    assert store.get_cloud_sync_profile() is None
 
 
 def test_cloud_app_handoff_complete_rejects_legacy_handoff_token(tmp_path: Path) -> None:
@@ -1726,12 +1742,7 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "cloud-token",
-        "2026-05-23T17:18:00.000Z",
-        workspace_id="workspace-1",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-1")
     sync_calls: list[str] = []
     sync_finished = threading.Event()
     store.record_guard_connect_pairing_completed(
@@ -1799,12 +1810,7 @@ def test_headless_app_scan_does_not_spawn_unbounded_cloud_sync_threads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "cloud-token",
-        "2026-05-23T17:18:00.000Z",
-        workspace_id="workspace-1",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-1")
     sync_calls: list[int] = []
     sync_started = threading.Event()
     sync_release = threading.Event()

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -166,9 +166,17 @@ def test_inventory_helpers_emit_safe_endpoint_and_stable_hashes(tmp_path: Path) 
     assert classify_endpoint_host("https://user:pass@example.com/mcp?token=value") == "remote_public"
     assert classify_endpoint_host("http://172.20.4.5:8080/mcp") == "local_private"
     assert classify_endpoint_host("http://[not-an-ip]/mcp") == "remote_public"
-    assert redact_url("https://user:pass@example.com/mcp?token=value&mode=safe") == "https://example.com/mcp?token=redacted&mode=safe"
-    assert redact_url("https://example.com/mcp?auth=value&mode=safe") == "https://example.com/mcp?auth=redacted&mode=safe"
-    assert redact_url("https://example.com/mcp?mode=safe;token=value") == "https://example.com/mcp?mode=safe&token=redacted"
+    assert (
+        redact_url("https://user:pass@example.com/mcp?token=value&mode=safe")
+        == "https://example.com/mcp?token=redacted&mode=safe"
+    )
+    assert (
+        redact_url("https://example.com/mcp?auth=value&mode=safe") == "https://example.com/mcp?auth=redacted&mode=safe"
+    )
+    assert (
+        redact_url("https://example.com/mcp?mode=safe;token=value")
+        == "https://example.com/mcp?mode=safe&token=redacted"
+    )
     assert redact_url("http://localhost:${PORT}/mcp?auth=value") == "http://localhost/mcp?auth=redacted"
     assert redact_url("http://[2001:db8::1]:8080/mcp?token=value") == "http://[2001:db8::1]:8080/mcp?token=redacted"
     assert redact_url("http://[not-an-ip]/mcp?token=value") == "malformed_url_redacted"
@@ -464,6 +472,7 @@ def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tm
         for layer in tool_layers
     )
     assert str(workspace) not in encoded
+
 
 def test_inventory_snapshot_handles_missing_mcp_tool_schema_and_scale(tmp_path: Path) -> None:
     tools = [{"name": f"tool_{index}", "description": "No schema available."} for index in range(500)]

--- a/tests/test_guard_js_package_hook_phase11.py
+++ b/tests/test_guard_js_package_hook_phase11.py
@@ -17,6 +17,38 @@ from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.store import GuardStore
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 WORKSPACE_ID = "workspace-alpha"
 
 
@@ -168,9 +200,7 @@ def test_guard_hook_blocks_js_exec_flows_before_subprocess(
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, command)
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _bundle_response(package_name=package_name, version=version, namespace=namespace),

--- a/tests/test_guard_js_package_intent_phase11.py
+++ b/tests/test_guard_js_package_intent_phase11.py
@@ -180,8 +180,8 @@ __metadata:
 def test_parse_manifest_dependency_changes_ignores_yarn_berry_metadata_sections() -> None:
     result = parse_manifest_dependency_changes(
         path="yarn.lock",
-        before_text='__metadata:\n  version: 4\n  cacheKey: 8\n',
-        after_text='__metadata:\n  version: 5\n  cacheKey: 9\n',
+        before_text="__metadata:\n  version: 4\n  cacheKey: 8\n",
+        after_text="__metadata:\n  version: 5\n  cacheKey: 9\n",
     )
 
     assert result.parse_errors == ()

--- a/tests/test_guard_legacy_token_fixtures.py
+++ b/tests/test_guard_legacy_token_fixtures.py
@@ -15,8 +15,7 @@ def test_guard_live_fixtures_are_rejection_only() -> None:
     offenders = sorted(
         str(path.relative_to(tests_root))
         for path in tests_root.rglob("test_*.py")
-        if str(path.relative_to(tests_root)) not in allowed_files
-        and legacy_prefix in path.read_text(encoding="utf-8")
+        if str(path.relative_to(tests_root)) not in allowed_files and legacy_prefix in path.read_text(encoding="utf-8")
     )
 
     assert offenders == []

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -13,6 +13,38 @@ from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_
 from codex_plugin_scanner.guard.runtime.runner import GuardSyncAuthorizationExpiredError
 from codex_plugin_scanner.guard.store import GuardStore
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 WORKSPACE_ID = "2de4fcb4-a5b2-447a-a67f-21c6eb4c5f3c"
 
 
@@ -22,12 +54,7 @@ def _write_text(path: Path, text: str) -> None:
 
 
 def _seed_premium_pairing(store: GuardStore, *, now: str) -> None:
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        now,
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.set_sync_payload(
         "supply_chain_bundle_summary",
         {
@@ -678,12 +705,7 @@ def test_audit_receipt_metadata_enriches_cloud_advisory_aliases_from_bundle(
 
     home_dir = tmp_path / "guard-home"
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-25T10:00:00+00:00",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _bundle_response(

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -23,6 +23,38 @@ from codex_plugin_scanner.guard.config import load_guard_config
 from codex_plugin_scanner.guard.protect import build_protect_payload
 from codex_plugin_scanner.guard.store import GuardStore
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 pytest_plugins = ["tests.bundle_first_cloud"]
 pytestmark = pytest.mark.usefixtures("bundle_first_cloud")
 
@@ -85,7 +117,9 @@ def _package(
     }
 
 
-def _bundle_response(*, packages: list[dict[str, object]], policy_rules: list[dict[str, object]] | None = None) -> dict[str, object]:
+def _bundle_response(
+    *, packages: list[dict[str, object]], policy_rules: list[dict[str, object]] | None = None
+) -> dict[str, object]:
     generated_at = datetime.now(timezone.utc)
     expires_at = generated_at + timedelta(days=7)
     bundle = {
@@ -152,12 +186,7 @@ def _seed_supply_chain_bundle(
     policy_rules: list[dict[str, object]] | None = None,
 ) -> None:
     response = _bundle_response(packages=packages, policy_rules=policy_rules)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        now,
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, response, now)
     store.set_sync_payload(
         "supply_chain_bundle_summary",

--- a/tests/test_guard_mcp_package_proxy_phase14.py
+++ b/tests/test_guard_mcp_package_proxy_phase14.py
@@ -27,6 +27,38 @@ from codex_plugin_scanner.guard.runtime.package_intent import (
 )
 from codex_plugin_scanner.guard.store import GuardStore
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 pytest_plugins = ["tests.bundle_first_cloud"]
 pytestmark = pytest.mark.usefixtures("bundle_first_cloud")
 
@@ -222,12 +254,7 @@ def test_phase14_runtime_mcp_proxy_queues_package_request_not_generic_tool_call(
     _allow_mcp_tool_calls(monkeypatch)
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
     config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
     marker_path = tmp_path / f"{harness}-mcp-forwarded.json"
@@ -280,12 +307,7 @@ def test_phase14_runtime_mcp_proxy_forwards_allowed_package_call(
     _allow_mcp_tool_calls(monkeypatch)
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="allow"), "2026-05-19T00:00:00Z")
     config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
     marker_path = tmp_path / "cursor-mcp-forwarded.json"
@@ -329,12 +351,7 @@ def test_phase14_runtime_mcp_proxy_rejects_stored_allow_when_current_package_blo
     _allow_mcp_tool_calls(monkeypatch)
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
     intent = extract_package_intent_request(
         "run_terminal_command",
@@ -404,12 +421,7 @@ def test_phase14_runtime_mcp_proxy_rejects_stored_allow_without_workspace_when_c
     _allow_mcp_tool_calls(monkeypatch)
     context = _context_without_workspace(tmp_path)
     store = GuardStore(context.guard_home)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
     intent = extract_package_intent_request(
         "run_terminal_command",
@@ -479,12 +491,7 @@ def test_phase14_runtime_mcp_proxy_skips_requeue_for_stored_package_block(
     _allow_mcp_tool_calls(monkeypatch)
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
     intent = extract_package_intent_request(
         "run_terminal_command",
@@ -715,12 +722,7 @@ def test_phase14_codex_package_inline_approval_is_remembered(
 ) -> None:
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="allow"), "2026-05-19T00:00:00Z")
     config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
     marker_path = tmp_path / "codex-inline-package.json"
@@ -807,12 +809,7 @@ def test_phase14_runtime_mcp_proxy_normalizes_stored_review_for_package_approval
     _allow_mcp_tool_calls(monkeypatch)
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="allow"), "2026-05-19T00:00:00Z")
     intent = extract_package_intent_request(
         "run_terminal_command",

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -904,7 +904,7 @@ def test_login_token_alias_rejects_raw_token_without_persisting_credentials(tmp_
     assert exit_code == 2
     assert "hol-guard connect" in captured.err
     assert "guard_live_secret" not in captured.err
-    assert store.get_sync_credentials() is None
+    assert store.get_cloud_sync_profile() is None
 
 
 def test_service_login_rejects_raw_token_without_persisting_credentials(tmp_path: Path, capsys) -> None:
@@ -919,7 +919,7 @@ def test_service_login_rejects_raw_token_without_persisting_credentials(tmp_path
     assert exit_code == 2
     assert "hol-guard connect --headless" in captured.out
     assert "guard_live_secret" not in captured.out
-    assert store.get_sync_credentials() is None
+    assert store.get_cloud_sync_profile() is None
 
 
 def test_service_login_without_token_points_to_ci_safe_connect(tmp_path: Path, capsys) -> None:
@@ -1699,7 +1699,7 @@ def test_connect_browser_reports_loopback_timeout_without_traceback(
     assert "Guard authorization failed" in captured.err
     assert "timed out" in captured.err
     assert "Traceback" not in captured.err
-    assert store.get_sync_credentials() is None
+    assert store.get_cloud_sync_profile() is None
     assert store.get_oauth_local_credentials() is None
 
 

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from contextlib import contextmanager
 import json
 import urllib.error
+from contextlib import contextmanager
 
 import pytest
 

--- a/tests/test_guard_package_hook.py
+++ b/tests/test_guard_package_hook.py
@@ -18,6 +18,38 @@ from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
 from codex_plugin_scanner.guard.store import GuardStore
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 pytest_plugins = ["tests.bundle_first_cloud"]
 pytestmark = pytest.mark.usefixtures("bundle_first_cloud")
 
@@ -205,9 +237,7 @@ def test_guard_hook_blocks_package_request_before_execution_and_queues_cloud_syn
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="block"), "2026-05-19T00:00:00Z")
     (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
     monkeypatch.setenv("CODEX_MANAGED_BY_BUN", "1")
@@ -264,9 +294,7 @@ def test_guard_hook_ask_queues_package_approval_with_advisory_context(
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _bundle_response(
@@ -332,9 +360,7 @@ def test_guard_hook_ask_package_live_wait_surfaces_approval_url(
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _bundle_response(
@@ -409,9 +435,7 @@ def test_guard_hook_ask_package_live_wait_caps_browser_approval_wait(
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _bundle_response(
@@ -482,12 +506,7 @@ def test_guard_hook_warns_for_package_request_without_blocking(
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="warn"), "2026-05-19T00:00:00Z")
 
     rc = main(
@@ -526,9 +545,7 @@ def test_guard_hook_keeps_block_copy_when_scanner_escalates_package_warning(
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="warn"), "2026-05-19T00:00:00Z")
     (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
@@ -591,9 +608,7 @@ def test_guard_hook_keeps_data_flow_summary_when_package_warning_is_weaker(
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, "npm install minimist@1.2.8")
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(WORKSPACE_ID, _bundle_response(action="warn"), "2026-05-19T00:00:00Z")
     (home_dir / "config.toml").write_text("approval_wait_timeout_seconds = 0\n", encoding="utf-8")
     monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")

--- a/tests/test_guard_package_hook_phase14.py
+++ b/tests/test_guard_package_hook_phase14.py
@@ -22,6 +22,38 @@ from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.store import GuardStore
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 pytest_plugins = ["tests.bundle_first_cloud"]
 pytestmark = pytest.mark.usefixtures("bundle_first_cloud")
 
@@ -183,14 +215,11 @@ def _run_guard_hook(
         ]
     )
     return rc, json.loads(capsys.readouterr().out)
+
+
 def _seed_review_bundle(home_dir: Path, *, harness_selector: str = "*") -> GuardStore:
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _bundle_response(
@@ -217,12 +246,7 @@ def _seed_review_bundle(home_dir: Path, *, harness_selector: str = "*") -> Guard
 
 def _seed_block_bundle(home_dir: Path) -> GuardStore:
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _bundle_response(action="block"),
@@ -402,9 +426,9 @@ def test_phase14_package_hook_block_copy_stays_consistent_across_harnesses(
     assert decision["harness_message"].startswith("HOL Guard blocked")
     assert "Reason:" in decision["harness_message"]
     assert "Fix: install `npm install minimist@1.2.9` or choose a team exception." in decision["harness_message"]
-    assert "Open HOL Guard to approve or keep this blocked: http://127.0.0.1:5474/requests/" in decision[
-        "harness_message"
-    ]
+    assert (
+        "Open HOL Guard to approve or keep this blocked: http://127.0.0.1:5474/requests/" in decision["harness_message"]
+    )
     assert "guard/inbox" not in decision["harness_message"]
 
 

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -32,6 +32,38 @@ from tests.shim_execution_helpers import write_fake_manager_script
 from tests.test_guard_protect import _seed_bundle_cache_only, _SyncAndEvaluateHandler
 from tests.test_guard_supply_chain_evaluator import _cloud_response, _EvaluateHandler
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 WORKSPACE_ID = "workspace-alpha"
 
 
@@ -180,7 +212,7 @@ def _seed_bundle(
 
 
 def _seed_workspace_sync_credentials(home_dir: Path, sync_url: str, *, now: str = "2026-05-19T00:00:00Z") -> None:
-    GuardStore(home_dir).set_sync_credentials(sync_url, "demo-token", now, workspace_id=WORKSPACE_ID)
+    _seed_guard_cloud(GuardStore(home_dir), workspace_id=WORKSPACE_ID)
 
 
 def _start_cloud_eval_server(

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -236,10 +236,7 @@ def test_update_treats_nonzero_pipx_repair_as_updated_when_version_changed(
     assert "dashboard_sync" in payload
     notes = payload.get("notes")
     assert isinstance(notes, list)
-    assert any(
-        "Installer exited with code 1 after version changed." in str(note)
-        for note in notes
-    )
+    assert any("Installer exited with code 1 after version changed." in str(note) for note in notes)
 
 
 def test_update_repairs_missing_pip_local_source_install(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:

--- a/tests/test_guard_phase04_install_reason_proofs.py
+++ b/tests/test_guard_phase04_install_reason_proofs.py
@@ -15,6 +15,8 @@ from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import evaluat
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.guard_python_phase12_support import (
     WORKSPACE_ID as PYTHON_WORKSPACE_ID,
+)
+from tests.guard_python_phase12_support import (
     artifact_from_command_fixture,
     bundle_response_fixture,
     package_fixture,

--- a/tests/test_guard_phase06_workspace_audit.py
+++ b/tests/test_guard_phase06_workspace_audit.py
@@ -8,10 +8,10 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.config import load_guard_config
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server
-from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
 from codex_plugin_scanner.guard.local_supply_chain import (
     audit_receipt_metadata,
     build_workspace_audit_payload,
@@ -33,6 +33,38 @@ from tests.test_guard_supply_chain_evaluator import (
     _package,
 )
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 WORKSPACE_AUDIT_NOW = "2026-06-08T12:00:00.000Z"
 
 
@@ -42,12 +74,7 @@ def _write_text(path: Path, text: str) -> None:
 
 
 def _seed_premium_entitlement(store: GuardStore) -> None:
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "cloud-token",
-        WORKSPACE_AUDIT_NOW,
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.set_sync_payload(
         "supply_chain_bundle_entitlement",
         {"tier": "premium", "workspace_id": WORKSPACE_ID},

--- a/tests/test_guard_phase07_entitlement_daemon_security.py
+++ b/tests/test_guard_phase07_entitlement_daemon_security.py
@@ -40,6 +40,7 @@ def _seed_free_connect_state(store: GuardStore) -> None:
         "2026-06-09T12:00:00.000Z",
     )
 
+
 def _seed_premium_entitlement(store: GuardStore) -> None:
     store.set_sync_payload(
         "supply_chain_bundle_entitlement",

--- a/tests/test_guard_phase11_package_firewall_receipts.py
+++ b/tests/test_guard_phase11_package_firewall_receipts.py
@@ -10,8 +10,8 @@ import pytest
 
 from codex_plugin_scanner.guard.local_supply_chain import audit_receipt_metadata
 from codex_plugin_scanner.guard.package_firewall_receipts import package_firewall_receipt_metadata
-from codex_plugin_scanner.guard.shims import install_package_shims, probe_package_shim_intercepts
 from codex_plugin_scanner.guard.shim_probe import protect_evaluator_evidence
+from codex_plugin_scanner.guard.shims import install_package_shims, probe_package_shim_intercepts
 from codex_plugin_scanner.guard.stable_digest import stable_digest_hex
 from tests.shim_execution_helpers import write_fake_manager_script
 

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -11,18 +11,12 @@ from typing import cast
 import pytest
 
 from codex_plugin_scanner.cli import main
-from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore, SystemKeyringSecretStore
 
 
 @pytest.fixture(autouse=True)
-def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
-
-
-@pytest.fixture(autouse=True)
-def _fake_policy_integrity_keyring(_default_store_platform: None, install_fake_system_keyring) -> None:
+def _fake_policy_integrity_keyring(install_fake_system_keyring) -> None:
     install_fake_system_keyring()
 
 
@@ -306,7 +300,6 @@ def test_policy_integrity_status_uses_timed_keychain_reads_once_per_secret(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
     store = _store(tmp_path)
     store.upsert_policy(
         _decision(artifact_id="codex:project:keychain-cache", artifact_hash="hash-keychain-cache"),
@@ -376,20 +369,26 @@ def test_policy_integrity_status_skips_passive_macos_keychain_reads(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    monkeypatch.setattr(
-        SystemKeyringSecretStore,
-        "_load_keyring_module",
-        staticmethod(lambda: (_ for _ in ()).throw(AssertionError("macOS policy integrity must not load keyring"))),
-    )
     store = _store(tmp_path)
     store.upsert_policy(
         _decision(artifact_id="codex:project:passive-skip", artifact_hash="hash-passive-skip"),
         "2026-06-14T00:00:00Z",
     )
     secret_store = store._policy_integrity_secret_store
-    assert secret_store is None
+    assert isinstance(secret_store, SystemKeyringSecretStore)
     store._clear_policy_integrity_cache()
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        secret_store,
+        "get_secret_with_timeout",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("passive policy-integrity status should skip macOS keychain reads")
+        ),
+    )
     monkeypatch.setattr(
         store,
         "_get_secret_from_store",
@@ -403,63 +402,8 @@ def test_policy_integrity_status_skips_passive_macos_keychain_reads(
 
     assert status["mode"] == "degraded"
     assert verify["mode"] == "degraded"
-    assert "system_keyring_unavailable" in status["degraded_reasons"]
+    assert "policy_integrity_key_unavailable" in status["degraded_reasons"]
     assert "policy_integrity_control_unavailable" in status["degraded_reasons"]
-    assert verify["local_rows_scanned"] == 1
-
-
-def test_policy_integrity_create_skips_macos_keychain_when_native_reads_are_unavailable(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    monkeypatch.setattr(
-        SystemKeyringSecretStore,
-        "_load_keyring_module",
-        staticmethod(lambda: (_ for _ in ()).throw(AssertionError("macOS policy integrity must not load keyring"))),
-    )
-    store = _store(tmp_path)
-    secret_store = store._policy_integrity_secret_store
-    assert secret_store is None
-
-    store.upsert_policy(
-        _decision(artifact_id="codex:project:no-native-create", artifact_hash="hash-no-native-create"),
-        "2026-06-14T00:00:00Z",
-    )
-    status = store.get_policy_integrity_status()
-
-    assert status["mode"] == "degraded"
-    assert "system_keyring_unavailable" in status["degraded_reasons"]
-    assert "policy_integrity_control_unavailable" in status["degraded_reasons"]
-
-
-def test_policy_integrity_status_disables_native_macos_keyring_reads(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    monkeypatch.setattr(
-        SystemKeyringSecretStore,
-        "_supports_native_macos_security_reads",
-        classmethod(
-            lambda cls: (_ for _ in ()).throw(
-                AssertionError("macOS policy integrity should not probe native keychain support")
-            )
-        ),
-    )
-    store = _store(tmp_path)
-    store.upsert_policy(
-        _decision(artifact_id="codex:project:native-disabled", artifact_hash="hash-native-disabled"),
-        "2026-06-14T00:00:00Z",
-    )
-
-    status = store.get_policy_integrity_status()
-    verify = store.verify_policy_integrity()
-
-    assert store._policy_integrity_secret_store is None
-    assert status["mode"] == "degraded"
-    assert "system_keyring_unavailable" in status["degraded_reasons"]
-    assert verify["mode"] == "degraded"
     assert verify["local_rows_scanned"] == 1
 
 

--- a/tests/test_guard_product_flow.py
+++ b/tests/test_guard_product_flow.py
@@ -204,7 +204,7 @@ args = ["workspace-skill.js", "--changed"]
         assert output["cloud_state"] == "local_only"
         assert output["approval_center_url"] == "http://127.0.0.1:5474"
         assert output["bootstrap_install"]["reason"] == "skipped_by_flag"
-        assert GuardStore(guard_home).get_sync_credentials() is None
+        assert GuardStore(guard_home).get_cloud_sync_profile() is None
 
     def test_guard_start_recommends_copilot_when_it_is_the_only_detected_harness(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_protect.py
+++ b/tests/test_guard_protect.py
@@ -18,12 +18,43 @@ from codex_plugin_scanner.guard.redaction import redact_text
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
 def _seed_sync_credentials(home_dir, sync_url: str, token: str = "demo-token") -> None:
-    GuardStore(home_dir).set_sync_credentials(sync_url, token, "2026-04-09T00:00:00Z")
+    _seed_guard_cloud(GuardStore(home_dir), sync_url=sync_url, token=token)
 
 
 class _SyncRequestHandler(BaseHTTPRequestHandler):
@@ -1103,12 +1134,11 @@ class TestGuardProtect:
         thread.start()
         try:
             store = GuardStore(home_dir)
-            sync_now = "2026-04-09T00:00:00Z"
-            store.set_sync_credentials(
-                f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-                "demo-token",
-                sync_now,
+            _seed_guard_cloud(
+                store,
                 workspace_id=WORKSPACE_ID,
+                sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+                token="demo-token",
             )
             _seed_bundle_cache_only(
                 home_dir=home_dir,

--- a/tests/test_guard_python_lab_phase12.py
+++ b/tests/test_guard_python_lab_phase12.py
@@ -65,9 +65,7 @@ def _write_simple_index(
         match = re.search(r"^labdemo-(.+)-py\d+-none-any\.whl$", wheel_path.name)
         version = match.group(1) if match is not None else ""
         yanked_attr = ' data-yanked="fixture-yanked"' if version in yanked_versions else ""
-        package_link_rows.append(
-            f'<a href="../../packages/{wheel_path.name}"{yanked_attr}>{wheel_path.name}</a><br/>'
-        )
+        package_link_rows.append(f'<a href="../../packages/{wheel_path.name}"{yanked_attr}>{wheel_path.name}</a><br/>')
     package_links = "\n".join(package_link_rows)
     write_text(index_root / "simple" / "index.html", '<a href="labdemo/">labdemo</a>\n')
     write_text(index_root / "simple" / "labdemo" / "index.html", package_links + "\n")

--- a/tests/test_guard_python_package_hook_phase12.py
+++ b/tests/test_guard_python_package_hook_phase12.py
@@ -18,6 +18,37 @@ from .guard_python_phase12_support import (
 )
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _write_codex_pre_tool_payload(path: Path, workspace_dir: Path, command: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(
@@ -60,12 +91,7 @@ def test_guard_hook_blocks_python_exec_flows_before_subprocess(
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, command)
     store = GuardStore(home_dir)
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         bundle_response_fixture(

--- a/tests/test_guard_receipt_p5_fields.py
+++ b/tests/test_guard_receipt_p5_fields.py
@@ -219,6 +219,7 @@ class TestReceiptFieldRoundtrip:
     def test_action_envelope_json_roundtrip(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
         from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+
         envelope = GuardActionEnvelope(
             schema_version=1,
             action_id="action-01",
@@ -257,6 +258,7 @@ class TestReceiptFieldRoundtrip:
         store = _make_store(tmp_path)
         from codex_plugin_scanner.guard.models import GuardApprovalRequest
         from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+
         envelope = GuardActionEnvelope(
             schema_version=1,
             action_id="action-02",
@@ -307,12 +309,7 @@ class TestV5MigrationPreservesRowids:
         db_path.parent.mkdir(parents=True, exist_ok=True)
         conn = sqlite3.connect(str(db_path))
         conn.row_factory = sqlite3.Row
-        conn.execute(
-            "create table schema_migrations ("
-            "  version integer primary key,"
-            "  applied_at text not null"
-            ")"
-        )
+        conn.execute("create table schema_migrations (  version integer primary key,  applied_at text not null)")
         conn.execute(
             """
             create table runtime_receipts (
@@ -335,9 +332,7 @@ class TestV5MigrationPreservesRowids:
             )
             """
         )
-        conn.execute(
-            "insert into schema_migrations (version, applied_at) values (4, '2025-01-01T00:00:00Z')"
-        )
+        conn.execute("insert into schema_migrations (version, applied_at) values (4, '2025-01-01T00:00:00Z')")
         conn.execute(
             """
             insert into runtime_receipts (
@@ -383,25 +378,28 @@ class TestV5MigrationPreservesRowids:
 
 
 class TestMapApprovalSource:
-    @pytest.mark.parametrize("decision_source,expected", [
-        ("inline-approved", "inline"),
-        ("inline-denied", "inline"),
-        ("native-approved", "inline"),
-        ("claude-native-approved", "inline"),
-        ("policy-allow", "policy"),
-        ("policy-block", "policy"),
-        ("policy_allow", "policy"),
-        ("heuristic-allow", "policy"),
-        ("heuristic_block", "policy"),
-        ("auto-allow", "policy"),
-        ("heuristic", "policy"),
-        ("policy", "policy"),
-        ("auto", "policy"),
-        ("pre-tool-hook", "policy"),
-        ("permission-request-hook", "policy"),
-        ("pending-approval", "approval_center"),
-        ("approval-center-allow", "approval_center"),
-        ("unknown-source", "approval_center"),
-    ])
+    @pytest.mark.parametrize(
+        "decision_source,expected",
+        [
+            ("inline-approved", "inline"),
+            ("inline-denied", "inline"),
+            ("native-approved", "inline"),
+            ("claude-native-approved", "inline"),
+            ("policy-allow", "policy"),
+            ("policy-block", "policy"),
+            ("policy_allow", "policy"),
+            ("heuristic-allow", "policy"),
+            ("heuristic_block", "policy"),
+            ("auto-allow", "policy"),
+            ("heuristic", "policy"),
+            ("policy", "policy"),
+            ("auto", "policy"),
+            ("pre-tool-hook", "policy"),
+            ("permission-request-hook", "policy"),
+            ("pending-approval", "approval_center"),
+            ("approval-center-allow", "approval_center"),
+            ("unknown-source", "approval_center"),
+        ],
+    )
     def test_decision_source_mapped_correctly(self, decision_source: str, expected: str) -> None:
         assert _map_approval_source(decision_source) == expected

--- a/tests/test_guard_receipt_persistence.py
+++ b/tests/test_guard_receipt_persistence.py
@@ -160,27 +160,31 @@ class TestReceiptOrdering:
     def test_list_receipts_limit_restricts_count(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
         for i in range(5):
-            store.add_receipt(_make_receipt(receipt_id=f"r-{i:03d}", timestamp=f"2025-01-{i+1:02d}T00:00:00Z"))
+            store.add_receipt(_make_receipt(receipt_id=f"r-{i:03d}", timestamp=f"2025-01-{i + 1:02d}T00:00:00Z"))
 
         items = store.list_receipts(limit=3)
         assert len(items) == 3
 
     def test_get_latest_receipt_returns_most_recent(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
-        store.add_receipt(_make_receipt(
-            receipt_id="r-old",
-            artifact_id="codex:project:my_tool",
-            harness="codex",
-            timestamp="2025-01-01T00:00:00Z",
-            policy_decision="require-reapproval",
-        ))
-        store.add_receipt(_make_receipt(
-            receipt_id="r-new",
-            artifact_id="codex:project:my_tool",
-            harness="codex",
-            timestamp="2025-12-01T00:00:00Z",
-            policy_decision="allow",
-        ))
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r-old",
+                artifact_id="codex:project:my_tool",
+                harness="codex",
+                timestamp="2025-01-01T00:00:00Z",
+                policy_decision="require-reapproval",
+            )
+        )
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r-new",
+                artifact_id="codex:project:my_tool",
+                harness="codex",
+                timestamp="2025-12-01T00:00:00Z",
+                policy_decision="allow",
+            )
+        )
 
         latest = store.get_latest_receipt("codex", "codex:project:my_tool")
         assert latest is not None
@@ -193,18 +197,22 @@ class TestReceiptOrdering:
 
     def test_get_latest_receipt_scoped_to_harness_artifact_pair(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
-        store.add_receipt(_make_receipt(
-            receipt_id="r-codex",
-            harness="codex",
-            artifact_id="codex:project:tool_a",
-            timestamp="2025-12-01T00:00:00Z",
-        ))
-        store.add_receipt(_make_receipt(
-            receipt_id="r-claude",
-            harness="claude",
-            artifact_id="claude:project:tool_a",
-            timestamp="2025-12-02T00:00:00Z",
-        ))
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r-codex",
+                harness="codex",
+                artifact_id="codex:project:tool_a",
+                timestamp="2025-12-01T00:00:00Z",
+            )
+        )
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r-claude",
+                harness="claude",
+                artifact_id="claude:project:tool_a",
+                timestamp="2025-12-02T00:00:00Z",
+            )
+        )
 
         latest_codex = store.get_latest_receipt("codex", "codex:project:tool_a")
         latest_claude = store.get_latest_receipt("claude", "claude:project:tool_a")
@@ -218,18 +226,22 @@ class TestReceiptDecisionCounts:
     def test_counts_aggregate_by_policy_decision(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
         for _ in range(3):
-            store.add_receipt(_make_receipt(
+            store.add_receipt(
+                _make_receipt(
+                    harness="codex",
+                    artifact_id="codex:project:my_tool",
+                    policy_decision="allow",
+                    timestamp="2025-01-01T00:00:00Z",
+                )
+            )
+        store.add_receipt(
+            _make_receipt(
                 harness="codex",
                 artifact_id="codex:project:my_tool",
-                policy_decision="allow",
-                timestamp="2025-01-01T00:00:00Z",
-            ))
-        store.add_receipt(_make_receipt(
-            harness="codex",
-            artifact_id="codex:project:my_tool",
-            policy_decision="block",
-            timestamp="2025-01-02T00:00:00Z",
-        ))
+                policy_decision="block",
+                timestamp="2025-01-02T00:00:00Z",
+            )
+        )
 
         counts = store.receipt_decision_counts("codex", "codex:project:my_tool")
         assert counts.get("allow") == 3
@@ -342,12 +354,14 @@ class TestInventoryForExplain:
             now="2025-01-01T00:00:00Z",
             approved=True,
         )
-        store.add_receipt(_make_receipt(
-            receipt_id="r-001",
-            artifact_id="codex:project:my_tool",
-            harness="codex",
-            timestamp="2025-01-01T00:00:00Z",
-        ))
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r-001",
+                artifact_id="codex:project:my_tool",
+                harness="codex",
+                timestamp="2025-01-01T00:00:00Z",
+            )
+        )
         store.record_diff(
             harness="codex",
             artifact_id="codex:project:my_tool",
@@ -377,27 +391,33 @@ class TestReceiptAnalytics:
         t2 = (now - timedelta(days=5)).isoformat().replace("+00:00", "Z")
         t3 = now.isoformat().replace("+00:00", "Z")
 
-        store.add_receipt(_make_receipt(
-            receipt_id="r1",
-            harness="codex",
-            policy_decision="allow",
-            timestamp=t1,
-            artifact_name="install npm",
-        ))
-        store.add_receipt(_make_receipt(
-            receipt_id="r2",
-            harness="codex",
-            policy_decision="block",
-            timestamp=t2,
-            artifact_name="curl outbound",
-        ))
-        store.add_receipt(_make_receipt(
-            receipt_id="r3",
-            harness="claude",
-            policy_decision="ask",
-            timestamp=t3,
-            artifact_name="read secrets",
-        ))
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r1",
+                harness="codex",
+                policy_decision="allow",
+                timestamp=t1,
+                artifact_name="install npm",
+            )
+        )
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r2",
+                harness="codex",
+                policy_decision="block",
+                timestamp=t2,
+                artifact_name="curl outbound",
+            )
+        )
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r3",
+                harness="claude",
+                policy_decision="ask",
+                timestamp=t3,
+                artifact_name="read secrets",
+            )
+        )
 
         analytics = store.receipt_analytics(activity_days=7, trend_days=7, top_limit=5)
 
@@ -416,18 +436,22 @@ class TestReceiptAnalytics:
 
     def test_receipt_analytics_merges_artifact_names_case_insensitively(self, tmp_path: Path) -> None:
         store = _make_store(tmp_path)
-        store.add_receipt(_make_receipt(
-            receipt_id="r1",
-            harness="codex",
-            policy_decision="allow",
-            artifact_name="bash",
-        ))
-        store.add_receipt(_make_receipt(
-            receipt_id="r2",
-            harness="codex",
-            policy_decision="allow",
-            artifact_name="Bash",
-        ))
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r1",
+                harness="codex",
+                policy_decision="allow",
+                artifact_name="bash",
+            )
+        )
+        store.add_receipt(
+            _make_receipt(
+                receipt_id="r2",
+                harness="codex",
+                policy_decision="allow",
+                artifact_name="Bash",
+            )
+        )
 
         analytics = store.receipt_analytics(top_limit=5)
         bash_entries = [entry for entry in analytics["top_artifacts"] if entry["name"].lower() == "bash"]

--- a/tests/test_guard_red_team.py
+++ b/tests/test_guard_red_team.py
@@ -41,11 +41,7 @@ def _all_string_literals(source: str, fixture_name: str) -> list[str]:
         raise AssertionError(
             f"{fixture_name}: Python syntax error — cannot safely scan for real key material: {exc}"
         ) from exc
-    return [
-        node.value
-        for node in ast.walk(tree)
-        if isinstance(node, ast.Constant) and isinstance(node.value, str)
-    ]
+    return [node.value for node in ast.walk(tree) if isinstance(node, ast.Constant) and isinstance(node.value, str)]
 
 
 def _all_text_tokens(text: str) -> list[str]:
@@ -68,11 +64,7 @@ class TestRedTeamManifest:
     def test_all_disk_fixtures_covered_by_manifest(self) -> None:
         decisions = _load_decisions()
         manifest_names: set[str] = set(decisions["fixtures"].keys())
-        disk_names = {
-            p.name
-            for p in FIXTURES_DIR.iterdir()
-            if p.is_file() and p.name not in _NON_FIXTURE_NAMES
-        }
+        disk_names = {p.name for p in FIXTURES_DIR.iterdir() if p.is_file() and p.name not in _NON_FIXTURE_NAMES}
         uncovered = sorted(disk_names - manifest_names)
         assert not uncovered, (
             f"Fixture files on disk not covered by manifest: {uncovered}. "
@@ -88,11 +80,7 @@ class TestRedTeamManifest:
 class TestMaliciousFixtures:
     def _malicious_fixtures(self) -> list[tuple[str, Path]]:
         decisions = _load_decisions()
-        return [
-            (name, FIXTURES_DIR / name)
-            for name, meta in decisions["fixtures"].items()
-            if not meta["benign"]
-        ]
+        return [(name, FIXTURES_DIR / name) for name, meta in decisions["fixtures"].items() if not meta["benign"]]
 
     def test_malicious_fixtures_use_only_fake_keys(self) -> None:
         for fixture_name, fixture_path in self._malicious_fixtures():
@@ -117,9 +105,7 @@ class TestMaliciousFixtures:
         for fixture_name, fixture_path in self._malicious_fixtures():
             source = fixture_path.read_text(encoding="utf-8")
             for pattern in _REAL_ENDPOINT_PATTERNS:
-                assert pattern not in source, (
-                    f"{fixture_name}: contains real endpoint pattern '{pattern}'"
-                )
+                assert pattern not in source, f"{fixture_name}: contains real endpoint pattern '{pattern}'"
 
     def test_no_local_user_paths_in_malicious_fixtures(self) -> None:
         for fixture_name, fixture_path in self._malicious_fixtures():
@@ -142,25 +128,19 @@ class TestBenignFixtures:
     def test_benign_fixtures_do_not_target_exfil_endpoint(self) -> None:
         for fixture_name, fixture_path in self._benign_fixtures():
             source = fixture_path.read_text(encoding="utf-8")
-            assert _CANARY_COLLECT_URL not in source, (
-                f"{fixture_name}: benign fixture contains canary exfil URL"
-            )
+            assert _CANARY_COLLECT_URL not in source, f"{fixture_name}: benign fixture contains canary exfil URL"
 
     def test_benign_fixtures_do_not_use_real_key_prefixes(self) -> None:
         for fixture_name, fixture_path in self._benign_fixtures():
             source = fixture_path.read_text(encoding="utf-8")
             for prefix in _REAL_KEY_PREFIXES:
-                assert prefix not in source, (
-                    f"{fixture_name}: benign fixture contains real key prefix '{prefix}'"
-                )
+                assert prefix not in source, f"{fixture_name}: benign fixture contains real key prefix '{prefix}'"
 
     def test_no_local_user_paths_in_benign_fixtures(self) -> None:
         for fixture_name, fixture_path in self._benign_fixtures():
             source = fixture_path.read_text(encoding="utf-8")
             match = _HOME_PATH_RE.search(source)
-            assert match is None, (
-                f"{fixture_name}: contains local path '{match.group()}'"
-            )
+            assert match is None, f"{fixture_name}: contains local path '{match.group()}'"
 
 
 class TestAllFixturesNoLocalSecrets:
@@ -179,6 +159,4 @@ class TestAllFixturesNoLocalSecrets:
                 for m in env_var_pattern.finditer(source)
                 if "hol-fake" not in m.group().lower() and "placeholder" not in m.group().lower()
             ]
-            assert not real_env_matches, (
-                f"{name}: looks like real env var contents: {real_env_matches[:2]}"
-            )
+            assert not real_env_matches, f"{name}: looks like real env var contents: {real_env_matches[:2]}"

--- a/tests/test_guard_red_team_e2e.py
+++ b/tests/test_guard_red_team_e2e.py
@@ -199,18 +199,14 @@ class TestRedTeamMaliciousMCP:
         action = _shell_action(command)
         context = _make_context(tmp_path)
         detectors = _run_detectors(action, context)
-        assert "bypass.shell" in detectors, (
-            f"Expected bypass.shell for 'pip uninstall hol-guard'; got {detectors}"
-        )
+        assert "bypass.shell" in detectors, f"Expected bypass.shell for 'pip uninstall hol-guard'; got {detectors}"
 
     def test_guard_config_deletion_triggers_bypass_shell(self, tmp_path: Path) -> None:
         command = "rm -rf ~/.hol-guard"
         action = _shell_action(command)
         context = _make_context(tmp_path)
         detectors = _run_detectors(action, context)
-        assert "bypass.shell" in detectors, (
-            f"Expected bypass.shell for 'rm -rf ~/.hol-guard'; got {detectors}"
-        )
+        assert "bypass.shell" in detectors, f"Expected bypass.shell for 'rm -rf ~/.hol-guard'; got {detectors}"
 
     def test_malicious_mcp_secret_read_prompt_triggers_safe_decode(self, tmp_path: Path) -> None:
         fixture = _FIXTURES / "malicious-mcp-secret-read.md"
@@ -227,9 +223,7 @@ class TestRedTeamMaliciousMCP:
         action = _file_read_action("~/.ssh/id_rsa")
         context = _make_context(tmp_path)
         detectors = _run_detectors(action, context)
-        assert "secret.path" in detectors, (
-            f"Expected secret.path for ~/.ssh/id_rsa file read; got {detectors}"
-        )
+        assert "secret.path" in detectors, f"Expected secret.path for ~/.ssh/id_rsa file read; got {detectors}"
 
 
 class TestRedTeamEncodedExfil:
@@ -275,9 +269,7 @@ class TestFalsePositiveSourceSearch:
         context = _make_context(tmp_path)
         detectors = _run_detectors(action, context)
         blocking = [d for d in detectors if d in ("data_flow.exfiltration", "bypass.shell")]
-        assert not blocking, (
-            f"Benign source search should not trigger blocking signals; got {blocking}"
-        )
+        assert not blocking, f"Benign source search should not trigger blocking signals; got {blocking}"
 
     def test_benign_source_search_fixture_as_prompt_has_no_safe_decode_signal(self, tmp_path: Path) -> None:
         fixture = _FIXTURES / "benign-source-search.py"
@@ -303,13 +295,9 @@ class TestFalsePositiveFakeToken:
         action = _file_read_action(fixture_path)
         context = _make_context(tmp_path)
         detectors = _run_detectors(action, context)
-        assert "secret.path" not in detectors, (
-            f"Docs file read should not trigger secret.path; got {detectors}"
-        )
+        assert "secret.path" not in detectors, f"Docs file read should not trigger secret.path; got {detectors}"
         outcome = _compose(action, context)
-        assert outcome.action != "block", (
-            f"Docs file read should not be blocked; got action={outcome.action!r}"
-        )
+        assert outcome.action != "block", f"Docs file read should not be blocked; got action={outcome.action!r}"
 
     def test_benign_fake_token_fixture_prompt_not_blocked(self, tmp_path: Path) -> None:
         fixture = _FIXTURES / "benign-docs-fake-token.py"
@@ -322,21 +310,16 @@ class TestFalsePositiveFakeToken:
         assert not blocking, f"Docs with fake token text triggered blocking detectors: {blocking}"
         outcome = _compose(action, context)
         assert outcome.action != "block", (
-            f"Docs with fake token text should not be blocked; got action={outcome.action!r}, "
-            f"detectors={detectors}"
+            f"Docs with fake token text should not be blocked; got action={outcome.action!r}, detectors={detectors}"
         )
 
     def test_benign_nvmrc_fake_creds_file_read_has_no_secret_path_signal(self, tmp_path: Path) -> None:
         action = _file_read_action("~/.nvmrc")
         context = _make_context(tmp_path)
         detectors = _run_detectors(action, context)
-        assert "secret.path" not in detectors, (
-            f"Benign nvmrc file read should not trigger secret.path; got {detectors}"
-        )
+        assert "secret.path" not in detectors, f"Benign nvmrc file read should not trigger secret.path; got {detectors}"
         outcome = _compose(action, context)
-        assert outcome.action != "block", (
-            f"nvmrc file read should not be blocked; got action={outcome.action!r}"
-        )
+        assert outcome.action != "block", f"nvmrc file read should not be blocked; got action={outcome.action!r}"
 
     def test_benign_nvmrc_fixture_prompt_has_no_blocking_signals(self, tmp_path: Path) -> None:
         fixture = _FIXTURES / "benign-nvmrc-fake-creds.py"
@@ -378,6 +361,4 @@ class TestFalsePositiveHealthEndpoint:
         context = _make_context(tmp_path)
         detectors = _run_detectors(action, context)
         blocking = [d for d in detectors if d in ("data_flow.exfiltration", "bypass.shell")]
-        assert not blocking, (
-            f"Loopback health check should not trigger blocking signals; got {blocking}"
-        )
+        assert not blocking, f"Loopback health check should not trigger blocking signals; got {blocking}"

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -56,6 +56,37 @@ from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 @pytest.fixture(autouse=True)
 def _isolate_codex_runtime_marker(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("CODEX_MANAGED_BY_BUN", raising=False)
@@ -3422,11 +3453,7 @@ clearer UX and an implementation plan with technical references.
         tmp_path,
     ) -> None:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "guard-token",
-            "2026-04-16T00:00:00.000Z",
-        )
+        _seed_guard_cloud(store)
 
         def _raise_not_found(*args, **kwargs):
             raise urllib.error.HTTPError(
@@ -14414,9 +14441,7 @@ def test_guard_runtime_rejects_saved_allows_for_different_risky_tool_action(
         is None
     )
     assert (
-        guard_commands_module._runtime_artifact_policy_action(
-            config, later_artifact, "opencode"
-        )
+        guard_commands_module._runtime_artifact_policy_action(config, later_artifact, "opencode")
         == "require-reapproval"
     )
 
@@ -16357,11 +16382,7 @@ def test_guard_daemon_serves_health_and_receipt_state(tmp_path):
 
 def test_sync_receipts_retries_once_after_timeout(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     timeouts: list[int] = []
 
     class _Response:
@@ -16390,11 +16411,7 @@ def test_sync_receipts_retries_once_after_timeout(tmp_path, monkeypatch):
 
 def test_sync_receipts_rejects_untrusted_sync_host_before_network(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     credentials_payload = store.get_sync_payload("credentials")
     assert isinstance(credentials_payload, dict)
     credentials_payload["sync_url"] = "https://evil.example/api/guard/receipts/sync"
@@ -16416,11 +16433,7 @@ def test_sync_receipts_rejects_untrusted_sync_host_before_network(tmp_path, monk
 
 def test_sync_receipts_batches_large_local_history(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     for index in range(65):
         store.add_receipt(
             GuardReceipt(
@@ -16480,11 +16493,7 @@ def test_sync_receipts_batches_large_local_history(tmp_path, monkeypatch):
 
 def test_sync_receipts_uses_rowid_cursor_and_sync_context(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     for index in range(3):
         store.add_receipt(
             GuardReceipt(
@@ -16574,11 +16583,7 @@ def test_sync_receipts_uses_rowid_cursor_and_sync_context(tmp_path, monkeypatch)
 
 def test_sync_receipts_backfills_when_cursor_is_ahead_of_local_rows(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     for index in range(2):
         store.add_receipt(
             GuardReceipt(
@@ -16646,11 +16651,7 @@ def test_sync_receipts_backfills_when_cursor_is_ahead_of_local_rows(tmp_path, mo
 
 def test_sync_receipts_marks_latest_connect_first_sync_succeeded(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "migration-compat-token",
-        "2026-05-23T19:20:00+00:00",
-    )
+    _seed_guard_cloud(store)
     request_id = "connect-imported-state"
     with store._connect() as connection:
         connection.execute(
@@ -16780,11 +16781,7 @@ def test_sync_receipts_marks_latest_connect_first_sync_succeeded(tmp_path, monke
 
 def test_sync_receipts_preserves_batch_metadata_and_reuses_device_metadata(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     for index in range(65):
         store.add_receipt(
             GuardReceipt(
@@ -17141,11 +17138,7 @@ def test_policy_bundle_validation_rejects_missing_rules_field():
 
 def test_sync_receipts_preserves_last_known_good_policy_bundle_on_invalid_update(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
 
     valid_bundle = {
         "contractVersion": "guard-policy-bundle.v1",
@@ -17529,11 +17522,7 @@ def test_policy_bundle_downgrade_check_ignores_mixed_timezone_formats():
 
 def test_sync_receipts_uploads_policy_bundle_acknowledgement(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-06-05T13:30:00+00:00",
-    )
+    _seed_guard_cloud(store)
     requests: list[dict[str, object]] = []
     bundle = {
         "contractVersion": "guard-policy-bundle.v1",
@@ -17660,10 +17649,10 @@ def test_sync_receipts_uploads_policy_bundle_acknowledgement_to_sync_route(tmp_p
     thread = threading.Thread(target=server.serve_forever, daemon=True)
     thread.start()
     try:
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "guard-live-token",
-            "2026-06-05T13:30:00+00:00",
+        _seed_guard_cloud(
+            store,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="guard-live-token",
         )
         monkeypatch.setattr(guard_runner_module, "sync_pain_signals", lambda _store, auth_context=None: 0)
 
@@ -17685,12 +17674,7 @@ def test_sync_receipts_uploads_policy_bundle_acknowledgement_to_sync_route(tmp_p
 
 def test_sync_receipts_rejects_policy_bundle_for_the_wrong_workspace(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-06-05T13:30:00+00:00",
-        workspace_id="workspace-a",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-a")
     bundle = {
         "contractVersion": "guard-policy-bundle.v1",
         "bundleVersion": "policy-2026-06-05.5",
@@ -17829,11 +17813,7 @@ def test_policy_bundle_decision_resolves_before_receipt_persistence(tmp_path, mo
 def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     dpop_key_material = generate_dpop_key_pair()
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     timeouts: list[int] = []
 
     class _Response:
@@ -17889,11 +17869,7 @@ def test_sync_runtime_session_retries_once_after_timeout(tmp_path, monkeypatch):
 def test_sync_runtime_session_retries_once_after_read_timeout(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     dpop_key_material = generate_dpop_key_pair()
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "guard-live-token",
-        "2026-04-19T00:00:00+00:00",
-    )
+    _seed_guard_cloud(store)
     timeouts: list[int] = []
 
     class _Response:
@@ -18001,12 +17977,7 @@ def test_sync_runtime_session_rejects_untrusted_oauth_issuer_before_network(tmp_
 
 def test_sync_runtime_session_rejects_non_https_legacy_sync_url_before_network(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "legacy-runtime-token",
-        "2026-06-01T00:00:00+00:00",
-        workspace_id="workspace-1",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-1")
     credentials_payload = store.get_sync_payload("credentials")
     assert isinstance(credentials_payload, dict)
     credentials_payload["sync_url"] = "http://hol.org/api/guard/receipts/sync"
@@ -18044,12 +18015,7 @@ def test_sync_runtime_session_rejects_non_https_legacy_sync_url_before_network(t
 
 def test_sync_runtime_session_rejects_unallowlisted_legacy_sync_url_before_network(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "legacy-runtime-token",
-        "2026-06-01T00:00:00+00:00",
-        workspace_id="workspace-1",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-1")
     credentials_payload = store.get_sync_payload("credentials")
     assert isinstance(credentials_payload, dict)
     credentials_payload["sync_url"] = "https://evil.example/api/guard/receipts/sync"

--- a/tests/test_guard_shell_command_wrappers.py
+++ b/tests/test_guard_shell_command_wrappers.py
@@ -13,9 +13,7 @@ from codex_plugin_scanner.guard.runtime.shell_command_wrappers import (
 
 
 def test_normalize_transparent_shell_command_unwraps_lean_ctx_chain() -> None:
-    wrapped = (
-        "env FOO=bar ./bin/lean-ctx -c 'rg -n \"service_principal|reauthorization\" src app __tests__ docs'"
-    )
+    wrapped = "env FOO=bar ./bin/lean-ctx -c 'rg -n \"service_principal|reauthorization\" src app __tests__ docs'"
 
     normalized = normalize_transparent_shell_command(wrapped)
 
@@ -36,7 +34,7 @@ def test_normalize_transparent_shell_command_unwraps_shell_c_wrapper() -> None:
 
 
 def test_normalize_transparent_shell_command_tolerates_malformed_inner_quotes() -> None:
-    wrapped = "FOO=bar ./bin/lean-ctx -c \"rg 'unclosed src\""
+    wrapped = 'FOO=bar ./bin/lean-ctx -c "rg \'unclosed src"'
 
     normalized = normalize_transparent_shell_command(wrapped)
 
@@ -60,9 +58,7 @@ def test_normalize_opencode_payload_uses_inner_command_for_shell_wrappers(tmp_pa
         "hook_event_name": "PreToolUse",
         "tool_name": "bash",
         "tool_input": {
-            "command": (
-                "./bin/lean-ctx -c 'rg -n \"service_principal|reauthorization\" src app __tests__ docs'"
-            )
+            "command": ("./bin/lean-ctx -c 'rg -n \"service_principal|reauthorization\" src app __tests__ docs'")
         },
     }
 
@@ -82,12 +78,7 @@ def test_wrapped_read_only_shell_command_stays_unblocked() -> None:
 
     request = extract_sensitive_tool_action_request(
         "bash",
-        {
-            "command": (
-                "./bin/lean-ctx -c "
-                "'rg -n \"service_principal|reauthorization\" src app __tests__ docs'"
-            )
-        },
+        {"command": ("./bin/lean-ctx -c 'rg -n \"service_principal|reauthorization\" src app __tests__ docs'")},
         **context_kwargs,
     )
 

--- a/tests/test_guard_shim_intercept_proofs.py
+++ b/tests/test_guard_shim_intercept_proofs.py
@@ -23,6 +23,37 @@ from tests.shim_execution_helpers import (
 from tests.test_guard_headless_daemon_api import _dashboard_token_for, _read_json_response, _request
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _harness_context(tmp_path: Path, *, workspace_dir: Path | None = None) -> HarnessContext:
     home_dir = tmp_path / "home"
     home_dir.mkdir(parents=True, exist_ok=True)
@@ -191,12 +222,7 @@ def test_daemon_package_shim_test_reports_path_inactive_without_evaluator(
     monkeypatch.setenv("HOME", str(home_dir))
     monkeypatch.setenv("SHELL", "/bin/zsh")
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "cloud-token",
-        "2026-05-27T16:00:00.000Z",
-        workspace_id="workspace-1",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-1")
     store.set_sync_payload(
         "supply_chain_bundle_entitlement",
         {"tier": "premium", "workspace_id": "workspace-1"},

--- a/tests/test_guard_source_view_secret_fixtures.py
+++ b/tests/test_guard_source_view_secret_fixtures.py
@@ -15,11 +15,7 @@ def test_codex_source_view_allows_placeholder_private_key_fixture_output(tmp_pat
     source_file = workspace_dir / "tests" / "test_connect_fixture.py"
     _write_text(
         source_file,
-        (
-            'dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\n'
-            "secret-key-material\n"
-            '-----END PRIVATE KEY-----\n"\n'
-        ),
+        ('dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n"\n'),
     )
 
     command = "sed -n '1,20p' tests/test_connect_fixture.py"

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import json
 import logging
 import os
@@ -14,15 +13,12 @@ import types
 import pytest
 
 from codex_plugin_scanner.guard import store as guard_store_module
-from codex_plugin_scanner.guard.models import GuardReceipt
 from codex_plugin_scanner.guard.store import (
     EncryptedFileSecretStore,
     FallbackSecretStore,
     GuardStore,
-    KeychainSecretStore,
     SystemKeyringSecretStore,
     _build_oauth_secret_store,
-    _build_secret_store,
 )
 from codex_plugin_scanner.guard.store_evidence import EvidenceRecord
 
@@ -92,45 +88,23 @@ def test_system_keyring_timeout_uses_noninteractive_macos_lookup(monkeypatch: py
     assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "secret-value"
 
 
-def test_system_keyring_timeout_fails_closed_on_macos_without_native_reads(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
-    monkeypatch.setattr(
-        SystemKeyringSecretStore,
-        "_supports_native_macos_security_reads",
-        classmethod(lambda cls: False),
-    )
-    monkeypatch.setattr(
-        secret_store,
-        "get_secret",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(
-            AssertionError("macOS timed reads should not fall back to interactive get_secret")
-        ),
-    )
-
-    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) is None
-
-
-def test_policy_integrity_store_is_disabled_on_macos_before_keyring_load(
+def test_policy_integrity_store_skips_macos_health_probe_when_backend_exists(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    monkeypatch.setattr(
-        SystemKeyringSecretStore,
-        "_load_keyring_module",
-        staticmethod(lambda: (_ for _ in ()).throw(AssertionError("macOS policy integrity must not load keyring"))),
-    )
+    module = _FakeSystemKeyringModule()
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
     monkeypatch.setattr(
         SystemKeyringSecretStore,
         "_macos_default_keychain_is_usable",
         classmethod(
-            lambda cls: (_ for _ in ()).throw(AssertionError("macOS policy integrity must not probe keychain"))
+            lambda cls: (_ for _ in ()).throw(AssertionError("policy integrity builder should skip health probe"))
         ),
     )
 
     secret_store = guard_store_module._build_policy_integrity_secret_store()
 
-    assert secret_store is None
+    assert isinstance(secret_store, SystemKeyringSecretStore)
 
 
 @pytest.fixture(autouse=True)
@@ -399,103 +373,6 @@ def test_windows_oauth_refresh_lock_wraps_permission_error_as_blocking(monkeypat
         guard_store_module._acquire_advisory_file_lock(_FakeHandle())
 
 
-def test_sync_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):
-    store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "secret-token-value",
-        "2026-04-19T00:00:00+00:00",
-    )
-
-    with sqlite3.connect(store.path) as connection:
-        row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
-
-    assert row is not None
-    payload = json.loads(str(row[0]))
-    assert payload["sync_url"] == "https://hol.org/api/guard/receipts/sync"
-    assert isinstance(payload.get("token_ref"), str)
-    assert str(payload["token_ref"]).startswith("guard-cloud-token:")
-    assert isinstance(payload.get("token_sha256"), str)
-    assert "token" not in payload
-    assert store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "secret-token-value",
-    }
-
-
-def test_legacy_plaintext_sync_payload_is_rejected_on_read(tmp_path):
-    store = GuardStore(tmp_path / "guard-home")
-    with sqlite3.connect(store.path) as connection:
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('credentials', ?, ?)
-            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
-            """,
-            (
-                json.dumps(
-                    {
-                        "sync_url": "https://hol.org/api/guard/receipts/sync",
-                        "token": "legacy-token",
-                    }
-                ),
-                "2026-04-19T00:00:00+00:00",
-            ),
-        )
-
-    credentials = store.get_sync_credentials()
-    assert credentials is None
-
-    with sqlite3.connect(store.path) as connection:
-        row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
-
-    payload = json.loads(str(row[0])) if row is not None else {}
-    assert payload == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "legacy-token",
-    }
-    assert "token_ref" not in payload
-    assert "token_sha256" not in payload
-
-
-def test_sync_credentials_are_scoped_per_guard_home(tmp_path):
-    home_a = tmp_path / "guard-home-a"
-    home_b = tmp_path / "guard-home-b"
-    store_a = GuardStore(home_a)
-    store_b = GuardStore(home_b)
-
-    store_a.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-a",
-        "2026-04-19T00:00:00+00:00",
-    )
-    store_b.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-b",
-        "2026-04-19T00:00:05+00:00",
-    )
-
-    assert store_a.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "token-a",
-    }
-    assert store_b.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "token-b",
-    }
-
-
-def test_set_sync_credentials_rejects_unallowlisted_sync_host(tmp_path):
-    store = GuardStore(tmp_path / "guard-home")
-
-    with pytest.raises(ValueError, match="allowlisted HOL origin"):
-        store.set_sync_credentials(
-            "https://evil.example/api/guard/receipts/sync",
-            "secret-token-value",
-            "2026-04-19T00:00:00+00:00",
-        )
-
-
 def test_set_oauth_local_credentials_rejects_unallowlisted_issuer(tmp_path):
     store = GuardStore(tmp_path / "guard-home")
 
@@ -509,61 +386,6 @@ def test_set_oauth_local_credentials_rejects_unallowlisted_issuer(tmp_path):
             dpop_public_jwk_thumbprint="thumbprint",
             now="2026-04-19T00:00:00+00:00",
         )
-
-
-def test_legacy_token_reference_is_rejected_on_read(tmp_path):
-    store = GuardStore(tmp_path / "guard-home")
-    legacy_token = "legacy-token-ref"
-    legacy_ref = "guard-cloud-token"
-    store._secret_store.set_secret(legacy_ref, legacy_token)
-    with sqlite3.connect(store.path) as connection:
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('credentials', ?, ?)
-            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
-            """,
-            (
-                json.dumps(
-                    {
-                        "sync_url": "https://hol.org/api/guard/receipts/sync",
-                        "token_ref": legacy_ref,
-                        "token_sha256": hashlib.sha256(legacy_token.encode("utf-8")).hexdigest(),
-                    }
-                ),
-                "2026-04-19T00:00:00+00:00",
-            ),
-        )
-
-    credentials = store.get_sync_credentials()
-    assert credentials is None
-    assert store._secret_store.get_secret(store._sync_token_ref) is None
-
-    with sqlite3.connect(store.path) as connection:
-        row = connection.execute("select payload_json from sync_state where state_key = 'credentials'").fetchone()
-    payload = json.loads(str(row[0])) if row is not None else {}
-    assert payload["token_ref"] == legacy_ref
-
-
-def test_sync_token_rotation_with_same_url_clears_cloud_sync_payloads(tmp_path):
-    store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "first-token",
-        "2026-04-19T00:00:00+00:00",
-    )
-    store.set_sync_payload("policy", {"mode": "enforce"}, "2026-04-19T00:01:00+00:00")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "rotated-token",
-        "2026-04-19T00:02:00+00:00",
-    )
-
-    assert store.get_sync_payload("policy") is None
-    assert store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "rotated-token",
-    }
 
 
 def test_fallback_secret_store_uses_secondary_backend_when_primary_fails():
@@ -638,81 +460,6 @@ def test_fallback_secret_store_logs_delete_failures(caplog):
     assert "guard-token" not in caplog.text
 
 
-def _install_fake_sync_keychain(monkeypatch) -> dict[tuple[str, str], str]:
-    secrets: dict[tuple[str, str], str] = {}
-
-    monkeypatch.setattr(
-        KeychainSecretStore,
-        "set_secret",
-        lambda self, secret_id, value: secrets.__setitem__((self.service_name, secret_id), value),
-    )
-    monkeypatch.setattr(
-        KeychainSecretStore,
-        "get_secret",
-        lambda self, secret_id: secrets.get((self.service_name, secret_id)),
-    )
-    monkeypatch.setattr(
-        KeychainSecretStore,
-        "delete_secret",
-        lambda self, secret_id: secrets.pop((self.service_name, secret_id), None),
-    )
-    return secrets
-
-
-def test_keychain_secret_store_rejects_cli_secret_writes(monkeypatch):
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-
-    def fake_run(
-        args: list[str],
-        *,
-        check: bool,
-        capture_output: bool,
-        text: bool,
-        **kwargs: object,
-    ) -> subprocess.CompletedProcess[str]:
-        raise AssertionError("keychain writes must not shell out with secret material")
-
-    monkeypatch.setattr(subprocess, "run", fake_run)
-
-    with pytest.raises(RuntimeError, match="argv exposure"):
-        KeychainSecretStore("hol-guard.sync").set_secret("guard-token", "secret-value")
-
-
-def test_secret_store_prefers_encrypted_file_backend_when_keychain_is_available_outside_macos(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
-
-    secret_store = _build_secret_store(guard_home)
-
-    assert isinstance(secret_store, FallbackSecretStore)
-    assert isinstance(secret_store.primary, EncryptedFileSecretStore)
-    assert isinstance(secret_store.fallback, KeychainSecretStore)
-
-
-def test_secret_store_prefers_keychain_backend_when_keychain_is_available_on_macos(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-
-    secret_store = _build_secret_store(guard_home)
-
-    assert isinstance(secret_store, FallbackSecretStore)
-    assert isinstance(secret_store.primary, KeychainSecretStore)
-    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
-
-
-def test_oauth_secret_store_prefers_system_keyring_backend_when_available(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    _install_fake_system_keyring(monkeypatch)
-
-    secret_store = _build_oauth_secret_store(guard_home)
-
-    assert isinstance(secret_store, FallbackSecretStore)
-    assert isinstance(secret_store.primary, SystemKeyringSecretStore)
-    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
-
-
 def test_encrypted_file_secret_store_secures_secret_directory_permissions(tmp_path):
     secret_store = EncryptedFileSecretStore(tmp_path / "guard-home")
 
@@ -738,82 +485,6 @@ def test_encrypted_file_secret_store_writes_key_and_payload_atomically(tmp_path,
 
     assert any(dst.endswith("key.bin") for _, dst in recorded_replacements)
     assert any(dst.endswith("guard-token.enc") for _, dst in recorded_replacements)
-
-
-def test_sync_credentials_do_not_shell_out_to_keychain_when_file_store_is_available(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-
-    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise AssertionError("keychain should not be used for sync credential writes")
-
-    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
-    GuardStore(guard_home)
-
-
-def test_sync_credentials_fall_back_when_keychain_cli_rejects_writes_on_macos(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    store = GuardStore(guard_home)
-
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "access-secret-value",
-        "2026-06-01T00:00:00+00:00",
-        workspace_id="workspace-123",
-    )
-
-    assert store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "access-secret-value",
-    }
-
-
-def test_get_sync_credentials_keeps_legacy_file_secret_when_keychain_cli_rejects_writes_on_macos(
-    tmp_path,
-    monkeypatch,
-):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
-    legacy_store = GuardStore(guard_home)
-    legacy_store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "legacy-access-secret",
-        "2026-06-01T00:00:00+00:00",
-        workspace_id="workspace-123",
-    )
-
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    migrated_store = GuardStore(guard_home)
-
-    assert migrated_store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "legacy-access-secret",
-    }
-
-
-def test_oauth_local_credentials_do_not_shell_out_to_keychain_when_system_keyring_is_available(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    _install_fake_system_keyring(monkeypatch)
-
-    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise AssertionError("keychain should not be used for OAuth credential writes")
-
-    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
-    store = GuardStore(guard_home)
-    store.set_oauth_local_credentials(
-        issuer="https://hol.org",
-        client_id="guard-local-daemon",
-        refresh_token="refresh-secret-value",
-        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
-        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
-        dpop_public_jwk_thumbprint="thumbprint-123",
-        now="2026-06-01T00:00:00+00:00",
-    )
-
-    assert store.get_oauth_local_credentials() is not None
 
 
 def test_guard_store_secures_guard_home_and_database_permissions(tmp_path):
@@ -849,46 +520,6 @@ def test_guard_store_repairs_existing_guard_home_and_database_permissions(tmp_pa
         sidecar = guard_home / name
         if sidecar.exists():
             assert sidecar.stat().st_mode & 0o777 == 0o600
-
-
-def test_sync_credential_health_reports_backend_and_workspace(tmp_path, monkeypatch):
-    store = GuardStore(tmp_path / "guard-home")
-
-    assert store.get_sync_credential_health() == {
-        "configured": False,
-        "state": "not_configured",
-        "backend": "encrypted-file",
-        "fallback_backend": None,
-    }
-
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
-    sync_keychain = _install_fake_sync_keychain(monkeypatch)
-    keychain_store = GuardStore(tmp_path / "guard-home-keychain")
-    keychain_store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "access-secret-value",
-        "2026-06-01T00:00:00+00:00",
-        workspace_id="workspace-123",
-    )
-
-    assert sync_keychain[("hol-guard.sync", keychain_store._sync_token_ref)] == "access-secret-value"
-    assert keychain_store.get_sync_credential_health() == {
-        "configured": True,
-        "state": "healthy",
-        "backend": "keychain",
-        "fallback_backend": "encrypted-file",
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "workspace_id": "workspace-123",
-    }
-
-    sync_keychain[("hol-guard.sync", keychain_store._sync_token_ref)] = "tampered-secret"
-    assert keychain_store.get_sync_credential_health() == {
-        "configured": True,
-        "state": "degraded",
-        "backend": "keychain",
-        "fallback_backend": "encrypted-file",
-    }
 
 
 def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path):
@@ -953,61 +584,6 @@ def test_oauth_local_credentials_are_not_persisted_in_plaintext_sqlite(tmp_path)
     assert store.get_cloud_workspace_id() == "workspace-123"
 
 
-def test_clear_oauth_local_credentials_preserves_local_receipt_history(tmp_path, monkeypatch):
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: False))
-
-    guard_home = tmp_path / "guard-home"
-    store = GuardStore(guard_home)
-    store.set_oauth_local_credentials(
-        issuer="https://hol.org",
-        client_id="guard-local-daemon",
-        refresh_token="refresh-secret-value",
-        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
-        dpop_public_jwk={
-            "kty": "EC",
-            "crv": "P-256",
-            "x": "x-value",
-            "y": "y-value",
-            "alg": "ES256",
-            "use": "sig",
-        },
-        dpop_public_jwk_thumbprint="thumbprint-123",
-        grant_id="grant-123",
-        machine_id="machine-123",
-        workspace_id="workspace-123",
-        runtime_id="hol-guard",
-        runtime_label="HOL Guard CLI",
-        now="2026-06-01T00:00:00+00:00",
-    )
-    store.add_receipt(
-        GuardReceipt(
-            receipt_id="receipt-1",
-            timestamp="2026-06-01T00:05:00+00:00",
-            harness="codex",
-            artifact_id="artifact-1",
-            artifact_hash="sha256:artifact",
-            policy_decision="allow",
-            capabilities_summary="safe",
-            changed_capabilities=("stdio",),
-            provenance_summary="known-good",
-        )
-    )
-
-    store.clear_oauth_local_credentials()
-
-    assert store.get_oauth_local_credentials() is None
-    assert store.count_receipts() == 1
-    assert store.get_receipt("receipt-1") is not None
-
-    with sqlite3.connect(store.path) as connection:
-        row = connection.execute(
-            "select payload_json from sync_state where state_key = 'oauth_local_credentials'"
-        ).fetchone()
-
-    assert row is None
-    assert list((guard_home / "secrets").glob("guard-oauth-*.enc")) == []
-
-
 def test_oauth_local_credentials_use_encrypted_file_fallback_when_system_keyring_write_fails(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     fake_keyring = _install_fake_system_keyring(monkeypatch)
@@ -1065,12 +641,6 @@ def test_oauth_local_credential_health_reports_backend_and_metadata(tmp_path, mo
         "machine_id": "machine-123",
         "workspace_id": "workspace-123",
     }
-
-    monkeypatch.setattr(
-        store,
-        "_promote_secret_to_primary",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("health check must not promote secrets")),
-    )
     assert store.get_oauth_local_credential_health()["state"] == "healthy"
 
 
@@ -1380,36 +950,6 @@ def test_get_recoverable_oauth_local_credentials_uses_encrypted_fallback_when_ha
     assert recoverable["workspace_id"] == "workspace-123"
 
 
-def test_set_oauth_local_credentials_does_not_use_generic_secret_promotion(tmp_path, monkeypatch):
-    _install_fake_system_keyring(monkeypatch)
-    guard_home = tmp_path / "guard-home"
-    store = GuardStore(guard_home)
-
-    monkeypatch.setattr(
-        store,
-        "_promote_secret_to_primary",
-        lambda *args, **kwargs: (_ for _ in ()).throw(AssertionError("OAuth writes must not use generic promotion")),
-    )
-
-    store.set_oauth_local_credentials(
-        issuer="https://hol.org",
-        client_id="guard-local-daemon",
-        refresh_token="refresh-secret-value",
-        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
-        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
-        dpop_public_jwk_thumbprint="thumbprint-123",
-        grant_id="grant-123",
-        machine_id="machine-123",
-        workspace_id="workspace-123",
-        now="2026-06-01T00:00:00+00:00",
-    )
-
-    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: None))
-    headless_store = GuardStore(guard_home)
-
-    assert headless_store.get_oauth_local_credentials() is not None
-
-
 def test_set_oauth_local_credentials_rejects_incomplete_fallback_mirror(tmp_path, monkeypatch, caplog):
     _install_fake_system_keyring(monkeypatch)
     guard_home = tmp_path / "guard-home"
@@ -1474,262 +1014,6 @@ def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_key
     headless_store = GuardStore(guard_home)
 
     assert headless_store.get_oauth_local_credentials(allow_primary=False) is not None
-
-
-def test_oauth_local_credentials_preserve_previous_material_on_partial_secret_write_failure(tmp_path, monkeypatch):
-    store = GuardStore(tmp_path / "guard-home")
-    store.set_oauth_local_credentials(
-        issuer="https://hol.org",
-        client_id="guard-local-daemon",
-        refresh_token="old-refresh-token",
-        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nold-key-material\n-----END PRIVATE KEY-----\n",
-        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "old-x", "y": "old-y"},
-        dpop_public_jwk_thumbprint="old-thumbprint",
-        grant_id="grant-old",
-        machine_id="machine-old",
-        workspace_id="workspace-old",
-        now="2026-06-01T00:00:00+00:00",
-    )
-    original_set_secret = store._oauth_secret_store.set_secret
-    write_calls: list[str] = []
-
-    def fail_on_first_write(secret_id: str, value: str) -> None:
-        write_calls.append(secret_id)
-        if len(write_calls) == 1:
-            raise RuntimeError("secret write failed")
-        original_set_secret(secret_id, value)
-
-    monkeypatch.setattr(store._oauth_secret_store, "set_secret", fail_on_first_write)
-
-    try:
-        store.set_oauth_local_credentials(
-            issuer="https://hol.org",
-            client_id="guard-local-daemon",
-            refresh_token="new-refresh-token",
-            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nnew-key-material\n-----END PRIVATE KEY-----\n",
-            dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "new-x", "y": "new-y"},
-            dpop_public_jwk_thumbprint="new-thumbprint",
-            grant_id="grant-new",
-            machine_id="machine-new",
-            workspace_id="workspace-new",
-            now="2026-06-01T00:05:00+00:00",
-        )
-    except RuntimeError as error:
-        assert str(error) == "secret write failed"
-    else:
-        raise AssertionError("OAuth secret write should fail in this regression test")
-
-    assert store.get_oauth_local_credentials() == {
-        "issuer": "https://hol.org",
-        "client_id": "guard-local-daemon",
-        "refresh_token": "old-refresh-token",
-        "dpop_private_key_pem": "-----BEGIN PRIVATE KEY-----\nold-key-material\n-----END PRIVATE KEY-----\n",
-        "dpop_public_jwk": {"kty": "EC", "crv": "P-256", "x": "old-x", "y": "old-y"},
-        "dpop_public_jwk_thumbprint": "old-thumbprint",
-        "grant_id": "grant-old",
-        "machine_id": "machine-old",
-        "workspace_id": "workspace-old",
-    }
-
-
-def test_validated_keychain_fallback_reads_are_migrated_into_encrypted_file_store(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-
-    keychain_reads = 0
-
-    def keychain_lookup(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        nonlocal keychain_reads
-        keychain_reads += 1
-        return subprocess.CompletedProcess(
-            args=["/usr/bin/security"],
-            returncode=0,
-            stdout="legacy-token\n",
-            stderr="",
-        )
-
-    monkeypatch.setattr(subprocess, "run", keychain_lookup)
-    store = GuardStore(guard_home)
-
-    with sqlite3.connect(store.path) as connection:
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('credentials', ?, ?)
-            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
-            """,
-            (
-                json.dumps(
-                    {
-                        "sync_url": "https://hol.org/api/guard/receipts/sync",
-                        "token_ref": store._sync_token_ref,
-                        "token_sha256": hashlib.sha256(b"legacy-token").hexdigest(),
-                    }
-                ),
-                "2026-04-19T00:00:00+00:00",
-            ),
-        )
-
-    assert store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "legacy-token",
-    }
-    assert keychain_reads == 1
-    assert any((guard_home / "secrets").glob("*.enc"))
-
-    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise AssertionError("fallback keychain should not be used after migration")
-
-    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
-
-    assert store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "legacy-token",
-    }
-
-
-def test_invalid_keychain_fallback_token_is_not_migrated_into_encrypted_file_store(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-
-    keychain_reads = 0
-
-    def keychain_lookup(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        nonlocal keychain_reads
-        keychain_reads += 1
-        return subprocess.CompletedProcess(
-            args=["/usr/bin/security"],
-            returncode=0,
-            stdout="stale-token\n",
-            stderr="",
-        )
-
-    monkeypatch.setattr(subprocess, "run", keychain_lookup)
-    store = GuardStore(guard_home)
-
-    with sqlite3.connect(store.path) as connection:
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('credentials', ?, ?)
-            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
-            """,
-            (
-                json.dumps(
-                    {
-                        "sync_url": "https://hol.org/api/guard/receipts/sync",
-                        "token_ref": store._sync_token_ref,
-                        "token_sha256": hashlib.sha256(b"fresh-token").hexdigest(),
-                    }
-                ),
-                "2026-04-19T00:00:00+00:00",
-            ),
-        )
-
-    assert store.get_sync_credentials() is None
-    assert keychain_reads == 1
-    assert list((guard_home / "secrets").glob("*.enc")) == []
-
-    assert store.get_sync_credentials() is None
-    assert keychain_reads == 2
-    assert list((guard_home / "secrets").glob("*.enc")) == []
-
-
-def test_stale_file_token_does_not_block_valid_keychain_token_migration(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-
-    keychain_reads = 0
-
-    def keychain_lookup(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        nonlocal keychain_reads
-        keychain_reads += 1
-        return subprocess.CompletedProcess(
-            args=["/usr/bin/security"],
-            returncode=0,
-            stdout="fresh-token\n",
-            stderr="",
-        )
-
-    monkeypatch.setattr(subprocess, "run", keychain_lookup)
-    store = GuardStore(guard_home)
-    store._secret_store.set_secret(store._sync_token_ref, "stale-token")
-
-    with sqlite3.connect(store.path) as connection:
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('credentials', ?, ?)
-            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
-            """,
-            (
-                json.dumps(
-                    {
-                        "sync_url": "https://hol.org/api/guard/receipts/sync",
-                        "token_ref": store._sync_token_ref,
-                        "token_sha256": hashlib.sha256(b"fresh-token").hexdigest(),
-                    }
-                ),
-                "2026-04-19T00:00:00+00:00",
-            ),
-        )
-
-    assert store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "fresh-token",
-    }
-    assert keychain_reads == 1
-    assert store._secret_store.get_secret(store._sync_token_ref) == "fresh-token"
-
-
-def test_valid_file_token_does_not_query_keychain_fallback(tmp_path, monkeypatch):
-    guard_home = tmp_path / "guard-home"
-    monkeypatch.setattr(KeychainSecretStore, "_is_available", staticmethod(lambda: True))
-
-    def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
-        raise AssertionError("keychain fallback should not run when file secret is valid")
-
-    monkeypatch.setattr(subprocess, "run", fail_on_keychain)
-    store = GuardStore(guard_home)
-    store._secret_store.set_secret(store._sync_token_ref, "fresh-token")
-
-    with sqlite3.connect(store.path) as connection:
-        connection.execute(
-            """
-            insert into sync_state (state_key, payload_json, updated_at)
-            values ('credentials', ?, ?)
-            on conflict(state_key) do update set payload_json = excluded.payload_json, updated_at = excluded.updated_at
-            """,
-            (
-                json.dumps(
-                    {
-                        "sync_url": "https://hol.org/api/guard/receipts/sync",
-                        "token_ref": store._sync_token_ref,
-                        "token_sha256": hashlib.sha256(b"fresh-token").hexdigest(),
-                    }
-                ),
-                "2026-04-19T00:00:00+00:00",
-            ),
-        )
-
-    assert store.get_sync_credentials() == {
-        "sync_url": "https://hol.org/api/guard/receipts/sync",
-        "token": "fresh-token",
-    }
-
-
-def test_device_identity_and_label_management_are_persistent(tmp_path):
-    store = GuardStore(tmp_path / "guard-home")
-    original = store.get_device_metadata()
-    assert original["installation_id"]
-    assert original["device_label"]
-
-    renamed = store.set_device_label("VPS - Guard Runtime", "2026-04-19T01:00:00+00:00")
-    assert renamed["device_label"] == "VPS - Guard Runtime"
-
-    rotated = store.rotate_installation_id("2026-04-19T02:00:00+00:00")
-    assert rotated["device_label"] == "VPS - Guard Runtime"
-    assert rotated["installation_id"] != original["installation_id"]
 
 
 def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_path, monkeypatch):

--- a/tests/test_guard_supply_chain_bundle.py
+++ b/tests/test_guard_supply_chain_bundle.py
@@ -381,9 +381,7 @@ def test_supply_chain_bundle_verifies_portal_signed_payload_with_emergency_denyl
             "recommendedFixVersion": "1.2.9",
         }
     ]
-    response = load_supply_chain_bundle_response(
-        json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key))
-    )
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
 
     verify_supply_chain_bundle_response(response, now=response.bundle.generated_at_timestamp + 5)
     assert len(response.bundle.emergency_denylist) == 1
@@ -410,9 +408,7 @@ def test_supply_chain_bundle_offline_evaluation_enforces_emergency_deny_without_
             "recommendedFixVersion": "1.2.9",
         }
     ]
-    response = load_supply_chain_bundle_response(
-        json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key))
-    )
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
 
     decision = evaluate_cached_supply_chain_bundle(
         response,
@@ -450,9 +446,7 @@ def test_supply_chain_bundle_offline_evaluation_enforces_emergency_deny_when_bun
             "recommendedFixVersion": None,
         }
     ]
-    response = load_supply_chain_bundle_response(
-        json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key))
-    )
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
 
     decision = evaluate_cached_supply_chain_bundle(
         response,
@@ -471,9 +465,7 @@ def test_supply_chain_bundle_verifies_portal_signed_payload_with_sparse_policy_r
     private_key, _public_key = _generate_key_pair()
     bundle = _bundle_dict()
     bundle["policyRules"] = [{"action": "block", "ruleId": "rule-1"}]
-    response = load_supply_chain_bundle_response(
-        json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key))
-    )
+    response = load_supply_chain_bundle_response(json.dumps(_sign_bundle_response(bundle, private_key_pem=private_key)))
 
     verify_supply_chain_bundle_response(response, now=response.bundle.generated_at_timestamp + 5)
 

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -10,17 +10,43 @@ from codex_plugin_scanner.guard.runtime.runner import GuardSyncAuthorizationExpi
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def test_daemon_refreshes_supply_chain_bundle_on_start_and_interval(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id="workspace-alpha",
-    )
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     calls: list[float] = []
 
     def _fake_sync(_store: GuardStore) -> dict[str, object]:

--- a/tests/test_guard_supply_chain_disclosure_reasons.py
+++ b/tests/test_guard_supply_chain_disclosure_reasons.py
@@ -8,13 +8,13 @@ from pathlib import Path
 import pytest
 
 import codex_plugin_scanner.guard.runtime.supply_chain_package_eval as evaluator_module
-from tests.guard_tier2_phase13_support import artifact_from_command_fixture
 from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
     _build_request_payload,
     _cloud_fail_closed_decision,
     evaluate_package_request_artifact,
 )
 from codex_plugin_scanner.guard.store import GuardStore
+from tests.guard_tier2_phase13_support import artifact_from_command_fixture
 from tests.test_guard_supply_chain_evaluator import (
     WORKSPACE_ID,
     _artifact_for_targets,
@@ -22,6 +22,38 @@ from tests.test_guard_supply_chain_evaluator import (
     _force_cloud_fallback,
     _package,
 )
+
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
 
 POLICY_HASH = "policy-hash-1"
 
@@ -40,12 +72,7 @@ def test_strict_mode_timeout_blocks_with_cloud_validation_error(
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
     (store.guard_home / "config.toml").write_text('security_level = "strict"\n', encoding="utf-8")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _bundle_response(
@@ -82,12 +109,7 @@ def test_local_fallback_disclosure_reason_surfaces_after_cloud_timeout(
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     result = evaluate_package_request_artifact(
         artifact=_artifact_for_targets("unknown-pkg@1.0.0"),
         store=store,
@@ -104,12 +126,7 @@ def test_stale_bundle_disclosure_reason_surfaces_in_final_evaluation(
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     stale_response = _bundle_response(
         packages=[
             _package(
@@ -160,23 +177,14 @@ def test_unknown_package_disclosure_reason(tmp_path: Path, monkeypatch: pytest.M
         now="2026-05-19T00:00:00Z",
     )
 
-    assert any(
-        reason["code"] == "no_cached_match"
-        for package in result.packages
-        for reason in package["reasons"]
-    )
+    assert any(reason["code"] == "no_cached_match" for package in result.packages for reason in package["reasons"])
 
 
 def test_policy_version_hash_consistency_between_cloud_request_and_local_evaluation(
     tmp_path: Path,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     bundle_response = _bundle_response(
         packages=[
             _package(

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -39,6 +39,38 @@ from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
 )
 from codex_plugin_scanner.guard.store import GuardStore
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 WORKSPACE_ID = "workspace-alpha"
 
 
@@ -314,11 +346,11 @@ def test_canonical_decision_order_prefers_cloud_over_signed_bundle(tmp_path: Pat
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
         bundle_response = _bundle_response(
             packages=[
@@ -363,11 +395,11 @@ def test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_re
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
         workspace_dir = tmp_path / "workspace"
         workspace_dir.mkdir()
@@ -412,9 +444,7 @@ def test_evaluate_package_request_artifact_uses_cached_eval_before_network(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -594,11 +624,11 @@ def test_evaluate_package_request_artifact_handles_upgrade_required_with_premium
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
         artifact = _artifact_for_targets("left-pad@1.0.0")
 
@@ -625,12 +655,7 @@ def test_evaluate_package_request_artifact_fails_closed_on_untrusted_cloud_http_
     status_code: int,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -678,12 +703,7 @@ def test_evaluate_package_request_artifact_strict_mode_blocks_on_cloud_unreachab
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
     (store.guard_home / "config.toml").write_text('security_level = "strict"\n', encoding="utf-8")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -819,12 +839,7 @@ def test_evaluate_package_request_artifact_fails_closed_on_invalid_cloud_respons
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -863,12 +878,7 @@ def test_evaluate_package_request_artifact_ignores_malformed_cached_bundle(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     monkeypatch.setattr(
         store,
         "get_cached_supply_chain_bundle",
@@ -901,12 +911,7 @@ def test_evaluate_package_request_artifact_normalizes_cloud_review_decision(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
 
     monkeypatch.setattr(
         evaluator_module,
@@ -963,9 +968,7 @@ def test_evaluate_package_request_artifact_applies_policy_rule_override(
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1115,9 +1118,7 @@ def test_evaluate_package_request_artifact_applies_allow_exception_rule(
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1162,9 +1163,7 @@ def test_evaluate_package_request_artifact_summarizes_multi_package_and_safe_alt
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1210,9 +1209,7 @@ def test_evaluate_package_request_artifact_blocks_maintainer_compromise_fixture(
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1252,9 +1249,7 @@ def test_evaluate_package_request_artifact_blocks_transitive_lockfile_match_with
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1302,9 +1297,7 @@ def test_evaluate_package_request_artifact_warns_for_low_confidence_transitive_l
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1523,9 +1516,7 @@ def test_evaluate_package_request_artifact_blocks_hoisted_lockfile_match(
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1696,12 +1687,7 @@ def test_evaluate_package_request_artifact_handles_unreadable_lockfile_context_w
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
     lockfile_path = workspace_dir / "package-lock.json"
@@ -1744,9 +1730,7 @@ def test_evaluate_package_request_artifact_range_only_timeout_falls_back_safely(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1781,9 +1765,7 @@ def test_evaluate_package_request_artifact_blocks_from_cached_bundle_after_cloud
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     response = _bundle_response(
         packages=[
             _package(
@@ -1824,9 +1806,7 @@ def test_evaluate_package_request_artifact_stale_bundle_requests_refresh_and_rec
 ) -> None:
     _force_cloud_fallback(monkeypatch)
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync", "demo-token", "2026-05-19T00:00:00Z", workspace_id=WORKSPACE_ID
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     stale_response = _bundle_response(
         packages=[
             _package(

--- a/tests/test_guard_supply_chain_sync.py
+++ b/tests/test_guard_supply_chain_sync.py
@@ -22,6 +22,38 @@ from codex_plugin_scanner.guard.runtime.runner import sync_supply_chain_bundle
 from codex_plugin_scanner.guard.runtime.supply_chain_bundle import canonical_supply_chain_bundle_payload
 from codex_plugin_scanner.guard.store import GuardStore
 
+
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 WORKSPACE_ID = "workspace-alpha"
 
 
@@ -294,11 +326,11 @@ def test_sync_supply_chain_bundle_fetches_and_caches_bundle(tmp_path: Path) -> N
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
 
         summary = sync_supply_chain_bundle(store)
@@ -353,11 +385,11 @@ def test_supply_chain_bundle_refresh_keeps_approval_queue_quiet(tmp_path: Path) 
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
         store.cache_supply_chain_bundle(
             WORKSPACE_ID,
@@ -441,11 +473,11 @@ def test_sync_supply_chain_bundle_refresh_downloads_only_changed_partitions(tmp_
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
         store.cache_supply_chain_bundle(WORKSPACE_ID, unchanged_partition, "2026-05-19T00:00:00Z")
         store.set_sync_payload(
@@ -540,11 +572,11 @@ def test_sync_supply_chain_bundle_reuses_cached_partitions_without_full_refresh(
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
         store.cache_supply_chain_bundle(WORKSPACE_ID, npm_partition, "2026-05-19T00:00:00Z")
         store.set_sync_payload(
@@ -628,11 +660,11 @@ def test_sync_supply_chain_bundle_refetches_tampered_cached_partition(tmp_path: 
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
         store.cache_supply_chain_bundle(
             WORKSPACE_ID,
@@ -731,11 +763,11 @@ def test_sync_supply_chain_bundle_refetches_full_bundle_for_tampered_cached_sign
     thread.start()
     try:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
-            "demo-token",
-            "2026-05-19T00:00:00Z",
+        _seed_guard_cloud(
+            store,
             workspace_id=WORKSPACE_ID,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="demo-token",
         )
         store.cache_supply_chain_bundle(
             WORKSPACE_ID,
@@ -815,12 +847,7 @@ def test_sync_supply_chain_bundle_wraps_runtime_error_when_cached_bundle_refetch
         "workspaceId": WORKSPACE_ID,
     }
     store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "demo-token",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
     store.cache_supply_chain_bundle(
         WORKSPACE_ID,
         _tamper_signature(
@@ -857,60 +884,3 @@ def test_sync_supply_chain_bundle_wraps_runtime_error_when_cached_bundle_refetch
 
     with pytest.raises(RuntimeError, match="Guard supply-chain bundle sync failed: simulated network failure"):
         sync_supply_chain_bundle(store)
-
-
-def test_supply_chain_cache_and_eval_cache_clear_on_sync_token_rotation(tmp_path: Path) -> None:
-    private_key_pem, public_key_pem = _generate_key_pair()
-    response_payload = _bundle_response(private_key_pem, public_key_pem)
-    store = GuardStore(tmp_path / "guard-home")
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-one",
-        "2026-05-19T00:00:00Z",
-        workspace_id=WORKSPACE_ID,
-    )
-    store.cache_supply_chain_bundle(WORKSPACE_ID, response_payload, "2026-05-19T00:00:00Z")
-    store.cache_supply_chain_evaluation(
-        workspace_id=WORKSPACE_ID,
-        package_intent_hash="intent-1",
-        feed_snapshot_hash="feed-snapshot-1",
-        policy_hash="policy-hash-1",
-        scoring_version="scf-v1",
-        bundle_version="1747612800000-deadbeef",
-        decision={"action": "block", "reason": "known_malware_or_kev"},
-        now="2026-05-19T00:00:00Z",
-    )
-    store.set_sync_payload("supply_chain_bundle_keyring", {"workspace_id": WORKSPACE_ID}, "2026-05-19T00:00:00Z")
-
-    assert store.get_cached_supply_chain_bundle(WORKSPACE_ID) is not None
-    assert (
-        store.get_cached_supply_chain_evaluation(
-            workspace_id=WORKSPACE_ID,
-            package_intent_hash="intent-1",
-            feed_snapshot_hash="feed-snapshot-1",
-            policy_hash="policy-hash-1",
-            scoring_version="scf-v1",
-            bundle_version="1747612800000-deadbeef",
-        )
-        is not None
-    )
-
-    store.set_sync_credentials(
-        "https://hol.org/api/guard/receipts/sync",
-        "token-two",
-        "2026-05-19T00:01:00Z",
-    )
-
-    assert store.get_cached_supply_chain_bundle(WORKSPACE_ID) is None
-    assert (
-        store.get_cached_supply_chain_evaluation(
-            workspace_id=WORKSPACE_ID,
-            package_intent_hash="intent-1",
-            feed_snapshot_hash="feed-snapshot-1",
-            policy_hash="policy-hash-1",
-            scoring_version="scf-v1",
-            bundle_version="1747612800000-deadbeef",
-        )
-        is None
-    )
-    assert store.get_sync_payload("supply_chain_bundle_keyring") is None

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -31,6 +31,37 @@ from codex_plugin_scanner.guard.schemas import build_surface_server_contract
 from codex_plugin_scanner.guard.store import GuardStore
 
 
+def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
+    """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
+
+    Also installs a test-only resolver override so sync-path exercises stay hermetic
+    (no OAuth token refresh against the network). Tests that need real sync against a
+    local server pass sync_url=<url>.
+    """
+    from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token=token,
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id=workspace_id,
+        now=now,
+    )
+    effective_sync_url = sync_url if sync_url is not None else "https://hol.org/api/guard/receipts/sync"
+    guard_runner_module._test_sync_auth_context_override = {
+        "sync_url": effective_sync_url,
+        "access_token": token,
+        "dpop_key_material": None,
+    }
+
+
 def _guard_get_request(port: int, path: str, auth_token: str) -> urllib.request.Request:
     return urllib.request.Request(
         f"http://127.0.0.1:{port}{path}",
@@ -913,11 +944,7 @@ class TestGuardSurfaceServer:
 
     def test_guard_daemon_runtime_snapshot_exposes_cloud_handoff_state(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "guard-token",
-            "2026-04-22T00:00:00Z",
-        )
+        _seed_guard_cloud(store)
         store.set_sync_payload(
             "sync_summary",
             {"synced_at": "2026-04-22T00:05:00Z"},
@@ -991,11 +1018,7 @@ class TestGuardSurfaceServer:
 
     def test_guard_daemon_runtime_snapshot_derives_cloud_urls_from_sync_origin(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
-        store.set_sync_credentials(
-            "https://hol.org/api/guard/receipts/sync",
-            "guard-token",
-            "2026-04-22T00:00:00Z",
-        )
+        _seed_guard_cloud(store)
         daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
         daemon.start()
 
@@ -2506,7 +2529,7 @@ class TestGuardSurfaceServer:
         assert error is not None
         assert error.code == 410
         assert payload["error"] == "legacy_pairing_disabled"
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
 
     def test_guard_daemon_allows_private_network_preflight_for_hosted_dashboard(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")
@@ -2568,7 +2591,7 @@ class TestGuardSurfaceServer:
         assert error is not None
         assert error.code == 410
         assert payload["error"] == "legacy_pairing_disabled"
-        assert store.get_sync_credentials() is None
+        assert store.get_cloud_sync_profile() is None
 
     def test_open_approval_center_skips_browser_when_live_surface_is_attached(self, tmp_path, monkeypatch) -> None:
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_sync_http_error_message.py
+++ b/tests/test_guard_sync_http_error_message.py
@@ -46,10 +46,7 @@ def test_sync_http_error_message_prefers_guard_error_msg_over_top_level_error() 
             },
         }
     )
-    assert (
-        _sync_http_error_message(_http_error(body))
-        == "Guard insights sharing is not live on Guard Cloud yet."
-    )
+    assert _sync_http_error_message(_http_error(body)) == "Guard insights sharing is not live on Guard Cloud yet."
 
 
 def test_sync_http_error_message_reads_guard_error_msg_field() -> None:

--- a/tests/test_guard_tier2_package_intent_phase13.py
+++ b/tests/test_guard_tier2_package_intent_phase13.py
@@ -121,11 +121,8 @@ GEM
 
 def test_parse_manifest_dependency_changes_truncates_large_cargo_workspace_safely() -> None:
     workspace_dependencies = "\n".join(f'crate{index} = "1.0.{index}"' for index in range(500))
-    before_text = "[workspace]\nmembers = [\"cli\"]\n[workspace.dependencies]\nclap = \"4.4\"\n"
-    after_text = (
-        "[workspace]\nmembers = [\"cli\", \"worker\"]\n[workspace.dependencies]\n"
-        f"{workspace_dependencies}\n"
-    )
+    before_text = '[workspace]\nmembers = ["cli"]\n[workspace.dependencies]\nclap = "4.4"\n'
+    after_text = f'[workspace]\nmembers = ["cli", "worker"]\n[workspace.dependencies]\n{workspace_dependencies}\n'
 
     result = parse_manifest_dependency_changes(
         path="Cargo.toml",

--- a/tests/test_guard_wrapper_flows.py
+++ b/tests/test_guard_wrapper_flows.py
@@ -53,9 +53,7 @@ def _make_detection(artifact: GuardArtifact) -> HarnessDetection:
 
 
 class TestWaitForApprovalRequests:
-    def _add_request(
-        self, store: GuardStore, req_id: str, status: str = "pending"
-    ) -> str:
+    def _add_request(self, store: GuardStore, req_id: str, status: str = "pending") -> str:
         from codex_plugin_scanner.guard.models import GuardApprovalRequest
 
         request = GuardApprovalRequest(

--- a/tests/test_harness_attribution.py
+++ b/tests/test_harness_attribution.py
@@ -6,8 +6,8 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.claude_code import ClaudeCodeHarnessAdapter
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.runtime.harness_attribution import (
     cursor_hook_query_extras,

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -100,7 +100,7 @@ def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path)
             "mcp_servers:\n"
             "  docs:\n"
             '    command: "/usr/bin/node --token ghp_secretvalue '
-            'HTTPS://user:pass@example.com/mcp?auth=ghp_secretvalue '
+            "HTTPS://user:pass@example.com/mcp?auth=ghp_secretvalue "
             'ws://user:pass@example.com/socket"\n'
             '    url: "https://user:pass@example.com/mcp?token=ghp_secretvalue&mode=safe"\n'
             "    headers:\n"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -9,6 +9,8 @@ from codex_plugin_scanner.scanner import scan_plugin
 
 FIXTURES = Path(__file__).parent / "fixtures"
 EXPECTED_GOOD_PLUGIN_SCORE = 91
+
+
 def test_good_plugin_expected_score():
     result = scan_plugin(FIXTURES / "good-plugin")
     assert result.score == EXPECTED_GOOD_PLUGIN_SCORE

--- a/tests/test_opencode_adapter.py
+++ b/tests/test_opencode_adapter.py
@@ -854,7 +854,6 @@ class TestOpenCodeScopeDetection:
         scope = OpenCodeHarnessAdapter._scope_for(ctx, some_file)
         assert scope == "global"
 
-
     def test_install_and_uninstall_are_inverse_for_new_config(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
         target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
@@ -887,9 +886,7 @@ class TestOpenCodeScopeDetection:
         adapter = get_adapter("opencode")
         assert adapter.harness == "opencode"
 
-    def test_managed_install_ignores_opencode_config_env_var(
-        self, tmp_path: Path, monkeypatch
-    ) -> None:
+    def test_managed_install_ignores_opencode_config_env_var(self, tmp_path: Path, monkeypatch) -> None:
         ctx = _ctx(tmp_path, workspace=False)
         custom_config = tmp_path / "my-opencode.json"
         custom_config.parent.mkdir(parents=True, exist_ok=True)
@@ -897,6 +894,3 @@ class TestOpenCodeScopeDetection:
         monkeypatch.setenv("OPENCODE_CONFIG", str(custom_config))
         target = OpenCodeHarnessAdapter._managed_install_config_path(ctx)
         assert target == ctx.home_dir / ".config" / "opencode" / CONFIG_FILENAMES[0]
-
-
-

--- a/tests/test_opencode_pretool.py
+++ b/tests/test_opencode_pretool.py
@@ -12,8 +12,8 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.hook_python import package_root_from_python, resolve_guard_hook_python
+from codex_plugin_scanner.guard.adapters.opencode import OpenCodeHarnessAdapter
 from codex_plugin_scanner.guard.adapters.opencode_pretool import (
     _HOOK_ARGV_ENV,
     _pretool_hook_env,
@@ -80,7 +80,7 @@ def test_pretool_plugin_source_embeds_guard_paths(tmp_path: Path) -> None:
     assert "nodeSpawn" in spawn_block
     assert "globalThis" not in spawn_block
     assert "Bun" not in spawn_block
-    assert '.stream()' not in spawn_block
+    assert ".stream()" not in spawn_block
     assert "try {" in source
     assert 'source_scope: directory?.trim() ? "project" : "global"' in source
     assert "GUARD_HOOK_LAUNCHER" in source
@@ -144,7 +144,9 @@ def test_pretool_hook_launcher_ignores_workspace_package_hijack(
     fake_pkg = workspace / "codex_plugin_scanner"
     fake_pkg.mkdir()
     (fake_pkg / "__init__.py").write_text("", encoding="utf-8")
-    (fake_pkg / "cli.py").write_text("import sys\nsys.stderr.write('hijacked')\nraise SystemExit(99)\n", encoding="utf-8")
+    (fake_pkg / "cli.py").write_text(
+        "import sys\nsys.stderr.write('hijacked')\nraise SystemExit(99)\n", encoding="utf-8"
+    )
 
     guard_home = tmp_path / "guard-home"
     guard_home.mkdir()
@@ -186,10 +188,14 @@ def test_pretool_plugin_source_does_not_spawn_python_m_module(tmp_path: Path) ->
 
 
 def test_pretool_plugin_source_includes_node_spawn_fallback(tmp_path: Path) -> None:
-    spawn_block = pretool_plugin_source(_ctx(tmp_path)).split("async function spawnGuardProcess", 1)[1].split(
-        "async function runGuardHook",
-        1,
-    )[0]
+    spawn_block = (
+        pretool_plugin_source(_ctx(tmp_path))
+        .split("async function spawnGuardProcess", 1)[1]
+        .split(
+            "async function runGuardHook",
+            1,
+        )[0]
+    )
     assert "nodeSpawn" in spawn_block
     assert "await import(" not in spawn_block
     assert "Bun" not in spawn_block
@@ -208,9 +214,7 @@ def test_install_pretool_plugin_writes_managed_and_global_copies(tmp_path: Path)
     manifest = install_pretool_plugin(ctx)
     assert Path(manifest["managed_plugin_path"]).is_file()
     assert Path(manifest["global_plugin_path"]).is_file()
-    assert managed_plugin_path(ctx).read_text(encoding="utf-8") == global_plugin_path(ctx).read_text(
-        encoding="utf-8"
-    )
+    assert managed_plugin_path(ctx).read_text(encoding="utf-8") == global_plugin_path(ctx).read_text(encoding="utf-8")
 
 
 def test_remove_pretool_plugin_deletes_installed_files(tmp_path: Path) -> None:

--- a/tests/test_policy_bundle_parser.py
+++ b/tests/test_policy_bundle_parser.py
@@ -78,32 +78,36 @@ def _signed_policy_bundle(
     key_id: str = "guard-policy-bundle-test-key",
 ) -> tuple[dict[str, object], tuple[object, ...]]:
     private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    public_key_pem = private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode('utf-8')
+    public_key_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
     trusted_key = policy_bundle_verification_key_from_public_key(
         key_id=key_id,
         public_key_pem=public_key_pem,
     )
     bundle = _sample_policy_bundle()
-    bundle['workspaceId'] = 'workspace-1'
-    verifier = dict(bundle['verifier']) if isinstance(bundle['verifier'], dict) else {}
-    verifier['algorithm'] = 'rsa-pss-sha256'
-    verifier['keyId'] = key_id
-    verifier['publicKeyPem'] = public_key_pem
-    verifier['signature'] = None
-    bundle['verifier'] = verifier
-    bundle['bundleHash'] = computed_policy_bundle_hash(bundle)
-    bundle['payloadHash'] = payload_hash_for_policy_bundle(bundle)
-    verifier['signature'] = base64.b64encode(
+    bundle["workspaceId"] = "workspace-1"
+    verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}
+    verifier["algorithm"] = "rsa-pss-sha256"
+    verifier["keyId"] = key_id
+    verifier["publicKeyPem"] = public_key_pem
+    verifier["signature"] = None
+    bundle["verifier"] = verifier
+    bundle["bundleHash"] = computed_policy_bundle_hash(bundle)
+    bundle["payloadHash"] = payload_hash_for_policy_bundle(bundle)
+    verifier["signature"] = base64.b64encode(
         private_key.sign(
             canonical_policy_bundle_payload(bundle),
             padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.MAX_LENGTH),
             hashes.SHA256(),
         )
-    ).decode('utf-8')
-    bundle['verifier'] = verifier
+    ).decode("utf-8")
+    bundle["verifier"] = verifier
     return bundle, (trusted_key,)
 
 
@@ -140,7 +144,7 @@ def test_hgc071_signed_policy_bundle_parses() -> None:
 def test_hgc073_signed_policy_bundle_rejects_invalid_signature() -> None:
     bundle, trusted_keys = _signed_policy_bundle()
     verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}
-    verifier["signature"] = base64.b64encode(b"tampered-signature").decode('utf-8')
+    verifier["signature"] = base64.b64encode(b"tampered-signature").decode("utf-8")
     bundle["verifier"] = verifier
 
     validated_bundle, reason = validated_policy_bundle_payload(
@@ -272,10 +276,14 @@ def test_hgc075_preserves_last_known_good_policy_on_invalid_update(tmp_path: Pat
 
 def test_signed_policy_bundle_rejects_attacker_self_signed_key() -> None:
     attacker_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    attacker_public_key_pem = attacker_private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode("utf-8")
+    attacker_public_key_pem = (
+        attacker_private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
     bundle = _sample_policy_bundle()
     bundle["workspaceId"] = "workspace-1"
     verifier = dict(bundle["verifier"]) if isinstance(bundle["verifier"], dict) else {}
@@ -333,10 +341,14 @@ def test_signed_policy_bundle_rejects_sync_only_keys_without_anchor() -> None:
 def test_validate_synced_policy_bundle_does_not_persist_unanchored_sync_keys() -> None:
     bundle, anchored_keys = _signed_policy_bundle(key_id="legitimate-anchor-key")
     attacker_private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-    attacker_public_key_pem = attacker_private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    ).decode("utf-8")
+    attacker_public_key_pem = (
+        attacker_private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+    )
     attacker_key = policy_bundle_verification_key_from_public_key(
         key_id="attacker-sync-key",
         public_key_pem=attacker_public_key_pem,
@@ -363,9 +375,7 @@ def test_validate_synced_policy_bundle_does_not_persist_unanchored_sync_keys() -
 
     attacker_bundle = _sample_policy_bundle()
     attacker_bundle["workspaceId"] = "workspace-1"
-    attacker_verifier = (
-        dict(attacker_bundle["verifier"]) if isinstance(attacker_bundle["verifier"], dict) else {}
-    )
+    attacker_verifier = dict(attacker_bundle["verifier"]) if isinstance(attacker_bundle["verifier"], dict) else {}
     attacker_verifier["algorithm"] = "rsa-pss-sha256"
     attacker_verifier["keyId"] = attacker_key.key_id
     attacker_verifier["publicKeyPem"] = attacker_public_key_pem

--- a/tests/test_skill_security.py
+++ b/tests/test_skill_security.py
@@ -260,9 +260,7 @@ def test_scan_plugin_handles_skills_outside_plugin_root_without_crashing(tmp_pat
     result = scan_plugin(plugin_dir, ScanOptions(cisco_skill_scan="off"))
 
     skill_security = next(category for category in result.categories if category.name == "Skill Security")
-    analyzable_check = next(
-        check for check in skill_security.checks if check.name == "Skills analyzable"
-    )
+    analyzable_check = next(check for check in skill_security.checks if check.name == "Skills analyzable")
 
     assert analyzable_check.applicable is False
     assert "unsafe" in analyzable_check.message.lower()
@@ -339,9 +337,7 @@ def test_scan_plugin_ignores_symlinked_skill_files_outside_plugin_root(tmp_path)
     result = scan_plugin(plugin_dir, ScanOptions(cisco_skill_scan="off"))
 
     skill_security = next(category for category in result.categories if category.name == "Skill Security")
-    analyzable_check = next(
-        check for check in skill_security.checks if check.name == "Skills analyzable"
-    )
+    analyzable_check = next(check for check in skill_security.checks if check.name == "Skills analyzable")
 
     assert analyzable_check.applicable is False
     assert "outside the plugin root" in analyzable_check.message

--- a/tests/test_trust_scoring.py
+++ b/tests/test_trust_scoring.py
@@ -249,11 +249,7 @@ def test_unsafe_skill_path_does_not_emit_skill_trust_domain(tmp_path: Path):
         encoding="utf-8",
     )
     (shared_skill_dir / "SKILL.md").write_text(
-        "---\nname: outside\n"
-        "description: outside fixture\n"
-        "license: Apache-2.0\n"
-        "languages:\n  - en\n---\n"
-        "Run safely.\n",
+        "---\nname: outside\ndescription: outside fixture\nlicense: Apache-2.0\nlanguages:\n  - en\n---\nRun safely.\n",
         encoding="utf-8",
     )
 

--- a/tests/test_verification.py
+++ b/tests/test_verification.py
@@ -93,9 +93,7 @@ def test_verify_plugin_reports_stdio_servers_without_spawning_them(tmp_path: Pat
     result = verify_plugin(tmp_path)
 
     assert result.verify_pass is False
-    expected_message = (
-        "Skipped stdio command execution for safety; manual review is required before trusting it."
-    )
+    expected_message = "Skipped stdio command execution for safety; manual review is required before trusting it."
     assert any(case.message == expected_message for case in result.cases)
 
 


### PR DESCRIPTION
## Summary
- Remove the deprecated legacy cloud sync token path (`guard-cloud-token` / `hol-guard.sync` keychain service, `set/get/clear_sync_credentials`, `get_sync_credential_health`, `KeychainSecretStore`, `_build_secret_store`) and the silent legacy fallback in `_resolve_guard_sync_auth_context`
- OAuth Device Code is now the only cloud sync auth path; the resolver raises `GuardSyncNotConfiguredError` when OAuth is absent instead of falling back to a legacy bearer token
- Trim `get_cloud_sync_profile` and `clear_cloud_sync_state_for_reconnect` to OAuth-only; simplify `connect_state_requires_oauth` now that `auth_mode` can only be `"oauth"`
- Migrate test fixtures from `set_sync_credentials` to OAuth-backed seeding with a test-only resolver override hook that keeps sync-path exercises hermetic

## Behavior change
A store with only a leftover legacy token (no OAuth) that runs `hol-guard sync` now raises `GuardSyncNotConfiguredError: "Guard is not logged in."` instead of syncing via the legacy token. The recovery path is `hol-guard connect`.

## Testing
- `python -m pytest tests/test_guard_store_migrations.py tests/test_guard_cli.py tests/test_guard_policy_integrity.py -q`
- `python -m pytest tests/test_guard_phase06_workspace_audit.py tests/test_guard_supply_chain_evaluator.py tests/test_guard_events.py tests/test_guard_protect.py -q`
- `python -m ruff check src/ tests/`
