### PR TITLE
feat(guard): add local trust backend contract

### DIFF
--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -150,8 +150,10 @@ def run_trust_backend_check(
         return timeout_result
     try:
         context = multiprocessing.get_context("fork")
-    except ValueError:
-        context = multiprocessing.get_context()
+    except ValueError as error:
+        if on_error is None:
+            return timeout_result
+        return on_error(error)
     results = context.Queue(maxsize=1)
 
     process = context.Process(target=_trust_backend_check_worker, args=(operation, results), daemon=True)

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -117,7 +117,8 @@ class TrustBackend(Protocol):
 
 
 class _ProcessHandle(Protocol):
-    pid: int | None
+    @property
+    def pid(self) -> int | None: ...
 
     def is_alive(self) -> bool: ...
 

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -92,18 +92,23 @@ class TrustBackend(Protocol):
 
     def status(self) -> TrustStatus:
         """Return current backend trust status."""
+        ...
 
     def sign(self, payload: bytes) -> str:
         """Sign canonical trust payload bytes."""
+        ...
 
     def verify(self, payload: bytes, signature: str) -> bool:
         """Verify canonical trust payload bytes."""
+        ...
 
     def setup(self) -> TrustStatus:
         """Run explicit foreground setup."""
+        ...
 
     def revoke(self) -> TrustStatus:
         """Revoke backend trust material."""
+        ...
 
 
 _TrustResult = TypeVar("_TrustResult")

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -116,6 +116,18 @@ class TrustBackend(Protocol):
         ...
 
 
+class _ProcessHandle(Protocol):
+    pid: int | None
+
+    def is_alive(self) -> bool: ...
+
+    def join(self, timeout: float | None = None) -> None: ...
+
+    def terminate(self) -> None: ...
+
+    def kill(self) -> None: ...
+
+
 _TrustResult = TypeVar("_TrustResult")
 
 
@@ -139,7 +151,7 @@ def _trust_backend_check_worker(
     os.replace(temp_result_path, result_path)
 
 
-def _terminate_trust_backend_process_tree(process: multiprocessing.Process) -> None:
+def _terminate_trust_backend_process_tree(process: _ProcessHandle) -> None:
     pid = process.pid
     if pid is None:
         return
@@ -147,17 +159,20 @@ def _terminate_trust_backend_process_tree(process: multiprocessing.Process) -> N
         try:
             os.killpg(pid, signal.SIGTERM)
         except ProcessLookupError:
-            return
+            pass
         except PermissionError:
-            process.terminate()
+            pass
+        process.terminate()
         process.join(timeout=0.2)
-        try:
-            os.killpg(pid, signal.SIGKILL)
-        except ProcessLookupError:
-            return
-        except PermissionError:
+        if process.is_alive():
+            try:
+                os.killpg(pid, signal.SIGKILL)
+            except ProcessLookupError:
+                pass
+            except PermissionError:
+                pass
             process.kill()
-        process.join(timeout=0.2)
+            process.join(timeout=0.2)
         return
     process.terminate()
     process.join(timeout=0.2)

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import json
-import queue
-import threading
+import multiprocessing
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from typing import Literal, Protocol, TypeVar, cast
@@ -128,28 +127,43 @@ def run_trust_backend_check(
     *,
     timeout_seconds: float,
     timeout_result: _TrustResult,
-    on_error: Callable[[BaseException], _TrustResult],
+    on_error: Callable[[BaseException], _TrustResult] | None = None,
 ) -> _TrustResult:
-    """Run passive backend work under a bounded timeout without blocking caller."""
+    """Run side-effect-free passive backend work under a contained timeout."""
 
     if timeout_seconds <= 0:
         return timeout_result
-    results: queue.Queue[tuple[bool, _TrustResult | BaseException]] = queue.Queue(maxsize=1)
-
-    def _worker() -> None:
-        try:
-            results.put((True, operation()))
-        except BaseException as error:
-            results.put((False, error))
-
-    thread = threading.Thread(target=_worker, daemon=True)
-    thread.start()
     try:
-        ok, value = results.get(timeout=timeout_seconds)
-    except queue.Empty:
+        context = multiprocessing.get_context("fork")
+    except ValueError:
         return timeout_result
+    results = context.Queue(maxsize=1)
+
+    def _worker(result_queue) -> None:
+        try:
+            result_queue.put((True, operation()))
+        except Exception as error:
+            result_queue.put((False, error))
+
+    process = context.Process(target=_worker, args=(results,), daemon=True)
+    process.start()
+    process.join(timeout=timeout_seconds)
+    if process.is_alive():
+        process.terminate()
+        process.join(timeout=0.2)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=0.2)
+        return timeout_result
+    if results.empty():
+        if on_error is None:
+            return timeout_result
+        return on_error(RuntimeError("trust_backend_process_failed"))
+    ok, value = results.get()
     if ok:
         return cast("_TrustResult", value)
+    if on_error is None:
+        return timeout_result
     return on_error(cast("BaseException", value))
 
 

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -6,6 +6,7 @@ import json
 import multiprocessing
 import os
 import pickle
+import signal
 import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
@@ -126,6 +127,8 @@ def _trust_backend_check_worker(
     operation: Callable[[], object],
     result_path: str,
 ) -> None:
+    if hasattr(os, "setsid"):
+        os.setsid()
     try:
         payload = (True, operation())
     except Exception as error:
@@ -134,6 +137,33 @@ def _trust_backend_check_worker(
     with Path(temp_result_path).open("wb") as handle:
         pickle.dump(payload, handle, protocol=pickle.HIGHEST_PROTOCOL)
     os.replace(temp_result_path, result_path)
+
+
+def _terminate_trust_backend_process_tree(process: multiprocessing.Process) -> None:
+    pid = process.pid
+    if pid is None:
+        return
+    if hasattr(os, "killpg"):
+        try:
+            os.killpg(pid, signal.SIGTERM)
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            process.terminate()
+        process.join(timeout=0.2)
+        try:
+            os.killpg(pid, signal.SIGKILL)
+        except ProcessLookupError:
+            return
+        except PermissionError:
+            process.kill()
+        process.join(timeout=0.2)
+        return
+    process.terminate()
+    process.join(timeout=0.2)
+    if process.is_alive():
+        process.kill()
+        process.join(timeout=0.2)
 
 
 def select_trust_backend(
@@ -177,11 +207,7 @@ def run_trust_backend_check(
             return on_error(error)
         process.join(timeout=timeout_seconds)
         if process.is_alive():
-            process.terminate()
-            process.join(timeout=0.2)
-            if process.is_alive():
-                process.kill()
-                process.join(timeout=0.2)
+            _terminate_trust_backend_process_tree(process)
             return timeout_result
         result_file = Path(result_path)
         if not result_file.exists():

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -109,6 +109,16 @@ class TrustBackend(Protocol):
 _TrustResult = TypeVar("_TrustResult")
 
 
+def _trust_backend_check_worker(
+    operation: Callable[[], object],
+    result_queue,
+) -> None:
+    try:
+        result_queue.put((True, operation()))
+    except Exception as error:
+        result_queue.put((False, error))
+
+
 def select_trust_backend(
     backends: tuple[TrustBackend, ...],
     *,
@@ -136,17 +146,16 @@ def run_trust_backend_check(
     try:
         context = multiprocessing.get_context("fork")
     except ValueError:
-        return timeout_result
+        context = multiprocessing.get_context()
     results = context.Queue(maxsize=1)
 
-    def _worker(result_queue) -> None:
-        try:
-            result_queue.put((True, operation()))
-        except Exception as error:
-            result_queue.put((False, error))
-
-    process = context.Process(target=_worker, args=(results,), daemon=True)
-    process.start()
+    process = context.Process(target=_trust_backend_check_worker, args=(operation, results), daemon=True)
+    try:
+        process.start()
+    except Exception as error:
+        if on_error is None:
+            return timeout_result
+        return on_error(error)
     process.join(timeout=timeout_seconds)
     if process.is_alive():
         process.terminate()

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import json
+import queue
+import threading
+from collections.abc import Callable
 from dataclasses import dataclass, field
-from typing import Literal
+from typing import Literal, Protocol, TypeVar, cast
 
 LocalTrustMode = Literal[
     "protected",
@@ -42,6 +46,10 @@ POLICY_INTEGRITY_DEGRADED_REASONS: tuple[str, ...] = (
     "guard_db_permissions",
     "guard_home_inaccessible",
     "guard_db_inaccessible",
+    "trust_backend_timeout",
+    "trust_backend_unavailable",
+    "trust_backend_permission_denied",
+    "trust_backend_corrupt",
 )
 
 POLICY_INTEGRITY_REASON_SYSTEM_KEYRING_UNAVAILABLE = "system_keyring_unavailable"
@@ -53,6 +61,10 @@ POLICY_INTEGRITY_REASON_GUARD_HOME_PERMISSIONS = "guard_home_permissions"
 POLICY_INTEGRITY_REASON_GUARD_DB_PERMISSIONS = "guard_db_permissions"
 POLICY_INTEGRITY_REASON_GUARD_HOME_INACCESSIBLE = "guard_home_inaccessible"
 POLICY_INTEGRITY_REASON_GUARD_DB_INACCESSIBLE = "guard_db_inaccessible"
+POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT = "trust_backend_timeout"
+POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE = "trust_backend_unavailable"
+POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED = "trust_backend_permission_denied"
+POLICY_INTEGRITY_REASON_BACKEND_CORRUPT = "trust_backend_corrupt"
 
 LOCAL_TRUST_DEGRADED_REASON_LABELS: dict[str, str] = {
     POLICY_INTEGRITY_REASON_SYSTEM_KEYRING_UNAVAILABLE: "System credential store unavailable",
@@ -64,7 +76,93 @@ LOCAL_TRUST_DEGRADED_REASON_LABELS: dict[str, str] = {
     POLICY_INTEGRITY_REASON_GUARD_DB_PERMISSIONS: "Guard database permissions are too broad",
     POLICY_INTEGRITY_REASON_GUARD_HOME_INACCESSIBLE: "Guard home could not be inspected",
     POLICY_INTEGRITY_REASON_GUARD_DB_INACCESSIBLE: "Guard database could not be inspected",
+    POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT: "Local trust backend timed out",
+    POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE: "Local trust backend unavailable",
+    POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED: "Local trust backend permission denied",
+    POLICY_INTEGRITY_REASON_BACKEND_CORRUPT: "Local trust backend data could not be read",
 }
+
+
+class TrustBackend(Protocol):
+    """Local trust backend contract for passive and explicit trust operations."""
+
+    name: str
+    priority: int
+    supported: bool
+    passive_no_ui_safe: bool
+
+    def status(self) -> TrustStatus:
+        """Return current backend trust status."""
+
+    def sign(self, payload: bytes) -> str:
+        """Sign canonical trust payload bytes."""
+
+    def verify(self, payload: bytes, signature: str) -> bool:
+        """Verify canonical trust payload bytes."""
+
+    def setup(self) -> TrustStatus:
+        """Run explicit foreground setup."""
+
+    def revoke(self) -> TrustStatus:
+        """Revoke backend trust material."""
+
+
+_TrustResult = TypeVar("_TrustResult")
+
+
+def select_trust_backend(
+    backends: tuple[TrustBackend, ...],
+    *,
+    passive: bool,
+) -> TrustBackend | None:
+    """Select highest-priority supported backend, gating passive use on no-UI safety."""
+
+    candidates = [backend for backend in backends if backend.supported and (not passive or backend.passive_no_ui_safe)]
+    if not candidates:
+        return None
+    return sorted(candidates, key=lambda backend: (-backend.priority, backend.name))[0]
+
+
+def run_trust_backend_check(
+    operation: Callable[[], _TrustResult],
+    *,
+    timeout_seconds: float,
+    timeout_result: _TrustResult,
+    on_error: Callable[[BaseException], _TrustResult],
+) -> _TrustResult:
+    """Run passive backend work under a bounded timeout without blocking caller."""
+
+    if timeout_seconds <= 0:
+        return timeout_result
+    results: queue.Queue[tuple[bool, _TrustResult | BaseException]] = queue.Queue(maxsize=1)
+
+    def _worker() -> None:
+        try:
+            results.put((True, operation()))
+        except BaseException as error:
+            results.put((False, error))
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    try:
+        ok, value = results.get(timeout=timeout_seconds)
+    except queue.Empty:
+        return timeout_result
+    if ok:
+        return cast("_TrustResult", value)
+    return on_error(cast("BaseException", value))
+
+
+def degraded_reason_for_backend_error(error: BaseException) -> str:
+    """Normalize backend failures into user-safe degraded reasons."""
+
+    if isinstance(error, TimeoutError):
+        return POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT
+    if isinstance(error, PermissionError):
+        return POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED
+    if isinstance(error, (ValueError, json.JSONDecodeError)):
+        return POLICY_INTEGRITY_REASON_BACKEND_CORRUPT
+    return POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
 
 
 @dataclass(frozen=True)

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -118,6 +118,10 @@ class TrustBackend(Protocol):
 _TrustResult = TypeVar("_TrustResult")
 
 
+class TrustBackendUnavailableError(RuntimeError):
+    """Raised when passive trust backend execution cannot be started."""
+
+
 def _trust_backend_check_worker(
     operation: Callable[[], object],
     result_path: str,
@@ -161,7 +165,7 @@ def run_trust_backend_check(
     except ValueError as error:
         if on_error is None:
             return timeout_result
-        return on_error(error)
+        return on_error(TrustBackendUnavailableError(str(error)))
     with tempfile.TemporaryDirectory(prefix="hol-guard-trust-") as temp_dir:
         result_path = str(Path(temp_dir) / "result.pickle")
         process = context.Process(target=_trust_backend_check_worker, args=(operation, result_path))
@@ -198,6 +202,8 @@ def degraded_reason_for_backend_error(error: BaseException) -> str:
 
     if isinstance(error, TimeoutError):
         return POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT
+    if isinstance(error, TrustBackendUnavailableError):
+        return POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
     if isinstance(error, PermissionError):
         return POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED
     if isinstance(error, (ValueError, json.JSONDecodeError)):

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -4,8 +4,12 @@ from __future__ import annotations
 
 import json
 import multiprocessing
+import os
+import pickle
+import tempfile
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Literal, Protocol, TypeVar, cast
 
 LocalTrustMode = Literal[
@@ -116,12 +120,16 @@ _TrustResult = TypeVar("_TrustResult")
 
 def _trust_backend_check_worker(
     operation: Callable[[], object],
-    result_queue,
+    result_path: str,
 ) -> None:
     try:
-        result_queue.put((True, operation()))
+        payload = (True, operation())
     except Exception as error:
-        result_queue.put((False, error))
+        payload = (False, error)
+    temp_result_path = f"{result_path}.{os.getpid()}.tmp"
+    with Path(temp_result_path).open("wb") as handle:
+        pickle.dump(payload, handle, protocol=pickle.HIGHEST_PROTOCOL)
+    os.replace(temp_result_path, result_path)
 
 
 def select_trust_backend(
@@ -154,33 +162,35 @@ def run_trust_backend_check(
         if on_error is None:
             return timeout_result
         return on_error(error)
-    results = context.Queue(maxsize=1)
-
-    process = context.Process(target=_trust_backend_check_worker, args=(operation, results), daemon=True)
-    try:
-        process.start()
-    except Exception as error:
-        if on_error is None:
-            return timeout_result
-        return on_error(error)
-    process.join(timeout=timeout_seconds)
-    if process.is_alive():
-        process.terminate()
-        process.join(timeout=0.2)
+    with tempfile.TemporaryDirectory(prefix="hol-guard-trust-") as temp_dir:
+        result_path = str(Path(temp_dir) / "result.pickle")
+        process = context.Process(target=_trust_backend_check_worker, args=(operation, result_path), daemon=True)
+        try:
+            process.start()
+        except Exception as error:
+            if on_error is None:
+                return timeout_result
+            return on_error(error)
+        process.join(timeout=timeout_seconds)
         if process.is_alive():
-            process.kill()
+            process.terminate()
             process.join(timeout=0.2)
-        return timeout_result
-    if results.empty():
+            if process.is_alive():
+                process.kill()
+                process.join(timeout=0.2)
+            return timeout_result
+        result_file = Path(result_path)
+        if not result_file.exists():
+            if on_error is None:
+                return timeout_result
+            return on_error(RuntimeError("trust_backend_process_failed"))
+        with result_file.open("rb") as handle:
+            ok, value = pickle.load(handle)
+        if ok:
+            return cast("_TrustResult", value)
         if on_error is None:
             return timeout_result
-        return on_error(RuntimeError("trust_backend_process_failed"))
-    ok, value = results.get()
-    if ok:
-        return cast("_TrustResult", value)
-    if on_error is None:
-        return timeout_result
-    return on_error(cast("BaseException", value))
+        return on_error(cast("BaseException", value))
 
 
 def degraded_reason_for_backend_error(error: BaseException) -> str:

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -164,7 +164,7 @@ def run_trust_backend_check(
         return on_error(error)
     with tempfile.TemporaryDirectory(prefix="hol-guard-trust-") as temp_dir:
         result_path = str(Path(temp_dir) / "result.pickle")
-        process = context.Process(target=_trust_backend_check_worker, args=(operation, result_path), daemon=True)
+        process = context.Process(target=_trust_backend_check_worker, args=(operation, result_path))
         try:
             process.start()
         except Exception as error:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -156,6 +156,45 @@ def test_trust_backend_timeout_returns_degraded_result_without_waiting() -> None
     assert time.monotonic() - started < 0.5
 
 
+def test_trust_backend_timeout_contains_late_side_effects(tmp_path: Path) -> None:
+    marker_path = tmp_path / "late-side-effect"
+
+    def slow_mutation() -> TrustStatus:
+        time.sleep(0.5)
+        marker_path.write_text("mutated", encoding="utf-8")
+        return _FakeTrustBackend("slow", 1).status()
+
+    timeout_result = TrustStatus(
+        runtime_protection="degraded",
+        remembered_rules="disabled_degraded",
+        cloud_policies="setup_unavailable",
+        backend="timeout",
+        degraded_reasons=(POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT,),
+    )
+
+    result = run_trust_backend_check(
+        slow_mutation,
+        timeout_seconds=0.01,
+        timeout_result=timeout_result,
+    )
+    time.sleep(0.1)
+
+    assert result == timeout_result
+    assert not marker_path.exists()
+
+
+def test_trust_backend_timeout_helper_allows_minimal_fallback_contract() -> None:
+    timeout_result = {"mode": "degraded"}
+
+    result = run_trust_backend_check(
+        lambda: (time.sleep(1.0), {"mode": "protected"})[1],
+        timeout_seconds=0.01,
+        timeout_result=timeout_result,
+    )
+
+    assert result == timeout_result
+
+
 def test_trust_backend_errors_normalize_to_safe_degraded_reasons() -> None:
     assert degraded_reason_for_backend_error(TimeoutError("slow")) == POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT
     assert (

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -223,6 +223,37 @@ def test_trust_backend_timeout_kills_nested_helper_process(tmp_path: Path) -> No
     assert not marker_path.exists()
 
 
+def test_trust_backend_timeout_falls_back_when_process_group_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls: list[str] = []
+
+    class FakeProcess:
+        pid = 12345
+
+        def is_alive(self) -> bool:
+            return False
+
+        def join(self, timeout: float | None = None) -> None:
+            calls.append(f"join:{timeout}")
+
+        def terminate(self) -> None:
+            calls.append("terminate")
+
+        def kill(self) -> None:
+            calls.append("kill")
+
+    def fake_killpg(pid: int, sig: int) -> None:
+        calls.append(f"killpg:{pid}:{sig}")
+        raise ProcessLookupError("process group not ready")
+
+    monkeypatch.setattr(local_trust_contract_module.os, "killpg", fake_killpg)
+
+    local_trust_contract_module._terminate_trust_backend_process_tree(FakeProcess())
+
+    assert calls == ["killpg:12345:15", "terminate", "join:0.2"]
+
+
 def test_trust_backend_timeout_helper_allows_minimal_fallback_contract() -> None:
     timeout_result = {"mode": "degraded"}
 

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -85,10 +85,6 @@ class _FakeTrustBackend:
         )
 
 
-def _fast_spawn_compatible_trust_probe() -> dict[str, str]:
-    return {"mode": "protected"}
-
-
 def test_local_trust_contract_exports_stable_status_vocabulary() -> None:
     assert LOCAL_TRUST_MODES == (
         "protected",
@@ -200,28 +196,27 @@ def test_trust_backend_timeout_helper_allows_minimal_fallback_contract() -> None
     assert result == timeout_result
 
 
-def test_trust_backend_check_uses_default_context_when_fork_unavailable(
+def test_trust_backend_check_degrades_without_spawn_when_fork_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    real_get_context = local_trust_contract_module.multiprocessing.get_context
     calls: list[str | None] = []
 
     def fake_get_context(method: str | None = None):
         calls.append(method)
         if method == "fork":
             raise ValueError("fork unavailable")
-        return real_get_context("fork")
+        raise AssertionError("spawn fallback must not be used for passive trust checks")
 
     monkeypatch.setattr(local_trust_contract_module.multiprocessing, "get_context", fake_get_context)
 
     result = run_trust_backend_check(
-        _fast_spawn_compatible_trust_probe,
+        lambda: {"mode": "protected"},
         timeout_seconds=1.0,
         timeout_result={"mode": "degraded"},
     )
 
-    assert result == {"mode": "protected"}
-    assert calls == ["fork", None]
+    assert result == {"mode": "degraded"}
+    assert calls == ["fork"]
 
 
 def test_trust_backend_errors_normalize_to_safe_degraded_reasons() -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -6,6 +6,8 @@ import base64
 import json
 import sqlite3
 import sys
+import time
+from dataclasses import dataclass
 from pathlib import Path
 from typing import cast
 
@@ -21,7 +23,14 @@ from codex_plugin_scanner.guard.local_trust_contract import (
     POLICY_INTEGRITY_ENFORCEMENT_WARN,
     POLICY_INTEGRITY_MODE_DEGRADED,
     POLICY_INTEGRITY_MODE_PROTECTED,
+    POLICY_INTEGRITY_REASON_BACKEND_CORRUPT,
+    POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED,
+    POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT,
+    POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE,
     TrustStatus,
+    degraded_reason_for_backend_error,
+    run_trust_backend_check,
+    select_trust_backend,
 )
 from codex_plugin_scanner.guard.models import PolicyDecision
 from codex_plugin_scanner.guard.store import GuardStore, SystemKeyringSecretStore
@@ -39,6 +48,40 @@ def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _store(tmp_path: Path) -> GuardStore:
     return GuardStore(tmp_path / "guard-home")
+
+
+@dataclass
+class _FakeTrustBackend:
+    name: str
+    priority: int
+    supported: bool = True
+    passive_no_ui_safe: bool = True
+
+    def status(self) -> TrustStatus:
+        return TrustStatus(
+            runtime_protection="protected",
+            remembered_rules="enforced",
+            cloud_policies="available",
+            backend=self.name,
+        )
+
+    def sign(self, payload: bytes) -> str:
+        return base64.urlsafe_b64encode(payload).decode("ascii")
+
+    def verify(self, payload: bytes, signature: str) -> bool:
+        return self.sign(payload) == signature
+
+    def setup(self) -> TrustStatus:
+        return self.status()
+
+    def revoke(self) -> TrustStatus:
+        return TrustStatus(
+            runtime_protection="degraded",
+            remembered_rules="disabled_degraded",
+            cloud_policies="setup_unavailable",
+            backend=self.name,
+            setup_available=True,
+        )
 
 
 def test_local_trust_contract_exports_stable_status_vocabulary() -> None:
@@ -61,6 +104,66 @@ def test_local_trust_contract_exports_stable_status_vocabulary() -> None:
     assert "guard_home_permissions" in POLICY_INTEGRITY_DEGRADED_REASONS
     assert "guard_db_permissions" in POLICY_INTEGRITY_DEGRADED_REASONS
     assert set(LOCAL_TRUST_DEGRADED_REASON_LABELS) == set(POLICY_INTEGRITY_DEGRADED_REASONS)
+
+
+def test_trust_backend_registry_requires_no_ui_safe_passive_backend() -> None:
+    unsafe_high_priority = _FakeTrustBackend(
+        name="unsafe-high",
+        priority=100,
+        passive_no_ui_safe=False,
+    )
+    safe_low_priority = _FakeTrustBackend(name="safe-low", priority=10)
+    unsupported = _FakeTrustBackend(name="unsupported", priority=200, supported=False)
+
+    passive_backend = select_trust_backend(
+        (unsupported, unsafe_high_priority, safe_low_priority),
+        passive=True,
+    )
+    explicit_backend = select_trust_backend(
+        (unsupported, unsafe_high_priority, safe_low_priority),
+        passive=False,
+    )
+
+    assert passive_backend is safe_low_priority
+    assert explicit_backend is unsafe_high_priority
+
+
+def test_trust_backend_timeout_returns_degraded_result_without_waiting() -> None:
+    timeout_result = TrustStatus(
+        runtime_protection="degraded",
+        remembered_rules="disabled_degraded",
+        cloud_policies="setup_unavailable",
+        backend="timeout",
+        degraded_reasons=(POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT,),
+        setup_available=True,
+    )
+
+    started = time.monotonic()
+    result = run_trust_backend_check(
+        lambda: (time.sleep(1.0), _FakeTrustBackend("slow", 1).status())[1],
+        timeout_seconds=0.01,
+        timeout_result=timeout_result,
+        on_error=lambda error: TrustStatus(
+            runtime_protection="degraded",
+            remembered_rules="disabled_degraded",
+            cloud_policies="setup_unavailable",
+            backend="error",
+            degraded_reasons=(degraded_reason_for_backend_error(error),),
+        ),
+    )
+
+    assert result == timeout_result
+    assert time.monotonic() - started < 0.5
+
+
+def test_trust_backend_errors_normalize_to_safe_degraded_reasons() -> None:
+    assert degraded_reason_for_backend_error(TimeoutError("slow")) == POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT
+    assert (
+        degraded_reason_for_backend_error(PermissionError("denied"))
+        == POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED
+    )
+    assert degraded_reason_for_backend_error(ValueError("bad payload")) == POLICY_INTEGRITY_REASON_BACKEND_CORRUPT
+    assert degraded_reason_for_backend_error(RuntimeError("broken")) == POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
 
 
 def test_trust_status_serializes_policy_integrity_authority_without_paths() -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -90,6 +90,11 @@ def _write_nested_trust_marker(marker_path: str) -> None:
     Path(marker_path).write_text("ok", encoding="utf-8")
 
 
+def _write_delayed_nested_trust_marker(marker_path: str) -> None:
+    time.sleep(0.4)
+    Path(marker_path).write_text("late", encoding="utf-8")
+
+
 def test_local_trust_contract_exports_stable_status_vocabulary() -> None:
     assert LOCAL_TRUST_MODES == (
         "protected",
@@ -184,6 +189,35 @@ def test_trust_backend_timeout_contains_late_side_effects(tmp_path: Path) -> Non
         timeout_result=timeout_result,
     )
     time.sleep(0.1)
+
+    assert result == timeout_result
+    assert not marker_path.exists()
+
+
+def test_trust_backend_timeout_kills_nested_helper_process(tmp_path: Path) -> None:
+    marker_path = tmp_path / "nested-late-side-effect"
+
+    def slow_nested_mutation() -> TrustStatus:
+        context = local_trust_contract_module.multiprocessing.get_context("fork")
+        process = context.Process(target=_write_delayed_nested_trust_marker, args=(str(marker_path),))
+        process.start()
+        time.sleep(2.0)
+        return _FakeTrustBackend("slow", 1).status()
+
+    timeout_result = TrustStatus(
+        runtime_protection="degraded",
+        remembered_rules="disabled_degraded",
+        cloud_policies="setup_unavailable",
+        backend="timeout",
+        degraded_reasons=(POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT,),
+    )
+
+    result = run_trust_backend_check(
+        slow_nested_mutation,
+        timeout_seconds=0.05,
+        timeout_result=timeout_result,
+    )
+    time.sleep(0.6)
 
     assert result == timeout_result
     assert not marker_path.exists()

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -14,6 +14,7 @@ from typing import cast
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import local_trust_contract as local_trust_contract_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.local_trust_contract import (
     LOCAL_TRUST_DEGRADED_REASON_LABELS,
@@ -82,6 +83,10 @@ class _FakeTrustBackend:
             backend=self.name,
             setup_available=True,
         )
+
+
+def _fast_spawn_compatible_trust_probe() -> dict[str, str]:
+    return {"mode": "protected"}
 
 
 def test_local_trust_contract_exports_stable_status_vocabulary() -> None:
@@ -193,6 +198,30 @@ def test_trust_backend_timeout_helper_allows_minimal_fallback_contract() -> None
     )
 
     assert result == timeout_result
+
+
+def test_trust_backend_check_uses_default_context_when_fork_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    real_get_context = local_trust_contract_module.multiprocessing.get_context
+    calls: list[str | None] = []
+
+    def fake_get_context(method: str | None = None):
+        calls.append(method)
+        if method == "fork":
+            raise ValueError("fork unavailable")
+        return real_get_context("fork")
+
+    monkeypatch.setattr(local_trust_contract_module.multiprocessing, "get_context", fake_get_context)
+
+    result = run_trust_backend_check(
+        _fast_spawn_compatible_trust_probe,
+        timeout_seconds=1.0,
+        timeout_result={"mode": "degraded"},
+    )
+
+    assert result == {"mode": "protected"}
+    assert calls == ["fork", None]
 
 
 def test_trust_backend_errors_normalize_to_safe_degraded_reasons() -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -85,6 +85,10 @@ class _FakeTrustBackend:
         )
 
 
+def _write_nested_trust_marker(marker_path: str) -> None:
+    Path(marker_path).write_text("ok", encoding="utf-8")
+
+
 def test_local_trust_contract_exports_stable_status_vocabulary() -> None:
     assert LOCAL_TRUST_MODES == (
         "protected",
@@ -207,6 +211,25 @@ def test_trust_backend_check_drains_large_completed_result_before_timeout() -> N
     )
 
     assert result == large_status
+
+
+def test_trust_backend_check_allows_native_helper_child_process(tmp_path: Path) -> None:
+    marker_path = tmp_path / "nested-helper"
+
+    def operation() -> dict[str, str]:
+        context = local_trust_contract_module.multiprocessing.get_context("fork")
+        process = context.Process(target=_write_nested_trust_marker, args=(str(marker_path),))
+        process.start()
+        process.join(timeout=1.0)
+        return {"mode": "protected", "nested": str(marker_path.exists())}
+
+    result = run_trust_backend_check(
+        operation,
+        timeout_seconds=1.0,
+        timeout_result={"mode": "degraded", "nested": "False"},
+    )
+
+    assert result == {"mode": "protected", "nested": "True"}
 
 
 def test_trust_backend_check_degrades_without_spawn_when_fork_unavailable(

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -28,6 +28,7 @@ from codex_plugin_scanner.guard.local_trust_contract import (
     POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED,
     POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT,
     POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE,
+    TrustBackendUnavailableError,
     TrustStatus,
     degraded_reason_for_backend_error,
     run_trust_backend_check,
@@ -249,14 +250,19 @@ def test_trust_backend_check_degrades_without_spawn_when_fork_unavailable(
         lambda: {"mode": "protected"},
         timeout_seconds=1.0,
         timeout_result={"mode": "degraded"},
+        on_error=lambda error: {"mode": "degraded", "reason": degraded_reason_for_backend_error(error)},
     )
 
-    assert result == {"mode": "degraded"}
+    assert result == {"mode": "degraded", "reason": POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE}
     assert calls == ["fork"]
 
 
 def test_trust_backend_errors_normalize_to_safe_degraded_reasons() -> None:
     assert degraded_reason_for_backend_error(TimeoutError("slow")) == POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT
+    assert (
+        degraded_reason_for_backend_error(TrustBackendUnavailableError("fork unavailable"))
+        == POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
+    )
     assert (
         degraded_reason_for_backend_error(PermissionError("denied"))
         == POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -196,6 +196,19 @@ def test_trust_backend_timeout_helper_allows_minimal_fallback_contract() -> None
     assert result == timeout_result
 
 
+def test_trust_backend_check_drains_large_completed_result_before_timeout() -> None:
+    timeout_result = {"mode": "degraded"}
+    large_status = {"mode": "protected", "payload": "x" * 1_000_000}
+
+    result = run_trust_backend_check(
+        lambda: large_status,
+        timeout_seconds=1.0,
+        timeout_result=timeout_result,
+    )
+
+    assert result == large_status
+
+
 def test_trust_backend_check_degrades_without_spawn_when_fork_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- Add a local trust backend protocol for passive and explicit trust operations.
- Add deterministic backend selection, no-UI passive gating, bounded backend checks, and safe degraded reason normalization.
- Add regression tests for passive backend selection, timeout fallback, and normalized backend errors.

## Testing
- `python3 -m pytest tests/test_guard_policy_integrity.py --tb=short -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/local_trust_contract.py tests/test_guard_policy_integrity.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/local_trust_contract.py tests/test_guard_policy_integrity.py`
- `git diff --check`
