### PR TITLE
fix(guard): repair stale approval review links

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -141,6 +141,7 @@ def primary_approval_request(
         for item in reversed(items):
             if _string_or_none(item.get("artifact_id")) == bound_artifact_id:
                 return item
+        return None
 
     if len(items) == 1:
         return items[0]
@@ -173,8 +174,8 @@ def primary_approval_url(
         return None
     approval_url = request.get("approval_url")
     if isinstance(approval_url, str) and approval_url.strip():
-        return _canonical_local_approval_url(
-            approval_url.strip().replace("/approvals/", "/requests/"),
+        return canonical_local_approval_url(
+            approval_url,
             approval_center_url=approval_center_url,
         )
     resolved_request_id = request.get("request_id")
@@ -185,19 +186,25 @@ def primary_approval_url(
     return None
 
 
-def _canonical_local_approval_url(approval_url: str, *, approval_center_url: str | None) -> str:
-    if not isinstance(approval_center_url, str) or not approval_center_url.strip():
-        return approval_url
+def canonical_local_approval_url(approval_url: str, *, approval_center_url: str | None) -> str:
+    """Rewrite stale loopback approval links to the active approval center."""
+
+    approval_url = approval_url.strip()
     try:
         parsed_approval = urlparse(approval_url)
-        parsed_center = urlparse(approval_center_url.strip())
     except ValueError:
         return approval_url
     loopback_hosts = {"127.0.0.1", "::1", "localhost"}
     approval_host = _parsed_url_host(parsed_approval)
-    center_host = _parsed_url_host(parsed_center)
     if parsed_approval.scheme not in {"http", "https"} or approval_host not in loopback_hosts:
         return approval_url
+    if not isinstance(approval_center_url, str) or not approval_center_url.strip():
+        return approval_url
+    try:
+        parsed_center = urlparse(approval_center_url.strip())
+    except ValueError:
+        return approval_url
+    center_host = _parsed_url_host(parsed_center)
     if parsed_center.scheme not in {"http", "https"} or center_host not in loopback_hosts:
         return approval_url
     return urlunparse(

--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -60,6 +60,7 @@ from ..approvals import (
     approval_prompt_flow,
     attach_primary_approval_link,
     build_approval_browser_url,
+    canonical_local_approval_url,
     first_approval_url,
     queue_blocked_approvals,
     wait_for_approval_requests,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -497,16 +497,45 @@ def _primary_approval_lookup_kwargs(response_payload: dict[str, object], *, harn
     }
 
 def _preferred_approval_review_url(response_payload: Mapping[str, object], *, harness: str) -> str | None:
+    approval_center_url = _optional_string(response_payload.get("approval_center_url"))
     queued = response_payload.get("approval_requests")
-    return (
-        _optional_string(response_payload.get("primary_approval_url"))
-        or (
-            first_approval_url(queued, **_primary_approval_lookup_kwargs(dict(response_payload), harness=harness))
-            if isinstance(queued, list)
-            else None
-        )
-        or _optional_string(response_payload.get("approval_center_url"))
+    lookup_kwargs = _primary_approval_lookup_kwargs(dict(response_payload), harness=harness)
+    artifact_id = lookup_kwargs.get("artifact_id")
+    queued_has_artifact_metadata = (
+        any(_optional_string(item.get("artifact_id")) is not None for item in queued if isinstance(item, Mapping))
+        if isinstance(queued, list)
+        else False
     )
+    queued_url = (
+        first_approval_url(
+            queued,
+            **lookup_kwargs,
+        )
+        if isinstance(queued, list)
+        else None
+    )
+    if queued_url is None and isinstance(queued, list) and artifact_id is not None:
+        queued_url = first_approval_url(
+            queued,
+            harness=harness,
+            approval_center_url=approval_center_url,
+            artifact_id=artifact_id,
+        )
+    if queued_url is None and isinstance(queued, list) and (artifact_id is None or not queued_has_artifact_metadata):
+        queued_url = first_approval_url(
+            queued,
+            harness=harness,
+            approval_center_url=approval_center_url,
+        )
+    if queued_url is not None:
+        return queued_url
+    primary_url = _optional_string(response_payload.get("primary_approval_url"))
+    if primary_url is not None:
+        return canonical_local_approval_url(
+            primary_url,
+            approval_center_url=approval_center_url,
+        )
+    return approval_center_url
 
 def _open_codex_live_approval(response_payload: Mapping[str, object], *, guard_home: Path | None = None) -> None:
     harness = _optional_string(response_payload.get("harness")) or "codex"

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -20,6 +20,7 @@ from codex_plugin_scanner.guard.approvals import (
     primary_approval_url,
 )
 from codex_plugin_scanner.guard.cli import approval_commands as approval_commands_module
+from codex_plugin_scanner.guard.cli.commands_support_interaction import _preferred_approval_review_url
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -198,6 +199,137 @@ def test_first_approval_url_does_not_rewrite_external_url() -> None:
         )
         == "https://guard.example/requests/req-cloud"
     )
+
+
+def test_preferred_approval_review_url_repairs_stale_primary_url() -> None:
+    payload = {
+        "approval_center_url": "http://127.0.0.1:5481",
+        "primary_approval_url": "http://127.0.0.1:4833/requests/req-stale-primary",
+        "approval_requests": [
+            {
+                "request_id": "req-stale-primary",
+                "harness": "codex",
+                "approval_url": "http://127.0.0.1:4833/requests/req-stale-primary",
+            }
+        ],
+    }
+
+    assert (
+        _preferred_approval_review_url(payload, harness="codex") == "http://127.0.0.1:5481/requests/req-stale-primary"
+    )
+
+
+def test_preferred_approval_review_url_keeps_external_primary_url() -> None:
+    payload = {
+        "approval_center_url": "http://127.0.0.1:5481",
+        "primary_approval_url": "https://guard.example/approvals/req-cloud",
+    }
+
+    assert _preferred_approval_review_url(payload, harness="codex") == "https://guard.example/approvals/req-cloud"
+
+
+def test_preferred_approval_review_url_does_not_normalize_approval_path() -> None:
+    payload = {
+        "approval_center_url": "http://127.0.0.1:5481",
+        "primary_approval_url": "http://127.0.0.1:4833/approvals/req-local",
+    }
+
+    assert _preferred_approval_review_url(payload, harness="codex") == "http://127.0.0.1:5481/approvals/req-local"
+
+
+def test_preferred_approval_review_url_uses_current_queue_over_stale_primary() -> None:
+    payload = {
+        "approval_center_url": "http://127.0.0.1:5481",
+        "primary_approval_url": "http://127.0.0.1:4833/requests/req-old",
+        "approval_requests": [
+            {
+                "request_id": "req-new",
+                "harness": "codex",
+                "approval_url": "http://127.0.0.1:4833/requests/req-new",
+            }
+        ],
+    }
+
+    assert _preferred_approval_review_url(payload, harness="codex") == "http://127.0.0.1:5481/requests/req-new"
+
+
+def test_preferred_approval_review_url_recovers_from_stale_request_id() -> None:
+    payload = {
+        "approval_center_url": "http://127.0.0.1:5481",
+        "primary_approval_request_id": "req-old",
+        "primary_approval_url": "http://127.0.0.1:4833/requests/req-old",
+        "approval_requests": [
+            {
+                "request_id": "req-new",
+                "harness": "codex",
+                "approval_url": "http://127.0.0.1:4833/requests/req-new",
+            }
+        ],
+    }
+
+    assert _preferred_approval_review_url(payload, harness="codex") == "http://127.0.0.1:5481/requests/req-new"
+
+
+def test_preferred_approval_review_url_keeps_artifact_binding_after_stale_request_id() -> None:
+    payload = {
+        "artifact_id": "artifact-a",
+        "approval_center_url": "http://127.0.0.1:5481",
+        "primary_approval_request_id": "req-old",
+        "primary_approval_url": "http://127.0.0.1:4833/requests/req-old",
+        "approval_requests": [
+            {
+                "artifact_id": "artifact-a",
+                "request_id": "req-a",
+                "harness": "codex",
+                "approval_url": "http://127.0.0.1:4833/requests/req-a",
+            },
+            {
+                "artifact_id": "artifact-b",
+                "request_id": "req-b",
+                "harness": "codex",
+                "approval_url": "http://127.0.0.1:4833/requests/req-b",
+            },
+        ],
+    }
+
+    assert _preferred_approval_review_url(payload, harness="codex") == "http://127.0.0.1:5481/requests/req-a"
+
+
+def test_preferred_approval_review_url_uses_primary_when_artifact_missing() -> None:
+    payload = {
+        "artifact_id": "artifact-a",
+        "approval_center_url": "http://127.0.0.1:5481",
+        "primary_approval_request_id": "req-old",
+        "primary_approval_url": "http://127.0.0.1:4833/requests/req-old",
+        "approval_requests": [
+            {
+                "artifact_id": "artifact-b",
+                "request_id": "req-b",
+                "harness": "codex",
+                "approval_url": "http://127.0.0.1:4833/requests/req-b",
+            }
+        ],
+    }
+
+    assert _preferred_approval_review_url(payload, harness="codex") == "http://127.0.0.1:5481/requests/req-old"
+
+
+def test_preferred_approval_review_url_uses_single_active_request_without_artifact_metadata() -> None:
+    payload = {
+        "artifact_id": "artifact-a",
+        "approval_center_url": "http://127.0.0.1:5481",
+        "primary_approval_request_id": "req-old",
+        "primary_approval_url": "http://127.0.0.1:4833/requests/req-old",
+        "approval_requests": [
+            {
+                "request_id": "req-new",
+                "harness": "codex",
+                "approval_url": "http://127.0.0.1:4833/requests/req-new",
+            }
+        ],
+    }
+
+    assert _preferred_approval_review_url(payload, harness="codex") == "http://127.0.0.1:5481/requests/req-new"
 
 
 def test_primary_approval_request_prefers_matching_harness() -> None:


### PR DESCRIPTION
## Summary
- Repair stale loopback approval review URLs when a payload already has `primary_approval_url`.
- Normalize legacy `/approvals/` deep links to `/requests/` before presenting them to harnesses.
- Keep external approval URLs unchanged.

## Tests
- `python3 -m pytest tests/test_guard_approval_copy_commands.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/_commands_shared.py src/codex_plugin_scanner/guard/cli/commands_support_interaction.py tests/test_guard_approval_copy_commands.py`
- `git diff --check`
