### PR TITLE
fix(aibom): add local trust coverage for hooks and skill files

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -43,6 +43,7 @@ _LOCAL_BASELINE_ITEM_KINDS = frozenset(
     {
         "agent",
         "daemon_plugin",
+        "hook",
         "mcp_server",
         "mcp_tool",
         "overlay",
@@ -52,7 +53,7 @@ _LOCAL_BASELINE_ITEM_KINDS = frozenset(
         "skill",
     }
 )
-_INSTRUCTION_BASELINE_ITEM_KINDS = frozenset({"agent", "daemon_plugin", "overlay", "policy", "prompt_pack"})
+_INSTRUCTION_BASELINE_ITEM_KINDS = frozenset({"agent", "daemon_plugin", "hook", "overlay", "policy", "prompt_pack"})
 
 
 def trust_resolution_from_domain(
@@ -367,6 +368,8 @@ def _trust_root_for_artifact(
         skill_dir = path.parent if path.name.lower() == "skill.md" else path
         for candidate in (skill_dir, *skill_dir.parents):
             if (candidate / ".codex-plugin" / "plugin.json").is_file():
+                return candidate
+            if path.name.lower() != "skill.md" and (candidate / "SKILL.md").is_file():
                 return candidate
             if workspace_dir is not None and candidate.resolve() == workspace_dir.resolve():
                 break

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -276,7 +276,11 @@ def test_inventory_snapshot_items_include_descriptions(tmp_path: Path) -> None:
     assert "Review code changes carefully." in skill_items[0].description
 
     payload = serialize_inventory_snapshot(snapshot)
-    assert payload["items"][0]["description"] == skill_items[0].description
+    payload_items = payload["items"]
+    assert isinstance(payload_items, list)
+    first_payload_item = payload_items[0]
+    assert isinstance(first_payload_item, dict)
+    assert first_payload_item["description"] == skill_items[0].description
 
 
 def test_hermes_and_openclaw_inventory_snapshots_include_workspace_agents_md(tmp_path: Path) -> None:

--- a/tests/test_guard_aibom_local_trust_coverage.py
+++ b/tests/test_guard_aibom_local_trust_coverage.py
@@ -1,0 +1,100 @@
+import json
+from pathlib import Path
+
+from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+
+
+def test_inventory_snapshot_adds_local_trust_to_hooks(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    hook_config = workspace / ".claude" / "settings.json"
+    hook_config.parent.mkdir(parents=True)
+    hook_config.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "PreToolUse": [
+                        {
+                            "matcher": "Bash",
+                            "hooks": [{"type": "command", "command": "python3 guard.py"}],
+                        }
+                    ]
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        HarnessDetection(
+            harness="claude-code",
+            installed=True,
+            command_available=True,
+            config_paths=(str(hook_config),),
+            artifacts=(
+                GuardArtifact(
+                    artifact_id="claude-code:project:pretooluse:0:0",
+                    name="PreToolUse",
+                    harness="claude-code",
+                    artifact_type="hook",
+                    source_scope="project",
+                    config_path=str(hook_config),
+                    command="python3 guard.py",
+                    metadata={"matcher": "Bash", "type": "command"},
+                ),
+            ),
+        ),
+        generated_at="2026-06-10T00:00:00Z",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+
+    hook_item = next(item for item in snapshot.items if item.item_kind == "hook")
+    hook_trust = hook_item.metadata.get("trustResolution")
+    assert isinstance(hook_trust, dict)
+    assert isinstance(hook_item.metadata.get("trustLayers"), list)
+    assert hook_trust["trustComponents"]
+
+
+def test_inventory_snapshot_adds_parent_skill_trust_to_skill_files(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    skill_dir = workspace / "skills" / "compress"
+    script_path = skill_dir / "scripts" / "cli.py"
+    script_path.parent.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: compress\ndescription: Compress memory files.\n---\n# Compress\nDo not read secrets.\n",
+        encoding="utf-8",
+    )
+    script_path.write_text("print('compress')\n", encoding="utf-8")
+
+    snapshot = inventory_snapshot_from_detection(
+        HarnessDetection(
+            harness="openclaw",
+            installed=True,
+            command_available=True,
+            config_paths=(str(skill_dir / "SKILL.md"),),
+            artifacts=(
+                GuardArtifact(
+                    artifact_id="openclaw:skill:local:compress:scripts/cli.py",
+                    name="compress/scripts/cli.py",
+                    harness="openclaw",
+                    artifact_type="skill_file",
+                    source_scope="workspace",
+                    config_path=str(script_path),
+                    command=str(script_path),
+                    metadata={"parent_skill": "compress"},
+                ),
+            ),
+        ),
+        generated_at="2026-06-10T00:00:00Z",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+
+    skill_file_item = next(item for item in snapshot.items if item.metadata.get("artifactType") == "skill_file")
+    skill_file_trust = skill_file_item.metadata.get("trustResolution")
+    assert isinstance(skill_file_trust, dict)
+    assert isinstance(skill_file_item.metadata.get("trustLayers"), list)
+    assert skill_file_trust["trustComponents"]

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -902,7 +902,7 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
     assert search_trust.get("trustScore") is not None
 
 
-def test_inventory_snapshot_does_not_score_hooks_as_instruction_trust(tmp_path: Path) -> None:
+def test_inventory_snapshot_scores_hooks_as_instruction_trust(tmp_path: Path) -> None:
     workspace = tmp_path / "repo"
     workspace.mkdir()
     hook_config = workspace / "settings.json"
@@ -927,5 +927,7 @@ def test_inventory_snapshot_does_not_score_hooks_as_instruction_trust(tmp_path: 
     )
     hook_item = next(item for item in snapshot.items if item.item_kind == "hook")
 
-    assert hook_item.metadata.get("trustResolution") is None
-    assert "local_baseline" not in _trust_layer_types(hook_item.metadata)
+    hook_trust = hook_item.metadata.get("trustResolution")
+    assert isinstance(hook_trust, dict)
+    assert hook_trust.get("trustScore") is not None
+    assert "local_baseline" in _trust_layer_types(hook_item.metadata)


### PR DESCRIPTION
## Summary
- add local baseline trust metadata to hook inventory items
- resolve skill-file artifacts to their parent skill root for baseline skill trust
- add regression coverage for hook and skill-file AIBOM trust metadata

## Testing
- `pytest tests/test_guard_aibom_detection.py tests/test_guard_aibom_trust_metadata.py tests/test_guard_aibom_local_trust_coverage.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/aibom_trust_metadata.py tests/test_guard_aibom_detection.py tests/test_guard_aibom_trust_metadata.py tests/test_guard_aibom_local_trust_coverage.py`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard aibom export --json --no-include-symlinks`
