### PR TITLE
fix(guard): persist dashboard cloud connect oauth state

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -59,6 +59,7 @@ from ..approvals import (
 from ..cli.connect_flow import (
     CONNECT_SYNC_AUTH_CONTEXT_KEY,
     _build_sync_auth_context,
+    _persist_oauth_local_credentials,
     exchange_guard_authorization_code,
     resolve_connect_url,
     resolve_guard_oauth_client_config,
@@ -127,6 +128,7 @@ from ..runtime.runner import (
     _persist_cloud_exceptions,
     _policy_bundle_acknowledgement_payload,
     _policy_bundle_is_version_downgrade,
+    prepare_guard_cloud_connect_authorization,
     sync_local_guard_cloud_proof,
     sync_supply_chain_bundle,
 )
@@ -2543,6 +2545,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             repair_copy=_package_firewall_connect_needs_repair(store, reason),
         )
         try:
+            prepare_guard_cloud_connect_authorization(store)
             device = store.get_device_metadata()
             session = start_guard_browser_session(
                 connect_url=connect_url,
@@ -2602,36 +2605,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 if token_result.refresh_token is None:
                     raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
                 timestamp = _now()
-                store.set_oauth_local_credentials(
+                _persist_oauth_local_credentials(
+                    store=store,
                     issuer=oauth_client.issuer,
                     client_id=oauth_client.client_id,
                     refresh_token=token_result.refresh_token,
-                    dpop_private_key_pem=session.dpop_key_material.private_key_pem,
-                    dpop_public_jwk=session.dpop_key_material.public_jwk,
-                    dpop_public_jwk_thumbprint=session.dpop_key_material.public_jwk_thumbprint,
+                    dpop_key_material=session.dpop_key_material,
                     grant_id=token_result.grant_id,
                     machine_id=token_result.machine_id,
-                    supply_chain_entitlement_expires_at=(
-                        str(token_result.supply_chain_entitlement.get("supply_chain_entitlement_expires_at"))
-                        if isinstance(token_result.supply_chain_entitlement, dict)
-                        and isinstance(
-                            token_result.supply_chain_entitlement.get("supply_chain_entitlement_expires_at"),
-                            str,
-                        )
-                        else None
-                    ),
-                    supply_chain_firewall=(
-                        bool(token_result.supply_chain_entitlement.get("supply_chain_firewall"))
-                        if isinstance(token_result.supply_chain_entitlement, dict)
-                        and isinstance(token_result.supply_chain_entitlement.get("supply_chain_firewall"), bool)
-                        else None
-                    ),
-                    supply_chain_plan_id=(
-                        str(token_result.supply_chain_entitlement.get("supply_chain_plan_id"))
-                        if isinstance(token_result.supply_chain_entitlement, dict)
-                        and isinstance(token_result.supply_chain_entitlement.get("supply_chain_plan_id"), str)
-                        else None
-                    ),
+                    supply_chain_entitlement=token_result.supply_chain_entitlement,
                     workspace_id=token_result.workspace_id,
                     runtime_id="hol-guard",
                     runtime_label="HOL Guard CLI",
@@ -2729,6 +2711,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         connect_url = _package_firewall_connect_url(store)
         action_label = "Repair Guard Cloud access" if repair_mode else "Connect Guard Cloud"
         try:
+            prepare_guard_cloud_connect_authorization(store)
             device = store.get_device_metadata()
             session = start_guard_browser_session(
                 connect_url=connect_url,
@@ -2791,36 +2774,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 if token_result.refresh_token is None:
                     raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
                 timestamp = _now()
-                store.set_oauth_local_credentials(
+                _persist_oauth_local_credentials(
+                    store=store,
                     issuer=oauth_client.issuer,
                     client_id=oauth_client.client_id,
                     refresh_token=token_result.refresh_token,
-                    dpop_private_key_pem=session.dpop_key_material.private_key_pem,
-                    dpop_public_jwk=session.dpop_key_material.public_jwk,
-                    dpop_public_jwk_thumbprint=session.dpop_key_material.public_jwk_thumbprint,
+                    dpop_key_material=session.dpop_key_material,
                     grant_id=token_result.grant_id,
                     machine_id=token_result.machine_id,
-                    supply_chain_entitlement_expires_at=(
-                        str(token_result.supply_chain_entitlement.get("supply_chain_entitlement_expires_at"))
-                        if isinstance(token_result.supply_chain_entitlement, dict)
-                        and isinstance(
-                            token_result.supply_chain_entitlement.get("supply_chain_entitlement_expires_at"),
-                            str,
-                        )
-                        else None
-                    ),
-                    supply_chain_firewall=(
-                        bool(token_result.supply_chain_entitlement.get("supply_chain_firewall"))
-                        if isinstance(token_result.supply_chain_entitlement, dict)
-                        and isinstance(token_result.supply_chain_entitlement.get("supply_chain_firewall"), bool)
-                        else None
-                    ),
-                    supply_chain_plan_id=(
-                        str(token_result.supply_chain_entitlement.get("supply_chain_plan_id"))
-                        if isinstance(token_result.supply_chain_entitlement, dict)
-                        and isinstance(token_result.supply_chain_entitlement.get("supply_chain_plan_id"), str)
-                        else None
-                    ),
+                    supply_chain_entitlement=token_result.supply_chain_entitlement,
                     workspace_id=token_result.workspace_id,
                     runtime_id="hol-guard",
                     runtime_label="HOL Guard CLI",

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 import urllib.error
 import urllib.request
 from pathlib import Path
@@ -17,6 +18,7 @@ from codex_plugin_scanner.guard.cli.connect_flow import (
 )
 from codex_plugin_scanner.guard.cli.oauth_client import GuardDpopKeyMaterial
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
+from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.package_firewall_entitlement import resolve_package_firewall_entitlement
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
@@ -73,6 +75,28 @@ def _post_legacy_connect_endpoint(
     raise AssertionError(f"{path} must reject legacy pairing")
 
 
+def _daemon_json_request(
+    *,
+    daemon: GuardDaemonServer,
+    path: str,
+    token: object,
+    method: str = "GET",
+) -> tuple[int, dict[str, object]]:
+    request = urllib.request.Request(
+        f"http://127.0.0.1:{daemon.port}{path}",
+        data=b"{}" if method == "POST" else None,
+        headers={
+            "Content-Type": "application/json",
+            "X-Guard-Token": str(token),
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(request, timeout=5) as response:
+        payload = json.loads(response.read().decode("utf-8"))
+        assert isinstance(payload, dict)
+        return response.status, payload
+
+
 def test_daemon_rejects_legacy_connect_pairing_endpoints(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
@@ -105,6 +129,116 @@ def test_daemon_rejects_legacy_connect_pairing_endpoints(tmp_path: Path) -> None
     assert result_status == 410
     assert result_payload["error"] == "legacy_pairing_disabled"
     assert "legacy-sync-secret" not in json.dumps([request_payload, complete_payload, result_payload])
+
+
+def test_daemon_guard_cloud_connect_persists_oauth_state_for_dashboard(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_device_label("Desk Mac", "2026-06-01T00:00:00+00:00")
+    dpop = GuardDpopKeyMaterial(
+        algorithm="ES256",
+        private_key_pem="private-key",
+        public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value"},
+        public_jwk_thumbprint="thumbprint-1",
+    )
+
+    class _FakeSession:
+        authorize_url = "https://hol.org/api/guard/oauth/authorize?client_id=guard-local-daemon"
+        redirect_uri = "http://127.0.0.1:61234/oauth/callback"
+        pkce_verifier = "verifier-123"
+        dpop_key_material = dpop
+        closed = False
+
+        def wait_for_callback(self, _timeout_seconds: float) -> GuardOAuthLoopbackCallback:
+            return GuardOAuthLoopbackCallback(code="auth-code-123", state="state-123")
+
+        def close(self) -> None:
+            self.closed = True
+
+    session = _FakeSession()
+    preflight_calls: list[GuardStore] = []
+
+    def fake_connect_preflight(preflight_store: GuardStore) -> dict[str, object]:
+        preflight_calls.append(preflight_store)
+        return {}
+
+    monkeypatch.setattr(daemon_server_module, "start_guard_browser_session", lambda **_: session)
+    monkeypatch.setattr(daemon_server_module.webbrowser, "open", lambda _url: True)
+    monkeypatch.setattr(daemon_server_module, "prepare_guard_cloud_connect_authorization", fake_connect_preflight)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "exchange_guard_authorization_code",
+        lambda **_: GuardOAuthTokenExchangeResult(
+            access_token="access-token-123",
+            refresh_token="refresh-token-123",
+            expires_in=3600,
+            scope="guard:runtime.sync guard:offline_access",
+            token_type="Bearer",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            supply_chain_entitlement={
+                "supply_chain_entitlement_expires_at": "2026-07-05T01:39:51+00:00",
+                "supply_chain_firewall": True,
+                "supply_chain_plan_id": "team",
+            },
+            workspace_id="workspace-123",
+        ),
+    )
+    monkeypatch.setattr(
+        daemon_server_module,
+        "sync_local_guard_cloud_proof",
+        lambda *_args, **_kwargs: {
+            "synced_at": "2026-06-01T12:00:00+00:00",
+            "runtime_session_id": "runtime-session-123",
+            "runtime_session_synced_at": "2026-06-01T12:00:00+00:00",
+            "runtime_sessions_visible": 1,
+        },
+    )
+    monkeypatch.setattr(daemon_server_module, "sync_supply_chain_bundle", lambda _store: {"packages": []})
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        _initialize_daemon(daemon)
+        auth_token = daemon._server.auth_token
+        status_code, start_payload = _daemon_json_request(
+            daemon=daemon,
+            path="/v1/cloud/connect",
+            token=auth_token,
+            method="POST",
+        )
+        assert status_code == 202
+        assert start_payload["connect_required"] is True
+
+        for _ in range(50):
+            if store.get_cloud_sync_profile() is not None:
+                break
+            time.sleep(0.05)
+
+        status_code, connect_status = _daemon_json_request(
+            daemon=daemon,
+            path="/v1/cloud/connect",
+            token=auth_token,
+        )
+        runtime_status, runtime = _daemon_json_request(
+            daemon=daemon,
+            path="/v1/runtime?include_items=false",
+            token=auth_token,
+        )
+    finally:
+        daemon.stop()
+
+    assert session.closed is True
+    assert preflight_calls == [store]
+    assert store.get_oauth_local_credential_health()["state"] == "healthy"
+    assert store.get_cloud_sync_profile() is not None
+    assert status_code == 200
+    assert connect_status == {"connect_required": False, "connect_flow": None}
+    assert runtime_status == 200
+    assert runtime["sync_configured"] is True
+    assert runtime["cloud_state"] in {"paired_active", "paired_waiting"}
 
 
 def test_connect_repair_copy_points_to_device_code(tmp_path: Path) -> None:

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -216,6 +216,7 @@ def test_daemon_guard_cloud_connect_persists_oauth_state_for_dashboard(
             if store.get_cloud_sync_profile() is not None:
                 break
             time.sleep(0.05)
+        assert store.get_cloud_sync_profile() is not None, "Timed out waiting for dashboard connect to persist OAuth"
 
         status_code, connect_status = _daemon_json_request(
             daemon=daemon,


### PR DESCRIPTION
## Summary
- Route dashboard Guard Cloud OAuth completion through the shared local credential persistence path.
- Run the same preflight repair used by CLI connect before dashboard browser OAuth starts.
- Add daemon coverage for dashboard-initiated Guard Cloud connect updating local runtime state.

## Testing
- `pytest tests/test_guard_connect_flow.py`
- `pytest tests/test_guard_package_firewall_entitlement.py`
