### PR TITLE
fix(guard): handle trust backend result failures

### DIFF
--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -136,6 +136,10 @@ class TrustBackendUnavailableError(RuntimeError):
     """Raised when passive trust backend execution cannot be started."""
 
 
+class TrustBackendProcessFailedError(RuntimeError):
+    """Raised when passive trust backend worker exits without a readable result."""
+
+
 def _trust_backend_check_worker(
     operation: Callable[[], object],
     result_path: str,
@@ -180,6 +184,13 @@ def _terminate_trust_backend_process_tree(process: _ProcessHandle) -> None:
     if process.is_alive():
         process.kill()
         process.join(timeout=0.2)
+
+
+def _trust_backend_process_failed_error(process: _ProcessHandle) -> TrustBackendProcessFailedError:
+    exitcode = getattr(process, "exitcode", None)
+    if isinstance(exitcode, int):
+        return TrustBackendProcessFailedError(f"trust_backend_process_failed:{exitcode}")
+    return TrustBackendProcessFailedError("trust_backend_process_failed")
 
 
 def select_trust_backend(
@@ -229,9 +240,14 @@ def run_trust_backend_check(
         if not result_file.exists():
             if on_error is None:
                 return timeout_result
-            return on_error(RuntimeError("trust_backend_process_failed"))
-        with result_file.open("rb") as handle:
-            ok, value = pickle.load(handle)
+            return on_error(_trust_backend_process_failed_error(process))
+        try:
+            with result_file.open("rb") as handle:
+                ok, value = pickle.load(handle)
+        except (EOFError, OSError, pickle.UnpicklingError) as error:
+            if on_error is None:
+                return timeout_result
+            return on_error(error)
         if ok:
             return cast("_TrustResult", value)
         if on_error is None:
@@ -244,7 +260,7 @@ def degraded_reason_for_backend_error(error: BaseException) -> str:
 
     if isinstance(error, TimeoutError):
         return POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT
-    if isinstance(error, TrustBackendUnavailableError):
+    if isinstance(error, (TrustBackendProcessFailedError, TrustBackendUnavailableError)):
         return POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
     if isinstance(error, PermissionError):
         return POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -28,6 +28,7 @@ from codex_plugin_scanner.guard.local_trust_contract import (
     POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED,
     POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT,
     POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE,
+    TrustBackendProcessFailedError,
     TrustBackendUnavailableError,
     TrustStatus,
     degraded_reason_for_backend_error,
@@ -93,6 +94,14 @@ def _write_nested_trust_marker(marker_path: str) -> None:
 def _write_delayed_nested_trust_marker(marker_path: str) -> None:
     time.sleep(0.4)
     Path(marker_path).write_text("late", encoding="utf-8")
+
+
+def _write_corrupt_trust_result(operation, result_path: str) -> None:
+    Path(result_path).write_bytes(b"not a pickle")
+
+
+def _skip_trust_result(operation, result_path: str) -> None:
+    operation()
 
 
 def test_local_trust_contract_exports_stable_status_vocabulary() -> None:
@@ -254,6 +263,36 @@ def test_trust_backend_timeout_falls_back_when_process_group_missing(
     assert calls == ["killpg:12345:15", "terminate", "join:0.2"]
 
 
+def test_trust_backend_check_handles_corrupt_result_file(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(local_trust_contract_module, "_trust_backend_check_worker", _write_corrupt_trust_result)
+
+    result = run_trust_backend_check(
+        lambda: {"mode": "protected"},
+        timeout_seconds=1.0,
+        timeout_result={"mode": "degraded"},
+        on_error=lambda error: {"mode": "degraded", "error": error.__class__.__name__},
+    )
+
+    assert result == {"mode": "degraded", "error": "UnpicklingError"}
+
+
+def test_trust_backend_check_reports_missing_result_with_exit_code(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(local_trust_contract_module, "_trust_backend_check_worker", _skip_trust_result)
+
+    result = run_trust_backend_check(
+        lambda: {"mode": "protected"},
+        timeout_seconds=1.0,
+        timeout_result={"mode": "degraded"},
+        on_error=lambda error: {"mode": "degraded", "error": str(error)},
+    )
+
+    assert result == {"mode": "degraded", "error": "trust_backend_process_failed:0"}
+
+
 def test_trust_backend_timeout_helper_allows_minimal_fallback_contract() -> None:
     timeout_result = {"mode": "degraded"}
 
@@ -326,6 +365,10 @@ def test_trust_backend_errors_normalize_to_safe_degraded_reasons() -> None:
     assert degraded_reason_for_backend_error(TimeoutError("slow")) == POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT
     assert (
         degraded_reason_for_backend_error(TrustBackendUnavailableError("fork unavailable"))
+        == POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
+    )
+    assert (
+        degraded_reason_for_backend_error(TrustBackendProcessFailedError("worker died"))
         == POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
     )
     assert (


### PR DESCRIPTION
## Summary\n- handle corrupt or truncated trust backend result files without throwing\n- surface worker crash diagnostics to error handlers\n- cover missing and corrupt result files in policy integrity tests\n\n## Test\n- python3 -m pytest tests/test_guard_policy_integrity.py --tb=short -q\n- python3 -m ruff check src/codex_plugin_scanner/guard/local_trust_contract.py tests/test_guard_policy_integrity.py\n- python3 -m ruff format --check src/codex_plugin_scanner/guard/local_trust_contract.py tests/test_guard_policy_integrity.py\n- git diff --check