### PR TITLE
fix(guard): disable macos oauth fallback storage

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -844,6 +844,31 @@ class EncryptedFileSecretStore:
             return None
 
 
+class UnavailableSecretStore:
+    """Secret store placeholder for platforms without safe credential storage."""
+
+    def __init__(self, guard_home: Path | None = None) -> None:
+        self._legacy_fallback = EncryptedFileSecretStore(guard_home) if guard_home is not None else None
+
+    def set_secret(self, secret_id: str, value: str) -> None:
+        _ = (secret_id, value)
+        raise RuntimeError(
+            "Guard local credentials require an available OS credential store. "
+            "Fix the system credential store, then sign in again."
+        )
+
+    def get_secret(self, secret_id: str) -> str | None:
+        _ = secret_id
+        return None
+
+    def delete_secret(self, secret_id: str) -> None:
+        if self._legacy_fallback is None:
+            return
+        legacy_path = self._legacy_fallback._path_for(secret_id)
+        with suppress(OSError):
+            legacy_path.unlink()
+
+
 class FallbackSecretStore:
     """Fallback-capable secret store that tolerates primary backend failures."""
 
@@ -965,16 +990,22 @@ def _write_system_keyring_availability_cache(guard_home: Path, *, available: boo
             tmp_path.unlink()
 
 
-def _system_keyring_is_available(guard_home: Path) -> bool:
-    cached = _read_system_keyring_availability_cache(guard_home)
+def _system_keyring_is_available(guard_home: Path, *, use_cache: bool = True) -> bool:
+    cached = _read_system_keyring_availability_cache(guard_home) if use_cache else None
     if cached is not None:
         return cached
+    if not use_cache and sys.platform == "darwin":
+        SystemKeyringSecretStore._clear_macos_keychain_health_cache()
     available = SystemKeyringSecretStore._is_available()
     _write_system_keyring_availability_cache(guard_home, available=available)
     return available
 
 
 def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
+    if sys.platform == "darwin":
+        if _system_keyring_is_available(guard_home, use_cache=False):
+            return SystemKeyringSecretStore(service_name="hol-guard.oauth")
+        return UnavailableSecretStore(guard_home)
     fallback_store = EncryptedFileSecretStore(guard_home)
     if _system_keyring_is_available(guard_home):
         return FallbackSecretStore(
@@ -998,6 +1029,8 @@ def _secret_store_backend_name(secret_store: SecretStore) -> str:
         return "system-keyring"
     if isinstance(secret_store, EncryptedFileSecretStore):
         return "encrypted-file"
+    if isinstance(secret_store, UnavailableSecretStore):
+        return "unavailable"
     if isinstance(secret_store, FallbackSecretStore):
         return _secret_store_backend_name(secret_store.primary)
     return "unknown"
@@ -1087,6 +1120,16 @@ class GuardStore:
 
     def _assert_oauth_secret_persisted(self, secret_id: str, value: str) -> None:
         secret_store = self._oauth_secret_store
+        if sys.platform == "darwin" and isinstance(secret_store, SystemKeyringSecretStore):
+            persisted_value = self._get_secret_from_primary_store(secret_store, secret_id)
+            if persisted_value == value:
+                return
+            raise RuntimeError("Guard could not persist local Guard Cloud authorization securely.")
+        if isinstance(secret_store, UnavailableSecretStore):
+            raise RuntimeError(
+                "Guard local credentials require an available OS credential store. "
+                "Fix the system credential store, then sign in again."
+            )
         if isinstance(secret_store, FallbackSecretStore) and isinstance(
             secret_store.fallback,
             EncryptedFileSecretStore,
@@ -1139,6 +1182,9 @@ class GuardStore:
         self._cached_policy_integrity_secret_material = None
         self._cached_policy_integrity_control_state = None
 
+    def _oauth_primary_reads_are_no_ui_safe(self) -> bool:
+        return sys.platform == "darwin" and isinstance(self._oauth_secret_store, SystemKeyringSecretStore)
+
     def _get_secret_candidates(
         self,
         secret_store: SecretStore,
@@ -1164,11 +1210,7 @@ class GuardStore:
                     return [primary_token]
                 if fallback_token is not None and expected_hash_value is not None:
                     return []
-            primary_token = (
-                self._get_secret_from_primary_store(secret_store.primary, secret_id)
-                if prefer_fallback_first
-                else self._get_secret_from_store(secret_store.primary, secret_id)
-            )
+            primary_token = self._get_secret_from_primary_store(secret_store.primary, secret_id)
             if primary_token is not None:
                 if expected_hash_value is None or _secret_matches_hash(primary_token, expected_hash_value):
                     return [primary_token]
@@ -1180,7 +1222,7 @@ class GuardStore:
             if fallback_token is None:
                 return []
             return [fallback_token]
-        token = secret_store.get_secret(secret_id)
+        token = self._get_secret_from_primary_store(secret_store, secret_id)
         if token is None:
             return []
         return [token]
@@ -4963,6 +5005,7 @@ class GuardStore:
             self._oauth_secret_store.set_secret(self._oauth_local_credentials_ref, secret_json)
         self._mirror_oauth_secret_to_fallback(self._oauth_local_credentials_ref, secret_json)
         self._assert_oauth_secret_persisted(self._oauth_local_credentials_ref, secret_json)
+        self._remember_oauth_secret_payload(self._oauth_local_credentials_ref, secret_hash, secret_json)
         self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
 
     def get_oauth_local_credentials(self, *, allow_primary: bool = False) -> dict[str, object] | None:
@@ -4972,7 +5015,10 @@ class GuardStore:
         metadata = self._oauth_local_credentials_metadata(payload)
         if metadata is None:
             return None
-        secret_payload = self._load_oauth_secret_payload(payload, allow_primary=allow_primary)
+        secret_payload = self._load_oauth_secret_payload(
+            payload,
+            allow_primary=allow_primary or self._oauth_primary_reads_are_no_ui_safe(),
+        )
         if secret_payload is None:
             return None
         return self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload)
@@ -4996,6 +5042,11 @@ class GuardStore:
             secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)
             if isinstance(secret_ref, str) and secret_ref:
                 self._oauth_secret_store.delete_secret(secret_ref)
+                if sys.platform == "darwin":
+                    legacy_fallback = EncryptedFileSecretStore(self.guard_home)
+                    legacy_path = legacy_fallback._path_for(secret_ref)
+                    with suppress(OSError):
+                        legacy_path.unlink()
         self.delete_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
 
     def get_oauth_local_credential_health(self) -> dict[str, object]:
@@ -5017,9 +5068,17 @@ class GuardStore:
         if cached_health is not None:
             health.update(cached_health)
             return health
-        secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
+        secret_payload = self._load_oauth_secret_payload(
+            payload,
+            promote=False,
+            allow_primary=self._oauth_primary_reads_are_no_ui_safe(),
+        )
         if secret_payload is None and self.repair_oauth_local_credential_storage_from_primary():
-            secret_payload = self._load_oauth_secret_payload(payload, promote=False, allow_primary=False)
+            secret_payload = self._load_oauth_secret_payload(
+                payload,
+                promote=False,
+                allow_primary=self._oauth_primary_reads_are_no_ui_safe(),
+            )
         if secret_payload is None:
             health["state"] = "degraded"
             self._remember_oauth_health_result(secret_hash, health)

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -11,6 +11,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import _build_parser
+from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.cli import commands as guard_commands
 from codex_plugin_scanner.guard.cli import connect_flow
 from codex_plugin_scanner.guard.cli.commands import run_guard_command
@@ -787,12 +788,15 @@ def test_headless_connect_slows_down_polling_when_server_requests_it(tmp_path: P
     assert sleeps == [7]
 
 
-def test_headless_connect_avoids_keychain_password_prompts_when_system_keyring_is_available(
+def test_headless_connect_rejects_unreadable_macos_keychain_credentials_without_prompt(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     guard_home = tmp_path / "guard-home"
     _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(SystemKeyringSecretStore, "_macos_default_keychain_is_usable", classmethod(lambda cls: True))
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", lambda *args, **kwargs: None)
 
     def fail_on_keychain(*args: object, **kwargs: object) -> subprocess.CompletedProcess[str]:
         raise AssertionError("device connect should not shell out to macOS keychain prompts")
@@ -823,31 +827,28 @@ def test_headless_connect_avoids_keychain_password_prompts_when_system_keyring_i
         def read(self) -> bytes:
             return json.dumps(self._payload).encode("utf-8")
 
-    payload = connect_flow.run_guard_device_connect_command(
-        store=store,
-        connect_url="https://hol.org/guard/connect",
-        request_device_authorization=fake_request,
-        token_urlopen=lambda request, timeout: _Response(
-            {
-                "access_token": _fake_access_token(
-                    grant_id="grant-123",
-                    machine_id="machine-123",
-                    workspace_id="workspace-123",
-                ),
-                "refresh_token": "refresh-123",
-                "expires_in": 3600,
-                "scope": "guard:runtime.sync guard:offline_access",
-                "token_type": "Bearer",
-            }
-        ),
-        now="2026-06-01T12:00:00+00:00",
-    )
+    with pytest.raises(RuntimeError, match="persist local Guard Cloud authorization"):
+        connect_flow.run_guard_device_connect_command(
+            store=store,
+            connect_url="https://hol.org/guard/connect",
+            request_device_authorization=fake_request,
+            token_urlopen=lambda request, timeout: _Response(
+                {
+                    "access_token": _fake_access_token(
+                        grant_id="grant-123",
+                        machine_id="machine-123",
+                        workspace_id="workspace-123",
+                    ),
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                }
+            ),
+            now="2026-06-01T12:00:00+00:00",
+        )
 
-    assert payload["status"] == "connected"
-    credentials = store.get_oauth_local_credentials()
-    assert credentials is not None
-    assert credentials["refresh_token"] == "refresh-123"
-    assert credentials["grant_id"] == "grant-123"
+    assert store.get_oauth_local_credentials() is None
 
 
 def test_headless_connect_expired_code_surfaces_retry_command(tmp_path: Path) -> None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -18,6 +18,7 @@ from codex_plugin_scanner.guard.store import (
     FallbackSecretStore,
     GuardStore,
     SystemKeyringSecretStore,
+    UnavailableSecretStore,
     _build_oauth_secret_store,
 )
 from codex_plugin_scanner.guard.store_evidence import EvidenceRecord
@@ -406,7 +407,7 @@ def test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_
     secret_store = _build_oauth_secret_store(tmp_path / "guard-home")
 
     assert SystemKeyringSecretStore._is_available() is False
-    assert isinstance(secret_store, EncryptedFileSecretStore)
+    assert isinstance(secret_store, UnavailableSecretStore)
 
 
 def test_oauth_secret_store_skips_system_keyring_when_macos_user_keychain_search_list_is_broken(
@@ -452,10 +453,211 @@ def test_oauth_secret_store_skips_system_keyring_when_macos_user_keychain_search
     secret_store = _build_oauth_secret_store(tmp_path / "guard-home")
 
     assert SystemKeyringSecretStore._is_available() is False
-    assert isinstance(secret_store, EncryptedFileSecretStore)
+    assert isinstance(secret_store, UnavailableSecretStore)
 
 
-def test_guard_store_reuses_persisted_system_keyring_unavailable_result_across_process_starts(
+def test_oauth_secret_store_uses_only_system_keyring_on_macos_when_available(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch, usable_macos_keychain=True)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    SystemKeyringSecretStore._clear_macos_keychain_health_cache()
+
+    secret_store = _build_oauth_secret_store(tmp_path / "guard-home")
+
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+
+
+def test_oauth_secret_store_unavailable_on_macos_does_not_create_local_secret_files(tmp_path, monkeypatch):
+    _install_fake_system_keyring(monkeypatch, usable_macos_keychain=False)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    SystemKeyringSecretStore._clear_macos_keychain_health_cache()
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+
+    with pytest.raises(RuntimeError, match="OS credential store"):
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            now="2026-06-01T00:00:00+00:00",
+        )
+
+    assert not (guard_home / "secrets").exists()
+    assert store.get_oauth_local_credential_health() == {
+        "configured": False,
+        "state": "not_configured",
+        "backend": "unavailable",
+        "fallback_backend": None,
+    }
+
+
+def test_oauth_secret_store_ignores_stale_macos_unavailable_cache_for_login(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    guard_store_module._write_system_keyring_availability_cache(guard_home, available=False)
+    monkeypatch.setattr(SystemKeyringSecretStore, "_is_available", classmethod(lambda cls: True))
+
+    secret_store = _build_oauth_secret_store(guard_home)
+
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+
+
+def test_oauth_secret_store_rechecks_stale_macos_health_cache_for_login(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    fake_keyring = _FakeSystemKeyringModule()
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: fake_keyring))
+    SystemKeyringSecretStore._macos_keychain_health_cache = (guard_store_module.time.monotonic(), False)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore, "_macos_default_keychain_is_usable_uncached", classmethod(lambda cls: True)
+    )
+
+    secret_store = _build_oauth_secret_store(guard_home)
+
+    assert isinstance(secret_store, SystemKeyringSecretStore)
+
+
+def test_macos_oauth_write_rejects_unreadable_keychain_secret(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    _install_fake_system_keyring(monkeypatch, usable_macos_keychain=True)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", lambda *args, **kwargs: None)
+    store = GuardStore(guard_home)
+
+    with pytest.raises(RuntimeError, match="persist local Guard Cloud authorization securely"):
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            now="2026-06-01T00:00:00+00:00",
+        )
+
+    assert store.get_sync_payload(guard_store_module._OAUTH_LOCAL_CREDENTIALS_STATE_KEY) is None
+    assert store.get_oauth_local_credentials() is None
+
+
+def test_oauth_health_uses_no_ui_primary_read_for_macos_keychain_only_store(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    fake_keyring = _install_fake_system_keyring(monkeypatch, usable_macos_keychain=True)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+
+    def fake_no_ui_read(self: SystemKeyringSecretStore, secret_id: str, *, timeout_seconds: float = 0.0) -> str | None:
+        _ = timeout_seconds
+        return fake_keyring.get_password(self.service_name, secret_id)
+
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", fake_no_ui_read)
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    restarted_store = GuardStore(guard_home)
+
+    assert restarted_store.get_oauth_local_credential_health()["state"] == "healthy"
+    credentials = restarted_store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-secret-value"
+
+
+def test_oauth_default_macos_keychain_read_uses_no_ui_path(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    fake_keyring = _install_fake_system_keyring(monkeypatch, usable_macos_keychain=True)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+
+    def fake_no_ui_read(self: SystemKeyringSecretStore, secret_id: str, *, timeout_seconds: float = 0.0) -> str | None:
+        _ = timeout_seconds
+        return fake_keyring._secrets.get((self.service_name, secret_id))
+
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", fake_no_ui_read)
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+
+    def fail_prompt_capable_read(service_name: str, secret_id: str) -> str | None:
+        _ = (service_name, secret_id)
+        raise AssertionError("default OAuth reads must use no-UI Keychain access")
+
+    monkeypatch.setattr(fake_keyring, "get_password", fail_prompt_capable_read)
+    restarted_store = GuardStore(guard_home)
+
+    credentials = restarted_store.get_oauth_local_credentials()
+
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-secret-value"
+
+
+def test_clear_oauth_local_credentials_removes_legacy_macos_encrypted_secret(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(SystemKeyringSecretStore, "_is_available", classmethod(lambda cls: False))
+    store = GuardStore(guard_home)
+    secret_ref = store._oauth_local_credentials_ref
+    secret_hash = "f" * 64
+    fallback = EncryptedFileSecretStore(guard_home)
+    fallback.set_secret(secret_ref, json.dumps({"refresh_token": "legacy-refresh"}, sort_keys=True))
+    legacy_path = fallback._path_for(secret_ref)
+    store.set_sync_payload(
+        guard_store_module._OAUTH_LOCAL_CREDENTIALS_STATE_KEY,
+        {
+            "issuer": "https://hol.org",
+            "client_id": "guard-local-daemon",
+            guard_store_module._OAUTH_LOCAL_CREDENTIALS_REF_KEY: secret_ref,
+            guard_store_module._OAUTH_LOCAL_CREDENTIALS_HASH_KEY: secret_hash,
+        },
+        "2026-06-01T00:00:00+00:00",
+    )
+
+    store.clear_oauth_local_credentials()
+
+    assert not legacy_path.exists()
+
+
+def test_unavailable_oauth_secret_store_deletes_legacy_encrypted_secret(tmp_path):
+    guard_home = tmp_path / "guard-home"
+    fallback = EncryptedFileSecretStore(guard_home)
+    secret_ref = "guard-oauth-local-credentials:test"
+    fallback.set_secret(secret_ref, "legacy-secret")
+    legacy_path = fallback._path_for(secret_ref)
+
+    UnavailableSecretStore(guard_home).delete_secret(secret_ref)
+
+    assert not legacy_path.exists()
+
+
+def test_guard_store_ignores_persisted_system_keyring_unavailable_result_for_macos_oauth(
     tmp_path,
     monkeypatch,
 ):
@@ -473,16 +675,16 @@ def test_guard_store_reuses_persisted_system_keyring_unavailable_result_across_p
 
     first_store = GuardStore(guard_home)
 
-    assert isinstance(first_store._oauth_secret_store, EncryptedFileSecretStore)
+    assert isinstance(first_store._oauth_secret_store, UnavailableSecretStore)
     assert first_store._policy_integrity_secret_store is None
 
     SystemKeyringSecretStore._clear_macos_keychain_health_cache()
 
     second_store = GuardStore(guard_home)
 
-    assert isinstance(second_store._oauth_secret_store, EncryptedFileSecretStore)
+    assert isinstance(second_store._oauth_secret_store, UnavailableSecretStore)
     assert second_store._policy_integrity_secret_store is None
-    assert availability_checks == 1
+    assert availability_checks == 2
 
 
 def test_windows_oauth_refresh_lock_wraps_permission_error_as_blocking(monkeypatch):
@@ -915,6 +1117,7 @@ def test_set_oauth_local_credentials_skips_keyring_rewrite_when_secret_material_
 
 def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before_keyring(tmp_path, monkeypatch):
     fake_keyring = _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
@@ -942,6 +1145,7 @@ def test_get_oauth_local_credentials_prefers_validated_encrypted_fallback_before
         return original_fallback_get_secret(secret_id)
 
     monkeypatch.setattr(store._oauth_secret_store.fallback, "get_secret", count_fallback_reads)
+    store._clear_oauth_secret_payload_cache()
 
     credentials = store.get_oauth_local_credentials()
     repeated_credentials = store.get_oauth_local_credentials()
@@ -1127,6 +1331,7 @@ def test_set_oauth_local_credentials_rejects_incomplete_fallback_mirror(tmp_path
 
 def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_keyring_only_state(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
 
@@ -1144,6 +1349,7 @@ def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_key
     )
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
     store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+    store._clear_oauth_secret_payload_cache()
 
     credentials = store.get_oauth_local_credentials(allow_primary=True)
 
@@ -1158,6 +1364,7 @@ def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_key
 
 def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
     store.set_oauth_local_credentials(
@@ -1174,6 +1381,7 @@ def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_pat
     )
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
     store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+    store._clear_oauth_secret_payload_cache()
 
     primary_reads = 0
 
@@ -1193,6 +1401,7 @@ def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_pat
 
 def test_oauth_secret_payload_process_cache_is_shared_across_store_instances(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
     store.set_oauth_local_credentials(
@@ -1209,6 +1418,7 @@ def test_oauth_secret_payload_process_cache_is_shared_across_store_instances(tmp
     )
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
     store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+    store._clear_oauth_secret_payload_cache()
 
     primary_reads = 0
 
@@ -1331,6 +1541,7 @@ def test_oauth_health_auto_repairs_stale_encrypted_fallback_from_primary(tmp_pat
 
 def test_oauth_health_caches_degraded_state_between_failed_repair_attempts(tmp_path, monkeypatch):
     fake_keyring = _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)
     store.set_oauth_local_credentials(
@@ -1351,6 +1562,7 @@ def test_oauth_health_caches_degraded_state_between_failed_repair_attempts(tmp_p
     assert isinstance(store._oauth_secret_store, FallbackSecretStore)
     store._oauth_secret_store.fallback.delete_secret(secret_id)
     fake_keyring.delete_password("hol-guard.oauth", secret_id)
+    store._clear_oauth_secret_payload_cache()
 
     repair_calls = 0
     original_repair = store.repair_oauth_local_credential_storage_from_primary


### PR DESCRIPTION
## Summary\n- stop macOS OAuth credential storage from falling back to local encrypted files\n- report unavailable credential storage when the macOS credential store is not usable\n- avoid immediate macOS keychain readback after successful active credential writes\n\n## Verification\n- python3 -m pytest tests/test_guard_store_migrations.py::test_oauth_secret_store_skips_system_keyring_when_macos_default_keychain_is_missing tests/test_guard_store_migrations.py::test_oauth_secret_store_skips_system_keyring_when_macos_user_keychain_search_list_is_broken tests/test_guard_store_migrations.py::test_oauth_secret_store_uses_only_system_keyring_on_macos_when_available tests/test_guard_store_migrations.py::test_oauth_secret_store_unavailable_on_macos_does_not_create_local_secret_files tests/test_guard_store_migrations.py::test_oauth_local_credential_health_reports_backend_and_metadata tests/test_guard_store_migrations.py::test_oauth_local_credential_health_reports_system_keyring_backend tests/test_guard_store_migrations.py::test_oauth_local_credentials_use_encrypted_file_fallback_when_system_keyring_write_fails tests/test_guard_store_migrations.py::test_policy_integrity_store_is_disabled_on_macos_without_health_probe tests/test_guard_oauth_device_connect.py::test_headless_connect_avoids_keychain_password_prompts_when_system_keyring_is_available tests/test_guard_policy_integrity.py::test_policies_cli_verify_status_migrate_and_repair --tb=short -q\n- python3 -m ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_store_migrations.py tests/test_guard_oauth_device_connect.py\n- python3 -m ruff format --check src/codex_plugin_scanner/guard/store.py tests/test_guard_store_migrations.py tests/test_guard_oauth_device_connect.py\n- git diff --check