### PR TITLE
fix(guard): prefer reconnect state over stale entitlement

### DIFF
--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -169,6 +169,27 @@ def _connect_state_entitlement(store: GuardStore, *, now: datetime) -> dict[str,
     }
 
 
+def _reconnect_required_entitlement(
+    *,
+    bundle: dict[str, object] | None,
+    oauth: dict[str, object] | None,
+    oauth_payload: object,
+) -> dict[str, object]:
+    tier = "unknown"
+    if isinstance(oauth, dict):
+        tier = _optional_string(oauth.get("tier")) or tier
+    if tier == "unknown" and isinstance(bundle, dict):
+        tier = _optional_string(bundle.get("tier")) or tier
+    if tier == "unknown" and isinstance(oauth_payload, dict):
+        tier = _optional_string(oauth_payload.get("supply_chain_plan_id")) or tier
+    return {
+        "allowed": False,
+        "reason": "guard_cloud_reconnect_required",
+        "tier": tier.lower(),
+        "upgrade_cta": PACKAGE_FIREWALL_RECONNECT_CTA,
+    }
+
+
 def _connect_required_entitlement(store: GuardStore) -> dict[str, object]:
     oauth_payload = store.get_sync_payload("oauth_local_credentials")
     tier = "unknown"
@@ -244,16 +265,20 @@ def resolve_package_firewall_entitlement(
         oauth_fields = _oauth_entitlement_fields_from_sync_payload(oauth_payload)
     oauth = _oauth_entitlement(oauth_fields, now=resolved_now)
     connect_state = _connect_state_entitlement(store, now=resolved_now)
+    is_healthy_profile = isinstance(oauth_health, dict) and oauth_health.get("state") == "healthy"
+    has_profile_backed_bundle = bundle is not None and bool(bundle.get("allowed")) and is_healthy_profile
+    if connect_state is not None and not has_profile_backed_bundle:
+        return connect_state
+    if _requires_guard_cloud_connect(store, bundle=bundle, oauth=oauth):
+        if bundle is not None and bool(bundle.get("allowed")):
+            return _reconnect_required_entitlement(bundle=bundle, oauth=oauth, oauth_payload=oauth_payload)
+        return _connect_required_entitlement(store)
     if bundle is not None and bool(bundle.get("allowed")):
         return bundle
     if oauth is not None and bool(oauth.get("allowed")):
         return oauth
     if oauth is not None and oauth.get("reason") == "guard_cloud_reconnect_required":
         return oauth
-    if connect_state is not None:
-        return connect_state
-    if _requires_guard_cloud_connect(store, bundle=bundle, oauth=oauth):
-        return _connect_required_entitlement(store)
     if bundle is not None:
         return bundle
     if oauth is not None:

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -444,6 +444,38 @@ def test_paid_metadata_without_usable_local_auth_still_prefers_connect_over_upgr
     }
 
 
+def test_cached_paid_bundle_does_not_hide_retry_required_connect_state(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {
+            "tier": "premium",
+        },
+        "2026-06-05T01:39:51+00:00",
+    )
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-05T01:39:51+00:00",
+        request_id="connect-1",
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-06-05T01:40:10+00:00",
+        reason="Guard authorization expired. Run `hol-guard connect` again.",
+    )
+
+    entitlement = resolve_package_firewall_entitlement(store)
+
+    assert entitlement == {
+        "allowed": False,
+        "reason": "guard_cloud_reconnect_required",
+        "tier": "unknown",
+        "upgrade_cta": "Reconnect HOL Guard Cloud to refresh package firewall access.",
+    }
+
+
 def test_sync_local_guard_cloud_proof_repairs_degraded_oauth_from_encrypted_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- make retry/expired Guard Cloud connect state override cached paid bundle entitlement unless a usable cloud profile exists
- keep profile-backed self-heal and local approval-gate install behavior intact
- add regression coverage for cached bundle plus retry-required connect state

## Tests
- pytest tests/test_guard_connect_flow.py tests/test_guard_package_shims_cli.py -q
