### PR TITLE
feat(guard): add no-ui trust CLI

### DIFF
--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -254,6 +254,7 @@ def _resolve_legacy_args(
         "allow",
         "deny",
         "policies",
+        "trust",
         "settings",
         "exceptions",
         "advisories",

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -24,6 +24,7 @@ if TYPE_CHECKING:
 
 
 from ..aibom_cli import _AIBOM_CLOUD_SYNC_OPTIONS, AibomCliOptions, AibomExportFormat
+from ..local_trust_contract import TrustStatus
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -412,6 +413,88 @@ def _run_guard_policies_command(
     return 0
 
 
+def _trust_status_payload(store: GuardStore, *, command: str, backend: str) -> dict[str, object]:
+    status_payload = store.get_policy_integrity_status()
+    trust_status = status_payload.get("trust_status")
+    if not isinstance(trust_status, dict):
+        trust_status = TrustStatus.from_policy_integrity_state(status_payload).to_dict()
+    degraded_reasons = trust_status.get("degraded_reasons")
+    reasons = (
+        [reason for reason in degraded_reasons if isinstance(reason, str)] if isinstance(degraded_reasons, list) else []
+    )
+    runtime_protection = str(trust_status.get("runtime_protection") or "unknown")
+    remembered_rules = str(trust_status.get("remembered_rules") or "unknown")
+    cloud_policies = str(trust_status.get("cloud_policies") or "unknown")
+    setup_available = bool(trust_status.get("setup_available"))
+    return {
+        "generated_at": _now(),
+        "command": command,
+        "backend_requested": backend,
+        "backend": trust_status.get("backend") or status_payload.get("backend") or "unknown",
+        "runtime_protection": runtime_protection,
+        "remembered_rules": remembered_rules,
+        "cloud_policies": cloud_policies,
+        "degraded_reasons": reasons,
+        "degraded_reason_labels": trust_status.get("degraded_reason_labels") or {},
+        "setup_available": setup_available,
+        "no_ui_passive": True,
+        "passive_prompt_allowed": False,
+        "one_time_approvals": "available",
+        "durable_local_rules": "enforced" if remembered_rules == "enforced" else "limited",
+        "cloud_policy_authority": cloud_policies,
+        "message": (
+            "Guard is blocking risky actions. Broad remembered local rules are limited until local trust is protected."
+            if remembered_rules != "enforced"
+            else "Guard local trust is protected. Remembered local rules are enforced."
+        ),
+    }
+
+
+def _run_guard_trust_command(
+    args: argparse.Namespace,
+    *,
+    guard_home: Path | None = None,
+    workspace: Path | None = None,
+    context: HarnessContext | None = None,
+    store: GuardStore | None = None,
+    config: GuardConfig | None = None,
+    input_text: str | None = None,
+    output_stream: TextIO | None = None,
+) -> int:
+    store = _require_guard_store(store)
+    trust_command = getattr(args, "trust_command", None) or "status"
+    backend = str(getattr(args, "backend", None) or "auto")
+    payload = _trust_status_payload(store, command=trust_command, backend=backend)
+    if trust_command in {"status", "doctor"}:
+        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+        return 0
+    if trust_command == "test":
+        if not bool(getattr(args, "no_ui", False)):
+            payload["error"] = "Use --no-ui so Guard can prove this probe will not open an OS credential prompt."
+            _emit("trust.test", payload, getattr(args, "json", False))
+            return 2
+        payload["probe"] = "passive_no_ui"
+        payload["ok"] = True
+        _emit("trust.test", payload, getattr(args, "json", False))
+        return 0
+    if trust_command in {"setup", "reset"}:
+        if backend == "macos-native":
+            payload["error"] = (
+                "macOS native trust setup is not enabled yet. Passive checks remain no-UI and degraded-safe."
+            )
+            payload["next_action"] = "Use one-time approvals or Guard Cloud policies until native setup is available."
+        elif trust_command == "setup":
+            payload["error"] = "No explicit local trust backend is available for setup on this platform."
+            payload["next_action"] = "Runtime protection remains active. Broad remembered local rules stay limited."
+        else:
+            payload["error"] = "No explicit local trust backend is active to reset."
+            payload["next_action"] = "Nothing changed."
+        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+        return 2
+    _emit("trust", {"error": "Use: hol-guard guard trust status|doctor|test|setup|reset"}, getattr(args, "json", False))
+    return 2
+
+
 def _run_guard_settings_command(
     args: argparse.Namespace,
     *,
@@ -477,4 +560,5 @@ __all__ = [
     "_run_guard_policies_command",
     "_run_guard_receipts_command",
     "_run_guard_settings_command",
+    "_run_guard_trust_command",
 ]

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -480,7 +480,7 @@ def _run_guard_trust_command(
     if trust_command in {"setup", "reset"}:
         if backend == "macos-native":
             payload["error"] = (
-                "macOS native trust setup is not enabled yet. Passive checks remain no-UI and degraded-safe."
+                f"macOS native trust {trust_command} is not enabled yet. Passive checks remain no-UI and degraded-safe."
             )
             payload["next_action"] = "Use one-time approvals or Guard Cloud policies until native setup is available."
         elif trust_command == "setup":

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
 
 
 from ..aibom_cli import _AIBOM_CLOUD_SYNC_OPTIONS, AibomCliOptions, AibomExportFormat
-from ..local_trust_contract import TrustStatus
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -413,88 +412,6 @@ def _run_guard_policies_command(
     return 0
 
 
-def _trust_status_payload(store: GuardStore, *, command: str, backend: str) -> dict[str, object]:
-    status_payload = store.get_policy_integrity_status()
-    trust_status = status_payload.get("trust_status")
-    if not isinstance(trust_status, dict):
-        trust_status = TrustStatus.from_policy_integrity_state(status_payload).to_dict()
-    degraded_reasons = trust_status.get("degraded_reasons")
-    reasons = (
-        [reason for reason in degraded_reasons if isinstance(reason, str)] if isinstance(degraded_reasons, list) else []
-    )
-    runtime_protection = str(trust_status.get("runtime_protection") or "unknown")
-    remembered_rules = str(trust_status.get("remembered_rules") or "unknown")
-    cloud_policies = str(trust_status.get("cloud_policies") or "unknown")
-    setup_available = bool(trust_status.get("setup_available"))
-    return {
-        "generated_at": _now(),
-        "command": command,
-        "backend_requested": backend,
-        "backend": trust_status.get("backend") or status_payload.get("backend") or "unknown",
-        "runtime_protection": runtime_protection,
-        "remembered_rules": remembered_rules,
-        "cloud_policies": cloud_policies,
-        "degraded_reasons": reasons,
-        "degraded_reason_labels": trust_status.get("degraded_reason_labels") or {},
-        "setup_available": setup_available,
-        "no_ui_passive": True,
-        "passive_prompt_allowed": False,
-        "one_time_approvals": "available",
-        "durable_local_rules": "enforced" if remembered_rules == "enforced" else "limited",
-        "cloud_policy_authority": cloud_policies,
-        "message": (
-            "Guard is blocking risky actions. Broad remembered local rules are limited until local trust is protected."
-            if remembered_rules != "enforced"
-            else "Guard local trust is protected. Remembered local rules are enforced."
-        ),
-    }
-
-
-def _run_guard_trust_command(
-    args: argparse.Namespace,
-    *,
-    guard_home: Path | None = None,
-    workspace: Path | None = None,
-    context: HarnessContext | None = None,
-    store: GuardStore | None = None,
-    config: GuardConfig | None = None,
-    input_text: str | None = None,
-    output_stream: TextIO | None = None,
-) -> int:
-    store = _require_guard_store(store)
-    trust_command = getattr(args, "trust_command", None) or "status"
-    backend = str(getattr(args, "backend", None) or "auto")
-    payload = _trust_status_payload(store, command=trust_command, backend=backend)
-    if trust_command in {"status", "doctor"}:
-        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
-        return 0
-    if trust_command == "test":
-        if not bool(getattr(args, "no_ui", False)):
-            payload["error"] = "Use --no-ui so Guard can prove this probe will not open an OS credential prompt."
-            _emit("trust.test", payload, getattr(args, "json", False))
-            return 2
-        payload["probe"] = "passive_no_ui"
-        payload["ok"] = True
-        _emit("trust.test", payload, getattr(args, "json", False))
-        return 0
-    if trust_command in {"setup", "reset"}:
-        if backend == "macos-native":
-            payload["error"] = (
-                f"macOS native trust {trust_command} is not enabled yet. Passive checks remain no-UI and degraded-safe."
-            )
-            payload["next_action"] = "Use one-time approvals or Guard Cloud policies until native setup is available."
-        elif trust_command == "setup":
-            payload["error"] = "No explicit local trust backend is available for setup on this platform."
-            payload["next_action"] = "Runtime protection remains active. Broad remembered local rules stay limited."
-        else:
-            payload["error"] = "No explicit local trust backend is active to reset."
-            payload["next_action"] = "Nothing changed."
-        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
-        return 2
-    _emit("trust", {"error": "Use: hol-guard guard trust status|doctor|test|setup|reset"}, getattr(args, "json", False))
-    return 2
-
-
 def _run_guard_settings_command(
     args: argparse.Namespace,
     *,
@@ -560,5 +477,4 @@ __all__ = [
     "_run_guard_policies_command",
     "_run_guard_receipts_command",
     "_run_guard_settings_command",
-    "_run_guard_trust_command",
 ]

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -1,0 +1,155 @@
+"""Guard local trust CLI dispatch helpers."""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import TextIO
+
+from ..adapters.base import HarnessContext
+from ..config import GuardConfig
+from ..local_trust_contract import TrustStatus
+from ..store import GuardStore
+from .commands_support_interaction import _emit
+
+
+def _now() -> str:
+    from ._commands_shared import _now as _shared_now
+
+    return _shared_now()
+
+
+def _require_guard_store(store: GuardStore | None) -> GuardStore:
+    from ._commands_shared import _require_guard_store as _shared_require_guard_store
+
+    return _shared_require_guard_store(store)
+
+
+def _degraded_safe_trust_status() -> dict[str, object]:
+    return TrustStatus(
+        runtime_protection="degraded",
+        remembered_rules="disabled_degraded",
+        cloud_policies="setup_unavailable",
+        backend="degraded-safe",
+        setup_available=False,
+    ).to_dict()
+
+
+def _unsupported_backend_payload(*, command: str, backend: str) -> dict[str, object]:
+    return {
+        "generated_at": _now(),
+        "command": command,
+        "backend_requested": backend,
+        "backend": backend,
+        "runtime_protection": "degraded",
+        "remembered_rules": "disabled_degraded",
+        "cloud_policies": "setup_unavailable",
+        "degraded_reasons": ["trust_backend_unavailable"],
+        "degraded_reason_labels": {"trust_backend_unavailable": "Local trust backend unavailable"},
+        "setup_available": backend == "macos-native",
+        "no_ui_passive": True,
+        "passive_prompt_allowed": False,
+        "one_time_approvals": "available",
+        "durable_local_rules": "limited",
+        "cloud_policy_authority": "setup_unavailable",
+        "error": (
+            f"Backend {backend!r} is not available for passive {command}. "
+            "Guard will not probe it in the background because that could open an OS credential prompt."
+        ),
+        "next_action": "Use --backend auto or run an explicit setup command when a backend is available.",
+    }
+
+
+def _trust_status_payload(store: GuardStore, *, command: str, backend: str) -> dict[str, object]:
+    if backend == "degraded-safe":
+        trust_status = _degraded_safe_trust_status()
+    else:
+        status_payload = store.get_policy_integrity_status()
+        trust_status = status_payload.get("trust_status")
+        if not isinstance(trust_status, dict):
+            trust_status = TrustStatus.from_policy_integrity_state(status_payload).to_dict()
+    degraded_reasons = trust_status.get("degraded_reasons")
+    reasons = (
+        [reason for reason in degraded_reasons if isinstance(reason, str)] if isinstance(degraded_reasons, list) else []
+    )
+    runtime_protection = str(trust_status.get("runtime_protection") or "unknown")
+    remembered_rules = str(trust_status.get("remembered_rules") or "unknown")
+    cloud_policies = str(trust_status.get("cloud_policies") or "unknown")
+    return {
+        "generated_at": _now(),
+        "command": command,
+        "backend_requested": backend,
+        "backend": trust_status.get("backend") or "unknown",
+        "runtime_protection": runtime_protection,
+        "remembered_rules": remembered_rules,
+        "cloud_policies": cloud_policies,
+        "degraded_reasons": reasons,
+        "degraded_reason_labels": trust_status.get("degraded_reason_labels") or {},
+        "setup_available": bool(trust_status.get("setup_available")),
+        "no_ui_passive": True,
+        "passive_prompt_allowed": False,
+        "one_time_approvals": "available",
+        "durable_local_rules": "enforced" if remembered_rules == "enforced" else "limited",
+        "cloud_policy_authority": cloud_policies,
+        "message": (
+            "Guard is blocking risky actions. Broad remembered local rules are limited until local trust is protected."
+            if remembered_rules != "enforced"
+            else "Guard local trust is protected. Remembered local rules are enforced."
+        ),
+    }
+
+
+def _run_guard_trust_command(
+    args: argparse.Namespace,
+    *,
+    guard_home: Path | None = None,
+    workspace: Path | None = None,
+    context: HarnessContext | None = None,
+    store: GuardStore | None = None,
+    config: GuardConfig | None = None,
+    input_text: str | None = None,
+    output_stream: TextIO | None = None,
+) -> int:
+    del guard_home, workspace, context, config, input_text, output_stream
+    store = _require_guard_store(store)
+    trust_command = getattr(args, "trust_command", None) or "status"
+    backend = str(getattr(args, "backend", None) or "auto")
+    if backend == "macos-native" and trust_command in {"status", "doctor", "test"}:
+        payload = _unsupported_backend_payload(command=trust_command, backend=backend)
+        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+        return 2
+    payload = _trust_status_payload(store, command=trust_command, backend=backend)
+    if trust_command in {"status", "doctor"}:
+        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+        return 0
+    if trust_command == "test":
+        if not bool(getattr(args, "no_ui", False)):
+            payload["error"] = "Use --no-ui so Guard can prove this probe will not open an OS credential prompt."
+            _emit("trust.test", payload, getattr(args, "json", False))
+            return 2
+        payload["probe"] = "passive_no_ui"
+        payload["ok"] = payload["passive_prompt_allowed"] is False
+        payload["trust_health"] = "protected" if payload["remembered_rules"] == "enforced" else "degraded_safe"
+        _emit("trust.test", payload, getattr(args, "json", False))
+        return 0
+    if trust_command in {"setup", "reset"}:
+        if backend == "macos-native":
+            payload["error"] = (
+                f"macOS native trust {trust_command} is not enabled yet. Passive checks remain no-UI and degraded-safe."
+            )
+            payload["next_action"] = "Use one-time approvals or Guard Cloud policies until native setup is available."
+        elif trust_command == "setup":
+            payload["error"] = "No explicit local trust backend is available for setup on this platform."
+            payload["next_action"] = "Runtime protection remains active. Broad remembered local rules stay limited."
+        else:
+            payload["error"] = "No explicit local trust backend is active to reset."
+            payload["next_action"] = "Nothing changed."
+        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+        return 2
+    _emit("trust", {"error": "Use: hol-guard guard trust status|doctor|test|setup|reset"}, getattr(args, "json", False))
+    return 2
+
+
+__all__ = [
+    "_run_guard_trust_command",
+]

--- a/src/codex_plugin_scanner/guard/cli/commands_parser.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser.py
@@ -51,7 +51,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         parser_class=FriendlyArgumentParser,
         metavar=(
             "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
-            "receipts,inventory,abom,aibom,approvals,explain,allow,deny,policies,exceptions,advisories,events,doctor,connect,"
+            "receipts,inventory,abom,aibom,approvals,explain,allow,deny,policies,trust,exceptions,advisories,events,doctor,connect,"
             "remote-pair,disconnect,"
             "login,sync,device,commands,bridge}"
         ),

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -62,6 +62,32 @@ def _configure_guard_policy_parsers(
     _add_guard_common_args(policies_parser)
     policies_parser.add_argument("--json", action="store_true")
 
+    trust_parser = guard_subparsers.add_parser("trust", help="Inspect local trust without passive OS prompts")
+    trust_parser.add_argument(
+        "trust_command",
+        nargs="?",
+        default="status",
+        choices=("status", "doctor", "test", "setup", "reset"),
+    )
+    trust_parser.add_argument(
+        "--backend",
+        choices=("auto", "degraded-safe", "macos-native"),
+        default="auto",
+        help="Local trust backend to inspect or set up.",
+    )
+    trust_parser.add_argument(
+        "--no-ui",
+        action="store_true",
+        help="Run only bounded no-user-interaction checks.",
+    )
+    trust_parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Confirm explicit setup or reset prompts.",
+    )
+    _add_guard_common_args(trust_parser)
+    trust_parser.add_argument("--json", action="store_true")
+
     settings_parser = guard_subparsers.add_parser("settings", help="Show or update local Guard settings")
     _add_guard_common_args(settings_parser)
     settings_parser.add_argument("--json", action="store_true")

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -80,11 +80,6 @@ def _configure_guard_policy_parsers(
         action="store_true",
         help="Run only bounded no-user-interaction checks.",
     )
-    trust_parser.add_argument(
-        "--yes",
-        action="store_true",
-        help="Confirm explicit setup or reset prompts.",
-    )
     _add_guard_common_args(trust_parser)
     trust_parser.add_argument("--json", action="store_true")
 

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -50,6 +50,7 @@ _COMMON_HANDLERS = {
     "aibom": "_run_guard_aibom_command",
     "abom": "_run_guard_abom_command",
     "policies": "_run_guard_policies_command",
+    "trust": "_run_guard_trust_command",
     "settings": "_run_guard_settings_command",
     "exceptions": "_run_guard_exceptions_command",
     "advisories": "_run_guard_advisories_command",

--- a/src/codex_plugin_scanner/guard/cli/commands_support.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support.py
@@ -30,6 +30,7 @@ from . import commands_support_service as _commands_support_service
 from . import commands_dispatch_local as _commands_dispatch_local
 from . import commands_dispatch_proxy as _commands_dispatch_proxy
 from . import commands_dispatch_records as _commands_dispatch_records
+from . import commands_dispatch_trust as _commands_dispatch_trust
 from . import commands_dispatch_admin as _commands_dispatch_admin
 from . import commands_dispatch_cloud as _commands_dispatch_cloud
 from . import commands_hook_copilot as _commands_hook_copilot
@@ -63,6 +64,7 @@ _SOURCE_MODULES: tuple[ModuleType, ...] = (
     _commands_dispatch_local,
     _commands_dispatch_proxy,
     _commands_dispatch_records,
+    _commands_dispatch_trust,
     _commands_dispatch_admin,
     _commands_dispatch_cloud,
     _commands_hook_copilot,

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1273,6 +1273,62 @@ def test_policies_cli_verify_status_migrate_and_repair(
     assert GuardStore(home_dir).list_policy_decisions() == []
 
 
+def test_trust_cli_status_reports_no_passive_prompts(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    rc = main(["guard", "trust", "status", "--home", str(home_dir), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["command"] == "status"
+    assert payload["no_ui_passive"] is True
+    assert payload["passive_prompt_allowed"] is False
+    assert payload["runtime_protection"] in {"protected", "degraded", "unknown"}
+    assert payload["remembered_rules"] in {"enforced", "disabled_degraded", "unknown"}
+    assert payload["one_time_approvals"] == "available"
+    assert payload["durable_local_rules"] in {"enforced", "limited"}
+    assert "key_id" not in payload
+    assert "last_proof" not in payload
+
+
+def test_trust_cli_no_ui_probe_requires_no_ui_flag(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+
+    missing_flag_rc = main(["guard", "trust", "test", "--home", str(home_dir), "--json"])
+    missing_flag_payload = json.loads(capsys.readouterr().out)
+    assert missing_flag_rc == 2
+    assert "Use --no-ui" in missing_flag_payload["error"]
+    assert missing_flag_payload["passive_prompt_allowed"] is False
+
+    no_ui_rc = main(["guard", "trust", "test", "--home", str(home_dir), "--no-ui", "--json"])
+    no_ui_payload = json.loads(capsys.readouterr().out)
+    assert no_ui_rc == 0
+    assert no_ui_payload["probe"] == "passive_no_ui"
+    assert no_ui_payload["ok"] is True
+    assert no_ui_payload["passive_prompt_allowed"] is False
+
+
+def test_trust_cli_macos_native_setup_is_explicitly_unavailable(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    rc = main(
+        [
+            "guard",
+            "trust",
+            "setup",
+            "--backend",
+            "macos-native",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert payload["backend_requested"] == "macos-native"
+    assert "not enabled yet" in payload["error"]
+    assert payload["passive_prompt_allowed"] is False
+
+
 def test_policies_cli_verify_returns_nonzero_for_rollback_detected(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1305,6 +1305,52 @@ def test_trust_cli_no_ui_probe_requires_no_ui_flag(tmp_path: Path, capsys) -> No
     assert no_ui_payload["probe"] == "passive_no_ui"
     assert no_ui_payload["ok"] is True
     assert no_ui_payload["passive_prompt_allowed"] is False
+    assert no_ui_payload["trust_health"] in {"protected", "degraded_safe"}
+
+
+def test_trust_cli_rejects_unavailable_backend_status(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    rc = main(
+        [
+            "guard",
+            "trust",
+            "status",
+            "--backend",
+            "macos-native",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert payload["backend_requested"] == "macos-native"
+    assert "not available for passive status" in payload["error"]
+    assert payload["passive_prompt_allowed"] is False
+
+
+def test_trust_cli_degraded_safe_backend_is_explicit(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    rc = main(
+        [
+            "guard",
+            "trust",
+            "status",
+            "--backend",
+            "degraded-safe",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["backend_requested"] == "degraded-safe"
+    assert payload["backend"] == "degraded-safe"
+    assert payload["remembered_rules"] == "disabled_degraded"
+    assert payload["durable_local_rules"] == "limited"
 
 
 def test_trust_cli_macos_native_setup_is_explicitly_unavailable(tmp_path: Path, capsys) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -14,7 +14,7 @@ from typing import cast
 
 import pytest
 
-from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.cli import _resolve_legacy_args, main
 from codex_plugin_scanner.guard import local_trust_contract as local_trust_contract_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.local_trust_contract import (
@@ -1288,6 +1288,15 @@ def test_trust_cli_status_reports_no_passive_prompts(tmp_path: Path, capsys) -> 
     assert payload["durable_local_rules"] in {"enforced", "limited"}
     assert "key_id" not in payload
     assert "last_proof" not in payload
+
+
+def test_trust_cli_bare_combined_command_routes_to_guard() -> None:
+    assert _resolve_legacy_args(["trust", "status", "--json"], program_mode="combined") == [
+        "guard",
+        "trust",
+        "status",
+        "--json",
+    ]
 
 
 def test_trust_cli_no_ui_probe_requires_no_ui_flag(tmp_path: Path, capsys) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1326,7 +1326,24 @@ def test_trust_cli_macos_native_setup_is_explicitly_unavailable(tmp_path: Path, 
     assert rc == 2
     assert payload["backend_requested"] == "macos-native"
     assert "not enabled yet" in payload["error"]
+    assert "trust setup" in payload["error"]
     assert payload["passive_prompt_allowed"] is False
+
+    reset_rc = main(
+        [
+            "guard",
+            "trust",
+            "reset",
+            "--backend",
+            "macos-native",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    reset_payload = json.loads(capsys.readouterr().out)
+    assert reset_rc == 2
+    assert "trust reset" in reset_payload["error"]
 
 
 def test_policies_cli_verify_returns_nonzero_for_rollback_detected(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- Add `guard trust` commands for no-UI local trust status, doctor, probe, setup, and reset flows
- Expose explicit degraded-safe messaging so passive checks never imply OS credential prompts are allowed
- Add regression coverage for trust status, no-UI probe behavior, and disabled macOS native setup

## Testing
- `python3 -m pytest tests/test_guard_policy_integrity.py --tb=short -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_parser.py src/codex_plugin_scanner/guard/cli/commands_parser_policy.py src/codex_plugin_scanner/guard/cli/commands_router.py src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py tests/test_guard_policy_integrity.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/cli/commands_parser.py src/codex_plugin_scanner/guard/cli/commands_parser_policy.py src/codex_plugin_scanner/guard/cli/commands_router.py src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py tests/test_guard_policy_integrity.py`
- `git diff --check`
