### PR TITLE
fix(connect): recover macos oauth sync state

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1006,11 +1006,14 @@ def _system_keyring_is_available(guard_home: Path, *, use_cache: bool = True) ->
 
 
 def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
+    fallback_store = EncryptedFileSecretStore(guard_home)
     if sys.platform == "darwin":
         if _system_keyring_is_available(guard_home, use_cache=False):
-            return SystemKeyringSecretStore(service_name="hol-guard.oauth")
+            return FallbackSecretStore(
+                SystemKeyringSecretStore(service_name="hol-guard.oauth"),
+                fallback_store,
+            )
         return UnavailableSecretStore(guard_home)
-    fallback_store = EncryptedFileSecretStore(guard_home)
     if _system_keyring_is_available(guard_home):
         return FallbackSecretStore(
             SystemKeyringSecretStore(service_name="hol-guard.oauth"),
@@ -5480,7 +5483,7 @@ class GuardStore:
                 """
                 select request_id
                 from guard_connect_states
-                where status = 'connected'
+                where status in ('connected', 'retry_required')
                   and milestone != 'first_sync_succeeded'
                 order by updated_at desc
                 limit 1

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1190,7 +1190,10 @@ class GuardStore:
         self._cached_policy_integrity_control_state = None
 
     def _oauth_primary_reads_are_no_ui_safe(self) -> bool:
-        return sys.platform == "darwin" and isinstance(self._oauth_secret_store, SystemKeyringSecretStore)
+        secret_store = self._oauth_secret_store
+        if isinstance(secret_store, FallbackSecretStore):
+            secret_store = secret_store.primary
+        return sys.platform == "darwin" and isinstance(secret_store, SystemKeyringSecretStore)
 
     def _get_secret_candidates(
         self,

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -356,6 +356,59 @@ def test_connect_status_requires_retry_when_legacy_sync_profile_exists_but_oauth
     assert latest_state["milestone"] == "first_sync_failed"
 
 
+def test_record_latest_guard_connect_sync_success_clears_retry_required_state_when_oauth_exists(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem="private-key",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value"},
+        dpop_public_jwk_thumbprint="thumbprint-1",
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-06-11T22:11:11+00:00",
+    )
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-11T22:11:11+00:00",
+        request_id="connect-403",
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-06-11T22:12:11+00:00",
+        reason="Guard authorization expired. Run `hol-guard connect` again.",
+    )
+
+    store.record_latest_guard_connect_sync_success(
+        sync_payload={
+            "synced_at": "2026-06-11T22:13:11+00:00",
+            "receipts_stored": 11,
+            "inventory_items": 261,
+        },
+        now="2026-06-11T22:13:11+00:00",
+    )
+
+    payload = build_connect_status_payload(
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+        action="status",
+    )
+
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_succeeded"
+    latest_state = payload["latest_connect_state"]
+    assert isinstance(latest_state, dict)
+    assert latest_state["status"] == "connected"
+    assert latest_state["milestone"] == "first_sync_succeeded"
+
+
 def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
 

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -788,7 +788,7 @@ def test_headless_connect_slows_down_polling_when_server_requests_it(tmp_path: P
     assert sleeps == [7]
 
 
-def test_headless_connect_rejects_unreadable_macos_keychain_credentials_without_prompt(
+def test_headless_connect_persists_encrypted_fallback_when_macos_keychain_reads_are_unavailable(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -827,28 +827,30 @@ def test_headless_connect_rejects_unreadable_macos_keychain_credentials_without_
         def read(self) -> bytes:
             return json.dumps(self._payload).encode("utf-8")
 
-    with pytest.raises(RuntimeError, match="persist local Guard Cloud authorization"):
-        connect_flow.run_guard_device_connect_command(
-            store=store,
-            connect_url="https://hol.org/guard/connect",
-            request_device_authorization=fake_request,
-            token_urlopen=lambda request, timeout: _Response(
-                {
-                    "access_token": _fake_access_token(
-                        grant_id="grant-123",
-                        machine_id="machine-123",
-                        workspace_id="workspace-123",
-                    ),
-                    "refresh_token": "refresh-123",
-                    "expires_in": 3600,
-                    "scope": "guard:runtime.sync guard:offline_access",
-                    "token_type": "Bearer",
-                }
-            ),
-            now="2026-06-01T12:00:00+00:00",
-        )
+    payload = connect_flow.run_guard_device_connect_command(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        request_device_authorization=fake_request,
+        token_urlopen=lambda request, timeout: _Response(
+            {
+                "access_token": _fake_access_token(
+                    grant_id="grant-123",
+                    machine_id="machine-123",
+                    workspace_id="workspace-123",
+                ),
+                "refresh_token": "refresh-123",
+                "expires_in": 3600,
+                "scope": "guard:runtime.sync guard:offline_access",
+                "token_type": "Bearer",
+            }
+        ),
+        now="2026-06-01T12:00:00+00:00",
+    )
 
-    assert store.get_oauth_local_credentials() is None
+    assert payload["status"] == "connected"
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-123"
 
 
 def test_headless_connect_expired_code_surfaces_retry_command(tmp_path: Path) -> None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -628,6 +628,46 @@ def test_oauth_default_macos_keychain_read_uses_no_ui_path(tmp_path, monkeypatch
     assert credentials["refresh_token"] == "refresh-secret-value"
 
 
+def test_macos_oauth_default_reads_backfill_encrypted_fallback_from_keychain_only_state(
+    tmp_path,
+    monkeypatch,
+):
+    guard_home = tmp_path / "guard-home"
+    fake_keyring = _install_fake_system_keyring(monkeypatch, usable_macos_keychain=True)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+
+    def fake_no_ui_read(self: SystemKeyringSecretStore, secret_id: str, *, timeout_seconds: float = 0.0) -> str | None:
+        _ = timeout_seconds
+        return fake_keyring._secrets.get((self.service_name, secret_id))
+
+    monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", fake_no_ui_read)
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    store._oauth_secret_store.fallback.delete_secret(store._oauth_local_credentials_ref)
+    store._clear_oauth_secret_payload_cache()
+
+    restarted_store = GuardStore(guard_home)
+
+    credentials = restarted_store.get_oauth_local_credentials()
+
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-secret-value"
+    assert isinstance(restarted_store._oauth_secret_store, FallbackSecretStore)
+    assert restarted_store._oauth_secret_store.fallback.get_secret(restarted_store._oauth_local_credentials_ref)
+
+
 def test_clear_oauth_local_credentials_removes_legacy_macos_encrypted_secret(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -456,14 +456,19 @@ def test_oauth_secret_store_skips_system_keyring_when_macos_user_keychain_search
     assert isinstance(secret_store, UnavailableSecretStore)
 
 
-def test_oauth_secret_store_uses_only_system_keyring_on_macos_when_available(tmp_path, monkeypatch):
+def test_oauth_secret_store_uses_system_keyring_with_encrypted_fallback_on_macos_when_available(
+    tmp_path,
+    monkeypatch,
+):
     _install_fake_system_keyring(monkeypatch, usable_macos_keychain=True)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
     SystemKeyringSecretStore._clear_macos_keychain_health_cache()
 
     secret_store = _build_oauth_secret_store(tmp_path / "guard-home")
 
-    assert isinstance(secret_store, SystemKeyringSecretStore)
+    assert isinstance(secret_store, FallbackSecretStore)
+    assert isinstance(secret_store.primary, SystemKeyringSecretStore)
+    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
 def test_oauth_secret_store_unavailable_on_macos_does_not_create_local_secret_files(tmp_path, monkeypatch):
@@ -509,7 +514,9 @@ def test_oauth_secret_store_ignores_stale_macos_unavailable_cache_for_login(tmp_
 
     secret_store = _build_oauth_secret_store(guard_home)
 
-    assert isinstance(secret_store, SystemKeyringSecretStore)
+    assert isinstance(secret_store, FallbackSecretStore)
+    assert isinstance(secret_store.primary, SystemKeyringSecretStore)
+    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
 def test_oauth_secret_store_rechecks_stale_macos_health_cache_for_login(tmp_path, monkeypatch):
@@ -525,7 +532,9 @@ def test_oauth_secret_store_rechecks_stale_macos_health_cache_for_login(tmp_path
 
     secret_store = _build_oauth_secret_store(guard_home)
 
-    assert isinstance(secret_store, SystemKeyringSecretStore)
+    assert isinstance(secret_store, FallbackSecretStore)
+    assert isinstance(secret_store.primary, SystemKeyringSecretStore)
+    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
 def test_macos_oauth_write_rejects_unreadable_keychain_secret(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- keep macOS Guard OAuth credentials mirrored into the encrypted fallback store while the keychain remains primary
- clear stale retry-required connect state after a later cloud sync succeeds

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py -k 'oauth_secret_store_uses_system_keyring_with_encrypted_fallback_on_macos_when_available or oauth_secret_store_ignores_stale_macos_unavailable_cache_for_login or oauth_secret_store_rechecks_stale_macos_health_cache_for_login'`
- `python3 -m pytest tests/test_guard_connect_flow.py -k 'record_latest_guard_connect_sync_success_clears_retry_required_state_when_oauth_exists'`
- `python3 -m pytest tests/test_guard_oauth_device_connect.py -k 'headless_connect_persists_encrypted_fallback_when_macos_keychain_reads_are_unavailable'`
