### PR TITLE
fix(connect): recover live cloud sync state on macOS

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import json
 import os
+import time
 import urllib.error
 import uuid
 from dataclasses import dataclass
@@ -60,17 +61,24 @@ def collect_aibom_snapshots(
 ) -> tuple[GuardAgentInventorySnapshot, ...]:
     resolved = options or AibomCliOptions()
     snapshots: list[GuardAgentInventorySnapshot] = []
+    remaining_cisco_timeout_seconds = resolved.cisco_timeout_seconds
     for detection in detect_all(context):
         if not detection.installed and not detection.artifacts:
             continue
+        cisco_started = time.monotonic()
         cisco_runs = run_cisco_inventory_scans(
             harness=str(getattr(detection, "harness", "unknown")),
             context=context,
             detection=detection,
             mcp_mode=resolved.cisco_mcp_scan,
             skill_mode=resolved.cisco_skill_scan,
-            timeout_seconds=resolved.cisco_timeout_seconds,
+            timeout_seconds=remaining_cisco_timeout_seconds,
         )
+        if remaining_cisco_timeout_seconds is not None:
+            remaining_cisco_timeout_seconds = max(
+                remaining_cisco_timeout_seconds - max(time.monotonic() - cisco_started, 0.0),
+                0.0,
+            )
         snapshots.append(
             inventory_snapshot_from_detection(
                 detection,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -324,6 +324,7 @@ def _finalize_guard_connect_payload(
     latest_state = store.record_latest_guard_connect_sync_success(
         sync_payload=sync_payload,
         now=str(sync_payload.get("synced_at") or now),
+        request_id=str(latest_state.get("request_id") or ""),
     )
     payload.update(
         {

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1075,6 +1075,7 @@ def _finalize_daemon_guard_connect_payload(
     latest_state = store.record_latest_guard_connect_sync_success(
         sync_payload=sync_payload,
         now=str(sync_payload.get("synced_at") or now),
+        request_id=str(latest_state.get("request_id") or ""),
     )
     payload.update(
         {

--- a/src/codex_plugin_scanner/guard/inventory_cisco.py
+++ b/src/codex_plugin_scanner/guard/inventory_cisco.py
@@ -35,8 +35,20 @@ def run_cisco_inventory_scans(
     timeout_seconds: float | None = None,
 ) -> tuple[CiscoInventoryRun, ...]:
     runs: list[CiscoInventoryRun] = []
+    remaining_timeout_seconds = timeout_seconds
     if mcp_mode != "off":
-        runs.append(_run_mcp_inventory_scan(context=context, mode=mcp_mode, timeout_seconds=timeout_seconds))
+        mcp_started = time.perf_counter()
+        runs.append(
+            _run_mcp_inventory_scan(
+                context=context,
+                mode=mcp_mode,
+                timeout_seconds=remaining_timeout_seconds,
+            )
+        )
+        remaining_timeout_seconds = _consume_timeout_budget(
+            remaining_timeout_seconds,
+            started_at=mcp_started,
+        )
     if skill_mode != "off":
         runs.extend(
             _run_skill_inventory_scans(
@@ -44,7 +56,7 @@ def run_cisco_inventory_scans(
                 context=context,
                 detection=detection,
                 mode=skill_mode,
-                timeout_seconds=timeout_seconds,
+                timeout_seconds=remaining_timeout_seconds,
             )
         )
     return tuple(runs)
@@ -65,6 +77,15 @@ def _run_mcp_inventory_scan(
             findings=(),
             duration_ms=0,
             metadata={"target": "missing", "targetsScanned": 0, "mode": mode},
+        )
+    if timeout_seconds is not None and timeout_seconds <= 0:
+        return CiscoInventoryRun(
+            source="cisco-mcp-scanner",
+            status="timed_out",
+            message="Cisco MCP inventory scan timed out before Guard could start it.",
+            findings=(),
+            duration_ms=0,
+            metadata={"target": root.name, "targetsScanned": 0, "mode": mode},
         )
     started = time.perf_counter()
     summary = run_cisco_mcp_scan(root, mode=mode, timeout_seconds=timeout_seconds)
@@ -107,14 +128,25 @@ def _run_skill_inventory_scans(
                 metadata={"target": "missing", "skillsScanned": 0, "mode": mode},
             ),
         )
-    return tuple(
-        _run_single_skill_inventory_scan(
-            root=root,
-            mode=mode,
-            timeout_seconds=timeout_seconds,
+    remaining_timeout_seconds = timeout_seconds
+    runs: list[CiscoInventoryRun] = []
+    for root in roots:
+        if remaining_timeout_seconds is not None and remaining_timeout_seconds <= 0:
+            runs.append(_build_skill_inventory_budget_exhausted_run(root=root, mode=mode))
+            continue
+        started = time.perf_counter()
+        runs.append(
+            _run_single_skill_inventory_scan(
+                root=root,
+                mode=mode,
+                timeout_seconds=remaining_timeout_seconds,
+            )
         )
-        for root in roots
-    )
+        remaining_timeout_seconds = _consume_timeout_budget(
+            remaining_timeout_seconds,
+            started_at=started,
+        )
+    return tuple(runs)
 
 
 def _run_single_skill_inventory_scan(
@@ -140,6 +172,26 @@ def _run_single_skill_inventory_scan(
             "findingsBySeverity": summary.findings_by_severity,
             "analyzersUsed": summary.analyzers_used,
             "policyName": summary.policy_name,
+            "mode": mode,
+        },
+    )
+
+
+def _build_skill_inventory_budget_exhausted_run(*, root: Path, mode: str) -> CiscoInventoryRun:
+    return CiscoInventoryRun(
+        source="cisco-skill-scanner",
+        status="timed_out",
+        message="Cisco skill scanner timed out before Guard could start this skill collection.",
+        findings=(),
+        duration_ms=0,
+        metadata={
+            "target": str(root),
+            "skillsScanned": 0,
+            "skillsSkipped": (),
+            "totalFindings": 0,
+            "findingsBySeverity": {},
+            "analyzersUsed": (),
+            "policyName": "balanced",
             "mode": mode,
         },
     )
@@ -190,15 +242,17 @@ def _artifact_skill_root(artifact: object, *, context: HarnessContext) -> Path |
                     continue
                 candidate = (base_dir / skill_root).resolve()
                 if candidate.is_dir():
-                    nested_skill_dirs = _skill_dirs_under(candidate)
-                    if len(nested_skill_dirs) == 1:
-                        return nested_skill_dirs[0]
                     if (candidate / "SKILL.md").is_file():
+                        return candidate
+                    if _skill_dirs_under(candidate):
                         return candidate
     config_path = getattr(artifact, "config_path", None)
     if not isinstance(config_path, str):
         return None
     skill_path = Path(config_path)
+    collection_root = _nearest_skill_collection_dir(skill_path)
+    if collection_root is not None and collection_root.is_dir():
+        return collection_root
     root = _nearest_skill_dir(skill_path)
     if root is not None and root.is_dir():
         return root
@@ -230,3 +284,23 @@ def _nearest_skill_dir(path: Path) -> Path | None:
         if (parent / "SKILL.md").is_file():
             return parent
     return None
+
+
+def _nearest_skill_collection_dir(path: Path) -> Path | None:
+    for parent in path.parents:
+        if parent.name != "skills":
+            continue
+        if _skill_dirs_under(parent):
+            return parent
+    return None
+
+
+def _consume_timeout_budget(
+    timeout_seconds: float | None,
+    *,
+    started_at: float,
+) -> float | None:
+    if timeout_seconds is None:
+        return None
+    elapsed_seconds = max(time.perf_counter() - started_at, 0.0)
+    return max(timeout_seconds - elapsed_seconds, 0.0)

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1015,6 +1015,12 @@ def _system_keyring_is_available(guard_home: Path, *, use_cache: bool = True) ->
 def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
     fallback_store = EncryptedFileSecretStore(guard_home)
     if sys.platform == "darwin":
+        cached_availability = _read_system_keyring_availability_cache(guard_home)
+        if cached_availability is True:
+            return FallbackSecretStore(
+                SystemKeyringSecretStore(service_name="hol-guard.oauth"),
+                fallback_store,
+            )
         if _system_keyring_is_available(guard_home, use_cache=False):
             return FallbackSecretStore(
                 SystemKeyringSecretStore(service_name="hol-guard.oauth"),
@@ -5499,25 +5505,32 @@ class GuardStore:
         milestone: str,
         now: str,
         reason: str | None = None,
+        request_id: str | None = None,
         sync_payload: dict[str, object] | None = None,
     ) -> dict[str, object] | None:
         with self._connect() as connection:
-            row = connection.execute(
-                """
-                select request_id
-                from guard_connect_states
-                where status in ('connected', 'retry_required')
-                  and milestone != 'first_sync_succeeded'
-                order by updated_at desc
-                limit 1
-                """
-            ).fetchone()
-            if row is None:
-                return None
-            latest_state = load_connect_state(connection, str(row["request_id"]), now=now)
+            latest_state: dict[str, object] | None
+            if isinstance(request_id, str) and request_id.strip():
+                latest_state = load_connect_state(connection, request_id.strip(), now=now)
+            else:
+                row = connection.execute(
+                    """
+                    select request_id
+                    from guard_connect_states
+                    where status in ('connected', 'retry_required')
+                      and milestone != 'first_sync_succeeded'
+                    order by updated_at desc
+                    limit 1
+                    """
+                ).fetchone()
+                if row is None:
+                    return None
+                latest_state = load_connect_state(connection, str(row["request_id"]), now=now)
             if latest_state is None:
                 return None
             if latest_state.get("status") not in {"connected", "retry_required"}:
+                return latest_state
+            if request_id is None and latest_state.get("status") != "connected":
                 return latest_state
             return persist_connect_result(
                 connection,
@@ -5534,12 +5547,14 @@ class GuardStore:
         *,
         sync_payload: dict[str, object],
         now: str,
+        request_id: str | None = None,
     ) -> dict[str, object] | None:
         return self.record_latest_guard_connect_sync_result(
             status="connected",
             milestone="first_sync_succeeded",
             now=now,
             reason=None,
+            request_id=request_id,
             sync_payload=sync_payload,
         )
 

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -4,6 +4,7 @@ import argparse
 import json
 from email.message import Message
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -594,6 +595,55 @@ def test_sync_aibom_snapshots_uses_cloud_sync_cisco_defaults(tmp_path: Path, mon
     assert isinstance(trust_attestation_context, dict)
     assert trust_attestation_context["deviceId"] is None
     assert trust_attestation_context["workspaceId"] is None
+
+
+def test_collect_aibom_snapshots_shares_cisco_timeout_budget_across_detections(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard",
+    )
+    context.home_dir.mkdir(parents=True)
+    assert context.workspace_dir is not None
+    context.workspace_dir.mkdir(parents=True)
+    context.guard_home.mkdir(parents=True)
+
+    detections = [
+        SimpleNamespace(installed=True, artifacts=(), harness="codex"),
+        SimpleNamespace(installed=True, artifacts=(), harness="openclaw"),
+    ]
+    observed_timeouts: list[float | None] = []
+    monotonic_values = iter([0.0, 4.0, 4.0, 9.0])
+
+    def fake_monotonic() -> float:
+        return next(monotonic_values)
+
+    monkeypatch.setattr(aibom_cli, "detect_all", lambda _context: detections)
+    monkeypatch.setattr(aibom_cli.time, "monotonic", fake_monotonic)
+    monkeypatch.setattr(
+        aibom_cli,
+        "run_cisco_inventory_scans",
+        lambda **kwargs: observed_timeouts.append(kwargs.get("timeout_seconds")) or (),
+    )
+    monkeypatch.setattr(
+        aibom_cli,
+        "inventory_snapshot_from_detection",
+        lambda *args, **kwargs: {"harness": getattr(args[0], "harness", "unknown"), "kwargs": kwargs},
+    )
+
+    snapshots = aibom_cli.collect_aibom_snapshots(
+        context,
+        generated_at="2026-06-10T12:00:00+00:00",
+        options=aibom_cli.AibomCliOptions(cisco_skill_scan="auto", cisco_timeout_seconds=10.0),
+    )
+
+    assert len(snapshots) == 2
+    assert observed_timeouts == [10.0, 6.0]
 
 
 def test_guard_aibom_sync_command_uses_cloud_sync_cisco_defaults(

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -392,6 +392,7 @@ def test_record_latest_guard_connect_sync_success_clears_retry_required_state_wh
             "inventory_items": 261,
         },
         now="2026-06-11T22:13:11+00:00",
+        request_id="connect-403",
     )
 
     payload = build_connect_status_payload(
@@ -407,6 +408,45 @@ def test_record_latest_guard_connect_sync_success_clears_retry_required_state_wh
     assert isinstance(latest_state, dict)
     assert latest_state["status"] == "connected"
     assert latest_state["milestone"] == "first_sync_succeeded"
+
+
+def test_background_sync_success_does_not_clear_newer_retry_required_connect_request(
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-11T22:10:11+00:00",
+        request_id="connect-older",
+    )
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-11T22:11:11+00:00",
+        request_id="connect-newer",
+    )
+    store.record_latest_guard_connect_sync_result(
+        status="retry_required",
+        milestone="first_sync_failed",
+        now="2026-06-11T22:12:11+00:00",
+        reason="Guard authorization expired. Run `hol-guard connect` again.",
+        request_id="connect-newer",
+    )
+
+    latest_state = store.record_latest_guard_connect_sync_success(
+        sync_payload={
+            "synced_at": "2026-06-11T22:13:11+00:00",
+            "receipts_stored": 11,
+            "inventory_items": 261,
+        },
+        now="2026-06-11T22:13:11+00:00",
+    )
+
+    assert latest_state is not None
+    assert latest_state["request_id"] == "connect-newer"
+    assert latest_state["status"] == "retry_required"
+    assert latest_state["milestone"] == "first_sync_failed"
 
 
 def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path) -> None:

--- a/tests/test_guard_inventory_cisco.py
+++ b/tests/test_guard_inventory_cisco.py
@@ -4,6 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from types import SimpleNamespace
 
+import codex_plugin_scanner.guard.inventory_cisco as inventory_cisco
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.inventory_cisco import run_cisco_inventory_scans
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
@@ -233,7 +234,7 @@ def test_cisco_inventory_scans_use_detected_nonstandard_skill_roots(tmp_path: Pa
         skill_mode="on",
     )
 
-    assert calls == [skill_path.parent]
+    assert calls == [extra_root]
 
 
 def test_cisco_inventory_scans_resolve_skill_root_collection_directories(tmp_path: Path, monkeypatch) -> None:
@@ -288,11 +289,13 @@ def test_cisco_inventory_scans_resolve_skill_root_collection_directories(tmp_pat
     )
 
     assert [run.source for run in runs] == ["cisco-skill-scanner"]
-    assert calls == [skill_path.parent]
-    assert [run.metadata["target"] for run in runs] == [str(skill_path.parent)]
+    assert calls == [collection_root]
+    assert [run.metadata["target"] for run in runs] == [str(collection_root)]
 
 
-def test_cisco_inventory_scans_runs_each_detected_skill_root(tmp_path: Path, monkeypatch) -> None:
+def test_cisco_inventory_scans_collapse_detected_skill_roots_into_collection_directories(
+    tmp_path: Path, monkeypatch
+) -> None:
     context = _ctx(tmp_path)
     home_dir = context.home_dir
     assert home_dir is not None
@@ -352,6 +355,77 @@ def test_cisco_inventory_scans_runs_each_detected_skill_root(tmp_path: Path, mon
         skill_mode="auto",
     )
 
-    assert [run.source for run in runs] == ["cisco-skill-scanner", "cisco-skill-scanner"]
-    assert calls == [skill_a.parent, skill_b.parent]
-    assert [run.metadata["target"] for run in runs] == [str(skill_a.parent), str(skill_b.parent)]
+    assert [run.source for run in runs] == ["cisco-skill-scanner"]
+    assert calls == [skill_a.parent.parent]
+    assert [run.metadata["target"] for run in runs] == [str(skill_a.parent.parent)]
+
+
+def test_cisco_inventory_scans_share_timeout_budget_across_skill_collection_roots(
+    tmp_path: Path, monkeypatch
+) -> None:
+    context = _ctx(tmp_path)
+    home_dir = context.home_dir
+    assert home_dir is not None
+    skill_a = home_dir / ".agents" / "skills" / "adapt" / "SKILL.md"
+    skill_b = home_dir / ".claude" / "skills" / "lean-ctx" / "SKILL.md"
+    skill_a.parent.mkdir(parents=True)
+    skill_b.parent.mkdir(parents=True)
+    skill_a.write_text("---\nname: adapt\n---\nAdapt layouts.\n")
+    skill_b.write_text("---\nname: lean-ctx\n---\nContext runtime.\n")
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_a), str(skill_b)),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:skill:adapt",
+                name="adapt",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_a),
+            ),
+            GuardArtifact(
+                artifact_id="codex:skill:lean-ctx",
+                name="lean-ctx",
+                harness="codex",
+                artifact_type="skill",
+                source_scope="global",
+                config_path=str(skill_b),
+            ),
+        ),
+    )
+    timeouts: list[float | None] = []
+    perf_counter_values = iter([0.0, 0.0, 0.0, 4.0, 4.0, 4.0, 4.0, 9.0])
+
+    def fake_perf_counter() -> float:
+        return next(perf_counter_values)
+
+    def fake_skill_scan(root: Path, mode: str, timeout_seconds: float | None = None) -> _SkillSummary:
+        del root, mode
+        timeouts.append(timeout_seconds)
+        return _SkillSummary(
+            status=CiscoIntegrationStatus.ENABLED,
+            message="Skill scanner completed.",
+            findings=(),
+            skills_scanned=1,
+            skills_skipped=(),
+            analyzers_used=("prompt-injection",),
+            policy_name="balanced",
+            total_findings=0,
+            findings_by_severity={severity.value: 0 for severity in Severity},
+        )
+
+    monkeypatch.setattr(inventory_cisco.time, "perf_counter", fake_perf_counter)
+    monkeypatch.setattr("codex_plugin_scanner.guard.inventory_cisco.run_cisco_skill_scan", fake_skill_scan)
+
+    run_cisco_inventory_scans(
+        harness="codex",
+        context=context,
+        detection=detection,
+        skill_mode="auto",
+        timeout_seconds=10.0,
+    )
+
+    assert timeouts == [10.0, 6.0]

--- a/tests/test_guard_inventory_cisco.py
+++ b/tests/test_guard_inventory_cisco.py
@@ -139,7 +139,10 @@ def test_cisco_inventory_scans_run_mcp_and_skill_scanners_with_required_mode(tmp
     assert [call[0] for call in calls] == ["mcp", "skill"]
     assert calls[0][1] == workspace_dir
     assert calls[1][1] == skill_path.parent
-    assert all(call[2] == "on" and call[3] == 3.5 for call in calls)
+    assert all(call[2] == "on" for call in calls)
+    assert calls[0][3] == 3.5
+    assert calls[1][3] is not None
+    assert 0 < calls[1][3] <= 3.5
     assert all(run.status == "enabled" for run in runs)
 
 

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -471,6 +471,24 @@ def test_oauth_secret_store_uses_system_keyring_with_encrypted_fallback_on_macos
     assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
+def test_oauth_secret_store_uses_cached_macos_availability_when_healthy(tmp_path, monkeypatch):
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir(parents=True)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    guard_store_module._write_system_keyring_availability_cache(guard_home, available=True)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_is_available",
+        classmethod(lambda cls: (_ for _ in ()).throw(AssertionError("cache miss"))),
+    )
+
+    secret_store = _build_oauth_secret_store(guard_home)
+
+    assert isinstance(secret_store, FallbackSecretStore)
+    assert isinstance(secret_store.primary, SystemKeyringSecretStore)
+    assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
+
+
 def test_oauth_secret_store_unavailable_on_macos_does_not_create_local_secret_files(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch, usable_macos_keychain=False)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -555,26 +555,29 @@ def test_oauth_secret_store_rechecks_stale_macos_health_cache_for_login(tmp_path
     assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
-def test_macos_oauth_write_rejects_unreadable_keychain_secret(tmp_path, monkeypatch):
+def test_macos_oauth_write_persists_with_encrypted_fallback_when_keychain_readback_is_unavailable(
+    tmp_path,
+    monkeypatch,
+):
     guard_home = tmp_path / "guard-home"
     _install_fake_system_keyring(monkeypatch, usable_macos_keychain=True)
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
     monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", lambda *args, **kwargs: None)
     store = GuardStore(guard_home)
 
-    with pytest.raises(RuntimeError, match="persist local Guard Cloud authorization securely"):
-        store.set_oauth_local_credentials(
-            issuer="https://hol.org",
-            client_id="guard-local-daemon",
-            refresh_token="refresh-secret-value",
-            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
-            dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
-            dpop_public_jwk_thumbprint="thumbprint-123",
-            now="2026-06-01T00:00:00+00:00",
-        )
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
 
-    assert store.get_sync_payload(guard_store_module._OAUTH_LOCAL_CREDENTIALS_STATE_KEY) is None
-    assert store.get_oauth_local_credentials() is None
+    assert store.get_sync_payload(guard_store_module._OAUTH_LOCAL_CREDENTIALS_STATE_KEY) is not None
+    assert store.get_oauth_local_credentials() is not None
+    assert store.get_recoverable_oauth_local_credentials() is not None
 
 
 def test_oauth_health_uses_no_ui_primary_read_for_macos_keychain_only_store(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- add an encrypted-file fallback mirror for macOS OAuth secrets when the system keyring is available
- clear stale retry-required connect state after a successful first sync and allow fallback backfill from keychain-only installs

## Testing
- `python3 -m pytest tests/test_guard_store_migrations.py -k "oauth_secret_store_uses_system_keyring_with_encrypted_fallback_on_macos_when_available or oauth_secret_store_ignores_stale_macos_unavailable_cache_for_login or oauth_secret_store_rechecks_stale_macos_health_cache_for_login or macos_oauth_default_reads_backfill_encrypted_fallback_from_keychain_only_state"`
- `python3 -m pytest tests/test_guard_connect_flow.py -k "record_latest_guard_connect_sync_success_clears_retry_required_state_when_oauth_exists"`
- `python3 -m pytest tests/test_guard_oauth_device_connect.py -k "headless_connect_persists_encrypted_fallback_when_macos_keychain_reads_are_unavailable"`
