### PR TITLE
fix(guard): clarify remembered rule trust handling

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -375,7 +375,8 @@ def apply_approval_resolution(
         approval_gate_grant=approval_gate_grant,
         now=resolved_at,
     )
-    if persist_policy is True or (persist_policy is None and scope != "artifact"):
+    persisted_rule = persist_policy is True or (persist_policy is None and scope != "artifact")
+    if persisted_rule:
         store.upsert_policy(decision, resolved_at, approval_gate_grant=resolved_gate_grant)
     elif persist_policy is None and scope == "artifact":
         store.upsert_policy(
@@ -421,7 +422,14 @@ def apply_approval_resolution(
             )
             if resolved_scope_ids:
                 _refresh_queue_result(store, result, resolved_scope_ids)
-        _record_resolution_event(store, request_id, action, scope, resolved_at)
+        _record_resolution_event(
+            store,
+            request_id,
+            action,
+            scope,
+            resolved_at,
+            persisted_rule=persisted_rule,
+        )
         return result
     resolved_ids: list[str] = []
     if resolve_scope_matches:
@@ -453,7 +461,14 @@ def apply_approval_resolution(
     updated = store.get_approval_request(request_id)
     if updated is None:
         raise ValueError(f"Approval request disappeared: {request_id}")
-    _record_resolution_event(store, request_id, action, scope, resolved_at)
+    _record_resolution_event(
+        store,
+        request_id,
+        action,
+        scope,
+        resolved_at,
+        persisted_rule=persisted_rule,
+    )
     return updated
 
 
@@ -566,9 +581,22 @@ def _string_or_none(value: object) -> str | None:
     return None
 
 
-def _record_resolution_event(store: GuardStore, request_id: str, action: str, scope: str, resolved_at: str) -> None:
+def _record_resolution_event(
+    store: GuardStore,
+    request_id: str,
+    action: str,
+    scope: str,
+    resolved_at: str,
+    *,
+    persisted_rule: bool,
+) -> None:
     store.add_event(
         "approval.resolved",
+        {"request_id": request_id, "action": action, "scope": scope, "persisted_rule": persisted_rule},
+        resolved_at,
+    )
+    store.add_event(
+        "rule.remembered.local" if persisted_rule else "approval.once",
         {"request_id": request_id, "action": action, "scope": scope},
         resolved_at,
     )

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -78,7 +78,7 @@ def add_approval_parser(
     )
     clear_history_parser.add_argument(
         "--source",
-        help="Optional source filter for policy decisions (for example: manual, claude-ask-user-question)",
+        help="Optional source filter for remembered rules (for example: manual, claude-ask-user-question)",
     )
     add_common_args(clear_history_parser)
     clear_history_parser.add_argument("--json", action="store_true")

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -260,7 +260,7 @@ def _run_guard_policies_command(
             _emit(
                 "policies",
                 {
-                    "error": "Choose either --all or --harness <name> when clearing Guard policy decisions.",
+                    "error": "Choose either --all or --harness <name> when clearing Guard rules.",
                     "cleared": 0,
                     "harness": harness,
                     "source": getattr(args, "source", None),
@@ -272,7 +272,7 @@ def _run_guard_policies_command(
             _emit(
                 "policies",
                 {
-                    "error": "Choose --harness <name> or --all when clearing Guard policy decisions.",
+                    "error": "Choose --harness <name> or --all when clearing Guard rules.",
                     "cleared": 0,
                 },
                 getattr(args, "json", False),

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -18,8 +18,6 @@ if TYPE_CHECKING:
     from .commands_support_prompts import _runtime_artifact_native_reason
     from .commands_support_runtime_artifacts import _hook_event_name, _optional_string
     from .commands_support_runtime_policy import (
-        _remembered_rule_rejection_reason,
-        _runtime_artifact_exact_match_context,
         _runtime_artifact_policy_action,
         _runtime_data_flow_summary,
         _runtime_stored_policy_action,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from .commands_support_prompts import _runtime_artifact_native_reason
     from .commands_support_runtime_artifacts import _hook_event_name, _optional_string
     from .commands_support_runtime_policy import (
+        _runtime_artifact_exact_match_context,
         _runtime_artifact_policy_action,
         _runtime_data_flow_summary,
         _runtime_stored_policy_action,
@@ -36,6 +37,7 @@ from ..models import GuardAction
 from ._commands_shared import *
 from .commands_hook_runtime_state import RuntimeArtifactHookState
 from .commands_parser_helpers import *
+from .commands_support_runtime_policy import _runtime_artifact_exact_match_context
 
 
 def _resolved_guard_action(value: object, fallback: GuardAction) -> GuardAction:
@@ -112,6 +114,15 @@ def _evaluate_runtime_artifact_hook(
             policy_action="allow",
         )
         return 0
+    runtime_exact_match_context = _runtime_artifact_exact_match_context(runtime_artifact)
+    policy_lookup = store.resolve_policy_decision_lookup(
+        policy_harness,
+        artifact_id,
+        runtime_artifact_hash,
+        str(runtime_workspace) if runtime_workspace else None,
+        runtime_artifact.publisher,
+        runtime_exact_match_context=runtime_exact_match_context,
+    )
     stored_policy_action = _runtime_stored_policy_action(
         store=store,
         harness=policy_harness,
@@ -119,7 +130,10 @@ def _evaluate_runtime_artifact_hook(
         artifact_id=artifact_id,
         artifact_hash=runtime_artifact_hash,
         workspace=str(runtime_workspace) if runtime_workspace else None,
+        decision_lookup=policy_lookup,
     )
+    remembered_rule_rejection = policy_lookup["ignored_local_integrity"]
+    trust_status = policy_lookup["trust_status"]
     if stored_policy_action is None:
         legacy_artifact = _legacy_claude_alias_runtime_artifact(
             artifact=runtime_artifact,
@@ -343,7 +357,20 @@ def _evaluate_runtime_artifact_hook(
         "launch_summary": incident["launch_summary"],
         "risk_headline": incident["risk_headline"],
         "path_summary": _runtime_requested_path(runtime_artifact),
+        "trust_status": trust_status,
     }
+    if remembered_rule_rejection is not None:
+        from .commands_support_runtime_policy import _remembered_rule_rejection_reason
+
+        response_payload["remembered_rule_rejection"] = remembered_rule_rejection
+        remembered_rule_reason = _remembered_rule_rejection_reason(
+            response_payload=response_payload,
+            artifact=runtime_artifact,
+        )
+        if remembered_rule_reason is not None:
+            decision_v2_payload["harness_message"] = remembered_rule_reason
+            decision_v2_payload["dashboard_primary_detail"] = remembered_rule_reason
+            response_payload["risk_headline"] = remembered_rule_reason
     if package_evaluation is not None:
         response_payload["supply_chain_evaluation"] = package_evaluation.to_dict()
     if (

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from .commands_support_prompts import _runtime_artifact_native_reason
     from .commands_support_runtime_artifacts import _hook_event_name, _optional_string
     from .commands_support_runtime_policy import (
+        _remembered_rule_rejection_reason,
         _runtime_artifact_exact_match_context,
         _runtime_artifact_policy_action,
         _runtime_data_flow_summary,
@@ -37,7 +38,7 @@ from ..models import GuardAction
 from ._commands_shared import *
 from .commands_hook_runtime_state import RuntimeArtifactHookState
 from .commands_parser_helpers import *
-from .commands_support_runtime_policy import _runtime_artifact_exact_match_context
+from .commands_support_runtime_policy import _remembered_rule_rejection_reason, _runtime_artifact_exact_match_context
 
 
 def _resolved_guard_action(value: object, fallback: GuardAction) -> GuardAction:
@@ -360,13 +361,14 @@ def _evaluate_runtime_artifact_hook(
         "trust_status": trust_status,
     }
     if remembered_rule_rejection is not None:
-        from .commands_support_runtime_policy import _remembered_rule_rejection_reason
-
         response_payload["remembered_rule_rejection"] = remembered_rule_rejection
-        remembered_rule_reason = _remembered_rule_rejection_reason(
-            response_payload=response_payload,
-            artifact=runtime_artifact,
-        )
+        if policy_action in {"review", "require-reapproval"}:
+            remembered_rule_reason = _remembered_rule_rejection_reason(
+                response_payload=response_payload,
+                artifact=runtime_artifact,
+            )
+        else:
+            remembered_rule_reason = None
         if remembered_rule_reason is not None:
             decision_v2_payload["harness_message"] = remembered_rule_reason
             decision_v2_payload["dashboard_primary_detail"] = remembered_rule_reason

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -118,9 +118,9 @@ def _evaluate_runtime_artifact_hook(
     policy_lookup = store.resolve_policy_decision_lookup(
         policy_harness,
         artifact_id,
-        runtime_artifact_hash,
-        str(runtime_workspace) if runtime_workspace else None,
-        runtime_artifact.publisher,
+        artifact_hash=runtime_artifact_hash,
+        workspace=str(runtime_workspace) if runtime_workspace else None,
+        publisher=runtime_artifact.publisher,
         runtime_exact_match_context=runtime_exact_match_context,
     )
     stored_policy_action = _runtime_stored_policy_action(

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -19,7 +19,10 @@ from .commands_parser_helpers import *
 def _configure_guard_policy_parsers(
     guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
-    policies_parser = guard_subparsers.add_parser("policies", help="List or clear stored Guard policy decisions")
+    policies_parser = guard_subparsers.add_parser(
+        "policies",
+        help="List or clear remembered rules and synced Cloud policy rows",
+    )
     policies_parser.add_argument(
         "policies_command",
         nargs="?",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -228,16 +228,21 @@ def _runtime_stored_policy_action(
     artifact_id: str,
     artifact_hash: str,
     workspace: str | None,
+    decision_lookup: Mapping[str, object] | None = None,
 ) -> str | None:
     runtime_exact_match_context = _runtime_artifact_exact_match_context(artifact)
-    decision = store.resolve_policy_decision(
-        harness,
-        artifact_id,
-        artifact_hash,
-        workspace,
-        artifact.publisher,
-        runtime_exact_match_context=runtime_exact_match_context,
-    )
+    if isinstance(decision_lookup, Mapping):
+        raw_decision = decision_lookup.get("decision")
+        decision = raw_decision if isinstance(raw_decision, Mapping) else None
+    else:
+        decision = store.resolve_policy_decision(
+            harness,
+            artifact_id,
+            artifact_hash,
+            workspace,
+            artifact.publisher,
+            runtime_exact_match_context=runtime_exact_match_context,
+        )
     if decision is None and runtime_exact_match_context is not None:
         legacy_decision = store.resolve_policy_decision(
             harness,
@@ -282,6 +287,34 @@ def _runtime_stored_policy_action(
             return action if decision_artifact_hash in exact_match_keys else None
         return None
     return action
+
+
+def _remembered_rule_rejection_reason(
+    *,
+    response_payload: dict[str, object],
+    artifact: GuardArtifact,
+) -> str | None:
+    rejection = response_payload.get("remembered_rule_rejection")
+    if not isinstance(rejection, Mapping):
+        return None
+    trust_status = rejection.get("trust_status")
+    remembered_rules = (
+        str(trust_status.get("remembered_rules") or "unknown") if isinstance(trust_status, Mapping) else "unknown"
+    )
+    if remembered_rules != "disabled_degraded":
+        return None
+    integrity_message = _optional_string(rejection.get("integrity_message"))
+    artifact_summary = _runtime_request_summary(artifact) or artifact.name
+    detail = (
+        f" {integrity_message.strip()}"
+        if isinstance(integrity_message, str) and integrity_message.strip()
+        else ""
+    )
+    return (
+        f"HOL Guard kept {artifact_summary} in review because a remembered local rule was ignored while local trust "
+        f"is degraded.{detail} One-time approvals still work, but broader remembered rules stay limited until local "
+        f"trust is protected."
+    )
 
 
 def _runtime_artifact_exact_match_context(artifact: GuardArtifact) -> str | None:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -235,9 +235,14 @@ def _runtime_stored_policy_action(
     decision_lookup: Mapping[str, object] | None = None,
 ) -> str | None:
     runtime_exact_match_context = _runtime_artifact_exact_match_context(artifact)
+    ignored_local_integrity: Mapping[str, object] | None = None
     if isinstance(decision_lookup, Mapping):
         raw_decision = decision_lookup.get("decision")
         decision = raw_decision if isinstance(raw_decision, Mapping) else None
+        raw_ignored_local_integrity = decision_lookup.get("ignored_local_integrity")
+        ignored_local_integrity = (
+            raw_ignored_local_integrity if isinstance(raw_ignored_local_integrity, Mapping) else None
+        )
     else:
         decision = store.resolve_policy_decision(
             harness,
@@ -247,7 +252,7 @@ def _runtime_stored_policy_action(
             publisher=artifact.publisher,
             runtime_exact_match_context=runtime_exact_match_context,
         )
-    if decision is None and runtime_exact_match_context is not None:
+    if decision is None and runtime_exact_match_context is not None and ignored_local_integrity is None:
         legacy_decision = store.resolve_policy_decision(
             harness,
             artifact_id,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -238,18 +238,18 @@ def _runtime_stored_policy_action(
         decision = store.resolve_policy_decision(
             harness,
             artifact_id,
-            artifact_hash,
-            workspace,
-            artifact.publisher,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=artifact.publisher,
             runtime_exact_match_context=runtime_exact_match_context,
         )
     if decision is None and runtime_exact_match_context is not None:
         legacy_decision = store.resolve_policy_decision(
             harness,
             artifact_id,
-            artifact_hash,
-            workspace,
-            artifact.publisher,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=artifact.publisher,
         )
         if _optional_string((legacy_decision or {}).get("scope")) in {"harness", "global"}:
             decision = legacy_decision
@@ -305,11 +305,11 @@ def _remembered_rule_rejection_reason(
         return None
     integrity_message = _optional_string(rejection.get("integrity_message"))
     artifact_summary = _runtime_request_summary(artifact) or artifact.name
-    detail = (
-        f" {integrity_message.strip()}"
-        if isinstance(integrity_message, str) and integrity_message.strip()
-        else ""
-    )
+    if isinstance(integrity_message, str) and integrity_message.strip():
+        message = integrity_message.strip()
+        detail = f" {message if message.endswith('.') else message + '.'}"
+    else:
+        detail = ""
     return (
         f"HOL Guard kept {artifact_summary} in review because a remembered local rule was ignored while local trust "
         f"is degraded.{detail} One-time approvals still work, but broader remembered rules stay limited until local "

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -43,6 +43,10 @@ def _canonical_harness_name(value: str) -> str:
     return _runtime_resolution_module()._canonical_harness_name(value)
 
 
+def _runtime_request_summary(artifact: GuardArtifact) -> str | None:
+    return _runtime_resolution_module()._runtime_request_summary(artifact)
+
+
 def _claude_notification_tool_name(payload: dict[str, object]) -> str | None:
     direct_name = _optional_string(payload.get("tool_name"))
     if direct_name is not None:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -939,7 +939,7 @@ def _render_policies(console: Console, payload: dict[str, object]) -> None:
         console.print(
             Panel(
                 body,
-                title="Guard policy clear",
+                title="Guard rules clear",
                 border_style="red" if error else "green",
             )
         )
@@ -947,7 +947,8 @@ def _render_policies(console: Console, payload: dict[str, object]) -> None:
     items = _coerce_dict_list(payload.get("items"))
     console.print(
         Panel.fit(
-            f"[bold]Guard policy decisions[/bold]\n{len(items)} active rule{'s' if len(items) != 1 else ''}",
+            f"[bold]Guard remembered rules and Cloud policies[/bold]\n"
+            f"{len(items)} active rule{'s' if len(items) != 1 else ''}",
             border_style="cyan",
         )
     )

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3118,10 +3118,10 @@ class GuardStore:
         lookup = self.resolve_policy_decision_lookup(
             harness,
             artifact_id,
-            artifact_hash,
-            workspace,
-            publisher,
-            now,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=publisher,
+            now=now,
         )
         decision = lookup["decision"]
         return str(decision["action"]) if decision is not None else None
@@ -3296,20 +3296,21 @@ class GuardStore:
                         "integrity_message": integrity_result.message,
                         "trust_status": trust_status,
                     }
-                events.append(
-                    (
-                        "rule.ignored.local_integrity",
-                        {
-                            "decision_id": int(candidate["decision_id"]),
-                            "harness": str(candidate["harness"]),
-                            "artifact_id": candidate["artifact_id"],
-                            "scope": str(candidate["scope"]),
-                            "source": str(candidate["source"]),
-                            "integrity_status": integrity_result.status,
-                            "message": integrity_result.message,
-                        },
+                if not is_remote_policy_source(str(candidate["source"])):
+                    events.append(
+                        (
+                            "rule.ignored.local_integrity",
+                            {
+                                "decision_id": int(candidate["decision_id"]),
+                                "harness": str(candidate["harness"]),
+                                "artifact_id": candidate["artifact_id"],
+                                "scope": str(candidate["scope"]),
+                                "source": str(candidate["source"]),
+                                "integrity_status": integrity_result.status,
+                                "message": integrity_result.message,
+                            },
+                        )
                     )
-                )
                 _store_logger.warning(
                     "Guard ignored local policy decision %s because integrity status was %s.",
                     candidate["decision_id"],
@@ -3336,11 +3337,11 @@ class GuardStore:
         lookup = self.resolve_policy_decision_lookup(
             harness,
             artifact_id,
-            artifact_hash,
-            workspace,
-            publisher,
-            now,
-            runtime_exact_match_context,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=publisher,
+            now=now,
+            runtime_exact_match_context=runtime_exact_match_context,
         )
         return lookup["decision"]
 

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -194,6 +194,12 @@ class _RecoveredOAuthLocalCredentialInputs(TypedDict):
     runtime_label: str | None
 
 
+class PolicyDecisionLookupResult(TypedDict):
+    decision: dict[str, object] | None
+    ignored_local_integrity: dict[str, object] | None
+    trust_status: dict[str, object]
+
+
 _POLICY_INTEGRITY_KEY_REF = "guard-policy-integrity-key"
 _POLICY_INTEGRITY_CONTROL_REF = "guard-policy-integrity-control"
 _POLICY_INTEGRITY_SERVICE_NAME = "hol-guard.policy-integrity"
@@ -3109,7 +3115,7 @@ class GuardStore:
         publisher: str | None = None,
         now: str | None = None,
     ) -> str | None:
-        decision = self.resolve_policy_decision(
+        lookup = self.resolve_policy_decision_lookup(
             harness,
             artifact_id,
             artifact_hash,
@@ -3117,9 +3123,10 @@ class GuardStore:
             publisher,
             now,
         )
+        decision = lookup["decision"]
         return str(decision["action"]) if decision is not None else None
 
-    def resolve_policy_decision(
+    def resolve_policy_decision_lookup(
         self,
         harness: str,
         artifact_id: str | None,
@@ -3128,7 +3135,7 @@ class GuardStore:
         publisher: str | None = None,
         now: str | None = None,
         runtime_exact_match_context: str | None = None,
-    ) -> dict[str, object] | None:
+    ) -> PolicyDecisionLookupResult:
         current_time = now or _now()
         workspace_key = _workspace_policy_key(workspace)
         action_family_key = _artifact_family_key(artifact_id)
@@ -3139,8 +3146,10 @@ class GuardStore:
         )
         events: list[tuple[str, dict[str, object]]] = []
         selected_payload: dict[str, object] | None = None
+        ignored_local_integrity: dict[str, object] | None = None
         with self._connect() as connection:
             state = self._refresh_policy_integrity_state(connection, now=current_time, create_key=True)
+            trust_status = TrustStatus.from_policy_integrity_state(state).to_dict()
             key, key_id = self._policy_integrity_secret_material(create=True)
             rows = connection.execute(
                 """
@@ -3208,7 +3217,11 @@ class GuardStore:
                 ),
             ).fetchall()
             if not rows:
-                return None
+                return {
+                    "decision": None,
+                    "ignored_local_integrity": None,
+                    "trust_status": trust_status,
+                }
             for candidate in rows:
                 if _scoped_runtime_row_requires_exact_match(
                     scope=str(candidate["scope"]),
@@ -3240,6 +3253,20 @@ class GuardStore:
                         integrity_result=integrity_result,
                         state=state,
                     )
+                    if is_remote_policy_source(str(candidate["source"])):
+                        events.append(
+                            (
+                                "policy.cloud.applied",
+                                {
+                                    "decision_id": int(candidate["decision_id"]),
+                                    "harness": str(candidate["harness"]),
+                                    "artifact_id": candidate["artifact_id"],
+                                    "scope": str(candidate["scope"]),
+                                    "source": str(candidate["source"]),
+                                    "action": str(candidate["action"]),
+                                },
+                            )
+                        )
                     if _is_approval_gate_one_shot_policy(candidate):
                         connection.execute(
                             "delete from policy_decisions where decision_id = ?",
@@ -3258,6 +3285,31 @@ class GuardStore:
                         },
                     )
                 )
+                if ignored_local_integrity is None and not is_remote_policy_source(str(candidate["source"])):
+                    ignored_local_integrity = {
+                        "decision_id": int(candidate["decision_id"]),
+                        "harness": str(candidate["harness"]),
+                        "artifact_id": candidate["artifact_id"],
+                        "scope": str(candidate["scope"]),
+                        "source": str(candidate["source"]),
+                        "integrity_status": integrity_result.status,
+                        "integrity_message": integrity_result.message,
+                        "trust_status": trust_status,
+                    }
+                events.append(
+                    (
+                        "rule.ignored.local_integrity",
+                        {
+                            "decision_id": int(candidate["decision_id"]),
+                            "harness": str(candidate["harness"]),
+                            "artifact_id": candidate["artifact_id"],
+                            "scope": str(candidate["scope"]),
+                            "source": str(candidate["source"]),
+                            "integrity_status": integrity_result.status,
+                            "message": integrity_result.message,
+                        },
+                    )
+                )
                 _store_logger.warning(
                     "Guard ignored local policy decision %s because integrity status was %s.",
                     candidate["decision_id"],
@@ -3265,7 +3317,32 @@ class GuardStore:
                 )
         for event_name, payload in events:
             self.add_event(event_name, payload, current_time)
-        return selected_payload
+        return {
+            "decision": selected_payload,
+            "ignored_local_integrity": ignored_local_integrity,
+            "trust_status": trust_status,
+        }
+
+    def resolve_policy_decision(
+        self,
+        harness: str,
+        artifact_id: str | None,
+        artifact_hash: str | None = None,
+        workspace: str | None = None,
+        publisher: str | None = None,
+        now: str | None = None,
+        runtime_exact_match_context: str | None = None,
+    ) -> dict[str, object] | None:
+        lookup = self.resolve_policy_decision_lookup(
+            harness,
+            artifact_id,
+            artifact_hash,
+            workspace,
+            publisher,
+            now,
+            runtime_exact_match_context,
+        )
+        return lookup["decision"]
 
     @staticmethod
     def _normalized_policy_keys(decision: PolicyDecision) -> tuple[str | None, str | None, str | None, str | None]:

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -274,6 +274,8 @@ def test_approval_gate_approve_once_does_not_persist_policy(
         )
         is None
     )
+    once_events = store.list_events(limit=20, event_name="approval.once")
+    assert any(event["payload"]["request_id"] == "req-once" for event in once_events)
     assert store.list_policy_decisions("codex") == []
 
 
@@ -318,6 +320,8 @@ def test_approval_gate_artifact_remember_persists_policy(
     assert second_retry is not None
     assert first_retry["action"] == "allow"
     assert second_retry["action"] == "allow"
+    remembered_events = store.list_events(limit=20, event_name="rule.remembered.local")
+    assert any(event["payload"]["request_id"] == "req-remember" for event in remembered_events)
 
 
 def test_approval_gate_cooldown_works_expires_and_revokes(tmp_path: Path) -> None:

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -2791,7 +2791,7 @@ class TestGuardApprovals:
         output = capsys.readouterr().out
 
         assert rc == 0
-        assert "Guard policy clear" in output
+        assert "Guard rules clear" in output
         assert "cleared 1 decision" in output
         assert store.list_policy_decisions("claude-code") == []
 
@@ -2800,8 +2800,45 @@ class TestGuardApprovals:
         output = capsys.readouterr().out
 
         assert rc == 2
-        assert "Guard policy clear" in output
+        assert "Guard rules clear" in output
         assert "Choose --harness <name> or --all" in output
+
+    def test_guard_policies_list_uses_remembered_rule_copy(self, tmp_path, capsys):
+        home_dir = tmp_path / "home"
+        store = GuardStore(home_dir)
+        store.upsert_policy(
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                action="allow",
+                artifact_id="codex:project:package-request:pnpm",
+                artifact_hash="hash-pnpm",
+                reason="approved",
+                source="manual",
+            ),
+            "2026-04-23T00:00:00+00:00",
+        )
+        store.replace_remote_policies(
+            [
+                PolicyDecision(
+                    harness="codex",
+                    scope="publisher",
+                    action="block",
+                    publisher="npm",
+                    reason="cloud bundle block",
+                    source="cloud-sync",
+                )
+            ],
+            "2026-04-23T00:01:00+00:00",
+            remote_write_authorized=True,
+        )
+
+        rc = main(["guard", "policies", "--home", str(home_dir)])
+        output = capsys.readouterr().out
+
+        assert rc == 0
+        assert "Guard remembered rules and Cloud policies" in output
+        assert "policy_decisions" not in output
 
     def test_guard_policies_clear_rejects_all_with_harness(self, tmp_path, capsys):
         rc = main(

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -1150,6 +1150,7 @@ def test_gr124_resolution_events_can_wake_polling_harness_clients(tmp_path: Path
     assert events[0]["payload"]["request_id"] == "req-event"
     assert events[0]["payload"]["action"] == "allow"
     assert events[0]["payload"]["scope"] == "artifact"
+    assert events[0]["payload"]["persisted_rule"] is False
 
 
 def test_gr122_duplicate_resolution_returns_idempotent_already_resolved_result(tmp_path: Path) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -963,9 +963,11 @@ def test_tampered_signed_row_is_ignored_and_event_emitted(tmp_path: Path) -> Non
         now="2026-06-14T00:01:00Z",
     )
     events = store.list_events(limit=100, event_name="policy_integrity_violation")
+    ignored_events = store.list_events(limit=100, event_name="rule.ignored.local_integrity")
 
     assert resolved is None
     assert any(event.get("payload", {}).get("artifact_id") == "codex:project:tampered" for event in events)
+    assert any(event.get("payload", {}).get("artifact_id") == "codex:project:tampered" for event in ignored_events)
 
 
 def test_remote_policy_row_is_honored_without_local_mac(tmp_path: Path) -> None:
@@ -982,8 +984,10 @@ def test_remote_policy_row_is_honored_without_local_mac(tmp_path: Path) -> None:
         "hash-remote",
         now="2026-06-14T00:01:00Z",
     )
+    events = store.list_events(limit=100, event_name="policy.cloud.applied")
 
     assert resolved == "allow"
+    assert any(event.get("payload", {}).get("artifact_id") == "codex:project:remote" for event in events)
 
 
 def test_local_policy_write_cannot_impersonate_remote_policy_source(tmp_path: Path) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -990,7 +990,10 @@ def test_remote_policy_row_is_honored_without_local_mac(tmp_path: Path) -> None:
     assert any(event.get("payload", {}).get("artifact_id") == "codex:project:remote" for event in events)
 
 
-def test_remote_policy_integrity_failure_does_not_emit_local_rule_event(tmp_path: Path) -> None:
+def test_remote_policy_integrity_failure_does_not_emit_local_rule_event(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from codex_plugin_scanner.guard.policy_integrity import PolicyIntegrityVerificationResult
 
     store = _store(tmp_path)
@@ -1021,7 +1024,6 @@ def test_remote_policy_integrity_failure_does_not_emit_local_rule_event(tmp_path
             trusted_generation=trusted_generation,
         )
 
-    monkeypatch = pytest.MonkeyPatch()
     monkeypatch.setattr(GuardStore, "_policy_integrity_result_for_row", _forced_invalid)
 
     resolved = store.resolve_policy(
@@ -1042,7 +1044,6 @@ def test_remote_policy_integrity_failure_does_not_emit_local_rule_event(tmp_path
         event.get("payload", {}).get("artifact_id") == "codex:project:remote-tampered"
         for event in ignored_events
     )
-    monkeypatch.undo()
 
 
 def test_local_policy_write_cannot_impersonate_remote_policy_source(tmp_path: Path) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -990,6 +990,61 @@ def test_remote_policy_row_is_honored_without_local_mac(tmp_path: Path) -> None:
     assert any(event.get("payload", {}).get("artifact_id") == "codex:project:remote" for event in events)
 
 
+def test_remote_policy_integrity_failure_does_not_emit_local_rule_event(tmp_path: Path) -> None:
+    from codex_plugin_scanner.guard.policy_integrity import PolicyIntegrityVerificationResult
+
+    store = _store(tmp_path)
+    store.replace_remote_policies(
+        [_decision(artifact_id="codex:project:remote-tampered", artifact_hash="hash-remote", source="cloud-sync")],
+        "2026-06-14T00:00:00Z",
+        remote_write_authorized=True,
+    )
+    original_result = GuardStore._policy_integrity_result_for_row
+
+    def _forced_invalid(
+        self: GuardStore,
+        row: sqlite3.Row,
+        *,
+        mode: str,
+        key: bytes | None,
+        key_id: str | None,
+        trusted_generation: int | None = None,
+    ) -> PolicyIntegrityVerificationResult:
+        if row["artifact_id"] == "codex:project:remote-tampered":
+            return PolicyIntegrityVerificationResult(status="invalid_mac", message="remote bundle row was tampered")
+        return original_result(
+            self,
+            row,
+            mode=mode,
+            key=key,
+            key_id=key_id,
+            trusted_generation=trusted_generation,
+        )
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(GuardStore, "_policy_integrity_result_for_row", _forced_invalid)
+
+    resolved = store.resolve_policy(
+        "codex",
+        "codex:project:remote-tampered",
+        "hash-remote",
+        now="2026-06-14T00:01:00Z",
+    )
+    integrity_events = store.list_events(limit=100, event_name="policy_integrity_violation")
+    ignored_events = store.list_events(limit=100, event_name="rule.ignored.local_integrity")
+
+    assert resolved is None
+    assert any(
+        event.get("payload", {}).get("artifact_id") == "codex:project:remote-tampered"
+        for event in integrity_events
+    )
+    assert not any(
+        event.get("payload", {}).get("artifact_id") == "codex:project:remote-tampered"
+        for event in ignored_events
+    )
+    monkeypatch.undo()
+
+
 def test_local_policy_write_cannot_impersonate_remote_policy_source(tmp_path: Path) -> None:
     store = _store(tmp_path)
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14836,23 +14836,25 @@ def test_guard_runtime_accepts_contextual_harness_tool_action_policy(tmp_path):
     )
     contextual_key = _runtime_scoped_exact_match_key(artifact_id, context)
     assert contextual_key is not None
+    expected_workspace = str(workspace)
 
     class _Store:
         def resolve_policy_decision(
             self,
             harness: str,
             requested_artifact_id: str,
-            artifact_hash: str,
-            workspace_value: str,
-            publisher: str | None,
-            *,
+            artifact_hash: str | None = None,
+            workspace: str | None = None,
+            publisher: str | None = None,
+            now: str | None = None,
             runtime_exact_match_context: str | None = None,
         ) -> dict[str, object]:
             assert harness == "opencode"
             assert requested_artifact_id == artifact_id
             assert artifact_hash == "hash-retry"
-            assert workspace_value == str(workspace)
+            assert workspace == expected_workspace
             assert publisher is None
+            assert now is None
             assert runtime_exact_match_context == context
             return {
                 "action": "allow",

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -10558,6 +10558,95 @@ def test_guard_hook_explains_ignored_remembered_rule_when_local_trust_is_degrade
     assert "remembered local rule was ignored" in output["approval_requests"][0]["decision_v2_json"]["harness_message"]
 
 
+def test_guard_hook_does_not_override_cloud_allow_with_remembered_rule_review_copy(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    command = "npm install minimist@1.2.8"
+    intent = extract_package_intent_request(
+        "Bash",
+        {"command": command},
+        action_envelope_command=None,
+        workspace=workspace_dir,
+    )
+    assert intent is not None
+    artifact = build_package_request_artifact(
+        "codex",
+        intent,
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        source_scope="project",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="workspace",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=None,
+            workspace=str(workspace_dir),
+            reason="remember this install in this project",
+            source="manual",
+        ),
+        "2026-06-19T00:00:00Z",
+    )
+    store.replace_remote_policies(
+        [
+                PolicyDecision(
+                    harness="codex",
+                    scope="harness",
+                    action="allow",
+                    artifact_id=artifact.artifact_id,
+                    artifact_hash=_runtime_scoped_exact_match_key(artifact.artifact_id),
+                    workspace=None,
+                    publisher=None,
+                    reason="cloud allow",
+                    source="cloud-sync",
+                )
+        ],
+        "2026-06-19T00:01:00Z",
+        remote_write_authorized=True,
+    )
+
+    def _degraded_state(_self, _connection, *, now, create_key):
+        return {
+            "mode": "degraded",
+            "enforcement": "enforce",
+            "generation": 1,
+            "degraded_reasons": ["system_keyring_unavailable"],
+        }
+
+    monkeypatch.setattr(GuardStore, "_refresh_policy_integrity_state", _degraded_state)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event={
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        },
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    assert rc == 0
+    assert output["policy_action"] == "allow"
+    assert output["trust_status"]["remembered_rules"] == "disabled_degraded"
+    assert output["remembered_rule_rejection"]["integrity_status"] == "degraded_mode"
+    assert "remembered local rule was ignored" not in output["decision_v2_json"]["harness_message"]
+    assert "kept npm install minimist in review" not in output["risk_headline"]
+
+
 def test_guard_hook_emits_claude_native_ask_for_sensitive_file_reads(
     tmp_path,
     capsys,

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -52,6 +52,10 @@ from codex_plugin_scanner.guard.proxy import stdio as stdio_proxy_module
 from codex_plugin_scanner.guard.receipts import build_receipt
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.runtime import secret_file_requests as secret_file_requests_module
+from codex_plugin_scanner.guard.runtime.package_intent import (
+    build_package_request_artifact,
+    extract_package_intent_request,
+)
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
 from codex_plugin_scanner.guard.store import (
@@ -10450,6 +10454,108 @@ def test_guard_hook_localizes_package_review_copy_with_daemon_client_approval_ur
     assert review_url in output["decision_v2_json"]["harness_message"]
     assert output["supply_chain_evaluation"]["user_copy"]["dashboard_url"] == review_url
     assert review_url in output["supply_chain_evaluation"]["user_copy"]["harness_message"]
+
+
+def test_guard_hook_explains_ignored_remembered_rule_when_local_trust_is_degraded(
+    tmp_path,
+    capsys,
+    monkeypatch,
+):
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import (
+        PackageRequestEvaluation,
+        SupplyChainUserCopy,
+    )
+
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    _build_guard_fixture(home_dir, workspace_dir)
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    store = GuardStore(home_dir)
+    command = "npm install minimist@1.2.8"
+    intent = extract_package_intent_request(
+        "Bash",
+        {"command": command},
+        action_envelope_command=None,
+        workspace=workspace_dir,
+    )
+    assert intent is not None
+    artifact = build_package_request_artifact(
+        "codex",
+        intent,
+        config_path=str(workspace_dir / ".codex" / "config.toml"),
+        source_scope="project",
+    )
+    store.upsert_policy(
+        PolicyDecision(
+            harness="codex",
+            scope="workspace",
+            action="allow",
+            artifact_id=artifact.artifact_id,
+            artifact_hash=None,
+            workspace=str(workspace_dir),
+            reason="remember this install in this project",
+            source="manual",
+        ),
+        "2026-06-19T00:00:00Z",
+    )
+
+    def _degraded_state(_self, _connection, *, now, create_key):
+        return {
+            "mode": "degraded",
+            "enforcement": "enforce",
+            "generation": 1,
+            "degraded_reasons": ["system_keyring_unavailable"],
+        }
+
+    def _package_requires_review(**_kwargs: object) -> PackageRequestEvaluation:
+        return PackageRequestEvaluation(
+            decision="review",
+            policy_action="require-reapproval",
+            enforcement="policy",
+            entitlement_state="offline",
+            cache_status="miss",
+            package_intent_hash="intent-hash",
+            policy_version="policy-v1",
+            bundle_version="bundle-v1",
+            workspace_fingerprint="workspace-fingerprint",
+            reasons=({"code": "package_review", "message": "Review npm install minimist@1.2.8"},),
+            packages=({"name": "minimist", "decision": "review", "reasons": ()},),
+            risk_summary="HOL Guard is reviewing npm install minimist@1.2.8.",
+            user_copy=SupplyChainUserCopy(
+                title="Review package install",
+                summary="minimist@1.2.8 needs review before install.",
+                next_step="Confirm the exact version in Codex's approval prompt.",
+                dashboard_url="https://hol.org/guard/inbox",
+                harness_message="HOL Guard is reviewing npm install minimist@1.2.8.",
+            ),
+        )
+
+    monkeypatch.setattr(GuardStore, "_refresh_policy_integrity_state", _degraded_state)
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(guard_commands_module, "evaluate_package_request_artifact", _package_requires_review)
+
+    rc, output = _run_guard_hook(
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+        harness="codex",
+        event={
+            "hook_event_name": "PreToolUse",
+            "tool_name": "Bash",
+            "tool_input": {"command": command},
+            "source_scope": "project",
+        },
+        capsys=capsys,
+        monkeypatch=monkeypatch,
+        as_json=True,
+    )
+
+    assert rc == 1
+    assert output["policy_action"] == "require-reapproval"
+    assert output["trust_status"]["remembered_rules"] == "disabled_degraded"
+    assert output["remembered_rule_rejection"]["integrity_status"] == "degraded_mode"
+    assert "remembered local rule was ignored" in output["decision_v2_json"]["harness_message"]
+    assert "One-time approvals still work" in output["decision_v2_json"]["harness_message"]
+    assert "remembered local rule was ignored" in output["approval_requests"][0]["decision_v2_json"]["harness_message"]
 
 
 def test_guard_hook_emits_claude_native_ask_for_sensitive_file_reads(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14891,6 +14891,51 @@ def test_guard_runtime_accepts_contextual_harness_tool_action_policy(tmp_path):
     )
 
 
+def test_guard_runtime_contextual_tool_action_lookup_skips_legacy_fallback_after_integrity_rejection(tmp_path):
+    workspace = tmp_path / "workspace"
+    artifact_id = "opencode:project:tool-action:docker-compose-postgres"
+    runtime_artifact = GuardArtifact(
+        artifact_id=artifact_id,
+        name="Bash docker-sensitive command",
+        harness="opencode",
+        artifact_type="tool_action_request",
+        source_scope="project",
+        config_path=str(workspace / "opencode.json"),
+        publisher=None,
+        metadata={
+            "action_class": "docker-sensitive command",
+            "raw_command_text": "docker compose up -d postgres",
+            "wrapper_chain": ["bash", "zsh"],
+        },
+    )
+
+    class _Store:
+        def resolve_policy_decision(self, *args, **kwargs) -> dict[str, object] | None:
+            raise AssertionError("legacy fallback should not re-query after an integrity rejection lookup")
+
+    assert (
+        guard_commands_module._runtime_stored_policy_action(
+            store=_Store(),
+            harness="opencode",
+            artifact=runtime_artifact,
+            artifact_id=runtime_artifact.artifact_id,
+            artifact_hash="hash-retry",
+            workspace=str(workspace),
+            decision_lookup={
+                "decision": None,
+                "ignored_local_integrity": {
+                    "source": "local_rule",
+                    "scope": "harness",
+                },
+                "trust_status": {
+                    "remembered_rules": "disabled_degraded",
+                },
+            },
+        )
+        is None
+    )
+
+
 def test_guard_runtime_tool_action_policy_prefers_configured_risk_action_over_default(tmp_path):
     artifact = GuardArtifact(
         artifact_id="codex:test:tool-action:upload",


### PR DESCRIPTION
## Summary
- surface when a remembered local rule is ignored because local trust is degraded and keep the hook response explicit about the fallback approval path
- rename user-facing policy-decision copy to remembered-rule wording and emit source-specific analytics for remembered local rules and applied cloud policies

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py src/codex_plugin_scanner/guard/cli/commands_parser_policy.py src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py src/codex_plugin_scanner/guard/cli/render.py src/codex_plugin_scanner/guard/store.py tests/test_guard_approval_gate.py tests/test_guard_approvals.py tests/test_guard_phase05_approval_memory.py tests/test_guard_policy_integrity.py tests/test_guard_runtime.py`
- `python3 -m pytest tests/test_guard_policy_integrity.py::test_tampered_signed_row_is_ignored_and_event_emitted tests/test_guard_policy_integrity.py::test_remote_policy_row_is_honored_without_local_mac tests/test_guard_approval_gate.py::test_approval_gate_approve_once_does_not_persist_policy tests/test_guard_approval_gate.py::test_approval_gate_artifact_remember_persists_policy tests/test_guard_phase05_approval_memory.py::test_gr124_resolution_events_can_wake_polling_harness_clients tests/test_guard_approvals.py::TestGuardApprovals::test_guard_policies_list_uses_remembered_rule_copy tests/test_guard_runtime.py::test_guard_hook_explains_ignored_remembered_rule_when_local_trust_is_degraded -q`
