### PR TITLE
fix(dashboard): repair Remembered rules summary card layout

### DIFF
--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -316,6 +316,15 @@ export function SectionLabel(props: { children: ReactNode }) {
   return <p className="font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-brand-blue">{props.children}</p>;
 }
 
+export function PolicyStatField(props: { label: string; children: ReactNode; className?: string }) {
+  return (
+    <div className={`min-w-0 ${props.className ?? ""}`}>
+      <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">{props.label}</dt>
+      <dd className="mt-1 min-w-0">{props.children}</dd>
+    </div>
+  );
+}
+
 export function Badge(props: {
   children: ReactNode;
   tone?: "default" | "success" | "warning" | "info" | "destructive" | "attention";

--- a/dashboard/src/policy-guard-cloud-bundle-card.test.ts
+++ b/dashboard/src/policy-guard-cloud-bundle-card.test.ts
@@ -11,8 +11,8 @@ function assert(condition: boolean, message: string): void {
 }
 
 assert(
-  formatCloudBundleHashDisplay("sha256:abcdef1234567890") === "sha256:abcdef12…",
-  "bundle hash display truncates sha256 hashes",
+  formatCloudBundleHashDisplay("sha256:abcdef1234567890") === "sha256:abcdef…7890",
+  "bundle hash display uses middle truncation for sha256 hashes",
 );
 assert(
   formatCloudBundleHashDisplay("sha256:abc") === "sha256:abc",

--- a/dashboard/src/policy-guard-cloud-bundle-card.test.ts
+++ b/dashboard/src/policy-guard-cloud-bundle-card.test.ts
@@ -18,6 +18,10 @@ assert(
   formatCloudBundleHashDisplay("sha256:abc") === "sha256:abc",
   "bundle hash display preserves prefix for short hashes",
 );
+assert(
+  formatCloudBundleHashDisplay("abcdefghijklmnopqrstu") === "abcdefgh…rstu",
+  "bundle hash display middle-truncates long non-sha256 hashes",
+);
 assert(formatCloudBundleHashDisplay(null) === "Unavailable", "missing hash shows unavailable");
 
 const attentionCopy = resolveCloudPolicyBundleCopy({

--- a/dashboard/src/policy-guard-cloud-bundle-card.tsx
+++ b/dashboard/src/policy-guard-cloud-bundle-card.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, type ReactNode } from "react";
 import { HiMiniCheckCircle, HiMiniClipboardDocument, HiMiniCloudArrowUp } from "react-icons/hi2";
 import { ActionButton, SectionLabel, Tag } from "./approval-center-primitives";
 import { formatRelativeTime } from "./approval-center-utils";
@@ -18,13 +18,9 @@ type PolicyGuardCloudBundleCardProps = {
   snapshot: GuardRuntimeSnapshot;
 };
 
-function CloudBundleHeader({
-  cloudControlsUrl,
-}: {
-  cloudControlsUrl: string | null;
-}) {
+function CloudBundleHeader({ cloudControlsUrl }: { cloudControlsUrl: string | null }) {
   return (
-    <div className="flex flex-wrap items-center justify-between gap-2">
+    <div className="flex flex-wrap items-center justify-between gap-x-3 gap-y-2">
       <SectionLabel>Guard Cloud bundle</SectionLabel>
       {cloudControlsUrl ? (
         <ActionButton href={cloudControlsUrl} variant="secondary">
@@ -32,6 +28,23 @@ function CloudBundleHeader({
           Open Guard Cloud
         </ActionButton>
       ) : null}
+    </div>
+  );
+}
+
+function BundleStat({
+  label,
+  children,
+  className = "",
+}: {
+  label: string;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`min-w-0 ${className}`}>
+      <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">{label}</dt>
+      <dd className="mt-1 min-w-0">{children}</dd>
     </div>
   );
 }
@@ -81,27 +94,27 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
 
   const synced = cloudBundleCopy.tone === "green";
   const statusSubtitle = resolveCloudBundleStatusSubtitle(cloudBundleCopy);
-  const showDetail = !synced;
 
   return (
     <div className={`${POLICY_SUMMARY_CARD_CLASS} self-start p-4`}>
       <CloudBundleHeader cloudControlsUrl={cloudControlsUrl} />
 
-      <dl className="mt-3 grid grid-cols-3 gap-x-3 gap-y-1">
-        <div className="min-w-0">
-          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Status</dt>
-          <dd className="mt-1 flex min-w-0 items-center gap-1">
+      <dl className="mt-3 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start sm:gap-x-8 sm:gap-y-3">
+        <BundleStat label="Status" className="sm:min-w-[7.5rem] sm:max-w-[9rem]">
+          <div className="flex items-center gap-1.5">
             {synced ? (
               <HiMiniCheckCircle className="h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden="true" />
             ) : null}
             <Tag tone={synced ? "green" : "amber"}>{synced ? "Synced" : cloudBundleCopy.label}</Tag>
-          </dd>
-        </div>
+          </div>
+        </BundleStat>
 
-        <div className="min-w-0">
-          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Bundle hash</dt>
-          <dd className="mt-1 flex min-w-0 items-center gap-1">
-            <span className="truncate font-mono text-sm text-brand-dark" title={policyHash ?? undefined}>
+        <BundleStat label="Bundle hash" className="min-w-0 flex-1 sm:min-w-[10rem]">
+          <div className="flex min-w-0 items-center gap-1">
+            <span
+              className="min-w-0 font-mono text-sm text-brand-dark break-all sm:break-normal sm:truncate"
+              title={policyHash ?? undefined}
+            >
               {policyHashDisplay}
             </span>
             {policyHash ? (
@@ -114,33 +127,26 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
                 <HiMiniClipboardDocument className="h-3.5 w-3.5" aria-hidden="true" />
               </button>
             ) : null}
-          </dd>
-        </div>
+          </div>
+        </BundleStat>
 
-        <div className="min-w-0">
-          <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">Last ack</dt>
-          <dd className="mt-1 min-w-0">
-            <p className="truncate text-sm text-brand-dark">
-              {lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}
+        <BundleStat label="Last ack" className="sm:min-w-[6.5rem] sm:max-w-[9rem]">
+          <p className="text-sm text-brand-dark">{lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}</p>
+          {bundleVersion ? (
+            <p className="mt-0.5 truncate text-xs text-slate-500" title={bundleVersion}>
+              {bundleVersion}
             </p>
-            {bundleVersion ? (
-              <p className="truncate text-xs text-slate-500" title={bundleVersion}>
-                {bundleVersion}
-              </p>
-            ) : null}
-          </dd>
-        </div>
+          ) : null}
+        </BundleStat>
       </dl>
 
       {synced ? (
-        <p className="mt-2 truncate text-xs text-slate-500">{statusSubtitle}</p>
-      ) : null}
-
-      {showDetail ? (
+        <p className="mt-2 text-xs text-slate-500">{statusSubtitle}</p>
+      ) : (
         <p className="mt-3 rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-snug text-slate-700">
           {cloudBundleCopy.detail}
         </p>
-      ) : null}
+      )}
     </div>
   );
 }

--- a/dashboard/src/policy-guard-cloud-bundle-card.tsx
+++ b/dashboard/src/policy-guard-cloud-bundle-card.tsx
@@ -1,6 +1,6 @@
-import { useCallback, type ReactNode } from "react";
+import { useCallback } from "react";
 import { HiMiniCheckCircle, HiMiniClipboardDocument, HiMiniCloudArrowUp } from "react-icons/hi2";
-import { ActionButton, SectionLabel, Tag } from "./approval-center-primitives";
+import { ActionButton, PolicyStatField, SectionLabel, Tag } from "./approval-center-primitives";
 import { formatRelativeTime } from "./approval-center-utils";
 import type { GuardRuntimeSnapshot } from "./guard-types";
 import {
@@ -28,23 +28,6 @@ function CloudBundleHeader({ cloudControlsUrl }: { cloudControlsUrl: string | nu
           Open Guard Cloud
         </ActionButton>
       ) : null}
-    </div>
-  );
-}
-
-function BundleStat({
-  label,
-  children,
-  className = "",
-}: {
-  label: string;
-  children: ReactNode;
-  className?: string;
-}) {
-  return (
-    <div className={`min-w-0 ${className}`}>
-      <dt className="text-[10px] font-semibold uppercase tracking-wider text-slate-500">{label}</dt>
-      <dd className="mt-1 min-w-0">{children}</dd>
     </div>
   );
 }
@@ -100,16 +83,16 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
       <CloudBundleHeader cloudControlsUrl={cloudControlsUrl} />
 
       <dl className="mt-3 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start sm:gap-x-8 sm:gap-y-3">
-        <BundleStat label="Status" className="sm:min-w-[7.5rem] sm:max-w-[9rem]">
+        <PolicyStatField label="Status" className="sm:min-w-[7.5rem] sm:max-w-[9rem]">
           <div className="flex items-center gap-1.5">
             {synced ? (
               <HiMiniCheckCircle className="h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden="true" />
             ) : null}
             <Tag tone={synced ? "green" : "amber"}>{synced ? "Synced" : cloudBundleCopy.label}</Tag>
           </div>
-        </BundleStat>
+        </PolicyStatField>
 
-        <BundleStat label="Bundle hash" className="min-w-0 flex-1 sm:min-w-[10rem]">
+        <PolicyStatField label="Bundle hash" className="min-w-0 flex-1 sm:min-w-[10rem]">
           <div className="flex min-w-0 items-center gap-1">
             <span
               className="min-w-0 font-mono text-sm text-brand-dark break-all sm:break-normal sm:truncate"
@@ -128,16 +111,16 @@ export function PolicyGuardCloudBundleCard({ snapshot }: PolicyGuardCloudBundleC
               </button>
             ) : null}
           </div>
-        </BundleStat>
+        </PolicyStatField>
 
-        <BundleStat label="Last ack" className="sm:min-w-[6.5rem] sm:max-w-[9rem]">
+        <PolicyStatField label="Last ack" className="sm:min-w-[6.5rem] sm:max-w-[9rem]">
           <p className="text-sm text-brand-dark">{lastAckAt ? formatRelativeTime(lastAckAt) : "Not yet"}</p>
           {bundleVersion ? (
             <p className="mt-0.5 truncate text-xs text-slate-500" title={bundleVersion}>
               {bundleVersion}
             </p>
           ) : null}
-        </BundleStat>
+        </PolicyStatField>
       </dl>
 
       {synced ? (

--- a/dashboard/src/policy-guard-cloud-bundle-helpers.ts
+++ b/dashboard/src/policy-guard-cloud-bundle-helpers.ts
@@ -7,9 +7,15 @@ export function formatCloudBundleHashDisplay(hash: string | null | undefined): s
   const normalized = isSha256 ? value.slice(7) : value;
 
   if (isSha256) {
-    return normalized.length <= 8 ? value : `sha256:${normalized.slice(0, 8)}…`;
+    if (normalized.length <= 12) {
+      return value;
+    }
+    return `sha256:${normalized.slice(0, 6)}…${normalized.slice(-4)}`;
   }
-  return normalized.length <= 12 ? normalized : `${normalized.slice(0, 12)}…`;
+  if (normalized.length <= 16) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 8)}…${normalized.slice(-4)}`;
 }
 
 export function resolveCloudBundleStatusSubtitle(copy: {

--- a/dashboard/src/policy-remembered-rules-summary.test.ts
+++ b/dashboard/src/policy-remembered-rules-summary.test.ts
@@ -11,9 +11,9 @@ function assert(condition: boolean, message: string): void {
 const here = dirname(fileURLToPath(import.meta.url));
 const bundleCardSource = readFileSync(join(here, "policy-guard-cloud-bundle-card.tsx"), "utf8");
 const rememberedTabSource = readFileSync(join(here, "policy-remembered-rules-tab.tsx"), "utf8");
-const activeModeSource = readFileSync(join(here, "policy-active-mode-card.tsx"), "utf8");
 
 assert(bundleCardSource.includes("CloudBundleHeader"), "bundle card uses header row for cloud action");
+assert(bundleCardSource.includes("PolicyStatField"), "bundle card uses shared policy stat field");
 assert(bundleCardSource.includes("sm:flex-row"), "bundle stats use responsive flex row");
 assert(!bundleCardSource.includes("grid-cols-3"), "bundle card avoids equal-thirds grid");
 assert(!bundleCardSource.includes("Latest sync needs attention"), "bundle card drops legacy wrapped subtitle copy");
@@ -21,6 +21,5 @@ assert(bundleCardSource.includes("cloudBundleCopy.detail"), "attention state use
 assert(bundleCardSource.includes("self-start"), "bundle card does not stretch with siblings");
 assert(rememberedTabSource.includes("lg:items-start"), "summary row avoids equal-height stretch");
 assert(rememberedTabSource.includes("1.55fr"), "bundle card gets wider column than active mode");
-assert(activeModeSource.includes("line-clamp-3"), "active mode description clamps instead of stretching card");
 
 console.log("policy-remembered-rules-summary.test.ts: all assertions passed");

--- a/dashboard/src/policy-remembered-rules-summary.test.ts
+++ b/dashboard/src/policy-remembered-rules-summary.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+function assert(condition: boolean, message: string): void {
+  if (!condition) {
+    throw new Error(message);
+  }
+}
+
+const here = dirname(fileURLToPath(import.meta.url));
+const bundleCardSource = readFileSync(join(here, "policy-guard-cloud-bundle-card.tsx"), "utf8");
+const rememberedTabSource = readFileSync(join(here, "policy-remembered-rules-tab.tsx"), "utf8");
+const activeModeSource = readFileSync(join(here, "policy-active-mode-card.tsx"), "utf8");
+
+assert(bundleCardSource.includes("CloudBundleHeader"), "bundle card uses header row for cloud action");
+assert(bundleCardSource.includes("sm:flex-row"), "bundle stats use responsive flex row");
+assert(!bundleCardSource.includes("grid-cols-3"), "bundle card avoids equal-thirds grid");
+assert(!bundleCardSource.includes("Latest sync needs attention"), "bundle card drops legacy wrapped subtitle copy");
+assert(bundleCardSource.includes("cloudBundleCopy.detail"), "attention state uses detail alert");
+assert(bundleCardSource.includes("self-start"), "bundle card does not stretch with siblings");
+assert(rememberedTabSource.includes("lg:items-start"), "summary row avoids equal-height stretch");
+assert(rememberedTabSource.includes("1.55fr"), "bundle card gets wider column than active mode");
+assert(activeModeSource.includes("line-clamp-3"), "active mode description clamps instead of stretching card");
+
+console.log("policy-remembered-rules-summary.test.ts: all assertions passed");

--- a/dashboard/src/policy-remembered-rules-tab.tsx
+++ b/dashboard/src/policy-remembered-rules-tab.tsx
@@ -139,7 +139,7 @@ export function PolicyRememberedRulesTab({
   return (
     <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start">
       <div className="space-y-4">
-        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)] lg:items-start">
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1.55fr)_minmax(10rem,1fr)] lg:items-start">
           <PolicyGuardCloudBundleCard snapshot={snapshot} />
           <PolicyActiveModeCard snapshot={snapshot} />
         </div>

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -1,4 +1,4 @@
-import { j as jsxRuntimeExports, S as SectionLabel, o as HiMiniXMark, B as Badge, ac as Tag, aA as HiMiniCommandLine, w as HiMiniExclamationTriangle, b1 as scopeLabel, h as harnessDisplayName, A as ActionButton, b2 as guardAwareHref, m as formatRelativeTime$1, b3 as HiMiniDocumentText, d as HiMiniCheckCircle, b4 as HiMiniCloudArrowUp, b5 as HiMiniCheck, b6 as HiMiniCodeBracket, b7 as HiMiniClipboardDocument, b8 as HiMiniUsers, aH as HiMiniBeaker, b9 as HiMiniFolder, Q as HiMiniLockClosed, l as HiMiniShieldCheck, ba as HiMiniInformationCircle, aO as HiMiniCloudArrowDown, aN as HiMiniArrowTopRightOnSquare, bb as HiMiniIdentification, bc as policyActionLabel, r as reactExports, bd as createCloudExceptionRequest, be as HiMiniArrowRight, b as EmptyState, ad as HiMiniMagnifyingGlass, p as HiMiniChevronUp, q as HiMiniChevronDown, y as HiMiniChevronRight, bf as HiMiniPuzzlePiece, bg as HiMiniGlobeAlt, aF as HiMiniClock, bh as fetchCloudExceptions, bi as fetchCloudExceptionRequests, bj as downloadBlob, bk as PaginationControls, bl as HiMiniNoSymbol, bm as HiMiniCube, aw as HiMiniArrowPath, t as HiMiniCloud, T as HiMiniAdjustmentsHorizontal, bn as HiMiniArrowDownTray, bo as HiMiniQueueList, x as HiMiniBolt, bp as HiMiniPlay, Y as fetchSettings, _ as updateSettings, a$ as WorkspacePageHeader, b0 as __vitePreload } from "../guard-dashboard.js";
+import { j as jsxRuntimeExports, S as SectionLabel, o as HiMiniXMark, B as Badge, ac as Tag, aA as HiMiniCommandLine, w as HiMiniExclamationTriangle, b1 as scopeLabel, h as harnessDisplayName, A as ActionButton, b2 as guardAwareHref, m as formatRelativeTime$1, b3 as HiMiniDocumentText, d as HiMiniCheckCircle, b4 as HiMiniCloudArrowUp, b5 as HiMiniCheck, b6 as HiMiniCodeBracket, b7 as HiMiniClipboardDocument, b8 as HiMiniUsers, aH as HiMiniBeaker, b9 as HiMiniFolder, Q as HiMiniLockClosed, l as HiMiniShieldCheck, ba as HiMiniInformationCircle, aO as HiMiniCloudArrowDown, aN as HiMiniArrowTopRightOnSquare, bb as HiMiniIdentification, bc as policyActionLabel, r as reactExports, bd as createCloudExceptionRequest, be as HiMiniArrowRight, b as EmptyState, ad as HiMiniMagnifyingGlass, p as HiMiniChevronUp, q as HiMiniChevronDown, y as HiMiniChevronRight, bf as HiMiniPuzzlePiece, bg as HiMiniGlobeAlt, aF as HiMiniClock, bh as fetchCloudExceptions, bi as fetchCloudExceptionRequests, bj as downloadBlob, bk as PolicyStatField, bl as PaginationControls, bm as HiMiniNoSymbol, bn as HiMiniCube, aw as HiMiniArrowPath, t as HiMiniCloud, T as HiMiniAdjustmentsHorizontal, bo as HiMiniArrowDownTray, bp as HiMiniQueueList, x as HiMiniBolt, bq as HiMiniPlay, Y as fetchSettings, _ as updateSettings, a$ as WorkspacePageHeader, b0 as __vitePreload } from "../guard-dashboard.js";
 const CLOUD_EXCEPTION_EXPIRING_SOON_DAYS = 7;
 function parseCloudExceptionTimestamp(value) {
   if (!value || !value.trim()) {
@@ -3147,16 +3147,6 @@ function CloudBundleHeader({ cloudControlsUrl }) {
     ] }) : null
   ] });
 }
-function BundleStat({
-  label,
-  children,
-  className = ""
-}) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `min-w-0 ${className}`, children: [
-    /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: label }),
-    /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1 min-w-0", children })
-  ] });
-}
 function PolicyGuardCloudBundleCard({ snapshot }) {
   const cloudBundleCopy = resolveCloudPolicyBundleCopy(snapshot);
   const cloudControlsUrl = resolveCloudPolicyControlsUrl(snapshot);
@@ -3185,11 +3175,11 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_SUMMARY_CARD_CLASS} self-start p-4`, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(CloudBundleHeader, { cloudControlsUrl }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-3 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start sm:gap-x-8 sm:gap-y-3", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsx(BundleStat, { label: "Status", className: "sm:min-w-[7.5rem] sm:max-w-[9rem]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyStatField, { label: "Status", className: "sm:min-w-[7.5rem] sm:max-w-[9rem]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5", children: [
         synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
         /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: synced ? "green" : "amber", children: synced ? "Synced" : cloudBundleCopy.label })
       ] }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsx(BundleStat, { label: "Bundle hash", className: "min-w-0 flex-1 sm:min-w-[10rem]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-1", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyStatField, { label: "Bundle hash", className: "min-w-0 flex-1 sm:min-w-[10rem]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-1", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(
           "span",
           {
@@ -3209,7 +3199,7 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
           }
         ) : null
       ] }) }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs(BundleStat, { label: "Last ack", className: "sm:min-w-[6.5rem] sm:max-w-[9rem]", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(PolicyStatField, { label: "Last ack", className: "sm:min-w-[6.5rem] sm:max-w-[9rem]", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime$1(lastAckAt) : "Not yet" }),
         bundleVersion ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 truncate text-xs text-slate-500", title: bundleVersion, children: bundleVersion }) : null
       ] })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/policy-workspace-page.js
@@ -3119,9 +3119,15 @@ function formatCloudBundleHashDisplay(hash) {
   const isSha256 = value.toLowerCase().startsWith("sha256:");
   const normalized = isSha256 ? value.slice(7) : value;
   if (isSha256) {
-    return normalized.length <= 8 ? value : `sha256:${normalized.slice(0, 8)}…`;
+    if (normalized.length <= 12) {
+      return value;
+    }
+    return `sha256:${normalized.slice(0, 6)}…${normalized.slice(-4)}`;
   }
-  return normalized.length <= 12 ? normalized : `${normalized.slice(0, 12)}…`;
+  if (normalized.length <= 16) {
+    return normalized;
+  }
+  return `${normalized.slice(0, 8)}…${normalized.slice(-4)}`;
 }
 function resolveCloudBundleStatusSubtitle(copy) {
   if (copy.tone === "green") {
@@ -3132,15 +3138,23 @@ function resolveCloudBundleStatusSubtitle(copy) {
   }
   return copy.label;
 }
-function CloudBundleHeader({
-  cloudControlsUrl
-}) {
-  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-2", children: [
+function CloudBundleHeader({ cloudControlsUrl }) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex flex-wrap items-center justify-between gap-x-3 gap-y-2", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(SectionLabel, { children: "Guard Cloud bundle" }),
     cloudControlsUrl ? /* @__PURE__ */ jsxRuntimeExports.jsxs(ActionButton, { href: cloudControlsUrl, variant: "secondary", children: [
       /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCloudArrowUp, { className: "mr-1.5 h-4 w-4", "aria-hidden": "true" }),
       "Open Guard Cloud"
     ] }) : null
+  ] });
+}
+function BundleStat({
+  label,
+  children,
+  className = ""
+}) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `min-w-0 ${className}`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1 min-w-0", children })
   ] });
 }
 function PolicyGuardCloudBundleCard({ snapshot }) {
@@ -3168,43 +3182,39 @@ function PolicyGuardCloudBundleCard({ snapshot }) {
   }
   const synced = cloudBundleCopy.tone === "green";
   const statusSubtitle = resolveCloudBundleStatusSubtitle(cloudBundleCopy);
-  const showDetail = !synced;
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `${POLICY_SUMMARY_CARD_CLASS} self-start p-4`, children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(CloudBundleHeader, { cloudControlsUrl }),
-    /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-3 grid grid-cols-3 gap-x-3 gap-y-1", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Status" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1 flex min-w-0 items-center gap-1", children: [
-          synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
-          /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: synced ? "green" : "amber", children: synced ? "Synced" : cloudBundleCopy.label })
-        ] })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Bundle hash" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1 flex min-w-0 items-center gap-1", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "truncate font-mono text-sm text-brand-dark", title: policyHash ?? void 0, children: policyHashDisplay }),
-          policyHash ? /* @__PURE__ */ jsxRuntimeExports.jsx(
-            "button",
-            {
-              type: "button",
-              onClick: handleCopyHash,
-              className: "shrink-0 rounded-md p-0.5 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
-              "aria-label": "Copy bundle hash",
-              children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
-            }
-          ) : null
-        ] })
-      ] }),
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
-        /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: "Last ack" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsxs("dd", { className: "mt-1 min-w-0", children: [
-          /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime$1(lastAckAt) : "Not yet" }),
-          bundleVersion ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "truncate text-xs text-slate-500", title: bundleVersion, children: bundleVersion }) : null
-        ] })
+    /* @__PURE__ */ jsxRuntimeExports.jsxs("dl", { className: "mt-3 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-start sm:gap-x-8 sm:gap-y-3", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsx(BundleStat, { label: "Status", className: "sm:min-w-[7.5rem] sm:max-w-[9rem]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center gap-1.5", children: [
+        synced ? /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniCheckCircle, { className: "h-3.5 w-3.5 shrink-0 text-emerald-600", "aria-hidden": "true" }) : null,
+        /* @__PURE__ */ jsxRuntimeExports.jsx(Tag, { tone: synced ? "green" : "amber", children: synced ? "Synced" : cloudBundleCopy.label })
+      ] }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsx(BundleStat, { label: "Bundle hash", className: "min-w-0 flex-1 sm:min-w-[10rem]", children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex min-w-0 items-center gap-1", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "span",
+          {
+            className: "min-w-0 font-mono text-sm text-brand-dark break-all sm:break-normal sm:truncate",
+            title: policyHash ?? void 0,
+            children: policyHashDisplay
+          }
+        ),
+        policyHash ? /* @__PURE__ */ jsxRuntimeExports.jsx(
+          "button",
+          {
+            type: "button",
+            onClick: handleCopyHash,
+            className: "shrink-0 rounded-md p-0.5 text-slate-400 hover:bg-slate-100 hover:text-brand-dark",
+            "aria-label": "Copy bundle hash",
+            children: /* @__PURE__ */ jsxRuntimeExports.jsx(HiMiniClipboardDocument, { className: "h-3.5 w-3.5", "aria-hidden": "true" })
+          }
+        ) : null
+      ] }) }),
+      /* @__PURE__ */ jsxRuntimeExports.jsxs(BundleStat, { label: "Last ack", className: "sm:min-w-[6.5rem] sm:max-w-[9rem]", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-sm text-brand-dark", children: lastAckAt ? formatRelativeTime$1(lastAckAt) : "Not yet" }),
+        bundleVersion ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-0.5 truncate text-xs text-slate-500", title: bundleVersion, children: bundleVersion }) : null
       ] })
     ] }),
-    synced ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 truncate text-xs text-slate-500", children: statusSubtitle }) : null,
-    showDetail ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-snug text-slate-700", children: cloudBundleCopy.detail }) : null
+    synced ? /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-slate-500", children: statusSubtitle }) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-3 rounded-xl border border-amber-200/80 bg-amber-50/60 px-3 py-2 text-sm leading-snug text-slate-700", children: cloudBundleCopy.detail })
   ] });
 }
 function EvidenceTable({ children, label, tableClassName = "" }) {
@@ -3821,7 +3831,7 @@ function PolicyRememberedRulesTab({
   }, [rememberedRules]);
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px] lg:items-start", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "space-y-4", children: [
-      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1.35fr)_minmax(0,1fr)] lg:items-start", children: [
+      /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "grid gap-4 lg:grid-cols-[minmax(0,1.55fr)_minmax(10rem,1fr)] lg:items-start", children: [
         /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyGuardCloudBundleCard, { snapshot }),
         /* @__PURE__ */ jsxRuntimeExports.jsx(PolicyActiveModeCard, { snapshot })
       ] }),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -17405,6 +17405,12 @@ function Surface(props) {
 function SectionLabel(props) {
   return /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "font-mono text-[11px] font-semibold uppercase tracking-[0.22em] text-brand-blue", children: props.children });
 }
+function PolicyStatField(props) {
+  return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: `min-w-0 ${props.className ?? ""}`, children: [
+    /* @__PURE__ */ jsxRuntimeExports.jsx("dt", { className: "text-[10px] font-semibold uppercase tracking-wider text-slate-500", children: props.label }),
+    /* @__PURE__ */ jsxRuntimeExports.jsx("dd", { className: "mt-1 min-w-0", children: props.children })
+  ] });
+}
 function Badge(props) {
   const toneClass = badgeToneClass(props.tone);
   return /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: `inline-flex items-center justify-center rounded-full border px-3 py-1 text-xs font-normal w-fit whitespace-nowrap shrink-0 [&>svg]:size-3 gap-1.5 [&>svg]:pointer-events-none transition-colors duration-200 overflow-hidden ${toneClass}`, children: props.children });
@@ -26271,8 +26277,9 @@ export {
   HiMiniClipboardDocument as b7,
   HiMiniUsers as b8,
   HiMiniFolder as b9,
-  runAuditRemediation as bA,
-  HiMiniSignal as bB,
+  HiMiniArrowUp as bA,
+  runAuditRemediation as bB,
+  HiMiniSignal as bC,
   HiMiniInformationCircle as ba,
   HiMiniIdentification as bb,
   policyActionLabel as bc,
@@ -26283,22 +26290,22 @@ export {
   fetchCloudExceptions as bh,
   fetchCloudExceptionRequests as bi,
   downloadBlob as bj,
-  PaginationControls as bk,
-  HiMiniNoSymbol as bl,
-  HiMiniCube as bm,
-  HiMiniArrowDownTray as bn,
-  HiMiniQueueList as bo,
-  HiMiniPlay as bp,
-  Surface as bq,
-  HiMiniCheckBadge as br,
-  fetchSupplyChainBundle as bs,
-  isSupplyChainScannerEvidence as bt,
-  HiMiniDocumentMagnifyingGlass as bu,
-  HiMiniShieldExclamation as bv,
-  HiMiniComputerDesktop as bw,
-  HiMiniChevronLeft as bx,
-  HiMiniArrowDown as by,
-  HiMiniArrowUp as bz,
+  PolicyStatField as bk,
+  PaginationControls as bl,
+  HiMiniNoSymbol as bm,
+  HiMiniCube as bn,
+  HiMiniArrowDownTray as bo,
+  HiMiniQueueList as bp,
+  HiMiniPlay as bq,
+  Surface as br,
+  HiMiniCheckBadge as bs,
+  fetchSupplyChainBundle as bt,
+  isSupplyChainScannerEvidence as bu,
+  HiMiniDocumentMagnifyingGlass as bv,
+  HiMiniShieldExclamation as bw,
+  HiMiniComputerDesktop as bx,
+  HiMiniChevronLeft as by,
+  HiMiniArrowDown as bz,
   EvidenceInsightsShareModal as c,
   HiMiniCheckCircle as d,
   GuardHero as e,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -5374,6 +5374,22 @@
       width: auto;
     }
 
+    .sm\:max-w-\[9rem\] {
+      max-width: 9rem;
+    }
+
+    .sm\:min-w-\[6\.5rem\] {
+      min-width: 6.5rem;
+    }
+
+    .sm\:min-w-\[7\.5rem\] {
+      min-width: 7.5rem;
+    }
+
+    .sm\:min-w-\[10rem\] {
+      min-width: 10rem;
+    }
+
     .sm\:flex-1 {
       flex: 1;
     }
@@ -5410,6 +5426,10 @@
       flex-wrap: nowrap;
     }
 
+    .sm\:flex-wrap {
+      flex-wrap: wrap;
+    }
+
     .sm\:items-center {
       align-items: center;
     }
@@ -5444,6 +5464,20 @@
 
     .sm\:gap-4 {
       gap: calc(var(--spacing) * 4);
+    }
+
+    .sm\:gap-x-8 {
+      column-gap: calc(var(--spacing) * 8);
+    }
+
+    .sm\:gap-y-3 {
+      row-gap: calc(var(--spacing) * 3);
+    }
+
+    .sm\:truncate {
+      text-overflow: ellipsis;
+      white-space: nowrap;
+      overflow: hidden;
     }
 
     .sm\:rounded-2xl {
@@ -5553,6 +5587,11 @@
     .sm\:text-xl {
       font-size: var(--text-xl);
       line-height: var(--tw-leading, var(--text-xl--line-height));
+    }
+
+    .sm\:break-normal {
+      overflow-wrap: normal;
+      word-break: normal;
     }
   }
 
@@ -5751,8 +5790,8 @@
       grid-template-columns: minmax(0, 1.4fr) minmax(0, .8fr);
     }
 
-    .lg\:grid-cols-\[minmax\(0\,1\.35fr\)_minmax\(0\,1fr\)\] {
-      grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+    .lg\:grid-cols-\[minmax\(0\,1\.55fr\)_minmax\(10rem\,1fr\)\] {
+      grid-template-columns: minmax(0, 1.55fr) minmax(10rem, 1fr);
     }
 
     .lg\:grid-cols-\[minmax\(0\,1fr\)_240px\] {


### PR DESCRIPTION
## Summary
- Replace the Guard Cloud bundle card equal-thirds stats grid with a responsive flex strip so status, hash, and action columns do not crush beside the 280px right rail
- Show bundle hash as middle-truncated `sha256:xxxxxx…yyyy` instead of CSS ellipsis that collapsed to `S...`
- Move Open Guard Cloud into the card header row and keep attention detail only in the amber alert (no duplicate subtitle under the status badge)
- Align the Remembered rules summary row with `lg:items-start` and `self-start` cards so Active mode stays compact instead of stretching

## Root causes
- P0: equal-thirds grid in too-narrow card width crushed columns and caused vertical letter-by-letter status wrapping
- P0: redundant attention copy under the badge plus alert duplicated text in a tight column
- P1: CSS truncate in a tight column collapsed long hashes to `S...`
- P1: summary row stretch let cards grow unevenly versus the right rail

## Testing
- `cd dashboard && ./node_modules/.bin/tsx src/policy-guard-cloud-bundle-card.test.ts`
- `cd dashboard && ./node_modules/.bin/tsx src/policy-remembered-rules-summary.test.ts`
- `cd dashboard && npm run build`
