### PR TITLE
fix(guard): preserve generic hook helper callers

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -61,7 +61,7 @@ def _run_hook_generic_payload(
     *,
     action_envelope: GuardActionEnvelope | None,
     config: GuardConfig,
-    home_dir: Path | None,
+    home_dir: Path | None = None,
     output_stream: TextIO | None = None,
     payload: Mapping[str, object],
     runtime_workspace: Path | None,


### PR DESCRIPTION
## Summary
- Preserve direct generic hook helper callers by defaulting the optional home context.

## Testing
- `/opt/homebrew/bin/python3 -m py_compile src/codex_plugin_scanner/guard/cli/commands_hook_generic.py`
- `/opt/homebrew/bin/python3 -m pytest tests/test_guard_shell_command_wrappers.py tests/test_guard_risk.py::test_explicitly_benign_tool_action_request_requires_all_command_variants_to_be_benign -q`
- `/opt/homebrew/bin/python3 -m pytest tests/test_zcode_adapter.py tests/test_kimi_adapter.py tests/test_grok_adapter.py -q`
- `/opt/homebrew/bin/python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_hook_generic.py`
