### PR TITLE
feat(guard): add full self-uninstall with managed harness and shim cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ See [docs/guard/get-started.md](docs/guard/get-started.md) for the full local fl
   Shows what Guard is watching now.
 - `hol-guard install <harness>`
   Creates the launcher shim for that harness.
+- `hol-guard uninstall --self`
+  Removes Guard-managed harness wiring, package shims, local Guard state, and uninstalls the current `hol-guard` package.
 - `hol-guard update`
   Updates the installed `hol-guard` package in the current environment.
 - `hol-guard run <harness> --dry-run`

--- a/docs/guard/get-started.md
+++ b/docs/guard/get-started.md
@@ -125,6 +125,7 @@ For security reviews, sales conversations, and GRC packets, see the
 | :--- | :--- | :--- |
 | I need the current protection posture | `hol-guard status` | What is Guard watching, is sync connected, and what is the next action? |
 | I need first-run setup | `hol-guard init` | Open the local dashboard, install supported harnesses, start optional Cloud connect, and check desktop notifications. |
+| I need to remove Guard from this machine | `hol-guard uninstall --self` | Can Guard disconnect its managed harnesses, remove package shims and local state, then uninstall itself cleanly? |
 | I need install/connect docs | `hol-guard explain install-connect` | Which local-first setup and optional cloud commands should I share? |
 | I need to preview one install before I run it | `hol-guard protect npm install <package> --dry-run` | Would Guard allow, warn, review, or block this exact install request right now? |
 | I need setup or runtime troubleshooting | `hol-guard doctor <harness>` | Why is this harness or Guard runtime not behaving correctly? |

--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -215,6 +215,7 @@ from .install_commands import (
 )
 from .protect_approvals import _queue_local_protect_approvals, _suppress_package_shim_allow_output
 from .remote_pair_flow import dispatch_guard_remote_pair_command
+from .uninstall_commands import run_guard_self_uninstall
 from .update_commands import run_guard_update
 
 DEFAULT_GUARD_APPS_URL = "https://hol.org/guard/apps"
@@ -279,7 +280,7 @@ _GUARD_HELP_GROUPS = (
     "  doctor       Run local diagnostics\n"
     "  bootstrap    Detect, install, and launch the approval center\n"
     "  install      Enable Guard management for a harness\n"
-    "  uninstall    Disable Guard management for a harness\n"
+    "  uninstall    Disable Guard management or remove hol-guard entirely\n"
     "  update       Update hol-guard in the current environment\n"
     "\n"
     "Command selection:\n"

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_proxy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_proxy.py
@@ -166,6 +166,21 @@ def _run_guard_uninstall_command(
 ) -> int:
     context = _require_guard_context(context)
     store = _require_guard_store(store)
+    if bool(getattr(args, "self_uninstall", False)):
+        if getattr(args, "harness", None) is not None or bool(getattr(args, "all", False)):
+            print("Guard self uninstall does not accept a harness or --all.", file=sys.stderr)
+            return 2
+        payload, exit_code = run_guard_self_uninstall(
+            dry_run=bool(getattr(args, "dry_run", False)),
+            context=context,
+            store=store,
+            now=_now(),
+        )
+        _emit("uninstall", payload, getattr(args, "json", False))
+        return exit_code
+    if bool(getattr(args, "dry_run", False)):
+        print("Guard uninstall --dry-run requires --self.", file=sys.stderr)
+        return 2
     try:
         payload = apply_managed_install(
             "uninstall",

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_local.py
@@ -106,10 +106,17 @@ def _configure_guard_local_parsers(
 
     uninstall_parser = guard_subparsers.add_parser(
         "uninstall",
-        help="Disable Guard management for one or more harnesses",
+        help="Disable Guard management or remove hol-guard entirely",
     )
     uninstall_parser.add_argument("harness", nargs="?")
     uninstall_parser.add_argument("--all", action="store_true")
+    uninstall_parser.add_argument(
+        "--self",
+        dest="self_uninstall",
+        action="store_true",
+        help="Remove the installed hol-guard package and local Guard state",
+    )
+    uninstall_parser.add_argument("--dry-run", action="store_true")
     _add_guard_common_args(uninstall_parser)
     uninstall_parser.add_argument("--json", action="store_true")
 

--- a/src/codex_plugin_scanner/guard/cli/install_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/install_commands.py
@@ -457,7 +457,8 @@ def _resolve_targets(
         return [get_adapter(requested_harness).harness]
     if not install_all:
         action = "install" if command == "install" else "uninstall"
-        raise ValueError(f"Guard {action} requires a harness or --all.")
+        suffix = " or --self" if command == "uninstall" else ""
+        raise ValueError(f"Guard {action} requires a harness or --all{suffix}.")
     detected = {
         detection.harness
         for detection in detect_all(context)

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1053,13 +1053,21 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
     supply_chain_risks = _coerce_dict_list(payload.get("supply_chain_risks"))
     safe_decode_risks = _coerce_dict_list(payload.get("safe_decode_risks"))
     sandbox_analysis = _coerce_dict_list(payload.get("sandbox_analysis"))
+    if bool(payload.get("self_uninstall")):
+        _render_self_uninstall(console, payload)
     managed_install = payload.get("managed_install")
     if isinstance(managed_install, dict):
         _render_single_managed_install(console, managed_install)
     else:
         managed_installs = _coerce_dict_list(payload.get("managed_installs"))
         if not managed_installs:
-            if not skill_scan and not supply_chain_risks and not safe_decode_risks and not sandbox_analysis:
+            if (
+                not bool(payload.get("self_uninstall"))
+                and not skill_scan
+                and not supply_chain_risks
+                and not safe_decode_risks
+                and not sandbox_analysis
+            ):
                 _render_fallback(console, payload)
                 return
         else:
@@ -1082,6 +1090,50 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
         _render_safe_decode_results(console, safe_decode_risks)
     if sandbox_analysis:
         _render_sandbox_results(console, sandbox_analysis)
+
+
+def _render_self_uninstall(console: Console, payload: dict[str, object]) -> None:
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Current version", str(payload.get("current_version") or "unknown"))
+    body.add_row("Installer", str(payload.get("installer") or "unknown"))
+    command = payload.get("command")
+    if isinstance(command, list) and command:
+        body.add_row("Command", " ".join(str(part) for part in command))
+    body.add_row("Dry run", _bool_label(bool(payload.get("dry_run"))))
+    planned_harnesses = _coerce_string_list(payload.get("planned_managed_harnesses"))
+    if planned_harnesses:
+        body.add_row("Planned harness cleanup", str(len(planned_harnesses)))
+    planned_shims = _coerce_string_list(payload.get("planned_package_shim_managers"))
+    if planned_shims:
+        body.add_row("Planned package shims", str(len(planned_shims)))
+    if payload.get("oauth_credentials_cleared") is not None:
+        body.add_row("Cloud credentials cleared", _bool_label(bool(payload.get("oauth_credentials_cleared"))))
+    if payload.get("guard_home_removed") is not None:
+        body.add_row("Guard home removed", _bool_label(bool(payload.get("guard_home_removed"))))
+    if payload.get("message"):
+        body.add_row("Message", str(payload.get("message")))
+    status = str(payload.get("status") or "unknown")
+    border_style = {
+        "planned": "blue",
+        "pending": "yellow",
+        "removed": "green",
+        "failed": "red",
+    }.get(status, "red")
+    console.print(Panel(body, title=f"Guard uninstall: {status}", border_style=border_style))
+    notes = _coerce_string_list(payload.get("notes"))
+    stdout = str(payload.get("stdout") or "").strip()
+    stderr = str(payload.get("stderr") or "").strip()
+    error = str(payload.get("error") or "").strip()
+    if notes:
+        console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
+    if status == "removed" and stdout:
+        console.print(Panel(stdout, title="stdout", border_style="green"))
+    if status == "failed" and stdout:
+        console.print(Panel(stdout, title="stdout", border_style="yellow"))
+    if status == "failed" and stderr:
+        console.print(Panel(stderr, title="stderr", border_style="yellow"))
+    if error:
+        console.print(Panel(error, title="error", border_style="red"))
 
 
 def _render_apps(console: Console, payload: dict[str, object]) -> None:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -12,6 +12,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, TextIO, TypeAlias
 
 from ..redaction import redact_text
+from .render_uninstall import render_self_uninstall
 
 try:
     from ..redaction import redact_local_path
@@ -1054,7 +1055,7 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
     safe_decode_risks = _coerce_dict_list(payload.get("safe_decode_risks"))
     sandbox_analysis = _coerce_dict_list(payload.get("sandbox_analysis"))
     if bool(payload.get("self_uninstall")):
-        _render_self_uninstall(console, payload)
+        render_self_uninstall(console, payload)
     managed_install = payload.get("managed_install")
     if isinstance(managed_install, dict):
         _render_single_managed_install(console, managed_install)
@@ -1090,50 +1091,6 @@ def _render_managed_install(console: Console, payload: dict[str, object]) -> Non
         _render_safe_decode_results(console, safe_decode_risks)
     if sandbox_analysis:
         _render_sandbox_results(console, sandbox_analysis)
-
-
-def _render_self_uninstall(console: Console, payload: dict[str, object]) -> None:
-    body = Table.grid(padding=(0, 1))
-    body.add_row("Current version", str(payload.get("current_version") or "unknown"))
-    body.add_row("Installer", str(payload.get("installer") or "unknown"))
-    command = payload.get("command")
-    if isinstance(command, list) and command:
-        body.add_row("Command", " ".join(str(part) for part in command))
-    body.add_row("Dry run", _bool_label(bool(payload.get("dry_run"))))
-    planned_harnesses = _coerce_string_list(payload.get("planned_managed_harnesses"))
-    if planned_harnesses:
-        body.add_row("Planned harness cleanup", str(len(planned_harnesses)))
-    planned_shims = _coerce_string_list(payload.get("planned_package_shim_managers"))
-    if planned_shims:
-        body.add_row("Planned package shims", str(len(planned_shims)))
-    if payload.get("oauth_credentials_cleared") is not None:
-        body.add_row("Cloud credentials cleared", _bool_label(bool(payload.get("oauth_credentials_cleared"))))
-    if payload.get("guard_home_removed") is not None:
-        body.add_row("Guard home removed", _bool_label(bool(payload.get("guard_home_removed"))))
-    if payload.get("message"):
-        body.add_row("Message", str(payload.get("message")))
-    status = str(payload.get("status") or "unknown")
-    border_style = {
-        "planned": "blue",
-        "pending": "yellow",
-        "removed": "green",
-        "failed": "red",
-    }.get(status, "red")
-    console.print(Panel(body, title=f"Guard uninstall: {status}", border_style=border_style))
-    notes = _coerce_string_list(payload.get("notes"))
-    stdout = str(payload.get("stdout") or "").strip()
-    stderr = str(payload.get("stderr") or "").strip()
-    error = str(payload.get("error") or "").strip()
-    if notes:
-        console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
-    if status == "removed" and stdout:
-        console.print(Panel(stdout, title="stdout", border_style="green"))
-    if status == "failed" and stdout:
-        console.print(Panel(stdout, title="stdout", border_style="yellow"))
-    if status == "failed" and stderr:
-        console.print(Panel(stderr, title="stderr", border_style="yellow"))
-    if error:
-        console.print(Panel(error, title="error", border_style="red"))
 
 
 def _render_apps(console: Console, payload: dict[str, object]) -> None:

--- a/src/codex_plugin_scanner/guard/cli/render_uninstall.py
+++ b/src/codex_plugin_scanner/guard/cli/render_uninstall.py
@@ -1,0 +1,72 @@
+"""Rich rendering helpers for Guard self-uninstall output."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from rich.console import Console
+
+
+def render_self_uninstall(console: Console, payload: dict[str, object]) -> None:
+    from rich.panel import Panel
+    from rich.table import Table
+    from rich.text import Text
+
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Current version", str(payload.get("current_version") or "unknown"))
+    body.add_row("Installer", str(payload.get("installer") or "unknown"))
+    command = payload.get("command")
+    if isinstance(command, list) and command:
+        body.add_row("Command", " ".join(str(part) for part in command))
+    body.add_row("Dry run", _bool_label(bool(payload.get("dry_run")), text_type=Text))
+    planned_harnesses = _coerce_string_list(payload.get("planned_managed_harnesses"))
+    if planned_harnesses:
+        body.add_row("Planned harness cleanup", str(len(planned_harnesses)))
+    planned_shims = _coerce_string_list(payload.get("planned_package_shim_managers"))
+    if planned_shims:
+        body.add_row("Planned package shims", str(len(planned_shims)))
+    if payload.get("oauth_credentials_cleared") is not None:
+        body.add_row(
+            "Cloud credentials cleared",
+            _bool_label(bool(payload.get("oauth_credentials_cleared")), text_type=Text),
+        )
+    if payload.get("guard_home_removed") is not None:
+        body.add_row("Guard home removed", _bool_label(bool(payload.get("guard_home_removed")), text_type=Text))
+    if payload.get("message"):
+        body.add_row("Message", str(payload.get("message")))
+    status = str(payload.get("status") or "unknown")
+    border_style = {
+        "planned": "blue",
+        "pending": "yellow",
+        "removed": "green",
+        "failed": "red",
+    }.get(status, "red")
+    console.print(Panel(body, title=f"Guard uninstall: {status}", border_style=border_style))
+    notes = _coerce_string_list(payload.get("notes"))
+    stdout = str(payload.get("stdout") or "").strip()
+    stderr = str(payload.get("stderr") or "").strip()
+    error = str(payload.get("error") or "").strip()
+    if notes:
+        console.print(Panel("\n".join(f"• {note}" for note in notes), title="Notes", border_style="blue"))
+    if status == "removed" and stdout:
+        console.print(Panel(stdout, title="stdout", border_style="green"))
+    if status == "failed" and stdout:
+        console.print(Panel(stdout, title="stdout", border_style="yellow"))
+    if status == "failed" and stderr:
+        console.print(Panel(stderr, title="stderr", border_style="yellow"))
+    if error:
+        console.print(Panel(error, title="error", border_style="red"))
+
+
+def _bool_label(value: bool, *, text_type) -> object:
+    return text_type("yes" if value else "no", style="green" if value else "red")
+
+
+def _coerce_string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item) for item in value if isinstance(item, str) and item]
+
+
+__all__ = ["render_self_uninstall"]

--- a/src/codex_plugin_scanner/guard/cli/render_uninstall.py
+++ b/src/codex_plugin_scanner/guard/cli/render_uninstall.py
@@ -6,12 +6,12 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from rich.console import Console
+    from rich.text import Text
 
 
 def render_self_uninstall(console: Console, payload: dict[str, object]) -> None:
     from rich.panel import Panel
     from rich.table import Table
-    from rich.text import Text
 
     body = Table.grid(padding=(0, 1))
     body.add_row("Current version", str(payload.get("current_version") or "unknown"))
@@ -19,7 +19,7 @@ def render_self_uninstall(console: Console, payload: dict[str, object]) -> None:
     command = payload.get("command")
     if isinstance(command, list) and command:
         body.add_row("Command", " ".join(str(part) for part in command))
-    body.add_row("Dry run", _bool_label(bool(payload.get("dry_run")), text_type=Text))
+    body.add_row("Dry run", _bool_label(bool(payload.get("dry_run"))))
     planned_harnesses = _coerce_string_list(payload.get("planned_managed_harnesses"))
     if planned_harnesses:
         body.add_row("Planned harness cleanup", str(len(planned_harnesses)))
@@ -29,10 +29,10 @@ def render_self_uninstall(console: Console, payload: dict[str, object]) -> None:
     if payload.get("oauth_credentials_cleared") is not None:
         body.add_row(
             "Cloud credentials cleared",
-            _bool_label(bool(payload.get("oauth_credentials_cleared")), text_type=Text),
+            _bool_label(bool(payload.get("oauth_credentials_cleared"))),
         )
     if payload.get("guard_home_removed") is not None:
-        body.add_row("Guard home removed", _bool_label(bool(payload.get("guard_home_removed")), text_type=Text))
+        body.add_row("Guard home removed", _bool_label(bool(payload.get("guard_home_removed"))))
     if payload.get("message"):
         body.add_row("Message", str(payload.get("message")))
     status = str(payload.get("status") or "unknown")
@@ -59,8 +59,10 @@ def render_self_uninstall(console: Console, payload: dict[str, object]) -> None:
         console.print(Panel(error, title="error", border_style="red"))
 
 
-def _bool_label(value: bool, *, text_type) -> object:
-    return text_type("yes" if value else "no", style="green" if value else "red")
+def _bool_label(value: bool) -> Text:
+    from rich.text import Text
+
+    return Text("yes" if value else "no", style="green" if value else "red")
 
 
 def _coerce_string_list(value: object) -> list[str]:

--- a/src/codex_plugin_scanner/guard/cli/uninstall_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/uninstall_commands.py
@@ -12,7 +12,7 @@ from ..daemon.manager import retire_all_guard_daemons_for_home
 from ..redaction import redact_sensitive_text
 from ..shims import package_shim_status, remove_guard_profile_blocks, uninstall_package_shims
 from ..store import GuardStore
-from .install_commands import _managed_install_payload, apply_managed_install
+from .install_commands import apply_managed_install
 from .update_commands import _current_version, _installer_kind
 
 
@@ -26,9 +26,16 @@ def run_guard_self_uninstall(
     current_version = _current_version()
     installer = _installer_kind()
     command = _uninstall_command(installer)
-    managed_installs = _active_managed_installs(store)
-    shim_status = package_shim_status(context)
-    planned_managers = [manager for manager in _string_items(shim_status.get("installed_managers"))]
+    managed_installs, managed_install_error = _active_managed_installs(store)
+    notes: list[str] = []
+    if managed_install_error is not None:
+        notes.append(managed_install_error)
+    try:
+        shim_status = package_shim_status(context)
+        planned_managers = _string_items(shim_status.get("installed_managers"))
+    except (OSError, RuntimeError, ValueError) as error:
+        planned_managers = []
+        notes.append(f"Could not read package shim state before uninstall: {error}")
     payload: dict[str, object] = {
         "self_uninstall": True,
         "status": "planned" if dry_run else "pending",
@@ -40,6 +47,8 @@ def run_guard_self_uninstall(
         "planned_managed_harnesses": [str(item.get("harness") or "unknown") for item in managed_installs],
         "planned_package_shim_managers": planned_managers,
     }
+    if notes:
+        payload["notes"] = [_clean_output(note) for note in notes]
     if dry_run:
         payload["changed"] = False
         payload["message"] = _planned_uninstall_message(
@@ -52,7 +61,6 @@ def run_guard_self_uninstall(
     package_shim_uninstall: dict[str, object] | None = None
     daemon_cleanup: dict[str, object] | None = None
     profile_cleanup: dict[str, object] | None = None
-    notes: list[str] = []
 
     try:
         retired_pids = retire_all_guard_daemons_for_home(context.guard_home)
@@ -63,8 +71,8 @@ def run_guard_self_uninstall(
 
     for managed_install in managed_installs:
         harness = str(managed_install.get("harness") or "").strip()
-        uninstall_context, uninstall_workspace = _managed_install_context(context, managed_install)
         try:
+            uninstall_context, uninstall_workspace = _managed_install_context(context, managed_install)
             uninstall_payload = apply_managed_install(
                 "uninstall",
                 harness,
@@ -83,7 +91,7 @@ def run_guard_self_uninstall(
                     "daemon_cleanup": daemon_cleanup,
                     "message": "HOL Guard removal stopped before the package uninstall command ran.",
                     "error": _clean_output(str(error)),
-                    "notes": notes,
+                    "notes": [_clean_output(note) for note in notes],
                 }
             )
             return payload, 1
@@ -102,7 +110,7 @@ def run_guard_self_uninstall(
                 "daemon_cleanup": daemon_cleanup,
                 "message": "HOL Guard removal stopped before the package uninstall command ran.",
                 "error": _clean_output(str(error)),
-                "notes": notes,
+                "notes": [_clean_output(note) for note in notes],
             }
         )
         return payload, 1
@@ -137,7 +145,7 @@ def run_guard_self_uninstall(
                 "package_removed": False,
                 "message": "HOL Guard package uninstall failed before the installer started.",
                 "error": _clean_output(str(error)),
-                "notes": notes,
+                "notes": [_clean_output(note) for note in notes],
             }
         )
         return payload, 1
@@ -161,7 +169,7 @@ def run_guard_self_uninstall(
         )
         payload["message"] = "HOL Guard package uninstall failed after local protection cleanup."
         if notes:
-            payload["notes"] = notes
+            payload["notes"] = [_clean_output(note) for note in notes]
         return payload, 1
 
     oauth_cleared = False
@@ -215,8 +223,12 @@ def _uninstall_command(installer: str) -> list[str]:
     return [sys.executable, "-m", "pip", "uninstall", "-y", "hol-guard"]
 
 
-def _active_managed_installs(store: GuardStore) -> list[dict[str, object]]:
-    return [_managed_install_payload(item) for item in store.list_managed_installs() if bool(item.get("active"))]
+def _active_managed_installs(store: GuardStore) -> tuple[list[dict[str, object]], str | None]:
+    try:
+        installs = [item for item in store.list_managed_installs() if bool(item.get("active"))]
+    except Exception as error:  # pragma: no cover - defensive path depends on local store failures.
+        return [], f"Could not read managed install state before uninstall: {error}"
+    return installs, None
 
 
 def _managed_install_context(
@@ -234,7 +246,7 @@ def _managed_install_context(
             ),
             str(workspace_path),
         )
-    return HarnessContext(context.home_dir, None, context.guard_home), None
+    return HarnessContext(home_dir=context.home_dir, workspace_dir=None, guard_home=context.guard_home), None
 
 
 def _planned_uninstall_message(*, managed_count: int, package_shim_count: int) -> str:

--- a/src/codex_plugin_scanner/guard/cli/uninstall_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/uninstall_commands.py
@@ -1,0 +1,284 @@
+"""Helpers for removing the installed HOL Guard CLI and local Guard state."""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from ..adapters.base import HarnessContext
+from ..daemon.manager import retire_all_guard_daemons_for_home
+from ..redaction import redact_sensitive_text
+from ..shims import package_shim_status, remove_guard_profile_blocks, uninstall_package_shims
+from ..store import GuardStore
+from .install_commands import _managed_install_payload, apply_managed_install
+from .update_commands import _current_version, _installer_kind
+
+
+def run_guard_self_uninstall(
+    *,
+    dry_run: bool,
+    context: HarnessContext,
+    store: GuardStore,
+    now: str,
+) -> tuple[dict[str, object], int]:
+    current_version = _current_version()
+    installer = _installer_kind()
+    command = _uninstall_command(installer)
+    managed_installs = _active_managed_installs(store)
+    shim_status = package_shim_status(context)
+    planned_managers = [manager for manager in _string_items(shim_status.get("installed_managers"))]
+    payload: dict[str, object] = {
+        "self_uninstall": True,
+        "status": "planned" if dry_run else "pending",
+        "current_version": current_version,
+        "installer": installer,
+        "dry_run": dry_run,
+        "command": command,
+        "guard_home": str(context.guard_home),
+        "planned_managed_harnesses": [str(item.get("harness") or "unknown") for item in managed_installs],
+        "planned_package_shim_managers": planned_managers,
+    }
+    if dry_run:
+        payload["changed"] = False
+        payload["message"] = _planned_uninstall_message(
+            managed_count=len(managed_installs),
+            package_shim_count=len(planned_managers),
+        )
+        return payload, 0
+
+    removed_managed_installs: list[dict[str, object]] = []
+    package_shim_uninstall: dict[str, object] | None = None
+    daemon_cleanup: dict[str, object] | None = None
+    profile_cleanup: dict[str, object] | None = None
+    notes: list[str] = []
+
+    try:
+        retired_pids = retire_all_guard_daemons_for_home(context.guard_home)
+        daemon_cleanup = {"retired_pids": retired_pids, "retired_count": len(retired_pids)}
+    except (OSError, RuntimeError) as error:
+        daemon_cleanup = {"retired_pids": [], "retired_count": 0, "error": _clean_output(str(error))}
+        notes.append(f"Could not stop every Guard daemon before uninstall: {error}")
+
+    for managed_install in managed_installs:
+        harness = str(managed_install.get("harness") or "").strip()
+        uninstall_context, uninstall_workspace = _managed_install_context(context, managed_install)
+        try:
+            uninstall_payload = apply_managed_install(
+                "uninstall",
+                harness,
+                False,
+                uninstall_context,
+                store,
+                uninstall_workspace,
+                now,
+            )
+        except (OSError, RuntimeError, ValueError) as error:
+            payload.update(
+                {
+                    "status": "failed",
+                    "changed": bool(removed_managed_installs),
+                    "managed_installs": removed_managed_installs,
+                    "daemon_cleanup": daemon_cleanup,
+                    "message": "HOL Guard removal stopped before the package uninstall command ran.",
+                    "error": _clean_output(str(error)),
+                    "notes": notes,
+                }
+            )
+            return payload, 1
+        removed = uninstall_payload.get("managed_install")
+        if isinstance(removed, dict):
+            removed_managed_installs.append(removed)
+
+    try:
+        package_shim_uninstall = uninstall_package_shims(context, managers=tuple(planned_managers) or None)
+    except (OSError, RuntimeError, ValueError) as error:
+        payload.update(
+            {
+                "status": "failed",
+                "changed": bool(removed_managed_installs),
+                "managed_installs": removed_managed_installs,
+                "daemon_cleanup": daemon_cleanup,
+                "message": "HOL Guard removal stopped before the package uninstall command ran.",
+                "error": _clean_output(str(error)),
+                "notes": notes,
+            }
+        )
+        return payload, 1
+
+    try:
+        profile_cleanup = remove_guard_profile_blocks(context)
+    except OSError as error:
+        profile_cleanup = {"changed": False, "error": _clean_output(str(error))}
+        notes.append(f"Could not remove Guard PATH entries from shell profiles: {error}")
+
+    try:
+        result = subprocess.run(
+            command,
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError as error:
+        payload.update(
+            {
+                "status": "failed",
+                "changed": _self_uninstall_changed(
+                    removed_managed_installs=removed_managed_installs,
+                    package_shim_uninstall=package_shim_uninstall,
+                    profile_cleanup=profile_cleanup,
+                    package_removed=False,
+                ),
+                "managed_installs": removed_managed_installs,
+                "package_shim_uninstall": package_shim_uninstall,
+                "daemon_cleanup": daemon_cleanup,
+                "profile_cleanup": profile_cleanup,
+                "package_removed": False,
+                "message": "HOL Guard package uninstall failed before the installer started.",
+                "error": _clean_output(str(error)),
+                "notes": notes,
+            }
+        )
+        return payload, 1
+
+    payload["stdout"] = _clean_output(result.stdout)
+    payload["stderr"] = _clean_output(result.stderr)
+    payload["return_code"] = result.returncode
+    payload["managed_installs"] = removed_managed_installs
+    payload["package_shim_uninstall"] = package_shim_uninstall
+    payload["daemon_cleanup"] = daemon_cleanup
+    payload["profile_cleanup"] = profile_cleanup
+    payload["package_removed"] = result.returncode == 0
+
+    if result.returncode != 0:
+        payload["status"] = "failed"
+        payload["changed"] = _self_uninstall_changed(
+            removed_managed_installs=removed_managed_installs,
+            package_shim_uninstall=package_shim_uninstall,
+            profile_cleanup=profile_cleanup,
+            package_removed=False,
+        )
+        payload["message"] = "HOL Guard package uninstall failed after local protection cleanup."
+        if notes:
+            payload["notes"] = notes
+        return payload, 1
+
+    oauth_cleared = False
+    cleanup_errors: list[str] = []
+    try:
+        store.clear_oauth_local_credentials()
+        oauth_cleared = True
+    except (OSError, RuntimeError) as error:
+        cleanup_errors.append(f"Could not clear Guard Cloud credentials: {error}")
+
+    guard_home_removed = False
+    if context.guard_home.exists():
+        try:
+            shutil.rmtree(context.guard_home)
+            guard_home_removed = True
+        except OSError as error:
+            cleanup_errors.append(f"Could not remove Guard home {context.guard_home}: {error}")
+    else:
+        guard_home_removed = True
+
+    payload["oauth_credentials_cleared"] = oauth_cleared
+    payload["guard_home_removed"] = guard_home_removed
+    payload["changed"] = _self_uninstall_changed(
+        removed_managed_installs=removed_managed_installs,
+        package_shim_uninstall=package_shim_uninstall,
+        profile_cleanup=profile_cleanup,
+        package_removed=True,
+    )
+    if cleanup_errors:
+        payload["status"] = "failed"
+        payload["message"] = "HOL Guard package was removed, but local cleanup needs attention."
+        notes.extend(cleanup_errors)
+        payload["notes"] = [_clean_output(note) for note in notes]
+        return payload, 1
+
+    payload["status"] = "removed"
+    payload["message"] = _success_uninstall_message(
+        managed_count=len(removed_managed_installs),
+        package_shim_count=len(_string_items(package_shim_uninstall.get("removed_managers"))),
+    )
+    if notes:
+        payload["notes"] = [_clean_output(note) for note in notes]
+    return payload, 0
+
+
+def _uninstall_command(installer: str) -> list[str]:
+    if installer == "uv":
+        return ["uv", "tool", "uninstall", "hol-guard"]
+    if installer == "pipx":
+        return ["pipx", "uninstall", "hol-guard"]
+    return [sys.executable, "-m", "pip", "uninstall", "-y", "hol-guard"]
+
+
+def _active_managed_installs(store: GuardStore) -> list[dict[str, object]]:
+    return [_managed_install_payload(item) for item in store.list_managed_installs() if bool(item.get("active"))]
+
+
+def _managed_install_context(
+    context: HarnessContext,
+    managed_install: dict[str, object],
+) -> tuple[HarnessContext, str | None]:
+    managed_workspace = managed_install.get("workspace")
+    if isinstance(managed_workspace, str) and managed_workspace.strip():
+        workspace_path = Path(managed_workspace).expanduser().resolve()
+        return (
+            HarnessContext(
+                home_dir=context.home_dir,
+                workspace_dir=workspace_path,
+                guard_home=context.guard_home,
+            ),
+            str(workspace_path),
+        )
+    return HarnessContext(context.home_dir, None, context.guard_home), None
+
+
+def _planned_uninstall_message(*, managed_count: int, package_shim_count: int) -> str:
+    actions: list[str] = ["remove the installed hol-guard package"]
+    if managed_count:
+        actions.append(
+            f"disconnect {managed_count} Guard-managed harness{'es' if managed_count != 1 else ''}"
+        )
+    if package_shim_count:
+        actions.append(
+            f"remove {package_shim_count} package-manager shim{'s' if package_shim_count != 1 else ''}"
+        )
+    return f"Review the planned steps to {' and '.join(actions)}."
+
+
+def _success_uninstall_message(*, managed_count: int, package_shim_count: int) -> str:
+    parts = ["Removed HOL Guard from this environment"]
+    if managed_count:
+        parts.append(f"disconnected {managed_count} managed harness{'es' if managed_count != 1 else ''}")
+    if package_shim_count:
+        parts.append(
+            f"removed {package_shim_count} package-manager shim{'s' if package_shim_count != 1 else ''}"
+        )
+    return "; ".join(parts) + "."
+
+
+def _self_uninstall_changed(
+    *,
+    removed_managed_installs: list[dict[str, object]],
+    package_shim_uninstall: dict[str, object] | None,
+    profile_cleanup: dict[str, object] | None,
+    package_removed: bool,
+) -> bool:
+    removed_managers = _string_items(package_shim_uninstall.get("removed_managers")) if package_shim_uninstall else []
+    profile_changed = bool(profile_cleanup and profile_cleanup.get("changed"))
+    return bool(removed_managed_installs or removed_managers or profile_changed or package_removed)
+
+
+def _string_items(value: object) -> list[str]:
+    return [item for item in value if isinstance(item, str) and item.strip()] if isinstance(value, list) else []
+
+
+def _clean_output(value: str) -> str:
+    return redact_sensitive_text(value.strip())
+
+
+__all__ = ["run_guard_self_uninstall"]

--- a/src/codex_plugin_scanner/guard/cli/uninstall_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/uninstall_commands.py
@@ -240,13 +240,9 @@ def _managed_install_context(
 def _planned_uninstall_message(*, managed_count: int, package_shim_count: int) -> str:
     actions: list[str] = ["remove the installed hol-guard package"]
     if managed_count:
-        actions.append(
-            f"disconnect {managed_count} Guard-managed harness{'es' if managed_count != 1 else ''}"
-        )
+        actions.append(f"disconnect {managed_count} Guard-managed harness{'es' if managed_count != 1 else ''}")
     if package_shim_count:
-        actions.append(
-            f"remove {package_shim_count} package-manager shim{'s' if package_shim_count != 1 else ''}"
-        )
+        actions.append(f"remove {package_shim_count} package-manager shim{'s' if package_shim_count != 1 else ''}")
     return f"Review the planned steps to {' and '.join(actions)}."
 
 
@@ -255,9 +251,7 @@ def _success_uninstall_message(*, managed_count: int, package_shim_count: int) -
     if managed_count:
         parts.append(f"disconnected {managed_count} managed harness{'es' if managed_count != 1 else ''}")
     if package_shim_count:
-        parts.append(
-            f"removed {package_shim_count} package-manager shim{'s' if package_shim_count != 1 else ''}"
-        )
+        parts.append(f"removed {package_shim_count} package-manager shim{'s' if package_shim_count != 1 else ''}")
     return "; ".join(parts) + "."
 
 

--- a/src/codex_plugin_scanner/guard/shell_profile_cleanup.py
+++ b/src/codex_plugin_scanner/guard/shell_profile_cleanup.py
@@ -1,0 +1,67 @@
+"""Helpers for removing Guard-managed shell profile blocks."""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Protocol
+
+
+class HarnessContextLike(Protocol):
+    @property
+    def home_dir(self) -> Path: ...
+
+
+def remove_guard_profile_blocks(
+    context: HarnessContextLike,
+    *,
+    strip_managed_marker_blocks: Callable[[str, str], str],
+    guard_profile_marker: str,
+    package_profile_marker: str,
+) -> dict[str, object]:
+    if os.name == "nt":
+        return {
+            "changed": False,
+            "changed_paths": [],
+            "removed_paths": [],
+            "markers_removed": [guard_profile_marker, package_profile_marker],
+        }
+    changed_paths: list[str] = []
+    removed_paths: list[str] = []
+    for profile_path in _managed_shell_profile_paths(context.home_dir):
+        if not profile_path.exists():
+            continue
+        existing = profile_path.read_text(encoding="utf-8")
+        if guard_profile_marker not in existing and package_profile_marker not in existing:
+            continue
+        cleaned = existing
+        if guard_profile_marker in cleaned:
+            cleaned = strip_managed_marker_blocks(cleaned, guard_profile_marker)
+        if package_profile_marker in cleaned:
+            cleaned = strip_managed_marker_blocks(cleaned, package_profile_marker)
+        if cleaned == existing:
+            continue
+        if cleaned:
+            profile_path.write_text(cleaned, encoding="utf-8")
+        else:
+            profile_path.unlink()
+            removed_paths.append(str(profile_path))
+        changed_paths.append(str(profile_path))
+    return {
+        "changed": bool(changed_paths),
+        "changed_paths": changed_paths,
+        "removed_paths": removed_paths,
+        "markers_removed": [guard_profile_marker, package_profile_marker],
+    }
+
+
+def _managed_shell_profile_paths(home_dir: Path) -> tuple[Path, ...]:
+    return (
+        home_dir / ".bashrc",
+        home_dir / ".zshrc",
+        home_dir / ".config" / "fish" / "config.fish",
+    )
+
+
+__all__ = ["remove_guard_profile_blocks"]

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -811,40 +811,14 @@ def ensure_package_shim_path_in_shell_profile(context: HarnessContext) -> dict[s
 def remove_guard_profile_blocks(context: HarnessContext) -> dict[str, object]:
     """Remove Guard-managed PATH blocks from common interactive shell profiles."""
 
-    if os.name == "nt":
-        return {
-            "changed": False,
-            "changed_paths": [],
-            "removed_paths": [],
-            "markers_removed": [_GUARD_PROFILE_MARKER, _PACKAGE_PROFILE_MARKER],
-        }
-    changed_paths: list[str] = []
-    removed_paths: list[str] = []
-    for profile_path in _managed_shell_profile_paths(context.home_dir):
-        if not profile_path.exists():
-            continue
-        existing = profile_path.read_text(encoding="utf-8")
-        if _GUARD_PROFILE_MARKER not in existing and _PACKAGE_PROFILE_MARKER not in existing:
-            continue
-        cleaned = existing
-        if _GUARD_PROFILE_MARKER in cleaned:
-            cleaned = _strip_managed_marker_blocks(cleaned, _GUARD_PROFILE_MARKER)
-        if _PACKAGE_PROFILE_MARKER in cleaned:
-            cleaned = _strip_managed_marker_blocks(cleaned, _PACKAGE_PROFILE_MARKER)
-        if cleaned == existing:
-            continue
-        if cleaned:
-            profile_path.write_text(cleaned, encoding="utf-8")
-        else:
-            profile_path.unlink()
-            removed_paths.append(str(profile_path))
-        changed_paths.append(str(profile_path))
-    return {
-        "changed": bool(changed_paths),
-        "changed_paths": changed_paths,
-        "removed_paths": removed_paths,
-        "markers_removed": [_GUARD_PROFILE_MARKER, _PACKAGE_PROFILE_MARKER],
-    }
+    from .shell_profile_cleanup import remove_guard_profile_blocks as remove_profile_blocks
+
+    return remove_profile_blocks(
+        context,
+        strip_managed_marker_blocks=_strip_managed_marker_blocks,
+        guard_profile_marker=_GUARD_PROFILE_MARKER,
+        package_profile_marker=_PACKAGE_PROFILE_MARKER,
+    )
 
 
 def _upsert_managed_profile_block(
@@ -963,14 +937,6 @@ def _package_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, 
     return (
         home_dir / ".zshrc",
         f'{marker}\nexport PATH="{shim_dir}:$PATH"',
-    )
-
-
-def _managed_shell_profile_paths(home_dir: Path) -> tuple[Path, ...]:
-    return (
-        home_dir / ".bashrc",
-        home_dir / ".zshrc",
-        home_dir / ".config" / "fish" / "config.fish",
     )
 
 

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -808,6 +808,45 @@ def ensure_package_shim_path_in_shell_profile(context: HarnessContext) -> dict[s
     }
 
 
+def remove_guard_profile_blocks(context: HarnessContext) -> dict[str, object]:
+    """Remove Guard-managed PATH blocks from common interactive shell profiles."""
+
+    if os.name == "nt":
+        return {
+            "changed": False,
+            "changed_paths": [],
+            "removed_paths": [],
+            "markers_removed": [_GUARD_PROFILE_MARKER, _PACKAGE_PROFILE_MARKER],
+        }
+    changed_paths: list[str] = []
+    removed_paths: list[str] = []
+    for profile_path in _managed_shell_profile_paths(context.home_dir):
+        if not profile_path.exists():
+            continue
+        existing = profile_path.read_text(encoding="utf-8")
+        if _GUARD_PROFILE_MARKER not in existing and _PACKAGE_PROFILE_MARKER not in existing:
+            continue
+        cleaned = existing
+        if _GUARD_PROFILE_MARKER in cleaned:
+            cleaned = _strip_managed_marker_blocks(cleaned, _GUARD_PROFILE_MARKER)
+        if _PACKAGE_PROFILE_MARKER in cleaned:
+            cleaned = _strip_managed_marker_blocks(cleaned, _PACKAGE_PROFILE_MARKER)
+        if cleaned == existing:
+            continue
+        if cleaned:
+            profile_path.write_text(cleaned, encoding="utf-8")
+        else:
+            profile_path.unlink()
+            removed_paths.append(str(profile_path))
+        changed_paths.append(str(profile_path))
+    return {
+        "changed": bool(changed_paths),
+        "changed_paths": changed_paths,
+        "removed_paths": removed_paths,
+        "markers_removed": [_GUARD_PROFILE_MARKER, _PACKAGE_PROFILE_MARKER],
+    }
+
+
 def _upsert_managed_profile_block(
     profile_path: Path,
     export_line: str,
@@ -924,6 +963,14 @@ def _package_shim_profile_target(home_dir: Path, shim_dir: Path) -> tuple[Path, 
     return (
         home_dir / ".zshrc",
         f'{marker}\nexport PATH="{shim_dir}:$PATH"',
+    )
+
+
+def _managed_shell_profile_paths(home_dir: Path) -> tuple[Path, ...]:
+    return (
+        home_dir / ".bashrc",
+        home_dir / ".zshrc",
+        home_dir / ".config" / "fish" / "config.fish",
     )
 
 
@@ -1285,6 +1332,7 @@ __all__ = [
     "package_shim_status",
     "package_shim_supported_managers",
     "probe_package_shim_intercepts",
+    "remove_guard_profile_blocks",
     "remove_guard_shim",
     "uninstall_package_shims",
 ]

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6428,6 +6428,66 @@ url = http://127.0.0.1:8787/guard-canary
         assert rc == 2
         assert "Guard install requires a harness or --all." in stderr
 
+    def test_guard_uninstall_requires_harness_all_or_self(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        _build_guard_fixture(home_dir, workspace_dir)
+
+        rc = main(
+            [
+                "guard",
+                "uninstall",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+            ]
+        )
+        stderr = capsys.readouterr().err
+
+        assert rc == 2
+        assert "Guard uninstall requires a harness or --all or --self." in stderr
+
+    def test_guard_uninstall_self_runs_full_package_removal(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        uninstall_calls: list[dict[str, object]] = []
+
+        monkeypatch.setattr(
+            guard_commands_module,
+            "run_guard_self_uninstall",
+            lambda **kwargs: (
+                uninstall_calls.append(kwargs)
+                or {
+                    "self_uninstall": True,
+                    "status": "removed",
+                    "current_version": "2.0.764",
+                    "installer": "pipx",
+                    "dry_run": False,
+                    "command": ["pipx", "uninstall", "hol-guard"],
+                    "message": "Removed HOL Guard from this environment.",
+                },
+                0,
+            ),
+        )
+
+        rc = main(["guard", "uninstall", "--self", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert uninstall_calls and uninstall_calls[0]["dry_run"] is False
+        assert output["self_uninstall"] is True
+        assert output["status"] == "removed"
+        assert output["command"] == ["pipx", "uninstall", "hol-guard"]
+
+    def test_guard_uninstall_self_rejects_harness_or_all(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+
+        rc = main(["guard", "uninstall", "codex", "--self", "--home", str(home_dir)])
+        stderr = capsys.readouterr().err
+
+        assert rc == 2
+        assert "Guard self uninstall does not accept a harness or --all." in stderr
+
     @pytest.mark.parametrize("command", ["install", "uninstall"])
     def test_guard_install_commands_reject_harness_with_all(self, tmp_path, capsys, command: str):
         home_dir = tmp_path / "home"

--- a/tests/test_guard_shim_profile.py
+++ b/tests/test_guard_shim_profile.py
@@ -24,6 +24,7 @@ from codex_plugin_scanner.guard.shims import (
     _upsert_managed_profile_block,
     ensure_guard_shim_path_in_shell_profile,
     ensure_package_shim_path_in_shell_profile,
+    remove_guard_profile_blocks,
 )
 
 
@@ -215,3 +216,54 @@ class TestEnsureSkipsOnWindows:
         assert result["changed"] is False
         assert result["manual_path_required"] is True
         assert not (ctx.home_dir / ".zshrc").exists()
+
+
+class TestRemoveGuardProfileBlocks:
+    def test_removes_guard_markers_across_common_shell_profiles(self, tmp_path: Path) -> None:
+        home = tmp_path / "home"
+        home.mkdir()
+        fish_config = home / ".config" / "fish" / "config.fish"
+        bash_profile = home / ".bashrc"
+        zsh_profile = home / ".zshrc"
+        bash_profile.write_text(
+            "\n".join(
+                [
+                    "export KEEP=1",
+                    "# HOL Guard harness launchers",
+                    'export PATH="/tmp/guard-home/bin:$PATH"',
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        zsh_profile.write_text(
+            "\n".join(
+                [
+                    "# HOL Guard package manager shims",
+                    'export PATH="/tmp/guard-home/package-shims/bin:$PATH"',
+                    "alias ll='ls -l'",
+                    "",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        fish_config.parent.mkdir(parents=True, exist_ok=True)
+        fish_config.write_text(
+            "# HOL Guard harness launchers\nfish_add_path --prepend /tmp/guard-home/bin\n",
+            encoding="utf-8",
+        )
+
+        result = remove_guard_profile_blocks(_context(home, home / ".hol-guard"))
+
+        assert result["changed"] is True
+        assert sorted(Path(path).name for path in result["changed_paths"]) == [
+            ".bashrc",
+            ".zshrc",
+            "config.fish",
+        ]
+        assert Path(fish_config) == Path(result["removed_paths"][0])
+        assert "# HOL Guard" not in bash_profile.read_text(encoding="utf-8")
+        assert bash_profile.read_text(encoding="utf-8") == "export KEEP=1\n"
+        assert "# HOL Guard" not in zsh_profile.read_text(encoding="utf-8")
+        assert "alias ll='ls -l'" in zsh_profile.read_text(encoding="utf-8")
+        assert not fish_config.exists()

--- a/tests/test_guard_uninstall_commands.py
+++ b/tests/test_guard_uninstall_commands.py
@@ -1,0 +1,160 @@
+"""Tests for full HOL Guard self-uninstall flows."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.cli import uninstall_commands
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _context(tmp_path: Path) -> HarnessContext:
+    home = tmp_path / "home"
+    guard_home = home / ".hol-guard"
+    home.mkdir(parents=True, exist_ok=True)
+    guard_home.mkdir(parents=True, exist_ok=True)
+    return HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)
+
+
+def test_self_uninstall_dry_run_reports_full_removal_plan(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install("codex", True, None, {"shim_path": "guard-codex"}, "2026-06-18T00:00:00Z")
+    monkeypatch.setattr(uninstall_commands, "_current_version", lambda: "2.0.764")
+    monkeypatch.setattr(uninstall_commands, "_installer_kind", lambda: "pip")
+    monkeypatch.setattr(
+        uninstall_commands,
+        "package_shim_status",
+        lambda _context: {"installed_managers": ["npm", "pip"]},
+    )
+
+    payload, exit_code = uninstall_commands.run_guard_self_uninstall(
+        dry_run=True,
+        context=context,
+        store=store,
+        now="2026-06-18T00:00:00Z",
+    )
+
+    assert exit_code == 0
+    assert payload["status"] == "planned"
+    assert payload["command"] == [sys.executable, "-m", "pip", "uninstall", "-y", "hol-guard"]
+    assert payload["planned_managed_harnesses"] == ["codex"]
+    assert payload["planned_package_shim_managers"] == ["npm", "pip"]
+    assert payload["changed"] is False
+    assert context.guard_home.exists()
+
+
+def test_self_uninstall_removes_managed_surfaces_before_package(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install("codex", True, None, {"shim_path": "guard-codex"}, "2026-06-18T00:00:00Z")
+    (context.guard_home / "state.txt").write_text("keep", encoding="utf-8")
+    commands: list[list[str]] = []
+
+    monkeypatch.setattr(uninstall_commands, "_current_version", lambda: "2.0.764")
+    monkeypatch.setattr(uninstall_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(uninstall_commands, "package_shim_status", lambda _context: {"installed_managers": ["npm"]})
+    monkeypatch.setattr(uninstall_commands, "retire_all_guard_daemons_for_home", lambda _guard_home: [4242])
+    monkeypatch.setattr(
+        uninstall_commands,
+        "apply_managed_install",
+        lambda command, harness, install_all, context, store, workspace, now: {
+            "managed_install": {
+                "harness": harness,
+                "active": False,
+                "workspace": workspace,
+                "manifest": {"removed_paths": [str(context.guard_home / "bin" / f"guard-{harness}")]},
+                "updated_at": now,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        uninstall_commands,
+        "uninstall_package_shims",
+        lambda _context, managers=None: {
+            "removed_managers": list(managers or ()),
+            "removed_paths": [],
+            "remaining_managers": [],
+            "manifest_path": str(context.guard_home / "package-shims" / "manifest.json"),
+            "shim_dir": str(context.guard_home / "package-shims" / "bin"),
+        },
+    )
+    monkeypatch.setattr(
+        uninstall_commands,
+        "remove_guard_profile_blocks",
+        lambda _context: {"changed": True, "changed_paths": [str(context.home_dir / ".zshrc")], "removed_paths": []},
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        commands.append(command)
+        return subprocess.CompletedProcess(command, 0, stdout="hol-guard removed", stderr="")
+
+    monkeypatch.setattr(uninstall_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = uninstall_commands.run_guard_self_uninstall(
+        dry_run=False,
+        context=context,
+        store=store,
+        now="2026-06-18T00:00:00Z",
+    )
+
+    assert exit_code == 0
+    assert commands == [["pipx", "uninstall", "hol-guard"]]
+    assert payload["status"] == "removed"
+    assert payload["package_removed"] is True
+    assert payload["guard_home_removed"] is True
+    assert payload["oauth_credentials_cleared"] is True
+    assert payload["managed_installs"][0]["harness"] == "codex"
+    assert payload["managed_installs"][0]["active"] is False
+    assert payload["package_shim_uninstall"]["removed_managers"] == ["npm"]
+    assert not context.guard_home.exists()
+
+
+def test_self_uninstall_stops_before_package_when_managed_cleanup_fails(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install("codex", True, None, {"shim_path": "guard-codex"}, "2026-06-18T00:00:00Z")
+    called = {"installer": False}
+
+    monkeypatch.setattr(uninstall_commands, "_current_version", lambda: "2.0.764")
+    monkeypatch.setattr(uninstall_commands, "_installer_kind", lambda: "uv")
+    monkeypatch.setattr(uninstall_commands, "package_shim_status", lambda _context: {"installed_managers": []})
+    monkeypatch.setattr(uninstall_commands, "retire_all_guard_daemons_for_home", lambda _guard_home: [])
+
+    def fail_uninstall(*args: object, **kwargs: object) -> dict[str, object]:
+        del args, kwargs
+        raise RuntimeError("hook cleanup failed")
+
+    monkeypatch.setattr(uninstall_commands, "apply_managed_install", fail_uninstall)
+
+    def unexpected_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        del command, kwargs
+        called["installer"] = True
+        raise AssertionError("package uninstall should not run after a managed cleanup failure")
+
+    monkeypatch.setattr(uninstall_commands.subprocess, "run", unexpected_run)
+
+    payload, exit_code = uninstall_commands.run_guard_self_uninstall(
+        dry_run=False,
+        context=context,
+        store=store,
+        now="2026-06-18T00:00:00Z",
+    )
+
+    assert exit_code == 1
+    assert payload["status"] == "failed"
+    assert payload["message"] == "HOL Guard removal stopped before the package uninstall command ran."
+    assert payload["error"] == "hook cleanup failed"
+    assert called["installer"] is False
+    assert context.guard_home.exists()

--- a/tests/test_guard_uninstall_commands.py
+++ b/tests/test_guard_uninstall_commands.py
@@ -158,3 +158,86 @@ def test_self_uninstall_stops_before_package_when_managed_cleanup_fails(
     assert payload["error"] == "hook cleanup failed"
     assert called["installer"] is False
     assert context.guard_home.exists()
+
+
+def test_self_uninstall_continues_when_managed_install_state_is_unreadable(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+
+    monkeypatch.setattr(uninstall_commands, "_current_version", lambda: "2.0.764")
+    monkeypatch.setattr(uninstall_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(store, "list_managed_installs", lambda: (_ for _ in ()).throw(RuntimeError("db locked")))
+    monkeypatch.setattr(uninstall_commands, "package_shim_status", lambda _context: {"installed_managers": []})
+    monkeypatch.setattr(uninstall_commands, "retire_all_guard_daemons_for_home", lambda _guard_home: [])
+    monkeypatch.setattr(
+        uninstall_commands,
+        "remove_guard_profile_blocks",
+        lambda _context: {"changed": False, "changed_paths": [], "removed_paths": []},
+    )
+    monkeypatch.setattr(
+        uninstall_commands,
+        "uninstall_package_shims",
+        lambda _context, managers=None: {
+            "removed_managers": list(managers or ()),
+            "removed_paths": [],
+            "remaining_managers": [],
+            "manifest_path": str(context.guard_home / "package-shims" / "manifest.json"),
+            "shim_dir": str(context.guard_home / "package-shims" / "bin"),
+        },
+    )
+    monkeypatch.setattr(
+        uninstall_commands.subprocess,
+        "run",
+        lambda command, **kwargs: subprocess.CompletedProcess(command, 0, stdout="removed", stderr=""),
+    )
+
+    payload, exit_code = uninstall_commands.run_guard_self_uninstall(
+        dry_run=False,
+        context=context,
+        store=store,
+        now="2026-06-18T00:00:00Z",
+    )
+
+    assert exit_code == 0
+    assert payload["status"] == "removed"
+    assert payload["planned_managed_harnesses"] == []
+    assert any("Could not read managed install state before uninstall: db locked" in note for note in payload["notes"])
+
+
+def test_self_uninstall_catches_managed_install_context_resolution_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    store.set_managed_install("codex", True, None, {"shim_path": "guard-codex"}, "2026-06-18T00:00:00Z")
+
+    monkeypatch.setattr(uninstall_commands, "_current_version", lambda: "2.0.764")
+    monkeypatch.setattr(uninstall_commands, "_installer_kind", lambda: "uv")
+    monkeypatch.setattr(uninstall_commands, "package_shim_status", lambda _context: {"installed_managers": []})
+    monkeypatch.setattr(uninstall_commands, "retire_all_guard_daemons_for_home", lambda _guard_home: [])
+    monkeypatch.setattr(
+        uninstall_commands,
+        "_managed_install_context",
+        lambda context, managed_install: (_ for _ in ()).throw(OSError("bad workspace")),
+    )
+    monkeypatch.setattr(
+        uninstall_commands.subprocess,
+        "run",
+        lambda command, **kwargs: (_ for _ in ()).throw(AssertionError("installer should not run")),
+    )
+
+    payload, exit_code = uninstall_commands.run_guard_self_uninstall(
+        dry_run=False,
+        context=context,
+        store=store,
+        now="2026-06-18T00:00:00Z",
+    )
+
+    assert exit_code == 1
+    assert payload["status"] == "failed"
+    assert payload["message"] == "HOL Guard removal stopped before the package uninstall command ran."
+    assert payload["error"] == "bad workspace"


### PR DESCRIPTION
This PR adds a `hol-guard uninstall --self` command that removes the installed hol-guard package and all local Guard state, including Guard-managed harness configurations, package manager shims, shell profile PATH entries, and Guard home directories.

## Summary

- add `remove_guard_profile_blocks()` to strip Guard-managed PATH blocks from common shell profiles (`~/.bashrc`, `~/.zshrc`, `~/.config/fish/config.fish`)
- add `run_guard_self_uninstall()` to coordinate full package removal: retire daemons, disconnect all managed harnesses, uninstall package shims, clear shell profiles, clear OAuth credentials, remove Guard home, then invoke the package installer (uv/pipx/pip) to uninstall hol-guard itself
- add `--self` and `--dry-run` flags to the `uninstall` command with validation that `--self` cannot be combined with a harness or `--all`
- render self-uninstall status (planned/pending/removed/failed) with detailed cleanup steps and error reporting

## Behavior

- `hol-guard uninstall --self --dry-run` reports all planned cleanup actions without making changes
- `hol-guard uninstall --self` runs all cleanup in a controlled sequence and stops before package uninstall if any step fails
- Guard home directory and OAuth credentials are removed after the package uninstall succeeds
- Errors during post-package cleanup are reported with a "failed" status but the package remains removed

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b259de13-c7a7-4faa-95ee-6bfe66724093/thread/5d5cc25a-bc1a-4cad-a9f3-b5af259346fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open POINT-010" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b259de13-c7a7-4faa-95ee-6bfe66724093/thread/5d5cc25a-bc1a-4cad-a9f3-b5af259346fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=POINT-010&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=POINT-010"><img alt="POINT-010" src="https://capy.ai/api/badge/thread.svg?label=POINT-010"></picture></a>
<!-- capy-pr-badge:end -->