### PR TITLE
fix(dashboard): polish Strict config tab mockup parity

### DIFF
--- a/dashboard/src/policy-strict-config-enforcement-preview.tsx
+++ b/dashboard/src/policy-strict-config-enforcement-preview.tsx
@@ -13,13 +13,13 @@ type PolicyEnforcementPreviewCardProps = {
 
 export function PolicyEnforcementPreviewCard({ cloudControlsUrl }: PolicyEnforcementPreviewCardProps) {
   return (
-    <div className={`${POLICY_PANEL_CARD_CLASS} p-5`}>
+    <div className={`${POLICY_PANEL_CARD_CLASS} p-4`}>
       <SectionLabel>Local enforcement preview</SectionLabel>
-      <p className="mt-2 text-sm leading-relaxed text-slate-600">
+      <p className="mt-1.5 text-sm leading-relaxed text-slate-600">
         Evaluation order when Guard decides what to do next.
       </p>
 
-      <div className="mt-5 -mx-1 overflow-x-auto px-1 pb-1">
+      <div className="mt-4 -mx-1 overflow-x-auto px-1 pb-1">
         <div className="flex min-w-[52rem] items-stretch">
           {STRICT_CONFIG_EVALUATION_STEPS.map((step, index) => {
             const Icon = step.icon;
@@ -44,7 +44,7 @@ export function PolicyEnforcementPreviewCard({ cloudControlsUrl }: PolicyEnforce
         </div>
       </div>
 
-      <div className="mt-5 flex flex-col gap-3 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-between">
+      <div className="mt-4 flex flex-col gap-3 border-t border-slate-100 pt-3 sm:flex-row sm:items-center sm:justify-between">
         <p className="max-w-xl text-xs leading-relaxed text-slate-500">
           Evaluation order: {STRICT_POLICY_EVALUATION_ORDER.join(" → ")}. Team-wide exceptions are managed in Guard
           Cloud.

--- a/dashboard/src/policy-strict-config-ia.test.ts
+++ b/dashboard/src/policy-strict-config-ia.test.ts
@@ -22,6 +22,10 @@ assert(rightRailSource.includes("Policy simulator outcome"), "strict config incl
 assert(enforcementSource.includes("Local enforcement preview"), "strict config shows enforcement preview");
 assert(rightRailSource.includes("Run simulation"), "strict config exposes run simulation");
 assert(tabSource.includes("PolicyStrictModeCard"), "strict config tab uses extracted cards");
+assert(tabSource.includes("resolveStrictScenarioSimulation"), "strict config derives simulation from settings");
+assert(!tabSource.includes("SCENARIO_FIXTURES"), "strict config removes scenario fixtures");
+assert(!tabSource.includes("simRemembered"), "strict config removes fake simulation state");
+assert(tabSource.includes("280px"), "strict config uses fixed-width right rail");
 assert(enforcementSource.includes("min-w-[52rem]"), "strict config uses horizontal enforcement flow");
 assert(rightRailSource.includes("Learn more"), "strict config links to cloud docs");
 assert(workspaceSource.includes("cloudControlsUrl={resolveCloudPolicyControlsUrl(snapshot)}"), "strict config receives cloud controls url");

--- a/dashboard/src/policy-strict-config-local-policy-card.tsx
+++ b/dashboard/src/policy-strict-config-local-policy-card.tsx
@@ -46,14 +46,9 @@ export function PolicyLocalStrictPolicyCard({
   const fileWriteAction = resolveStrictFileWriteAction(settings);
 
   return (
-    <div className={`${POLICY_PANEL_CARD_CLASS} p-5`}>
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0">
-          <SectionLabel>Local strict policy</SectionLabel>
-          <p className="mt-2 text-sm leading-relaxed text-slate-600">
-            Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches.
-          </p>
-        </div>
+    <div className={`${POLICY_PANEL_CARD_CLASS} p-4`}>
+      <div className="flex flex-wrap items-center justify-between gap-3">
+        <SectionLabel>Local strict policy</SectionLabel>
         <button
           type="button"
           onClick={onResetDefaults}
@@ -64,7 +59,7 @@ export function PolicyLocalStrictPolicyCard({
           Reset to defaults
         </button>
       </div>
-      <div className="mt-4 divide-y divide-slate-100">
+      <div className="mt-3 divide-y divide-slate-100">
         <StrictConfigActionSegmented
           label="Default action"
           help="For any action not explicitly allowed."

--- a/dashboard/src/policy-strict-config-right-rail.tsx
+++ b/dashboard/src/policy-strict-config-right-rail.tsx
@@ -7,17 +7,8 @@ import {
 } from "react-icons/hi2";
 import { ActionButton, Badge, SectionLabel } from "./approval-center-primitives";
 import { policyActionLabel } from "./approval-center-utils";
-import { POLICY_PANEL_CARD_CLASS, STRICT_CONFIG_WHAT_CHANGES } from "./policy-strict-config-surfaces";
+import { POLICY_PANEL_CARD_CLASS, STRICT_CONFIG_SCENARIOS, STRICT_CONFIG_WHAT_CHANGES } from "./policy-strict-config-surfaces";
 import type { StrictPolicySimulationResult, StrictScenarioId } from "./policy-strict-config-utils";
-
-const TEST_SCENARIOS: Array<{
-  id: StrictScenarioId;
-  label: string;
-}> = [
-  { id: "first-time", label: "New tool contacting unknown domain" },
-  { id: "remembered-allow", label: "Remembered allow wins" },
-  { id: "cloud-exception", label: "Active Cloud exception" },
-];
 
 function resolveExpectedActionTone(action: string): "success" | "destructive" | "warning" | "default" {
   if (action === "block") {
@@ -75,7 +66,7 @@ export function PolicyStrictConfigRightRail({
         <SectionLabel>Affected pending Inbox items</SectionLabel>
         <p className="mt-2 text-4xl font-semibold tabular-nums text-brand-blue">
           {pendingInboxCount}
-          <span className="ml-1.5 text-lg font-medium text-brand-blue/75">items</span>
+          <span className="ml-1.5 text-lg font-medium text-brand-blue/75">Items</span>
         </p>
         <p className="mt-1 text-sm leading-relaxed text-slate-600">
           Pending review items may be affected by stricter fallback controls.
@@ -123,7 +114,7 @@ export function PolicyStrictConfigRightRail({
             onChange={onScenarioChange}
             className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark"
           >
-            {TEST_SCENARIOS.map((scenario) => (
+            {STRICT_CONFIG_SCENARIOS.map((scenario) => (
               <option key={scenario.id} value={scenario.id}>
                 {scenario.label}
               </option>

--- a/dashboard/src/policy-strict-config-segmented.tsx
+++ b/dashboard/src/policy-strict-config-segmented.tsx
@@ -54,7 +54,7 @@ export function StrictConfigActionSegmented({
       </div>
       <div className="w-full max-w-[17.5rem] lg:justify-self-end">
         <div
-          className="inline-flex w-full max-w-[17.5rem] flex-wrap gap-0.5 rounded-xl border border-slate-200 bg-slate-100/80 p-0.5"
+          className="flex w-full flex-wrap gap-0.5 rounded-xl border border-slate-200 bg-slate-100/80 p-0.5"
           role="group"
           aria-label={label}
         >

--- a/dashboard/src/policy-strict-config-segmented.tsx
+++ b/dashboard/src/policy-strict-config-segmented.tsx
@@ -40,7 +40,7 @@ export function StrictConfigActionSegmented({
   const showAdvanced = !PRIMARY_STRICT_ACTION_VALUES.has(value);
 
   return (
-    <div className="grid gap-4 py-5 first:pt-0 last:pb-0 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center lg:gap-6">
+    <div className="grid gap-3 py-4 first:pt-0 last:pb-0 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center lg:gap-4">
       <div className="flex min-w-0 items-start gap-3">
         {Icon ? (
           <span className="mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500">
@@ -52,9 +52,9 @@ export function StrictConfigActionSegmented({
           {help ? <p className="mt-0.5 text-xs leading-relaxed text-slate-500">{help}</p> : null}
         </div>
       </div>
-      <div className="min-w-0 lg:justify-self-end">
+      <div className="w-full max-w-[17.5rem] lg:justify-self-end">
         <div
-          className="inline-flex max-w-full flex-wrap gap-1 rounded-xl border border-slate-200 bg-slate-100/80 p-1"
+          className="inline-flex w-full max-w-[17.5rem] flex-wrap gap-0.5 rounded-xl border border-slate-200 bg-slate-100/80 p-0.5"
           role="group"
           aria-label={label}
         >
@@ -67,7 +67,7 @@ export function StrictConfigActionSegmented({
                 disabled={disabled}
                 aria-pressed={selected}
                 onClick={() => handleSelect(option.value)}
-                className={`rounded-lg px-3 py-1.5 text-sm font-medium transition ${
+                className={`rounded-lg px-2.5 py-1 text-xs font-medium transition ${
                   selected
                     ? "bg-brand-blue text-white shadow-sm"
                     : "text-slate-600 hover:bg-white/70 hover:text-brand-dark disabled:opacity-50"

--- a/dashboard/src/policy-strict-config-strict-mode-card.tsx
+++ b/dashboard/src/policy-strict-config-strict-mode-card.tsx
@@ -41,17 +41,15 @@ export function PolicyStrictModeCard({
   onReloadPolicy,
 }: PolicyStrictModeCardProps) {
   return (
-    <div className={`${POLICY_PANEL_CARD_CLASS} p-5`}>
-      <div className="flex flex-wrap items-start justify-between gap-4">
+    <div className={`${POLICY_PANEL_CARD_CLASS} p-4`}>
+      <div className="flex flex-wrap items-start justify-between gap-3">
         <div className="flex min-w-0 items-start gap-3">
-          <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue">
-            <HiMiniShieldCheck className="h-5 w-5" aria-hidden="true" />
+          <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue">
+            <HiMiniShieldCheck className="h-4 w-4" aria-hidden="true" />
           </span>
           <div className="min-w-0">
             <h3 className="text-base font-semibold text-brand-dark">Strict mode</h3>
-            <p className="mt-1 text-sm leading-relaxed text-slate-600">
-              Local enforcement tuning when no remembered rule, Cloud policy, or Cloud exception matches.
-            </p>
+            <p className="mt-0.5 text-sm text-slate-600">Local enforcement tuning</p>
           </div>
         </div>
         <div className="flex shrink-0 items-center gap-2">
@@ -76,7 +74,7 @@ export function PolicyStrictModeCard({
         </div>
       </div>
 
-      <dl className="mt-5 grid gap-4 border-t border-slate-100 pt-4 sm:grid-cols-2 xl:grid-cols-4">
+      <dl className="mt-4 grid gap-3 border-t border-slate-100 pt-3 sm:grid-cols-2 lg:grid-cols-4">
         <div>
           <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Strict mode</dt>
           <dd className="mt-1.5 text-sm font-medium text-brand-dark">{isStrict ? "Enabled" : "Disabled"}</dd>
@@ -122,7 +120,7 @@ export function PolicyStrictModeCard({
       </dl>
 
       {!isStrict && onOpenSettings ? (
-        <div className="mt-4 border-t border-slate-100 pt-4">
+        <div className="mt-3 border-t border-slate-100 pt-3">
           <ActionButton variant="secondary" onClick={onOpenSettings}>
             Enable in Settings
           </ActionButton>
@@ -130,7 +128,7 @@ export function PolicyStrictModeCard({
       ) : null}
 
       {onReloadPolicy ? (
-        <div className="mt-4 flex justify-end border-t border-slate-100 pt-4">
+        <div className="mt-3 flex justify-end border-t border-slate-100 pt-3">
           <ActionButton variant="secondary" onClick={onReloadPolicy} disabled={reloadingPolicy}>
             <HiMiniArrowPath className={`mr-1.5 h-4 w-4 ${reloadingPolicy ? "animate-spin" : ""}`} aria-hidden="true" />
             Reload policy

--- a/dashboard/src/policy-strict-config-surfaces.ts
+++ b/dashboard/src/policy-strict-config-surfaces.ts
@@ -57,5 +57,10 @@ export const STRICT_CONFIG_WHAT_CHANGES = [
   "First-time actions follow your default strict action.",
   "Changed tool hashes trigger your configured review path.",
   "New network domains and subprocesses use strict fallback rules.",
-  "Cloud exceptions and remembered rules still win when they match.",
+] as const;
+
+export const STRICT_CONFIG_SCENARIOS = [
+  { id: "first-time", label: "New tool contacting unknown domain" },
+  { id: "remembered-allow", label: "Remembered allow wins" },
+  { id: "cloud-exception", label: "Active Cloud exception" },
 ] as const;

--- a/dashboard/src/policy-strict-config-tab.tsx
+++ b/dashboard/src/policy-strict-config-tab.tsx
@@ -15,7 +15,7 @@ import { PolicyStrictModeCard } from "./policy-strict-config-strict-mode-card";
 import {
   fingerprintLocalPolicySettings,
   resolveStrictScenarioOutcome,
-  simulateStrictPolicyOutcome,
+  resolveStrictScenarioSimulation,
   STRICT_POLICY_DEFAULTS,
   type StrictScenarioId,
 } from "./policy-strict-config-utils";
@@ -32,15 +32,6 @@ type PolicyStrictConfigTabProps = {
 
 type LoadState = "loading" | "ready" | "error";
 
-const SCENARIO_FIXTURES: Record<
-  StrictScenarioId,
-  { remembered: "allow" | "block" | "none"; cloudPolicy: "allow" | "block" | "none"; cloudException: boolean }
-> = {
-  "first-time": { remembered: "none", cloudPolicy: "none", cloudException: false },
-  "remembered-allow": { remembered: "allow", cloudPolicy: "block", cloudException: false },
-  "cloud-exception": { remembered: "block", cloudPolicy: "block", cloudException: true },
-};
-
 export function PolicyStrictConfigTab({
   snapshot,
   cloudControlsUrl = null,
@@ -54,9 +45,6 @@ export function PolicyStrictConfigTab({
   const [settings, setSettings] = useState<GuardSettings | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [savingKey, setSavingKey] = useState<string | null>(null);
-  const [simRemembered, setSimRemembered] = useState<"allow" | "block" | "none">("none");
-  const [simCloudPolicy, setSimCloudPolicy] = useState<"allow" | "block" | "none">("none");
-  const [simCloudException, setSimCloudException] = useState(false);
   const [scenarioId, setScenarioId] = useState<StrictScenarioId>("first-time");
   const [simulationVisible, setSimulationVisible] = useState(false);
 
@@ -101,16 +89,11 @@ export function PolicyStrictConfigTab({
   }, [scenarioId, settings]);
 
   const simulation = useMemo(() => {
-    if (!settings) {
+    if (!settings || !simulationVisible) {
       return null;
     }
-    return simulateStrictPolicyOutcome({
-      rememberedRuleAction: simRemembered,
-      cloudPolicyAction: simCloudPolicy,
-      cloudExceptionActive: simCloudException,
-      fallbackAction: settings.default_action,
-    });
-  }, [settings, simRemembered, simCloudPolicy, simCloudException]);
+    return resolveStrictScenarioSimulation(settings, scenarioId);
+  }, [settings, scenarioId, simulationVisible]);
 
   const persistSetting = useCallback(async (key: StrictConfigSettingKey, value: string) => {
     if (!settings) {
@@ -200,13 +183,8 @@ export function PolicyStrictConfigTab({
   }, []);
 
   const handleScenarioChange = useCallback((event: ChangeEvent<HTMLSelectElement>) => {
-    const nextId = event.target.value as StrictScenarioId;
-    setScenarioId(nextId);
+    setScenarioId(event.target.value as StrictScenarioId);
     setSimulationVisible(false);
-    const scenario = SCENARIO_FIXTURES[nextId];
-    setSimRemembered(scenario.remembered);
-    setSimCloudPolicy(scenario.cloudPolicy);
-    setSimCloudException(scenario.cloudException);
   }, []);
 
   if (loadState === "loading") {
@@ -238,7 +216,7 @@ export function PolicyStrictConfigTab({
   const expectedReasoning = scenarioOutcome?.reasoning ?? "";
 
   return (
-    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(17rem,20rem)] xl:items-start">
+    <div className="grid gap-4 xl:grid-cols-[minmax(0,1fr)_280px] xl:items-start">
       <div className="min-w-0 space-y-4">
         <PolicyStrictModeCard
           isStrict={isStrict}

--- a/dashboard/src/policy-strict-config-utils.test.ts
+++ b/dashboard/src/policy-strict-config-utils.test.ts
@@ -1,5 +1,6 @@
 import {
   resolveStrictScenarioOutcome,
+  resolveStrictScenarioSimulation,
   fingerprintLocalPolicySettings,
   simulateStrictPolicyOutcome,
   STRICT_POLICY_EVALUATION_ORDER,
@@ -79,5 +80,12 @@ assert(
 const scenario = resolveStrictScenarioOutcome("first-time", baseSettings);
 assert(scenario.outcome === "review", "first-time scenario uses network domain action");
 assert(scenario.reasoning.includes("New network domain action"), "scenario reasoning names control");
+
+const firstTimeSimulation = resolveStrictScenarioSimulation(baseSettings, "first-time");
+assert(firstTimeSimulation.outcome === "review", "first-time simulation uses network domain fallback");
+assert(firstTimeSimulation.winningStep === "Ask or block", "first-time simulation reaches strict fallback");
+
+const rememberedSimulation = resolveStrictScenarioSimulation(baseSettings, "remembered-allow");
+assert(rememberedSimulation.outcome === "allow", "remembered-allow simulation wins at remembered rule");
 
 console.log("policy-strict-config-utils.test.ts: all assertions passed");

--- a/dashboard/src/policy-strict-config-utils.ts
+++ b/dashboard/src/policy-strict-config-utils.ts
@@ -70,6 +70,38 @@ export function resolveStrictScenarioOutcome(
   };
 }
 
+export function resolveStrictScenarioSimulation(
+  settings: GuardSettings,
+  scenarioId: StrictScenarioId,
+): StrictPolicySimulationResult {
+  const fallbackAction = settings.new_network_domain_action;
+
+  if (scenarioId === "remembered-allow") {
+    return simulateStrictPolicyOutcome({
+      rememberedRuleAction: "allow",
+      cloudPolicyAction: "none",
+      cloudExceptionActive: false,
+      fallbackAction,
+    });
+  }
+
+  if (scenarioId === "cloud-exception") {
+    return simulateStrictPolicyOutcome({
+      rememberedRuleAction: "none",
+      cloudPolicyAction: "none",
+      cloudExceptionActive: true,
+      fallbackAction,
+    });
+  }
+
+  return simulateStrictPolicyOutcome({
+    rememberedRuleAction: "none",
+    cloudPolicyAction: "none",
+    cloudExceptionActive: false,
+    fallbackAction,
+  });
+}
+
 export function fingerprintLocalPolicySettings(settings: GuardSettings): string {
   const payload = JSON.stringify({
     mode: settings.mode,

--- a/dashboard/src/policy-strict-config-utils.ts
+++ b/dashboard/src/policy-strict-config-utils.ts
@@ -74,7 +74,7 @@ export function resolveStrictScenarioSimulation(
   settings: GuardSettings,
   scenarioId: StrictScenarioId,
 ): StrictPolicySimulationResult {
-  const fallbackAction = settings.new_network_domain_action;
+  const fallbackAction = settings.new_network_domain_action ?? settings.default_action ?? "review";
 
   if (scenarioId === "remembered-allow") {
     return simulateStrictPolicyOutcome({

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -3231,8 +3231,12 @@ const STRICT_CONFIG_EVALUATION_STEPS = [
 const STRICT_CONFIG_WHAT_CHANGES = [
   "First-time actions follow your default strict action.",
   "Changed tool hashes trigger your configured review path.",
-  "New network domains and subprocesses use strict fallback rules.",
-  "Cloud exceptions and remembered rules still win when they match."
+  "New network domains and subprocesses use strict fallback rules."
+];
+const STRICT_CONFIG_SCENARIOS = [
+  { id: "first-time", label: "New tool contacting unknown domain" },
+  { id: "remembered-allow", label: "Remembered allow wins" },
+  { id: "cloud-exception", label: "Active Cloud exception" }
 ];
 const STRICT_CONFIG_ACTION_OPTIONS = [
   { value: "allow", label: "Allow without asking" },
@@ -3274,6 +3278,31 @@ function resolveStrictScenarioOutcome(scenarioId, settings) {
     outcome,
     reasoning: `Because New network domain action is set to ${policyActionLabel(outcome)}.`
   };
+}
+function resolveStrictScenarioSimulation(settings, scenarioId) {
+  const fallbackAction = settings.new_network_domain_action;
+  if (scenarioId === "remembered-allow") {
+    return simulateStrictPolicyOutcome({
+      rememberedRuleAction: "allow",
+      cloudPolicyAction: "none",
+      cloudExceptionActive: false,
+      fallbackAction
+    });
+  }
+  if (scenarioId === "cloud-exception") {
+    return simulateStrictPolicyOutcome({
+      rememberedRuleAction: "none",
+      cloudPolicyAction: "none",
+      cloudExceptionActive: true,
+      fallbackAction
+    });
+  }
+  return simulateStrictPolicyOutcome({
+    rememberedRuleAction: "none",
+    cloudPolicyAction: "none",
+    cloudExceptionActive: false,
+    fallbackAction
+  });
 }
 function fingerprintLocalPolicySettings(settings) {
   const payload = JSON.stringify({
@@ -3339,10 +3368,10 @@ function simulateStrictPolicyOutcome(input) {
   };
 }
 function PolicyEnforcementPreviewCard({ cloudControlsUrl }) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-5`, children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-4`, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local enforcement preview" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-slate-600", children: "Evaluation order when Guard decides what to do next." }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-5 -mx-1 overflow-x-auto px-1 pb-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex min-w-[52rem] items-stretch", children: STRICT_CONFIG_EVALUATION_STEPS.map((step, index) => {
+    /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1.5 text-sm leading-relaxed text-slate-600", children: "Evaluation order when Guard decides what to do next." }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 -mx-1 overflow-x-auto px-1 pb-1", children: /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex min-w-[52rem] items-stretch", children: STRICT_CONFIG_EVALUATION_STEPS.map((step, index) => {
       const Icon = step.icon;
       const isLast = index === STRICT_CONFIG_EVALUATION_STEPS.length - 1;
       return /* @__PURE__ */ jsxRuntimeExports.jsxs(reactExports.Fragment, { children: [
@@ -3354,7 +3383,7 @@ function PolicyEnforcementPreviewCard({ cloudControlsUrl }) {
         !isLast ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "flex w-7 shrink-0 items-center justify-center", "aria-hidden": "true", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowRight, { className: "h-4 w-4 text-slate-300" }) }) : null
       ] }, step.label);
     }) }) }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-5 flex flex-col gap-3 border-t border-slate-100 pt-4 sm:flex-row sm:items-center sm:justify-between", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 flex flex-col gap-3 border-t border-slate-100 pt-3 sm:flex-row sm:items-center sm:justify-between", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "max-w-xl text-xs leading-relaxed text-slate-500", children: [
         "Evaluation order: ",
         STRICT_POLICY_EVALUATION_ORDER.join(" → "),
@@ -3390,7 +3419,7 @@ function StrictConfigActionSegmented({
     [onSettingChange, settingKey]
   );
   const showAdvanced = !PRIMARY_STRICT_ACTION_VALUES.has(value);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 py-5 first:pt-0 last:pb-0 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center lg:gap-6", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-3 py-4 first:pt-0 last:pb-0 lg:grid-cols-[minmax(0,1fr)_auto] lg:items-center lg:gap-4", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-start gap-3", children: [
       Icon ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-0.5 flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-slate-100 text-slate-500", children: /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: "h-4 w-4", "aria-hidden": "true" }) }) : null,
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
@@ -3398,11 +3427,11 @@ function StrictConfigActionSegmented({
         help ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-xs leading-relaxed text-slate-500", children: help }) : null
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 lg:justify-self-end", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "w-full max-w-[17.5rem] lg:justify-self-end", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "div",
         {
-          className: "inline-flex max-w-full flex-wrap gap-1 rounded-xl border border-slate-200 bg-slate-100/80 p-1",
+          className: "inline-flex w-full max-w-[17.5rem] flex-wrap gap-0.5 rounded-xl border border-slate-200 bg-slate-100/80 p-0.5",
           role: "group",
           "aria-label": label,
           children: PRIMARY_STRICT_ACTIONS.map((option) => {
@@ -3414,7 +3443,7 @@ function StrictConfigActionSegmented({
                 disabled,
                 "aria-pressed": selected,
                 onClick: () => handleSelect(option.value),
-                className: `rounded-lg px-3 py-1.5 text-sm font-medium transition ${selected ? "bg-brand-blue text-white shadow-sm" : "text-slate-600 hover:bg-white/70 hover:text-brand-dark disabled:opacity-50"}`,
+                className: `rounded-lg px-2.5 py-1 text-xs font-medium transition ${selected ? "bg-brand-blue text-white shadow-sm" : "text-slate-600 hover:bg-white/70 hover:text-brand-dark disabled:opacity-50"}`,
                 children: option.label
               },
               option.value
@@ -3479,12 +3508,9 @@ function PolicyLocalStrictPolicyCard({
   onSettingChange
 }) {
   const fileWriteAction = resolveStrictFileWriteAction(settings);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-5`, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local strict policy" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-slate-600", children: "Fallback controls when no remembered rule, Cloud policy, or Cloud exception matches." })
-      ] }),
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-4`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Local strict policy" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs(
         "button",
         {
@@ -3499,7 +3525,7 @@ function PolicyLocalStrictPolicyCard({
         }
       )
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-4 divide-y divide-slate-100", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 divide-y divide-slate-100", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         StrictConfigActionSegmented,
         {
@@ -3570,11 +3596,6 @@ function PolicyLocalStrictPolicyCard({
     ] }) : null
   ] });
 }
-const TEST_SCENARIOS = [
-  { id: "first-time", label: "New tool contacting unknown domain" },
-  { id: "remembered-allow", label: "Remembered allow wins" },
-  { id: "cloud-exception", label: "Active Cloud exception" }
-];
 function resolveExpectedActionTone(action) {
   if (action === "block") {
     return "destructive";
@@ -3611,7 +3632,7 @@ function PolicyStrictConfigRightRail({
       /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Affected pending Inbox items" }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "mt-2 text-4xl font-semibold tabular-nums text-brand-blue", children: [
         pendingInboxCount,
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-1.5 text-lg font-medium text-brand-blue/75", children: "items" })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "ml-1.5 text-lg font-medium text-brand-blue/75", children: "Items" })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: "Pending review items may be affected by stricter fallback controls." }),
       onOpenInbox && pendingInboxCount > 0 ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onOpenInbox, children: [
@@ -3652,7 +3673,7 @@ function PolicyStrictConfigRightRail({
             value: scenarioId,
             onChange: onScenarioChange,
             className: "w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark",
-            children: TEST_SCENARIOS.map((scenario) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: scenario.id, children: scenario.label }, scenario.id))
+            children: STRICT_CONFIG_SCENARIOS.map((scenario) => /* @__PURE__ */ jsxRuntimeExports.jsx("option", { value: scenario.id, children: scenario.label }, scenario.id))
           }
         )
       ] }),
@@ -3693,13 +3714,13 @@ function PolicyStrictModeCard({
   onOpenSettings,
   onReloadPolicy
 }) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-5`, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-4", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_PANEL_CARD_CLASS} p-4`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-start justify-between gap-3", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-start gap-3", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-5 w-5", "aria-hidden": "true" }) }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-4 w-4", "aria-hidden": "true" }) }),
         /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
           /* @__PURE__ */ jsxRuntimeExports.jsx("h3", { className: "text-base font-semibold text-brand-dark", children: "Strict mode" }),
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: "Local enforcement tuning when no remembered rule, Cloud policy, or Cloud exception matches." })
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 text-sm text-slate-600", children: "Local enforcement tuning" })
         ] })
       ] }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex shrink-0 items-center gap-2", children: [
@@ -3724,7 +3745,7 @@ function PolicyStrictModeCard({
         )
       ] })
     ] }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-5 grid gap-4 border-t border-slate-100 pt-4 sm:grid-cols-2 xl:grid-cols-4", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-4 grid gap-3 border-t border-slate-100 pt-3 sm:grid-cols-2 lg:grid-cols-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Strict mode" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1.5 text-sm font-medium text-brand-dark", children: isStrict ? "Enabled" : "Disabled" })
@@ -3764,18 +3785,13 @@ function PolicyStrictModeCard({
         ] })
       ] })
     ] }),
-    !isStrict && onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 border-t border-slate-100 pt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Enable in Settings" }) }) : null,
-    onReloadPolicy ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-4 flex justify-end border-t border-slate-100 pt-4", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onReloadPolicy, disabled: reloadingPolicy, children: [
+    !isStrict && onOpenSettings ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 border-t border-slate-100 pt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "secondary", onClick: onOpenSettings, children: "Enable in Settings" }) }) : null,
+    onReloadPolicy ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3 flex justify-end border-t border-slate-100 pt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { variant: "secondary", onClick: onReloadPolicy, disabled: reloadingPolicy, children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniArrowPath, { className: `mr-1.5 h-4 w-4 ${reloadingPolicy ? "animate-spin" : ""}`, "aria-hidden": "true" }),
       "Reload policy"
     ] }) }) : null
   ] });
 }
-const SCENARIO_FIXTURES = {
-  "first-time": { remembered: "none", cloudPolicy: "none", cloudException: false },
-  "remembered-allow": { remembered: "allow", cloudPolicy: "block", cloudException: false },
-  "cloud-exception": { remembered: "block", cloudPolicy: "block", cloudException: true }
-};
 function PolicyStrictConfigTab({
   snapshot,
   cloudControlsUrl = null,
@@ -3789,9 +3805,6 @@ function PolicyStrictConfigTab({
   const [settings, setSettings] = reactExports.useState(null);
   const [saveError, setSaveError] = reactExports.useState(null);
   const [savingKey, setSavingKey] = reactExports.useState(null);
-  const [simRemembered, setSimRemembered] = reactExports.useState("none");
-  const [simCloudPolicy, setSimCloudPolicy] = reactExports.useState("none");
-  const [simCloudException, setSimCloudException] = reactExports.useState(false);
   const [scenarioId, setScenarioId] = reactExports.useState("first-time");
   const [simulationVisible, setSimulationVisible] = reactExports.useState(false);
   const isStrict = settings?.security_level === "strict";
@@ -3829,16 +3842,11 @@ function PolicyStrictConfigTab({
     return resolveStrictScenarioOutcome(scenarioId, settings);
   }, [scenarioId, settings]);
   const simulation = reactExports.useMemo(() => {
-    if (!settings) {
+    if (!settings || !simulationVisible) {
       return null;
     }
-    return simulateStrictPolicyOutcome({
-      rememberedRuleAction: simRemembered,
-      cloudPolicyAction: simCloudPolicy,
-      cloudExceptionActive: simCloudException,
-      fallbackAction: settings.default_action
-    });
-  }, [settings, simRemembered, simCloudPolicy, simCloudException]);
+    return resolveStrictScenarioSimulation(settings, scenarioId);
+  }, [settings, scenarioId, simulationVisible]);
   const persistSetting = reactExports.useCallback(async (key, value) => {
     if (!settings) {
       return;
@@ -3917,13 +3925,8 @@ function PolicyStrictConfigTab({
     setSimulationVisible(true);
   }, []);
   const handleScenarioChange = reactExports.useCallback((event) => {
-    const nextId = event.target.value;
-    setScenarioId(nextId);
+    setScenarioId(event.target.value);
     setSimulationVisible(false);
-    const scenario = SCENARIO_FIXTURES[nextId];
-    setSimRemembered(scenario.remembered);
-    setSimCloudPolicy(scenario.cloudPolicy);
-    setSimCloudException(scenario.cloudException);
   }, []);
   if (loadState === "loading") {
     return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "space-y-3", "aria-busy": "true", children: [0, 1, 2].map((index) => /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "h-24 animate-pulse rounded-2xl border border-slate-200 bg-slate-100" }, index)) });
@@ -3945,7 +3948,7 @@ function PolicyStrictConfigTab({
   const daemonAckLabel = daemonAckSynced ? "Acknowledged" : cloudBundleCopy?.label ?? "Needs attention";
   const expectedAction = scenarioOutcome?.outcome ?? settings.new_network_domain_action ?? "review";
   const expectedReasoning = scenarioOutcome?.reasoning ?? "";
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(17rem,20rem)] xl:items-start", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 xl:grid-cols-[minmax(0,1fr)_280px] xl:items-start", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 space-y-4", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         PolicyStrictModeCard,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16535,7 +16535,7 @@ function normalizePackageFirewallConnectFlow(value) {
     return null;
   }
   const state = value.state;
-  if (state !== "idle" && state !== "running" && state !== "failed") {
+  if (state !== "idle" && state !== "starting" && state !== "running" && state !== "failed") {
     return null;
   }
   const title = stringValue(value.title);
@@ -20154,7 +20154,7 @@ function resolveConnectUnlockCopy(purpose) {
   };
 }
 function resolveConnectSteps(connectFlow, purpose = "package_firewall") {
-  const running = connectFlow.state === "running";
+  const running = connectFlow.state === "running" || connectFlow.state === "starting";
   const failed = connectFlow.state === "failed";
   const browserOpened = connectFlow.browser_opened === true;
   const unlockCopy = resolveConnectUnlockCopy(purpose);
@@ -20233,9 +20233,9 @@ function ConnectFlowCard({
   onStartConnect,
   purpose = "package_firewall"
 }) {
-  const manualHref = connectFlow.authorize_url ?? connectFlow.connect_url;
-  const running = connectFlow.state === "running";
+  const running = connectFlow.state === "running" || connectFlow.state === "starting";
   const failed = connectFlow.state === "failed";
+  const manualHref = connectFlow.authorize_url ?? (failed ? connectFlow.connect_url : null);
   const primaryBusy = connectStarting || running;
   const primaryLabel = resolveConnectPrimaryLabel({
     actionLabel: connectFlow.action_label,
@@ -20245,7 +20245,7 @@ function ConnectFlowCard({
   const steps = resolveConnectSteps(connectFlow, purpose);
   const statusTone = running ? "blue" : mode === "repair" ? "attention" : "blue";
   const statusLabel = running ? "Waiting for approval" : mode === "repair" ? "Repair required" : "Connection required";
-  const showManualLink = connectFlow.authorize_url !== null || running || failed;
+  const showManualLink = manualHref !== null;
   const titleCopy = headline ?? connectFlow.title;
   const detailCopy = detail ?? connectFlow.detail;
   if (minimal) {
@@ -20510,6 +20510,12 @@ function openPackageFirewallAuthorizeWindow(authorizeUrl) {
   }
   return false;
 }
+function openPackageFirewallAuthorizeFallback(authorizeUrl, browserOpened) {
+  if (browserOpened === true) {
+    return true;
+  }
+  return openPackageFirewallAuthorizeWindow(authorizeUrl);
+}
 function FiShare2(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 24 24", "fill": "none", "stroke": "currentColor", "strokeWidth": "2", "strokeLinecap": "round", "strokeLinejoin": "round" }, "child": [{ "tag": "circle", "attr": { "cx": "18", "cy": "5", "r": "3" }, "child": [] }, { "tag": "circle", "attr": { "cx": "6", "cy": "12", "r": "3" }, "child": [] }, { "tag": "circle", "attr": { "cx": "18", "cy": "19", "r": "3" }, "child": [] }, { "tag": "line", "attr": { "x1": "8.59", "y1": "13.51", "x2": "15.42", "y2": "17.49" }, "child": [] }, { "tag": "line", "attr": { "x1": "15.41", "y1": "6.51", "x2": "8.59", "y2": "10.49" }, "child": [] }] })(props);
 }
@@ -20747,7 +20753,7 @@ function EvidenceInsightsShareModal({
     });
   }, [cloudConnected, refreshConnectState]);
   reactExports.useEffect(() => {
-    if (connectFlow?.state !== "running") {
+    if (connectFlow?.state !== "running" && connectFlow?.state !== "starting") {
       return;
     }
     const handle = window.setTimeout(() => {
@@ -20761,7 +20767,10 @@ function EvidenceInsightsShareModal({
     try {
       const status = await startGuardCloudConnect();
       setConnectFlow(status.connect_flow);
-      if (status.connect_flow?.authorize_url && !openPackageFirewallAuthorizeWindow(status.connect_flow.authorize_url)) {
+      if (status.connect_flow?.authorize_url && !openPackageFirewallAuthorizeFallback(
+        status.connect_flow.authorize_url,
+        status.connect_flow.browser_opened
+      )) {
         setConnectError(PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE);
       }
       if (!status.connect_required) {
@@ -26215,7 +26224,7 @@ export {
   resolveSupplyChainAuditFailure as aR,
   runPackageSync as aS,
   startPackageFirewallConnect as aT,
-  openPackageFirewallAuthorizeWindow as aU,
+  openPackageFirewallAuthorizeFallback as aU,
   PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE as aV,
   runPackageFirewallAction as aW,
   parseInterceptProofSnapshot as aX,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -1277,6 +1277,10 @@
     max-width: 3.25rem;
   }
 
+  .max-w-\[17\.5rem\] {
+    max-width: 17.5rem;
+  }
+
   .max-w-\[260px\] {
     max-width: 260px;
   }
@@ -5734,8 +5738,8 @@
       justify-content: space-between;
     }
 
-    .lg\:gap-6 {
-      gap: calc(var(--spacing) * 6);
+    .lg\:gap-4 {
+      gap: calc(var(--spacing) * 4);
     }
 
     :where(.lg\:divide-x > :not(:last-child)) {
@@ -5818,12 +5822,12 @@
       grid-template-columns: 300px minmax(0, 1fr);
     }
 
-    .xl\:grid-cols-\[minmax\(0\,1fr\)_380px\] {
-      grid-template-columns: minmax(0, 1fr) 380px;
+    .xl\:grid-cols-\[minmax\(0\,1fr\)_280px\] {
+      grid-template-columns: minmax(0, 1fr) 280px;
     }
 
-    .xl\:grid-cols-\[minmax\(0\,1fr\)_minmax\(17rem\,20rem\)\] {
-      grid-template-columns: minmax(0, 1fr) minmax(17rem, 20rem);
+    .xl\:grid-cols-\[minmax\(0\,1fr\)_380px\] {
+      grid-template-columns: minmax(0, 1fr) 380px;
     }
 
     .xl\:items-start {


### PR DESCRIPTION
## Summary
- Tighten Strict config card spacing, segmented controls, and 280px right rail to match the mockup.
- Remove scenario fixture state; derive policy simulations from live Guard settings via `resolveStrictScenarioSimulation`.

## Testing
- `cd dashboard && ./node_modules/.bin/tsx src/policy-strict-config-ia.test.ts`
- `cd dashboard && ./node_modules/.bin/tsx src/policy-strict-config-utils.test.ts`
- `cd dashboard && npm run build`
