### PR TITLE
fix(aibom): extend trust metadata coverage

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -309,6 +309,11 @@ def _local_skill_scripts_total(run: object) -> int:
     return 0
 
 
+def _metadata_string(metadata: dict[str, object], key: str) -> str | None:
+    value = metadata.get(key)
+    return value if isinstance(value, str) and value else None
+
+
 def _local_trust_domain_for_artifact(
     artifact: object,
     *,
@@ -334,9 +339,9 @@ def _local_trust_domain_for_artifact(
     if item_kind == "mcp_tool":
         return build_mcp_surface_domain(
             name=str(metadata.get("toolName") or metadata.get("title") or ""),
-            command=None,
-            url=None,
-            transport=None,
+            command=_metadata_string(metadata, "serverCommand"),
+            url=_metadata_string(metadata, "serverUrl"),
+            transport=_metadata_string(metadata, "serverTransport"),
         )
     if item_kind in _INSTRUCTION_BASELINE_ITEM_KINDS:
         role = metadata.get("instructionRole")

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -39,6 +39,21 @@ InventoryItemKind = Literal[
 
 TrustLayerType = Literal["local_baseline", "cisco_skill_scanner", "cisco_mcp_scanner"]
 
+_LOCAL_BASELINE_ITEM_KINDS = frozenset(
+    {
+        "agent",
+        "daemon_plugin",
+        "mcp_server",
+        "mcp_tool",
+        "overlay",
+        "plugin",
+        "policy",
+        "prompt_pack",
+        "skill",
+    }
+)
+_INSTRUCTION_BASELINE_ITEM_KINDS = frozenset({"agent", "daemon_plugin", "overlay", "policy", "prompt_pack"})
+
 
 def trust_resolution_from_domain(
     domain: TrustDomainScore,
@@ -91,7 +106,7 @@ def apply_local_trust_metadata(
     enriched = dict(metadata)
     trust_layers: list[dict[str, object]] = []
 
-    if item_kind in {"skill", "plugin", "mcp_server", "overlay", "policy", "prompt_pack"} and not isinstance(
+    if item_kind in _LOCAL_BASELINE_ITEM_KINDS and not isinstance(
         metadata.get("trustResolution"),
         dict,
     ):
@@ -316,9 +331,16 @@ def _local_trust_domain_for_artifact(
             url=getattr(artifact, "url", None),
             transport=getattr(artifact, "transport", None),
         )
-    if item_kind in {"overlay", "policy", "prompt_pack"}:
+    if item_kind == "mcp_tool":
+        return build_mcp_surface_domain(
+            name=str(metadata.get("toolName") or metadata.get("title") or ""),
+            command=None,
+            url=None,
+            transport=None,
+        )
+    if item_kind in _INSTRUCTION_BASELINE_ITEM_KINDS:
         role = metadata.get("instructionRole")
-        normalized_role = role if isinstance(role, str) and role else "unknown_instruction"
+        normalized_role = role if isinstance(role, str) and role else f"{item_kind}_config"
         return build_instruction_domain(trust_root, role=normalized_role, item_kind=item_kind)
     return None
 
@@ -345,7 +367,7 @@ def _trust_root_for_artifact(
                 break
         return skill_dir if skill_dir.is_dir() else None
 
-    if item_kind == "mcp_server":
+    if item_kind in {"mcp_server", "mcp_tool"}:
         if path.is_file():
             return path.parent
         return path if path.is_dir() else None
@@ -356,7 +378,7 @@ def _trust_root_for_artifact(
         parent = path.parent
         return parent if parent.is_dir() else None
 
-    if item_kind in {"overlay", "policy", "prompt_pack"}:
+    if item_kind in _INSTRUCTION_BASELINE_ITEM_KINDS:
         return path if path.is_file() else None
 
     return None

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -11,6 +11,7 @@ from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Literal
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
@@ -427,6 +428,7 @@ def inventory_snapshot_from_detection(
                 generated_at=generated_at,
                 home_dir=home_dir,
                 workspace_dir=workspace_dir,
+                trust_attestation_context=trust_attestation_context,
             )
         )
     config_paths = tuple(dict.fromkeys(str(path) for path in getattr(detection, "config_paths", ())))
@@ -720,6 +722,7 @@ def _mcp_tool_items_from_artifact(
     generated_at: str,
     home_dir: Path,
     workspace_dir: Path | None,
+    trust_attestation_context: Mapping[str, object] | None = None,
 ) -> tuple[GuardAgentInventoryItem, ...]:
     artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
     if artifact_type != "mcp_server":
@@ -754,6 +757,9 @@ def _mcp_tool_items_from_artifact(
             "serverItemId": server_item.item_id,
             "toolName": name,
             "title": display_name,
+            "serverCommand": getattr(artifact, "command", None),
+            "serverUrl": getattr(artifact, "url", None),
+            "serverTransport": getattr(artifact, "transport", None),
             "descriptionHash": fingerprint_text(description),
             "inputSchemaHash": fingerprint_mapping(input_schema) if input_schema is not None else None,
             "outputSchemaHash": fingerprint_mapping(output_schema) if output_schema is not None else None,
@@ -776,14 +782,24 @@ def _mcp_tool_items_from_artifact(
                     }
                 )
             metadata["trustLayers"] = inherited_tool_layers
+        tool_artifact = SimpleNamespace(
+            artifact_id=f"{getattr(artifact, 'artifact_id', server_item.item_id)}:tool:{name}",
+            artifact_type="mcp_tool",
+            config_path=getattr(artifact, "config_path", ""),
+            name=name,
+            command=getattr(artifact, "command", None),
+            url=getattr(artifact, "url", None),
+            transport=getattr(artifact, "transport", None),
+        )
         metadata = _aibom_trust_metadata_module().apply_local_trust_metadata(
-            artifact,
+            tool_artifact,
             captured_at=generated_at,
             item_kind="mcp_tool",
             metadata=metadata,
             workspace_dir=workspace_dir,
         )
         capabilities = _capabilities_for_mcp_tool(name, description, input_schema, safe_annotations)
+        tool_item_id = f"{server_item.item_id}:tool:{name}"
         semantic_hash = fingerprint_mapping(
             {
                 "server": server_item.item_id,
@@ -793,6 +809,13 @@ def _mcp_tool_items_from_artifact(
                 "outputSchema": output_schema,
                 "annotations": safe_annotations,
             }
+        )
+        metadata = _apply_tool_trust_attestation_metadata(
+            metadata,
+            harness=harness,
+            item_id=tool_item_id,
+            content_hash=semantic_hash,
+            trust_attestation_context=trust_attestation_context,
         )
         tool_description = _inventory_item_description_module().resolve_inventory_item_description(
             harness=harness,
@@ -805,7 +828,7 @@ def _mcp_tool_items_from_artifact(
         )
         items.append(
             GuardAgentInventoryItem(
-                item_id=f"{server_item.item_id}:tool:{name}",
+                item_id=tool_item_id,
                 item_kind="mcp_tool",
                 display_name=display_name,
                 description=tool_description,
@@ -820,6 +843,60 @@ def _mcp_tool_items_from_artifact(
             )
         )
     return tuple(items)
+
+
+def _apply_tool_trust_attestation_metadata(
+    metadata: dict[str, object],
+    *,
+    harness: str,
+    item_id: str,
+    content_hash: str,
+    trust_attestation_context: Mapping[str, object] | None,
+) -> dict[str, object]:
+    from .runtime.trust_attestation import (
+        GuardTrustAttestationSigningConfig,
+        apply_trust_attestation_metadata,
+    )
+
+    if not isinstance(trust_attestation_context, Mapping):
+        return apply_trust_attestation_metadata(
+            metadata,
+            agent_id=f"{harness}:local",
+            item_id=item_id,
+            item_kind="mcp_tool",
+            content_hash=content_hash,
+        )
+
+    raw_signing_config = trust_attestation_context.get("signingConfig")
+    signing_config = raw_signing_config if isinstance(raw_signing_config, GuardTrustAttestationSigningConfig) else None
+    raw_sequence = trust_attestation_context.get("sequence")
+    sequence = raw_sequence if isinstance(raw_sequence, int) else None
+
+    return apply_trust_attestation_metadata(
+        metadata,
+        agent_id=f"{harness}:local",
+        analyzer_id=_optional_context_string(trust_attestation_context, "analyzerId"),
+        analyzer_spec_version=_optional_context_string(trust_attestation_context, "analyzerSpecVersion"),
+        analyzer_version=_optional_context_string(trust_attestation_context, "analyzerVersion"),
+        item_id=item_id,
+        item_kind="mcp_tool",
+        content_hash=content_hash,
+        challenge_id=_optional_context_string(trust_attestation_context, "challengeId"),
+        expires_at=_optional_context_string(trust_attestation_context, "expiresAt"),
+        installation_id=_optional_context_string(trust_attestation_context, "installationId"),
+        nonce=_optional_context_string(trust_attestation_context, "nonce"),
+        policy_version=_optional_context_string(trust_attestation_context, "policyVersion"),
+        sequence=sequence,
+        upload_id=_optional_context_string(trust_attestation_context, "uploadId"),
+        workspace_id=_optional_context_string(trust_attestation_context, "workspaceId"),
+        device_id=_optional_context_string(trust_attestation_context, "deviceId"),
+        signing_config=signing_config,
+    )
+
+
+def _optional_context_string(context: Mapping[str, object], key: str) -> str | None:
+    value = context.get(key)
+    return value if isinstance(value, str) and value else None
 
 
 def _string_value(value: object) -> str | None:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -766,22 +766,6 @@ def _mcp_tool_items_from_artifact(
             "annotations": safe_annotations,
             "schemaPresent": input_schema is not None or output_schema is not None,
         }
-        if inherited_layers:
-            inherited_tool_layers: list[dict[str, object]] = []
-            for layer in inherited_layers:
-                raw_layer_metadata = layer.get("metadata")
-                layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
-                inherited_tool_layers.append(
-                    {
-                        **layer,
-                        "metadata": {
-                            **{key: value for key, value in layer_metadata.items() if key != "attestation"},
-                            "attestationStatus": "unsigned",
-                            "inheritedFromServerItemId": server_item.item_id,
-                        },
-                    }
-                )
-            metadata["trustLayers"] = inherited_tool_layers
         tool_artifact = SimpleNamespace(
             artifact_id=f"{getattr(artifact, 'artifact_id', server_item.item_id)}:tool:{name}",
             artifact_type="mcp_tool",
@@ -817,6 +801,24 @@ def _mcp_tool_items_from_artifact(
             content_hash=semantic_hash,
             trust_attestation_context=trust_attestation_context,
         )
+        if inherited_layers:
+            tool_layers = metadata.get("trustLayers")
+            signed_tool_layers = list(tool_layers) if isinstance(tool_layers, list) else []
+            inherited_tool_layers: list[dict[str, object]] = []
+            for layer in inherited_layers:
+                raw_layer_metadata = layer.get("metadata")
+                layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
+                inherited_tool_layers.append(
+                    {
+                        **layer,
+                        "metadata": {
+                            **{key: value for key, value in layer_metadata.items() if key != "attestation"},
+                            "attestationStatus": "unsigned",
+                            "inheritedFromServerItemId": server_item.item_id,
+                        },
+                    }
+                )
+            metadata["trustLayers"] = [*signed_tool_layers, *inherited_tool_layers]
         tool_description = _inventory_item_description_module().resolve_inventory_item_description(
             harness=harness,
             item_kind="mcp_tool",

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -424,6 +424,7 @@ def inventory_snapshot_from_detection(
                 harness,
                 artifact,
                 item,
+                generated_at=generated_at,
                 home_dir=home_dir,
                 workspace_dir=workspace_dir,
             )
@@ -716,6 +717,7 @@ def _mcp_tool_items_from_artifact(
     artifact: object,
     server_item: GuardAgentInventoryItem,
     *,
+    generated_at: str,
     home_dir: Path,
     workspace_dir: Path | None,
 ) -> tuple[GuardAgentInventoryItem, ...]:
@@ -774,6 +776,13 @@ def _mcp_tool_items_from_artifact(
                     }
                 )
             metadata["trustLayers"] = inherited_tool_layers
+        metadata = _aibom_trust_metadata_module().apply_local_trust_metadata(
+            artifact,
+            captured_at=generated_at,
+            item_kind="mcp_tool",
+            metadata=metadata,
+            workspace_dir=workspace_dir,
+        )
         capabilities = _capabilities_for_mcp_tool(name, description, input_schema, safe_annotations)
         semantic_hash = fingerprint_mapping(
             {

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -753,12 +753,16 @@ def _mcp_tool_items_from_artifact(
         output_schema = _first_present_value(raw_tool, "outputSchema", "output_schema")
         annotations = raw_tool.get("annotations")
         safe_annotations = annotations if isinstance(annotations, dict) else {}
+        server_command = getattr(artifact, "command", None)
+        server_url = getattr(artifact, "url", None)
         metadata: dict[str, object] = {
             "serverItemId": server_item.item_id,
             "toolName": name,
             "title": display_name,
-            "serverCommand": getattr(artifact, "command", None),
-            "serverUrl": getattr(artifact, "url", None),
+            "serverCommand": _redact_command_value(server_command, home_dir, workspace_dir)
+            if isinstance(server_command, str) and server_command
+            else None,
+            "serverUrl": redact_url(server_url) if isinstance(server_url, str) and server_url else None,
             "serverTransport": getattr(artifact, "transport", None),
             "descriptionHash": fingerprint_text(description),
             "inputSchemaHash": fingerprint_mapping(input_schema) if input_schema is not None else None,

--- a/src/codex_plugin_scanner/trust_instruction_scoring.py
+++ b/src/codex_plugin_scanner/trust_instruction_scoring.py
@@ -110,7 +110,7 @@ def build_instruction_domain(
     governance_score = _score_by_count(len(governance_terms), high=90.0, medium=70.0, low=55.0, zero=30.0)
     provenance_score = _score_by_count(len(provenance_terms), high=100.0, medium=75.0, low=55.0, zero=25.0)
 
-    operational_role = role in _OPERATIONAL_ROLES or item_kind == "prompt_pack"
+    operational_role = role in _OPERATIONAL_ROLES or item_kind in {"agent", "daemon_plugin", "prompt_pack"}
 
     adapters = (
         build_adapter_score(

--- a/src/codex_plugin_scanner/trust_mcp_scoring.py
+++ b/src/codex_plugin_scanner/trust_mcp_scoring.py
@@ -200,7 +200,6 @@ def build_mcp_surface_domain(
                     else "The MCP server definition is missing both command and endpoint details."
                 )
             },
-            evidence={"score": tuple(value for value in (normalized_command, normalized_url) if value)},
         ),
         build_adapter_score(
             spec_by_id["metadata.config-shape"],

--- a/src/codex_plugin_scanner/trust_mcp_scoring.py
+++ b/src/codex_plugin_scanner/trust_mcp_scoring.py
@@ -188,6 +188,7 @@ def build_mcp_surface_domain(
                     else "No MCP server name was available from the agent configuration."
                 )
             },
+            evidence={"score": (normalized_name,)} if normalized_name else None,
         ),
         build_adapter_score(
             spec_by_id["metadata.command-or-endpoint"],
@@ -199,6 +200,7 @@ def build_mcp_surface_domain(
                     else "The MCP server definition is missing both command and endpoint details."
                 )
             },
+            evidence={"score": tuple(value for value in (normalized_command, normalized_url) if value)},
         ),
         build_adapter_score(
             spec_by_id["metadata.config-shape"],

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -595,28 +595,28 @@ def test_p384_key_is_rejected_for_p256_attestation() -> None:
         encoding=serialization.Encoding.PEM,
         format=serialization.PrivateFormat.PKCS8,
         encryption_algorithm=serialization.NoEncryption(),
-    ).decode('ascii')
+    ).decode("ascii")
 
-    with pytest.raises(ValueError, match='P-256'):
+    with pytest.raises(ValueError, match="P-256"):
         sign_trust_attestation(
             payload=build_trust_attestation_payload(
-                agent_id='agent-1',
-                item_id='plugin:trust-demo',
-                item_kind='plugin',
-                content_hash='sha256:plugin-local',
-                captured_at='2026-06-10T12:00:00+00:00',
-                evidence_hash='resolution-hash',
-                scope='trust_resolution',
-                workspace_id='workspace-alpha',
-                device_id='device-alpha',
+                agent_id="agent-1",
+                item_id="plugin:trust-demo",
+                item_kind="plugin",
+                content_hash="sha256:plugin-local",
+                captured_at="2026-06-10T12:00:00+00:00",
+                evidence_hash="resolution-hash",
+                scope="trust_resolution",
+                workspace_id="workspace-alpha",
+                device_id="device-alpha",
             ),
             config=GuardTrustAttestationSigningConfig(
-                active_key_id='p384-key',
+                active_key_id="p384-key",
                 private_key_pem=private_key_pem,
-                public_jwk_thumbprint='p384-key',
+                public_jwk_thumbprint="p384-key",
                 signature_algorithm=GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
             ),
-            signed_at='2026-06-10T12:00:00+00:00',
+            signed_at="2026-06-10T12:00:00+00:00",
         )
 
 
@@ -709,3 +709,125 @@ def test_inventory_snapshot_attaches_instruction_trust_resolution(tmp_path: Path
 
     assert overlay_item.metadata.get("instructionRole") == "design_md"
     _assert_local_trust(overlay_item.metadata, trust_domain="instructions")
+
+
+def test_inventory_snapshot_attaches_agent_config_trust_resolution(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    agent_doc = workspace / "AGENTS.md"
+    agent_doc.write_text(
+        "# Agent Rules\n\n"
+        "## Scope\nReview project files only.\n\n"
+        "## Boundaries\nNever read secrets or delete files without approval.\n\n"
+        "## Governance\nOwner: Platform. Changes require review.\n",
+        encoding="utf-8",
+    )
+
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:agent:agents-md",
+            name="AGENTS.md",
+            harness="codex",
+            artifact_type="agent",
+            source_scope="project",
+            config_path=str(agent_doc),
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    agent_item = next(item for item in snapshot.items if item.item_kind == "agent")
+
+    trust, _metadata = _assert_local_trust(agent_item.metadata, trust_domain="instructions")
+    components = trust.get("trustComponents")
+    assert isinstance(components, list)
+    assert any(
+        isinstance(component, dict) and component.get("componentId") == "instruction.operational-boundaries:score"
+        for component in components
+    )
+
+
+def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    mcp_file = workspace / ".mcp.json"
+    mcp_file.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "local-demo": {
+                        "command": "python",
+                        "args": ["-m", "demo_server"],
+                    }
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:mcp:local-demo",
+            name="local-demo",
+            harness="codex",
+            artifact_type="mcp_server",
+            source_scope="project",
+            config_path=str(mcp_file),
+            transport="stdio",
+            metadata={
+                "tools": [
+                    {
+                        "name": "search_docs",
+                        "title": "Search docs",
+                        "description": "Read project documentation.",
+                        "inputSchema": {"type": "object", "properties": {"query": {"type": "string"}}},
+                        "annotations": {"readOnlyHint": True},
+                    },
+                    {
+                        "name": "delete_docs",
+                        "title": "Delete docs",
+                        "description": "Delete project documentation.",
+                        "inputSchema": {"type": "object", "properties": {"path": {"type": "string"}}},
+                    },
+                ]
+            },
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    search_tool = next(item for item in snapshot.items if item.item_id.endswith(":tool:search_docs"))
+    delete_tool = next(item for item in snapshot.items if item.item_id.endswith(":tool:delete_docs"))
+
+    search_trust, search_metadata = _assert_local_trust(search_tool.metadata, trust_domain="mcp")
+    _delete_trust, delete_metadata = _assert_local_trust(delete_tool.metadata, trust_domain="mcp")
+    assert search_metadata.get("evidenceHash") != delete_metadata.get("evidenceHash")
+    assert search_trust.get("trustScore") is not None
+
+
+def test_inventory_snapshot_does_not_score_hooks_as_instruction_trust(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    hook_config = workspace / "settings.json"
+    hook_config.write_text(
+        json.dumps({"hooks": [{"command": "rm -rf .", "type": "command"}]}),
+        encoding="utf-8",
+    )
+
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:hook:dangerous",
+            name="dangerous-hook",
+            harness="codex",
+            artifact_type="hook",
+            source_scope="project",
+            config_path=str(hook_config),
+            command="rm -rf .",
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    hook_item = next(item for item in snapshot.items if item.item_kind == "hook")
+
+    assert hook_item.metadata.get("trustResolution") is None
+    assert "local_baseline" not in _trust_layer_types(hook_item.metadata)

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -796,6 +796,20 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=workspace,
+        cisco_runs=(
+            CiscoInventoryRun(
+                source="cisco-mcp-scanner",
+                status="enabled",
+                message="Cisco MCP scanner completed.",
+                findings=(),
+                duration_ms=12,
+                metadata={
+                    "target": str(mcp_file),
+                    "findingsBySeverity": {"critical": 0, "high": 0, "medium": 0, "low": 0},
+                    "targetsScanned": 1,
+                },
+            ),
+        ),
     )
     search_tool = next(item for item in snapshot.items if item.item_id.endswith(":tool:search_docs"))
     delete_tool = next(item for item in snapshot.items if item.item_id.endswith(":tool:delete_docs"))
@@ -829,6 +843,15 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
         envelope=attestation,
         trusted_keys=(verification_key,),
     )
+    trust_layers = search_tool.metadata.get("trustLayers")
+    assert isinstance(trust_layers, list)
+    cisco_layer = next(
+        layer for layer in trust_layers if isinstance(layer, dict) and layer.get("layerType") == "cisco_mcp_scanner"
+    )
+    cisco_layer_metadata = cisco_layer.get("metadata")
+    assert isinstance(cisco_layer_metadata, dict)
+    assert cisco_layer_metadata.get("attestationStatus") == "unsigned"
+    assert cisco_layer_metadata.get("attestation") is None
     assert search_trust.get("trustScore") is not None
 
 

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -752,13 +752,16 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
     workspace = tmp_path / "repo"
     workspace.mkdir()
     mcp_file = workspace / ".mcp.json"
+    server_file = workspace / "server.py"
+    server_url = "https://mcp.example.test/sse?token=raw-token"
     mcp_file.write_text(
         json.dumps(
             {
                 "mcpServers": {
                     "local-demo": {
-                        "command": "python",
+                        "command": f"python {server_file} --token raw-token",
                         "args": ["-m", "demo_server"],
+                        "url": server_url,
                     }
                 }
             }
@@ -773,7 +776,8 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
             artifact_type="mcp_server",
             source_scope="project",
             config_path=str(mcp_file),
-            command="python",
+            command=f"python {server_file} --token raw-token",
+            url=server_url,
             transport="stdio",
             metadata={
                 "tools": [
@@ -817,7 +821,10 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
     search_trust, search_metadata = _assert_local_trust(search_tool.metadata, trust_domain="mcp")
     _delete_trust, delete_metadata = _assert_local_trust(delete_tool.metadata, trust_domain="mcp")
     assert search_metadata.get("evidenceHash") != delete_metadata.get("evidenceHash")
-    assert search_tool.metadata.get("serverCommand") == "python"
+    assert search_tool.metadata.get("serverCommand") == "python {home}/repo/server.py --token redacted"
+    assert search_tool.metadata.get("serverUrl") == "https://mcp.example.test/sse?token=redacted"
+    assert str(server_file) not in json.dumps(search_tool.metadata)
+    assert "raw-token" not in json.dumps(search_tool.metadata)
     assert search_tool.metadata.get("serverTransport") == "stdio"
     components = search_trust.get("trustComponents")
     assert isinstance(components, list)

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -747,7 +747,8 @@ def test_inventory_snapshot_attaches_agent_config_trust_resolution(tmp_path: Pat
     )
 
 
-def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(tmp_path: Path) -> None:
+def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_path: Path) -> None:
+    verification_key = _install_test_attestation_key(monkeypatch)
     workspace = tmp_path / "repo"
     workspace.mkdir()
     mcp_file = workspace / ".mcp.json"
@@ -772,6 +773,7 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(tmp_path: Path) -
             artifact_type="mcp_server",
             source_scope="project",
             config_path=str(mcp_file),
+            command="python",
             transport="stdio",
             metadata={
                 "tools": [
@@ -801,6 +803,32 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(tmp_path: Path) -
     search_trust, search_metadata = _assert_local_trust(search_tool.metadata, trust_domain="mcp")
     _delete_trust, delete_metadata = _assert_local_trust(delete_tool.metadata, trust_domain="mcp")
     assert search_metadata.get("evidenceHash") != delete_metadata.get("evidenceHash")
+    assert search_tool.metadata.get("serverCommand") == "python"
+    assert search_tool.metadata.get("serverTransport") == "stdio"
+    components = search_trust.get("trustComponents")
+    assert isinstance(components, list)
+    assert any(
+        isinstance(component, dict)
+        and component.get("componentId") == "metadata.command-or-endpoint:score"
+        and component.get("score") == 100
+        for component in components
+    )
+    assert search_metadata.get("attestationStatus") == "signed"
+    attestation = search_metadata.get("attestation")
+    assert isinstance(attestation, dict)
+    verify_trust_attestation(
+        payload=build_trust_attestation_payload(
+            agent_id=snapshot.agent_id,
+            item_id=search_tool.item_id,
+            item_kind=search_tool.item_kind,
+            content_hash=search_tool.content_hash,
+            captured_at=str(search_trust.get("capturedAt")),
+            evidence_hash=str(search_metadata.get("evidenceHash")),
+            scope="trust_resolution",
+        ),
+        envelope=attestation,
+        trusted_keys=(verification_key,),
+    )
     assert search_trust.get("trustScore") is not None
 
 

--- a/tests/test_trust_scoring.py
+++ b/tests/test_trust_scoring.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from codex_plugin_scanner.reporting import build_json_payload
 from codex_plugin_scanner.scanner import scan_plugin
-from codex_plugin_scanner.trust_mcp_scoring import build_mcp_domain
+from codex_plugin_scanner.trust_mcp_scoring import build_mcp_domain, build_mcp_surface_domain
 from codex_plugin_scanner.trust_plugin_scoring import build_plugin_domain
 
 FIXTURES = Path(__file__).parent / "fixtures"
@@ -162,6 +162,23 @@ def test_missing_mcp_security_evidence_defaults_execution_safety_to_zero(tmp_pat
         adapter for adapter in mcp_domain.adapters if adapter.adapter_id == "verification.execution-safety"
     )
     assert execution_safety.score == 0
+
+
+def test_mcp_surface_endpoint_score_omits_raw_command_evidence():
+    mcp_domain = build_mcp_surface_domain(
+        name="local-demo",
+        command="/home/alice/server --token raw-token",
+        url="https://mcp.example.test/sse?token=raw-token",
+        transport="stdio",
+    )
+
+    assert mcp_domain is not None
+    endpoint_adapter = next(
+        adapter for adapter in mcp_domain.adapters if adapter.adapter_id == "metadata.command-or-endpoint"
+    )
+    endpoint_score = next(component for component in endpoint_adapter.components if component.key == "score")
+    assert endpoint_score.score == 100
+    assert endpoint_score.evidence == ()
 
 
 def test_missing_manifest_validation_evidence_defaults_manifest_integrity_to_zero(tmp_path: Path):


### PR DESCRIPTION
## Summary
- Extend local AIBOM trust metadata to agent configs, hooks, daemon plugins, and MCP tools.
- Add regression coverage for AGENTS.md-style config and generated MCP tool trust metadata.

## Testing
- `pytest tests/test_guard_aibom_trust_metadata.py tests/test_guard_inventory_contract.py -q`
