### PR TITLE
fix(guard): require reconnect when oauth state is missing

### DIFF
--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -152,11 +152,19 @@ def _connect_state_entitlement(store: GuardStore, *, now: datetime) -> dict[str,
         return None
     status = _optional_string(latest_state.get("status"))
     milestone = _optional_string(latest_state.get("milestone"))
-    if status not in {"retry_required", "expired"} and milestone not in {
-        "first_sync_failed",
-        "expired",
-        "sync_not_available",
-    }:
+    missing_oauth_after_success = (
+        status == "connected" and milestone == "first_sync_succeeded" and not isinstance(oauth_payload, dict)
+    )
+    if (
+        not missing_oauth_after_success
+        and status not in {"retry_required", "expired"}
+        and milestone
+        not in {
+            "first_sync_failed",
+            "expired",
+            "sync_not_available",
+        }
+    ):
         return None
     tier = "unknown"
     if isinstance(oauth_fields, dict):

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -476,6 +476,40 @@ def test_cached_paid_bundle_does_not_hide_retry_required_connect_state(tmp_path:
     }
 
 
+def test_cached_paid_bundle_does_not_hide_missing_oauth_after_success(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {
+            "tier": "premium",
+        },
+        "2026-06-15T18:38:57+00:00",
+    )
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-15T00:52:39+00:00",
+        request_id="connect-1",
+    )
+    store.record_latest_guard_connect_sync_success(
+        sync_payload={
+            "synced_at": "2026-06-15T18:38:57+00:00",
+            "receipts_stored": 11,
+            "inventory_items": 261,
+        },
+        now="2026-06-15T18:38:57+00:00",
+    )
+
+    entitlement = resolve_package_firewall_entitlement(store)
+
+    assert entitlement == {
+        "allowed": False,
+        "reason": "guard_cloud_reconnect_required",
+        "tier": "unknown",
+        "upgrade_cta": "Reconnect HOL Guard Cloud to refresh package firewall access.",
+    }
+
+
 def test_sync_local_guard_cloud_proof_repairs_degraded_oauth_from_encrypted_fallback(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- treat a previously successful Guard Cloud connect with missing local OAuth credentials as reconnect-required
- prevent cached paid supply-chain bundle entitlement from hiding the reconnect state
- add regression coverage for the missing-OAuth-after-success local state

## Tests
- pytest tests/test_guard_connect_flow.py tests/test_guard_package_shims_cli.py -q
