### PR TITLE
fix(guard): restore native macos trust reads

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -665,7 +665,7 @@ class SystemKeyringSecretStore:
             from ctypes import byref, c_ubyte
 
             macos_keyring_api = self._load_macos_keyring_api_module()
-            cfdata_to_str = getattr(macos_keyring_api, "cfdata_to_str", None)
+            cfdata_to_str = getattr(macos_keyring_api, "cfstr_to_str", None)
             cf_release = getattr(macos_keyring_api, "CFRelease", None)
             security_library = getattr(macos_keyring_api, "_sec", None)
             get_interaction_allowed = (

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -665,7 +665,9 @@ class SystemKeyringSecretStore:
             from ctypes import byref, c_ubyte
 
             macos_keyring_api = self._load_macos_keyring_api_module()
-            cfdata_to_str = getattr(macos_keyring_api, "cfstr_to_str", None)
+            # The macOS keyring backend returns password bytes here but exposes
+            # its decoder under the historical cfstr_to_str name.
+            cfstr_to_str = getattr(macos_keyring_api, "cfstr_to_str", None)
             cf_release = getattr(macos_keyring_api, "CFRelease", None)
             security_library = getattr(macos_keyring_api, "_sec", None)
             get_interaction_allowed = (
@@ -708,10 +710,10 @@ class SystemKeyringSecretStore:
                 with suppress(Exception):
                     set_interaction_allowed(restore_value)
         if status == 0:
-            if not callable(cfdata_to_str):
+            if not callable(cfstr_to_str):
                 return None
             try:
-                value = cfdata_to_str(data)
+                value = cfstr_to_str(data)
             except Exception:
                 value = None
             finally:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -208,6 +208,37 @@ def test_system_keyring_timeout_keeps_non_policy_integrity_macos_services(
     assert secret_store.get_secret_with_timeout("oauth-token", timeout_seconds=1.0) == "oauth-secret"
 
 
+def test_system_keyring_native_macos_read_uses_cfstr_decoder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_supports_native_macos_security_reads",
+        classmethod(lambda cls: True),
+    )
+    fake_api = types.SimpleNamespace(
+        OS_status=guard_store_module.ctypes.c_int32,
+        _sec=types.SimpleNamespace(),
+        error=types.SimpleNamespace(
+            item_not_found=-25300,
+            keychain_denied=-128,
+            sec_auth_failed=-25293,
+            plist_missing=-67030,
+            sec_interaction_not_allowed=-25308,
+        ),
+        c_void_p=guard_store_module.ctypes.c_void_p,
+        k_=lambda name: name,
+        create_query=lambda **kwargs: kwargs,
+        SecItemCopyMatching=lambda _query, _data: 0,
+        cfstr_to_str=lambda _data: "native-secret",
+    )
+    monkeypatch.setattr(secret_store, "_load_macos_keyring_api_module", lambda: fake_api)
+
+    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "native-secret"
+
+
 def test_system_keyring_timeout_blocks_non_policy_macos_prompt_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- fix the macOS native no-UI policy-integrity read path to use the backend's actual CoreFoundation decoder
- add regression coverage for the macOS passive-read success path and re-verify local trust setup/reset flows

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_store_migrations.py`
- `python3 -m pytest tests/test_guard_store_migrations.py -q`
- `python3 -m pytest tests/test_guard_policy_integrity.py -q`
