### PR TITLE
fix(guard): surface trust diagnostics in doctor

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
 
 from ..runtime.command_queue import command_queue_status, repair_command_queue_state
 from ._commands_shared import *
+from .commands_dispatch_trust import build_trust_doctor_payload
 from .commands_parser_helpers import *
 
 
@@ -340,6 +341,7 @@ def _run_guard_doctor_command(
     if getattr(args, "repair", False):
         command_queue_payload["repair"] = repair_command_queue_state(store)
     payload["command_queue"] = command_queue_payload
+    payload["trust"] = build_trust_doctor_payload(store)
     payload["supply_chain"] = build_local_supply_chain_posture(store, config, now=_now())
     payload["aibom"] = build_aibom_status_payload(store, context, generated_at=_now())
     _emit("doctor", payload, getattr(args, "json", False))

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.metadata
 from pathlib import Path
 from typing import TextIO
 
@@ -99,6 +100,57 @@ def _trust_status_payload(store: GuardStore, *, command: str, backend: str) -> d
     }
 
 
+def _installed_trust_cli_payload() -> dict[str, object]:
+    try:
+        version = importlib.metadata.version("hol-guard")
+    except importlib.metadata.PackageNotFoundError:
+        version = None
+    return {
+        "package": "hol-guard",
+        "version": version,
+        "update_command": "hol-guard update",
+        "dry_run_command": "hol-guard update --dry-run --json",
+    }
+
+
+def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> dict[str, object]:
+    payload = _trust_status_payload(store, command="doctor", backend=backend)
+    remembered_rules = str(payload.get("remembered_rules") or "unknown")
+    runtime_protection = str(payload.get("runtime_protection") or "unknown")
+    if runtime_protection != "protected":
+        payload["summary"] = (
+            "Runtime protection is degraded. One-time approvals remain available, but broad remembered local rules "
+            "stay limited until local trust is protected."
+        )
+    elif remembered_rules != "enforced":
+        payload["summary"] = (
+            "Runtime protection is active. Broad remembered local rules are limited until local trust is protected."
+        )
+    else:
+        payload["summary"] = "Runtime protection and remembered local rules are protected."
+    payload["checks"] = {
+        "runtime_protection": runtime_protection == "protected",
+        "one_time_approvals": payload.get("one_time_approvals") == "available",
+        "passive_no_ui": payload.get("passive_prompt_allowed") is False,
+        "local_rules_protected": remembered_rules == "enforced",
+        "cloud_policy_authority": payload.get("cloud_policy_authority") == "available",
+    }
+    payload["recommended_actions"] = (
+        [
+            "Use one-time approvals for local-only work.",
+            "Use Guard Cloud policies for durable team exceptions.",
+            "Run `hol-guard guard trust test --no-ui --json` to verify passive checks stay prompt-free.",
+        ]
+        if remembered_rules != "enforced"
+        else [
+            "Run `hol-guard guard trust test --no-ui --json` after Guard updates.",
+            "Use Guard Cloud policies for team-wide exceptions.",
+        ]
+    )
+    payload["official_install"] = _installed_trust_cli_payload()
+    return payload
+
+
 def _run_guard_trust_command(
     args: argparse.Namespace,
     *,
@@ -118,7 +170,11 @@ def _run_guard_trust_command(
         payload = _unsupported_backend_payload(command=trust_command, backend=backend)
         _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
         return 2
-    payload = _trust_status_payload(store, command=trust_command, backend=backend)
+    payload = (
+        build_trust_doctor_payload(store, backend=backend)
+        if trust_command == "doctor"
+        else _trust_status_payload(store, command=trust_command, backend=backend)
+    )
     if trust_command in {"status", "doctor"}:
         _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
         return 0
@@ -152,4 +208,5 @@ def _run_guard_trust_command(
 
 __all__ = [
     "_run_guard_trust_command",
+    "build_trust_doctor_payload",
 ]

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -703,6 +703,9 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
         supply_chain = payload.get("supply_chain")
         if isinstance(supply_chain, dict):
             console.print(_build_supply_chain_posture_panel(supply_chain))
+    trust = payload.get("trust")
+    if isinstance(trust, dict):
+        console.print(_build_trust_doctor_panel(trust))
     perf_items = payload.get("detector_perf")
     if isinstance(perf_items, list) and perf_items:
         perf_table = Table(title="Detector performance", box=box.SIMPLE_HEAVY, show_header=True)
@@ -719,6 +722,37 @@ def _render_doctor(console: Console, payload: dict[str, object]) -> None:
                 "[red]yes[/red]" if slow else "no",
             )
         console.print(perf_table)
+    console.print(_build_diagnostic_command_panel())
+
+
+def _build_trust_doctor_panel(trust: dict[str, object]) -> Panel:
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Runtime", str(trust.get("runtime_protection") or "unknown"))
+    body.add_row("Remembered rules", str(trust.get("remembered_rules") or "unknown"))
+    body.add_row("Cloud policies", str(trust.get("cloud_policies") or "unknown"))
+    body.add_row("Passive OS prompts", "blocked" if trust.get("passive_prompt_allowed") is False else "unknown")
+    checks = trust.get("checks")
+    if isinstance(checks, dict):
+        body.add_row("Local rules protected", _bool_label(bool(checks.get("local_rules_protected"))))
+        body.add_row("Passive no-UI check", _bool_label(bool(checks.get("passive_no_ui"))))
+    official_install = trust.get("official_install")
+    if isinstance(official_install, dict):
+        version = official_install.get("version") or "unknown"
+        update_command = official_install.get("update_command") or "hol-guard update"
+        body.add_row("Installed package", f"hol-guard {version}")
+        body.add_row("Update", str(update_command))
+    summary = trust.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        body.add_row("Summary", textwrap.fill(summary.strip(), width=72))
+    actions = _coerce_string_list(trust.get("recommended_actions"))
+    if actions:
+        body.add_row("Next", "\n".join(textwrap.fill(f"* {action}", width=72) for action in actions))
+    border_style = "green" if str(trust.get("remembered_rules") or "") == "enforced" else "yellow"
+    return Panel(body, title="Local trust", border_style=border_style)
+
+
+def _render_trust_doctor(console: Console, payload: dict[str, object]) -> None:
+    console.print(_build_trust_doctor_panel(payload))
     console.print(_build_diagnostic_command_panel())
 
 
@@ -2593,6 +2627,7 @@ _RENDERERS: dict[str, Renderer] = {
     "bootstrap": _render_bootstrap,
     "detect": _render_detect,
     "doctor": _render_doctor,
+    "trust.doctor": _render_trust_doctor,
     "run": _render_run,
     "diff": _render_diff,
     "receipts": _render_receipts,

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1323,6 +1323,71 @@ def test_trust_cli_status_reports_no_passive_prompts(tmp_path: Path, capsys) -> 
     assert "last_proof" not in payload
 
 
+def test_guard_doctor_includes_safe_trust_diagnostics(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    rc = main(
+        [
+            "guard",
+            "doctor",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    trust_payload = payload["trust"]
+
+    assert rc == 0
+    assert trust_payload["command"] == "doctor"
+    assert trust_payload["no_ui_passive"] is True
+    assert trust_payload["passive_prompt_allowed"] is False
+    assert trust_payload["one_time_approvals"] == "available"
+    assert trust_payload["durable_local_rules"] in {"enforced", "limited"}
+    assert trust_payload["checks"]["passive_no_ui"] is True
+    assert trust_payload["checks"]["runtime_protection"] is (
+        trust_payload["runtime_protection"] == "protected"
+    )
+    assert trust_payload["official_install"]["package"] == "hol-guard"
+    assert trust_payload["official_install"]["update_command"] == "hol-guard update"
+    assert "recommended_actions" in trust_payload
+    assert "key_id" not in trust_payload
+    assert "last_proof" not in trust_payload
+
+
+def test_guard_doctor_human_output_includes_trust_diagnostics(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    rc = main(["guard", "doctor", "--home", str(home_dir), "--workspace", str(workspace_dir)])
+    output = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Local trust" in output
+    assert "Passive OS prompts" in output
+    assert "hol-guard update" in output
+    assert "Guard Cloud policies" in output
+    assert "trust test --no-ui --json" in output
+
+
+def test_trust_cli_doctor_human_output_uses_trust_renderer(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+
+    rc = main(["guard", "trust", "doctor", "--home", str(home_dir)])
+    output = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Local trust" in output
+    assert "Passive OS prompts" in output
+    assert "hol-guard update" in output
+    assert '"runtime_protection"' not in output
+
+
 def test_trust_cli_bare_combined_command_routes_to_guard() -> None:
     assert _resolve_legacy_args(["trust", "status", "--json"], program_mode="combined") == [
         "guard",
@@ -1393,6 +1458,29 @@ def test_trust_cli_degraded_safe_backend_is_explicit(tmp_path: Path, capsys) -> 
     assert payload["backend"] == "degraded-safe"
     assert payload["remembered_rules"] == "disabled_degraded"
     assert payload["durable_local_rules"] == "limited"
+
+
+def test_trust_cli_doctor_degraded_safe_does_not_pass_runtime_check(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    rc = main(
+        [
+            "guard",
+            "trust",
+            "doctor",
+            "--backend",
+            "degraded-safe",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["runtime_protection"] == "degraded"
+    assert payload["checks"]["runtime_protection"] is False
+    assert payload["checks"]["local_rules_protected"] is False
+    assert payload["summary"].startswith("Runtime protection is degraded.")
 
 
 def test_trust_cli_macos_native_setup_is_explicitly_unavailable(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary\n- add safe local-trust diagnostics to guard doctor output\n- expose no-UI passive trust checks and update guidance without leaking proof IDs\n- cover trust doctor JSON contract in regression tests\n\n## Verification\n- python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py src/codex_plugin_scanner/guard/cli/commands_dispatch_admin.py tests/test_guard_policy_integrity.py\n- python3 -m pytest tests/test_guard_policy_integrity.py::test_trust_cli_status_reports_no_passive_prompts tests/test_guard_policy_integrity.py::test_guard_doctor_includes_safe_trust_diagnostics tests/test_guard_policy_integrity.py::test_trust_cli_no_ui_probe_requires_no_ui_flag tests/test_guard_policy_integrity.py::test_trust_cli_rejects_unavailable_backend_status tests/test_guard_policy_integrity.py::test_trust_cli_degraded_safe_backend_is_explicit tests/test_guard_policy_integrity.py::test_trust_cli_macos_native_setup_is_explicitly_unavailable -q