### PR TITLE
fix(aibom): enrich store-only skill file trust

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -11,6 +11,7 @@ import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any, Literal
 
 from ..version import __version__
@@ -223,7 +224,7 @@ def build_aibom_export_payload(
         trust_attestation_context=_resolve_trust_attestation_context(store, generated_at=generated_at),
     )
     serialized_snapshots = [serialize_inventory_snapshot(snapshot) for snapshot in snapshots]
-    artifacts = _artifact_rows_from_store(store, snapshots)
+    artifacts = _artifact_rows_from_store(store, snapshots, context=context, generated_at=generated_at)
     layer_summary, trust_summary, drift_summary = summarize_aibom_layers(
         snapshots,
         generated_at=generated_at,
@@ -594,6 +595,9 @@ def _metadata_lookup_from_snapshots(
 def _artifact_rows_from_store(
     store: Any,
     snapshots: tuple[GuardAgentInventorySnapshot, ...],
+    *,
+    context: HarnessContext,
+    generated_at: str,
 ) -> list[dict[str, object]]:
     metadata_by_artifact = _metadata_lookup_from_snapshots(snapshots)
     artifacts: list[dict[str, object]] = []
@@ -604,10 +608,52 @@ def _artifact_rows_from_store(
         row: dict[str, object] = dict(item)
         row["trust_verdict"] = trust_verdict
         extensions = metadata_by_artifact.get((harness, artifact_id))
+        if not extensions:
+            extensions = _store_only_artifact_metadata_extensions(row, context=context, generated_at=generated_at)
+            if str(row.get("artifact_type") or "") == "skill_file" and not _store_row_config_path_exists(row):
+                row["present"] = False
         if extensions:
             row.update(extensions)
         artifacts.append(row)
     return artifacts
+
+
+def _store_row_config_path_exists(row: dict[str, object]) -> bool:
+    raw_config_path = row.get("config_path")
+    if not isinstance(raw_config_path, str) or not raw_config_path.strip():
+        return False
+    return Path(raw_config_path).expanduser().exists()
+
+
+def _store_only_artifact_metadata_extensions(
+    row: dict[str, object],
+    *,
+    context: HarnessContext,
+    generated_at: str,
+) -> dict[str, object]:
+    artifact_type = str(row.get("artifact_type") or "")
+    if artifact_type != "skill_file":
+        return {}
+    raw_config_path = row.get("config_path")
+    if not isinstance(raw_config_path, str) or not raw_config_path.strip():
+        return {}
+    config_path = Path(raw_config_path).expanduser()
+    if not config_path.exists():
+        return {}
+    artifact = SimpleNamespace(
+        artifact_id=str(row.get("artifact_id") or ""),
+        artifact_type=artifact_type,
+        config_path=str(config_path),
+        name=str(row.get("artifact_name") or row.get("artifact_id") or "skill_file"),
+    )
+    metadata = importlib.import_module(".aibom_trust_metadata", __package__).apply_local_trust_metadata(
+        artifact,
+        captured_at=generated_at,
+        item_kind="skill",
+        metadata={"artifactType": artifact_type},
+        workspace_dir=context.workspace_dir,
+    )
+    return extract_aibom_metadata_extensions(metadata)
 
 
 def _aggregate_redaction_report(

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -664,9 +664,9 @@ def _store_only_artifact_metadata_extensions(
         config_path=str(config_path),
         name=str(row.get("artifact_name") or row.get("artifact_id") or "skill_file"),
     )
-    from . import aibom_trust_metadata
+    from .aibom_trust_metadata import apply_local_trust_metadata
 
-    metadata = aibom_trust_metadata.apply_local_trust_metadata(
+    metadata = apply_local_trust_metadata(
         artifact,
         captured_at=generated_at,
         item_kind="skill",

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -16,6 +16,7 @@ from typing import Any, Literal
 
 from ..version import __version__
 from .adapters.base import HarnessContext
+from .aibom_trust_metadata import apply_local_trust_metadata
 from .inventory_cisco import run_cisco_inventory_scans
 from .inventory_contract import (
     GuardAgentInventorySnapshot,
@@ -664,8 +665,6 @@ def _store_only_artifact_metadata_extensions(
         config_path=str(config_path),
         name=str(row.get("artifact_name") or row.get("artifact_id") or "skill_file"),
     )
-    from .aibom_trust_metadata import apply_local_trust_metadata
-
     metadata = apply_local_trust_metadata(
         artifact,
         captured_at=generated_at,

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -166,6 +166,18 @@ def build_inventory_json_payload(
         artifact_id = str(item.get("artifact_id") or "")
         harness = str(item.get("harness") or "")
         extensions = metadata_by_artifact.get((harness, artifact_id))
+        config_path = _store_row_config_path(item) if str(item.get("artifact_type") or "") == "skill_file" else None
+        config_path_exists = config_path.exists() if config_path is not None else None
+        if not extensions:
+            extensions = _store_only_artifact_metadata_extensions(
+                item,
+                context=context,
+                generated_at=generated_at,
+                config_path=config_path,
+                config_path_exists=config_path_exists,
+            )
+            if config_path_exists is False:
+                enriched["present"] = False
         if extensions:
             enriched.update(extensions)
         items.append(enriched)
@@ -608,9 +620,17 @@ def _artifact_rows_from_store(
         row: dict[str, object] = dict(item)
         row["trust_verdict"] = trust_verdict
         extensions = metadata_by_artifact.get((harness, artifact_id))
+        config_path = _store_row_config_path(row) if str(row.get("artifact_type") or "") == "skill_file" else None
+        config_path_exists = config_path.exists() if config_path is not None else None
         if not extensions:
-            extensions = _store_only_artifact_metadata_extensions(row, context=context, generated_at=generated_at)
-            if str(row.get("artifact_type") or "") == "skill_file" and not _store_row_config_path_exists(row):
+            extensions = _store_only_artifact_metadata_extensions(
+                row,
+                context=context,
+                generated_at=generated_at,
+                config_path=config_path,
+                config_path_exists=config_path_exists,
+            )
+            if config_path_exists is False:
                 row["present"] = False
         if extensions:
             row.update(extensions)
@@ -618,11 +638,11 @@ def _artifact_rows_from_store(
     return artifacts
 
 
-def _store_row_config_path_exists(row: dict[str, object]) -> bool:
+def _store_row_config_path(row: dict[str, object]) -> Path | None:
     raw_config_path = row.get("config_path")
     if not isinstance(raw_config_path, str) or not raw_config_path.strip():
-        return False
-    return Path(raw_config_path).expanduser().exists()
+        return None
+    return Path(raw_config_path).expanduser()
 
 
 def _store_only_artifact_metadata_extensions(
@@ -630,15 +650,13 @@ def _store_only_artifact_metadata_extensions(
     *,
     context: HarnessContext,
     generated_at: str,
+    config_path: Path | None,
+    config_path_exists: bool | None,
 ) -> dict[str, object]:
     artifact_type = str(row.get("artifact_type") or "")
     if artifact_type != "skill_file":
         return {}
-    raw_config_path = row.get("config_path")
-    if not isinstance(raw_config_path, str) or not raw_config_path.strip():
-        return {}
-    config_path = Path(raw_config_path).expanduser()
-    if not config_path.exists():
+    if config_path is None or config_path_exists is not True:
         return {}
     artifact = SimpleNamespace(
         artifact_id=str(row.get("artifact_id") or ""),
@@ -646,7 +664,9 @@ def _store_only_artifact_metadata_extensions(
         config_path=str(config_path),
         name=str(row.get("artifact_name") or row.get("artifact_id") or "skill_file"),
     )
-    metadata = importlib.import_module(".aibom_trust_metadata", __package__).apply_local_trust_metadata(
+    from . import aibom_trust_metadata
+
+    metadata = aibom_trust_metadata.apply_local_trust_metadata(
         artifact,
         captured_at=generated_at,
         item_kind="skill",

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -170,7 +170,7 @@ def build_inventory_json_payload(
         config_path_exists = config_path.exists() if config_path is not None else None
         if not extensions:
             extensions = _store_only_artifact_metadata_extensions(
-                item,
+                enriched,
                 context=context,
                 generated_at=generated_at,
                 config_path=config_path,

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -384,6 +384,7 @@ def _trust_root_for_artifact(
                 getattr(artifact, "artifact_type", None) == "skill_file"
                 and candidate.parent.name.lower() == "skills"
                 and ((candidate / "README.md").is_file() or (candidate / "SECURITY.md").is_file())
+                and _skill_file_name_matches_root(artifact, candidate)
             ):
                 return candidate
             if workspace_dir is not None and candidate.resolve() == workspace_dir.resolve():
@@ -405,6 +406,15 @@ def _trust_root_for_artifact(
         return path if path.is_file() else None
 
     return None
+
+
+def _skill_file_name_matches_root(artifact: object, root: Path) -> bool:
+    root_name = root.name
+    name = getattr(artifact, "name", None)
+    if isinstance(name, str) and (name == root_name or name.startswith(f"{root_name}/")):
+        return True
+    artifact_id = getattr(artifact, "artifact_id", None)
+    return isinstance(artifact_id, str) and f":{root_name}:" in artifact_id
 
 
 def _trust_layer_from_domain(

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -329,7 +329,16 @@ def _local_trust_domain_for_artifact(
         return build_plugin_domain(trust_root, ())
     if item_kind == "skill":
         context = resolve_skill_security_context(trust_root, _INVENTORY_TRUST_SCAN_OPTIONS)
-        return build_skill_domain(trust_root, context)
+        skill_domain = build_skill_domain(trust_root, context)
+        if skill_domain is not None:
+            return skill_domain
+        if getattr(artifact, "artifact_type", None) == "skill_file":
+            config_path = getattr(artifact, "config_path", None)
+            if isinstance(config_path, str) and config_path.strip():
+                file_path = Path(config_path)
+                if file_path.is_file():
+                    return build_instruction_domain(file_path, role="skill_file", item_kind="skill")
+        return None
     if item_kind == "mcp_server":
         return build_mcp_domain(trust_root, ()) or build_mcp_surface_domain(
             name=getattr(artifact, "name", None),
@@ -370,6 +379,12 @@ def _trust_root_for_artifact(
             if (candidate / ".codex-plugin" / "plugin.json").is_file():
                 return candidate
             if path.name.lower() != "skill.md" and (candidate / "SKILL.md").is_file():
+                return candidate
+            if (
+                getattr(artifact, "artifact_type", None) == "skill_file"
+                and candidate.parent.name == "skills"
+                and ((candidate / "README.md").is_file() or (candidate / "SECURITY.md").is_file())
+            ):
                 return candidate
             if workspace_dir is not None and candidate.resolve() == workspace_dir.resolve():
                 break

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -382,7 +382,7 @@ def _trust_root_for_artifact(
                 return candidate
             if (
                 getattr(artifact, "artifact_type", None) == "skill_file"
-                and candidate.parent.name == "skills"
+                and candidate.parent.name.lower() == "skills"
                 and ((candidate / "README.md").is_file() or (candidate / "SECURITY.md").is_file())
             ):
                 return candidate

--- a/tests/test_guard_aibom_local_trust_coverage.py
+++ b/tests/test_guard_aibom_local_trust_coverage.py
@@ -1,8 +1,18 @@
 import json
 from pathlib import Path
 
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.aibom_cli import _artifact_rows_from_store
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+
+
+class _FakeInventoryStore:
+    def __init__(self, rows: list[dict[str, object]]) -> None:
+        self._rows = rows
+
+    def list_inventory(self) -> list[dict[str, object]]:
+        return self._rows
 
 
 def test_inventory_snapshot_adds_local_trust_to_hooks(tmp_path: Path) -> None:
@@ -98,3 +108,100 @@ def test_inventory_snapshot_adds_parent_skill_trust_to_skill_files(tmp_path: Pat
     assert isinstance(skill_file_trust, dict)
     assert isinstance(skill_file_item.metadata.get("trustLayers"), list)
     assert skill_file_trust["trustComponents"]
+
+
+def test_aibom_export_adds_parent_skill_trust_to_store_only_skill_files(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".agents" / "skills" / "caveman-compress"
+    script_path = skill_dir / "scripts" / "cli.py"
+    script_path.parent.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: caveman-compress\ndescription: Compress memory files.\n---\n# Caveman Compress\n",
+        encoding="utf-8",
+    )
+    script_path.write_text("print('compress')\n", encoding="utf-8")
+    store = _FakeInventoryStore(
+        [
+            {
+                "artifact_id": "openclaw:skill:local:caveman-compress:scripts/cli.py",
+                "artifact_name": "caveman-compress/scripts/cli.py",
+                "artifact_type": "skill_file",
+                "config_path": str(script_path),
+                "harness": "openclaw",
+                "last_policy_action": None,
+                "present": True,
+                "source_scope": "skill-root:local",
+            }
+        ]
+    )
+
+    rows = _artifact_rows_from_store(
+        store,
+        (),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=tmp_path, guard_home=tmp_path / ".guard"),
+        generated_at="2026-06-10T00:00:00Z",
+    )
+
+    trust = rows[0].get("trustResolution")
+    assert isinstance(trust, dict)
+    assert isinstance(rows[0].get("trustLayers"), list)
+    assert trust["trustComponents"]
+
+
+def test_aibom_export_adds_trust_to_readme_marked_store_only_skill_files(tmp_path: Path) -> None:
+    skill_dir = tmp_path / ".agents" / "skills" / "caveman-compress"
+    script_path = skill_dir / "scripts" / "cli.py"
+    script_path.parent.mkdir(parents=True)
+    (skill_dir / "README.md").write_text("# Caveman Compress\n", encoding="utf-8")
+    script_path.write_text("print('compress')\n", encoding="utf-8")
+    store = _FakeInventoryStore(
+        [
+            {
+                "artifact_id": "openclaw:skill:local:caveman-compress:scripts/cli.py",
+                "artifact_name": "caveman-compress/scripts/cli.py",
+                "artifact_type": "skill_file",
+                "config_path": str(script_path),
+                "harness": "openclaw",
+                "last_policy_action": None,
+                "present": True,
+                "source_scope": "skill-root:local",
+            }
+        ]
+    )
+
+    rows = _artifact_rows_from_store(
+        store,
+        (),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=tmp_path, guard_home=tmp_path / ".guard"),
+        generated_at="2026-06-10T00:00:00Z",
+    )
+
+    trust = rows[0].get("trustResolution")
+    assert isinstance(trust, dict)
+    assert isinstance(rows[0].get("trustLayers"), list)
+
+
+def test_aibom_export_marks_missing_store_only_skill_files_not_present(tmp_path: Path) -> None:
+    store = _FakeInventoryStore(
+        [
+            {
+                "artifact_id": "openclaw:skill:local:missing:references/example.md",
+                "artifact_name": "missing/references/example.md",
+                "artifact_type": "skill_file",
+                "config_path": str(tmp_path / ".agents" / "skills" / "missing" / "references" / "example.md"),
+                "harness": "openclaw",
+                "last_policy_action": None,
+                "present": True,
+                "source_scope": "skill-root:local",
+            }
+        ]
+    )
+
+    rows = _artifact_rows_from_store(
+        store,
+        (),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=tmp_path, guard_home=tmp_path / ".guard"),
+        generated_at="2026-06-10T00:00:00Z",
+    )
+
+    assert rows[0]["present"] is False
+    assert "trustResolution" not in rows[0]

--- a/tests/test_guard_aibom_local_trust_coverage.py
+++ b/tests/test_guard_aibom_local_trust_coverage.py
@@ -1,6 +1,7 @@
 import json
 from pathlib import Path
 
+from codex_plugin_scanner.guard import aibom_cli as aibom_cli_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.aibom_cli import _artifact_rows_from_store
 from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
@@ -13,6 +14,15 @@ class _FakeInventoryStore:
 
     def list_inventory(self) -> list[dict[str, object]]:
         return self._rows
+
+    def get_oauth_local_credentials(self, *, allow_primary: bool = False) -> None:
+        return None
+
+    def get_or_create_installation_id(self) -> str:
+        return "installation-1"
+
+    def get_cloud_workspace_id(self) -> None:
+        return None
 
 
 def test_inventory_snapshot_adds_local_trust_to_hooks(tmp_path: Path) -> None:
@@ -205,3 +215,40 @@ def test_aibom_export_marks_missing_store_only_skill_files_not_present(tmp_path:
 
     assert rows[0]["present"] is False
     assert "trustResolution" not in rows[0]
+
+
+def test_inventory_json_payload_enriches_store_only_skill_files(tmp_path: Path, monkeypatch) -> None:
+    skill_dir = tmp_path / ".agents" / "skills" / "caveman-compress"
+    script_path = skill_dir / "scripts" / "cli.py"
+    script_path.parent.mkdir(parents=True)
+    (skill_dir / "README.md").write_text("# Caveman Compress\n", encoding="utf-8")
+    script_path.write_text("print('compress')\n", encoding="utf-8")
+    store = _FakeInventoryStore(
+        [
+            {
+                "artifact_id": "openclaw:skill:local:caveman-compress:scripts/cli.py",
+                "artifact_name": "caveman-compress/scripts/cli.py",
+                "artifact_type": "skill_file",
+                "config_path": str(script_path),
+                "harness": "openclaw",
+                "last_policy_action": None,
+                "present": True,
+                "source_scope": "skill-root:local",
+            }
+        ]
+    )
+    monkeypatch.setattr(aibom_cli_module, "collect_aibom_snapshots", lambda *args, **kwargs: ())
+
+    payload = aibom_cli_module.build_inventory_json_payload(
+        store,
+        HarnessContext(home_dir=tmp_path, workspace_dir=tmp_path, guard_home=tmp_path / ".guard"),
+        generated_at="2026-06-10T00:00:00Z",
+    )
+
+    items = payload["items"]
+    assert isinstance(items, list)
+    item = items[0]
+    assert isinstance(item, dict)
+    assert item["present"] is True
+    assert isinstance(item.get("trustResolution"), dict)
+    assert isinstance(item.get("trustLayers"), list)

--- a/tests/test_guard_aibom_local_trust_coverage.py
+++ b/tests/test_guard_aibom_local_trust_coverage.py
@@ -190,6 +190,39 @@ def test_aibom_export_adds_trust_to_readme_marked_store_only_skill_files(tmp_pat
     assert isinstance(rows[0].get("trustLayers"), list)
 
 
+def test_aibom_export_does_not_use_unrelated_skills_ancestor_as_skill_root(tmp_path: Path) -> None:
+    utility_root = tmp_path / ".agents" / "skills" / "utilities"
+    skill_dir = utility_root / "caveman-compress"
+    script_path = skill_dir / "scripts" / "cli.py"
+    script_path.parent.mkdir(parents=True)
+    (utility_root / "README.md").write_text("# Utilities\n", encoding="utf-8")
+    script_path.write_text("print('compress')\n", encoding="utf-8")
+    store = _FakeInventoryStore(
+        [
+            {
+                "artifact_id": "openclaw:skill:local:caveman-compress:scripts/cli.py",
+                "artifact_name": "caveman-compress/scripts/cli.py",
+                "artifact_type": "skill_file",
+                "config_path": str(script_path),
+                "harness": "openclaw",
+                "last_policy_action": None,
+                "present": True,
+                "source_scope": "skill-root:local",
+            }
+        ]
+    )
+
+    rows = _artifact_rows_from_store(
+        store,
+        (),
+        context=HarnessContext(home_dir=tmp_path, workspace_dir=tmp_path, guard_home=tmp_path / ".guard"),
+        generated_at="2026-06-10T00:00:00Z",
+    )
+
+    assert rows[0]["present"] is True
+    assert "trustResolution" not in rows[0]
+
+
 def test_aibom_export_marks_missing_store_only_skill_files_not_present(tmp_path: Path) -> None:
     store = _FakeInventoryStore(
         [


### PR DESCRIPTION
## Summary

- Enrich store-only AIBOM `skill_file` artifact rows with local trust metadata when their files still exist.
- Resolve installed skill-file roots that use README/SECURITY markers instead of `SKILL.md`, then fall back to file-level instruction trust when no skill manifest exists.
- Mark missing store-only skill-file paths as not present instead of exporting stale present rows without trust metadata.

## Verification

- `python3 -m pytest --tb=short tests/test_guard_aibom_local_trust_coverage.py tests/test_guard_aibom_trust_metadata.py tests/test_guard_aibom_detection.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/aibom_cli.py src/codex_plugin_scanner/guard/aibom_trust_metadata.py tests/test_guard_aibom_local_trust_coverage.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/aibom_cli.py src/codex_plugin_scanner/guard/aibom_trust_metadata.py tests/test_guard_aibom_local_trust_coverage.py`
- Patched source export confirmed all present hook and skill-file artifacts include trust metadata.
