### PR TITLE
fix(guard): sync workspace audits to guard cloud

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -110,10 +110,12 @@ from ..harness_usage import record_harness_usage_events
 from ..incident import build_incident_context
 from ..local_dashboard_session import build_local_dashboard_session_token
 from ..local_supply_chain import (
+    _resolve_guard_sync_auth_context,
     apply_stored_package_policy_override,
     build_local_supply_chain_posture,
     build_supply_chain_explain_payload,
     build_supply_chain_status_payload,
+    sync_supply_chain_cloud_state,
     build_workspace_audit_payload,
     build_workspace_scan_payload,
     package_request_policy_hash,

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -236,12 +236,19 @@ def _run_guard_sync_command(
     store = _require_guard_store(store)
     context = _require_guard_context(context)
     try:
+        auth_context = _resolve_guard_sync_auth_context(store)
         payload = sync_receipts(
             store,
+            auth_context=auth_context,
             home_dir=context.home_dir,
             workspace_dir=context.workspace_dir,
         )
-    except GuardSyncNotConfiguredError as error:
+        payload["supply_chain"] = sync_supply_chain_cloud_state(
+            store,
+            auth_context=auth_context,
+            workspace_dir=context.workspace_dir,
+        )
+    except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
         message = _guard_sync_failure_message(error)
         if getattr(args, "json", False):
             _emit("sync", {"synced": False, "error": message}, True)
@@ -340,8 +347,15 @@ def _run_guard_supply_chain_command(
         return exit_code
     if supply_chain_command == "sync":
         try:
-            payload = _validated_supply_chain_sync_payload(sync_supply_chain_bundle(store))
-        except GuardSyncNotConfiguredError as error:
+            auth_context = _resolve_guard_sync_auth_context(store)
+            payload = _validated_supply_chain_sync_payload(
+                sync_supply_chain_cloud_state(
+                    store,
+                    auth_context=auth_context,
+                    workspace_dir=workspace_dir,
+                )
+            )
+        except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
             message = _guard_sync_failure_message(error)
             if getattr(args, "json", False):
                 _emit("supply-chain-sync", {"synced": False, "error": message}, True)

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -144,25 +144,9 @@ def _refresh_cloud_policy_bundle(store: GuardStore) -> None:
         return
     now = _now()
     try:
-        sync_receipts(store)
-    except GuardSyncAuthorizationExpiredError as error:
-        store.set_sync_payload(
-            "policy_bundle_last_error",
-            {"reason": "auth_expired", "message": str(error)},
-            now,
-        )
-        return
-    except GuardSyncNotConfiguredError:
-        return
-    except RuntimeError as error:
-        store.set_sync_payload(
-            "policy_bundle_last_error",
-            {"reason": "sync_failed", "message": str(error)},
-            now,
-        )
-        return
-    try:
-        sync_supply_chain_bundle(store)
+        auth_context = _resolve_guard_sync_auth_context(store)
+        sync_receipts(store, auth_context=auth_context)
+        sync_supply_chain_cloud_state(store, auth_context=auth_context)
     except GuardSyncAuthorizationExpiredError as error:
         store.set_sync_payload(
             "policy_bundle_last_error",
@@ -337,7 +321,10 @@ def _finalize_guard_connect_payload(
         }
     )
     try:
-        payload["supply_chain"] = sync_supply_chain_bundle(store)
+        payload["supply_chain"] = sync_supply_chain_cloud_state(
+            store,
+            auth_context=resolved_sync_auth_context,
+        )
     except (GuardSyncNotConfiguredError, GuardSyncNotAvailableError, RuntimeError) as error:
         payload["supply_chain_error"] = str(error)
     return payload

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -6,6 +6,7 @@ import argparse
 import base64
 import hashlib
 import hmac
+import inspect
 import io
 import json
 import mimetypes
@@ -102,6 +103,7 @@ from ..local_supply_chain import (
     managed_install_audit_workspace_dirs,
     resolve_package_firewall_entitlement_with_refresh,
     resolve_supply_chain_audit_workspace_dir,
+    sync_supply_chain_cloud_state,
 )
 from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, DecisionScope, GuardAction, PolicyDecision
 from ..package_firewall_action_rate_limit import PackageFirewallActionRateLimiter
@@ -110,6 +112,7 @@ from ..package_firewall_entitlement import (
     package_firewall_available_actions,
     package_firewall_block_details,
     package_firewall_operation_allowed,
+    resolve_package_firewall_entitlement,
 )
 from ..package_firewall_receipts import package_firewall_receipt_metadata
 from ..package_shim_status import record_package_shim_audit_result
@@ -129,6 +132,7 @@ from ..runtime.runner import (
     _policy_bundle_acknowledgement_payload,
     _policy_bundle_is_version_downgrade,
     prepare_guard_cloud_connect_authorization,
+    _resolve_guard_sync_auth_context,
     sync_local_guard_cloud_proof,
     sync_supply_chain_bundle,
 )
@@ -544,7 +548,12 @@ def _run_headless_cloud_sync(
     recorded_at = _now()
     summary: dict[str, object]
     try:
-        sync_payload = sync_local_guard_cloud_proof(store)
+        auth_context = _resolve_guard_sync_auth_context(store)
+        sync_payload = sync_local_guard_cloud_proof(store, auth_context=auth_context)
+        supply_chain_payload = _sync_supply_chain_cloud_state_with_optional_auth_context(
+            store,
+            auth_context,
+        )
         summary = {
             "status": "synced",
             "synced_at": sync_payload.get("synced_at"),
@@ -552,6 +561,7 @@ def _run_headless_cloud_sync(
             "runtime_session_id": sync_payload.get("runtime_session_id"),
             "runtime_session_synced_at": sync_payload.get("runtime_session_synced_at"),
             "runtime_sessions_visible": sync_payload.get("runtime_sessions_visible"),
+            "supply_chain": supply_chain_payload,
         }
     except GuardSyncAuthorizationExpiredError as error:
         store.record_latest_guard_connect_sync_result(
@@ -948,6 +958,24 @@ def _guard_cloud_connect_succeeded(store: GuardStore) -> bool:
     return not _guard_cloud_connect_required_for_insights(store)
 
 
+def _sync_supply_chain_cloud_state_with_optional_auth_context(
+    store: GuardStore,
+    auth_context: dict[str, object] | None,
+    *,
+    workspace_dir: Path | None = None,
+) -> dict[str, object]:
+    try:
+        parameters = inspect.signature(sync_supply_chain_cloud_state).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    kwargs: dict[str, object] = {}
+    if auth_context is not None and "auth_context" in parameters:
+        kwargs["auth_context"] = auth_context
+    if workspace_dir is not None and "workspace_dir" in parameters:
+        kwargs["workspace_dir"] = workspace_dir
+    return sync_supply_chain_cloud_state(store, **kwargs)
+
+
 def _finalize_daemon_guard_connect_payload(
     *,
     store: GuardStore,
@@ -1088,7 +1116,10 @@ def _finalize_daemon_guard_connect_payload(
         }
     )
     try:
-        payload["supply_chain"] = sync_supply_chain_bundle(store)
+        payload["supply_chain"] = _sync_supply_chain_cloud_state_with_optional_auth_context(
+            store,
+            resolved_sync_auth_context,
+        )
     except (GuardSyncNotConfiguredError, GuardSyncNotAvailableError, RuntimeError) as error:
         payload["supply_chain_error"] = str(error)
     return payload
@@ -2539,7 +2570,11 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 record_package_shim_audit_result(context, audited_at=now)
             return audit_payload
         if operation == "sync":
-            return sync_supply_chain_bundle(self.server.store)  # type: ignore[attr-defined]
+            return _sync_supply_chain_cloud_state_with_optional_auth_context(
+                self.server.store,  # type: ignore[attr-defined]
+                None,
+                workspace_dir=context.workspace_dir,
+            )
         raise ValueError("unsupported_supply_chain_operation")
 
     def _resolve_supply_chain_workspace_dir(self, payload: dict[str, object]) -> Path | None:
@@ -2729,7 +2764,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     },
                     now=timestamp,
                 )
-                resolved_entitlement = resolve_package_firewall_entitlement_with_refresh(store)
+                resolved_entitlement = resolve_package_firewall_entitlement(store)
                 resolved_reason = str(resolved_entitlement.get("reason") or "")
                 if bool(resolved_entitlement.get("allowed")) or resolved_reason == "paid_guard_cloud_required":
                     _set_package_firewall_connect_state(self.server, None)  # type: ignore[arg-type]

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20513,8 +20513,7 @@ function openPackageFirewallAuthorizeWindow(authorizeUrl) {
   }
   return false;
 }
-function openPackageFirewallAuthorizeFallback(authorizeUrl, browserOpened) {
-  void authorizeUrl;
+function openPackageFirewallAuthorizeFallback(_authorizeUrl, browserOpened) {
   return browserOpened === true;
 }
 function FiShare2(props) {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -20514,10 +20514,8 @@ function openPackageFirewallAuthorizeWindow(authorizeUrl) {
   return false;
 }
 function openPackageFirewallAuthorizeFallback(authorizeUrl, browserOpened) {
-  if (browserOpened === true) {
-    return true;
-  }
-  return openPackageFirewallAuthorizeWindow(authorizeUrl);
+  void authorizeUrl;
+  return browserOpened === true;
 }
 function FiShare2(props) {
   return GenIcon({ "attr": { "viewBox": "0 0 24 24", "fill": "none", "stroke": "currentColor", "strokeWidth": "2", "strokeLinecap": "round", "strokeLinejoin": "round" }, "child": [{ "tag": "circle", "attr": { "cx": "18", "cy": "5", "r": "3" }, "child": [] }, { "tag": "circle", "attr": { "cx": "6", "cy": "12", "r": "3" }, "child": [] }, { "tag": "circle", "attr": { "cx": "18", "cy": "19", "r": "3" }, "child": [] }, { "tag": "line", "attr": { "x1": "8.59", "y1": "13.51", "x2": "15.42", "y2": "17.49" }, "child": [] }, { "tag": "line", "attr": { "x1": "15.41", "y1": "6.51", "x2": "8.59", "y2": "10.49" }, "child": [] }] })(props);

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import inspect
 import json
 import os
 import shlex
@@ -133,6 +134,10 @@ _STALE_REFRESH_GRACE_SECONDS = 5 * 60
 _CLOUD_AUDIT_TIMEOUT_SECONDS = 20
 _CLOUD_AUDIT_PAGE_SIZE = 500
 _CLOUD_AUDIT_MAX_PAGES = 100
+_CLOUD_AUDIT_JOB_PAGE_SIZE = 1
+_CLOUD_AUDIT_JOB_POLL_INTERVAL_SECONDS = 0.5
+_CLOUD_AUDIT_JOB_POLL_TIMEOUT_SECONDS = 20
+_CLOUD_AUDIT_SYNC_PAGE_SIZE = 25
 _MAX_SBOM_BYTES = 10 * 1024 * 1024
 _ECOSYSTEM_BY_LOCKFILE = {
     "package-lock.json": "npm",
@@ -212,12 +217,20 @@ def _supply_chain_package_eval_module():
     return importlib.import_module(".runtime.supply_chain_package_eval", __package__)
 
 
-def sync_local_guard_cloud_proof(store: GuardStore) -> dict[str, object]:
-    return _runtime_runner_module().sync_local_guard_cloud_proof(store)
+def sync_local_guard_cloud_proof(
+    store: GuardStore,
+    *,
+    auth_context: dict[str, object] | None = None,
+) -> dict[str, object]:
+    return _runtime_runner_module().sync_local_guard_cloud_proof(store, auth_context=auth_context)
 
 
-def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object] | None:
-    return _runtime_runner_module().sync_supply_chain_bundle(store)
+def sync_supply_chain_bundle(
+    store: GuardStore,
+    *,
+    auth_context: dict[str, object] | None = None,
+) -> dict[str, object] | None:
+    return _runtime_runner_module().sync_supply_chain_bundle(store, auth_context=auth_context)
 
 
 def _resolve_guard_sync_auth_context(store: GuardStore):
@@ -409,6 +422,21 @@ def build_supply_chain_status_payload(
     }
 
 
+def _call_sync_with_optional_auth_context(
+    refresh: Any,
+    *,
+    store: Any,
+    auth_context: dict[str, object],
+) -> dict[str, object]:
+    try:
+        parameters = inspect.signature(refresh).parameters
+    except (TypeError, ValueError):
+        parameters = {}
+    if "auth_context" in parameters:
+        return refresh(store, auth_context=auth_context)
+    return refresh(store)
+
+
 def resolve_package_firewall_entitlement_with_refresh(store: Any) -> dict[str, object]:
     """Resolve package-firewall access and opportunistically heal stale cloud state."""
 
@@ -437,9 +465,26 @@ def resolve_package_firewall_entitlement_with_refresh(store: Any) -> dict[str, o
         ):
             return entitlement
         _write_package_firewall_refresh_state(store.guard_home, now)
+    try:
+        shared_auth_context = runner._resolve_guard_sync_auth_context(store)
+    except runner.GuardSyncAuthorizationExpiredError as error:
+        if str(entitlement.get("reason") or "") == "guard_cloud_connect_required":
+            store.record_latest_guard_connect_sync_result(
+                status="retry_required",
+                milestone="first_sync_failed",
+                now=now_iso,
+                reason=str(error),
+            )
+        return entitlement_module.resolve_package_firewall_entitlement(store)
+    except (runner.GuardSyncNotAvailableError, runner.GuardSyncNotConfiguredError, OSError, RuntimeError):
+        return entitlement_module.resolve_package_firewall_entitlement(store)
     for refresh in (sync_local_guard_cloud_proof, sync_supply_chain_bundle):
         try:
-            refresh(store)
+            _call_sync_with_optional_auth_context(
+                refresh,
+                store=store,
+                auth_context=shared_auth_context,
+            )
         except runner.GuardSyncAuthorizationExpiredError as error:
             if str(entitlement.get("reason") or "") == "guard_cloud_connect_required":
                 store.record_latest_guard_connect_sync_result(
@@ -494,6 +539,32 @@ def managed_install_audit_workspace_dirs(store: Any) -> tuple[str, ...]:
             continue
         seen.add(normalized)
         candidates.append(normalized)
+    return tuple(candidates)
+
+
+def _managed_workspace_audit_candidates(
+    store: Any,
+    *,
+    workspace_dir: Path | None = None,
+) -> tuple[Path, ...]:
+    candidates: list[Path] = []
+    seen: set[str] = set()
+    raw_candidates: list[Path] = []
+    if workspace_dir is not None:
+        raw_candidates.append(workspace_dir)
+    raw_candidates.extend(Path(entry).expanduser() for entry in managed_install_audit_workspace_dirs(store))
+    for candidate in raw_candidates:
+        try:
+            resolved = candidate.resolve()
+        except OSError:
+            continue
+        normalized = str(resolved)
+        if normalized in seen or not resolved.exists() or not resolved.is_dir():
+            continue
+        if not _workspace_has_project_markers(resolved):
+            continue
+        seen.add(normalized)
+        candidates.append(resolved)
     return tuple(candidates)
 
 
@@ -2197,6 +2268,8 @@ def _build_cloud_audit_payload(
     manifest_paths: tuple[str, ...],
     lockfile_paths: tuple[str, ...],
     inventory: tuple[dict[str, object], ...],
+    mode: str = "paged",
+    page_size: int | None = None,
 ) -> dict[str, object]:
     summary = store.get_sync_payload("supply_chain_bundle_summary")
     policy_version = "local:none"
@@ -2221,8 +2294,8 @@ def _build_cloud_audit_payload(
         },
         "harness": _LOCAL_SUPPLY_CHAIN_HARNESS,
         "lockfileContext": _workspace_audit_lockfile_context(workspace_dir, manifest_paths, lockfile_paths, inventory),
-        "mode": "paged",
-        "pageSize": min(_CLOUD_AUDIT_PAGE_SIZE, max(len(inventory), 1)),
+        "mode": mode,
+        "pageSize": min(_CLOUD_AUDIT_PAGE_SIZE, max(page_size or len(inventory), 1)),
         "packages": [
             {
                 "direct": bool(item.get("direct")),
@@ -2240,6 +2313,121 @@ def _build_cloud_audit_payload(
     if payload["lockfileContext"] is None:
         payload.pop("lockfileContext")
     return payload
+
+
+def _execute_cloud_workspace_audit_request(
+    *,
+    auth_context: dict[str, object],
+    request_url: str,
+    method: str,
+    payload: dict[str, object] | None = None,
+) -> dict[str, object]:
+    runner = _runtime_runner_module()
+    request_headers = runner._guard_sync_headers(auth_context, request_url=request_url, method=method)
+    if payload is not None:
+        request_headers["Content-Type"] = "application/json"
+    request = urllib.request.Request(
+        request_url,
+        data=json.dumps(payload).encode("utf-8") if payload is not None else None,
+        headers=request_headers,
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=_CLOUD_AUDIT_TIMEOUT_SECONDS) as response:
+            response_payload = json.load(response)
+    except urllib.error.HTTPError as error:
+        if error.code == 403:
+            is_plan_restricted, message = runner._check_plan_restriction_403(error)
+            if is_plan_restricted:
+                raise runner.GuardSyncNotAvailableError(message) from error
+            raise RuntimeError(message) from error
+        message, retryable = runner._guard_cloud_http_error_details(error)
+        if retryable:
+            raise runner.GuardSyncNotAvailableError(message, retryable=True) from error
+        raise RuntimeError(message) from error
+    except OSError as error:
+        raise RuntimeError(runner._sync_url_error_message(error)) from error
+    except (ValueError, json.JSONDecodeError) as error:
+        raise RuntimeError("Guard cloud workspace audit returned an invalid response.") from error
+    if not isinstance(response_payload, dict):
+        raise RuntimeError("Guard cloud workspace audit returned an invalid response.")
+    return response_payload
+
+
+def _normalized_supply_chain_batch_job_url(
+    sync_url: str,
+    workspace_id: str,
+    job_id: str,
+    *,
+    page_size: int,
+) -> str:
+    batch_url = _normalized_supply_chain_batch_url(sync_url, workspace_id)
+    parsed = urllib.parse.urlsplit(batch_url)
+    query_pairs = urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)
+    query_pairs = [(key, value) for key, value in query_pairs if key not in {"cursor", "pageSize"}]
+    query_pairs.append(("pageSize", str(max(page_size, 1))))
+    return urllib.parse.urlunsplit(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            f"{parsed.path.rstrip('/')}/{urllib.parse.quote(job_id, safe='')}",
+            urllib.parse.urlencode(query_pairs),
+            "",
+        )
+    )
+
+
+def _enqueue_cloud_workspace_audit_job(
+    *,
+    auth_context: dict[str, object],
+    request_payload: dict[str, object],
+    workspace_id: str,
+) -> dict[str, object]:
+    sync_url = str(auth_context["sync_url"])
+    request_url = _normalized_supply_chain_batch_url(sync_url, workspace_id)
+    response_payload = _execute_cloud_workspace_audit_request(
+        auth_context=auth_context,
+        request_url=request_url,
+        method="POST",
+        payload=request_payload,
+    )
+    job_id = response_payload.get("jobId")
+    if not isinstance(job_id, str) or not job_id.strip():
+        raise RuntimeError("Guard cloud workspace audit did not return a batch job id.")
+    return response_payload
+
+
+def _poll_cloud_workspace_audit_job(
+    *,
+    auth_context: dict[str, object],
+    job_id: str,
+    workspace_id: str,
+) -> dict[str, object]:
+    sync_url = str(auth_context["sync_url"])
+    request_url = _normalized_supply_chain_batch_job_url(
+        sync_url,
+        workspace_id,
+        job_id,
+        page_size=_CLOUD_AUDIT_JOB_PAGE_SIZE,
+    )
+    deadline = time.monotonic() + _CLOUD_AUDIT_JOB_POLL_TIMEOUT_SECONDS
+    last_response: dict[str, object] = {
+        "jobId": job_id,
+        "status": "queued",
+        "workspaceId": workspace_id,
+    }
+    while time.monotonic() < deadline:
+        response_payload = _execute_cloud_workspace_audit_request(
+            auth_context=auth_context,
+            request_url=request_url,
+            method="GET",
+        )
+        status = str(response_payload.get("status") or "").strip().lower()
+        last_response = response_payload
+        if status in {"completed", "failed"}:
+            return response_payload
+        time.sleep(_CLOUD_AUDIT_JOB_POLL_INTERVAL_SECONDS)
+    return last_response
 
 
 def _workspace_audit_lockfile_context(
@@ -2392,6 +2580,145 @@ def _normalized_supply_chain_batch_url(sync_url: str, workspace_id: str) -> str:
             "",
         )
     )
+
+
+def sync_managed_workspace_audits(
+    store: GuardStore,
+    *,
+    auth_context: dict[str, object] | None = None,
+    workspace_dir: Path | None = None,
+) -> dict[str, object]:
+    runner = _runtime_runner_module()
+    resolved_auth_context = auth_context if auth_context is not None else runner._resolve_guard_sync_auth_context(store)
+    workspace_id = store.get_cloud_workspace_id()
+    if not isinstance(workspace_id, str) or not workspace_id.strip():
+        raise runner.GuardSyncNotConfiguredError(
+            "Guard Cloud is not connected yet. Run `hol-guard connect` to sign in and pair this machine, "
+            "or use `hol-guard login` as a compatibility alias for the same browser flow."
+        )
+    synced_at = datetime.now(timezone.utc).isoformat()
+    workspaces_payload: list[dict[str, object]] = []
+    completed_jobs = 0
+    failed_jobs = 0
+    queued_jobs = 0
+    skipped_workspaces = 0
+    for candidate in _managed_workspace_audit_candidates(store, workspace_dir=workspace_dir):
+        workspace_label = candidate.name or str(candidate)
+        try:
+            manifest_paths, lockfile_paths, _sbom_paths, inventory = _workspace_audit_inventory(
+                candidate,
+                sbom_paths=(),
+            )
+            if not inventory:
+                skipped_workspaces += 1
+                workspaces_payload.append(
+                    {
+                        "workspace": workspace_label,
+                        "status": "skipped",
+                        "message": "No supported package inventory was detected for workspace audit sync.",
+                        "package_count": 0,
+                    }
+                )
+                continue
+            request_payload = _build_cloud_audit_payload(
+                workspace_dir=candidate,
+                workspace_id=workspace_id,
+                store=store,
+                manifest_paths=manifest_paths,
+                lockfile_paths=lockfile_paths,
+                inventory=inventory,
+                mode="job",
+                page_size=min(_CLOUD_AUDIT_SYNC_PAGE_SIZE, max(len(inventory), 1)),
+            )
+            enqueue_response = _enqueue_cloud_workspace_audit_job(
+                auth_context=resolved_auth_context,
+                request_payload=request_payload,
+                workspace_id=workspace_id,
+            )
+            job_id = str(enqueue_response.get("jobId") or "").strip()
+            final_response = _poll_cloud_workspace_audit_job(
+                auth_context=resolved_auth_context,
+                job_id=job_id,
+                workspace_id=workspace_id,
+            )
+            final_status = str(final_response.get("status") or enqueue_response.get("status") or "queued").strip().lower()
+            if final_status == "completed":
+                completed_jobs += 1
+            elif final_status == "failed":
+                failed_jobs += 1
+            else:
+                queued_jobs += 1
+            workspaces_payload.append(
+                {
+                    "workspace": workspace_label,
+                    "workspace_fingerprint": request_payload.get("workspaceFingerprint"),
+                    "job_id": job_id,
+                    "status": final_status,
+                    "package_count": len(inventory),
+                    "manifest_paths": list(manifest_paths),
+                    "lockfile_paths": list(lockfile_paths),
+                    "message": final_response.get("error"),
+                }
+            )
+        except (
+            runner.GuardSyncAuthorizationExpiredError,
+            runner.GuardSyncNotAvailableError,
+            runner.GuardSyncNotConfiguredError,
+        ):
+            raise
+        except (OSError, RuntimeError, ValueError) as error:
+            failed_jobs += 1
+            workspaces_payload.append(
+                {
+                    "workspace": workspace_label,
+                    "status": "failed",
+                    "message": str(error),
+                    "package_count": 0,
+                }
+            )
+    if failed_jobs > 0 and completed_jobs == 0 and queued_jobs == 0:
+        status = "failed"
+    elif failed_jobs > 0:
+        status = "partial"
+    elif completed_jobs > 0 or queued_jobs > 0:
+        status = "synced"
+    else:
+        status = "idle"
+    summary = {
+        "synced_at": synced_at,
+        "status": status,
+        "workspace_count": len(workspaces_payload),
+        "completed_jobs": completed_jobs,
+        "queued_jobs": queued_jobs,
+        "failed_jobs": failed_jobs,
+        "skipped_workspaces": skipped_workspaces,
+        "workspaces": workspaces_payload,
+    }
+    store.set_sync_payload("workspace_audits_sync_summary", summary, synced_at)
+    return summary
+
+
+def sync_supply_chain_cloud_state(
+    store: GuardStore,
+    *,
+    auth_context: dict[str, object] | None = None,
+    workspace_dir: Path | None = None,
+) -> dict[str, object]:
+    resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
+    bundle_summary = _call_sync_with_optional_auth_context(
+        sync_supply_chain_bundle,
+        store=store,
+        auth_context=resolved_auth_context,
+    )
+    payload = dict(bundle_summary) if isinstance(bundle_summary, dict) else {}
+    workspace_audits = sync_managed_workspace_audits(
+        store,
+        auth_context=resolved_auth_context,
+        workspace_dir=workspace_dir,
+    )
+    payload["workspace_audits"] = workspace_audits
+    payload.setdefault("synced_at", workspace_audits.get("synced_at"))
+    return payload
 
 
 def _target_from_manifest_dependency(ecosystem: str, package_name: str, version: str) -> PackageIntentTarget:

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -20,10 +20,10 @@ from ..local_supply_chain import (
     build_workspace_audit_payload,
     managed_install_audit_workspace_dirs,
     resolve_supply_chain_audit_workspace_dir,
+    sync_supply_chain_cloud_state,
 )
 from ..models import DecisionScope, PolicyDecision
 from ..package_shim_status import record_package_shim_audit_result
-from ..runtime.runner import sync_supply_chain_bundle
 from ..shims import (
     activate_package_shims,
     package_shim_status,
@@ -138,7 +138,13 @@ def _execute_package_shim_operation(
             generated_at=generated_at,
         )
     if operation == "guard.packageShims.sync":
-        return _result(sync_supply_chain_bundle(store), generated_at=generated_at)
+        return _result(
+            sync_supply_chain_cloud_state(
+                store,
+                workspace_dir=command_context.workspace_dir,
+            ),
+            generated_at=generated_at,
+        )
     if operation == "guard.packageShims.audit":
         if command_context.workspace_dir is None:
             return {

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3699,12 +3699,35 @@ def _cloud_package_manager_coverage(
         ),
         generated_at=generated_at,
     )
-    summary = store.get_sync_payload("supply_chain_bundle_summary")
     synced_at = None
     next_refresh_at = None
-    if isinstance(summary, dict):
-        synced_at = _optional_string(summary.get("synced_at") or summary.get("syncedAt"))
-        next_refresh_at = _optional_string(summary.get("next_refresh_at") or summary.get("nextRefreshAt"))
+    synced_timestamp = None
+    for source_name, summary in (
+        ("sync", store.get_sync_payload("sync_summary")),
+        ("runtime", store.get_sync_payload("runtime_session_summary")),
+        ("bundle", store.get_sync_payload("supply_chain_bundle_summary")),
+    ):
+        if not isinstance(summary, dict):
+            continue
+        candidate_synced_at = _optional_string(
+            summary.get("synced_at")
+            or summary.get("syncedAt")
+            or summary.get("runtime_session_synced_at")
+            or summary.get("runtimeSessionSyncedAt")
+            or summary.get("local_guard_online_at"),
+        )
+        candidate_timestamp = _parse_iso_timestamp(candidate_synced_at) if candidate_synced_at is not None else None
+        if candidate_timestamp is None:
+            continue
+        if synced_timestamp is not None and candidate_timestamp <= synced_timestamp:
+            continue
+        synced_at = candidate_synced_at
+        synced_timestamp = candidate_timestamp
+        next_refresh_at = (
+            _optional_string(summary.get("next_refresh_at") or summary.get("nextRefreshAt"))
+            if source_name == "bundle"
+            else None
+        )
     reference_timestamp = _parse_iso_timestamp(generated_at) or datetime.now(timezone.utc)
     stale_status = "unknown"
     if synced_at is not None:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1642,14 +1642,18 @@ def _sync_supply_chain_bundle_incremental(
     }
 
 
-def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
+def sync_supply_chain_bundle(
+    store: GuardStore,
+    *,
+    auth_context: dict[str, object] | None = None,
+) -> dict[str, object]:
     """Fetch, verify, and persist the active supply-chain bundle for the cloud workspace."""
 
-    auth_context = _resolve_guard_sync_auth_context(store)
+    resolved_auth_context = auth_context if auth_context is not None else _resolve_guard_sync_auth_context(store)
     workspace_id = store.get_cloud_workspace_id()
     if workspace_id is None:
         raise GuardSyncNotConfiguredError("Guard Cloud workspace is not connected.")
-    bundle_url = _normalized_supply_chain_bundle_url(str(auth_context["sync_url"]), workspace_id)
+    bundle_url = _normalized_supply_chain_bundle_url(str(resolved_auth_context["sync_url"]), workspace_id)
     cached_bundle = store.get_cached_supply_chain_bundle(workspace_id)
     cached_bundle_version = None
     if isinstance(cached_bundle, dict):
@@ -1663,7 +1667,7 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
         partition_sync: dict[str, object] | None = _sync_supply_chain_bundle_incremental(
             bundle_url=bundle_url,
             cached_bundle_version=cached_bundle_version,
-            auth_context=auth_context,
+            auth_context=resolved_auth_context,
             store=store,
             trusted_keys=trusted_keys,
             workspace_id=workspace_id,
@@ -1685,7 +1689,7 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
         except SupplyChainBundleError:
             try:
                 request = _guard_sync_request(
-                    auth_context,
+                    resolved_auth_context,
                     request_url=bundle_url,
                     method="GET",
                     data=None,
@@ -1702,7 +1706,7 @@ def sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
                 raise RuntimeError(f"Guard supply-chain bundle sync failed: {error}") from error
     else:
         request = _guard_sync_request(
-            auth_context,
+            resolved_auth_context,
             request_url=bundle_url,
             method="GET",
             data=None,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -253,6 +253,8 @@ _SECRET_FINGERPRINT_PREFIX = "pbkdf2-sha256$"
 _SECRET_FINGERPRINT_SALT = b"hol-guard-secret-fingerprint:v1"
 _OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS = 30.0
 _OAUTH_REFRESH_LOCK_POLL_SECONDS = 0.05
+_OAUTH_CREDENTIAL_LOCK_TIMEOUT_SECONDS = 30.0
+_OAUTH_CREDENTIAL_LOCK_POLL_SECONDS = 0.05
 _CLOUD_SYNC_LOCK_TIMEOUT_SECONDS = 30.0
 _CLOUD_SYNC_LOCK_POLL_SECONDS = 0.05
 _GUARD_STORE_PRIVATE_DIR_MODE = 0o700
@@ -1152,6 +1154,14 @@ class GuardStore:
                 persisted_value = self._get_secret_from_primary_store(primary, secret_id)
                 if persisted_value == value:
                     return
+                if isinstance(secret_store.fallback, EncryptedFileSecretStore):
+                    fallback_value = self._get_secret_from_store(secret_store.fallback, secret_id)
+                    if fallback_value == value:
+                        _store_logger.warning(
+                            "OAuth secret persisted via encrypted fallback store because Keychain "
+                            "readback was unavailable."
+                        )
+                        return
                 raise RuntimeError("Guard could not persist local Guard Cloud authorization securely.")
         if isinstance(secret_store, UnavailableSecretStore):
             raise RuntimeError(
@@ -1817,6 +1827,29 @@ class GuardStore:
                     if time.monotonic() >= deadline:
                         raise TimeoutError("Timed out waiting for Guard Cloud sync lock.") from None
                     time.sleep(_CLOUD_SYNC_LOCK_POLL_SECONDS)
+            try:
+                yield
+            finally:
+                with suppress(OSError):
+                    _release_advisory_file_lock(handle)
+
+    @contextmanager
+    def hold_oauth_credential_lock(
+        self,
+        *,
+        timeout_seconds: float = _OAUTH_CREDENTIAL_LOCK_TIMEOUT_SECONDS,
+    ) -> Iterator[None]:
+        lock_path = self.guard_home / "oauth-credentials.lock"
+        deadline = time.monotonic() + max(timeout_seconds, 0.0)
+        with lock_path.open("a+b") as handle:
+            while True:
+                try:
+                    _acquire_advisory_file_lock(handle)
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError("Timed out waiting for Guard OAuth credential lock.") from None
+                    time.sleep(_OAUTH_CREDENTIAL_LOCK_POLL_SECONDS)
             try:
                 yield
             finally:
@@ -5024,6 +5057,44 @@ class GuardStore:
         runtime_id: str | None = None,
         runtime_label: str | None = None,
     ) -> None:
+        with self.hold_oauth_credential_lock():
+            self._set_oauth_local_credentials_unlocked(
+                issuer=issuer,
+                client_id=client_id,
+                refresh_token=refresh_token,
+                dpop_private_key_pem=dpop_private_key_pem,
+                dpop_public_jwk=dpop_public_jwk,
+                dpop_public_jwk_thumbprint=dpop_public_jwk_thumbprint,
+                now=now,
+                grant_id=grant_id,
+                machine_id=machine_id,
+                supply_chain_entitlement_expires_at=supply_chain_entitlement_expires_at,
+                supply_chain_firewall=supply_chain_firewall,
+                supply_chain_plan_id=supply_chain_plan_id,
+                workspace_id=workspace_id,
+                runtime_id=runtime_id,
+                runtime_label=runtime_label,
+            )
+
+    def _set_oauth_local_credentials_unlocked(
+        self,
+        *,
+        issuer: str,
+        client_id: str,
+        refresh_token: str,
+        dpop_private_key_pem: str,
+        dpop_public_jwk: dict[str, str],
+        dpop_public_jwk_thumbprint: str,
+        now: str,
+        grant_id: str | None = None,
+        machine_id: str | None = None,
+        supply_chain_entitlement_expires_at: str | None = None,
+        supply_chain_firewall: bool | None = None,
+        supply_chain_plan_id: str | None = None,
+        workspace_id: str | None = None,
+        runtime_id: str | None = None,
+        runtime_label: str | None = None,
+    ) -> None:
         normalized_issuer = resolve_guard_oauth_client_config(issuer).issuer
         secret_payload = {
             "refresh_token": refresh_token,
@@ -5148,6 +5219,10 @@ class GuardStore:
             allow_primary=self._oauth_primary_reads_are_no_ui_safe(),
         )
         if secret_payload is None and self.repair_oauth_local_credential_storage_from_primary():
+            refreshed_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+            if isinstance(refreshed_payload, dict):
+                payload = refreshed_payload
+                secret_hash = payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)
             secret_payload = self._load_oauth_secret_payload(
                 payload,
                 promote=False,
@@ -5241,20 +5316,75 @@ class GuardStore:
         self._write_oauth_keychain_access_state(state)
 
     def repair_oauth_local_credential_storage_from_primary(self) -> bool:
-        """Re-mirror OAuth secrets from the system keychain into encrypted fallback storage."""
+        """Rebuild OAuth credential storage from primary or recoverable fallback state."""
         payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if not isinstance(payload, dict):
             return False
-        if not self._should_attempt_oauth_storage_repair():
-            return False
-        self._mark_oauth_storage_repair_attempt()
-        repaired_payload = self._load_oauth_secret_payload(payload, promote=True, allow_primary=True)
-        if repaired_payload is None:
-            return False
-        cache_key = self._oauth_health_process_cache_key(_string_value(payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)))
-        if cache_key is not None:
-            _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
-        return True
+        with self.hold_oauth_credential_lock():
+            repaired_payload = None
+            if self._should_attempt_oauth_storage_repair():
+                self._mark_oauth_storage_repair_attempt()
+                repaired_payload = self._load_oauth_secret_payload(payload, promote=True, allow_primary=True)
+            if repaired_payload is None:
+                recoverable_credentials = self.get_recoverable_oauth_local_credentials()
+                if recoverable_credentials is None:
+                    return False
+                recovered_inputs = self._build_recovered_oauth_local_credentials_inputs(
+                    recoverable_credentials,
+                )
+                if recovered_inputs is None:
+                    return False
+                self._set_oauth_local_credentials_unlocked(now=_now(), **recovered_inputs)
+            cache_key = self._oauth_health_process_cache_key(
+                _string_value(payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)),
+            )
+            if cache_key is not None:
+                _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
+            return True
+
+    @staticmethod
+    def _build_recovered_oauth_local_credentials_inputs(
+        credentials: dict[str, object],
+    ) -> dict[str, object] | None:
+        issuer = _string_value(credentials.get("issuer"))
+        client_id = _string_value(credentials.get("client_id"))
+        refresh_token = _string_value(credentials.get("refresh_token"))
+        dpop_private_key_pem = _string_value(credentials.get("dpop_private_key_pem"))
+        dpop_public_jwk = credentials.get("dpop_public_jwk")
+        dpop_public_jwk_thumbprint = _string_value(credentials.get("dpop_public_jwk_thumbprint"))
+        if (
+            issuer is None
+            or client_id is None
+            or refresh_token is None
+            or dpop_private_key_pem is None
+            or not isinstance(dpop_public_jwk, dict)
+            or dpop_public_jwk_thumbprint is None
+        ):
+            return None
+        return {
+            "issuer": issuer,
+            "client_id": client_id,
+            "refresh_token": refresh_token,
+            "dpop_private_key_pem": dpop_private_key_pem,
+            "dpop_public_jwk": {
+                str(key): str(value) for key, value in dpop_public_jwk.items()
+            },
+            "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
+            "grant_id": _string_value(credentials.get("grant_id")),
+            "machine_id": _string_value(credentials.get("machine_id")),
+            "supply_chain_entitlement_expires_at": _string_value(
+                credentials.get("supply_chain_entitlement_expires_at"),
+            ),
+            "supply_chain_firewall": (
+                credentials.get("supply_chain_firewall")
+                if isinstance(credentials.get("supply_chain_firewall"), bool)
+                else None
+            ),
+            "supply_chain_plan_id": _string_value(credentials.get("supply_chain_plan_id")),
+            "workspace_id": _string_value(credentials.get("workspace_id")),
+            "runtime_id": _string_value(credentials.get("runtime_id")),
+            "runtime_label": _string_value(credentials.get("runtime_label")),
+        }
 
     def _load_oauth_secret_payload(
         self,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -5366,9 +5366,7 @@ class GuardStore:
             "client_id": client_id,
             "refresh_token": refresh_token,
             "dpop_private_key_pem": dpop_private_key_pem,
-            "dpop_public_jwk": {
-                str(key): str(value) for key, value in dpop_public_jwk.items()
-            },
+            "dpop_public_jwk": {str(key): str(value) for key, value in dpop_public_jwk.items()},
             "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
             "grant_id": _string_value(credentials.get("grant_id")),
             "machine_id": _string_value(credentials.get("machine_id")),

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -1793,22 +1793,13 @@ class GuardStore:
         *,
         timeout_seconds: float = _OAUTH_REFRESH_LOCK_TIMEOUT_SECONDS,
     ) -> Iterator[None]:
-        lock_path = self.guard_home / "oauth-refresh.lock"
-        deadline = time.monotonic() + max(timeout_seconds, 0.0)
-        with lock_path.open("a+b") as handle:
-            while True:
-                try:
-                    _acquire_advisory_file_lock(handle)
-                    break
-                except BlockingIOError:
-                    if time.monotonic() >= deadline:
-                        raise TimeoutError("Timed out waiting for Guard OAuth refresh lock.") from None
-                    time.sleep(_OAUTH_REFRESH_LOCK_POLL_SECONDS)
-            try:
-                yield
-            finally:
-                with suppress(OSError):
-                    _release_advisory_file_lock(handle)
+        with self._hold_advisory_file_lock(
+            path=self.guard_home / "oauth-refresh.lock",
+            timeout_seconds=timeout_seconds,
+            poll_seconds=_OAUTH_REFRESH_LOCK_POLL_SECONDS,
+            timeout_message="Timed out waiting for Guard OAuth refresh lock.",
+        ):
+            yield
 
     @contextmanager
     def hold_cloud_sync_lock(
@@ -1816,22 +1807,13 @@ class GuardStore:
         *,
         timeout_seconds: float = _CLOUD_SYNC_LOCK_TIMEOUT_SECONDS,
     ) -> Iterator[None]:
-        lock_path = self.guard_home / "cloud-sync.lock"
-        deadline = time.monotonic() + max(timeout_seconds, 0.0)
-        with lock_path.open("a+b") as handle:
-            while True:
-                try:
-                    _acquire_advisory_file_lock(handle)
-                    break
-                except BlockingIOError:
-                    if time.monotonic() >= deadline:
-                        raise TimeoutError("Timed out waiting for Guard Cloud sync lock.") from None
-                    time.sleep(_CLOUD_SYNC_LOCK_POLL_SECONDS)
-            try:
-                yield
-            finally:
-                with suppress(OSError):
-                    _release_advisory_file_lock(handle)
+        with self._hold_advisory_file_lock(
+            path=self.guard_home / "cloud-sync.lock",
+            timeout_seconds=timeout_seconds,
+            poll_seconds=_CLOUD_SYNC_LOCK_POLL_SECONDS,
+            timeout_message="Timed out waiting for Guard Cloud sync lock.",
+        ):
+            yield
 
     @contextmanager
     def hold_oauth_credential_lock(
@@ -1839,17 +1821,33 @@ class GuardStore:
         *,
         timeout_seconds: float = _OAUTH_CREDENTIAL_LOCK_TIMEOUT_SECONDS,
     ) -> Iterator[None]:
-        lock_path = self.guard_home / "oauth-credentials.lock"
+        with self._hold_advisory_file_lock(
+            path=self.guard_home / "oauth-credentials.lock",
+            timeout_seconds=timeout_seconds,
+            poll_seconds=_OAUTH_CREDENTIAL_LOCK_POLL_SECONDS,
+            timeout_message="Timed out waiting for Guard OAuth credential lock.",
+        ):
+            yield
+
+    @contextmanager
+    def _hold_advisory_file_lock(
+        self,
+        *,
+        path: Path,
+        timeout_seconds: float,
+        poll_seconds: float,
+        timeout_message: str,
+    ) -> Iterator[None]:
         deadline = time.monotonic() + max(timeout_seconds, 0.0)
-        with lock_path.open("a+b") as handle:
+        with path.open("a+b") as handle:
             while True:
                 try:
                     _acquire_advisory_file_lock(handle)
                     break
                 except BlockingIOError:
                     if time.monotonic() >= deadline:
-                        raise TimeoutError("Timed out waiting for Guard OAuth credential lock.") from None
-                    time.sleep(_OAUTH_CREDENTIAL_LOCK_POLL_SECONDS)
+                        raise TimeoutError(timeout_message) from None
+                    time.sleep(poll_seconds)
             try:
                 yield
             finally:
@@ -5317,10 +5315,10 @@ class GuardStore:
 
     def repair_oauth_local_credential_storage_from_primary(self) -> bool:
         """Rebuild OAuth credential storage from primary or recoverable fallback state."""
-        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
-        if not isinstance(payload, dict):
-            return False
         with self.hold_oauth_credential_lock():
+            payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+            if not isinstance(payload, dict):
+                return False
             repaired_payload = None
             if self._should_attempt_oauth_storage_repair():
                 self._mark_oauth_storage_repair_attempt()

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -236,6 +236,7 @@ def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_onc
     connect_url = "https://hol.org/guard/connect"
     now = "2026-06-04T12:00:00+00:00"
     sync_calls: list[dict[str, object] | None] = []
+    bundle_calls: list[dict[str, object] | None] = []
 
     monkeypatch.setattr(
         store,
@@ -264,6 +265,11 @@ def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_onc
         }
 
     monkeypatch.setattr(daemon_server_module, "sync_local_guard_cloud_proof", _fake_sync)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "sync_supply_chain_bundle",
+        lambda _store, *, auth_context=None: bundle_calls.append(auth_context) or {"packages": []},
+    )
 
     payload = daemon_server_module._finalize_daemon_guard_connect_payload(
         store=store,
@@ -280,6 +286,13 @@ def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_onc
     )
 
     assert sync_calls == [
+        {
+            "access_token": "access-token-1",
+            "dpop_key_material": "dpop",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        }
+    ]
+    assert bundle_calls == [
         {
             "access_token": "access-token-1",
             "dpop_key_material": "dpop",

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6789,14 +6789,25 @@ url = http://127.0.0.1:8787/guard-canary
                 },
             }
 
-        def fake_sync_supply_chain_bundle(store: GuardStore) -> dict[str, object]:
+        def fake_sync_supply_chain_cloud_state(
+            store: GuardStore,
+            *,
+            auth_context: dict[str, object] | None = None,
+            workspace_dir: Path | None = None,
+        ) -> dict[str, object]:
             del store
+            assert auth_context is None
+            assert workspace_dir is None
             bundle_calls.append("bundle")
-            return {"synced_at": "2026-06-04T18:31:05+00:00", "status": "synced"}
+            return {
+                "synced_at": "2026-06-04T18:31:05+00:00",
+                "status": "synced",
+                "workspace_audits": {"status": "synced", "completed_jobs": 1},
+            }
 
         monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
         monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof)
-        monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", fake_sync_supply_chain_bundle)
+        monkeypatch.setattr(guard_commands_module, "sync_supply_chain_cloud_state", fake_sync_supply_chain_cloud_state)
 
         rc = main(
             [
@@ -8887,12 +8898,12 @@ url = http://127.0.0.1:8787/guard-canary
     def test_guard_sync_surfaces_auth_expired_reauth_message(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
 
-        def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        def _fail_auth(_store: GuardStore) -> dict[str, object]:
             raise guard_commands_module.GuardSyncAuthorizationExpiredError(
                 "Guard authorization expired. Run `hol-guard connect` to sign in again."
             )
 
-        monkeypatch.setattr(guard_commands_module, "sync_receipts", _fail_sync)
+        monkeypatch.setattr(guard_commands_module, "_resolve_guard_sync_auth_context", _fail_auth)
 
         rc = main(["guard", "sync", "--home", str(home_dir), "--json"])
         output = json.loads(capsys.readouterr().out)
@@ -8903,17 +8914,77 @@ url = http://127.0.0.1:8787/guard-canary
             "error": "Guard authorization expired. Run `hol-guard connect` to sign in again.",
         }
 
+    def test_guard_sync_includes_supply_chain_workspace_audits(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        captured_auth_context: list[dict[str, object]] = []
+
+        monkeypatch.setattr(
+            guard_commands_module,
+            "_resolve_guard_sync_auth_context",
+            lambda _store: {
+                "access_token": "token",
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+            },
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "_require_guard_context",
+            lambda _context: HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        )
+
+        def _fake_sync_receipts(_store: GuardStore, **kwargs: object) -> dict[str, object]:
+            auth_context = kwargs.get("auth_context")
+            assert isinstance(auth_context, dict)
+            captured_auth_context.append(auth_context)
+            assert kwargs.get("workspace_dir") == workspace_dir
+            return {
+                "synced_at": "2026-06-18T22:00:00Z",
+                "receipts_stored": 2,
+            }
+
+        def _fake_sync_supply_chain_cloud_state(_store: GuardStore, **kwargs: object) -> dict[str, object]:
+            auth_context = kwargs.get("auth_context")
+            assert isinstance(auth_context, dict)
+            captured_auth_context.append(auth_context)
+            assert kwargs.get("workspace_dir") == workspace_dir
+            return {
+                "synced_at": "2026-06-18T22:00:01Z",
+                "status": "synced",
+                "workspace_audits": {
+                    "status": "synced",
+                    "completed_jobs": 1,
+                },
+            }
+
+        monkeypatch.setattr(guard_commands_module, "sync_receipts", _fake_sync_receipts)
+        monkeypatch.setattr(
+            guard_commands_module,
+            "sync_supply_chain_cloud_state",
+            _fake_sync_supply_chain_cloud_state,
+        )
+
+        sync_rc = main(["guard", "sync", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert sync_rc == 0
+        assert output["receipts_stored"] == 2
+        assert output["supply_chain"]["workspace_audits"]["completed_jobs"] == 1
+        assert len(captured_auth_context) == 2
+        assert captured_auth_context[0] == captured_auth_context[1]
+
     def test_refresh_cloud_policy_bundle_records_auth_expired_reason(self, tmp_path, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         _seed_guard_cloud(store)
 
-        def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        def _fail_auth(_store: GuardStore) -> dict[str, object]:
             raise guard_commands_module.GuardSyncAuthorizationExpiredError(
                 "Guard authorization expired. Run `hol-guard connect` to sign in again."
             )
 
-        monkeypatch.setattr(guard_commands_module, "sync_receipts", _fail_sync)
+        monkeypatch.setattr(guard_commands_module, "_resolve_guard_sync_auth_context", _fail_auth)
 
         guard_commands_module._refresh_cloud_policy_bundle(store)
 
@@ -8935,8 +9006,20 @@ url = http://127.0.0.1:8787/guard-canary
             )
             return {"synced": True}
 
+        monkeypatch.setattr(
+            guard_commands_module,
+            "_resolve_guard_sync_auth_context",
+            lambda _store: {
+                "access_token": "token",
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+            },
+        )
         monkeypatch.setattr(guard_commands_module, "sync_receipts", _bundle_rejected)
-        monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", lambda _store: None)
+        monkeypatch.setattr(
+            guard_commands_module,
+            "sync_supply_chain_cloud_state",
+            lambda _store, **_kwargs: {"synced_at": "2026-04-09T00:00:00Z"},
+        )
 
         guard_commands_module._refresh_cloud_policy_bundle(store)
 
@@ -8958,7 +9041,11 @@ url = http://127.0.0.1:8787/guard-canary
             return {"synced": True}
 
         monkeypatch.setattr(guard_commands_module, "sync_receipts", _bundle_rejected)
-        monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", lambda _store: None)
+        monkeypatch.setattr(
+            guard_commands_module,
+            "sync_supply_chain_cloud_state",
+            lambda _store, **_kwargs: {"synced_at": "2026-04-09T00:00:00Z"},
+        )
 
         guard_commands_module._refresh_cloud_policy_bundle(store)
 
@@ -8981,7 +9068,19 @@ url = http://127.0.0.1:8787/guard-canary
             "sync_receipts",
             lambda _store, **_kwargs: {"synced": True},
         )
-        monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", lambda _store: None)
+        monkeypatch.setattr(
+            guard_commands_module,
+            "_resolve_guard_sync_auth_context",
+            lambda _store: {
+                "access_token": "token",
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+            },
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "sync_supply_chain_cloud_state",
+            lambda _store, **_kwargs: {"synced_at": "2026-04-09T00:00:00Z"},
+        )
 
         guard_commands_module._refresh_cloud_policy_bundle(store)
 

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -841,6 +841,71 @@ def test_sync_runtime_session_emits_package_manager_coverage_payload(
     }
 
 
+def test_sync_runtime_session_prefers_latest_sync_summary_for_package_manager_coverage_freshness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    context = HarnessContext(
+        home_dir=store.guard_home,
+        workspace_dir=workspace_dir,
+        guard_home=store.guard_home,
+    )
+    install_payload = install_package_shims(context, managers=("npm",))
+    shim_dir = Path(str(install_payload["shim_dir"]))
+    original_path = os.environ.get("PATH", "")
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}{original_path}")
+    store.set_sync_payload(
+        "supply_chain_bundle_summary",
+        {
+            "synced_at": "2026-04-24T00:00:00+00:00",
+        },
+        "2026-04-24T00:00:00+00:00",
+    )
+    store.set_sync_payload(
+        "sync_summary",
+        {
+            "synced_at": "2026-04-24T00:20:00+00:00",
+        },
+        "2026-04-24T00:20:00+00:00",
+    )
+
+    captured_body: dict[str, object] = {}
+
+    def _runtime_sync_response(**kwargs):
+        request = kwargs["request"]
+        captured_body.update(json.loads(request.data.decode("utf-8")))
+        return {"syncedAt": "2026-04-24T00:21:00+00:00", "items": []}
+
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_urlopen_json_with_timeout_retry",
+        _runtime_sync_response,
+    )
+
+    guard_runner_module.sync_runtime_session(
+        store,
+        session={
+            "harness": "codex",
+            "surface": "cli",
+            "status": "active",
+            "updatedAt": "2026-04-24T00:21:00+00:00",
+            "workspace": str(workspace_dir),
+        },
+    )
+
+    session_payload = captured_body["session"]
+    assert isinstance(session_payload, dict)
+    assert session_payload["packageManagerCoverage"]["staleIntel"] == {
+        "status": "fresh",
+        "lastSyncedAt": "2026-04-24T00:20:00+00:00",
+        "nextRefreshAt": "2026-04-24T00:35:00+00:00",
+    }
+
+
 def test_sync_runtime_session_prefers_ipv6_private_identity_when_ipv4_unavailable(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -21,7 +21,9 @@ from codex_plugin_scanner.guard.daemon import GuardDaemonServer
 from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.package_firewall_entitlement import resolve_package_firewall_entitlement
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.store import GuardStore
+from tests.test_guard_store_migrations import _install_fake_system_keyring
 
 
 def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
@@ -503,6 +505,76 @@ def test_browser_connect_caches_paid_package_firewall_entitlement(tmp_path: Path
         "tier": "pro",
         "upgrade_cta": None,
     }
+
+
+def test_browser_connect_persists_oauth_state_when_macos_keychain_readback_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    _install_fake_system_keyring(monkeypatch)
+    store = GuardStore(tmp_path / "guard-home")
+
+    class _BrowserSession:
+        authorize_url = "https://hol.org/guard/connect?step=authorize"
+        redirect_uri = "http://127.0.0.1:55221/oauth/callback"
+        pkce_verifier = "pkce-verifier"
+        dpop_key_material = GuardDpopKeyMaterial(
+            algorithm="ES256",
+            private_key_pem="private-key",
+            public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value"},
+            public_jwk_thumbprint="thumbprint-1",
+        )
+
+        def wait_for_callback(self, _timeout_seconds: float) -> GuardOAuthLoopbackCallback:
+            return GuardOAuthLoopbackCallback(code="auth-code-1", state="state-1")
+
+        def close(self) -> None:
+            return None
+
+    monkeypatch.setattr(
+        store._oauth_secret_store.primary,
+        "get_secret_with_timeout",
+        lambda _secret_id, *, timeout_seconds: None,
+    )
+
+    payload = run_guard_browser_connect_command(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        start_browser_session=lambda **_kwargs: _BrowserSession(),
+        open_browser=lambda _url: True,
+        exchange_authorization_code=lambda **_kwargs: GuardOAuthTokenExchangeResult(
+            access_token="access-token-1",
+            refresh_token="refresh-token-1",
+            expires_in=300,
+            scope=(
+                "guard:runtime.sync guard:receipt.write guard:runtime.session.write "
+                "guard:insights.share guard:offline_access"
+            ),
+            token_type="Bearer",
+            grant_id="grant-1",
+            machine_id="machine-1",
+            supply_chain_entitlement={
+                "supply_chain_entitlement_expires_at": "2026-07-05T01:39:51+00:00",
+                "supply_chain_firewall": True,
+                "supply_chain_plan_id": "pro",
+            },
+            workspace_id="workspace-1",
+        ),
+        now="2026-06-05T01:39:51+00:00",
+    )
+
+    assert payload["status"] == "connected"
+    assert store.get_oauth_local_credential_health()["state"] == "healthy"
+    assert store.get_cloud_sync_profile() == {
+        "auth_mode": "oauth",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "workspace_id": "workspace-1",
+    }
+    credentials = store.get_oauth_local_credentials(allow_primary=False)
+    assert isinstance(credentials, dict)
+    assert credentials["grant_id"] == "grant-1"
+    assert credentials["machine_id"] == "machine-1"
 
 
 def test_missing_cloud_connection_prefers_connect_over_false_paywall(tmp_path: Path) -> None:

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -944,7 +944,7 @@ def test_supply_chain_sync_returns_json_when_bundle_sync_fails_after_approval(
     def _fail_sync(_store: GuardStore) -> dict[str, object]:
         raise RuntimeError("Guard supply-chain bundle sync failed: simulated network failure")
 
-    monkeypatch.setattr(daemon_server, "sync_supply_chain_bundle", _fail_sync)
+    monkeypatch.setattr(daemon_server, "sync_supply_chain_cloud_state", _fail_sync)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
@@ -994,7 +994,7 @@ def test_supply_chain_sync_returns_retryable_unavailable_when_cloud_outage(
             retryable=True,
         )
 
-    monkeypatch.setattr(daemon_server, "sync_supply_chain_bundle", _fail_sync)
+    monkeypatch.setattr(daemon_server, "sync_supply_chain_cloud_state", _fail_sync)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
@@ -1043,7 +1043,7 @@ def test_supply_chain_sync_returns_reconnect_error_when_auth_expired(
             "Guard authorization expired. Run `hol-guard connect` to sign in again."
         )
 
-    monkeypatch.setattr(daemon_server, "sync_supply_chain_bundle", _fail_sync)
+    monkeypatch.setattr(daemon_server, "sync_supply_chain_cloud_state", _fail_sync)
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -176,6 +176,67 @@ def test_guard_supply_chain_scan_uses_cloud_batch_for_premium_workspaces(
     assert {item["name"] for item in captured["request_payload"]["packages"]} == {"minimist", "chalk"}
 
 
+def test_sync_managed_workspace_audits_enqueues_persisted_job_mode_for_managed_workspaces(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(
+        workspace_dir / "package.json",
+        '{"name":"demo","dependencies":{"react":"18.2.0"}}\n',
+    )
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "name": "demo",
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"dependencies": {"react": "18.2.0"}},
+                    "node_modules/react": {"version": "18.2.0"},
+                },
+            }
+        )
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    _seed_premium_pairing(store, now="2026-05-25T10:00:00+00:00")
+    store.set_managed_install("codex", True, str(workspace_dir), {}, "2026-05-25T10:00:00+00:00")
+    captured_payloads: list[dict[str, object]] = []
+
+    def _fake_enqueue_job(**kwargs: object) -> dict[str, object]:
+        request_payload = kwargs.get("request_payload")
+        assert isinstance(request_payload, dict)
+        captured_payloads.append(request_payload)
+        return {"jobId": "job-1", "status": "queued"}
+
+    monkeypatch.setattr(local_supply_chain_module, "_enqueue_cloud_workspace_audit_job", _fake_enqueue_job)
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "_poll_cloud_workspace_audit_job",
+        lambda **_kwargs: {"jobId": "job-1", "status": "completed"},
+    )
+
+    summary = local_supply_chain_module.sync_managed_workspace_audits(
+        store,
+        auth_context={
+            "access_token": "token",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        },
+    )
+
+    assert captured_payloads
+    assert captured_payloads[0]["mode"] == "job"
+    assert captured_payloads[0]["pageSize"] == 1
+    assert summary["status"] == "synced"
+    assert summary["completed_jobs"] == 1
+    assert summary["failed_jobs"] == 0
+    assert summary["workspaces"][0]["job_id"] == "job-1"
+    assert summary["workspaces"][0]["package_count"] == 1
+
+
 def test_guard_supply_chain_audit_alias_accepts_sbom_input(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_guard_package_shims_cli.py
+++ b/tests/test_guard_package_shims_cli.py
@@ -162,9 +162,20 @@ def test_package_shims_status_self_heals_connected_cloud_auth_without_cached_ent
     capsys: pytest.CaptureFixture[str],
     seed_connected_oauth_without_entitlement,
 ) -> None:
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
     guard_home = tmp_path / "guard-home"
     seed_connected_oauth_without_entitlement(GuardStore(guard_home))
     calls: list[str] = []
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_test_sync_auth_context_override",
+        {
+            "access_token": "demo-token",
+            "dpop_key_material": None,
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        },
+    )
 
     def _fake_sync_local_guard_cloud_proof(store: GuardStore) -> dict[str, object]:
         calls.append("proof")
@@ -204,6 +215,77 @@ def test_package_shims_status_self_heals_connected_cloud_auth_without_cached_ent
         "upgrade_cta": None,
     }
     assert payload["actions"]["install"] == "available"
+
+
+def test_package_firewall_entitlement_refresh_reuses_one_auth_context(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    seed_connected_oauth_without_entitlement,
+) -> None:
+    from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
+
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    seed_connected_oauth_without_entitlement(store)
+    shared_auth_context = {
+        "access_token": "demo-token",
+        "dpop_key_material": None,
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+    }
+    calls: list[tuple[str, dict[str, object] | None]] = []
+
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_test_sync_auth_context_override",
+        shared_auth_context,
+    )
+
+    def _fake_sync_local_guard_cloud_proof(
+        current_store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append(("proof", auth_context))
+        current_store.record_latest_guard_connect_sync_success(
+            sync_payload={"synced_at": "2026-06-05T01:41:00+00:00", "receipts_stored": 1},
+            now="2026-06-05T01:41:00+00:00",
+        )
+        return {"synced_at": "2026-06-05T01:41:00+00:00", "receipts_stored": 1}
+
+    def _fake_sync_supply_chain_bundle(
+        current_store: GuardStore,
+        *,
+        auth_context: dict[str, object] | None = None,
+    ) -> dict[str, object]:
+        calls.append(("bundle", auth_context))
+        current_store.set_sync_payload(
+            "supply_chain_bundle_entitlement",
+            {
+                "bundle_version": "bundle-version-test",
+                "key_id": "bundle-key-test",
+                "policy_hash": "policy-hash-test",
+                "tier": "pro",
+                "workspace_id": "workspace-1",
+            },
+            "2026-06-05T01:41:05+00:00",
+        )
+        return {"bundle_version": "bundle-version-test", "tier": "pro"}
+
+    monkeypatch.setattr(local_supply_chain_module, "sync_local_guard_cloud_proof", _fake_sync_local_guard_cloud_proof)
+    monkeypatch.setattr(local_supply_chain_module, "sync_supply_chain_bundle", _fake_sync_supply_chain_bundle)
+
+    entitlement = local_supply_chain_module.resolve_package_firewall_entitlement_with_refresh(store)
+
+    assert calls == [
+        ("proof", shared_auth_context),
+        ("bundle", shared_auth_context),
+    ]
+    assert entitlement == {
+        "allowed": True,
+        "reason": "paid_entitlement_active",
+        "tier": "pro",
+        "upgrade_cta": None,
+    }
 
 
 def test_package_shims_status_preserves_reconnect_gate_when_connected_auth_refresh_expires(

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -1616,6 +1616,98 @@ def test_oauth_health_auto_repairs_stale_encrypted_fallback_from_primary(tmp_pat
     }
 
 
+def test_oauth_health_auto_repairs_from_recoverable_fallback_when_primary_secret_is_missing(
+    tmp_path,
+    monkeypatch,
+):
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----[REDACTED:Private key block]\\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    secret_id = str(oauth_payload["credentials_ref"])
+    fallback_secret = store._oauth_secret_store.fallback.get_secret(secret_id)
+    assert isinstance(fallback_secret, str)
+    fake_keyring.delete_password("hol-guard.oauth", secret_id)
+    oauth_payload["credentials_sha256"] = "pbkdf2-sha256$" + ("0" * 64)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-01T00:01:00+00:00")
+
+    health = store.get_oauth_local_credential_health()
+    profile = store.get_cloud_sync_profile()
+    repaired_payload = store.get_sync_payload("oauth_local_credentials")
+
+    assert health["state"] == "healthy"
+    assert store.get_oauth_local_credentials() is not None
+    assert profile == {
+        "auth_mode": "oauth",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "workspace_id": "workspace-123",
+    }
+    assert isinstance(repaired_payload, dict)
+    assert repaired_payload["credentials_sha256"] == guard_store_module._secret_fingerprint(fallback_secret)
+
+
+def test_oauth_health_auto_repairs_from_recoverable_fallback_when_macos_keychain_readback_is_unavailable(
+    tmp_path,
+    monkeypatch,
+):
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    guard_home = tmp_path / "guard-home"
+    store = GuardStore(guard_home)
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----[REDACTED:Private key block]\\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    oauth_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(oauth_payload, dict)
+    secret_id = str(oauth_payload["credentials_ref"])
+    fallback_secret = store._oauth_secret_store.fallback.get_secret(secret_id)
+    assert isinstance(fallback_secret, str)
+    fake_keyring.delete_password("hol-guard.oauth", secret_id)
+    oauth_payload["credentials_sha256"] = "pbkdf2-sha256$" + ("0" * 64)
+    store.set_sync_payload("oauth_local_credentials", oauth_payload, "2026-06-01T00:01:00+00:00")
+    monkeypatch.setattr(
+        store._oauth_secret_store.primary,
+        "get_secret_with_timeout",
+        lambda _secret_id, *, timeout_seconds: None,
+    )
+
+    health = store.get_oauth_local_credential_health()
+    profile = store.get_cloud_sync_profile()
+    repaired_payload = store.get_sync_payload("oauth_local_credentials")
+
+    assert health["state"] == "healthy"
+    assert store.get_oauth_local_credentials(allow_primary=False) is not None
+    assert profile == {
+        "auth_mode": "oauth",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "workspace_id": "workspace-123",
+    }
+    assert isinstance(repaired_payload, dict)
+    assert repaired_payload["credentials_sha256"] == guard_store_module._secret_fingerprint(fallback_secret)
+
+
 def test_oauth_health_caches_degraded_state_between_failed_repair_attempts(tmp_path, monkeypatch):
     fake_keyring = _install_fake_system_keyring(monkeypatch)
     monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)


### PR DESCRIPTION
## Summary
- reuse a single Guard Cloud auth context across first-sync proof, bundle refresh, and package-firewall self-heal paths
- persist workspace supply-chain audits during connect, sync, and daemon-triggered package sync so Guard Cloud receives durable batch jobs instead of local-only paged scans
- return workspace-audit sync summaries through CLI and daemon sync responses while keeping existing reconnect and outage errors intact

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_guard_local_supply_chain_audit_phase16.py -k 'sync_managed_workspace_audits_enqueues_persisted_job_mode_for_managed_workspaces or guard_supply_chain_scan_uses_cloud_batch_for_premium_workspaces or run_cloud_workspace_audit_falls_back_after_page_limit'`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_cli.py -k 'guard_connect_runs_first_sync_and_surfaces_cloud_urls or guard_sync_includes_supply_chain_workspace_audits or guard_sync_surfaces_auth_expired_reauth_message or refresh_cloud_policy_bundle_records_auth_expired_reason or refresh_cloud_policy_bundle_preserves_bundle_rejection_reason or refresh_cloud_policy_bundle_clears_non_bundle_errors_after_success'`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_headless_daemon_api.py -k 'test_supply_chain_sync_returns_json_when_bundle_sync_fails_after_approval or test_supply_chain_sync_returns_retryable_unavailable_when_cloud_outage or test_supply_chain_sync_returns_reconnect_error_when_auth_expired'`
