### PR TITLE
feat(guard): enable explicit macos local trust setup

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import argparse
 import importlib.metadata
+import sys
 from pathlib import Path
 from typing import TextIO
 
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
 from ..local_trust_contract import TrustStatus
-from ..store import GuardStore
+from ..store import GuardStore, SystemKeyringSecretStore
 from .commands_support_interaction import _emit
 
 
@@ -151,6 +152,15 @@ def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> d
     return payload
 
 
+def _macos_native_backend_supported(store: GuardStore) -> bool:
+    secret_store = getattr(store, "_policy_integrity_secret_store", None)
+    return (
+        sys.platform == "darwin"
+        and isinstance(secret_store, SystemKeyringSecretStore)
+        and secret_store._supports_native_macos_security_reads()
+    )
+
+
 def _run_guard_trust_command(
     args: argparse.Namespace,
     *,
@@ -166,7 +176,7 @@ def _run_guard_trust_command(
     store = _require_guard_store(store)
     trust_command = getattr(args, "trust_command", None) or "status"
     backend = str(getattr(args, "backend", None) or "auto")
-    if backend == "macos-native" and trust_command in {"status", "doctor", "test"}:
+    if backend == "macos-native" and not _macos_native_backend_supported(store):
         payload = _unsupported_backend_payload(command=trust_command, backend=backend)
         _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
         return 2
@@ -189,19 +199,87 @@ def _run_guard_trust_command(
         _emit("trust.test", payload, getattr(args, "json", False))
         return 0
     if trust_command in {"setup", "reset"}:
-        if backend == "macos-native":
+        if backend == "degraded-safe":
             payload["error"] = (
-                f"macOS native trust {trust_command} is not enabled yet. Passive checks remain no-UI and degraded-safe."
+                "No explicit local trust backend is available for setup on this platform."
+                if trust_command == "setup"
+                else "No explicit local trust backend is active to reset."
+            )
+            payload["next_action"] = (
+                "Runtime protection remains active. Broad remembered local rules stay limited."
+                if trust_command == "setup"
+                else "Nothing changed."
+            )
+            _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+            return 2
+        if sys.platform != "darwin":
+            payload["error"] = (
+                "No explicit local trust backend is available for setup on this platform."
+                if trust_command == "setup"
+                else "No explicit local trust backend is active to reset."
+            )
+            payload["next_action"] = (
+                "Guard already uses the default passive backend on this platform."
+                if trust_command == "setup"
+                else "Nothing changed."
+            )
+            _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+            return 2
+        if not _macos_native_backend_supported(store):
+            payload["error"] = (
+                f"macOS native trust {trust_command} is unavailable. "
+                "Guard will not fall back to a prompt-capable backend."
             )
             payload["next_action"] = "Use one-time approvals or Guard Cloud policies until native setup is available."
-        elif trust_command == "setup":
-            payload["error"] = "No explicit local trust backend is available for setup on this platform."
-            payload["next_action"] = "Runtime protection remains active. Broad remembered local rules stay limited."
+            _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+            return 2
+        result = (
+            store.setup_policy_integrity(now=_now())
+            if trust_command == "setup"
+            else store.reset_policy_integrity(now=_now())
+        )
+        trust_status = result.get("trust_status")
+        if not isinstance(trust_status, dict):
+            trust_status = TrustStatus.from_policy_integrity_state(result).to_dict()
+        payload = {
+            **payload,
+            **result,
+            "backend_requested": backend,
+            "backend": trust_status.get("backend") or result.get("backend") or "unknown",
+            "runtime_protection": trust_status.get("runtime_protection") or "unknown",
+            "remembered_rules": trust_status.get("remembered_rules") or "unknown",
+            "cloud_policies": trust_status.get("cloud_policies") or "unknown",
+            "setup_available": bool(trust_status.get("setup_available")),
+            "passive_prompt_allowed": False,
+            "no_ui_passive": True,
+            "one_time_approvals": "available",
+            "durable_local_rules": (
+                "enforced" if trust_status.get("remembered_rules") == "enforced" else "limited"
+            ),
+            "cloud_policy_authority": trust_status.get("cloud_policies") or "unknown",
+            "ok": bool(result.get("mode") == "protected") if trust_command == "setup" else True,
+        }
+        if trust_command == "setup":
+            payload["message"] = (
+                "Local trust is protected. Broad remembered local rules can be enforced."
+                if payload["ok"]
+                else "Local trust setup did not finish. Guard stayed in degraded-safe mode."
+            )
+            if not payload["ok"]:
+                payload["next_action"] = "Keep using one-time approvals, then run trust doctor for the degraded reason."
+                _emit("trust.setup", payload, getattr(args, "json", False))
+                return 2
         else:
-            payload["error"] = "No explicit local trust backend is active to reset."
-            payload["next_action"] = "Nothing changed."
+            payload["message"] = (
+                "Local trust material was removed. Runtime blocking stays active, "
+                "and broad remembered local rules are limited."
+            )
+            payload["next_action"] = (
+                "Run `hol-guard guard trust setup --backend macos-native --json` "
+                "to protect local rules again."
+            )
         _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
-        return 2
+        return 0
     _emit("trust", {"error": "Use: hol-guard guard trust status|doctor|test|setup|reset"}, getattr(args, "json", False))
     return 2
 

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -253,9 +253,7 @@ def _run_guard_trust_command(
             "passive_prompt_allowed": False,
             "no_ui_passive": True,
             "one_time_approvals": "available",
-            "durable_local_rules": (
-                "enforced" if trust_status.get("remembered_rules") == "enforced" else "limited"
-            ),
+            "durable_local_rules": ("enforced" if trust_status.get("remembered_rules") == "enforced" else "limited"),
             "cloud_policy_authority": trust_status.get("cloud_policies") or "unknown",
             "ok": bool(result.get("mode") == "protected") if trust_command == "setup" else True,
         }
@@ -275,8 +273,7 @@ def _run_guard_trust_command(
                 "and broad remembered local rules are limited."
             )
             payload["next_action"] = (
-                "Run `hol-guard guard trust setup --backend macos-native --json` "
-                "to protect local rules again."
+                "Run `hol-guard guard trust setup --backend macos-native --json` to protect local rules again."
             )
         _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
         return 0

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -4624,8 +4624,7 @@ class GuardStore:
                 and trusted_state is not None
             ):
                 local_ids = {
-                    int(row["decision_id"])
-                    for row in self._load_local_policy_rows(connection, harness=harness)
+                    int(row["decision_id"]) for row in self._load_local_policy_rows(connection, harness=harness)
                 }
                 next_control_state = self._advance_policy_integrity_generation(
                     connection,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -4617,12 +4617,14 @@ class GuardStore:
             )
             key, key_id = self._policy_integrity_secret_material(create=True)
             trusted_state = self._load_policy_integrity_control_state(create=True)
-            if (
+            if not (
                 state.get("mode") == "protected"
                 and key is not None
                 and key_id is not None
                 and trusted_state is not None
             ):
+                connection.rollback()
+            else:
                 local_ids = {
                     int(row["decision_id"]) for row in self._load_local_policy_rows(connection, harness=harness)
                 }

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -636,6 +636,8 @@ class SystemKeyringSecretStore:
     def _supports_native_macos_security_reads(cls) -> bool:
         if sys.platform != "darwin":
             return False
+        if cls._test_keyring_module() is not None:
+            return True
         loader_ref = cls._load_keyring_module
         loader_id = id(loader_ref)
         cached = cls._native_macos_security_reads_cache
@@ -731,14 +733,12 @@ class SystemKeyringSecretStore:
     def get_secret_with_timeout(self, secret_id: str, *, timeout_seconds: float = 0.0) -> str | None:
         _ = timeout_seconds
         if sys.platform == "darwin":
-            if self.service_name == _POLICY_INTEGRITY_SERVICE_NAME:
-                # Passive Guard paths must never touch macOS Keychain. Even
-                # no-UI Security-framework reads can regress into OS prompts
-                # when the user keychain is missing, locked, or owned by
-                # another ACL.
-                return None
             if self._supports_native_macos_security_reads():
                 return self._get_secret_without_macos_ui(secret_id)
+            if self.service_name == _POLICY_INTEGRITY_SERVICE_NAME:
+                # Passive policy-integrity reads must fail closed when native
+                # no-UI access is unavailable.
+                return None
             if self._test_keyring_module() is not None:
                 return self.get_secret(secret_id)
             return None
@@ -1085,8 +1085,11 @@ def _build_oauth_secret_store(guard_home: Path) -> SecretStore:
 
 def _build_policy_integrity_secret_store() -> SystemKeyringSecretStore | None:
     if sys.platform == "darwin":
-        # Policy integrity is passive hardening; it must never raise Keychain UI.
-        return None
+        if not SystemKeyringSecretStore._backend_is_available():
+            return None
+        if not SystemKeyringSecretStore._supports_native_macos_security_reads():
+            return None
+        return SystemKeyringSecretStore(service_name=_POLICY_INTEGRITY_SERVICE_NAME)
     if SystemKeyringSecretStore._backend_is_available():
         return SystemKeyringSecretStore(service_name=_POLICY_INTEGRITY_SERVICE_NAME)
     return None
@@ -4597,6 +4600,66 @@ class GuardStore:
             "local_rows_scanned": sum(counts.values()),
             "items": [item for item in items if item.get("integrity_status") != "valid"],
         }
+
+    def setup_policy_integrity(
+        self,
+        *,
+        harness: str | None = None,
+        now: str,
+    ) -> dict[str, object]:
+        next_control_state: dict[str, object] | None = None
+        with self._connect() as connection:
+            state = self._refresh_policy_integrity_state(
+                connection,
+                now=now,
+                create_key=True,
+                allow_cutover_resign=False,
+            )
+            key, key_id = self._policy_integrity_secret_material(create=True)
+            trusted_state = self._load_policy_integrity_control_state(create=True)
+            if (
+                state.get("mode") == "protected"
+                and key is not None
+                and key_id is not None
+                and trusted_state is not None
+            ):
+                local_ids = {
+                    int(row["decision_id"])
+                    for row in self._load_local_policy_rows(connection, harness=harness)
+                }
+                next_control_state = self._advance_policy_integrity_generation(
+                    connection,
+                    now=now,
+                    key=key,
+                    key_id=key_id,
+                    trusted_state=trusted_state,
+                    force_sign_decision_ids=local_ids,
+                    harness=harness,
+                )
+                connection.commit()
+        if next_control_state is not None:
+            self._finalize_policy_integrity_control_state(next_control_state)
+        return self.verify_policy_integrity(harness=harness)
+
+    def reset_policy_integrity(
+        self,
+        *,
+        harness: str | None = None,
+        now: str,
+    ) -> dict[str, object]:
+        secret_store = self._policy_integrity_secret_store
+        if secret_store is not None:
+            secret_store.delete_secret(self._policy_integrity_key_ref)
+            secret_store.delete_secret(self._policy_integrity_control_ref)
+        self._clear_policy_integrity_cache()
+        with self._connect() as connection:
+            self._refresh_policy_integrity_state(
+                connection,
+                now=now,
+                create_key=False,
+                allow_cutover_resign=False,
+            )
+        return self.verify_policy_integrity(harness=harness)
 
     def clear_policy_decisions(
         self,

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1647,6 +1647,28 @@ def test_trust_cli_macos_native_setup_and_reset_work(
     assert reset_payload["ok"] is True
 
 
+def test_setup_policy_integrity_rolls_back_degraded_refresh_state(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "home")
+    monkeypatch.setattr(store, "_load_policy_integrity_control_state", lambda create: None)
+
+    baseline = _policy_integrity_state_payload(store.guard_home)
+    observed: dict[str, dict[str, object]] = {}
+
+    def _verify_policy_integrity(*, harness: str | None = None) -> dict[str, object]:
+        observed["state_payload"] = _policy_integrity_state_payload(store.guard_home)
+        return {"harness": harness, "mode": "degraded"}
+
+    monkeypatch.setattr(store, "verify_policy_integrity", _verify_policy_integrity)
+
+    result = store.setup_policy_integrity(harness="codex", now="2026-06-14T00:00:00Z")
+
+    assert result == {"harness": "codex", "mode": "degraded"}
+    assert observed["state_payload"] == baseline
+
+
 def test_policies_cli_verify_returns_nonzero_for_rollback_detected(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -6,7 +6,6 @@ import base64
 import json
 import pickle
 import sqlite3
-import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
@@ -54,6 +53,25 @@ def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
 
 def _store(tmp_path: Path) -> GuardStore:
     return GuardStore(tmp_path / "guard-home")
+
+
+def _enable_macos_native_policy_integrity(
+    monkeypatch: pytest.MonkeyPatch,
+    install_fake_system_keyring,
+):
+    fake_keyring = install_fake_system_keyring()
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_get_secret_without_macos_ui",
+        lambda self, secret_id: fake_keyring.get_password(self.service_name, secret_id),
+    )
+    return fake_keyring
 
 
 @dataclass
@@ -894,31 +912,31 @@ def test_policy_integrity_status_and_verify_do_not_create_keyring_material_on_fr
     assert secret_store.get_secret(store._policy_integrity_control_ref) is None
 
 
-def test_policy_integrity_status_skips_passive_macos_keychain_reads(
+def test_policy_integrity_status_uses_native_no_ui_reads_on_macos(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    install_fake_system_keyring,
 ) -> None:
-    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    _enable_macos_native_policy_integrity(monkeypatch, install_fake_system_keyring)
     store = _store(tmp_path)
     store.upsert_policy(
         _decision(artifact_id="codex:project:passive-skip", artifact_hash="hash-passive-skip"),
         "2026-06-14T00:00:00Z",
     )
-    assert store._policy_integrity_secret_store is None
+    secret_store = store._policy_integrity_secret_store
+    assert isinstance(secret_store, SystemKeyringSecretStore)
     store._clear_policy_integrity_cache()
-    monkeypatch.setattr(sys, "platform", "darwin", raising=False)
     monkeypatch.setattr(
-        SystemKeyringSecretStore,
-        "_supports_native_macos_security_reads",
-        classmethod(lambda cls: (_ for _ in ()).throw(AssertionError("passive macOS keychain probe should not run"))),
+        secret_store,
+        "get_secret",
+        lambda _secret_id: (_ for _ in ()).throw(AssertionError("plain keyring reads should not run")),
     )
 
     status = store.get_policy_integrity_status()
     verify = store.verify_policy_integrity()
 
-    assert status["mode"] == "degraded"
-    assert verify["mode"] == "degraded"
-    assert status["degraded_reasons"] == ["system_keyring_unavailable", "policy_integrity_control_unavailable"]
+    assert status["mode"] == "protected"
+    assert verify["mode"] == "protected"
     assert verify["local_rows_scanned"] == 1
 
 
@@ -1573,8 +1591,21 @@ def test_trust_cli_doctor_degraded_safe_does_not_pass_runtime_check(tmp_path: Pa
     assert payload["summary"].startswith("Runtime protection is degraded.")
 
 
-def test_trust_cli_macos_native_setup_is_explicitly_unavailable(tmp_path: Path, capsys) -> None:
+def test_trust_cli_macos_native_setup_and_reset_work(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+    install_fake_system_keyring,
+) -> None:
+    _enable_macos_native_policy_integrity(monkeypatch, install_fake_system_keyring)
     home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:trust-setup", artifact_hash="hash-trust-setup"),
+        "2026-06-14T00:00:00Z",
+    )
+    store.reset_policy_integrity(now="2026-06-14T00:00:01Z")
+
     rc = main(
         [
             "guard",
@@ -1589,10 +1620,12 @@ def test_trust_cli_macos_native_setup_is_explicitly_unavailable(tmp_path: Path, 
     )
     payload = json.loads(capsys.readouterr().out)
 
-    assert rc == 2
+    assert rc == 0
     assert payload["backend_requested"] == "macos-native"
-    assert "not enabled yet" in payload["error"]
-    assert "trust setup" in payload["error"]
+    assert payload["backend"] == "system-keyring"
+    assert payload["mode"] == "protected"
+    assert payload["remembered_rules"] == "enforced"
+    assert payload["ok"] is True
     assert payload["passive_prompt_allowed"] is False
 
     reset_rc = main(
@@ -1608,8 +1641,10 @@ def test_trust_cli_macos_native_setup_is_explicitly_unavailable(tmp_path: Path, 
         ]
     )
     reset_payload = json.loads(capsys.readouterr().out)
-    assert reset_rc == 2
-    assert "trust reset" in reset_payload["error"]
+    assert reset_rc == 0
+    assert reset_payload["mode"] == "degraded"
+    assert reset_payload["remembered_rules"] == "disabled_degraded"
+    assert reset_payload["ok"] is True
 
 
 def test_policies_cli_verify_returns_nonzero_for_rollback_detected(tmp_path: Path, capsys) -> None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -172,9 +172,7 @@ def test_system_keyring_timeout_skips_all_passive_macos_reads(monkeypatch: pytes
     monkeypatch.setattr(
         SystemKeyringSecretStore,
         "_supports_native_macos_security_reads",
-        classmethod(
-            lambda cls: (_ for _ in ()).throw(AssertionError("native macOS Security reads should not be probed"))
-        ),
+        classmethod(lambda cls: False),
     )
     monkeypatch.setattr(
         secret_store,
@@ -229,12 +227,17 @@ def test_system_keyring_timeout_blocks_non_policy_macos_prompt_fallback(
     assert secret_store.get_secret_with_timeout("oauth-token", timeout_seconds=1.0) is None
 
 
-def test_policy_integrity_store_is_disabled_on_macos_without_health_probe(
+def test_policy_integrity_store_uses_native_backend_on_macos_without_health_probe(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
     module = _FakeSystemKeyringModule()
     monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
     monkeypatch.setattr(
         SystemKeyringSecretStore,
         "_macos_default_keychain_is_usable",
@@ -245,7 +248,7 @@ def test_policy_integrity_store_is_disabled_on_macos_without_health_probe(
 
     secret_store = guard_store_module._build_policy_integrity_secret_store()
 
-    assert secret_store is None
+    assert isinstance(secret_store, SystemKeyringSecretStore)
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
## Summary
- enable the macOS native policy-integrity backend when passive no-UI reads are available
- add explicit `guard trust setup|reset` flows for the native macOS backend
- cover the new macOS passive-read and trust-command behavior with regression tests

## Testing
- python3 -m ruff check src/codex_plugin_scanner/guard/store.py src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py tests/test_guard_policy_integrity.py tests/test_guard_store_migrations.py
- python3 -m pytest tests/test_guard_policy_integrity.py -q
- python3 -m pytest tests/test_guard_store_migrations.py -q