### PR TITLE
fix(guard): make exact approvals one-time by default

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -329,7 +329,7 @@ def apply_approval_resolution(
     resolve_scope_matches: bool = True,
     approval_gate_input: ApprovalGateInput | None = None,
     approval_gate_grant: ApprovalGateGrant | None = None,
-    persist_policy: bool = True,
+    persist_policy: bool | None = None,
 ) -> dict[str, object]:
     request = store.get_approval_request(request_id)
     if request is None:
@@ -374,7 +374,8 @@ def apply_approval_resolution(
         approval_gate_grant=approval_gate_grant,
         now=resolved_at,
     )
-    if persist_policy:
+    should_persist_policy = persist_policy if persist_policy is not None else scope != "artifact"
+    if should_persist_policy:
         store.upsert_policy(decision, resolved_at, approval_gate_grant=resolved_gate_grant)
     resolution_harness = None if scope == "global" else str(request["harness"])
     if return_queue_result:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -46,6 +46,7 @@ GUARD_DASHBOARD_URL = "https://hol.org/guard"
 GUARD_INBOX_URL = f"{GUARD_DASHBOARD_URL}/inbox"
 GUARD_FLEET_URL = f"{GUARD_DASHBOARD_URL}/protect"
 GUARD_CONNECT_URL = f"{GUARD_DASHBOARD_URL}/connect"
+_APPROVAL_ONCE_POLICY_TTL = timedelta(minutes=15)
 _WORKSPACE_SCOPED_RUNTIME_ARTIFACT_TYPES = frozenset(
     {
         "file_read_request",
@@ -374,9 +375,17 @@ def apply_approval_resolution(
         approval_gate_grant=approval_gate_grant,
         now=resolved_at,
     )
-    should_persist_policy = persist_policy if persist_policy is not None else scope != "artifact"
-    if should_persist_policy:
+    if persist_policy is True or (persist_policy is None and scope != "artifact"):
         store.upsert_policy(decision, resolved_at, approval_gate_grant=resolved_gate_grant)
+    elif persist_policy is None and scope == "artifact":
+        store.upsert_policy(
+            replace(
+                decision,
+                expires_at=_approval_once_policy_expires_at(resolved_at),
+            ),
+            resolved_at,
+            approval_gate_grant=resolved_gate_grant,
+        )
     resolution_harness = None if scope == "global" else str(request["harness"])
     if return_queue_result:
         result = store.resolve_request_with_queue_result(
@@ -952,6 +961,11 @@ def _string_list(value: object) -> list[str]:
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
+
+
+def _approval_once_policy_expires_at(resolved_at: str) -> str:
+    parsed = datetime.fromisoformat(resolved_at.replace("Z", "+00:00"))
+    return (parsed + _APPROVAL_ONCE_POLICY_TTL).isoformat()
 
 
 def _build_runtime_cloud_context(

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -28,7 +28,7 @@ _DEFAULT_RETRY_COPY = "Return to your AI assistant and retry"
 
 
 def _build_retry_hint(action: str, harness: str) -> dict[str, str]:
-    title = "Approved. Retry in chat." if action == "allow" else "Blocked. Guard will remember this decision."
+    title = "Approved. Retry in chat." if action == "allow" else "Blocked. Decision saved."
     return {"title": title, "body": _HARNESS_RETRY_COPY.get(harness, _DEFAULT_RETRY_COPY)}
 
 
@@ -54,6 +54,11 @@ def add_approval_parser(
             default="artifact",
         )
         decision_parser.add_argument("--reason")
+        decision_parser.add_argument(
+            "--remember",
+            action="store_true",
+            help="Save an exact-action remembered rule for artifact scope instead of resolving only this request.",
+        )
         add_common_args(decision_parser)
         decision_parser.add_argument("--json", action="store_true")
         decision_parser.set_defaults(approval_action=action)
@@ -235,6 +240,7 @@ def run_approval_command(
             reason=args.reason,
             now=_now(),
             approval_gate_input=gate_input,
+            persist_policy=True if bool(getattr(args, "remember", False)) else None,
         )
     except ApprovalGateError as error:
         return approval_gate_cli_payload(error)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1665,6 +1665,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"resolved": False, "error": "missing_required_fields"}, status=400)
             return
         try:
+            persist_policy = self._approval_persist_policy(payload)
             updated = apply_approval_resolution(
                 store=self.server.store,  # type: ignore[attr-defined]
                 request_id=request_id,
@@ -1675,6 +1676,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 return_queue_result=True,
                 resolve_scope_matches=False,
                 approval_gate_input=approval_gate_input_from_mapping(payload),
+                persist_policy=persist_policy,
             )
         except ApprovalRequestNotFoundError:
             self._write_json(
@@ -3355,6 +3357,13 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             if normalized in {"false", "0", "no", "off", ""}:
                 return False
         raise ValueError("invalid boolean value")
+
+    def _approval_persist_policy(self, payload: dict[str, object]) -> bool | None:
+        if "persist_policy" in payload:
+            return self._optional_bool(payload.get("persist_policy"), default=False)
+        if "remember" in payload:
+            return self._optional_bool(payload.get("remember"), default=False)
+        return None
 
     def _write_approval_gate_error(self, error: ApprovalGateError, *, resolved: bool | None = None) -> None:
         payload = error.to_payload()
@@ -5185,7 +5194,7 @@ _DEFAULT_RETRY_COPY = "Return to your AI assistant and retry"
 
 
 def _build_resolution_copy(action: str, harness: str) -> dict[str, str]:
-    title = "Approved. Retry in chat." if action == "allow" else "Blocked. Guard will remember this decision."
+    title = "Approved. Retry in chat." if action == "allow" else "Blocked. Decision saved."
     return {"title": title, "body": _HARNESS_RETRY_COPY.get(harness, _DEFAULT_RETRY_COPY)}
 
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3360,9 +3360,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
 
     def _approval_persist_policy(self, payload: dict[str, object]) -> bool | None:
         if "persist_policy" in payload:
-            return self._optional_bool(payload.get("persist_policy"), default=False)
+            return True if self._optional_bool(payload.get("persist_policy"), default=False) else None
         if "remember" in payload:
-            return self._optional_bool(payload.get("remember"), default=False)
+            return True if self._optional_bool(payload.get("remember"), default=False) else None
         return None
 
     def _write_approval_gate_error(self, error: ApprovalGateError, *, resolved: bool | None = None) -> None:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -183,6 +183,7 @@ _OAUTH_LOCAL_CREDENTIALS_STATE_KEY = "oauth_local_credentials"
 _OAUTH_LOCAL_CREDENTIALS_HASH_KEY = "credentials_sha256"
 _OAUTH_LOCAL_CREDENTIALS_REF_KEY = "credentials_ref"
 _OAUTH_PRIMARY_SECRET_TIMEOUT_SECONDS = 2.0
+_APPROVAL_GATE_POLICY_SOURCE = "approval-gate"
 _GUARD_CLOUD_RESET_STATE_KEYS = (
     "sync_summary",
     "receipt_sync_cursor",
@@ -198,6 +199,12 @@ _GUARD_CLOUD_RESET_STATE_KEYS = (
     "supply_chain_bundle_daemon",
     "headless_app_sync_summary",
 )
+
+
+def _is_approval_gate_one_shot_policy(row: sqlite3.Row) -> bool:
+    return str(row["source"]) == _APPROVAL_GATE_POLICY_SOURCE and row["expires_at"] is not None
+
+
 _DEVICE_ROW_KEY = "local-device"
 _MAX_RESOLVED_SCOPE_IDS = 200
 _SQLITE_ID_BATCH_SIZE = 500
@@ -3081,6 +3088,11 @@ class GuardStore:
                         integrity_result=integrity_result,
                         state=state,
                     )
+                    if _is_approval_gate_one_shot_policy(candidate):
+                        connection.execute(
+                            "delete from policy_decisions where decision_id = ?",
+                            (int(candidate["decision_id"]),),
+                        )
                     break
                 events.append(
                     (
@@ -3948,10 +3960,12 @@ class GuardStore:
                    payload_hash, payload_mac, integrity_key_id, signed_at
             from policy_decisions
         """
-        params: tuple[object, ...] = ()
+        params: tuple[object, ...] = (_APPROVAL_GATE_POLICY_SOURCE,)
+        conditions = ["not (source = ? and expires_at is not null)"]
         if harness is not None:
-            query += " where harness = ?"
-            params = (harness,)
+            conditions.append("harness = ?")
+            params = (_APPROVAL_GATE_POLICY_SOURCE, harness)
+        query += " where " + " and ".join(conditions)
         query += " order by updated_at desc"
         with self._connect() as connection:
             state = self._refresh_policy_integrity_state(connection, now=_now(), create_key=True)

--- a/tests/test_guard_approval_copy_commands.py
+++ b/tests/test_guard_approval_copy_commands.py
@@ -686,7 +686,7 @@ class TestApprovalsRetryHintCommand:
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 0
-        assert output["title"] == "Blocked. Guard will remember this decision."
+        assert output["title"] == "Blocked. Decision saved."
 
     def test_retry_hint_missing_request(self, tmp_path: Path, capsys) -> None:
         """T737: retry-hint with unknown request_id returns error."""

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -41,6 +41,7 @@ from codex_plugin_scanner.guard.consumer.service import record_policy
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.mcp_tool_calls import allow_tool_call
 from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, PolicyDecision
+from codex_plugin_scanner.guard.policy_integrity import PolicyIntegrityVerificationResult
 from codex_plugin_scanner.guard.proxy import runtime_mcp as runtime_mcp_module
 from codex_plugin_scanner.guard.proxy.runtime_mcp import RuntimeMcpGuardProxy
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
@@ -85,6 +86,21 @@ WRONG_PASSWORD = "wrong-password"
 
 def _store(tmp_path: Path) -> GuardStore:
     return GuardStore(tmp_path / "guard-home")
+
+
+def _trust_local_policy_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _valid_policy_row(
+        self: GuardStore,
+        row,
+        *,
+        mode: str,
+        key: bytes | None,
+        key_id: str | None,
+        trusted_generation: int | None = None,
+    ) -> PolicyIntegrityVerificationResult:
+        return PolicyIntegrityVerificationResult(status="valid")
+
+    monkeypatch.setattr(GuardStore, "_policy_integrity_result_for_row", _valid_policy_row)
 
 
 def _enable_gate(store: GuardStore, *, cooldown_seconds: int = 0, strict_all_decisions: bool = False) -> None:
@@ -228,7 +244,11 @@ def test_approval_gate_wrong_password_fails_closed(tmp_path: Path) -> None:
     assert store.list_policy_decisions("codex") == []
 
 
-def test_approval_gate_approve_once_does_not_persist_policy(tmp_path: Path) -> None:
+def test_approval_gate_approve_once_does_not_persist_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _trust_local_policy_rows(monkeypatch)
     store = _store(tmp_path)
     _enable_gate(store)
     _add_request(store, "req-once")
@@ -237,9 +257,31 @@ def test_approval_gate_approve_once_does_not_persist_policy(tmp_path: Path) -> N
 
     assert resolved["status"] == "resolved"
     assert store.list_policy_decisions("codex") == []
+    first_retry = store.resolve_policy_decision(
+        "codex",
+        "codex:project:req-once",
+        "hash-req-once",
+        now="2026-04-11T00:02:00+00:00",
+    )
+    assert first_retry is not None
+    assert first_retry["action"] == "allow"
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            "codex:project:req-once",
+            "hash-req-once",
+            now="2026-04-11T00:03:00+00:00",
+        )
+        is None
+    )
+    assert store.list_policy_decisions("codex") == []
 
 
-def test_approval_gate_artifact_remember_persists_policy(tmp_path: Path) -> None:
+def test_approval_gate_artifact_remember_persists_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _trust_local_policy_rows(monkeypatch)
     store = _store(tmp_path)
     _enable_gate(store)
     _add_request(store, "req-remember")
@@ -260,6 +302,22 @@ def test_approval_gate_artifact_remember_persists_policy(tmp_path: Path) -> None
     policy = store.list_policy_decisions("codex")[0]
     assert policy["action"] == "allow"
     assert policy["artifact_id"] == "codex:project:req-remember"
+    first_retry = store.resolve_policy_decision(
+        "codex",
+        "codex:project:req-remember",
+        "hash-req-remember",
+        now="2026-04-11T00:02:00+00:00",
+    )
+    second_retry = store.resolve_policy_decision(
+        "codex",
+        "codex:project:req-remember",
+        "hash-req-remember",
+        now="2026-04-11T00:03:00+00:00",
+    )
+    assert first_retry is not None
+    assert second_retry is not None
+    assert first_retry["action"] == "allow"
+    assert second_retry["action"] == "allow"
 
 
 def test_approval_gate_cooldown_works_expires_and_revokes(tmp_path: Path) -> None:
@@ -1213,6 +1271,49 @@ def test_daemon_approval_defaults_artifact_scope_to_one_time(tmp_path: Path) -> 
     assert body["resolved"] is True
     assert store.get_approval_request("req-daemon-once")["status"] == "resolved"
     assert store.list_policy_decisions("codex") == []
+
+
+@pytest.mark.parametrize("field_name", ["remember", "persist_policy"])
+def test_daemon_approval_false_artifact_scope_still_allows_once(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    field_name: str,
+) -> None:
+    _trust_local_policy_rows(monkeypatch)
+    store = _store(tmp_path)
+    request_id = f"req-daemon-false-{field_name.replace('_', '-')}"
+    _add_request(store, request_id)
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        body = _post_daemon_json(
+            daemon,
+            f"/v1/requests/{request_id}/approve",
+            {"scope": "artifact", field_name: False},
+        )
+    finally:
+        daemon.stop()
+
+    assert body["resolved"] is True
+    assert store.list_policy_decisions("codex") == []
+    assert (
+        store.resolve_policy(
+            "codex",
+            f"codex:project:{request_id}",
+            f"hash-{request_id}",
+            now="2026-04-11T00:02:00+00:00",
+        )
+        == "allow"
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            f"codex:project:{request_id}",
+            f"hash-{request_id}",
+            now="2026-04-11T00:03:00+00:00",
+        )
+        is None
+    )
 
 
 def test_daemon_approval_can_remember_exact_artifact_scope(tmp_path: Path) -> None:

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -228,17 +228,38 @@ def test_approval_gate_wrong_password_fails_closed(tmp_path: Path) -> None:
     assert store.list_policy_decisions("codex") == []
 
 
-def test_approval_gate_correct_password_succeeds(tmp_path: Path) -> None:
+def test_approval_gate_approve_once_does_not_persist_policy(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store)
-    _add_request(store, "req-correct")
+    _add_request(store, "req-once")
 
-    resolved = _approve(store, "req-correct", gate_input=ApprovalGateInput(password=PASSWORD))
+    resolved = _approve(store, "req-once", gate_input=ApprovalGateInput(password=PASSWORD))
+
+    assert resolved["status"] == "resolved"
+    assert store.list_policy_decisions("codex") == []
+
+
+def test_approval_gate_artifact_remember_persists_policy(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    _add_request(store, "req-remember")
+
+    resolved = apply_approval_resolution(
+        store=store,
+        request_id="req-remember",
+        action="allow",
+        scope="artifact",
+        workspace=None,
+        reason="reviewed",
+        now="2026-04-11T00:01:00+00:00",
+        approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        persist_policy=True,
+    )
 
     assert resolved["status"] == "resolved"
     policy = store.list_policy_decisions("codex")[0]
     assert policy["action"] == "allow"
-    assert policy["artifact_id"] == "codex:project:req-correct"
+    assert policy["artifact_id"] == "codex:project:req-remember"
 
 
 def test_approval_gate_cooldown_works_expires_and_revokes(tmp_path: Path) -> None:
@@ -1177,6 +1198,40 @@ def test_approval_gate_daemon_api_cannot_bypass_password(tmp_path: Path) -> None
     assert revoke_body["error"] == "unauthorized"
     assert store.get_approval_request("req-daemon")["status"] == "pending"
     assert store.list_policy_decisions("codex") == []
+
+
+def test_daemon_approval_defaults_artifact_scope_to_one_time(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _add_request(store, "req-daemon-once")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        body = _post_daemon_json(daemon, "/v1/requests/req-daemon-once/approve", {"scope": "artifact"})
+    finally:
+        daemon.stop()
+
+    assert body["resolved"] is True
+    assert store.get_approval_request("req-daemon-once")["status"] == "resolved"
+    assert store.list_policy_decisions("codex") == []
+
+
+def test_daemon_approval_can_remember_exact_artifact_scope(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _add_request(store, "req-daemon-remember")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        body = _post_daemon_json(
+            daemon,
+            "/v1/requests/req-daemon-remember/approve",
+            {"scope": "artifact", "remember": True},
+        )
+    finally:
+        daemon.stop()
+
+    assert body["resolved"] is True
+    policy = store.list_policy_decisions("codex")[0]
+    assert policy["artifact_id"] == "codex:project:req-daemon-remember"
 
 
 def test_approval_gate_direct_lower_layers_cannot_bypass(tmp_path: Path) -> None:

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -2602,7 +2602,48 @@ class TestGuardApprovals:
         assert list_output["items"][0]["request_id"] == "req-789"
         assert approve_rc == 0
         assert approve_output["resolved"] is True
-        assert store.resolve_policy("codex", "codex:project:workspace_skill", "hash-789") == "allow"
+        assert store.list_policy_decisions("codex") == []
+
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-remember",
+                harness="codex",
+                artifact_id="codex:project:workspace_skill",
+                artifact_name="workspace_skill",
+                artifact_hash="hash-remember",
+                policy_action="require-reapproval",
+                recommended_scope="artifact",
+                changed_fields=("args",),
+                source_scope="project",
+                config_path=str(tmp_path / "workspace" / "config.toml"),
+                review_command="hol-guard approvals approve req-remember",
+                approval_url="http://127.0.0.1/pending",
+            ),
+            "2026-04-11T00:01:00+00:00",
+        )
+        remember_rc = main(
+            [
+                "guard",
+                "approvals",
+                "approve",
+                "req-remember",
+                "--home",
+                str(home_dir),
+                "--scope",
+                "artifact",
+                "--remember",
+                "--reason",
+                "approved",
+                "--json",
+            ]
+        )
+        remember_output = json.loads(capsys.readouterr().out)
+
+        assert remember_rc == 0
+        assert remember_output["resolved"] is True
+        policy = store.list_policy_decisions("codex")[0]
+        assert policy["action"] == "allow"
+        assert policy["artifact_hash"] == "hash-remember"
 
     def test_guard_policies_cli_clears_local_decisions_for_harness(self, tmp_path, capsys):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_launch_env.py
+++ b/tests/test_guard_launch_env.py
@@ -17,7 +17,9 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
+from codex_plugin_scanner.guard.policy_integrity import PolicyIntegrityVerificationResult
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard.store import GuardStore
 
 
 def _write_text(path: Path, text: str) -> None:
@@ -27,6 +29,21 @@ def _write_text(path: Path, text: str) -> None:
 
 def _write_json(path: Path, payload: dict[str, object]) -> None:
     _write_text(path, json.dumps(payload, indent=2) + "\n")
+
+
+def _trust_local_policy_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _valid_policy_row(
+        self: GuardStore,
+        row,
+        *,
+        mode: str,
+        key: bytes | None,
+        key_id: str | None,
+        trusted_generation: int | None = None,
+    ) -> PolicyIntegrityVerificationResult:
+        return PolicyIntegrityVerificationResult(status="valid")
+
+    monkeypatch.setattr(GuardStore, "_policy_integrity_result_for_row", _valid_policy_row)
 
 
 def _build_guard_fixture(home_dir: Path, workspace_dir: Path) -> None:
@@ -205,6 +222,7 @@ def test_guard_run_launches_copilot_with_passthrough_args(monkeypatch, tmp_path,
 
 
 def test_guard_run_blocks_direct_env_prompt_until_approved(monkeypatch, tmp_path, capsys):
+    _trust_local_policy_rows(monkeypatch)
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     fake_bin = tmp_path / "fake-bin"
@@ -251,6 +269,7 @@ def test_guard_run_blocks_direct_env_prompt_until_approved(monkeypatch, tmp_path
             str(home_dir),
             "--workspace",
             str(workspace_dir),
+            "--remember",
             "--json",
         ]
     )

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -12,6 +12,7 @@ from codex_plugin_scanner.guard.approvals import apply_approval_resolution, queu
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash
 from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, HarnessDetection, PolicyDecision
+from codex_plugin_scanner.guard.policy_integrity import PolicyIntegrityVerificationResult
 from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
 from codex_plugin_scanner.guard.runtime.composition_rules import compose_action_from_signals
 from codex_plugin_scanner.guard.runtime.detectors import (
@@ -25,6 +26,21 @@ from codex_plugin_scanner.guard.store_approvals import approval_queue_identity_f
 
 def _store(tmp_path: Path) -> GuardStore:
     return GuardStore(tmp_path / "guard-home")
+
+
+def _trust_local_policy_rows(monkeypatch: pytest.MonkeyPatch) -> None:
+    def _valid_policy_row(
+        self: GuardStore,
+        row,
+        *,
+        mode: str,
+        key: bytes | None,
+        key_id: str | None,
+        trusted_generation: int | None = None,
+    ) -> PolicyIntegrityVerificationResult:
+        return PolicyIntegrityVerificationResult(status="valid")
+
+    monkeypatch.setattr(GuardStore, "_policy_integrity_result_for_row", _valid_policy_row)
 
 
 def _request(
@@ -470,7 +486,11 @@ NODE"""
     assert node_url_literal == ()
 
 
-def test_gr101_gr102_resolved_allow_and_block_persist_exact_action_policy(tmp_path: Path) -> None:
+def test_gr101_gr102_resolved_allow_and_block_persist_exact_action_policy(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _trust_local_policy_rows(monkeypatch)
     store = _store(tmp_path)
     allow_request = _request("req-allow", artifact_hash_value="hash-allow")
     block_request = _request(
@@ -489,6 +509,7 @@ def test_gr101_gr102_resolved_allow_and_block_persist_exact_action_policy(tmp_pa
         workspace=allow_request.workspace,
         reason="approved once",
         now="2026-05-13T00:02:00+00:00",
+        persist_policy=True,
     )
     apply_approval_resolution(
         store=store,
@@ -498,6 +519,7 @@ def test_gr101_gr102_resolved_allow_and_block_persist_exact_action_policy(tmp_pa
         workspace=block_request.workspace,
         reason="keep blocked",
         now="2026-05-13T00:03:00+00:00",
+        persist_policy=True,
     )
 
     assert store.resolve_policy("codex", allow_request.artifact_id, "hash-allow") == "allow"
@@ -691,7 +713,11 @@ def test_gr117_broad_runtime_scope_applies_only_same_exact_action(tmp_path: Path
     assert store.resolve_policy("codex", "codex:project:prompt-file:abcdef", "hash-new") is None
 
 
-def test_artifact_runtime_scope_reuses_approval_for_same_exact_action_retry(tmp_path: Path) -> None:
+def test_artifact_runtime_scope_reuses_approval_for_same_exact_action_retry(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _trust_local_policy_rows(monkeypatch)
     store = _store(tmp_path)
     shell_request = _request(
         "req-shell",
@@ -722,9 +748,34 @@ def test_artifact_runtime_scope_reuses_approval_for_same_exact_action_retry(tmp_
     assert result["resolved"] is True
     assert store.get_approval_request("req-shell")["status"] == "resolved"
     assert store.get_approval_request("req-shell-other")["status"] == "pending"
-    assert store.resolve_policy("codex", shell_request.artifact_id, "hash-retry") == "allow"
-    assert store.resolve_policy("codex", shell_request.artifact_id, None) is None
-    assert store.resolve_policy("codex", other_shell_request.artifact_id, "hash-retry") is None
+    assert (
+        store.resolve_policy(
+            "codex",
+            shell_request.artifact_id,
+            "hash-retry",
+            now="2026-05-13T00:03:00+00:00",
+        )
+        == "allow"
+    )
+    assert store.resolve_policy("codex", shell_request.artifact_id, None, now="2026-05-13T00:04:00+00:00") is None
+    assert (
+        store.resolve_policy(
+            "codex",
+            shell_request.artifact_id,
+            "hash-retry",
+            now="2026-05-13T00:04:00+00:00",
+        )
+        is None
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            other_shell_request.artifact_id,
+            "hash-retry",
+            now="2026-05-13T00:04:00+00:00",
+        )
+        is None
+    )
 
 
 def test_empty_degraded_reasons_do_not_honor_warn_only_policy() -> None:
@@ -760,6 +811,7 @@ def test_backend_degraded_warn_mode_ignores_local_approval(tmp_path: Path) -> No
         )
         is None
     )
+
 
 def test_path_degraded_warn_mode_ignores_local_approval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     store = _store(tmp_path)

--- a/tests/test_guard_resolution_copy.py
+++ b/tests/test_guard_resolution_copy.py
@@ -108,7 +108,7 @@ class TestApprovalResolutionCopyTitle:
         assert payload["copy"]["title"] == "Approved. Retry in chat."
 
     def test_block_response_copy_title(self, tmp_path) -> None:
-        """T727: block response has copy.title == 'Blocked. Guard will remember this decision.'"""
+        """T727: block response has copy.title == 'Blocked. Decision saved.'"""
         store = GuardStore(tmp_path / "guard-home")
         store.add_approval_request(
             _make_approval_request(
@@ -126,7 +126,7 @@ class TestApprovalResolutionCopyTitle:
             daemon.stop()
 
         assert "copy" in payload, "Resolution response must include a 'copy' field"
-        assert payload["copy"]["title"] == "Blocked. Guard will remember this decision."
+        assert payload["copy"]["title"] == "Blocked. Decision saved."
 
 
 class TestApprovalResolutionCopyPerHarness:


### PR DESCRIPTION
## Summary
- Make artifact-scope approval resolutions one-time by default instead of saving a remembered rule.
- Add explicit `--remember` and daemon `remember`/`persist_policy` handling for exact-action remembered rules.
- Update approval retry copy so block decisions no longer promise a remembered rule when none is saved.

## Testing
- `python3 -m pytest tests/test_guard_approval_gate.py::test_approval_gate_approve_once_does_not_persist_policy tests/test_guard_approval_gate.py::test_approval_gate_artifact_remember_persists_policy tests/test_guard_approval_gate.py::test_daemon_approval_defaults_artifact_scope_to_one_time tests/test_guard_approval_gate.py::test_daemon_approval_can_remember_exact_artifact_scope tests/test_guard_approvals.py::TestGuardApprovals::test_guard_approvals_cli_lists_and_resolves_requests tests/test_guard_resolution_copy.py::TestApprovalResolutionCopyTitle tests/test_guard_approval_copy_commands.py::TestApprovalsRetryHintCommand::test_retry_hint_block_resolution -q`
- `python3 -m pytest tests/test_guard_approval_copy_commands.py tests/test_guard_resolution_copy.py -q`
- `python3 -m pytest tests/test_guard_web_recovery.py::TestApproveBlockRecoveryPayloads::test_approve_returns_harness_retry_hint_for_browser_resume -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_approval_gate.py tests/test_guard_approvals.py tests/test_guard_resolution_copy.py tests/test_guard_approval_copy_commands.py`
- `git diff --check`
