### PR TITLE
fix(dashboard): compact Remembered rules summary cards

### DIFF
--- a/dashboard/src/policy-active-mode-card.tsx
+++ b/dashboard/src/policy-active-mode-card.tsx
@@ -1,6 +1,7 @@
 import { HiMiniShieldCheck } from "react-icons/hi2";
 import { SectionLabel } from "./approval-center-primitives";
 import type { GuardRuntimeSnapshot } from "./guard-types";
+import { POLICY_SUMMARY_CARD_CLASS } from "./policy-summary-surfaces";
 import { resolveSecurityModeCopy } from "./policy-workspace-helpers";
 
 type PolicyActiveModeCardProps = {
@@ -11,15 +12,15 @@ export function PolicyActiveModeCard({ snapshot }: PolicyActiveModeCardProps) {
   const modeCopy = resolveSecurityModeCopy(snapshot.security_level);
 
   return (
-    <div className="rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm">
+    <div className={`${POLICY_SUMMARY_CARD_CLASS} self-start p-4`}>
       <SectionLabel>Active mode</SectionLabel>
-      <div className="mt-3 flex items-start gap-3">
-        <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue">
-          <HiMiniShieldCheck className="h-5 w-5" aria-hidden="true" />
+      <div className="mt-2 flex items-start gap-2.5">
+        <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue">
+          <HiMiniShieldCheck className="h-4 w-4" aria-hidden="true" />
         </span>
         <div className="min-w-0">
           <p className="text-sm font-semibold text-brand-dark">{modeCopy.label}</p>
-          <p className="mt-1 text-sm leading-relaxed text-slate-600">{modeCopy.description}</p>
+          <p className="mt-0.5 line-clamp-3 text-sm leading-snug text-slate-600">{modeCopy.description}</p>
         </div>
       </div>
     </div>

--- a/dashboard/src/policy-guard-cloud-bundle-card.test.ts
+++ b/dashboard/src/policy-guard-cloud-bundle-card.test.ts
@@ -11,7 +11,7 @@ function assert(condition: boolean, message: string): void {
 }
 
 assert(
-  formatCloudBundleHashDisplay("sha256:abcdef1234567890") === "sha256:abcd…",
+  formatCloudBundleHashDisplay("sha256:abcdef1234567890") === "sha256:abcdef12…",
   "bundle hash display truncates sha256 hashes",
 );
 assert(
@@ -27,7 +27,7 @@ const attentionCopy = resolveCloudPolicyBundleCopy({
 });
 assert(attentionCopy?.label === "Needs attention", "sync error surfaces attention label");
 assert(
-  resolveCloudBundleStatusSubtitle(attentionCopy!) === "Latest sync needs attention",
+  resolveCloudBundleStatusSubtitle(attentionCopy!) === "Sync needs attention",
   "status subtitle stays short when sync needs attention",
 );
 assert(

--- a/dashboard/src/policy-guard-cloud-bundle-card.tsx
+++ b/dashboard/src/policy-guard-cloud-bundle-card.tsx
@@ -7,6 +7,7 @@ import {
   formatCloudBundleHashDisplay,
   resolveCloudBundleStatusSubtitle,
 } from "./policy-guard-cloud-bundle-helpers";
+import { POLICY_SUMMARY_CARD_CLASS } from "./policy-summary-surfaces";
 import {
   resolveCloudPolicyBundleCopy,
   resolveCloudExceptionsConnected,
@@ -16,6 +17,24 @@ import {
 type PolicyGuardCloudBundleCardProps = {
   snapshot: GuardRuntimeSnapshot;
 };
+
+function CloudBundleHeader({
+  cloudControlsUrl,
+}: {
+  cloudControlsUrl: string | null;
+}) {
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2">
+      <SectionLabel>Guard Cloud bundle</SectionLabel>
+      {cloudControlsUrl ? (
+        <ActionButton href={cloudControlsUrl} variant="secondary">
+          <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
+          Open Guard Cloud
+        </ActionButton>
+      ) : null}
+    </div>
+  );
+}
 
 export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleCardProps) {
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
@@ -39,8 +58,8 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
 
   if (!cloudBundleCopy) {
     return (
-      <div className="rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm">
-        <SectionLabel>Guard Cloud bundle</SectionLabel>
+      <div className={`${POLICY_SUMMARY_CARD_CLASS} self-start p-4`}>
+        <CloudBundleHeader cloudControlsUrl={cloudControlsUrl} />
         {cloudConnected ? (
           <>
             <p className="mt-2 text-sm font-medium text-brand-dark">
@@ -56,14 +75,6 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
             Guard Cloud is not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle.
           </p>
         )}
-        {cloudControlsUrl ? (
-          <div className="mt-3">
-            <ActionButton href={cloudControlsUrl} variant="secondary">
-              <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
-              Open Guard Cloud
-            </ActionButton>
-          </div>
-        ) : null}
       </div>
     );
   }
@@ -73,78 +84,63 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
   const showDetail = !synced;
 
   return (
-    <div className="rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm">
-      <SectionLabel>Guard Cloud bundle</SectionLabel>
+    <div className={`${POLICY_SUMMARY_CARD_CLASS} self-start p-4`}>
+      <CloudBundleHeader cloudControlsUrl={cloudControlsUrl} />
 
-      <div className="mt-3 space-y-3">
-        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
-          <dl className="grid min-w-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3">
-            <div className="min-w-0">
-              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Status</dt>
-              <dd className="mt-1.5">
-                <div className="flex min-w-0 items-center gap-1.5">
-                  {synced ? (
-                    <HiMiniCheckCircle className="h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
-                  ) : null}
-                  <Tag tone={synced ? "green" : "amber"}>{synced ? "Synced" : cloudBundleCopy.label}</Tag>
-                </div>
-                <p className="mt-1 text-xs leading-relaxed text-slate-500">{statusSubtitle}</p>
-              </dd>
-            </div>
-
-            <div className="min-w-0">
-              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Bundle hash</dt>
-              <dd className="mt-1.5 flex min-w-0 items-center gap-1.5">
-                <p className="truncate font-mono text-sm text-brand-dark" title={policyHash ?? undefined}>
-                  {policyHashDisplay}
-                </p>
-                {policyHash ? (
-                  <button
-                    type="button"
-                    onClick={handleCopyHash}
-                    className="shrink-0 rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark"
-                    aria-label="Copy bundle hash"
-                  >
-                    <HiMiniClipboardDocument className="h-4 w-4" aria-hidden="true" />
-                  </button>
-                ) : null}
-              </dd>
-            </div>
-
-            <div className="min-w-0 sm:col-span-2 xl:col-span-1">
-              <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last ack</dt>
-              <dd className="mt-1.5">
-                <div className="flex min-w-0 items-center gap-1.5">
-                  {lastAckAt && synced ? (
-                    <HiMiniCheckCircle className="h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
-                  ) : null}
-                  <p className="text-sm text-brand-dark">{lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}</p>
-                </div>
-                {bundleVersion ? (
-                  <p className="mt-1 truncate text-xs text-slate-500" title={bundleVersion}>
-                    {bundleVersion}
-                  </p>
-                ) : null}
-              </dd>
-            </div>
-          </dl>
-
-          {cloudControlsUrl ? (
-            <div className="w-full shrink-0 sm:w-auto lg:pt-5">
-              <ActionButton href={cloudControlsUrl} variant="secondary">
-                <HiMiniCloudArrowUp className="mr-1.5 h-4 w-4" aria-hidden="true" />
-                Open Guard Cloud
-              </ActionButton>
-            </div>
-          ) : null}
+      <dl className="mt-3 grid grid-cols-3 gap-x-3 gap-y-1">
+        <div className="min-w-0">
+          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Status</dt>
+          <dd className="mt-1 flex min-w-0 items-center gap-1">
+            {synced ? (
+              <HiMiniCheckCircle className="h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden="true" />
+            ) : null}
+            <Tag tone={synced ? "green" : "amber"}>{synced ? "Synced" : cloudBundleCopy.label}</Tag>
+          </dd>
         </div>
 
-        {showDetail ? (
-          <p className="rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-relaxed text-slate-700">
-            {cloudBundleCopy.detail}
-          </p>
-        ) : null}
-      </div>
+        <div className="min-w-0">
+          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Bundle hash</dt>
+          <dd className="mt-1 flex min-w-0 items-center gap-1">
+            <span className="truncate font-mono text-sm text-brand-dark" title={policyHash ?? undefined}>
+              {policyHashDisplay}
+            </span>
+            {policyHash ? (
+              <button
+                type="button"
+                onClick={handleCopyHash}
+                className="shrink-0 rounded-md p-0.5 text-slate-400 hover:bg-slate-100 hover:text-brand-dark"
+                aria-label="Copy bundle hash"
+              >
+                <HiMiniClipboardDocument className="h-3.5 w-3.5" aria-hidden="true" />
+              </button>
+            ) : null}
+          </dd>
+        </div>
+
+        <div className="min-w-0">
+          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last ack</dt>
+          <dd className="mt-1 min-w-0">
+            <p className="truncate text-sm text-brand-dark">
+              {lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}
+            </p>
+            {bundleVersion ? (
+              <p className="truncate text-xs text-slate-500" title={bundleVersion}>
+                {bundleVersion}
+              </p>
+            ) : null}
+          </dd>
+        </div>
+      </dl>
+
+      {synced ? (
+        <p className="mt-2 truncate text-xs text-slate-500">{statusSubtitle}</p>
+      ) : null}
+
+      {showDetail ? (
+        <p className="mt-3 rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-snug text-slate-700">
+          {cloudBundleCopy.detail}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/dashboard/src/policy-guard-cloud-bundle-helpers.ts
+++ b/dashboard/src/policy-guard-cloud-bundle-helpers.ts
@@ -7,9 +7,9 @@ export function formatCloudBundleHashDisplay(hash: string | null | undefined): s
   const normalized = isSha256 ? value.slice(7) : value;
 
   if (isSha256) {
-    return normalized.length <= 4 ? value : `sha256:${normalized.slice(0, 4)}…`;
+    return normalized.length <= 8 ? value : `sha256:${normalized.slice(0, 8)}…`;
   }
-  return normalized.length <= 8 ? normalized : `${normalized.slice(0, 8)}…`;
+  return normalized.length <= 12 ? normalized : `${normalized.slice(0, 12)}…`;
 }
 
 export function resolveCloudBundleStatusSubtitle(copy: {
@@ -21,7 +21,7 @@ export function resolveCloudBundleStatusSubtitle(copy: {
     return "All policies up to date";
   }
   if (copy.tone === "attention") {
-    return "Latest sync needs attention";
+    return "Sync needs attention";
   }
   return copy.label;
 }

--- a/dashboard/src/policy-remembered-rules-tab.tsx
+++ b/dashboard/src/policy-remembered-rules-tab.tsx
@@ -139,7 +139,7 @@ export function PolicyRememberedRulesTab({
   return (
     <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start">
       <div className="space-y-4">
-        <div className="grid gap-4 lg:grid-cols-2">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)] lg:items-start">
           <PolicyGuardCloudBundleCard snapshot={snapshot} />
           <PolicyActiveModeCard snapshot={snapshot} />
         </div>

--- a/dashboard/src/policy-summary-surfaces.ts
+++ b/dashboard/src/policy-summary-surfaces.ts
@@ -1,0 +1,2 @@
+export const POLICY_SUMMARY_CARD_CLASS =
+  "rounded-2xl border border-slate-200/80 bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04),0_8px_20px_rgba(15,23,42,0.04)]";

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -420,9 +420,12 @@ function toDatetimeLocalValue(iso) {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 function fromDatetimeLocalValue(value) {
+  if (!value) {
+    return "";
+  }
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) {
-    return (/* @__PURE__ */ new Date()).toISOString();
+    return "";
   }
   return date.toISOString();
 }
@@ -469,7 +472,7 @@ function createDefaultDraft(snapshot) {
   };
 }
 function isDraftRecord(value) {
-  return value !== null && typeof value === "object";
+  return value !== null && typeof value === "object" && !Array.isArray(value);
 }
 function loadDraftFromStorage() {
   try {
@@ -540,8 +543,12 @@ function canAdvanceFromScope(draft) {
   }
   return true;
 }
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+function isEmailValid(value) {
+  return EMAIL_REGEX.test(value.trim());
+}
 function canAdvanceFromGuardrails(draft) {
-  return draft.owner.trim().length > 0 && draft.requestedBy.trim().length > 0 && isReasonValid(draft.reason) && isExpiryValid(draft.requestedExpiresAt);
+  return isEmailValid(draft.owner) && isEmailValid(draft.requestedBy) && isReasonValid(draft.reason) && isExpiryValid(draft.requestedExpiresAt);
 }
 function canSubmitDraft(draft) {
   return hasValidSourceAnchor(draft) && canAdvanceFromScope(draft) && canAdvanceFromGuardrails(draft);
@@ -1251,8 +1258,7 @@ function CloudExceptionScopeStep({
     {
       value: "harness",
       label: "This harness",
-      description: "Any matching action for this harness.",
-      disabledReason: "Needs signed project identity"
+      description: "Any matching action for this harness."
     },
     {
       value: "team-policy",
@@ -2196,7 +2202,9 @@ function PolicyCloudExceptionRequestPanel({
   onSubmitted,
   onCancel
 }) {
-  const openerRef = reactExports.useRef(document.activeElement);
+  const openerRef = reactExports.useRef(
+    typeof document !== "undefined" ? document.activeElement : null
+  );
   const receiptOptions = snapshot.latest_receipts ?? [];
   const harnessOptions = reactExports.useMemo(() => {
     const fromReceipts = receiptOptions.map((receipt) => receipt.harness).filter(Boolean);
@@ -3019,15 +3027,16 @@ function PolicyCloudExceptionsTab({
     ] })
   ] });
 }
+const POLICY_SUMMARY_CARD_CLASS = "rounded-2xl border border-slate-200/80 bg-white shadow-[0_1px_2px_rgba(15,23,42,0.04),0_8px_20px_rgba(15,23,42,0.04)]";
 function PolicyActiveModeCard({ snapshot }) {
   const modeCopy = resolveSecurityModeCopy(snapshot.security_level);
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm", children: [
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_SUMMARY_CARD_CLASS} self-start p-4`, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Active mode" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex items-start gap-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-5 w-5", "aria-hidden": "true" }) }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-2 flex items-start gap-2.5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-brand-blue/10 text-brand-blue", children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniShieldCheck, { className: "h-4 w-4", "aria-hidden": "true" }) }),
       /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm font-semibold text-brand-dark", children: modeCopy.label }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-slate-600", children: modeCopy.description })
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 line-clamp-3 text-sm leading-snug text-slate-600", children: modeCopy.description })
       ] })
     ] })
   ] });
@@ -3110,18 +3119,29 @@ function formatCloudBundleHashDisplay(hash) {
   const isSha256 = value.toLowerCase().startsWith("sha256:");
   const normalized = isSha256 ? value.slice(7) : value;
   if (isSha256) {
-    return normalized.length <= 4 ? value : `sha256:${normalized.slice(0, 4)}…`;
+    return normalized.length <= 8 ? value : `sha256:${normalized.slice(0, 8)}…`;
   }
-  return normalized.length <= 8 ? normalized : `${normalized.slice(0, 8)}…`;
+  return normalized.length <= 12 ? normalized : `${normalized.slice(0, 12)}…`;
 }
 function resolveCloudBundleStatusSubtitle(copy) {
   if (copy.tone === "green") {
     return "All policies up to date";
   }
   if (copy.tone === "attention") {
-    return "Latest sync needs attention";
+    return "Sync needs attention";
   }
   return copy.label;
+}
+function CloudBundleHeader({
+  cloudControlsUrl
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-2", children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
+    cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
+      "Open Guard Cloud"
+    ] }) : null
+  ] });
 }
 function PolicyGuardCloudBundleCard({ snapshot }) {
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
@@ -3138,70 +3158,53 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
     void navigator.clipboard.writeText(policyHash);
   }, [policyHash]);
   if (!cloudBundleCopy) {
-    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
+    return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_SUMMARY_CARD_CLASS} self-start p-4`, children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(CloudBundleHeader, { cloudControlsUrl }),
       cloudConnected ? /* @__PURE__ */ jsxRuntimeExports.jsxs(jsxRuntimeExports.Fragment, { children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm font-medium text-brand-dark", children: snapshot.cloud_state_label?.trim() || "Connected to Guard Cloud" }),
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-sm leading-relaxed text-brand-dark/75", children: snapshot.cloud_state_detail?.trim() || "Guard Cloud is connected. Policy bundle details will appear after the next successful sync." })
-      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-brand-dark/75", children: "Guard Cloud is not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle." }),
-      cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-3", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
-        "Open Guard Cloud"
-      ] }) }) : null
+      ] }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-sm leading-relaxed text-brand-dark/75", children: "Guard Cloud is not connected. Remembered Cloud rules appear when Guard Cloud syncs a bundle." })
     ] });
   }
   const synced = cloudBundleCopy.tone === "green";
   const statusSubtitle = resolveCloudBundleStatusSubtitle(cloudBundleCopy);
   const showDetail = !synced;
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "rounded-2xl border border-slate-200/70 bg-white p-4 shadow-sm", children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 space-y-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "grid min-w-0 flex-1 grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-3", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Status" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-1.5", children: [
-                synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
-                /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: synced ? "green" : "amber", children: synced ? "Synced" : cloudBundleCopy.label })
-              ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-xs leading-relaxed text-slate-500", children: statusSubtitle })
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Bundle hash" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5 flex min-w-0 items-center gap-1.5", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate font-mono text-sm text-brand-dark", title: policyHash ?? void 0, children: policyHashDisplay }),
-              policyHash ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-                "button",
-                {
-                  type: "button",
-                  onClick: handleCopyHash,
-                  className: "shrink-0 rounded-md p-1 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
-                  "aria-label": "Copy bundle hash",
-                  children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-4 w-4", "aria-hidden": "true" })
-                }
-              ) : null
-            ] })
-          ] }),
-          /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 sm:col-span-2 xl:col-span-1", children: [
-            /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last ack" }),
-            /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1.5", children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-1.5", children: [
-                lastAckAt && synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-4 w-4 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
-                /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime$1(lastAckAt) : "Not yet" })
-              ] }),
-              bundleVersion ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 truncate text-xs text-slate-500", title: bundleVersion, children: bundleVersion }) : null
-            ] })
-          ] })
-        ] }),
-        cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "w-full shrink-0 sm:w-auto lg:pt-5", children: /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
-          "Open Guard Cloud"
-        ] }) }) : null
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_SUMMARY_CARD_CLASS} self-start p-4`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx(CloudBundleHeader, { cloudControlsUrl }),
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-3 grid grid-cols-3 gap-x-3 gap-y-1", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Status" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1 flex min-w-0 items-center gap-1", children: [
+          synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
+          /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: synced ? "green" : "amber", children: synced ? "Synced" : cloudBundleCopy.label })
+        ] })
       ] }),
-      showDetail ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-relaxed text-slate-700", children: cloudBundleCopy.detail }) : null
-    ] })
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Bundle hash" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1 flex min-w-0 items-center gap-1", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "truncate font-mono text-sm text-brand-dark", title: policyHash ?? void 0, children: policyHashDisplay }),
+          policyHash ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+            "button",
+            {
+              type: "button",
+              onClick: handleCopyHash,
+              className: "shrink-0 rounded-md p-0.5 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
+              "aria-label": "Copy bundle hash",
+              children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
+            }
+          ) : null
+        ] })
+      ] }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last ack" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1 min-w-0", children: [
+          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime$1(lastAckAt) : "Not yet" }),
+          bundleVersion ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-xs text-slate-500", title: bundleVersion, children: bundleVersion }) : null
+        ] })
+      ] })
+    ] }),
+    synced ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 truncate text-xs text-slate-500", children: statusSubtitle }) : null,
+    showDetail ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-snug text-slate-700", children: cloudBundleCopy.detail }) : null
   ] });
 }
 function EvidenceTable({ children, label, tableClassName = "" }) {
@@ -3818,7 +3821,7 @@ function PolicyRememberedRulesTab({
   }, [rememberedRules]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-2", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)] lg:items-start", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyGuardCloudBundleCard, { snapshot }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyActiveModeCard, { snapshot })
       ] }),
@@ -4012,7 +4015,7 @@ function resolveStrictScenarioOutcome(scenarioId, settings) {
   };
 }
 function resolveStrictScenarioSimulation(settings, scenarioId) {
-  const fallbackAction = settings.new_network_domain_action;
+  const fallbackAction = settings.new_network_domain_action ?? settings.default_action ?? "review";
   if (scenarioId === "remembered-allow") {
     return simulateStrictPolicyOutcome({
       rememberedRuleAction: "allow",
@@ -4163,7 +4166,7 @@ function StrictConfigActionSegmented({
       /* @__PURE__ */ jsxRuntimeExports.jsx(
         "div",
         {
-          className: "inline-flex w-full max-w-[17.5rem] flex-wrap gap-0.5 rounded-xl border border-slate-200 bg-slate-100/80 p-0.5",
+          className: "flex w-full flex-wrap gap-0.5 rounded-xl border border-slate-200 bg-slate-100/80 p-0.5",
           role: "group",
           "aria-label": label,
           children: PRIMARY_STRICT_ACTIONS.map((option) => {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -852,6 +852,13 @@
     overflow: hidden;
   }
 
+  .line-clamp-3 {
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    display: -webkit-box;
+    overflow: hidden;
+  }
+
   .block {
     display: block;
   }
@@ -1703,6 +1710,10 @@
 
   .self-center {
     align-self: center;
+  }
+
+  .self-start {
+    align-self: flex-start;
   }
 
   .truncate {
@@ -4360,6 +4371,11 @@
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
   }
 
+  .shadow-\[0_1px_2px_rgba\(15\,23\,42\,0\.04\)\,0_8px_20px_rgba\(15\,23\,42\,0\.04\)\] {
+    --tw-shadow: 0 1px 2px var(--tw-shadow-color, #0f172a0a), 0 8px 20px var(--tw-shadow-color, #0f172a0a);
+    box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
+  }
+
   .shadow-\[0_1px_2px_rgba\(15\,23\,42\,0\.04\)\,0_10px_28px_rgba\(15\,23\,42\,0\.05\)\] {
     --tw-shadow: 0 1px 2px var(--tw-shadow-color, #0f172a0a), 0 10px 28px var(--tw-shadow-color, #0f172a0d);
     box-shadow: var(--tw-inset-shadow), var(--tw-inset-ring-shadow), var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow);
@@ -5735,6 +5751,10 @@
       grid-template-columns: minmax(0, 1.4fr) minmax(0, .8fr);
     }
 
+    .lg\:grid-cols-\[minmax\(0\,1\.35fr\)_minmax\(0\,1fr\)\] {
+      grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+    }
+
     .lg\:grid-cols-\[minmax\(0\,1fr\)_240px\] {
       grid-template-columns: minmax(0, 1fr) 240px;
     }
@@ -5824,10 +5844,6 @@
       padding-inline: calc(var(--spacing) * 8);
     }
 
-    .lg\:pt-5 {
-      padding-top: calc(var(--spacing) * 5);
-    }
-
     .lg\:pl-20 {
       padding-left: calc(var(--spacing) * 20);
     }
@@ -5849,10 +5865,6 @@
 
     .xl\:top-6 {
       top: calc(var(--spacing) * 6);
-    }
-
-    .xl\:col-span-1 {
-      grid-column: span 1 / span 1;
     }
 
     .xl\:grid-cols-3 {


### PR DESCRIPTION
## Summary
- Fix Guard Cloud bundle card overlap by moving Open Guard Cloud to the header and using a compact three-column stats row.
- Stop Remembered rules summary cards from stretching to equal height; give the bundle card more width than Active mode.

## Testing
- `cd dashboard && ./node_modules/.bin/tsx src/policy-guard-cloud-bundle-card.test.ts`
- `cd dashboard && npm run build`
