### PR TITLE
fix(guard): coalesce cloud connect browser starts

### DIFF
--- a/dashboard/src/evidence/evidence-insights-share-modal.tsx
+++ b/dashboard/src/evidence/evidence-insights-share-modal.tsx
@@ -15,7 +15,7 @@ import {
 } from "../guard-api";
 import { ConnectFlowCard } from "../supply-chain-firewall-views";
 import {
-  openPackageFirewallAuthorizeWindow,
+  openPackageFirewallAuthorizeFallback,
   PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE,
 } from "../package-firewall-connect-browser";
 import { EvidenceInsightsShareSheet } from "./evidence-insights-share-sheet";
@@ -85,7 +85,7 @@ export function EvidenceInsightsShareModal({
   }, [cloudConnected, refreshConnectState]);
 
   useEffect(() => {
-    if (connectFlow?.state !== "running") {
+    if (connectFlow?.state !== "running" && connectFlow?.state !== "starting") {
       return;
     }
     const handle = window.setTimeout(() => {
@@ -102,7 +102,10 @@ export function EvidenceInsightsShareModal({
       setConnectFlow(status.connect_flow);
       if (
         status.connect_flow?.authorize_url &&
-        !openPackageFirewallAuthorizeWindow(status.connect_flow.authorize_url)
+        !openPackageFirewallAuthorizeFallback(
+          status.connect_flow.authorize_url,
+          status.connect_flow.browser_opened,
+        )
       ) {
         setConnectError(PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE);
       }

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2371,7 +2371,7 @@ function normalizePackageFirewallConnectFlow(
     return null;
   }
   const state = value.state;
-  if (state !== "idle" && state !== "running" && state !== "failed") {
+  if (state !== "idle" && state !== "starting" && state !== "running" && state !== "failed") {
     return null;
   }
   const title = stringValue(value.title);

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -765,7 +765,7 @@ export type PackageFirewallCliFallback = {
 };
 
 export type PackageFirewallConnectFlow = {
-  state: "idle" | "running" | "failed";
+  state: "idle" | "starting" | "running" | "failed";
   title: string;
   detail: string;
   action_label: string;

--- a/dashboard/src/package-firewall-connect-browser.test.ts
+++ b/dashboard/src/package-firewall-connect-browser.test.ts
@@ -1,4 +1,5 @@
 import {
+  openPackageFirewallAuthorizeFallback,
   openPackageFirewallAuthorizeWindow,
   PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE,
 } from "./package-firewall-connect-browser";
@@ -29,6 +30,25 @@ assert(
   openedUrls[0] === "https://hol.org/api/guard/oauth/authorize?client_id=test",
   "expected authorize URL to be passed to window.open",
 );
+
+openedUrls.length = 0;
+assert(
+  openPackageFirewallAuthorizeFallback(
+    "https://hol.org/api/guard/oauth/authorize?client_id=test",
+    true,
+  ),
+  "daemon-opened browser flow should be treated as handled",
+);
+assert(openedUrls.length === 0, "daemon-opened browser flow should not call window.open");
+
+assert(
+  openPackageFirewallAuthorizeFallback(
+    "https://hol.org/api/guard/oauth/authorize?client_id=test",
+    false,
+  ),
+  "daemon-blocked browser flow should open dashboard fallback window",
+);
+assert(openedUrls.length === 1, "daemon-blocked browser flow should call window.open once");
 
 openedUrls.length = 0;
 assert(!openPackageFirewallAuthorizeWindow(null), "null authorize URL should not open");

--- a/dashboard/src/package-firewall-connect-browser.ts
+++ b/dashboard/src/package-firewall-connect-browser.ts
@@ -14,3 +14,13 @@ export function openPackageFirewallAuthorizeWindow(
   }
   return false;
 }
+
+export function openPackageFirewallAuthorizeFallback(
+  authorizeUrl: string | null | undefined,
+  browserOpened: boolean | null | undefined,
+): boolean {
+  if (browserOpened === true) {
+    return true;
+  }
+  return openPackageFirewallAuthorizeWindow(authorizeUrl);
+}

--- a/dashboard/src/package-firewall-connect.test.tsx
+++ b/dashboard/src/package-firewall-connect.test.tsx
@@ -67,6 +67,32 @@ assert(
   "PF1: compact connect state should not render the nested security card",
 );
 
+const startingMarkup = renderToStaticMarkup(
+  <ConnectFlowCard
+    compact
+    connectError={null}
+    connectStarting={false}
+    connectFlow={{
+      state: "starting",
+      title: "Finish Guard Cloud sign-in in your browser",
+      detail: "HOL Guard is opening the secure sign-in flow in your browser.",
+      action_label: "Repair Guard Cloud access",
+      connect_url: "https://hol.org/guard/connect",
+      authorize_url: null,
+      browser_opened: false,
+      request_id: "guard-connect-2",
+      poll_after_ms: 1500,
+    }}
+    mode="repair"
+    onStartConnect={() => undefined}
+  />,
+);
+
+assert(
+  !startingMarkup.includes("Open sign-in page"),
+  "PF2: starting connect card should not link to generic connect before authorize URL exists",
+);
+
 const connectRequiredStatus: PackageFirewallStatusResponse = {
   operation: "status",
   status: "completed",

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -24,7 +24,7 @@ import {
   resolveApprovalGateSyncFailure,
 } from "./harness-action-errors";
 import {
-  openPackageFirewallAuthorizeWindow,
+  openPackageFirewallAuthorizeFallback,
   PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE,
 } from "./package-firewall-connect-browser";
 import { EntitlementNotice, ConnectFlowCard } from "./supply-chain-firewall-views";
@@ -258,7 +258,7 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
       return;
     }
     const flow = panelLoad.data.connect_flow;
-    if (flow === null || flow.state !== "running") {
+    if (flow === null || (flow.state !== "running" && flow.state !== "starting")) {
       return;
     }
     const handle = window.setTimeout(() => {
@@ -444,7 +444,10 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
       const connectFlow = await startPackageFirewallConnect();
       if (
         connectFlow?.authorize_url &&
-        !openPackageFirewallAuthorizeWindow(connectFlow.authorize_url)
+        !openPackageFirewallAuthorizeFallback(
+          connectFlow.authorize_url,
+          connectFlow.browser_opened,
+        )
       ) {
         setConnectError(PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE);
       }

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -231,7 +231,7 @@ function resolveConnectSteps(
   connectFlow: NonNullable<PackageFirewallStatusResponse["connect_flow"]>,
   purpose: "package_firewall" | "insights_share" | "audit" = "package_firewall",
 ): Array<{ body: string; current: boolean; done: boolean; title: string }> {
-  const running = connectFlow.state === "running";
+  const running = connectFlow.state === "running" || connectFlow.state === "starting";
   const failed = connectFlow.state === "failed";
   const browserOpened = connectFlow.browser_opened === true;
   const unlockCopy = resolveConnectUnlockCopy(purpose);
@@ -329,7 +329,7 @@ export function ConnectFlowCard({
   purpose = "package_firewall",
 }: ConnectFlowCardProps) {
   const manualHref = connectFlow.authorize_url ?? connectFlow.connect_url;
-  const running = connectFlow.state === "running";
+  const running = connectFlow.state === "running" || connectFlow.state === "starting";
   const failed = connectFlow.state === "failed";
   const primaryBusy = connectStarting || running;
   const primaryLabel = resolveConnectPrimaryLabel({

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -328,9 +328,9 @@ export function ConnectFlowCard({
   onStartConnect,
   purpose = "package_firewall",
 }: ConnectFlowCardProps) {
-  const manualHref = connectFlow.authorize_url ?? connectFlow.connect_url;
   const running = connectFlow.state === "running" || connectFlow.state === "starting";
   const failed = connectFlow.state === "failed";
+  const manualHref = connectFlow.authorize_url ?? (failed ? connectFlow.connect_url : null);
   const primaryBusy = connectStarting || running;
   const primaryLabel = resolveConnectPrimaryLabel({
     actionLabel: connectFlow.action_label,
@@ -340,7 +340,7 @@ export function ConnectFlowCard({
   const steps = resolveConnectSteps(connectFlow, purpose);
   const statusTone = running ? "blue" : mode === "repair" ? "attention" : "blue";
   const statusLabel = running ? "Waiting for approval" : mode === "repair" ? "Repair required" : "Connection required";
-  const showManualLink = connectFlow.authorize_url !== null || running || failed;
+  const showManualLink = manualHref !== null;
   const titleCopy = headline ?? connectFlow.title;
   const detailCopy = detail ?? connectFlow.detail;
   if (minimal) {

--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -81,6 +81,8 @@ def _queue_local_protect_approvals(
 def _should_queue_local_protect_approval(response_payload: dict[str, object]) -> bool:
     if os.environ.get(SHIM_PROBE_ENV_VAR) == SHIM_PROBE_ENV_VALUE:
         return False
+    if os.environ.get("PYTEST_CURRENT_TEST") and os.environ.get("HOL_GUARD_TEST_SKIP_LOCAL_APPROVAL_QUEUE") == "1":
+        return False
     return not _protect_has_reason_code(response_payload, "saved_package_block")
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -681,7 +681,7 @@ def _set_package_firewall_connect_state(server: _GuardDaemonHttpServer, state: d
         server.package_firewall_connect_state = dict(state) if isinstance(state, dict) else None
 
 
-def _guard_cloud_connect_state_is_in_flight(state: dict[str, object] | None) -> bool:
+def _guard_cloud_connect_state_is_in_flight(state: dict[str, object] | None) -> TypeGuard[dict[str, object]]:
     return isinstance(state, dict) and str(state.get("state") or "") in {"starting", "running"}
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -909,7 +909,9 @@ def _resolve_guard_cloud_connect_flow(*, server: _GuardDaemonHttpServer, store: 
     if not _guard_cloud_connect_required_for_insights(store):
         return None
     repair_mode = _guard_cloud_connect_repair_mode(store)
-    current = _copy_guard_cloud_connect_state(server)
+    cloud_current = _copy_guard_cloud_connect_state(server)
+    package_current = _copy_package_firewall_connect_state(server)
+    current = package_current if _guard_cloud_connect_state_is_in_flight(package_current) else cloud_current
     if current is None:
         return _default_guard_cloud_connect_flow(store=store, repair_mode=repair_mode)
     state = str(current.get("state") or "idle")

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -245,6 +245,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
     package_firewall_connect_state_lock: threading.Lock
     guard_cloud_connect_state: dict[str, object] | None
     guard_cloud_connect_state_lock: threading.Lock
+    guard_cloud_browser_session_lock: threading.Lock
     package_firewall_action_rate_limiter: PackageFirewallActionRateLimiter
     package_firewall_session_nonces: dict[str, float]
     package_firewall_session_nonces_lock: threading.Lock
@@ -277,6 +278,7 @@ class _GuardDaemonHttpServer(ThreadingHTTPServer):
         self.package_firewall_connect_state_lock = threading.Lock()
         self.guard_cloud_connect_state = None
         self.guard_cloud_connect_state_lock = threading.Lock()
+        self.guard_cloud_browser_session_lock = threading.Lock()
         self.package_firewall_action_rate_limiter = PackageFirewallActionRateLimiter()
         self.package_firewall_session_nonces = {}
         self.package_firewall_session_nonces_lock = threading.Lock()
@@ -679,15 +681,22 @@ def _set_package_firewall_connect_state(server: _GuardDaemonHttpServer, state: d
         server.package_firewall_connect_state = dict(state) if isinstance(state, dict) else None
 
 
+def _guard_cloud_connect_state_is_in_flight(state: dict[str, object] | None) -> bool:
+    return isinstance(state, dict) and str(state.get("state") or "") in {"starting", "running"}
+
+
 def _begin_package_firewall_connect_state(
     server: _GuardDaemonHttpServer,
     starting_state: dict[str, object],
 ) -> tuple[bool, dict[str, object]]:
-    with server.package_firewall_connect_state_lock:
-        current = server.package_firewall_connect_state
-        if isinstance(current, dict) and str(current.get("state") or "") in {"starting", "running"}:
+    with server.guard_cloud_browser_session_lock:
+        current = _copy_package_firewall_connect_state(server)
+        if _guard_cloud_connect_state_is_in_flight(current):
             return False, dict(current)
-        server.package_firewall_connect_state = dict(starting_state)
+        current = _copy_guard_cloud_connect_state(server)
+        if _guard_cloud_connect_state_is_in_flight(current):
+            return False, dict(current)
+        _set_package_firewall_connect_state(server, starting_state)
         return True, dict(starting_state)
 
 
@@ -834,11 +843,14 @@ def _begin_guard_cloud_connect_state(
     server: _GuardDaemonHttpServer,
     starting_state: dict[str, object],
 ) -> tuple[bool, dict[str, object]]:
-    with server.guard_cloud_connect_state_lock:
-        current = server.guard_cloud_connect_state
-        if isinstance(current, dict) and str(current.get("state") or "") in {"starting", "running"}:
+    with server.guard_cloud_browser_session_lock:
+        current = _copy_guard_cloud_connect_state(server)
+        if _guard_cloud_connect_state_is_in_flight(current):
             return False, dict(current)
-        server.guard_cloud_connect_state = dict(starting_state)
+        current = _copy_package_firewall_connect_state(server)
+        if _guard_cloud_connect_state_is_in_flight(current):
+            return False, dict(current)
+        _set_guard_cloud_connect_state(server, starting_state)
         return True, dict(starting_state)
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -793,9 +793,14 @@ def _resolve_package_firewall_connect_flow(
     reason = str(entitlement.get("reason") or "").strip().lower()
     if reason not in {"guard_cloud_connect_required", "guard_cloud_reconnect_required"}:
         return None
-    current = _copy_package_firewall_connect_state(server)
-    if current is None:
-        current = _copy_guard_cloud_connect_state(server)
+    package_current = _copy_package_firewall_connect_state(server)
+    cloud_current = _copy_guard_cloud_connect_state(server)
+    if _guard_cloud_connect_state_is_in_flight(cloud_current):
+        current = cloud_current
+    elif package_current is not None:
+        current = package_current
+    else:
+        current = cloud_current
     if current is None:
         return _default_package_firewall_connect_flow(store=server.store, reason=reason)
     state = str(current.get("state") or "idle")

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -679,6 +679,18 @@ def _set_package_firewall_connect_state(server: _GuardDaemonHttpServer, state: d
         server.package_firewall_connect_state = dict(state) if isinstance(state, dict) else None
 
 
+def _begin_package_firewall_connect_state(
+    server: _GuardDaemonHttpServer,
+    starting_state: dict[str, object],
+) -> tuple[bool, dict[str, object]]:
+    with server.package_firewall_connect_state_lock:
+        current = server.package_firewall_connect_state
+        if isinstance(current, dict) and str(current.get("state") or "") in {"starting", "running"}:
+            return False, dict(current)
+        server.package_firewall_connect_state = dict(starting_state)
+        return True, dict(starting_state)
+
+
 def _default_package_firewall_connect_flow(
     *,
     store: GuardStore,
@@ -782,7 +794,7 @@ def _resolve_package_firewall_connect_flow(
         **_default_package_firewall_connect_flow(store=server.store, reason=reason),
         **current,
     }
-    if state == "running":
+    if state in {"starting", "running"}:
         flow["title"] = "Finish Guard Cloud sign-in in your browser"
         browser_opened = flow.get("browser_opened") is True
         flow["detail"] = (
@@ -790,8 +802,12 @@ def _resolve_package_firewall_connect_flow(
             "unlock package-firewall controls automatically."
             if browser_opened
             else (
-                "HOL Guard is waiting for browser approval. Open the sign-in page below if your browser did "
-                "not open automatically."
+                "HOL Guard is opening the secure sign-in flow in your browser."
+                if state == "starting"
+                else (
+                    "HOL Guard is waiting for browser approval. Open the sign-in page below if your browser did "
+                    "not open automatically."
+                )
             )
         )
         flow["poll_after_ms"] = _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS
@@ -812,6 +828,18 @@ def _copy_guard_cloud_connect_state(server: _GuardDaemonHttpServer) -> dict[str,
 def _set_guard_cloud_connect_state(server: _GuardDaemonHttpServer, state: dict[str, object] | None) -> None:
     with server.guard_cloud_connect_state_lock:
         server.guard_cloud_connect_state = dict(state) if isinstance(state, dict) else None
+
+
+def _begin_guard_cloud_connect_state(
+    server: _GuardDaemonHttpServer,
+    starting_state: dict[str, object],
+) -> tuple[bool, dict[str, object]]:
+    with server.guard_cloud_connect_state_lock:
+        current = server.guard_cloud_connect_state
+        if isinstance(current, dict) and str(current.get("state") or "") in {"starting", "running"}:
+            return False, dict(current)
+        server.guard_cloud_connect_state = dict(starting_state)
+        return True, dict(starting_state)
 
 
 def _guard_cloud_connect_repair_mode_from_health(oauth_health: dict[str, object]) -> bool:
@@ -872,7 +900,7 @@ def _resolve_guard_cloud_connect_flow(*, server: _GuardDaemonHttpServer, store: 
         **_default_guard_cloud_connect_flow(store=store, repair_mode=repair_mode),
         **current,
     }
-    if state == "running":
+    if state in {"starting", "running"}:
         flow["title"] = "Finish Guard Cloud sign-in in your browser"
         browser_opened = flow.get("browser_opened") is True
         flow["detail"] = (
@@ -880,8 +908,12 @@ def _resolve_guard_cloud_connect_flow(*, server: _GuardDaemonHttpServer, store: 
             "unlock public sharing automatically."
             if browser_opened
             else (
-                "HOL Guard is waiting for browser approval. Open the sign-in page below if your browser did "
-                "not open automatically."
+                "HOL Guard is opening the secure sign-in flow in your browser."
+                if state == "starting"
+                else (
+                    "HOL Guard is waiting for browser approval. Open the sign-in page below if your browser did "
+                    "not open automatically."
+                )
             )
         )
         flow["poll_after_ms"] = _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS
@@ -2549,16 +2581,31 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 status=409,
             )
             return
-        current = _copy_package_firewall_connect_state(self.server)  # type: ignore[arg-type]
-        if isinstance(current, dict) and str(current.get("state") or "") == "running":
-            self._write_json(current, status=202)
-            return
         store = self.server.store  # type: ignore[attr-defined]
         connect_url = _package_firewall_connect_url(store)
         action_label = _package_firewall_connect_action_label(
             reason,
             repair_copy=_package_firewall_connect_needs_repair(store, reason),
         )
+        request_id = f"guard-connect-{uuid.uuid4().hex}"
+        starting_state = {
+            **_default_package_firewall_connect_flow(store=store, reason=reason),
+            "state": "starting",
+            "title": "Opening Guard Cloud sign-in",
+            "detail": "HOL Guard is opening the secure sign-in flow in your browser.",
+            "action_label": action_label,
+            "authorize_url": None,
+            "browser_opened": None,
+            "request_id": request_id,
+            "poll_after_ms": _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS,
+        }
+        started, current = _begin_package_firewall_connect_state(  # type: ignore[arg-type]
+            self.server,
+            starting_state,
+        )
+        if not started:
+            self._write_json(current, status=202)
+            return
         try:
             prepare_guard_cloud_connect_authorization(store)
             device = store.get_device_metadata()
@@ -2580,7 +2627,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json(failure, status=500)
             return
 
-        request_id = f"guard-connect-{uuid.uuid4().hex}"
         running_state = {
             **_default_package_firewall_connect_flow(store=store, reason=reason),
             "state": "running",
@@ -2719,12 +2765,27 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             )
             return
         repair_mode = _guard_cloud_connect_repair_mode(store)
-        current = _copy_guard_cloud_connect_state(self.server)  # type: ignore[arg-type]
-        if isinstance(current, dict) and str(current.get("state") or "") == "running":
-            self._write_json({"connect_required": True, "connect_flow": current}, status=202)
-            return
         connect_url = _package_firewall_connect_url(store)
         action_label = "Repair Guard Cloud access" if repair_mode else "Connect Guard Cloud"
+        request_id = f"guard-connect-{uuid.uuid4().hex}"
+        starting_state = {
+            **_default_guard_cloud_connect_flow(store=store, repair_mode=repair_mode),
+            "state": "starting",
+            "title": "Opening Guard Cloud sign-in",
+            "detail": "HOL Guard is opening the secure sign-in flow in your browser.",
+            "action_label": action_label,
+            "authorize_url": None,
+            "browser_opened": None,
+            "request_id": request_id,
+            "poll_after_ms": _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS,
+        }
+        started, current = _begin_guard_cloud_connect_state(  # type: ignore[arg-type]
+            self.server,
+            starting_state,
+        )
+        if not started:
+            self._write_json({"connect_required": True, "connect_flow": current}, status=202)
+            return
         try:
             prepare_guard_cloud_connect_authorization(store)
             device = store.get_device_metadata()
@@ -2749,7 +2810,6 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             )
             return
 
-        request_id = f"guard-connect-{uuid.uuid4().hex}"
         running_state = {
             **_default_guard_cloud_connect_flow(store=store, repair_mode=repair_mode),
             "state": "running",

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2706,13 +2706,42 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
 _test_sync_auth_context_override: dict[str, object] | None = None
 
 
+def _test_sync_auth_context_from_env() -> dict[str, object] | None:
+    if not os.environ.get("PYTEST_CURRENT_TEST"):
+        return None
+    raw = os.environ.get("HOL_GUARD_TEST_SYNC_AUTH_CONTEXT_JSON")
+    if raw is None:
+        return None
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    sync_url = payload.get("sync_url")
+    access_token = payload.get("access_token")
+    if not isinstance(sync_url, str) or not isinstance(access_token, str):
+        return None
+    sync_url = _validate_guard_sync_url(sync_url)
+    return {
+        "sync_url": sync_url,
+        "access_token": access_token,
+        "dpop_key_material": None,
+    }
+
+
 def _resolve_guard_sync_auth_context(
     store: GuardStore,
     *,
     allow_primary_repair: bool = True,
 ) -> dict[str, object]:
     if _test_sync_auth_context_override is not None:
-        return dict(_test_sync_auth_context_override)
+        override = dict(_test_sync_auth_context_override)
+        override["sync_url"] = _validate_guard_sync_url(_auth_context_sync_url(override))
+        return override
+    env_override = _test_sync_auth_context_from_env()
+    if env_override is not None:
+        return env_override
     with _guard_sync_auth_lock(store):
         oauth_health = store.get_oauth_local_credential_health()
         oauth_credentials = store.get_oauth_local_credentials(allow_primary=allow_primary_repair)

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -656,6 +656,20 @@ def _evaluate_with_cloud(
             None,
         )
     except GuardSyncNotConfiguredError:
+        if bool(store.get_oauth_local_credential_health().get("configured")):
+            return (
+                _cloud_fail_closed_evaluation(
+                    code="cloud_validation_error",
+                    message="Guard cloud evaluation endpoint was not trusted, so this package request needs review.",
+                    artifact=artifact,
+                    targets=targets,
+                    workspace_dir=workspace_dir,
+                    workspace_fingerprint=workspace_fingerprint,
+                    bundle_meta=bundle_meta,
+                    fail_closed_decision=resolve_fail_closed_decision(),
+                ),
+                None,
+            )
         return None, None
     except RuntimeError:
         if can_defer_auth_failure_to_bundle():

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3014,7 +3014,11 @@ class GuardStore:
                     key_id=key_id,
                     trusted_generation=_mapping_int(state, "generation"),
                 )
-                if integrity_result.status == "valid":
+                if integrity_result.status == "valid" or _warn_only_policy_integrity_status(
+                    integrity_result.status,
+                    state,
+                    source=str(candidate["source"]),
+                ):
                     selected_payload = self._policy_row_payload(
                         candidate,
                         integrity_result=integrity_result,
@@ -6303,11 +6307,11 @@ def _scoped_runtime_row_requires_exact_match(
 def _warn_only_policy_integrity_status(status: str, state: Mapping[str, object], *, source: str = "local") -> bool:
     if state.get("enforcement") != "warn":
         return False
+    if source != "approval-gate":
+        return False
     if status == "missing_integrity":
         return True
     if status != "degraded_mode":
-        return False
-    if source != "approval-gate":
         return False
     reasons = state.get("degraded_reasons")
     if not isinstance(reasons, list):

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -353,6 +353,9 @@ class SystemKeyringSecretStore:
         backend init error, etc.) is allowed to propagate so callers can surface
         it rather than silently degrading credential storage.
         """
+        test_keyring = SystemKeyringSecretStore._test_keyring_module()
+        if test_keyring is not None:
+            return test_keyring
         try:
             return importlib.import_module("keyring")
         except ModuleNotFoundError as exc:
@@ -377,6 +380,67 @@ class SystemKeyringSecretStore:
                 exc_info=True,
             )
             return None
+
+    @staticmethod
+    def _test_keyring_module():
+        if not os.environ.get("PYTEST_CURRENT_TEST"):
+            return None
+        store_path_raw = os.environ.get("HOL_GUARD_TEST_KEYRING_FILE", "").strip()
+        if not store_path_raw:
+            return None
+
+        class _TestKeyringModule:
+            @staticmethod
+            def _store_path() -> Path:
+                return Path(store_path_raw)
+
+            @classmethod
+            def _load(cls) -> dict[tuple[str, str], str]:
+                store_path = cls._store_path()
+                if not store_path.is_file():
+                    return {}
+                payload = json.loads(store_path.read_text(encoding="utf-8"))
+                return {
+                    (str(service_name), str(secret_id)): str(secret_value)
+                    for service_name, secrets in payload.items()
+                    if isinstance(service_name, str) and isinstance(secrets, dict)
+                    for secret_id, secret_value in secrets.items()
+                    if isinstance(secret_id, str) and isinstance(secret_value, str)
+                }
+
+            @classmethod
+            def _persist(cls, secrets: dict[tuple[str, str], str]) -> None:
+                payload: dict[str, dict[str, str]] = {}
+                for (service_name, secret_id), secret_value in secrets.items():
+                    payload.setdefault(service_name, {})[secret_id] = secret_value
+                store_path = cls._store_path()
+                store_path.parent.mkdir(parents=True, exist_ok=True)
+                store_path.write_text(json.dumps(payload, sort_keys=True, separators=(",", ":")), encoding="utf-8")
+
+            @staticmethod
+            def get_keyring():
+                class _Backend:
+                    priority = 1
+
+                return _Backend()
+
+            @classmethod
+            def set_password(cls, service_name: str, secret_id: str, value: str) -> None:
+                secrets = cls._load()
+                secrets[(service_name, secret_id)] = value
+                cls._persist(secrets)
+
+            @classmethod
+            def get_password(cls, service_name: str, secret_id: str) -> str | None:
+                return cls._load().get((service_name, secret_id))
+
+            @classmethod
+            def delete_password(cls, service_name: str, secret_id: str) -> None:
+                secrets = cls._load()
+                secrets.pop((service_name, secret_id), None)
+                cls._persist(secrets)
+
+        return _TestKeyringModule
 
     @staticmethod
     def _load_macos_keyring_api_module():
@@ -487,6 +551,8 @@ class SystemKeyringSecretStore:
 
     @classmethod
     def _is_available(cls) -> bool:
+        if cls._test_keyring_module() is not None:
+            return True
         if not cls._backend_is_available():
             return False
         if sys.platform == "darwin" and not cls._macos_default_keychain_is_usable():

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -400,7 +400,14 @@ def test_resolve_guard_home_does_not_migrate_retired_legacy_credentials(tmp_path
     legacy_home = home_dir / ".ai-plugin-scanner-guard"
     GuardStore(canonical_home)
     legacy_store = GuardStore(legacy_home)
-    _seed_guard_cloud(legacy_store)
+    legacy_store.set_sync_payload(
+        "credentials",
+        {
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "demo-token",
+        },
+        "2026-05-19T00:00:00Z",
+    )
     monkeypatch.setattr(Path, "home", lambda: home_dir)
 
     resolved_home = resolve_guard_home()

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -548,6 +548,8 @@ def _assert_connect_endpoint_coalesces_concurrent_browser_starts(
     *,
     endpoint: str,
     extract_flow,
+    second_endpoint: str | None = None,
+    second_extract_flow=None,
     timeout_message: str,
     store: GuardStore,
     monkeypatch: pytest.MonkeyPatch,
@@ -616,13 +618,13 @@ def _assert_connect_endpoint_coalesces_concurrent_browser_starts(
         second_status, second_payload = _read_json_response(
             _request(
                 daemon.port,
-                endpoint,
+                second_endpoint or endpoint,
                 token=token,
                 payload={},
             ),
         )
         assert second_status == 202
-        second_flow = extract_flow(second_payload)
+        second_flow = (second_extract_flow or extract_flow)(second_payload)
         assert isinstance(second_flow, dict)
         assert second_flow["state"] == "starting"
         assert second_flow["authorize_url"] is None
@@ -668,6 +670,38 @@ def test_package_firewall_connect_coalesces_concurrent_browser_starts(
     _assert_connect_endpoint_coalesces_concurrent_browser_starts(
         endpoint="/v1/supply-chain/package-shims/connect",
         extract_flow=lambda payload: payload,
+        timeout_message="Timed out waiting for first package-firewall session start",
+        store=store,
+        monkeypatch=monkeypatch,
+    )
+
+
+def test_guard_cloud_and_package_firewall_connect_share_in_flight_browser_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _assert_connect_endpoint_coalesces_concurrent_browser_starts(
+        endpoint="/v1/cloud/connect",
+        extract_flow=lambda payload: payload["connect_flow"],
+        second_endpoint="/v1/supply-chain/package-shims/connect",
+        second_extract_flow=lambda payload: payload,
+        timeout_message="Timed out waiting for first connect session start",
+        store=store,
+        monkeypatch=monkeypatch,
+    )
+
+
+def test_package_firewall_and_guard_cloud_connect_share_in_flight_browser_start(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _assert_connect_endpoint_coalesces_concurrent_browser_starts(
+        endpoint="/v1/supply-chain/package-shims/connect",
+        extract_flow=lambda payload: payload,
+        second_endpoint="/v1/cloud/connect",
+        second_extract_flow=lambda payload: payload["connect_flow"],
         timeout_message="Timed out waiting for first package-firewall session start",
         store=store,
         monkeypatch=monkeypatch,

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -753,6 +753,28 @@ def test_package_firewall_and_guard_cloud_connect_share_in_flight_browser_start(
     )
 
 
+def test_guard_cloud_connect_status_preserves_package_firewall_in_flight_flow(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    server = daemon._server
+    daemon_server._set_package_firewall_connect_state(
+        server,
+        {
+            "state": "starting",
+            "request_id": "shared-connect-request",
+            "authorize_url": None,
+            "browser_opened": False,
+        },
+    )
+
+    flow = daemon_server._resolve_guard_cloud_connect_flow(server=server, store=store)
+
+    assert flow is not None
+    assert flow["state"] == "starting"
+    assert flow["request_id"] == "shared-connect-request"
+    assert flow["poll_after_ms"] == 1500
+
+
 def test_supply_chain_package_firewall_status_reports_reconnect_gate_for_expired_cloud_auth(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -308,6 +308,51 @@ def test_supply_chain_package_firewall_status_reports_connect_gate_when_cloud_is
     }
 
 
+def test_supply_chain_package_firewall_status_prefers_active_cloud_connect_flow(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        daemon_server._set_package_firewall_connect_state(
+            daemon._server,
+            {
+                "state": "failed",
+                "request_id": "package-failed-1",
+                "authorize_url": None,
+                "browser_opened": False,
+                "message": "Previous package-firewall connect failed.",
+            },
+        )
+        daemon_server._set_guard_cloud_connect_state(
+            daemon._server,
+            {
+                "state": "running",
+                "request_id": "cloud-running-1",
+                "authorize_url": "https://hol.org/mock-authorize",
+                "browser_opened": True,
+            },
+        )
+        token = _dashboard_token_for(store)
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims",
+                method="GET",
+                token=token,
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 200
+    assert payload["entitlement"]["reason"] == "guard_cloud_connect_required"
+    assert payload["connect_flow"]["state"] == "running"
+    assert payload["connect_flow"]["request_id"] == "cloud-running-1"
+    assert payload["connect_flow"]["authorize_url"] == "https://hol.org/mock-authorize"
+
+
 def test_supply_chain_package_firewall_install_requires_cloud_connect_first(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -544,6 +544,136 @@ def test_guard_cloud_connect_starts_local_browser_flow_for_insights_share(
     assert store.get_cloud_sync_profile() is not None
 
 
+def _assert_connect_endpoint_coalesces_concurrent_browser_starts(
+    *,
+    endpoint: str,
+    extract_flow,
+    timeout_message: str,
+    store: GuardStore,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    session_started = threading.Event()
+    release_session = threading.Event()
+    opened_urls: list[str] = []
+    start_calls = 0
+
+    class _FakeSession:
+        authorize_url = "https://hol.org/mock-authorize"
+        redirect_uri = "http://127.0.0.1:53111/oauth/callback"
+        pkce_verifier = "pkce-verifier"
+        dpop_key_material = type(
+            "KeyMaterial",
+            (),
+            {
+                "private_key_pem": "private-key-new",
+                "public_jwk": {"kty": "EC", "crv": "P-256", "x": "x-value-new", "y": "y-value-new"},
+                "public_jwk_thumbprint": "thumbprint-new",
+            },
+        )()
+
+        def wait_for_callback(self, _timeout_seconds: float):
+            return None
+
+        def close(self) -> None:
+            return None
+
+    def _start_session_once(**_kwargs):
+        nonlocal start_calls
+        start_calls += 1
+        session_started.set()
+        assert release_session.wait(5), "Timed out waiting to release fake browser session"
+        return _FakeSession()
+
+    monkeypatch.setattr(daemon_server, "start_guard_browser_session", _start_session_once)
+    monkeypatch.setattr(daemon_server.webbrowser, "open", lambda url: opened_urls.append(url) or True)
+
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+        first_response: list[tuple[int, dict[str, object]]] = []
+        first_error: list[BaseException] = []
+
+        def _first_post() -> None:
+            try:
+                first_response.append(
+                    _read_json_response(
+                        _request(
+                            daemon.port,
+                            endpoint,
+                            token=token,
+                            payload={},
+                        ),
+                    )
+                )
+            except BaseException as error:  # pragma: no cover - assertion path
+                first_error.append(error)
+
+        first_thread = threading.Thread(target=_first_post, daemon=True)
+        first_thread.start()
+        assert session_started.wait(5), timeout_message
+
+        second_status, second_payload = _read_json_response(
+            _request(
+                daemon.port,
+                endpoint,
+                token=token,
+                payload={},
+            ),
+        )
+        assert second_status == 202
+        second_flow = extract_flow(second_payload)
+        assert isinstance(second_flow, dict)
+        assert second_flow["state"] == "starting"
+        assert second_flow["authorize_url"] is None
+
+        release_session.set()
+        first_thread.join(5)
+        assert not first_error
+        assert first_response
+        first_status, first_payload = first_response[0]
+        assert first_status == 202
+        first_flow = extract_flow(first_payload)
+        assert isinstance(first_flow, dict)
+        assert first_flow["state"] == "running"
+        assert first_flow["authorize_url"] == "https://hol.org/mock-authorize"
+        assert first_flow["request_id"] == second_flow["request_id"]
+    finally:
+        release_session.set()
+        daemon.stop()
+
+    assert start_calls == 1
+    assert opened_urls == ["https://hol.org/mock-authorize"]
+
+
+def test_guard_cloud_connect_coalesces_concurrent_browser_starts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _assert_connect_endpoint_coalesces_concurrent_browser_starts(
+        endpoint="/v1/cloud/connect",
+        extract_flow=lambda payload: payload["connect_flow"],
+        timeout_message="Timed out waiting for first connect session start",
+        store=store,
+        monkeypatch=monkeypatch,
+    )
+
+
+def test_package_firewall_connect_coalesces_concurrent_browser_starts(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _assert_connect_endpoint_coalesces_concurrent_browser_starts(
+        endpoint="/v1/supply-chain/package-shims/connect",
+        extract_flow=lambda payload: payload,
+        timeout_message="Timed out waiting for first package-firewall session start",
+        store=store,
+        monkeypatch=monkeypatch,
+    )
+
+
 def test_supply_chain_package_firewall_status_reports_reconnect_gate_for_expired_cloud_auth(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -215,6 +215,16 @@ def _seed_workspace_sync_credentials(home_dir: Path, sync_url: str, *, now: str 
     _seed_guard_cloud(GuardStore(home_dir), workspace_id=WORKSPACE_ID, sync_url=sync_url, now=now)
 
 
+def _with_subprocess_sync_auth(env: dict[str, str], sync_url: str) -> dict[str, str]:
+    env["HOL_GUARD_TEST_SYNC_AUTH_CONTEXT_JSON"] = json.dumps(
+        {
+            "sync_url": sync_url,
+            "access_token": "demo-token",
+        }
+    )
+    return env
+
+
 def _start_cloud_eval_server(
     *,
     decision: str,
@@ -899,39 +909,34 @@ def test_guard_package_shims_block_before_manager_execution(
     fake_bin.mkdir(parents=True, exist_ok=True)
     marker_path = tmp_path / f"{manager}-marker.json"
     write_fake_manager_script(fake_bin=fake_bin, manager=manager, marker_path=marker_path, exit_code=0)
-    server, thread, sync_url = _start_cloud_eval_server(
-        decision="allow",
+    sync_url = "http://127.0.0.1:9/api/guard/receipts/sync"
+    _seed_bundle(
+        home_dir=home_dir,
+        ecosystem=ecosystem,
         package_name=package_name,
-        evaluate_status=401,
+        package_version=package_version,
+        action="block",
     )
-    try:
-        _seed_bundle(
-            home_dir=home_dir,
-            ecosystem=ecosystem,
-            package_name=package_name,
-            package_version=package_version,
-            action="block",
-        )
-        _seed_workspace_sync_credentials(home_dir, sync_url)
-        shim_path = _install_single_manager_shim(
-            home_dir=home_dir,
-            workspace_dir=workspace_dir,
-            manager=manager,
-            capsys=capsys,
-        )
+    _seed_workspace_sync_credentials(home_dir, sync_url)
+    shim_path = _install_single_manager_shim(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        manager=manager,
+        capsys=capsys,
+    )
 
-        env = dict(os.environ)
-        env["PATH"] = os.pathsep.join(filter(None, [str(fake_bin), env.get("PATH")]))
-        result = subprocess.run(
-            [str(shim_path), *shim_args],
-            cwd=workspace_dir,
-            env=env,
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-    finally:
-        _stop_cloud_eval_server(server, thread)
+    env = _with_subprocess_sync_auth(dict(os.environ), sync_url)
+    env["HOL_GUARD_TEST_SKIP_LOCAL_APPROVAL_QUEUE"] = "1"
+    env["PATH"] = os.pathsep.join(filter(None, [str(fake_bin), env.get("PATH")]))
+    result = subprocess.run(
+        [str(shim_path), *shim_args],
+        cwd=workspace_dir,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=30,
+    )
 
     assert result.returncode != 0
     assert marker_path.exists() is False


### PR DESCRIPTION
## Summary
- Coalesce concurrent Guard Cloud connect starts so one user action cannot mint and open duplicate OAuth browser sessions.
- Share in-flight connect state across cloud and package-firewall connect endpoints while preserving dashboard fallback behavior.
- Prefer active shared cloud connect flows over stale package-firewall terminal states.
- Keep OAuth sync and package-shim subprocess tests hermetic so CI does not call live Guard Cloud or platform keychain services.
- Fail closed when configured Guard Cloud auth points at an invalid endpoint, while preserving local approvals only for backend-only degraded policy integrity.

## Testing
- `pytest tests/test_guard_headless_daemon_api.py -k 'guard_cloud_connect or package_firewall_connect_coalesces or share_in_flight or prefers_active_cloud_connect_flow' --tb=short`
- `pytest tests/test_guard_phase05_approval_memory.py::test_backend_degraded_warn_mode_honors_local_approval tests/test_guard_phase05_approval_memory.py::test_path_degraded_warn_mode_ignores_local_approval tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_rejects_untrusted_cloud_endpoint_before_network --tb=short`
- `pytest tests/test_guard_daemon_manager.py tests/test_guard_config_paths.py::test_resolve_guard_home_does_not_migrate_retired_legacy_credentials tests/test_guard_runtime.py::test_sync_receipts_rejects_untrusted_sync_host_before_network tests/test_guard_runtime.py::test_sync_runtime_session_rejects_non_https_legacy_sync_url_before_network tests/test_guard_runtime.py::test_sync_runtime_session_rejects_unallowlisted_legacy_sync_url_before_network tests/test_guard_package_shims.py::test_guard_package_shims_block_before_manager_execution --tb=short`
- `basedpyright --level error`
