### PR TITLE
fix(guard): preserve active daemon state on duplicate shutdown

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -336,10 +336,17 @@ def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> _ExistingG
 def _retire_duplicate_guard_daemons(guard_home: Path, *, keep_port: int | None) -> None:
     if keep_port is None:
         return
+    retired_any = False
     for pid, port in _running_guard_daemon_processes_for_guard_home(guard_home):
         if port == keep_port:
             continue
-        _retire_guard_daemon_pid(pid, expected_guard_home=guard_home)
+        retired_any = _retire_guard_daemon_pid(pid, expected_guard_home=guard_home) or retired_any
+    if not retired_any:
+        return
+    kept_pid = _guard_daemon_pid_for_guard_home_port(guard_home, keep_port)
+    auth_token = load_guard_daemon_auth_token(guard_home)
+    if kept_pid is not None and auth_token is not None:
+        write_guard_daemon_state(guard_home, keep_port, auth_token, pid=kept_pid)
 
 
 def _guard_daemon_pid_for_guard_home_port(guard_home: Path, port: int) -> int | None:
@@ -375,6 +382,16 @@ def clear_guard_daemon_state(guard_home: Path) -> None:
     state_path = _state_path(guard_home)
     _ensure_private_directory(state_path.parent)
     _write_private_text(state_path, "{}")
+
+
+def clear_guard_daemon_state_if_current(guard_home: Path, *, pid: int, port: int) -> bool:
+    payload = _load_state(guard_home)
+    if not isinstance(payload, dict):
+        return False
+    if payload.get("pid") != pid or payload.get("port") != port:
+        return False
+    clear_guard_daemon_state(guard_home)
+    return True
 
 
 def repair_approval_center_locator(guard_home: Path) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -94,13 +94,17 @@ def ensure_guard_daemon(
         if existing_url is not None:
             existing_port = _guard_daemon_url_port(existing_url)
             if preferred_port is None or existing_port == preferred_port:
-                _retire_duplicate_guard_daemons(guard_home, keep_port=existing_port)
+                _retire_duplicate_guard_daemons(guard_home, keep_port=existing_port, start_lock_held=True)
                 return existing_url
             retire_all_guard_daemons_for_home(guard_home)
             clear_guard_daemon_state(guard_home)
         adopted_url = _adopt_existing_guard_daemon(guard_home, preferred_port=preferred_port)
         if adopted_url is not None:
-            _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(adopted_url))
+            _retire_duplicate_guard_daemons(
+                guard_home,
+                keep_port=_guard_daemon_url_port(adopted_url),
+                start_lock_held=True,
+            )
             return adopted_url
         stale_state = _load_state(guard_home)
         if isinstance(stale_state, dict) and not _guard_daemon_state_matches_current_runtime(stale_state):
@@ -108,7 +112,11 @@ def ensure_guard_daemon(
         if _guard_daemon_start_in_progress(guard_home):
             inflight_url = _wait_for_guard_daemon_url(guard_home, timeout=timeout)
             if inflight_url is not None:
-                _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(inflight_url))
+                _retire_duplicate_guard_daemons(
+                    guard_home,
+                    keep_port=_guard_daemon_url_port(inflight_url),
+                    start_lock_held=True,
+                )
                 return inflight_url
         clear_guard_daemon_state(guard_home)
         for candidate_port in _candidate_ports(guard_home, preferred_port=preferred_port):
@@ -333,13 +341,30 @@ def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> _ExistingG
     return {"url": url, "auth_token": auth_token, "pid": pid}
 
 
-def _retire_duplicate_guard_daemons(guard_home: Path, *, keep_port: int | None) -> None:
+def _retire_duplicate_guard_daemons(
+    guard_home: Path,
+    *,
+    keep_port: int | None,
+    start_lock_held: bool = False,
+) -> None:
     if keep_port is None:
         return
+    saw_duplicate = False
     for pid, port in _running_guard_daemon_processes_for_guard_home(guard_home):
         if port == keep_port:
             continue
+        saw_duplicate = True
         _retire_guard_daemon_pid(pid, expected_guard_home=guard_home)
+    if not saw_duplicate:
+        return
+    if start_lock_held:
+        _rewrite_kept_daemon_state_if_missing(guard_home, keep_port=keep_port)
+        return
+    with _guard_daemon_start_lock(guard_home):
+        _rewrite_kept_daemon_state_if_missing(guard_home, keep_port=keep_port)
+
+
+def _rewrite_kept_daemon_state_if_missing(guard_home: Path, *, keep_port: int) -> None:
     kept_pid = _guard_daemon_pid_for_guard_home_port(guard_home, keep_port)
     if kept_pid is None or _daemon_state_points_to(guard_home, pid=kept_pid, port=keep_port):
         return

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -156,7 +156,11 @@ def ensure_guard_daemon(
                 process=process,
             )
             if url is not None:
-                _retire_duplicate_guard_daemons(guard_home, keep_port=_guard_daemon_url_port(url))
+                _retire_duplicate_guard_daemons(
+                    guard_home,
+                    keep_port=_guard_daemon_url_port(url),
+                    start_lock_held=True,
+                )
                 return url
     raise RuntimeError(f"Guard approval center did not start. Expected state file at {state_path}.")
 
@@ -349,19 +353,26 @@ def _retire_duplicate_guard_daemons(
 ) -> None:
     if keep_port is None:
         return
+    if start_lock_held:
+        _retire_duplicate_guard_daemons_unlocked(guard_home, keep_port=keep_port)
+        return
+    with _guard_daemon_start_lock(guard_home):
+        _retire_duplicate_guard_daemons_unlocked(guard_home, keep_port=keep_port)
+
+
+def _retire_duplicate_guard_daemons_unlocked(guard_home: Path, *, keep_port: int) -> None:
     saw_duplicate = False
     for pid, port in _running_guard_daemon_processes_for_guard_home(guard_home):
         if port == keep_port:
             continue
         saw_duplicate = True
-        _retire_guard_daemon_pid(pid, expected_guard_home=guard_home)
+        if not _retire_guard_daemon_pid(pid, expected_guard_home=guard_home):
+            return
     if not saw_duplicate:
         return
-    if start_lock_held:
-        _rewrite_kept_daemon_state_if_missing(guard_home, keep_port=keep_port)
+    if any(port != keep_port for _pid, port in _running_guard_daemon_processes_for_guard_home(guard_home)):
         return
-    with _guard_daemon_start_lock(guard_home):
-        _rewrite_kept_daemon_state_if_missing(guard_home, keep_port=keep_port)
+    _rewrite_kept_daemon_state_if_missing(guard_home, keep_port=keep_port)
 
 
 def _rewrite_kept_daemon_state_if_missing(guard_home: Path, *, keep_port: int) -> None:
@@ -369,8 +380,15 @@ def _rewrite_kept_daemon_state_if_missing(guard_home: Path, *, keep_port: int) -
     if kept_pid is None or _daemon_state_points_to(guard_home, pid=kept_pid, port=keep_port):
         return
     auth_token = load_guard_daemon_auth_token(guard_home)
-    if auth_token is not None:
-        write_guard_daemon_state(guard_home, keep_port, auth_token, pid=kept_pid)
+    if auth_token is None:
+        return
+    daemon_url = f"http://127.0.0.1:{keep_port}"
+    details = _daemon_healthz_details_payload(daemon_url, auth_token)
+    if details is None or not _healthz_payload_matches_guard_home(json.dumps(details), guard_home):
+        return
+    if details.get("pid") != kept_pid:
+        return
+    write_guard_daemon_state(guard_home, keep_port, auth_token, pid=kept_pid, write_auth_token=False)
 
 
 def _guard_daemon_pid_for_guard_home_port(guard_home: Path, port: int) -> int | None:
@@ -380,7 +398,14 @@ def _guard_daemon_pid_for_guard_home_port(guard_home: Path, port: int) -> int | 
     return None
 
 
-def write_guard_daemon_state(guard_home: Path, port: int, auth_token: str, *, pid: int | None = None) -> None:
+def write_guard_daemon_state(
+    guard_home: Path,
+    port: int,
+    auth_token: str,
+    *,
+    pid: int | None = None,
+    write_auth_token: bool = True,
+) -> None:
     state_path = _state_path(guard_home)
     _ensure_private_directory(state_path.parent)
     _write_private_text(
@@ -399,7 +424,8 @@ def write_guard_daemon_state(guard_home: Path, port: int, auth_token: str, *, pi
             indent=2,
         ),
     )
-    _write_private_text(_auth_token_path(guard_home), auth_token)
+    if write_auth_token:
+        _write_private_text(_auth_token_path(guard_home), auth_token)
 
 
 def clear_guard_daemon_state(guard_home: Path) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -336,16 +336,15 @@ def _initialize_existing_guard_daemon(guard_home: Path, port: int) -> _ExistingG
 def _retire_duplicate_guard_daemons(guard_home: Path, *, keep_port: int | None) -> None:
     if keep_port is None:
         return
-    retired_any = False
     for pid, port in _running_guard_daemon_processes_for_guard_home(guard_home):
         if port == keep_port:
             continue
-        retired_any = _retire_guard_daemon_pid(pid, expected_guard_home=guard_home) or retired_any
-    if not retired_any:
-        return
+        _retire_guard_daemon_pid(pid, expected_guard_home=guard_home)
     kept_pid = _guard_daemon_pid_for_guard_home_port(guard_home, keep_port)
+    if kept_pid is None or _daemon_state_points_to(guard_home, pid=kept_pid, port=keep_port):
+        return
     auth_token = load_guard_daemon_auth_token(guard_home)
-    if kept_pid is not None and auth_token is not None:
+    if auth_token is not None:
         write_guard_daemon_state(guard_home, keep_port, auth_token, pid=kept_pid)
 
 
@@ -385,6 +384,11 @@ def clear_guard_daemon_state(guard_home: Path) -> None:
 
 
 def clear_guard_daemon_state_if_current(guard_home: Path, *, pid: int, port: int) -> bool:
+    with _guard_daemon_start_lock(guard_home):
+        return _clear_guard_daemon_state_if_current_unlocked(guard_home, pid=pid, port=port)
+
+
+def _clear_guard_daemon_state_if_current_unlocked(guard_home: Path, *, pid: int, port: int) -> bool:
     payload = _load_state(guard_home)
     if not isinstance(payload, dict):
         return False
@@ -392,6 +396,11 @@ def clear_guard_daemon_state_if_current(guard_home: Path, *, pid: int, port: int
         return False
     clear_guard_daemon_state(guard_home)
     return True
+
+
+def _daemon_state_points_to(guard_home: Path, *, pid: int, port: int) -> bool:
+    payload = _load_state(guard_home)
+    return isinstance(payload, dict) and payload.get("pid") == pid and payload.get("port") == port
 
 
 def repair_approval_center_locator(guard_home: Path) -> dict[str, object]:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -155,7 +155,7 @@ from .command_queue_worker import CommandQueueWorker, start_command_queue_worker
 from .dashboard_update import merge_dashboard_update_progress, schedule_guard_dashboard_update
 from .manager import (
     GUARD_DAEMON_COMPATIBILITY_VERSION,
-    clear_guard_daemon_state,
+    clear_guard_daemon_state_if_current,
     load_guard_daemon_auth_token,
     repair_approval_center_locator,
     write_guard_daemon_state,
@@ -4969,11 +4969,11 @@ class GuardDaemonServer:
 
     def _finish_service(self) -> None:
         if self._shutdown_started.is_set():
-            clear_guard_daemon_state(self._server.store.guard_home)
+            clear_guard_daemon_state_if_current(self._server.store.guard_home, pid=os.getpid(), port=self.port)
             self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
             return
         self._shutdown_started.set()
-        clear_guard_daemon_state(self._server.store.guard_home)
+        clear_guard_daemon_state_if_current(self._server.store.guard_home, pid=os.getpid(), port=self.port)
         self._server.store.clear_runtime_state(session_id=self._server.runtime_session_id)
 
     def _start_watchdog(self) -> None:

--- a/tests/test_guard_daemon_wake.py
+++ b/tests/test_guard_daemon_wake.py
@@ -221,6 +221,8 @@ class TestNoDashboardApprovalURLWake:
         assert url == f"http://127.0.0.1:{port}"
         assert len(retire_calls) >= 1, "_retire_guard_daemon_process must be called to recover stale daemon state"
 
+
+class TestDaemonLifecycle:
     def test_daemon_shutdown_only_clears_own_state(self, tmp_path) -> None:
         """A retired duplicate daemon must not erase the active daemon state file."""
         guard_home = tmp_path / "guard-home"

--- a/tests/test_guard_daemon_wake.py
+++ b/tests/test_guard_daemon_wake.py
@@ -253,16 +253,22 @@ class TestDaemonLifecycle:
         monkeypatch.setattr(
             daemon_manager_module,
             "_running_guard_daemon_processes_for_guard_home",
-            lambda _guard_home: [(111, 5707), (222, 5708)],
+            lambda _guard_home: [(111, 5707), (222, 5708)] if not (guard_home / "retired").exists() else [(111, 5707)],
         )
 
         def fake_retire(pid: int, *, expected_guard_home: Path | None = None) -> bool:
             del expected_guard_home
             killed.append(pid)
             daemon_manager_module.clear_guard_daemon_state(guard_home)
+            (guard_home / "retired").write_text("1", encoding="utf-8")
             return True
 
         monkeypatch.setattr(daemon_manager_module, "_retire_guard_daemon_pid", fake_retire)
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_daemon_healthz_details_payload",
+            lambda _url, _auth_token: {"guard_home": str(guard_home), "pid": 111},
+        )
 
         daemon_manager_module._retire_duplicate_guard_daemons(guard_home, keep_port=5707)
         state = json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8"))
@@ -270,3 +276,59 @@ class TestDaemonLifecycle:
         assert killed == [222]
         assert state["pid"] == 111
         assert state["port"] == 5707
+
+    def test_retiring_duplicate_daemons_does_not_rewrite_when_retire_fails(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """A duplicate that could not be retired must block kept-state recovery."""
+        guard_home = tmp_path / "guard-home"
+        guard_home.mkdir()
+        daemon_manager_module.write_guard_daemon_state(guard_home, 5709, "token-1", pid=111)
+
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [(111, 5709), (222, 5710)],
+        )
+
+        def fake_retire(_pid: int, *, expected_guard_home: Path | None = None) -> bool:
+            del expected_guard_home
+            daemon_manager_module.clear_guard_daemon_state(guard_home)
+            return False
+
+        monkeypatch.setattr(daemon_manager_module, "_retire_guard_daemon_pid", fake_retire)
+
+        daemon_manager_module._retire_duplicate_guard_daemons(guard_home, keep_port=5709)
+
+        assert json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8")) == {}
+
+    def test_retiring_duplicate_daemons_requires_kept_daemon_auth(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """Do not recover state with a token that cannot authenticate to the kept daemon."""
+        guard_home = tmp_path / "guard-home"
+        guard_home.mkdir()
+        daemon_manager_module.write_guard_daemon_state(guard_home, 5711, "token-1", pid=111)
+
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [(111, 5711), (222, 5712)] if not (guard_home / "retired").exists() else [(111, 5711)],
+        )
+
+        def fake_retire(_pid: int, *, expected_guard_home: Path | None = None) -> bool:
+            del expected_guard_home
+            daemon_manager_module.clear_guard_daemon_state(guard_home)
+            (guard_home / "retired").write_text("1", encoding="utf-8")
+            return True
+
+        monkeypatch.setattr(daemon_manager_module, "_retire_guard_daemon_pid", fake_retire)
+        monkeypatch.setattr(daemon_manager_module, "_daemon_healthz_details_payload", lambda _url, _auth_token: None)
+
+        daemon_manager_module._retire_duplicate_guard_daemons(guard_home, keep_port=5711)
+
+        assert json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8")) == {}

--- a/tests/test_guard_daemon_wake.py
+++ b/tests/test_guard_daemon_wake.py
@@ -220,3 +220,51 @@ class TestNoDashboardApprovalURLWake:
 
         assert url == f"http://127.0.0.1:{port}"
         assert len(retire_calls) >= 1, "_retire_guard_daemon_process must be called to recover stale daemon state"
+
+    def test_daemon_shutdown_only_clears_own_state(self, tmp_path) -> None:
+        """A retired duplicate daemon must not erase the active daemon state file."""
+        guard_home = tmp_path / "guard-home"
+        guard_home.mkdir()
+        daemon_manager_module.write_guard_daemon_state(guard_home, 5705, "token-1", pid=111)
+
+        cleared = daemon_manager_module.clear_guard_daemon_state_if_current(guard_home, pid=222, port=5706)
+        state = json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8"))
+
+        assert cleared is False
+        assert state["pid"] == 111
+        assert state["port"] == 5705
+
+        assert daemon_manager_module.clear_guard_daemon_state_if_current(guard_home, pid=111, port=5705) is True
+        assert json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8")) == {}
+
+    def test_retiring_duplicate_daemons_rewrites_kept_state_after_old_exit(
+        self,
+        tmp_path,
+        monkeypatch,
+    ) -> None:
+        """Old duplicate daemons may clear daemon-state.json on exit; rewrite the kept daemon state."""
+        guard_home = tmp_path / "guard-home"
+        guard_home.mkdir()
+        daemon_manager_module.write_guard_daemon_state(guard_home, 5707, "token-1", pid=111)
+        killed: list[int] = []
+
+        monkeypatch.setattr(
+            daemon_manager_module,
+            "_running_guard_daemon_processes_for_guard_home",
+            lambda _guard_home: [(111, 5707), (222, 5708)],
+        )
+
+        def fake_retire(pid: int, *, expected_guard_home: Path | None = None) -> bool:
+            del expected_guard_home
+            killed.append(pid)
+            daemon_manager_module.clear_guard_daemon_state(guard_home)
+            return True
+
+        monkeypatch.setattr(daemon_manager_module, "_retire_guard_daemon_pid", fake_retire)
+
+        daemon_manager_module._retire_duplicate_guard_daemons(guard_home, keep_port=5707)
+        state = json.loads((guard_home / "daemon-state.json").read_text(encoding="utf-8"))
+
+        assert killed == [222]
+        assert state["pid"] == 111
+        assert state["port"] == 5707


### PR DESCRIPTION
## Summary
- Prevent retired duplicate Guard daemons from clearing the active daemon state file.
- Rewrite the kept daemon state after duplicate retirement to recover from older daemons clearing state on exit.
- Add daemon lifecycle regression tests for duplicate shutdown and kept-state preservation.

## Testing
- `pytest tests/test_guard_daemon_wake.py tests/test_guard_approval_continuity.py`
- `pytest tests/test_guard_cli.py -k 'sync_without_login or guard_cloud_sync_intel_without_login or stale_connected_state_retry_required or login_and_sync_posts_receipts'`
