### PR TITLE
fix(guard): reuse Claude tool approvals on retry

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py
@@ -315,10 +315,12 @@ def _persist_claude_guard_question_decision(store: GuardStore, payload: dict[str
     artifact_hash_value = _optional_string(pending.get("artifact_hash"))
     if artifact_id is None or artifact_hash_value is None:
         return False
+    artifact_type = _optional_string(pending.get("artifact_type"))
     saved = _persist_claude_native_permission_policy(
         store=store,
         artifact_id=artifact_id,
         artifact_hash=artifact_hash_value,
+        artifact_type=artifact_type,
         action=action,
         reason=(
             "Allowed through HOL Guard AskUserQuestion approval."

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -421,10 +421,21 @@ def _persist_claude_native_permission_policy(
     now: str,
     source: str = "claude-native-approval",
 ) -> bool:
-    stored_artifact_hash = (
+    exact_artifact_hash = (
         _runtime_scoped_exact_match_key(artifact_id) if artifact_type == "tool_action_request" else None
-    ) or artifact_hash
+    )
+    stored_artifact_hash = exact_artifact_hash or artifact_hash
     try:
+        if artifact_type == "tool_action_request" and exact_artifact_hash is None:
+            store.add_event(
+                "claude/native_permission_exact_key_missing",
+                {
+                    "artifact_id": artifact_id,
+                    "artifact_type": artifact_type,
+                    "source": source,
+                },
+                now,
+            )
         store.upsert_policy(
             PolicyDecision(
                 harness="claude-code",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from .commands_support_runtime_resolution import _runtime_capabilities_summary
 
 
+from ..store import _runtime_scoped_exact_match_key
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -414,11 +415,17 @@ def _persist_claude_native_permission_policy(
     store: GuardStore,
     artifact_id: str,
     artifact_hash: str,
+    artifact_type: str | None = None,
     action: str,
     reason: str,
     now: str,
     source: str = "claude-native-approval",
 ) -> bool:
+    stored_artifact_hash = (
+        _runtime_scoped_exact_match_key(artifact_id)
+        if artifact_type == "tool_action_request"
+        else None
+    ) or artifact_hash
     try:
         store.upsert_policy(
             PolicyDecision(
@@ -426,7 +433,7 @@ def _persist_claude_native_permission_policy(
                 scope="artifact",
                 action="allow" if action == "allow" else "block",
                 artifact_id=artifact_id,
-                artifact_hash=artifact_hash,
+                artifact_hash=stored_artifact_hash,
                 reason=reason,
                 source=source,
             ),
@@ -436,7 +443,7 @@ def _persist_claude_native_permission_policy(
             "claude/native_permission_saved",
             {
                 "artifact_id": artifact_id,
-                "artifact_hash": artifact_hash,
+                "artifact_hash": stored_artifact_hash,
                 "action": action,
                 "reason": reason,
             },
@@ -464,6 +471,7 @@ def _persist_claude_native_permission_for_runtime_artifact(
         store=store,
         artifact_id=artifact.artifact_id,
         artifact_hash=artifact_hash,
+        artifact_type=artifact.artifact_type,
         action=action,
         reason=reason,
         now=now,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -422,9 +422,7 @@ def _persist_claude_native_permission_policy(
     source: str = "claude-native-approval",
 ) -> bool:
     stored_artifact_hash = (
-        _runtime_scoped_exact_match_key(artifact_id)
-        if artifact_type == "tool_action_request"
-        else None
+        _runtime_scoped_exact_match_key(artifact_id) if artifact_type == "tool_action_request" else None
     ) or artifact_hash
     try:
         store.upsert_policy(

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -238,6 +238,9 @@ _REMOTE_POLICY_SOURCE_PARAMS = tuple(sorted(REMOTE_POLICY_SOURCES))
 _REMOTE_POLICY_SOURCE_PLACEHOLDERS = "(" + ",".join("?" for _ in _REMOTE_POLICY_SOURCE_PARAMS) + ")"
 _POLICY_SCOPES = frozenset({"artifact", "workspace", "publisher", "harness", "global"})
 _SLOW_STORE_WARNING_ENV = "HOL_GUARD_WARN_SLOW_STORE"
+_SQLITE_CONNECT_TIMEOUT_SECONDS = 30.0
+_SQLITE_LOCK_RETRY_ATTEMPTS = 5
+_SQLITE_LOCK_RETRY_DELAY_SECONDS = 0.1
 _SECRET_FINGERPRINT_PREFIX = "pbkdf2-sha256$"
 _SECRET_FINGERPRINT_SALT = b"hol-guard-secret-fingerprint:v1"
 _OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS = 30.0
@@ -1729,7 +1732,7 @@ class GuardStore:
 
     @contextmanager
     def _connect(self) -> Iterator[sqlite3.Connection]:
-        connection = sqlite3.connect(self.path)
+        connection = sqlite3.connect(self.path, timeout=_SQLITE_CONNECT_TIMEOUT_SECONDS)
         connection.row_factory = sqlite3.Row
         start = time.monotonic()
         try:
@@ -2167,9 +2170,20 @@ class GuardStore:
             self._ensure_local_device(connection)
             if not self._schema_version_applied(connection, version=2):
                 self._record_schema_version(connection, version=2)
-            connection.execute("pragma journal_mode=WAL")
+            self._enable_wal_mode(connection)
             self._repair_store_permissions()
             self._refresh_policy_integrity_state(connection, now=_now(), create_key=False)
+
+    @staticmethod
+    def _enable_wal_mode(connection: sqlite3.Connection) -> None:
+        for attempt in range(_SQLITE_LOCK_RETRY_ATTEMPTS):
+            try:
+                connection.execute("pragma journal_mode=WAL")
+                return
+            except sqlite3.OperationalError as exc:
+                if "database is locked" not in str(exc).lower() or attempt == _SQLITE_LOCK_RETRY_ATTEMPTS - 1:
+                    raise
+                time.sleep(_SQLITE_LOCK_RETRY_DELAY_SECONDS)
 
     @staticmethod
     def _ensure_policy_column(connection: sqlite3.Connection, column_name: str, column_type: str) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -25,6 +25,7 @@ from typing import ClassVar
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
@@ -53,7 +54,7 @@ from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.runtime import secret_file_requests as secret_file_requests_module
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
-from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store import GuardStore, _runtime_scoped_exact_match_key
 
 
 def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
@@ -8119,6 +8120,119 @@ def test_guard_hook_claude_ask_user_question_allow_persists_approval(tmp_path, c
     assert second_rc == 0
     assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
     assert policies[0]["source"] == "claude-ask-user-question"
+
+
+def test_guard_hook_claude_ask_user_question_docker_retry_uses_exact_action_policy(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    monkeypatch.setattr(GuardStore, "_policy_integrity_path_warnings", lambda self: [])
+    monkeypatch.setattr(
+        guard_store_module,
+        "_warn_only_policy_integrity_status",
+        lambda status, state, *, source="local": status == "degraded_mode",
+    )
+    command = "docker compose -f scripts/guard-cloud/docker-lab/docker-compose.yml up -d postgres"
+    first_event = {
+        "session_id": "session-claude-docker-allow",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": {"command": command},
+        "source_scope": "project",
+    }
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    first_rc, first_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event=first_event,
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    permission_rc, permission_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={**first_event, "hook_event_name": "PermissionRequest"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    approval_question, question_options = _load_claude_pending_question_contract(
+        home_dir,
+        "session-claude-docker-allow",
+    )
+    question_rc, question_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={
+            "session_id": "session-claude-docker-allow",
+            "hook_event_name": "PostToolUse",
+            "tool_name": "AskUserQuestion",
+            "tool_input": {
+                "questions": [
+                    {
+                        "header": "HOL Guard",
+                        "question": approval_question,
+                        "options": question_options,
+                    }
+                ]
+            },
+            "tool_response": {
+                "questions": [
+                    {
+                        "header": "HOL Guard",
+                        "question": approval_question,
+                        "options": question_options,
+                    }
+                ],
+                "answers": {approval_question: "Allow during this session"},
+            },
+        },
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    second_rc, second_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="claude-code",
+        event={**first_event, "session_id": "session-claude-docker-allow-retry"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
+    store = GuardStore(home_dir)
+    policies = store.list_policy_decisions("claude-code")
+    policy = policies[0]
+    artifact_id = str(policy["artifact_id"])
+    stored_hash = str(policy["artifact_hash"])
+    drifted_hash_decision = store.resolve_policy_decision(
+        "claude-code",
+        artifact_id,
+        "runtime-hash-from-retry",
+        str(workspace_dir),
+    )
+    first_payload = json.loads(first_output)
+    permission_payload = json.loads(permission_output)
+    second_payload = json.loads(second_output)
+
+    assert first_rc == 0
+    assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "docker-sensitive command" in first_payload["hookSpecificOutput"]["permissionDecisionReason"]
+    assert permission_rc == 0
+    assert permission_payload["hookSpecificOutput"]["decision"]["behavior"] == "deny"
+    assert question_rc == 0
+    assert question_output == ""
+    assert second_rc == 0
+    assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert policy["source"] == "claude-ask-user-question"
+    assert stored_hash == _runtime_scoped_exact_match_key(artifact_id)
+    assert drifted_hash_decision is not None
+    assert drifted_hash_decision["action"] == "allow"
 
 
 def test_guard_hook_claude_notification_only_ask_user_question_persists_approval(tmp_path, capsys, monkeypatch):


### PR DESCRIPTION
## Summary
- Persist Claude AskUserQuestion approvals for runtime tool actions using the stable exact-action policy key.
- Reuse the approval when the same sensitive Bash action is retried with a different runtime hash.
- Add regression coverage for the Docker-sensitive Claude approval retry flow.

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py tests/test_guard_runtime.py`
- `python3 -m pytest -q tests/test_guard_runtime.py::test_guard_hook_claude_ask_user_question_docker_retry_uses_exact_action_policy`

## Notes
- `uv run --no-sync` hung before executing commands in this local shell, so focused verification used `python3` directly.
