### PR TITLE
feat(guard): add trust authority explain diagnostics

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import argparse
 import importlib.metadata
+import json
 import sys
 from pathlib import Path
 from typing import TextIO
 
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
+from ..daemon.manager import _guard_daemon_url_port, load_guard_daemon_url, read_approval_center_locator
 from ..local_trust_contract import TrustStatus
+from ..policy_integrity import is_remote_policy_source
 from ..store import GuardStore, SystemKeyringSecretStore
 from .commands_support_interaction import _emit
 
@@ -53,7 +56,7 @@ def _unsupported_backend_payload(*, command: str, backend: str) -> dict[str, obj
         "passive_prompt_allowed": False,
         "one_time_approvals": "available",
         "durable_local_rules": "limited",
-        "cloud_policy_authority": "setup_unavailable",
+        "cloud_policy_status": "setup_unavailable",
         "error": (
             f"Backend {backend!r} is not available for passive {command}. "
             "Guard will not probe it in the background because that could open an OS credential prompt."
@@ -92,7 +95,7 @@ def _trust_status_payload(store: GuardStore, *, command: str, backend: str) -> d
         "passive_prompt_allowed": False,
         "one_time_approvals": "available",
         "durable_local_rules": "enforced" if remembered_rules == "enforced" else "limited",
-        "cloud_policy_authority": cloud_policies,
+        "cloud_policy_status": cloud_policies,
         "message": (
             "Guard is blocking risky actions. Broad remembered local rules are limited until local trust is protected."
             if remembered_rules != "enforced"
@@ -102,20 +105,88 @@ def _trust_status_payload(store: GuardStore, *, command: str, backend: str) -> d
 
 
 def _installed_trust_cli_payload() -> dict[str, object]:
+    version = None
+    installation_mode = "unknown"
+    editable_install = False
+    official_install = False
     try:
-        version = importlib.metadata.version("hol-guard")
+        distribution = importlib.metadata.distribution("hol-guard")
     except importlib.metadata.PackageNotFoundError:
-        version = None
+        distribution = None
+    if distribution is not None:
+        version = distribution.version
+        direct_url_text = distribution.read_text("direct_url.json")
+        if isinstance(direct_url_text, str) and direct_url_text.strip():
+            try:
+                direct_url_payload = json.loads(direct_url_text)
+            except json.JSONDecodeError:
+                direct_url_payload = None
+            dir_info = direct_url_payload.get("dir_info") if isinstance(direct_url_payload, dict) else None
+            editable_install = bool(isinstance(dir_info, dict) and dir_info.get("editable") is True)
+        try:
+            distribution_root = str(distribution.locate_file("")).replace("\\", "/")
+        except Exception:
+            distribution_root = ""
+        official_install = (
+            "pipx/venvs/hol-guard/" in distribution_root or "/venvs/hol-guard/" in distribution_root
+        ) and not editable_install
+        if official_install:
+            installation_mode = "official-pipx"
+        elif editable_install:
+            installation_mode = "editable"
+        else:
+            installation_mode = "packaged"
     return {
         "package": "hol-guard",
         "version": version,
+        "installation_mode": installation_mode,
+        "official_install": official_install,
+        "editable_install": editable_install,
         "update_command": "hol-guard update",
         "dry_run_command": "hol-guard update --dry-run --json",
     }
 
 
+def _approval_center_status_payload(guard_home: Path) -> dict[str, object]:
+    locator = read_approval_center_locator(guard_home)
+    if locator is not None:
+        return {
+            "active": True,
+            "approval_url_base": locator.approval_url_base,
+            "daemon_url": locator.daemon_url,
+            "port": (
+                _guard_daemon_url_port(locator.approval_url_base)
+                if isinstance(locator.approval_url_base, str) and locator.approval_url_base.strip()
+                else None
+            ),
+            "started_at": locator.started_at,
+            "pid": locator.pid,
+        }
+    daemon_url = load_guard_daemon_url(guard_home)
+    if isinstance(daemon_url, str) and daemon_url.strip():
+        return {
+            "active": True,
+            "approval_url_base": daemon_url,
+            "daemon_url": daemon_url,
+            "port": _guard_daemon_url_port(daemon_url),
+            "detail": "Guard daemon is healthy, but the browser approval locator has not been refreshed yet.",
+        }
+    return {
+        "active": False,
+        "detail": "No active Guard approval center daemon detected.",
+    }
+
+
+def _passive_read_guarantee() -> str:
+    if sys.platform == "darwin":
+        return "No passive macOS Keychain access"
+    return "No passive OS credential prompts"
+
+
 def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> dict[str, object]:
     payload = _trust_status_payload(store, command="doctor", backend=backend)
+    approval_center = _approval_center_status_payload(store.guard_home)
+    install_info = _installed_trust_cli_payload()
     remembered_rules = str(payload.get("remembered_rules") or "unknown")
     runtime_protection = str(payload.get("runtime_protection") or "unknown")
     if runtime_protection != "protected":
@@ -134,7 +205,8 @@ def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> d
         "one_time_approvals": payload.get("one_time_approvals") == "available",
         "passive_no_ui": payload.get("passive_prompt_allowed") is False,
         "local_rules_protected": remembered_rules == "enforced",
-        "cloud_policy_authority": payload.get("cloud_policy_authority") == "available",
+        "cloud_policy_available": payload.get("cloud_policy_status") == "available",
+        "approval_center_active": bool(approval_center.get("active")),
     }
     payload["recommended_actions"] = (
         [
@@ -148,8 +220,87 @@ def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> d
             "Use Guard Cloud policies for team-wide exceptions.",
         ]
     )
-    payload["official_install"] = _installed_trust_cli_payload()
+    if not bool(approval_center.get("active")):
+        payload["recommended_actions"].append(
+            "Run `hol-guard dashboard` if browser approvals are unavailable and Guard needs a fresh local route."
+        )
+    if bool(install_info.get("editable_install")):
+        payload["recommended_actions"].append(
+            "Use the official pipx install before relying on packaged update and daemon lifecycle checks."
+        )
+    payload["approval_center"] = approval_center
+    payload["approval_url_base"] = approval_center.get("approval_url_base")
+    payload["passive_read_guarantee"] = _passive_read_guarantee()
+    payload["official_install"] = install_info
     return payload
+
+
+def _trust_rule_authority(
+    decision: dict[str, object],
+    *,
+    trust_status: dict[str, object],
+) -> tuple[str, str, str]:
+    source = str(decision.get("source") or "unknown")
+    if is_remote_policy_source(source):
+        return (
+            "guard_cloud",
+            "From Guard Cloud",
+            "This policy came from a validated Guard Cloud sync path and stays read-only on this device.",
+        )
+    integrity_status = str(decision.get("integrity_status") or "unknown")
+    remembered_rules = str(trust_status.get("remembered_rules") or "unknown")
+    if integrity_status == "valid" and remembered_rules == "enforced":
+        return (
+            "remembered_rule_protected",
+            "Remembered and protected",
+            "Local trust is protected, so this remembered rule can be enforced durably on this device.",
+        )
+    if integrity_status == "valid":
+        return (
+            "remembered_rule_limited",
+            "Remembered but limited",
+            "Local trust is not fully protected, so Guard limits broad remembered rules "
+            "and still prefers one-time approvals.",
+        )
+    integrity_message = decision.get("integrity_message")
+    return (
+        "remembered_rule_ignored",
+        "Remembered but ignored",
+        str(integrity_message or "Guard cannot trust this remembered rule after integrity verification."),
+    )
+
+
+def build_trust_explain_payload(store: GuardStore, *, rule_id: int, backend: str = "auto") -> dict[str, object]:
+    decision = store.get_policy_decision(rule_id)
+    if decision is None:
+        return {
+            "generated_at": _now(),
+            "command": "explain",
+            "rule_id": rule_id,
+            "error": f"Remembered rule {rule_id} was not found.",
+        }
+    trust_payload = _trust_status_payload(store, command="explain", backend=backend)
+    rule_status, rule_status_label, rule_status_reason = _trust_rule_authority(
+        decision,
+        trust_status=trust_payload,
+    )
+    safe_rule = {key: value for key, value in decision.items() if key not in {"integrity_key_id"}}
+    return {
+        "generated_at": _now(),
+        "command": "explain",
+        "rule_id": rule_id,
+        "rule": safe_rule,
+        "rule_status": rule_status,
+        "rule_status_label": rule_status_label,
+        "rule_status_reason": rule_status_reason,
+        "trust_status": {
+            "backend": trust_payload.get("backend"),
+            "runtime_protection": trust_payload.get("runtime_protection"),
+            "remembered_rules": trust_payload.get("remembered_rules"),
+            "cloud_policies": trust_payload.get("cloud_policies"),
+            "degraded_reasons": trust_payload.get("degraded_reasons"),
+        },
+    }
 
 
 def _macos_native_backend_supported(store: GuardStore) -> bool:
@@ -198,6 +349,22 @@ def _run_guard_trust_command(
         payload["trust_health"] = "protected" if payload["remembered_rules"] == "enforced" else "degraded_safe"
         _emit("trust.test", payload, getattr(args, "json", False))
         return 0
+    if trust_command == "explain":
+        rule_id = getattr(args, "rule", None)
+        if not isinstance(rule_id, int) or isinstance(rule_id, bool):
+            _emit(
+                "trust.explain",
+                {
+                    "generated_at": _now(),
+                    "command": "explain",
+                    "error": "Use `hol-guard guard trust explain --rule <decision_id>`.",
+                },
+                getattr(args, "json", False),
+            )
+            return 2
+        payload = build_trust_explain_payload(store, rule_id=rule_id, backend=backend)
+        _emit("trust.explain", payload, getattr(args, "json", False))
+        return 0 if "error" not in payload else 2
     if trust_command in {"setup", "reset"}:
         if backend == "degraded-safe":
             payload["error"] = (
@@ -254,7 +421,7 @@ def _run_guard_trust_command(
             "no_ui_passive": True,
             "one_time_approvals": "available",
             "durable_local_rules": ("enforced" if trust_status.get("remembered_rules") == "enforced" else "limited"),
-            "cloud_policy_authority": trust_status.get("cloud_policies") or "unknown",
+            "cloud_policy_status": trust_status.get("cloud_policies") or "unknown",
             "ok": bool(result.get("mode") == "protected") if trust_command == "setup" else True,
         }
         if trust_command == "setup":
@@ -284,4 +451,5 @@ def _run_guard_trust_command(
 __all__ = [
     "_run_guard_trust_command",
     "build_trust_doctor_payload",
+    "build_trust_explain_payload",
 ]

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_policy.py
@@ -70,7 +70,7 @@ def _configure_guard_policy_parsers(
         "trust_command",
         nargs="?",
         default="status",
-        choices=("status", "doctor", "test", "setup", "reset"),
+        choices=("status", "doctor", "test", "setup", "reset", "explain"),
     )
     trust_parser.add_argument(
         "--backend",
@@ -82,6 +82,11 @@ def _configure_guard_policy_parsers(
         "--no-ui",
         action="store_true",
         help="Run only bounded no-user-interaction checks.",
+    )
+    trust_parser.add_argument(
+        "--rule",
+        type=int,
+        help="Explain one remembered rule or Cloud policy row by decision ID.",
     )
     _add_guard_common_args(trust_parser)
     trust_parser.add_argument("--json", action="store_true")

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -731,15 +731,27 @@ def _build_trust_doctor_panel(trust: dict[str, object]) -> Panel:
     body.add_row("Remembered rules", str(trust.get("remembered_rules") or "unknown"))
     body.add_row("Cloud policies", str(trust.get("cloud_policies") or "unknown"))
     body.add_row("Passive OS prompts", "blocked" if trust.get("passive_prompt_allowed") is False else "unknown")
+    passive_read_guarantee = trust.get("passive_read_guarantee")
+    if isinstance(passive_read_guarantee, str) and passive_read_guarantee.strip():
+        body.add_row("Prompt-free reads", passive_read_guarantee.strip())
     checks = trust.get("checks")
     if isinstance(checks, dict):
         body.add_row("Local rules protected", _bool_label(bool(checks.get("local_rules_protected"))))
         body.add_row("Passive no-UI check", _bool_label(bool(checks.get("passive_no_ui"))))
+    approval_center = trust.get("approval_center")
+    if isinstance(approval_center, dict):
+        body.add_row("Approval center", str(approval_center.get("approval_url_base") or "inactive"))
+        if approval_center.get("port") is not None:
+            body.add_row("Approval port", str(approval_center.get("port")))
+        detail = approval_center.get("detail")
+        if isinstance(detail, str) and detail.strip():
+            body.add_row("Approval route", textwrap.fill(detail.strip(), width=72))
     official_install = trust.get("official_install")
     if isinstance(official_install, dict):
         version = official_install.get("version") or "unknown"
         update_command = official_install.get("update_command") or "hol-guard update"
         body.add_row("Installed package", f"hol-guard {version}")
+        body.add_row("Install mode", str(official_install.get("installation_mode") or "unknown"))
         body.add_row("Update", str(update_command))
     summary = trust.get("summary")
     if isinstance(summary, str) and summary.strip():
@@ -754,6 +766,34 @@ def _build_trust_doctor_panel(trust: dict[str, object]) -> Panel:
 def _render_trust_doctor(console: Console, payload: dict[str, object]) -> None:
     console.print(_build_trust_doctor_panel(payload))
     console.print(_build_diagnostic_command_panel())
+
+
+def _render_trust_explain(console: Console, payload: dict[str, object]) -> None:
+    rule = payload.get("rule")
+    if not isinstance(rule, dict):
+        _render_fallback(console, payload)
+        return
+    body = Table.grid(padding=(0, 1))
+    body.add_row("Rule", str(payload.get("rule_id") or "unknown"))
+    body.add_row("Scope", str(rule.get("scope") or "unknown"))
+    body.add_row("Action", str(rule.get("action") or "unknown"))
+    body.add_row("Source", str(rule.get("source") or "unknown"))
+    body.add_row("Authority", str(payload.get("rule_status_label") or "unknown"))
+    integrity_status = rule.get("integrity_status")
+    if integrity_status is not None:
+        body.add_row("Integrity", str(integrity_status))
+    updated_at = rule.get("updated_at")
+    if updated_at is not None:
+        body.add_row("Updated", str(updated_at))
+    rule_status_reason = payload.get("rule_status_reason")
+    if isinstance(rule_status_reason, str) and rule_status_reason.strip():
+        body.add_row("Why", textwrap.fill(rule_status_reason.strip(), width=72))
+    trust_status = payload.get("trust_status")
+    if isinstance(trust_status, dict):
+        body.add_row("Runtime", str(trust_status.get("runtime_protection") or "unknown"))
+        body.add_row("Local trust", str(trust_status.get("remembered_rules") or "unknown"))
+        body.add_row("Cloud", str(trust_status.get("cloud_policies") or "unknown"))
+    console.print(Panel(body, title="Remembered rule authority", border_style="cyan"))
 
 
 def _render_run(console: Console, payload: dict[str, object]) -> None:
@@ -2634,6 +2674,7 @@ _RENDERERS: dict[str, Renderer] = {
     "detect": _render_detect,
     "doctor": _render_doctor,
     "trust.doctor": _render_trust_doctor,
+    "trust.explain": _render_trust_explain,
     "run": _render_run,
     "diff": _render_diff,
     "receipts": _render_receipts,

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -4238,6 +4238,16 @@ class GuardStore:
                 items.append(payload)
             return items
 
+    def get_policy_decision(self, decision_id: int) -> dict[str, object] | None:
+        from .store_policy_decision import get_policy_decision_payload
+
+        return get_policy_decision_payload(
+            self,
+            decision_id=decision_id,
+            approval_gate_policy_source=_APPROVAL_GATE_POLICY_SOURCE,
+            now=_now(),
+        )
+
     @staticmethod
     def _policy_decision_dict_from_row(
         connection: sqlite3.Connection,

--- a/src/codex_plugin_scanner/guard/store_policy_decision.py
+++ b/src/codex_plugin_scanner/guard/store_policy_decision.py
@@ -1,0 +1,62 @@
+"""Single policy-decision lookup helpers for GuardStore."""
+
+from __future__ import annotations
+
+from .policy_integrity import is_remote_policy_source
+from .store_policy_source_context import build_policy_source_context_index
+
+
+def get_policy_decision_payload(
+    store,
+    *,
+    decision_id: int,
+    approval_gate_policy_source: str,
+    now: str,
+) -> dict[str, object] | None:
+    query = """
+        select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher,
+               action, reason, owner, source, expires_at, updated_at, integrity_version,
+               integrity_generation,
+               payload_hash, payload_mac, integrity_key_id, signed_at
+        from policy_decisions
+        where decision_id = ?
+          and not (source = ? and expires_at is not null)
+    """
+    with store._connect() as connection:
+        state = store._refresh_policy_integrity_state(connection, now=now, create_key=False)
+        key, key_id = store._policy_integrity_secret_material(create=False)
+        row = connection.execute(query, (decision_id, approval_gate_policy_source)).fetchone()
+        if row is None:
+            return None
+        source_context_index = build_policy_source_context_index(
+            connection,
+            items=[
+                (
+                    str(row["harness"]),
+                    str(row["artifact_id"]) if row["artifact_id"] is not None else None,
+                    str(row["artifact_hash"]) if row["artifact_hash"] is not None else None,
+                )
+            ],
+        )
+        payload = store._policy_decision_dict_from_row(
+            connection,
+            row,
+            source_context_index=source_context_index,
+        )
+        if not is_remote_policy_source(row["source"]):
+            generation = state.get("generation")
+            trusted_generation = (
+                generation if isinstance(generation, int) and not isinstance(generation, bool) else None
+            )
+            integrity_result = store._policy_integrity_result_for_row(
+                row,
+                mode=str(state.get("mode") or "degraded"),
+                key=key,
+                key_id=key_id,
+                trusted_generation=trusted_generation,
+            )
+            payload["integrity_status"] = integrity_result.status
+            payload["integrity_message"] = integrity_result.message
+            payload["integrity_mode"] = state.get("mode")
+            payload["integrity_enforcement"] = state.get("enforcement")
+        return payload

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import argparse
 import base64
 import json
 import pickle
@@ -16,6 +17,8 @@ import pytest
 from codex_plugin_scanner.cli import _resolve_legacy_args, main
 from codex_plugin_scanner.guard import local_trust_contract as local_trust_contract_module
 from codex_plugin_scanner.guard import store as guard_store_module
+from codex_plugin_scanner.guard.cli import commands_dispatch_trust as trust_dispatch_module
+from codex_plugin_scanner.guard.daemon.manager import ApprovalCenterLocator
 from codex_plugin_scanner.guard.local_trust_contract import (
     LOCAL_TRUST_DEGRADED_REASON_LABELS,
     LOCAL_TRUST_MODES,
@@ -1462,6 +1465,9 @@ def test_guard_doctor_includes_safe_trust_diagnostics(tmp_path: Path, capsys) ->
     )
     assert trust_payload["official_install"]["package"] == "hol-guard"
     assert trust_payload["official_install"]["update_command"] == "hol-guard update"
+    assert trust_payload["approval_center"]["active"] is False
+    assert trust_payload["approval_url_base"] is None
+    assert trust_payload["passive_read_guarantee"]
     assert "recommended_actions" in trust_payload
     assert "key_id" not in trust_payload
     assert "last_proof" not in trust_payload
@@ -1492,8 +1498,101 @@ def test_trust_cli_doctor_human_output_uses_trust_renderer(tmp_path: Path, capsy
     assert rc == 0
     assert "Local trust" in output
     assert "Passive OS prompts" in output
+    assert "Install mode" in output
     assert "hol-guard update" in output
     assert '"runtime_protection"' not in output
+
+
+def test_build_trust_doctor_payload_reports_active_approval_center_port(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    locator = ApprovalCenterLocator(
+        guard_home=home_dir,
+        daemon_url="http://127.0.0.1:5481",
+        approval_url_base="http://127.0.0.1:5481",
+        pid=1234,
+        started_at="2026-06-19T12:00:00+00:00",
+        state_path=home_dir / "guard-daemon-state.json",
+    )
+    monkeypatch.setattr(trust_dispatch_module, "read_approval_center_locator", lambda _home: locator)
+    monkeypatch.setattr(trust_dispatch_module, "load_guard_daemon_url", lambda _home: locator.daemon_url)
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["approval_center"]["active"] is True
+    assert payload["approval_center"]["approval_url_base"] == "http://127.0.0.1:5481"
+    assert payload["approval_center"]["port"] == 5481
+    assert payload["checks"]["approval_center_active"] is True
+    assert payload["approval_url_base"] == "http://127.0.0.1:5481"
+
+
+def test_build_trust_doctor_payload_detects_editable_install(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+
+    class _FakeDistribution:
+        version = "9.9.9"
+
+        def read_text(self, filename: str) -> str | None:
+            if filename == "direct_url.json":
+                return json.dumps({"dir_info": {"editable": True}})
+            return None
+
+        def locate_file(self, _path: str) -> Path:
+            return Path("editable/hol-guard/src")
+
+    monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["official_install"]["version"] == "9.9.9"
+    assert payload["official_install"]["installation_mode"] == "editable"
+    assert payload["official_install"]["editable_install"] is True
+    assert payload["official_install"]["official_install"] is False
+    assert any("official pipx install" in action for action in payload["recommended_actions"])
+
+
+def test_build_trust_doctor_payload_tolerates_distribution_path_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+
+    class _FakeDistribution:
+        version = "9.9.9"
+
+        def read_text(self, _filename: str) -> str | None:
+            return None
+
+        def locate_file(self, _path: str) -> Path:
+            raise RuntimeError("bad metadata")
+
+    monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["official_install"]["version"] == "9.9.9"
+    assert payload["official_install"]["installation_mode"] == "packaged"
+    assert payload["official_install"]["official_install"] is False
+
+
+def test_trust_cli_doctor_reports_macos_no_prompt_copy(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    monkeypatch.setattr(trust_dispatch_module.sys, "platform", "darwin", raising=False)
+
+    rc = main(["guard", "trust", "doctor", "--home", str(home_dir)])
+    output = capsys.readouterr().out
+
+    assert rc == 0
+    assert "No passive macOS Keychain access" in output
 
 
 def test_trust_cli_bare_combined_command_routes_to_guard() -> None:
@@ -1521,6 +1620,105 @@ def test_trust_cli_no_ui_probe_requires_no_ui_flag(tmp_path: Path, capsys) -> No
     assert no_ui_payload["ok"] is True
     assert no_ui_payload["passive_prompt_allowed"] is False
     assert no_ui_payload["trust_health"] in {"protected", "degraded_safe"}
+
+
+def test_trust_cli_explain_requires_rule_id(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+
+    rc = main(["guard", "trust", "explain", "--home", str(home_dir), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "trust explain --rule" in payload["error"]
+
+
+def test_trust_cli_explain_rejects_boolean_rule_id(tmp_path: Path, capsys) -> None:
+    store = GuardStore(tmp_path / "home")
+
+    rc = trust_dispatch_module._run_guard_trust_command(
+        argparse.Namespace(trust_command="explain", rule=True, json=True, backend="auto"),
+        store=store,
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert "trust explain --rule" in payload["error"]
+
+
+def test_trust_cli_explain_reports_protected_local_rule(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+    install_fake_system_keyring,
+) -> None:
+    home_dir = tmp_path / "home"
+    _enable_macos_native_policy_integrity(monkeypatch, install_fake_system_keyring)
+    store = GuardStore(home_dir)
+    setup = store.setup_policy_integrity(now="2026-06-19T12:00:00Z")
+    assert setup["mode"] == "protected"
+    store.upsert_policy(_decision(artifact_id="codex:project:local-rule"), "2026-06-19T12:01:00Z")
+    decision_id = int(_policy_row(home_dir, artifact_id="codex:project:local-rule")["decision_id"])
+
+    rc = main(["guard", "trust", "explain", "--home", str(home_dir), "--rule", str(decision_id), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["rule_status"] == "remembered_rule_protected"
+    assert payload["rule_status_label"] == "Remembered and protected"
+    assert payload["rule"]["decision_id"] == decision_id
+    assert payload["rule"]["integrity_status"] == "valid"
+    assert payload["trust_status"]["remembered_rules"] == "enforced"
+    assert "integrity_key_id" not in payload["rule"]
+
+
+def test_trust_cli_explain_human_output_uses_trust_renderer(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+    install_fake_system_keyring,
+) -> None:
+    home_dir = tmp_path / "home"
+    _enable_macos_native_policy_integrity(monkeypatch, install_fake_system_keyring)
+    store = GuardStore(home_dir)
+    store.setup_policy_integrity(now="2026-06-19T12:00:00Z")
+    store.upsert_policy(_decision(artifact_id="codex:project:local-rule-human"), "2026-06-19T12:01:00Z")
+    decision_id = int(_policy_row(home_dir, artifact_id="codex:project:local-rule-human")["decision_id"])
+
+    rc = main(["guard", "trust", "explain", "--home", str(home_dir), "--rule", str(decision_id)])
+    output = capsys.readouterr().out
+
+    assert rc == 0
+    assert "Remembered rule authority" in output
+    assert "Remembered and protected" in output
+
+
+def test_trust_cli_explain_reports_guard_cloud_rule(tmp_path: Path, capsys) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="publisher",
+                action="block",
+                publisher="npm",
+                reason="cloud block",
+                source="cloud-sync",
+            )
+        ],
+        "2026-06-19T12:01:00Z",
+        remote_write_authorized=True,
+    )
+    decision_id = int(store.list_policy_decisions("codex")[0]["decision_id"])
+
+    rc = main(["guard", "trust", "explain", "--home", str(home_dir), "--rule", str(decision_id), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["rule_status"] == "guard_cloud"
+    assert payload["rule_status_label"] == "From Guard Cloud"
+    assert payload["rule"]["source"] == "cloud-sync"
+    assert "integrity_status" not in payload["rule"]
 
 
 def test_trust_cli_rejects_unavailable_backend_status(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
- add `guard trust explain --rule <id>` so a remembered decision can be traced back to Guard Cloud or local protected trust
- expand `guard trust doctor` with install mode, approval-center status, and prompt-free read diagnostics for faster local trust audits
- cover the new trust diagnostics and render paths with focused regression tests

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_parser_policy.py src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py src/codex_plugin_scanner/guard/cli/render.py src/codex_plugin_scanner/guard/store.py tests/test_guard_policy_integrity.py`
- `python3 -m pytest tests/test_guard_policy_integrity.py tests/test_guard_approval_continuity.py -q`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard trust doctor --home <temp-home> --json`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard trust explain --home <temp-home> --rule 1 --json`
