### PR TITLE
fix(guard): expose structured trust status

### DIFF
--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass, field
 from typing import Literal
 
 LocalTrustMode = Literal[
@@ -49,3 +50,73 @@ POLICY_INTEGRITY_REASON_GUARD_HOME_PERMISSIONS = "guard_home_permissions"
 POLICY_INTEGRITY_REASON_GUARD_DB_PERMISSIONS = "guard_db_permissions"
 POLICY_INTEGRITY_REASON_GUARD_HOME_INACCESSIBLE = "guard_home_inaccessible"
 POLICY_INTEGRITY_REASON_GUARD_DB_INACCESSIBLE = "guard_db_inaccessible"
+
+LOCAL_TRUST_DEGRADED_REASON_LABELS: dict[str, str] = {
+    POLICY_INTEGRITY_REASON_SYSTEM_KEYRING_UNAVAILABLE: "System credential store unavailable",
+    POLICY_INTEGRITY_REASON_KEY_UNAVAILABLE: "Local rule signing key unavailable",
+    POLICY_INTEGRITY_REASON_CONTROL_UNAVAILABLE: "Local rollback control unavailable",
+    POLICY_INTEGRITY_REASON_GUARD_HOME_SYMLINK: "Guard home path is not trusted",
+    POLICY_INTEGRITY_REASON_GUARD_DB_SYMLINK: "Guard database path is not trusted",
+    POLICY_INTEGRITY_REASON_GUARD_HOME_PERMISSIONS: "Guard home permissions are too broad",
+    POLICY_INTEGRITY_REASON_GUARD_DB_PERMISSIONS: "Guard database permissions are too broad",
+    POLICY_INTEGRITY_REASON_GUARD_HOME_INACCESSIBLE: "Guard home could not be inspected",
+    POLICY_INTEGRITY_REASON_GUARD_DB_INACCESSIBLE: "Guard database could not be inspected",
+}
+
+
+@dataclass(frozen=True)
+class TrustStatus:
+    """User-safe trust summary for runtime, local rules, and Cloud policy authority."""
+
+    runtime_protection: LocalTrustMode
+    remembered_rules: LocalTrustMode
+    cloud_policies: LocalTrustMode
+    backend: str
+    degraded_reasons: tuple[str, ...] = field(default_factory=tuple)
+    setup_available: bool = False
+    last_proof: str | None = None
+
+    @classmethod
+    def from_policy_integrity_state(cls, state: dict[str, object]) -> TrustStatus:
+        mode = state.get("mode")
+        reasons = state.get("degraded_reasons")
+        clean_reasons = (
+            tuple(reason for reason in reasons if isinstance(reason, str)) if isinstance(reasons, list) else ()
+        )
+        if mode == POLICY_INTEGRITY_MODE_PROTECTED:
+            remembered_rules: LocalTrustMode = "protected"
+        elif mode == POLICY_INTEGRITY_MODE_DEGRADED:
+            remembered_rules = "degraded_safe"
+        else:
+            remembered_rules = "unsupported"
+        setup_available = bool(state.get("setup_available"))
+        if not setup_available:
+            setup_available = any(reason in LOCAL_TRUST_DEGRADED_REASON_LABELS for reason in clean_reasons)
+        runtime_protection = state.get("runtime_protection")
+        cloud_policies = state.get("cloud_policies")
+        if mode == POLICY_INTEGRITY_MODE_PROTECTED and runtime_protection not in LOCAL_TRUST_MODES:
+            runtime_protection = "protected"
+        return cls(
+            runtime_protection=runtime_protection if runtime_protection in LOCAL_TRUST_MODES else "unsupported",
+            remembered_rules=remembered_rules,
+            cloud_policies=cloud_policies if cloud_policies in LOCAL_TRUST_MODES else "unsupported",
+            backend=str(state.get("backend") or "unknown"),
+            degraded_reasons=clean_reasons,
+            setup_available=setup_available,
+            last_proof=None,
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "runtime_protection": self.runtime_protection,
+            "remembered_rules": self.remembered_rules,
+            "cloud_policies": self.cloud_policies,
+            "backend": self.backend,
+            "degraded_reasons": list(self.degraded_reasons),
+            "degraded_reason_labels": {
+                reason: LOCAL_TRUST_DEGRADED_REASON_LABELS.get(reason, "Guard trust check degraded")
+                for reason in self.degraded_reasons
+            },
+            "setup_available": self.setup_available,
+            "last_proof": self.last_proof,
+        }

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -12,6 +12,9 @@ LocalTrustMode = Literal[
     "setup_required",
     "unsupported",
 ]
+RuntimeProtectionStatus = Literal["protected", "degraded", "unknown"]
+RememberedRulesStatus = Literal["enforced", "disabled_degraded", "unknown"]
+CloudPoliciesStatus = Literal["available", "setup_unavailable", "unknown"]
 
 PolicyIntegrityMode = Literal["protected", "degraded"]
 PolicyIntegrityEnforcement = Literal["enforce", "warn"]
@@ -68,9 +71,9 @@ LOCAL_TRUST_DEGRADED_REASON_LABELS: dict[str, str] = {
 class TrustStatus:
     """User-safe trust summary for runtime, local rules, and Cloud policy authority."""
 
-    runtime_protection: LocalTrustMode
-    remembered_rules: LocalTrustMode
-    cloud_policies: LocalTrustMode
+    runtime_protection: RuntimeProtectionStatus
+    remembered_rules: RememberedRulesStatus
+    cloud_policies: CloudPoliciesStatus
     backend: str
     degraded_reasons: tuple[str, ...] = field(default_factory=tuple)
     setup_available: bool = False
@@ -84,22 +87,31 @@ class TrustStatus:
             tuple(reason for reason in reasons if isinstance(reason, str)) if isinstance(reasons, list) else ()
         )
         if mode == POLICY_INTEGRITY_MODE_PROTECTED:
-            remembered_rules: LocalTrustMode = "protected"
+            runtime_protection: RuntimeProtectionStatus = "protected"
+            remembered_rules: RememberedRulesStatus = "enforced"
         elif mode == POLICY_INTEGRITY_MODE_DEGRADED:
-            remembered_rules = "degraded_safe"
+            runtime_protection = "degraded"
+            remembered_rules = "disabled_degraded"
         else:
-            remembered_rules = "unsupported"
+            runtime_protection = "unknown"
+            remembered_rules = "unknown"
         setup_available = bool(state.get("setup_available"))
         if not setup_available:
             setup_available = any(reason in LOCAL_TRUST_DEGRADED_REASON_LABELS for reason in clean_reasons)
-        runtime_protection = state.get("runtime_protection")
-        cloud_policies = state.get("cloud_policies")
-        if mode == POLICY_INTEGRITY_MODE_PROTECTED and runtime_protection not in LOCAL_TRUST_MODES:
-            runtime_protection = "protected"
+        runtime_override = state.get("runtime_protection")
+        if runtime_override in ("protected", "degraded", "unknown"):
+            runtime_protection = runtime_override
+        cloud_override = state.get("cloud_policies")
+        if cloud_override in ("available", "setup_unavailable", "unknown"):
+            cloud_policies: CloudPoliciesStatus = cloud_override
+        elif setup_available:
+            cloud_policies = "setup_unavailable"
+        else:
+            cloud_policies = "available"
         return cls(
-            runtime_protection=runtime_protection if runtime_protection in LOCAL_TRUST_MODES else "unsupported",
+            runtime_protection=runtime_protection,
             remembered_rules=remembered_rules,
-            cloud_policies=cloud_policies if cloud_policies in LOCAL_TRUST_MODES else "unsupported",
+            cloud_policies=cloud_policies,
             backend=str(state.get("backend") or "unknown"),
             degraded_reasons=clean_reasons,
             setup_available=setup_available,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -39,6 +39,7 @@ from .local_trust_contract import (
     POLICY_INTEGRITY_REASON_GUARD_HOME_SYMLINK,
     POLICY_INTEGRITY_REASON_KEY_UNAVAILABLE,
     POLICY_INTEGRITY_REASON_SYSTEM_KEYRING_UNAVAILABLE,
+    TrustStatus,
 )
 from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
 from .policy_integrity import (
@@ -4118,6 +4119,7 @@ class GuardStore:
             "generation": state.get("generation"),
             "key_id": state.get("key_id"),
             "degraded_reasons": state.get("degraded_reasons", []),
+            "trust_status": TrustStatus.from_policy_integrity_state(state).to_dict(),
             "counts": counts,
             "local_rows_scanned": sum(counts.values()),
         }
@@ -4143,6 +4145,7 @@ class GuardStore:
             "generation": state.get("generation"),
             "key_id": state.get("key_id"),
             "degraded_reasons": state.get("degraded_reasons", []),
+            "trust_status": TrustStatus.from_policy_integrity_state(state).to_dict(),
             "counts": counts,
             "local_rows_scanned": sum(counts.values()),
             "items": invalid_items,
@@ -4214,6 +4217,7 @@ class GuardStore:
             "generation": state.get("generation"),
             "key_id": state.get("key_id"),
             "degraded_reasons": state.get("degraded_reasons", []),
+            "trust_status": TrustStatus.from_policy_integrity_state(state).to_dict(),
             "counts": counts,
             "local_rows_scanned": sum(counts.values()),
             "cleared": cleared,
@@ -4319,6 +4323,7 @@ class GuardStore:
             "generation": final_state.get("generation"),
             "key_id": final_state.get("key_id"),
             "degraded_reasons": final_state.get("degraded_reasons", []),
+            "trust_status": TrustStatus.from_policy_integrity_state(final_state).to_dict(),
             "legacy_row_ids": legacy_ids,
             "rollback_row_ids": rollback_row_ids,
             "unknown_key_row_ids": unknown_key_ids,

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -73,9 +73,9 @@ def test_trust_status_serializes_policy_integrity_authority_without_paths() -> N
         }
     ).to_dict()
 
-    assert status["runtime_protection"] == "unsupported"
-    assert status["remembered_rules"] == "degraded_safe"
-    assert status["cloud_policies"] == "unsupported"
+    assert status["runtime_protection"] == "degraded"
+    assert status["remembered_rules"] == "disabled_degraded"
+    assert status["cloud_policies"] == "setup_unavailable"
     assert status["backend"] == "unavailable"
     assert status["degraded_reasons"] == ["system_keyring_unavailable", "guard_home_symlink"]
     assert status["setup_available"] is True
@@ -92,7 +92,9 @@ def test_trust_status_hides_policy_integrity_proof_ids_and_handles_unknown_mode(
         }
     ).to_dict()
 
-    assert status["remembered_rules"] == "unsupported"
+    assert status["runtime_protection"] == "unknown"
+    assert status["remembered_rules"] == "unknown"
+    assert status["cloud_policies"] == "available"
     assert status["setup_available"] is False
     assert status["last_proof"] is None
 
@@ -115,9 +117,9 @@ def test_policy_integrity_status_includes_trust_status(tmp_path: Path) -> None:
     trust_status = status["trust_status"]
 
     assert isinstance(trust_status, dict)
-    assert trust_status["runtime_protection"] == "unsupported"
-    assert trust_status["remembered_rules"] == "degraded_safe"
-    assert trust_status["cloud_policies"] == "unsupported"
+    assert trust_status["runtime_protection"] == "degraded"
+    assert trust_status["remembered_rules"] == "disabled_degraded"
+    assert trust_status["cloud_policies"] == "setup_unavailable"
     assert trust_status["degraded_reasons"] == status["degraded_reasons"]
 
     verify = store.verify_policy_integrity()

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -14,12 +14,14 @@ import pytest
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.local_trust_contract import (
+    LOCAL_TRUST_DEGRADED_REASON_LABELS,
     LOCAL_TRUST_MODES,
     POLICY_INTEGRITY_DEGRADED_REASONS,
     POLICY_INTEGRITY_ENFORCEMENT_ENFORCE,
     POLICY_INTEGRITY_ENFORCEMENT_WARN,
     POLICY_INTEGRITY_MODE_DEGRADED,
     POLICY_INTEGRITY_MODE_PROTECTED,
+    TrustStatus,
 )
 from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore, SystemKeyringSecretStore
@@ -58,6 +60,68 @@ def test_local_trust_contract_exports_stable_status_vocabulary() -> None:
     assert "guard_db_symlink" in POLICY_INTEGRITY_DEGRADED_REASONS
     assert "guard_home_permissions" in POLICY_INTEGRITY_DEGRADED_REASONS
     assert "guard_db_permissions" in POLICY_INTEGRITY_DEGRADED_REASONS
+    assert set(LOCAL_TRUST_DEGRADED_REASON_LABELS) == set(POLICY_INTEGRITY_DEGRADED_REASONS)
+
+
+def test_trust_status_serializes_policy_integrity_authority_without_paths() -> None:
+    status = TrustStatus.from_policy_integrity_state(
+        {
+            "backend": "unavailable",
+            "mode": POLICY_INTEGRITY_MODE_DEGRADED,
+            "degraded_reasons": ["system_keyring_unavailable", "guard_home_symlink"],
+            "key_id": "/Users/example/.hol-guard/key",
+        }
+    ).to_dict()
+
+    assert status["runtime_protection"] == "unsupported"
+    assert status["remembered_rules"] == "degraded_safe"
+    assert status["cloud_policies"] == "unsupported"
+    assert status["backend"] == "unavailable"
+    assert status["degraded_reasons"] == ["system_keyring_unavailable", "guard_home_symlink"]
+    assert status["setup_available"] is True
+    assert status["last_proof"] is None
+
+
+def test_trust_status_hides_policy_integrity_proof_ids_and_handles_unknown_mode() -> None:
+    status = TrustStatus.from_policy_integrity_state(
+        {
+            "backend": "system-keyring",
+            "mode": "future-mode",
+            "degraded_reasons": [],
+            "key_id": "abc/def==",
+        }
+    ).to_dict()
+
+    assert status["remembered_rules"] == "unsupported"
+    assert status["setup_available"] is False
+    assert status["last_proof"] is None
+
+    windows_status = TrustStatus.from_policy_integrity_state(
+        {
+            "backend": "system-keyring",
+            "mode": POLICY_INTEGRITY_MODE_PROTECTED,
+            "degraded_reasons": [],
+            "key_id": "\\Users\\alice\\.hol-guard\\key",
+        }
+    ).to_dict()
+    assert windows_status["runtime_protection"] == "protected"
+    assert windows_status["last_proof"] is None
+
+
+def test_policy_integrity_status_includes_trust_status(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    status = store.get_policy_integrity_status()
+    trust_status = status["trust_status"]
+
+    assert isinstance(trust_status, dict)
+    assert trust_status["runtime_protection"] == "unsupported"
+    assert trust_status["remembered_rules"] == "degraded_safe"
+    assert trust_status["cloud_policies"] == "unsupported"
+    assert trust_status["degraded_reasons"] == status["degraded_reasons"]
+
+    verify = store.verify_policy_integrity()
+    assert verify["trust_status"] == trust_status
 
 
 def test_guard_store_init_does_not_create_policy_integrity_keyring_material(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add structured local trust status serialization for runtime, remembered-rule, and Cloud-policy authority
- expose trust_status in policy integrity status payloads without changing existing fields
- add regression coverage for stable vocabulary and local path redaction

## Tests
- python3 -m pytest tests/test_guard_policy_integrity.py::test_local_trust_contract_exports_stable_status_vocabulary tests/test_guard_policy_integrity.py::test_trust_status_serializes_policy_integrity_authority_without_paths tests/test_guard_policy_integrity.py::test_policy_integrity_status_includes_trust_status tests/test_guard_policy_integrity.py::test_policies_cli_verify_status_migrate_and_repair --tb=short -q
- python3 -m ruff check src/codex_plugin_scanner/guard/local_trust_contract.py src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py
- python3 -m ruff format --check src/codex_plugin_scanner/guard/local_trust_contract.py src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py
- git diff --check