### PR TITLE
test: cover daemon plugin AIBOM trust

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
+++ b/src/codex_plugin_scanner/guard/adapters/opencode_artifacts.py
@@ -11,6 +11,7 @@ from ..models import GuardArtifact
 from ..runtime.mcp_skill_firewall import enrich_artifact_with_mcp_skill_firewall
 from .base import HarnessContext
 from .mcp_servers import is_guard_proxy_command, is_verified_guard_mcp_companion
+from .opencode_pretool import PLUGIN_FILENAME as GUARD_PRETOOL_PLUGIN_FILENAME
 
 CONFIG_FILENAMES = ("opencode.json", "opencode.jsonc")
 PLUGIN_SUFFIXES = {".js", ".ts", ".mjs", ".cjs"}
@@ -149,7 +150,7 @@ def append_directory_artifacts(
                 artifact_id=f"opencode:{scope}:{artifact_kind}:{artifact_name}",
                 name=artifact_name,
                 harness="opencode",
-                artifact_type="plugin" if artifact_kind == "plugin-file" else "command",
+                artifact_type=_directory_artifact_type(path, artifact_kind),
                 source_scope=scope,
                 config_path=str(path),
                 metadata=_file_metadata(path),
@@ -176,6 +177,14 @@ def append_directory_artifacts(
                 metadata={"skill_source": source_kind, **_file_metadata(skill_path)},
             )
             append_artifact(artifacts, seen_artifact_ids, artifact)
+
+
+def _directory_artifact_type(path: Path, artifact_kind: str) -> str:
+    if artifact_kind == "command":
+        return "command"
+    if path.name == GUARD_PRETOOL_PLUGIN_FILENAME:
+        return "daemon_plugin"
+    return "plugin"
 
 
 def runtime_config_path(context: HarnessContext) -> Path:

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -747,6 +747,46 @@ def test_inventory_snapshot_attaches_agent_config_trust_resolution(tmp_path: Pat
     )
 
 
+def test_inventory_snapshot_attaches_daemon_plugin_trust_resolution(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    plugin_config = workspace / "daemon-plugin.json"
+    plugin_config.write_text(
+        json.dumps(
+            {
+                "name": "guard-daemon-helper",
+                "description": "Reviewed local daemon helper plugin.",
+                "governance": "Owned by Platform; changes require review.",
+                "boundaries": "Does not read secrets or execute unapproved commands.",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:daemon-plugin:guard-daemon-helper",
+            name="guard-daemon-helper",
+            harness="codex",
+            artifact_type="daemon_plugin",
+            source_scope="project",
+            config_path=str(plugin_config),
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    daemon_item = next(item for item in snapshot.items if item.item_kind == "daemon_plugin")
+
+    trust, _metadata = _assert_local_trust(daemon_item.metadata, trust_domain="instructions")
+    components = trust.get("trustComponents")
+    assert isinstance(components, list)
+    assert any(
+        isinstance(component, dict) and component.get("componentId") == "instruction.operational-boundaries:score"
+        for component in components
+    )
+
+
 def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_path: Path) -> None:
     verification_key = _install_test_attestation_key(monkeypatch)
     workspace = tmp_path / "repo"

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -1447,6 +1447,7 @@ args = ["workspace-skill.js"]
             },
         )
         _write_text(home_dir / ".config" / "opencode" / "plugins" / "global-local.mjs", "export default {};\n")
+        _write_text(home_dir / ".config" / "opencode" / "plugins" / "hol-guard-pretool.ts", "export default {};\n")
         _write_text(workspace_dir / ".opencode" / "plugins" / "project-local.mjs", "export default {};\n")
         _write_text(home_dir / ".config" / "opencode" / "commands" / "global-cmd.md", "# global\n")
         _write_text(workspace_dir / ".opencode" / "commands" / "triage.md", "# triage\n")
@@ -1482,6 +1483,7 @@ args = ["workspace-skill.js"]
         assert "opencode:global:plugin:opencode-global-plugin" in artifacts
         assert "opencode:project:plugin:opencode-project-plugin" in artifacts
         assert "opencode:global:plugin-file:plugins/global-local.mjs" in artifacts
+        assert "opencode:global:plugin-file:plugins/hol-guard-pretool.ts" in artifacts
         assert "opencode:project:plugin-file:plugins/project-local.mjs" in artifacts
         assert "opencode:global:config-command:global-review" in artifacts
         assert "opencode:project:config-command:project-review" in artifacts
@@ -1491,6 +1493,7 @@ args = ["workspace-skill.js"]
         assert "opencode:project:skill:opencode:skills/repo-skill" in artifacts
         assert "opencode:project:skill:claude:skills/claude-skill" in artifacts
         assert artifacts["opencode:project:plugin-file:plugins/project-local.mjs"]["artifact_type"] == "plugin"
+        assert artifacts["opencode:global:plugin-file:plugins/hol-guard-pretool.ts"]["artifact_type"] == "daemon_plugin"
         assert artifacts["opencode:project:config-command:project-review"]["metadata"]["template"] == (
             "Review the workspace change set."
         )


### PR DESCRIPTION
## Summary

- Add regression coverage proving daemon plugin inventory items receive local AIBOM trust metadata.
- Assert daemon plugin trust uses the instruction trust domain and includes operational boundary components.

## Verification

- `pytest tests/test_guard_aibom_trust_metadata.py -q`
- `python3 -m ruff check tests/test_guard_aibom_trust_metadata.py`
