### PR TITLE
fix(guard): tighten wrapper trust follow-up

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -258,6 +258,7 @@ def _run_guard_hook_command(
         args,
         action_envelope=action_envelope,
         config=config,
+        home_dir=context.home_dir,
         output_stream=output_stream,
         payload=payload,
         runtime_workspace=runtime_workspace,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -61,6 +61,7 @@ def _run_hook_generic_payload(
     *,
     action_envelope: GuardActionEnvelope | None,
     config: GuardConfig,
+    home_dir: Path | None,
     output_stream: TextIO | None = None,
     payload: Mapping[str, object],
     runtime_workspace: Path | None,
@@ -103,6 +104,7 @@ def _run_hook_generic_payload(
             payload_map.get("tool_name"),
             payload_map.get("tool_input", payload_map.get("arguments")),
             cwd=runtime_workspace,
+            home_dir=home_dir,
         )
     ):
         policy_action = "allow"

--- a/src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py
+++ b/src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py
@@ -463,7 +463,7 @@ def _trusted_symlink_component(path: Path) -> bool:
 
 
 def _path_is_non_writable(path: Path) -> bool:
-    return not path.stat().st_mode & 0o022
+    return not (path.stat().st_mode & 0o022)
 
 
 def _env_assignments_override_path(env_assignments: list[str] | tuple[str, ...]) -> bool:


### PR DESCRIPTION
## Summary
- Make the wrapper path writability check explicit with parenthesized mode masking.
- Pass home context into the generic hook benign-command classifier when evaluating shell wrapper trust.

## Testing
- `/opt/homebrew/bin/python3 -m pytest tests/test_guard_shell_command_wrappers.py tests/test_guard_risk.py::test_explicitly_benign_tool_action_request_requires_all_command_variants_to_be_benign -q`
- `/opt/homebrew/bin/python3 -m ruff format src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py src/codex_plugin_scanner/guard/cli/commands_hook_generic.py src/codex_plugin_scanner/guard/cli/commands_hook.py`
- `/opt/homebrew/bin/python3 -m ruff check src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py src/codex_plugin_scanner/guard/cli/commands_hook_generic.py src/codex_plugin_scanner/guard/cli/commands_hook.py`
