### PR TITLE
test(guard): align degraded policy approval expectation

### DIFF
--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -735,7 +735,7 @@ def test_empty_degraded_reasons_do_not_honor_warn_only_policy() -> None:
     )
 
 
-def test_backend_degraded_warn_mode_honors_local_approval(tmp_path: Path) -> None:
+def test_backend_degraded_warn_mode_ignores_local_approval(tmp_path: Path) -> None:
     store = _store(tmp_path)
     store._policy_integrity_secret_store = None
     shell_request = _request("req-shell", artifact_id="codex:project:tool-action:shell", command="cat ~/.npmrc")
@@ -751,16 +751,15 @@ def test_backend_degraded_warn_mode_honors_local_approval(tmp_path: Path) -> Non
         now="2026-05-13T00:01:00+00:00",
     )
 
-    decision = store.resolve_policy_decision(
-        "codex",
-        shell_request.artifact_id,
-        "hash-retry",
-        now="2026-05-13T00:02:00+00:00",
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            shell_request.artifact_id,
+            "hash-retry",
+            now="2026-05-13T00:02:00+00:00",
+        )
+        is None
     )
-
-    assert decision is not None
-    assert decision["action"] == "allow"
-    assert decision["integrity_status"] == "degraded_mode"
 
 
 def test_path_degraded_warn_mode_ignores_local_approval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- Align degraded policy approval regression coverage with enforce-mode behavior.
- Confirm degraded local policy rows are ignored instead of reused as authorization.

## Testing
- `python3 -m pytest tests/test_guard_phase05_approval_memory.py::test_backend_degraded_warn_mode_ignores_local_approval tests/test_guard_phase05_approval_memory.py::test_path_degraded_warn_mode_ignores_local_approval tests/test_guard_policy_integrity.py::test_policies_cli_verify_status_migrate_and_repair --tb=short -q`
- `python3 -m ruff check tests/test_guard_phase05_approval_memory.py`
- `python3 -m ruff format --check tests/test_guard_phase05_approval_memory.py`
- `git diff --check`
