### PR TITLE
fix(guard): scope Claude tool approvals to context

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -39,7 +39,7 @@ from .models import (
     PolicyDecision,
 )
 from .risk import artifact_risk_signals, artifact_risk_summary
-from .store import GuardStore, _runtime_scoped_exact_match_key
+from .store import GuardStore, _runtime_scoped_exact_match_key, runtime_tool_action_exact_match_context
 
 GUARD_COMMAND = "hol-guard"
 GUARD_DASHBOARD_URL = "https://hol.org/guard"
@@ -463,7 +463,11 @@ def _artifact_scope_runtime_exact_match_key(request: Mapping[str, object], scope
     if scope != "artifact" or request.get("artifact_type") != "tool_action_request":
         return None
     artifact_id = request.get("artifact_id")
-    return _runtime_scoped_exact_match_key(artifact_id) if isinstance(artifact_id, str) else None
+    context = runtime_tool_action_exact_match_context(
+        config_path=_string_or_none(request.get("config_path")),
+        source_scope=_string_or_none(request.get("source_scope")),
+    )
+    return _runtime_scoped_exact_match_key(artifact_id, context) if isinstance(artifact_id, str) else None
 
 
 def _broad_runtime_exact_match_key(request: Mapping[str, object], scope: str) -> str | None:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -463,9 +463,21 @@ def _artifact_scope_runtime_exact_match_key(request: Mapping[str, object], scope
     if scope != "artifact" or request.get("artifact_type") != "tool_action_request":
         return None
     artifact_id = request.get("artifact_id")
+    raw_command_text = _string_or_none(request.get("raw_command_text"))
+    wrapper_chain = request.get("wrapper_chain")
+    envelope = request.get("action_envelope_json")
+    if isinstance(envelope, Mapping):
+        raw_command_text = raw_command_text or _string_or_none(envelope.get("raw_command_text"))
+        if not isinstance(wrapper_chain, Sequence) or isinstance(wrapper_chain, str):
+            wrapper_chain = envelope.get("wrapper_chain")
+    normalized_wrapper_chain = (
+        wrapper_chain if isinstance(wrapper_chain, Sequence) and not isinstance(wrapper_chain, str) else None
+    )
     context = runtime_tool_action_exact_match_context(
         config_path=_string_or_none(request.get("config_path")),
         source_scope=_string_or_none(request.get("source_scope")),
+        raw_command_text=raw_command_text,
+        wrapper_chain=normalized_wrapper_chain,
     )
     return _runtime_scoped_exact_match_key(artifact_id, context) if isinstance(artifact_id, str) else None
 

--- a/src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py
@@ -316,11 +316,20 @@ def _persist_claude_guard_question_decision(store: GuardStore, payload: dict[str
     if artifact_id is None or artifact_hash_value is None:
         return False
     artifact_type = _optional_string(pending.get("artifact_type"))
+    config_path = _optional_string(pending.get("config_path"))
+    source_scope = _optional_string(pending.get("source_scope"))
+    raw_command_text = _optional_string(pending.get("raw_command_text"))
+    pending_wrapper_chain = pending.get("wrapper_chain")
+    wrapper_chain = pending_wrapper_chain if isinstance(pending_wrapper_chain, list) else None
     saved = _persist_claude_native_permission_policy(
         store=store,
         artifact_id=artifact_id,
         artifact_hash=artifact_hash_value,
         artifact_type=artifact_type,
+        config_path=config_path,
+        source_scope=source_scope,
+        raw_command_text=raw_command_text,
+        wrapper_chain=wrapper_chain,
         action=action,
         reason=(
             "Allowed through HOL Guard AskUserQuestion approval."

--- a/src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py
@@ -58,10 +58,21 @@ def _persist_claude_pending_permission_denials(store: GuardStore, payload: dict[
         if artifact_id is None or artifact_hash_value is None:
             continue
         reason = _optional_string(pending.get("reason")) or "Denied in Claude's native approval prompt."
+        artifact_type = _optional_string(pending.get("artifact_type"))
+        config_path = _optional_string(pending.get("config_path"))
+        source_scope = _optional_string(pending.get("source_scope"))
+        raw_command_text = _optional_string(pending.get("raw_command_text"))
+        pending_wrapper_chain = pending.get("wrapper_chain")
+        wrapper_chain = pending_wrapper_chain if isinstance(pending_wrapper_chain, list) else None
         saved_policy = _persist_claude_native_permission_policy(
             store=store,
             artifact_id=artifact_id,
             artifact_hash=artifact_hash_value,
+            artifact_type=artifact_type,
+            config_path=config_path,
+            source_scope=source_scope,
+            raw_command_text=raw_command_text,
+            wrapper_chain=wrapper_chain,
             action="block",
             reason=f"Denied in Claude native approval prompt. {reason}",
             now=_now(),

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
@@ -168,6 +168,12 @@ def _record_claude_permission_notice(
         "approval_options": list(_CLAUDE_GUARD_APPROVAL_OPTIONS),
         "approval_code": approval_code,
     }
+    raw_command_text = artifact.metadata.get("raw_command_text")
+    if isinstance(raw_command_text, str) and raw_command_text:
+        notice_payload["raw_command_text"] = raw_command_text
+    wrapper_chain = artifact.metadata.get("wrapper_chain")
+    if isinstance(wrapper_chain, list):
+        notice_payload["wrapper_chain"] = [str(item) for item in wrapper_chain if isinstance(item, str) and item]
     if tool_name is not None:
         notice_payload["tool_name"] = tool_name
     try:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py
@@ -173,7 +173,7 @@ def _record_claude_permission_notice(
         notice_payload["raw_command_text"] = raw_command_text
     wrapper_chain = artifact.metadata.get("wrapper_chain")
     if isinstance(wrapper_chain, list):
-        notice_payload["wrapper_chain"] = [str(item) for item in wrapper_chain if isinstance(item, str) and item]
+        notice_payload["wrapper_chain"] = [item for item in wrapper_chain if isinstance(item, str) and item]
     if tool_name is not None:
         notice_payload["tool_name"] = tool_name
     try:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -29,7 +30,7 @@ if TYPE_CHECKING:
     from .commands_support_runtime_resolution import _runtime_capabilities_summary
 
 
-from ..store import _runtime_scoped_exact_match_key
+from ..store import _runtime_scoped_exact_match_key, runtime_tool_action_exact_match_context
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -416,13 +417,29 @@ def _persist_claude_native_permission_policy(
     artifact_id: str,
     artifact_hash: str,
     artifact_type: str | None = None,
+    config_path: str | None = None,
+    source_scope: str | None = None,
+    raw_command_text: str | None = None,
+    wrapper_chain: Sequence[object] | None = None,
     action: str,
     reason: str,
     now: str,
     source: str = "claude-native-approval",
 ) -> bool:
+    exact_match_context = (
+        runtime_tool_action_exact_match_context(
+            config_path=config_path,
+            source_scope=source_scope,
+            raw_command_text=raw_command_text,
+            wrapper_chain=wrapper_chain,
+        )
+        if artifact_type == "tool_action_request"
+        else None
+    )
     exact_artifact_hash = (
-        _runtime_scoped_exact_match_key(artifact_id) if artifact_type == "tool_action_request" else None
+        _runtime_scoped_exact_match_key(artifact_id, exact_match_context)
+        if artifact_type == "tool_action_request"
+        else None
     )
     stored_artifact_hash = exact_artifact_hash or artifact_hash
     try:
@@ -481,6 +498,15 @@ def _persist_claude_native_permission_for_runtime_artifact(
         artifact_id=artifact.artifact_id,
         artifact_hash=artifact_hash,
         artifact_type=artifact.artifact_type,
+        config_path=artifact.config_path,
+        source_scope=artifact.source_scope,
+        raw_command_text=artifact.metadata.get("raw_command_text")
+        if isinstance(artifact.metadata.get("raw_command_text"), str)
+        else None,
+        wrapper_chain=artifact.metadata.get("wrapper_chain")
+        if isinstance(artifact.metadata.get("wrapper_chain"), Sequence)
+        and not isinstance(artifact.metadata.get("wrapper_chain"), str)
+        else None,
         action=action,
         reason=reason,
         now=now,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py
@@ -493,6 +493,14 @@ def _persist_claude_native_permission_for_runtime_artifact(
     if pending is None:
         return False
     now = _now()
+    raw_command_text_value = artifact.metadata.get("raw_command_text")
+    raw_command_text = raw_command_text_value if isinstance(raw_command_text_value, str) else None
+    wrapper_chain_value = artifact.metadata.get("wrapper_chain")
+    wrapper_chain = (
+        wrapper_chain_value
+        if isinstance(wrapper_chain_value, Sequence) and not isinstance(wrapper_chain_value, str)
+        else None
+    )
     saved_policy = _persist_claude_native_permission_policy(
         store=store,
         artifact_id=artifact.artifact_id,
@@ -500,13 +508,8 @@ def _persist_claude_native_permission_for_runtime_artifact(
         artifact_type=artifact.artifact_type,
         config_path=artifact.config_path,
         source_scope=artifact.source_scope,
-        raw_command_text=artifact.metadata.get("raw_command_text")
-        if isinstance(artifact.metadata.get("raw_command_text"), str)
-        else None,
-        wrapper_chain=artifact.metadata.get("wrapper_chain")
-        if isinstance(artifact.metadata.get("wrapper_chain"), Sequence)
-        and not isinstance(artifact.metadata.get("wrapper_chain"), str)
-        else None,
+        raw_command_text=raw_command_text,
+        wrapper_chain=wrapper_chain,
         action=action,
         reason=reason,
         now=now,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Sequence
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -13,7 +14,7 @@ if TYPE_CHECKING:
     from .commands_support_prompts import _prompt_request_classes, _prompt_requires_hard_block
 
 
-from ..store import _runtime_scoped_exact_match_key
+from ..store import _runtime_scoped_exact_match_key, runtime_tool_action_exact_match_context
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -228,13 +229,25 @@ def _runtime_stored_policy_action(
     artifact_hash: str,
     workspace: str | None,
 ) -> str | None:
+    runtime_exact_match_context = _runtime_artifact_exact_match_context(artifact)
     decision = store.resolve_policy_decision(
         harness,
         artifact_id,
         artifact_hash,
         workspace,
         artifact.publisher,
+        runtime_exact_match_context=runtime_exact_match_context,
     )
+    if decision is None and runtime_exact_match_context is not None:
+        legacy_decision = store.resolve_policy_decision(
+            harness,
+            artifact_id,
+            artifact_hash,
+            workspace,
+            artifact.publisher,
+        )
+        if _optional_string((legacy_decision or {}).get("scope")) in {"harness", "global"}:
+            decision = legacy_decision
     if decision is None:
         return None
     action = _optional_string(decision.get("action"))
@@ -262,6 +275,22 @@ def _runtime_stored_policy_action(
             return action if decision_artifact_hash == exact_match_key else None
         return None
     return action
+
+
+def _runtime_artifact_exact_match_context(artifact: GuardArtifact) -> str | None:
+    if artifact.artifact_type != "tool_action_request":
+        return None
+    raw_command_text = artifact.metadata.get("raw_command_text")
+    wrapper_chain = artifact.metadata.get("wrapper_chain")
+    normalized_wrapper_chain = (
+        wrapper_chain if isinstance(wrapper_chain, Sequence) and not isinstance(wrapper_chain, str) else None
+    )
+    return runtime_tool_action_exact_match_context(
+        config_path=artifact.config_path,
+        source_scope=artifact.source_scope,
+        raw_command_text=raw_command_text if isinstance(raw_command_text, str) else None,
+        wrapper_chain=normalized_wrapper_chain,
+    )
 def _runtime_artifact_policy_action(config: GuardConfig, artifact: GuardArtifact, harness: str) -> str:
     if _prompt_requires_hard_block(artifact):
         return "block"

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -269,10 +269,17 @@ def _runtime_stored_policy_action(
             return None
         if scope in {"harness", "global"}:
             decision_artifact_hash = _optional_string(decision.get("artifact_hash"))
-            exact_match_key = _runtime_scoped_exact_match_key(artifact_id)
-            if exact_match_key is None:
+            exact_match_keys = {
+                key
+                for key in (
+                    _runtime_scoped_exact_match_key(artifact_id),
+                    _runtime_scoped_exact_match_key(artifact_id, runtime_exact_match_context),
+                )
+                if key is not None
+            }
+            if not exact_match_keys:
                 return action if decision_artifact_id is not None else None
-            return action if decision_artifact_hash == exact_match_key else None
+            return action if decision_artifact_hash in exact_match_keys else None
         return None
     return action
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2974,11 +2974,16 @@ class GuardStore:
         workspace: str | None = None,
         publisher: str | None = None,
         now: str | None = None,
+        runtime_exact_match_context: str | None = None,
     ) -> dict[str, object] | None:
         current_time = now or _now()
         workspace_key = _workspace_policy_key(workspace)
         action_family_key = _artifact_family_key(artifact_id)
-        runtime_exact_match_key = _runtime_scoped_exact_match_key(artifact_id) if artifact_hash is not None else None
+        runtime_exact_match_key = (
+            _runtime_scoped_exact_match_key(artifact_id, runtime_exact_match_context)
+            if artifact_hash is not None
+            else None
+        )
         events: list[tuple[str, dict[str, object]]] = []
         selected_payload: dict[str, object] | None = None
         with self._connect() as connection:
@@ -6352,14 +6357,48 @@ def _artifact_family_key(artifact_id: str | None) -> str | None:
     return f"family:{family}"
 
 
-def _runtime_scoped_exact_match_key(artifact_id: str | None) -> str | None:
+def _runtime_scoped_exact_match_key(
+    artifact_id: str | None,
+    runtime_exact_match_context: str | None = None,
+) -> str | None:
     if artifact_id is None or not artifact_id.strip() or artifact_id.startswith("family:"):
         return None
     family_key = _artifact_family_key(artifact_id)
     if family_key is None or _family_key_value(family_key) not in _SCOPED_RUNTIME_EXACT_FAMILIES:
         return None
-    digest = sha256(artifact_id.encode("utf-8")).hexdigest()
+    if runtime_exact_match_context is None:
+        digest = sha256(artifact_id.encode("utf-8")).hexdigest()
+    else:
+        digest = sha256(
+            json.dumps(
+                {
+                    "artifact_id": artifact_id,
+                    "context": runtime_exact_match_context,
+                    "version": 2,
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+        ).hexdigest()
     return f"{_RUNTIME_SCOPED_EXACT_MATCH_PREFIX}{digest}"
+
+
+def runtime_tool_action_exact_match_context(
+    *,
+    config_path: str | None,
+    source_scope: str | None,
+    raw_command_text: str | None = None,
+    wrapper_chain: Sequence[object] | None = None,
+) -> str | None:
+    if not config_path and not source_scope and not raw_command_text and not wrapper_chain:
+        return None
+    payload: dict[str, object] = {
+        "config_path": str(Path(config_path).expanduser()) if config_path else None,
+        "source_scope": source_scope,
+        "raw_command_text": raw_command_text,
+        "wrapper_chain": [str(item) for item in wrapper_chain or () if isinstance(item, str) and item],
+    }
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 
 
 def _is_runtime_scoped_exact_match_key(value: str | None) -> bool:

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -6396,7 +6396,7 @@ def runtime_tool_action_exact_match_context(
         "config_path": str(Path(config_path).expanduser()) if config_path else None,
         "source_scope": source_scope,
         "raw_command_text": raw_command_text,
-        "wrapper_chain": [str(item) for item in wrapper_chain or () if isinstance(item, str) and item],
+        "wrapper_chain": [item for item in wrapper_chain or () if isinstance(item, str) and item],
     }
     return json.dumps(payload, sort_keys=True, separators=(",", ":"))
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3067,6 +3067,7 @@ class GuardStore:
                     ),
                     source=str(candidate["source"]),
                     requested_artifact_id=artifact_id,
+                    requested_runtime_exact_match_key=runtime_exact_match_key,
                 ):
                     continue
                 integrity_result = self._policy_integrity_result_for_row(
@@ -6412,6 +6413,7 @@ def _scoped_runtime_row_requires_exact_match(
     stored_artifact_hash: str | None,
     source: str,
     requested_artifact_id: str | None,
+    requested_runtime_exact_match_key: str | None = None,
 ) -> bool:
     if scope not in {"harness", "global"}:
         return False
@@ -6420,10 +6422,17 @@ def _scoped_runtime_row_requires_exact_match(
     family_key = _artifact_family_key(stored_artifact_id)
     if family_key is None or _family_key_value(family_key) not in _SCOPED_RUNTIME_EXACT_FAMILIES:
         return False
-    expected_exact_key = _runtime_scoped_exact_match_key(requested_artifact_id)
-    if expected_exact_key is None:
+    expected_exact_keys = {
+        key
+        for key in (
+            _runtime_scoped_exact_match_key(requested_artifact_id),
+            requested_runtime_exact_match_key,
+        )
+        if key is not None
+    }
+    if not expected_exact_keys:
         return True
-    return stored_artifact_hash != expected_exact_key
+    return stored_artifact_hash not in expected_exact_keys
 
 
 def _warn_only_policy_integrity_status(status: str, state: Mapping[str, object], *, source: str = "local") -> bool:

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -22,6 +22,7 @@ from codex_plugin_scanner.guard.runtime.detectors import (
 from codex_plugin_scanner.guard.store import (
     GuardStore,
     _runtime_scoped_exact_match_key,
+    _scoped_runtime_row_requires_exact_match,
     _warn_only_policy_integrity_status,
     runtime_tool_action_exact_match_context,
 )
@@ -745,6 +746,107 @@ def test_artifact_runtime_scope_reuses_approval_for_same_exact_action_retry(tmp_
         (shell_request.artifact_id, contextual_exact_key, "allow")
     ]
     assert contextual_exact_key != legacy_exact_key
+
+
+def test_artifact_runtime_scope_includes_wrapped_action_context(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    wrapper_chain = ["bash", "zsh"]
+    request = GuardApprovalRequest(
+        request_id="req-wrapped-shell",
+        harness="codex",
+        artifact_id="codex:project:tool-action:shell",
+        artifact_name="Shell command",
+        artifact_type="tool_action_request",
+        artifact_hash="hash-original",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("shell_command",),
+        source_scope="project",
+        config_path="workspace/app/codex-config.toml",
+        workspace="workspace/app",
+        launch_target="docker compose up -d postgres",
+        review_command="hol-guard approvals approve req-wrapped-shell",
+        approval_url="http://127.0.0.1:5474/approvals/req-wrapped-shell",
+        action_envelope_json={
+            "action_type": "shell_command",
+            "tool_name": "Bash",
+            "command": "docker compose up -d postgres",
+            "raw_command_text": "docker compose up -d postgres",
+            "wrapper_chain": wrapper_chain,
+        },
+    )
+    store.add_approval_request(request, "2026-05-13T00:00:00+00:00")
+
+    result = apply_approval_resolution(
+        store=store,
+        request_id=request.request_id,
+        action="allow",
+        scope="artifact",
+        workspace=request.workspace,
+        reason="same wrapped runtime action only",
+        now="2026-05-13T00:02:00+00:00",
+        return_queue_result=True,
+    )
+    runtime_exact_match_context = runtime_tool_action_exact_match_context(
+        config_path=request.config_path,
+        source_scope=request.source_scope,
+        raw_command_text="docker compose up -d postgres",
+        wrapper_chain=wrapper_chain,
+    )
+    contextual_exact_key = _runtime_scoped_exact_match_key(request.artifact_id, runtime_exact_match_context)
+    legacy_exact_key = _runtime_scoped_exact_match_key(request.artifact_id)
+    with store._connect() as connection:
+        rows = connection.execute(
+            """
+            select artifact_id, artifact_hash, action
+            from policy_decisions
+            where scope = 'artifact'
+            """,
+        ).fetchall()
+
+    assert result["resolved"] is True
+    assert [(row["artifact_id"], row["artifact_hash"], row["action"]) for row in rows] == [
+        (request.artifact_id, contextual_exact_key, "allow")
+    ]
+    assert contextual_exact_key != legacy_exact_key
+
+
+def test_contextual_harness_runtime_exact_key_matches_same_context() -> None:
+    artifact_id = "codex:project:tool-action:shell"
+    runtime_exact_match_context = runtime_tool_action_exact_match_context(
+        config_path="workspace/app/codex-config.toml",
+        source_scope="project",
+        raw_command_text="docker compose up -d postgres",
+        wrapper_chain=("bash", "zsh"),
+    )
+    contextual_exact_key = _runtime_scoped_exact_match_key(artifact_id, runtime_exact_match_context)
+    legacy_exact_key = _runtime_scoped_exact_match_key(artifact_id)
+
+    assert contextual_exact_key is not None
+    assert legacy_exact_key is not None
+    assert not _scoped_runtime_row_requires_exact_match(
+        scope="harness",
+        stored_artifact_id=artifact_id,
+        stored_artifact_hash=contextual_exact_key,
+        source="claude-native-approval",
+        requested_artifact_id=artifact_id,
+        requested_runtime_exact_match_key=contextual_exact_key,
+    )
+    assert not _scoped_runtime_row_requires_exact_match(
+        scope="harness",
+        stored_artifact_id=artifact_id,
+        stored_artifact_hash=legacy_exact_key,
+        source="claude-native-approval",
+        requested_artifact_id=artifact_id,
+        requested_runtime_exact_match_key=contextual_exact_key,
+    )
+    assert _scoped_runtime_row_requires_exact_match(
+        scope="harness",
+        stored_artifact_id=artifact_id,
+        stored_artifact_hash=contextual_exact_key,
+        source="claude-native-approval",
+        requested_artifact_id=artifact_id,
+    )
 
 
 def test_empty_degraded_reasons_do_not_honor_warn_only_policy() -> None:

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -19,7 +19,12 @@ from codex_plugin_scanner.guard.runtime.detectors import (
     DetectorContext,
     FalsePositiveSuppressorDetector,
 )
-from codex_plugin_scanner.guard.store import GuardStore, _warn_only_policy_integrity_status
+from codex_plugin_scanner.guard.store import (
+    GuardStore,
+    _runtime_scoped_exact_match_key,
+    _warn_only_policy_integrity_status,
+    runtime_tool_action_exact_match_context,
+)
 from codex_plugin_scanner.guard.store_approvals import approval_queue_identity_for_request
 
 
@@ -722,9 +727,24 @@ def test_artifact_runtime_scope_reuses_approval_for_same_exact_action_retry(tmp_
     assert result["resolved"] is True
     assert store.get_approval_request("req-shell")["status"] == "resolved"
     assert store.get_approval_request("req-shell-other")["status"] == "pending"
-    assert store.resolve_policy("codex", shell_request.artifact_id, "hash-retry") == "allow"
-    assert store.resolve_policy("codex", shell_request.artifact_id, None) is None
-    assert store.resolve_policy("codex", other_shell_request.artifact_id, "hash-retry") is None
+    runtime_exact_match_context = runtime_tool_action_exact_match_context(
+        config_path=shell_request.config_path,
+        source_scope=shell_request.source_scope,
+    )
+    contextual_exact_key = _runtime_scoped_exact_match_key(shell_request.artifact_id, runtime_exact_match_context)
+    legacy_exact_key = _runtime_scoped_exact_match_key(shell_request.artifact_id)
+    with store._connect() as connection:
+        rows = connection.execute(
+            """
+            select artifact_id, artifact_hash, action
+            from policy_decisions
+            where scope = 'artifact'
+            """,
+        ).fetchall()
+    assert [(row["artifact_id"], row["artifact_hash"], row["action"]) for row in rows] == [
+        (shell_request.artifact_id, contextual_exact_key, "allow")
+    ]
+    assert contextual_exact_key != legacy_exact_key
 
 
 def test_empty_degraded_reasons_do_not_honor_warn_only_policy() -> None:
@@ -760,6 +780,7 @@ def test_backend_degraded_warn_mode_ignores_local_approval(tmp_path: Path) -> No
         )
         is None
     )
+
 
 def test_path_degraded_warn_mode_ignores_local_approval(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     store = _store(tmp_path)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -8210,15 +8210,26 @@ def test_guard_hook_claude_ask_user_question_docker_retry_uses_exact_action_poli
     policy = policies[0]
     artifact_id = str(policy["artifact_id"])
     stored_hash = str(policy["artifact_hash"])
-    drifted_hash_decision = store.resolve_policy_decision(
+    legacy_context_decision = store.resolve_policy_decision(
         "claude-code",
         artifact_id,
         "runtime-hash-from-retry",
         str(workspace_dir),
     )
+    other_workspace_dir = tmp_path / "other-workspace"
+    _build_guard_fixture(home_dir, other_workspace_dir)
+    other_workspace_rc, other_workspace_output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=other_workspace_dir,
+        harness="claude-code",
+        event={**first_event, "session_id": "session-claude-docker-allow-other-workspace"},
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+    )
     first_payload = json.loads(first_output)
     permission_payload = json.loads(permission_output)
     second_payload = json.loads(second_output)
+    other_workspace_payload = json.loads(other_workspace_output)
 
     assert first_rc == 0
     assert first_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
@@ -8229,10 +8240,12 @@ def test_guard_hook_claude_ask_user_question_docker_retry_uses_exact_action_poli
     assert question_output == ""
     assert second_rc == 0
     assert second_payload["hookSpecificOutput"]["permissionDecision"] == "allow"
+    assert other_workspace_rc == 0
+    assert other_workspace_payload["hookSpecificOutput"]["permissionDecision"] == "ask"
     assert policy["source"] == "claude-ask-user-question"
-    assert stored_hash == _runtime_scoped_exact_match_key(artifact_id)
-    assert drifted_hash_decision is not None
-    assert drifted_hash_decision["action"] == "allow"
+    assert stored_hash.startswith("runtime-exact:")
+    assert stored_hash != _runtime_scoped_exact_match_key(artifact_id)
+    assert legacy_context_decision is None
 
 
 def test_guard_hook_claude_notification_only_ask_user_question_persists_approval(tmp_path, capsys, monkeypatch):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -54,7 +54,11 @@ from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.runtime import secret_file_requests as secret_file_requests_module
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
-from codex_plugin_scanner.guard.store import GuardStore, _runtime_scoped_exact_match_key
+from codex_plugin_scanner.guard.store import (
+    GuardStore,
+    _runtime_scoped_exact_match_key,
+    runtime_tool_action_exact_match_context,
+)
 
 
 def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
@@ -8931,6 +8935,58 @@ def test_guard_hook_claude_ask_user_question_legacy_pending_state_still_persists
     assert policies[0]["source"] == "claude-ask-user-question"
 
 
+def test_guard_hook_claude_native_denial_uses_contextual_tool_action_key(tmp_path):
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    session_id = "session-claude-deny"
+    artifact_id = "claude-code:runtime:tool-action:bash"
+    now = "2026-04-24T00:00:00+00:00"
+    pending_key = guard_commands_module._claude_pending_permission_state_key(session_id, artifact_id)
+    wrapper_chain = ["bash", "zsh"]
+    store.set_sync_payload(
+        pending_key,
+        {
+            "saved_at": now,
+            "reason": "HOL Guard intercepted Claude's shell action.",
+            "artifact_id": artifact_id,
+            "artifact_hash": "hash-denied",
+            "artifact_name": "Bash",
+            "artifact_type": "tool_action_request",
+            "tool_name": "Bash",
+            "config_path": "workspace/app/claude-settings.json",
+            "source_scope": "project",
+            "raw_command_text": "docker compose up -d postgres",
+            "wrapper_chain": wrapper_chain,
+            "permission_prompt_seen": True,
+        },
+        now,
+    )
+    store.set_sync_payload(
+        guard_commands_module._claude_pending_permission_index_key(session_id),
+        [pending_key],
+        now,
+    )
+
+    denied = guard_commands_module._persist_claude_pending_permission_denials(
+        store,
+        {"session_id": session_id},
+    )
+    context = runtime_tool_action_exact_match_context(
+        config_path="workspace/app/claude-settings.json",
+        source_scope="project",
+        raw_command_text="docker compose up -d postgres",
+        wrapper_chain=wrapper_chain,
+    )
+    contextual_key = _runtime_scoped_exact_match_key(artifact_id, context)
+
+    policies = store.list_policy_decisions("claude-code")
+    assert denied == 1
+    assert len(policies) == 1
+    assert policies[0]["artifact_id"] == artifact_id
+    assert policies[0]["artifact_hash"] == contextual_key
+    assert policies[0]["action"] == "block"
+
+
 def test_guard_hook_claude_ask_user_question_bound_pending_without_prompt_seen_still_persists_decision(tmp_path):
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
@@ -14570,6 +14626,71 @@ def test_guard_runtime_rejects_saved_allows_for_different_risky_tool_action(
     assert (
         guard_commands_module._runtime_artifact_policy_action(config, later_artifact, "opencode")
         == "require-reapproval"
+    )
+
+
+def test_guard_runtime_accepts_contextual_harness_tool_action_policy(tmp_path):
+    workspace = tmp_path / "workspace"
+    artifact_id = "opencode:project:tool-action:docker-compose-postgres"
+    wrapper_chain = ["bash", "zsh"]
+    context = runtime_tool_action_exact_match_context(
+        config_path=str(workspace / "opencode.json"),
+        source_scope="project",
+        raw_command_text="docker compose up -d postgres",
+        wrapper_chain=wrapper_chain,
+    )
+    contextual_key = _runtime_scoped_exact_match_key(artifact_id, context)
+    assert contextual_key is not None
+
+    class _Store:
+        def resolve_policy_decision(
+            self,
+            harness: str,
+            requested_artifact_id: str,
+            artifact_hash: str,
+            workspace_value: str,
+            publisher: str | None,
+            *,
+            runtime_exact_match_context: str | None = None,
+        ) -> dict[str, object]:
+            assert harness == "opencode"
+            assert requested_artifact_id == artifact_id
+            assert artifact_hash == "hash-retry"
+            assert workspace_value == str(workspace)
+            assert publisher is None
+            assert runtime_exact_match_context == context
+            return {
+                "action": "allow",
+                "scope": "harness",
+                "artifact_id": artifact_id,
+                "artifact_hash": contextual_key,
+            }
+
+    runtime_artifact = GuardArtifact(
+        artifact_id=artifact_id,
+        name="Bash docker-sensitive command",
+        harness="opencode",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / "opencode.json"),
+        publisher=None,
+        metadata={
+            "action_class": "docker-sensitive command",
+            "raw_command_text": "docker compose up -d postgres",
+            "wrapper_chain": wrapper_chain,
+        },
+    )
+
+    assert (
+        guard_commands_module._runtime_stored_policy_action(
+            store=_Store(),
+            harness="opencode",
+            artifact=runtime_artifact,
+            artifact_id=runtime_artifact.artifact_id,
+            artifact_hash="hash-retry",
+            workspace=str(workspace),
+        )
+        == "allow"
     )
 
 


### PR DESCRIPTION
## Summary
- Scope runtime exact-match keys for tool-action approvals to execution context instead of artifact identity alone.
- Keep same-context Claude tool retries working while prompting again when the same sensitive command is run from a different project context.
- Preserve legacy exact-key fallback only for explicit harness/global tool-action policies.

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py src/codex_plugin_scanner/guard/cli/commands_support_permission_store.py src/codex_plugin_scanner/guard/cli/commands_support_claude_approval.py src/codex_plugin_scanner/guard/cli/commands_support_hook_state.py src/codex_plugin_scanner/guard/approvals.py tests/test_guard_runtime.py`
- `python3 -m pytest -q tests/test_guard_runtime.py::test_guard_hook_claude_ask_user_question_docker_retry_uses_exact_action_policy`
