### PR TITLE
fix(guard): reject local cloud policy impersonation

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2090,7 +2090,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     device_name=device_name,
                 )
             )
-            self.server.store.replace_remote_policies(existing_remote_decisions, applied_at)  # type: ignore[attr-defined]
+            self.server.store.replace_remote_policies(  # type: ignore[attr-defined]
+                existing_remote_decisions,
+                applied_at,
+                remote_write_authorized=True,
+            )
             _persist_cloud_exceptions(
                 self.server.store,  # type: ignore[attr-defined]
                 policy_bundle=validated_policy_bundle,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2158,6 +2158,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 decision,
                 _now(),
                 approval_gate_grant=approval_gate_grant,
+                remote_write_authorized=True,
             )
         except ApprovalGateError as error:
             self._write_approval_gate_error(error)

--- a/src/codex_plugin_scanner/guard/policy_authority.py
+++ b/src/codex_plugin_scanner/guard/policy_authority.py
@@ -1,0 +1,23 @@
+"""Authority checks for remembered local rules and Cloud policy rows."""
+
+from __future__ import annotations
+
+from .models import PolicyDecision
+from .policy_integrity import is_remote_policy_source
+
+
+class PolicyAuthorityError(ValueError):
+    """Raised when a policy row would cross its allowed authority boundary."""
+
+
+def validate_policy_write_authority(
+    decision: PolicyDecision,
+    *,
+    remote_write_authorized: bool = False,
+) -> None:
+    """Reject local writes that would impersonate stronger authority."""
+
+    if is_remote_policy_source(decision.source):
+        if remote_write_authorized:
+            return
+        raise PolicyAuthorityError("remote_policy_source_requires_validated_sync_path")

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -284,7 +284,7 @@ def _execute_policy_sync(
         source="cloud-sync",
         expires_at=_optional_string(policy_memory.get("expiry")),
     )
-    store.upsert_policy(decision, generated_at)
+    store.upsert_policy(decision, generated_at, remote_write_authorized=True)
     return _result(
         {
             "action": "policy_sync",

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1397,7 +1397,7 @@ def sync_receipts(
     remote_policies_stored = len(remote_decisions)
     remote_policy_sync_blocked = False
     try:
-        store.replace_remote_policies(list(remote_decisions), now)
+        store.replace_remote_policies(list(remote_decisions), now, remote_write_authorized=True)
     except ApprovalGateError as error:
         remote_policies_stored = 0
         remote_policy_sync_blocked = True

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2858,10 +2858,6 @@ class GuardStore:
                 secret_material=secret_material,
                 allow_cutover_resign=False,
             )
-            validate_policy_write_authority(
-                decision,
-                remote_write_authorized=False,
-            )
             connection.execute(
                 """
                 delete from policy_decisions

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -2932,8 +2932,13 @@ class GuardStore:
         now: str,
         *,
         approval_gate_grant: ApprovalGateGrant | None = None,
+        remote_write_authorized: bool = False,
     ) -> None:
         for decision in decisions:
+            validate_policy_write_authority(
+                decision,
+                remote_write_authorized=remote_write_authorized,
+            )
             require_policy_write(
                 self.guard_home,
                 decision=decision,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1146,6 +1146,13 @@ class GuardStore:
             if persisted_value == value:
                 return
             raise RuntimeError("Guard could not persist local Guard Cloud authorization securely.")
+        if sys.platform == "darwin" and isinstance(secret_store, FallbackSecretStore):
+            primary = secret_store.primary
+            if isinstance(primary, SystemKeyringSecretStore):
+                persisted_value = self._get_secret_from_primary_store(primary, secret_id)
+                if persisted_value == value:
+                    return
+                raise RuntimeError("Guard could not persist local Guard Cloud authorization securely.")
         if isinstance(secret_store, UnavailableSecretStore):
             raise RuntimeError(
                 "Guard local credentials require an available OS credential store. "
@@ -2833,10 +2840,11 @@ class GuardStore:
         now: str,
         *,
         approval_gate_grant: ApprovalGateGrant | None = None,
+        remote_write_authorized: bool = False,
     ) -> None:
         validate_policy_write_authority(
             decision,
-            remote_write_authorized=False,
+            remote_write_authorized=remote_write_authorized,
         )
         require_policy_write(
             self.guard_home,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -42,6 +42,7 @@ from .local_trust_contract import (
     TrustStatus,
 )
 from .models import GuardApprovalRequest, GuardArtifact, GuardReceipt, GuardRuntimeState, PolicyDecision
+from .policy_authority import validate_policy_write_authority
 from .policy_integrity import (
     REMOTE_POLICY_SOURCES,
     PolicyIntegrityVerificationResult,
@@ -2833,6 +2834,10 @@ class GuardStore:
         *,
         approval_gate_grant: ApprovalGateGrant | None = None,
     ) -> None:
+        validate_policy_write_authority(
+            decision,
+            remote_write_authorized=False,
+        )
         require_policy_write(
             self.guard_home,
             decision=decision,
@@ -2852,6 +2857,10 @@ class GuardStore:
                 create_key=not is_remote_policy_source(decision.source),
                 secret_material=secret_material,
                 allow_cutover_resign=False,
+            )
+            validate_policy_write_authority(
+                decision,
+                remote_write_authorized=False,
             )
             connection.execute(
                 """

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1089,10 +1089,16 @@ def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
     class PolicyStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
-            self.upserts: list[tuple[dict[str, object], str]] = []
+            self.upserts: list[tuple[dict[str, object], str, bool]] = []
 
-        def upsert_policy(self, decision: object, generated_at: str) -> None:
-            self.upserts.append((decision.to_dict(), generated_at))
+        def upsert_policy(
+            self,
+            decision: object,
+            generated_at: str,
+            *,
+            remote_write_authorized: bool = False,
+        ) -> None:
+            self.upserts.append((decision.to_dict(), generated_at, remote_write_authorized))
 
     store = PolicyStore(tmp_path / "guard-home")
     result = command_executors.execute_guard_command_job(
@@ -1134,6 +1140,7 @@ def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
                 "expires_at": None,
             },
             "2026-06-13T00:00:00+00:00",
+            True,
         )
     ]
 
@@ -1144,8 +1151,15 @@ def test_executor_maps_unknown_cloud_policy_scope_to_artifact(tmp_path: Path) ->
             super().__init__(guard_home)
             self.upserts: list[dict[str, object]] = []
 
-        def upsert_policy(self, decision: object, generated_at: str) -> None:
+        def upsert_policy(
+            self,
+            decision: object,
+            generated_at: str,
+            *,
+            remote_write_authorized: bool = False,
+        ) -> None:
             del generated_at
+            assert remote_write_authorized is True
             self.upserts.append(decision.to_dict())
 
     store = PolicyStore(tmp_path / "guard-home")

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -788,7 +788,7 @@ def test_headless_connect_slows_down_polling_when_server_requests_it(tmp_path: P
     assert sleeps == [7]
 
 
-def test_headless_connect_persists_encrypted_fallback_when_macos_keychain_reads_are_unavailable(
+def test_headless_connect_rejects_macos_keychain_readback_failure(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -827,30 +827,28 @@ def test_headless_connect_persists_encrypted_fallback_when_macos_keychain_reads_
         def read(self) -> bytes:
             return json.dumps(self._payload).encode("utf-8")
 
-    payload = connect_flow.run_guard_device_connect_command(
-        store=store,
-        connect_url="https://hol.org/guard/connect",
-        request_device_authorization=fake_request,
-        token_urlopen=lambda request, timeout: _Response(
-            {
-                "access_token": _fake_access_token(
-                    grant_id="grant-123",
-                    machine_id="machine-123",
-                    workspace_id="workspace-123",
-                ),
-                "refresh_token": "refresh-123",
-                "expires_in": 3600,
-                "scope": "guard:runtime.sync guard:offline_access",
-                "token_type": "Bearer",
-            }
-        ),
-        now="2026-06-01T12:00:00+00:00",
-    )
+    with pytest.raises(RuntimeError, match="persist local Guard Cloud authorization securely"):
+        connect_flow.run_guard_device_connect_command(
+            store=store,
+            connect_url="https://hol.org/guard/connect",
+            request_device_authorization=fake_request,
+            token_urlopen=lambda request, timeout: _Response(
+                {
+                    "access_token": _fake_access_token(
+                        grant_id="grant-123",
+                        machine_id="machine-123",
+                        workspace_id="workspace-123",
+                    ),
+                    "refresh_token": "refresh-123",
+                    "expires_in": 3600,
+                    "scope": "guard:runtime.sync guard:offline_access",
+                    "token_type": "Bearer",
+                }
+            ),
+            now="2026-06-01T12:00:00+00:00",
+        )
 
-    assert payload["status"] == "connected"
-    credentials = store.get_oauth_local_credentials()
-    assert credentials is not None
-    assert credentials["refresh_token"] == "refresh-123"
+    assert store.get_oauth_local_credentials() is None
 
 
 def test_headless_connect_expired_code_surfaces_retry_command(tmp_path: Path) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -38,6 +38,7 @@ from codex_plugin_scanner.guard.local_trust_contract import (
     select_trust_backend,
 )
 from codex_plugin_scanner.guard.models import PolicyDecision
+from codex_plugin_scanner.guard.policy_authority import PolicyAuthorityError
 from codex_plugin_scanner.guard.store import GuardStore, SystemKeyringSecretStore
 
 
@@ -979,6 +980,30 @@ def test_remote_policy_row_is_honored_without_local_mac(tmp_path: Path) -> None:
         "codex:project:remote",
         "hash-remote",
         now="2026-06-14T00:01:00Z",
+    )
+
+    assert resolved == "allow"
+
+
+def test_local_policy_write_cannot_impersonate_remote_policy_source(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+
+    with pytest.raises(PolicyAuthorityError, match="remote_policy_source_requires_validated_sync_path"):
+        store.upsert_policy(
+            _decision(artifact_id="codex:project:forged-remote", artifact_hash="hash-forged", source="team-policy"),
+            "2026-06-14T00:00:00Z",
+        )
+
+    store.replace_remote_policies(
+        [_decision(artifact_id="codex:project:valid-remote", artifact_hash="hash-valid", source="team-policy")],
+        "2026-06-14T00:01:00Z",
+    )
+
+    resolved = store.resolve_policy(
+        "codex",
+        "codex:project:valid-remote",
+        "hash-valid",
+        now="2026-06-14T00:02:00Z",
     )
 
     assert resolved == "allow"

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -973,6 +973,7 @@ def test_remote_policy_row_is_honored_without_local_mac(tmp_path: Path) -> None:
     store.replace_remote_policies(
         [_decision(artifact_id="codex:project:remote", artifact_hash="hash-remote", source="cloud-sync")],
         "2026-06-14T00:00:00Z",
+        remote_write_authorized=True,
     )
 
     resolved = store.resolve_policy(
@@ -994,9 +995,16 @@ def test_local_policy_write_cannot_impersonate_remote_policy_source(tmp_path: Pa
             "2026-06-14T00:00:00Z",
         )
 
+    with pytest.raises(PolicyAuthorityError, match="remote_policy_source_requires_validated_sync_path"):
+        store.replace_remote_policies(
+            [_decision(artifact_id="codex:project:forged-replace", artifact_hash="hash-forged", source="team-policy")],
+            "2026-06-14T00:01:00Z",
+        )
+
     store.replace_remote_policies(
         [_decision(artifact_id="codex:project:valid-remote", artifact_hash="hash-valid", source="team-policy")],
         "2026-06-14T00:01:00Z",
+        remote_write_authorized=True,
     )
 
     resolved = store.resolve_policy(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -17589,7 +17589,7 @@ def test_policy_bundle_decisions_map_to_runtime_families(tmp_path):
         device_id=guard_runner_module._guard_device_metadata(store)[0],
         device_name="MacBook Pro",
     )
-    store.replace_remote_policies(decisions, "2026-04-19T00:00:11+00:00")
+    store.replace_remote_policies(decisions, "2026-04-19T00:00:11+00:00", remote_write_authorized=True)
 
     assert store.resolve_policy("codex", "codex:project:package-request:abc", "hash") == "block"
     assert store.resolve_policy("codex", "codex:project:mcp:shell", "hash") == "review"
@@ -18054,6 +18054,7 @@ def test_policy_bundle_decision_resolves_before_receipt_persistence(tmp_path, mo
             device_name="MacBook Pro",
         ),
         "2026-06-05T13:31:00+00:00",
+        remote_write_authorized=True,
     )
 
     order: list[str] = []

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -555,7 +555,7 @@ def test_oauth_secret_store_rechecks_stale_macos_health_cache_for_login(tmp_path
     assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
-def test_macos_oauth_write_persists_with_encrypted_fallback_when_keychain_readback_is_unavailable(
+def test_macos_oauth_write_rejects_unreadable_keychain_secret(
     tmp_path,
     monkeypatch,
 ):
@@ -565,19 +565,26 @@ def test_macos_oauth_write_persists_with_encrypted_fallback_when_keychain_readba
     monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", lambda *args, **kwargs: None)
     store = GuardStore(guard_home)
 
-    store.set_oauth_local_credentials(
-        issuer="https://hol.org",
-        client_id="guard-local-daemon",
-        refresh_token="refresh-secret-value",
-        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
-        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
-        dpop_public_jwk_thumbprint="thumbprint-123",
-        now="2026-06-01T00:00:00+00:00",
-    )
+    with pytest.raises(RuntimeError, match="persist local Guard Cloud authorization securely"):
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="refresh-secret-value",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            now="2026-06-01T00:00:00+00:00",
+        )
 
-    assert store.get_sync_payload(guard_store_module._OAUTH_LOCAL_CREDENTIALS_STATE_KEY) is not None
-    assert store.get_oauth_local_credentials() is not None
-    assert store.get_recoverable_oauth_local_credentials() is not None
+    assert store.get_sync_payload(guard_store_module._OAUTH_LOCAL_CREDENTIALS_STATE_KEY) is None
+    assert store.get_oauth_local_credentials() is None
 
 
 def test_oauth_health_uses_no_ui_primary_read_for_macos_keychain_only_store(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Reject direct local writes that try to create Cloud-owned policy source rows.
- Add a policy authority helper and regression coverage proving validated remote sync still works.

## Testing
- `python3 -m ruff format src/codex_plugin_scanner/guard/policy_authority.py src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/policy_authority.py src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py`
- `python3 -m pytest tests/test_guard_policy_integrity.py -q`
