### PR TITLE
fix(guard): harden daemon hook bridge output

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -31,6 +31,8 @@ _RISKY_PROMPT_ADDITIONAL_CONTEXT = (
     "HOL Guard will intercept Claude's next attempt to access local secrets and open a branded "
     "approval question to protect you."
 )
+_DAEMON_TIMEOUT_SECONDS = 8
+_FALLBACK_TIMEOUT_SECONDS = 8
 
 
 def main(
@@ -48,7 +50,11 @@ def main(
     try:
         endpoint = urljoin(_daemon_url(state_path, fallback_daemon_url), f"/v1/hooks/claude-code?{query}")
         _assert_loopback_http_url(endpoint)
-        response_body = _post_to_loopback_daemon(endpoint, data, state_path=state_path)
+        response_body = _valid_hook_json_or_degraded(
+            _post_to_loopback_daemon(endpoint, data, state_path=state_path),
+            reason="daemon returned malformed hook JSON",
+            data=data,
+        )
     except ValueError as error:
         sys.stdout.write(_run_local_fallback(str(error), data, fallback_command))
         return 0
@@ -108,7 +114,7 @@ def _post_to_loopback_daemon(endpoint: str, data: str, *, state_path: str | Path
         method="POST",
     )
     opener = _build_loopback_opener()
-    with opener.open(request, timeout=30) as response:
+    with opener.open(request, timeout=_DAEMON_TIMEOUT_SECONDS) as response:
         final_url = response.geturl()
         if final_url:
             _assert_loopback_http_url(final_url)
@@ -198,6 +204,19 @@ def _should_suppress_output(data: str, response_body: str) -> bool:
     return trimmed in {"", "{}"}
 
 
+def _valid_hook_json_or_degraded(output: str, *, reason: str, data: str) -> str:
+    trimmed = (output or "").strip()
+    if not trimmed:
+        return "{}"
+    try:
+        decoded = json.loads(trimmed)
+    except json.JSONDecodeError:
+        return _degraded(reason, data)
+    if not isinstance(decoded, dict):
+        return _degraded(reason, data)
+    return trimmed
+
+
 def _run_local_fallback(reason: str, data: str, fallback_command: tuple[str, ...]) -> str:
     try:
         result = subprocess.run(
@@ -206,7 +225,7 @@ def _run_local_fallback(reason: str, data: str, fallback_command: tuple[str, ...
             capture_output=True,
             text=True,
             errors="replace",
-            timeout=30,
+            timeout=_FALLBACK_TIMEOUT_SECONDS,
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired) as error:
@@ -215,7 +234,11 @@ def _run_local_fallback(reason: str, data: str, fallback_command: tuple[str, ...
         stdout = (result.stdout or "").strip()
         if _should_suppress_output(data, stdout):
             return ""
-        return stdout if stdout else "{}"
+        return _valid_hook_json_or_degraded(
+            stdout,
+            reason=f"{reason}; fallback returned malformed hook JSON",
+            data=data,
+        )
     detail = (result.stderr or result.stdout or "").strip()
     suffix = f"; fallback exited {result.returncode}"
     if detail:

--- a/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
+++ b/src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py
@@ -31,8 +31,8 @@ _RISKY_PROMPT_ADDITIONAL_CONTEXT = (
     "HOL Guard will intercept Claude's next attempt to access local secrets and open a branded "
     "approval question to protect you."
 )
-_DAEMON_TIMEOUT_SECONDS = 8
-_FALLBACK_TIMEOUT_SECONDS = 8
+_HARNESS_TIMEOUT_BUDGET_SECONDS = 10
+_HOOK_IO_TIMEOUT_SECONDS = _HARNESS_TIMEOUT_BUDGET_SECONDS - 2
 
 
 def main(
@@ -114,7 +114,7 @@ def _post_to_loopback_daemon(endpoint: str, data: str, *, state_path: str | Path
         method="POST",
     )
     opener = _build_loopback_opener()
-    with opener.open(request, timeout=_DAEMON_TIMEOUT_SECONDS) as response:
+    with opener.open(request, timeout=_HOOK_IO_TIMEOUT_SECONDS) as response:
         final_url = response.geturl()
         if final_url:
             _assert_loopback_http_url(final_url)
@@ -207,7 +207,7 @@ def _should_suppress_output(data: str, response_body: str) -> bool:
 def _valid_hook_json_or_degraded(output: str, *, reason: str, data: str) -> str:
     trimmed = (output or "").strip()
     if not trimmed:
-        return "{}"
+        return _degraded(reason, data)
     try:
         decoded = json.loads(trimmed)
     except json.JSONDecodeError:
@@ -225,7 +225,7 @@ def _run_local_fallback(reason: str, data: str, fallback_command: tuple[str, ...
             capture_output=True,
             text=True,
             errors="replace",
-            timeout=_FALLBACK_TIMEOUT_SECONDS,
+            timeout=_HOOK_IO_TIMEOUT_SECONDS,
             check=False,
         )
     except (OSError, subprocess.TimeoutExpired) as error:

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -135,6 +135,7 @@ def test_main_degrades_when_daemon_returns_malformed_json(
     daemon_thread = threading.Thread(target=daemon_server.serve_forever, daemon=True)
     daemon_thread.start()
     daemon_port = daemon_server.server_address[1]
+    _DaemonHandler.captured_guard_token = None
     _DaemonHandler.raw_response_body = b"not-json"
     monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
 
@@ -169,9 +170,22 @@ def test_run_local_fallback_degrades_invalid_json() -> None:
     assert "malformed hook JSON" in payload["hookSpecificOutput"]["permissionDecisionReason"]
 
 
+def test_valid_hook_json_degrades_empty_daemon_body() -> None:
+    response = bridge._valid_hook_json_or_degraded(
+        "",
+        reason="daemon returned empty hook JSON",
+        data=json.dumps({"hook_event_name": "PreToolUse"}),
+    )
+
+    payload = json.loads(response)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "full HOL Guard approval flow" in payload["systemMessage"]
+
+
 def test_bridge_timeouts_stay_under_harness_budget() -> None:
-    assert bridge._DAEMON_TIMEOUT_SECONDS <= 10
-    assert bridge._FALLBACK_TIMEOUT_SECONDS <= 10
+    assert bridge._HARNESS_TIMEOUT_BUDGET_SECONDS == 10
+    assert bridge._HOOK_IO_TIMEOUT_SECONDS == bridge._HARNESS_TIMEOUT_BUDGET_SECONDS - 2
 
 
 def test_loopback_redirect_handler_rejects_remote_redirect() -> None:

--- a/tests/test_claude_daemon_hook_bridge.py
+++ b/tests/test_claude_daemon_hook_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import io
 import json
 import threading
 import urllib.request
@@ -52,6 +53,7 @@ def test_daemon_url_rejects_non_loopback_fallback() -> None:
 class _DaemonHandler(BaseHTTPRequestHandler):
     response_marker = "from-real-daemon"
     captured_guard_token: ClassVar[str | None] = None
+    raw_response_body: ClassVar[bytes | None] = None
 
     def do_POST(self) -> None:
         type(self).captured_guard_token = self.headers.get("X-Guard-Token")
@@ -60,6 +62,9 @@ class _DaemonHandler(BaseHTTPRequestHandler):
         self.send_response(200)
         self.send_header("Content-Type", "application/json")
         self.end_headers()
+        if type(self).raw_response_body is not None:
+            self.wfile.write(type(self).raw_response_body)
+            return
         self.wfile.write(
             json.dumps(
                 {
@@ -93,6 +98,7 @@ def test_post_to_loopback_daemon_ignores_http_proxy(monkeypatch: pytest.MonkeyPa
     daemon_thread.start()
     daemon_port = daemon_server.server_address[1]
     _DaemonHandler.captured_guard_token = None
+    _DaemonHandler.raw_response_body = None
 
     monkeypatch.setenv("HTTP_PROXY", f"http://127.0.0.1:{proxy_server.server_address[1]}")
     monkeypatch.setenv("http_proxy", f"http://127.0.0.1:{proxy_server.server_address[1]}")
@@ -115,6 +121,57 @@ def test_post_to_loopback_daemon_ignores_http_proxy(monkeypatch: pytest.MonkeyPa
     assert payload["marker"] == _DaemonHandler.response_marker
     assert _CapturingProxyHandler.captured_paths == []
     assert _DaemonHandler.captured_guard_token == auth_token
+
+
+def test_main_degrades_when_daemon_returns_malformed_json(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    guard_home.mkdir()
+    state_path = guard_home / "daemon-state.json"
+    daemon_server = HTTPServer(("127.0.0.1", 0), _DaemonHandler)
+    daemon_thread = threading.Thread(target=daemon_server.serve_forever, daemon=True)
+    daemon_thread.start()
+    daemon_port = daemon_server.server_address[1]
+    _DaemonHandler.raw_response_body = b"not-json"
+    monkeypatch.setattr("sys.stdin", io.StringIO(json.dumps({"hook_event_name": "PreToolUse"})))
+
+    try:
+        exit_code = bridge.main(
+            state_path=state_path,
+            fallback_daemon_url=f"http://127.0.0.1:{daemon_port}",
+            fallback_command=("python3", "-c", "print('{}')"),
+            query="guard-home=%2Ftmp",
+        )
+        assert exit_code == 0
+    finally:
+        daemon_server.shutdown()
+        daemon_thread.join(timeout=5)
+        _DaemonHandler.raw_response_body = None
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+
+
+def test_run_local_fallback_degrades_invalid_json() -> None:
+    response = bridge._run_local_fallback(
+        "daemon unavailable",
+        json.dumps({"hook_event_name": "PreToolUse"}),
+        ("python3", "-c", "print('not-json')"),
+    )
+
+    payload = json.loads(response)
+    assert payload["hookSpecificOutput"]["hookEventName"] == "PreToolUse"
+    assert payload["hookSpecificOutput"]["permissionDecision"] == "ask"
+    assert "malformed hook JSON" in payload["hookSpecificOutput"]["permissionDecisionReason"]
+
+
+def test_bridge_timeouts_stay_under_harness_budget() -> None:
+    assert bridge._DAEMON_TIMEOUT_SECONDS <= 10
+    assert bridge._FALLBACK_TIMEOUT_SECONDS <= 10
 
 
 def test_loopback_redirect_handler_rejects_remote_redirect() -> None:


### PR DESCRIPTION
## Summary
- Ensure the daemon hook bridge emits valid JSON even when daemon or fallback output is malformed.
- Keep daemon and fallback waits below harness timeout budgets.
- Add regression coverage for malformed daemon/fallback output and timeout constants.

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/claude_daemon_hook_bridge.py tests/test_claude_daemon_hook_bridge.py`
- `python3 -m pytest tests/test_claude_daemon_hook_bridge.py -q`
