### PR TITLE
fix(guard): normalize runtime connect state without oauth

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1109,10 +1109,6 @@ def _runtime_proof_status_name(
     reason: str | None,
     proof: Mapping[str, object],
 ) -> str:
-    if milestone == "first_sync_succeeded" or proof.get("first_synced_at"):
-        return "synced"
-    if milestone == "sync_not_available":
-        return "sync_unavailable"
     if status == "retry_required" or milestone == "first_sync_failed":
         if connect_retry_refresh_race_from_reason(reason):
             return "stalled"
@@ -1123,6 +1119,10 @@ def _runtime_proof_status_name(
         return "expired"
     if milestone == "waiting_for_browser" or status == "waiting":
         return "waiting"
+    if milestone == "first_sync_succeeded" or proof.get("first_synced_at"):
+        return "synced"
+    if milestone == "sync_not_available":
+        return "sync_unavailable"
     return "not_connected"
 
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -5320,6 +5320,15 @@ class GuardStore:
         now: str,
     ) -> dict[str, object] | None:
         if cloud_profile is None:
+            if latest_state is not None and self._guard_connect_state_requires_oauth(latest_state):
+                return self._coerce_guard_connect_state_status(
+                    state=latest_state,
+                    status="retry_required",
+                    milestone="first_sync_failed",
+                    reason="Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again.",
+                    sync_summary=sync_summary,
+                    now=now,
+                )
             return latest_state
         normalized = self._hydrate_guard_connect_state_from_cloud_profile(
             latest_state=latest_state,
@@ -5355,6 +5364,13 @@ class GuardStore:
                 now=now,
             )
         return normalized
+
+    def _guard_connect_state_requires_oauth(self, latest_state: dict[str, object]) -> bool:
+        request_id = latest_state.get("request_id")
+        if not isinstance(request_id, str) or not request_id.strip():
+            return False
+        status = str(latest_state.get("status") or "")
+        return status == "connected"
 
     def _hydrate_guard_connect_state_from_cloud_profile(
         self,

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -422,6 +422,7 @@ def test_runtime_snapshot_exposes_cloud_policy_bundle_fields(tmp_path: Path) -> 
 
 def test_runtime_snapshot_exposes_latest_connect_proof_without_pairing_secrets(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
     request_id = "connect-imported-state"
     with store._connect() as connection:
         connection.execute(
@@ -502,6 +503,68 @@ def test_runtime_snapshot_exposes_latest_connect_proof_without_pairing_secrets(t
     }
 
 
+def test_runtime_snapshot_marks_connected_state_retry_required_when_oauth_missing(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    request_id = "connect-missing-oauth"
+    with store._connect() as connection:
+        connection.execute(
+            """
+            insert into guard_connect_states (
+              request_id,
+              sync_url,
+              allowed_origin,
+              status,
+              milestone,
+              reason,
+              created_at,
+              updated_at,
+              expires_at,
+              completed_at,
+              proof_json
+            )
+            values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                request_id,
+                "https://hol.org/api/guard/receipts/sync",
+                "https://hol.org",
+                "connected",
+                "first_sync_succeeded",
+                None,
+                "2026-04-24T00:00:00+00:00",
+                "2026-04-24T00:02:00+00:00",
+                "2026-04-24T00:05:00+00:00",
+                "2026-04-24T00:01:00+00:00",
+                json.dumps(
+                    {
+                        "pairing_completed_at": "2026-04-24T00:01:00+00:00",
+                        "first_synced_at": "2026-04-24T00:02:00+00:00",
+                        "receipts_stored": 3,
+                        "inventory_items": 5,
+                    }
+                ),
+            ),
+        )
+
+    snapshot = build_runtime_snapshot(
+        store=store,
+        approval_center_url=None,
+        now="2026-04-24T00:03:00+00:00",
+    )
+    latest_connect_state = snapshot["latest_connect_state"]
+
+    assert isinstance(latest_connect_state, dict)
+    assert latest_connect_state["request_id"] == request_id
+    assert latest_connect_state["status"] == "retry_required"
+    assert latest_connect_state["milestone"] == "first_sync_failed"
+    assert latest_connect_state["reason"] == (
+        "Guard Cloud authorization on this machine is incomplete. Run hol-guard connect again."
+    )
+    assert snapshot["cloud_state"] == "local_only"
+    assert snapshot["sync_configured"] is False
+    assert snapshot["proof_status"]["state"] == "failed"
+
+
 @pytest.mark.parametrize(
     ("status", "milestone", "expected_state", "expected_label", "expected_detail"),
     [
@@ -547,6 +610,8 @@ def test_runtime_snapshot_uses_oauth_connect_copy_for_proof_statuses(
     expected_detail: str,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
+    if status == "connected":
+        _seed_guard_cloud(store, workspace_id="workspace-alpha")
     request_id = f"connect-{expected_state}"
     with store._connect() as connection:
         connection.execute(


### PR DESCRIPTION
## Summary
- normalize OAuth-backed runtime connect state to retry-required when local OAuth credentials are missing
- make runtime proof status prioritize current retry/waiting/expired state over stale proof timestamps
- add regression coverage for dashboard runtime snapshots with missing OAuth after prior sync success

## Tests
- pytest tests/test_guard_cloud_local_sync.py tests/test_guard_package_firewall_entitlement.py tests/test_guard_connect_flow.py tests/test_guard_package_shims_cli.py -q
- python3 -m ruff format --check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/approvals.py tests/test_guard_cloud_local_sync.py
