### PR TITLE
fix(guard): validate trust backend result payloads

### DIFF
--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -264,7 +264,7 @@ def run_trust_backend_check(
             return on_error(_trust_backend_process_failed_error(process))
         try:
             ok, value = _load_trust_backend_result(result_file)
-        except TrustBackendCorruptResultError as error:
+        except (PermissionError, TrustBackendCorruptResultError) as error:
             if on_error is None:
                 return timeout_result
             return on_error(error)

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import json
 import multiprocessing
 import os
 import pickle
@@ -201,9 +200,11 @@ def _load_trust_backend_result(result_file: Path) -> tuple[bool, object]:
     try:
         with result_file.open("rb") as handle:
             payload = pickle.load(handle)
+    except PermissionError:
+        raise
     except Exception as error:
         raise TrustBackendCorruptResultError("trust_backend_result_corrupt") from error
-    if not isinstance(payload, (tuple, list)) or len(payload) != 2:
+    if not isinstance(payload, tuple) or len(payload) != 2:
         raise TrustBackendCorruptResultError("trust_backend_result_corrupt")
     ok, value = payload
     if not isinstance(ok, bool):
@@ -283,7 +284,7 @@ def degraded_reason_for_backend_error(error: BaseException) -> str:
         return POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
     if isinstance(error, PermissionError):
         return POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED
-    if isinstance(error, (TrustBackendCorruptResultError, ValueError, json.JSONDecodeError)):
+    if isinstance(error, ValueError):
         return POLICY_INTEGRITY_REASON_BACKEND_CORRUPT
     return POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
 

--- a/src/codex_plugin_scanner/guard/local_trust_contract.py
+++ b/src/codex_plugin_scanner/guard/local_trust_contract.py
@@ -140,6 +140,10 @@ class TrustBackendProcessFailedError(RuntimeError):
     """Raised when passive trust backend worker exits without a readable result."""
 
 
+class TrustBackendCorruptResultError(ValueError):
+    """Raised when passive trust backend worker writes malformed result data."""
+
+
 def _trust_backend_check_worker(
     operation: Callable[[], object],
     result_path: str,
@@ -193,6 +197,22 @@ def _trust_backend_process_failed_error(process: _ProcessHandle) -> TrustBackend
     return TrustBackendProcessFailedError("trust_backend_process_failed")
 
 
+def _load_trust_backend_result(result_file: Path) -> tuple[bool, object]:
+    try:
+        with result_file.open("rb") as handle:
+            payload = pickle.load(handle)
+    except Exception as error:
+        raise TrustBackendCorruptResultError("trust_backend_result_corrupt") from error
+    if not isinstance(payload, (tuple, list)) or len(payload) != 2:
+        raise TrustBackendCorruptResultError("trust_backend_result_corrupt")
+    ok, value = payload
+    if not isinstance(ok, bool):
+        raise TrustBackendCorruptResultError("trust_backend_result_corrupt")
+    if not ok and not isinstance(value, BaseException):
+        raise TrustBackendCorruptResultError("trust_backend_result_corrupt")
+    return ok, value
+
+
 def select_trust_backend(
     backends: tuple[TrustBackend, ...],
     *,
@@ -242,9 +262,8 @@ def run_trust_backend_check(
                 return timeout_result
             return on_error(_trust_backend_process_failed_error(process))
         try:
-            with result_file.open("rb") as handle:
-                ok, value = pickle.load(handle)
-        except (EOFError, OSError, pickle.UnpicklingError) as error:
+            ok, value = _load_trust_backend_result(result_file)
+        except TrustBackendCorruptResultError as error:
             if on_error is None:
                 return timeout_result
             return on_error(error)
@@ -264,7 +283,7 @@ def degraded_reason_for_backend_error(error: BaseException) -> str:
         return POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
     if isinstance(error, PermissionError):
         return POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED
-    if isinstance(error, (ValueError, json.JSONDecodeError)):
+    if isinstance(error, (TrustBackendCorruptResultError, ValueError, json.JSONDecodeError)):
         return POLICY_INTEGRITY_REASON_BACKEND_CORRUPT
     return POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
 

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -351,6 +351,32 @@ def test_trust_backend_result_loader_preserves_permission_denied() -> None:
         local_trust_contract_module._load_trust_backend_result(cast(Path, PermissionDeniedResultPath()))
 
 
+def test_trust_backend_check_handles_result_permission_denied(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def denied_loader(result_file: Path):
+        raise PermissionError("denied")
+
+    monkeypatch.setattr(local_trust_contract_module, "_load_trust_backend_result", denied_loader)
+
+    result = run_trust_backend_check(
+        lambda: {"mode": "protected"},
+        timeout_seconds=1.0,
+        timeout_result={"mode": "degraded"},
+        on_error=lambda error: {
+            "mode": "degraded",
+            "error": error.__class__.__name__,
+            "reason": degraded_reason_for_backend_error(error),
+        },
+    )
+
+    assert result == {
+        "mode": "degraded",
+        "error": "PermissionError",
+        "reason": POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED,
+    }
+
+
 def test_trust_backend_check_reports_missing_result_with_exit_code(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import pickle
 import sqlite3
 import sys
 import time
@@ -28,6 +29,7 @@ from codex_plugin_scanner.guard.local_trust_contract import (
     POLICY_INTEGRITY_REASON_BACKEND_PERMISSION_DENIED,
     POLICY_INTEGRITY_REASON_BACKEND_TIMEOUT,
     POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE,
+    TrustBackendCorruptResultError,
     TrustBackendProcessFailedError,
     TrustBackendUnavailableError,
     TrustStatus,
@@ -98,6 +100,10 @@ def _write_delayed_nested_trust_marker(marker_path: str) -> None:
 
 def _write_corrupt_trust_result(operation, result_path: str) -> None:
     Path(result_path).write_bytes(b"not a pickle")
+
+
+def _write_malformed_trust_result(operation, result_path: str) -> None:
+    Path(result_path).write_bytes(pickle.dumps({"ok": True}))
 
 
 def _skip_trust_result(operation, result_path: str) -> None:
@@ -272,10 +278,41 @@ def test_trust_backend_check_handles_corrupt_result_file(
         lambda: {"mode": "protected"},
         timeout_seconds=1.0,
         timeout_result={"mode": "degraded"},
-        on_error=lambda error: {"mode": "degraded", "error": error.__class__.__name__},
+        on_error=lambda error: {
+            "mode": "degraded",
+            "error": error.__class__.__name__,
+            "reason": degraded_reason_for_backend_error(error),
+        },
     )
 
-    assert result == {"mode": "degraded", "error": "UnpicklingError"}
+    assert result == {
+        "mode": "degraded",
+        "error": "TrustBackendCorruptResultError",
+        "reason": POLICY_INTEGRITY_REASON_BACKEND_CORRUPT,
+    }
+
+
+def test_trust_backend_check_rejects_malformed_result_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(local_trust_contract_module, "_trust_backend_check_worker", _write_malformed_trust_result)
+
+    result = run_trust_backend_check(
+        lambda: {"mode": "protected"},
+        timeout_seconds=1.0,
+        timeout_result={"mode": "degraded"},
+        on_error=lambda error: {
+            "mode": "degraded",
+            "error": error.__class__.__name__,
+            "reason": degraded_reason_for_backend_error(error),
+        },
+    )
+
+    assert result == {
+        "mode": "degraded",
+        "error": "TrustBackendCorruptResultError",
+        "reason": POLICY_INTEGRITY_REASON_BACKEND_CORRUPT,
+    }
 
 
 def test_trust_backend_check_reports_missing_result_with_exit_code(
@@ -370,6 +407,10 @@ def test_trust_backend_errors_normalize_to_safe_degraded_reasons() -> None:
     assert (
         degraded_reason_for_backend_error(TrustBackendProcessFailedError("worker died"))
         == POLICY_INTEGRITY_REASON_BACKEND_UNAVAILABLE
+    )
+    assert (
+        degraded_reason_for_backend_error(TrustBackendCorruptResultError("bad result"))
+        == POLICY_INTEGRITY_REASON_BACKEND_CORRUPT
     )
     assert (
         degraded_reason_for_backend_error(PermissionError("denied"))

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -106,6 +106,10 @@ def _write_malformed_trust_result(operation, result_path: str) -> None:
     Path(result_path).write_bytes(pickle.dumps({"ok": True}))
 
 
+def _write_list_trust_result(operation, result_path: str) -> None:
+    Path(result_path).write_bytes(pickle.dumps([True, {"mode": "protected"}]))
+
+
 def _skip_trust_result(operation, result_path: str) -> None:
     operation()
 
@@ -313,6 +317,38 @@ def test_trust_backend_check_rejects_malformed_result_payload(
         "error": "TrustBackendCorruptResultError",
         "reason": POLICY_INTEGRITY_REASON_BACKEND_CORRUPT,
     }
+
+
+def test_trust_backend_check_rejects_list_result_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(local_trust_contract_module, "_trust_backend_check_worker", _write_list_trust_result)
+
+    result = run_trust_backend_check(
+        lambda: {"mode": "protected"},
+        timeout_seconds=1.0,
+        timeout_result={"mode": "degraded"},
+        on_error=lambda error: {
+            "mode": "degraded",
+            "error": error.__class__.__name__,
+            "reason": degraded_reason_for_backend_error(error),
+        },
+    )
+
+    assert result == {
+        "mode": "degraded",
+        "error": "TrustBackendCorruptResultError",
+        "reason": POLICY_INTEGRITY_REASON_BACKEND_CORRUPT,
+    }
+
+
+def test_trust_backend_result_loader_preserves_permission_denied() -> None:
+    class PermissionDeniedResultPath:
+        def open(self, mode: str = "rb"):
+            raise PermissionError("denied")
+
+    with pytest.raises(PermissionError):
+        local_trust_contract_module._load_trust_backend_result(cast(Path, PermissionDeniedResultPath()))
 
 
 def test_trust_backend_check_reports_missing_result_with_exit_code(


### PR DESCRIPTION
## Summary\n- wrap malformed trust backend result files in a dedicated corruption error\n- validate result payload shape before using worker output\n- normalize corrupt result errors to the corrupt backend reason\n\n## Test\n- python3 -m pytest tests/test_guard_policy_integrity.py --tb=short -q\n- python3 -m ruff check src/codex_plugin_scanner/guard/local_trust_contract.py tests/test_guard_policy_integrity.py\n- python3 -m ruff format --check src/codex_plugin_scanner/guard/local_trust_contract.py tests/test_guard_policy_integrity.py\n- git diff --check