### PR TITLE
fix(guard): validate remembered-rule approval scopes

### DIFF
--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -1,0 +1,94 @@
+"""Derived approval-scope support for pending Guard review requests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+
+from .models import DecisionScope
+
+_SCOPED_APPROVAL_FAMILIES = frozenset(
+    {
+        "file-read",
+        "mcp",
+        "mcp-tool",
+        "package-request",
+        "prompt",
+        "prompt-env-read",
+        "prompt-file",
+        "tool-action",
+    }
+)
+
+
+def supported_request_scopes(request: Mapping[str, object]) -> tuple[DecisionScope, ...]:
+    scopes: list[DecisionScope] = ["artifact"]
+    if _string_or_none(request.get("publisher")) is not None:
+        scopes.append("publisher")
+    if _derived_workspace_scope_target(request) is not None:
+        scopes.append("workspace")
+    if _request_scoped_family_key(request) is not None:
+        scopes.extend(("harness", "global"))
+    return tuple(scopes)
+
+
+def resolve_request_workspace_scope(
+    request: Mapping[str, object],
+    selected_workspace: str | None,
+) -> str:
+    workspace = _derived_workspace_scope_target(request)
+    if workspace is None:
+        raise ValueError("workspace_scope_unavailable")
+    if selected_workspace is not None and _normalized_workspace_path(selected_workspace) != _normalized_workspace_path(
+        workspace
+    ):
+        raise ValueError("workspace_scope_mismatch")
+    return workspace
+
+
+def _derived_workspace_scope_target(request: Mapping[str, object]) -> str | None:
+    stored_workspace = _string_or_none(request.get("workspace"))
+    if stored_workspace is not None:
+        return stored_workspace
+    config_path = _string_or_none(request.get("config_path"))
+    if config_path is None:
+        return None
+    config_file = Path(config_path)
+    parent = config_file.parent
+    workspace_root = parent.parent if parent.name.startswith(".") else parent
+    workspace_value = str(workspace_root)
+    return workspace_value or None
+
+
+def _request_scoped_family_key(request: Mapping[str, object]) -> str | None:
+    return _artifact_family_key(_string_or_none(request.get("artifact_id")))
+
+
+def _artifact_family_key(artifact_id: str | None) -> str | None:
+    if artifact_id is None or not artifact_id.strip():
+        return None
+    if artifact_id.startswith("family:"):
+        family = artifact_id.removeprefix("family:").strip().lower()
+        return artifact_id if family in _SCOPED_APPROVAL_FAMILIES else None
+    parts = artifact_id.split(":")
+    if len(parts) < 3:
+        return None
+    family = parts[2].strip().lower()
+    if family not in _SCOPED_APPROVAL_FAMILIES:
+        return None
+    return f"family:{family}"
+
+
+def _string_or_none(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _normalized_workspace_path(value: str) -> str:
+    normalized = value.strip().replace("\\", "/")
+    while len(normalized) > 1 and normalized.endswith("/"):
+        normalized = normalized[:-1]
+    if len(normalized) >= 2 and normalized[1] == ":":
+        normalized = normalized.lower()
+    return normalized

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -39,7 +39,8 @@ def resolve_request_workspace_scope(
     workspace = _derived_workspace_scope_target(request)
     if workspace is None:
         raise ValueError("workspace_scope_unavailable")
-    if selected_workspace is not None and _normalized_workspace_path(selected_workspace) != _normalized_workspace_path(
+    bound_selected = _string_or_none(selected_workspace)
+    if bound_selected is not None and _normalized_workspace_path(bound_selected) != _normalized_workspace_path(
         workspace
     ):
         raise ValueError("workspace_scope_mismatch")
@@ -53,7 +54,10 @@ def _derived_workspace_scope_target(request: Mapping[str, object]) -> str | None
     config_path = _string_or_none(request.get("config_path"))
     if config_path is None:
         return None
-    config_file = Path(config_path)
+    try:
+        config_file = Path(config_path).resolve()
+    except Exception:
+        config_file = Path(config_path)
     parent = config_file.parent
     workspace_root = parent.parent if parent.name.startswith(".") else parent
     workspace_value = str(workspace_root)
@@ -69,7 +73,7 @@ def _artifact_family_key(artifact_id: str | None) -> str | None:
         return None
     if artifact_id.startswith("family:"):
         family = artifact_id.removeprefix("family:").strip().lower()
-        return artifact_id if family in _SCOPED_APPROVAL_FAMILIES else None
+        return f"family:{family}" if family in _SCOPED_APPROVAL_FAMILIES else None
     parts = artifact_id.split(":")
     if len(parts) < 3:
         return None
@@ -86,7 +90,11 @@ def _string_or_none(value: object) -> str | None:
 
 
 def _normalized_workspace_path(value: str) -> str:
-    normalized = value.strip().replace("\\", "/")
+    try:
+        resolved = str(Path(value).resolve())
+    except Exception:
+        resolved = value
+    normalized = resolved.strip().replace("\\", "/")
     while len(normalized) > 1 and normalized.endswith("/"):
         normalized = normalized[:-1]
     if len(normalized) >= 2 and normalized[1] == ":":

--- a/src/codex_plugin_scanner/guard/approval_scope_support.py
+++ b/src/codex_plugin_scanner/guard/approval_scope_support.py
@@ -60,8 +60,7 @@ def _derived_workspace_scope_target(request: Mapping[str, object]) -> str | None
         config_file = Path(config_path)
     parent = config_file.parent
     workspace_root = parent.parent if parent.name.startswith(".") else parent
-    workspace_value = str(workspace_root)
-    return workspace_value or None
+    return str(workspace_root)
 
 
 def _request_scoped_family_key(request: Mapping[str, object]) -> str | None:

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -345,9 +345,9 @@ def apply_approval_resolution(
     request_publisher = _string_or_none(request.get("publisher"))
     if scope == "publisher" and request_publisher is None:
         raise ValueError("no publisher scope")
-    resolved_workspace = resolve_request_workspace_scope(request, workspace) if scope == "workspace" else None
     if scope not in supported_request_scopes(request):
         raise ValueError("unsupported_request_scope")
+    resolved_workspace = resolve_request_workspace_scope(request, workspace) if scope == "workspace" else None
     workspace_artifact_id, workspace_artifact_hash = _workspace_policy_artifact_keys(request, scope)
     request_artifact_id = _string_or_none(request.get("artifact_id"))
     request_artifact_hash = _string_or_none(request.get("artifact_hash"))

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -342,13 +342,15 @@ def apply_approval_resolution(
         raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
     if not _is_decision_scope(scope):
         raise ValueError(f"Unsupported approval scope: {scope}")
+    request_publisher = _string_or_none(request.get("publisher"))
+    if scope == "publisher" and request_publisher is None:
+        raise ValueError("no publisher scope")
+    resolved_workspace = resolve_request_workspace_scope(request, workspace) if scope == "workspace" else None
     if scope not in supported_request_scopes(request):
         raise ValueError("unsupported_request_scope")
-    resolved_workspace = resolve_request_workspace_scope(request, workspace) if scope == "workspace" else None
     workspace_artifact_id, workspace_artifact_hash = _workspace_policy_artifact_keys(request, scope)
     request_artifact_id = _string_or_none(request.get("artifact_id"))
     request_artifact_hash = _string_or_none(request.get("artifact_hash"))
-    request_publisher = _string_or_none(request.get("publisher"))
     scoped_artifact_id = request_artifact_id if scope in {"artifact", "harness", "global"} else workspace_artifact_id
     scoped_artifact_hash = request_artifact_hash if scope == "artifact" else workspace_artifact_hash
     artifact_runtime_exact_match_key = _artifact_scope_runtime_exact_match_key(request, scope)

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -342,15 +342,13 @@ def apply_approval_resolution(
         raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
     if not _is_decision_scope(scope):
         raise ValueError(f"Unsupported approval scope: {scope}")
-    request_publisher = _string_or_none(request.get("publisher"))
-    if scope == "publisher" and request_publisher is None:
-        raise ValueError("no publisher scope")
     if scope not in supported_request_scopes(request):
         raise ValueError("unsupported_request_scope")
     resolved_workspace = resolve_request_workspace_scope(request, workspace) if scope == "workspace" else None
     workspace_artifact_id, workspace_artifact_hash = _workspace_policy_artifact_keys(request, scope)
     request_artifact_id = _string_or_none(request.get("artifact_id"))
     request_artifact_hash = _string_or_none(request.get("artifact_hash"))
+    request_publisher = _string_or_none(request.get("publisher"))
     scoped_artifact_id = request_artifact_id if scope in {"artifact", "harness", "global"} else workspace_artifact_id
     scoped_artifact_hash = request_artifact_hash if scope == "artifact" else workspace_artifact_hash
     artifact_runtime_exact_match_key = _artifact_scope_runtime_exact_match_key(request, scope)

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -15,6 +15,7 @@ from urllib.parse import ParseResult, parse_qsl, urlencode, urlparse, urlunparse
 from .adapters import get_adapter
 from .adapters.base import HarnessContext
 from .approval_gate import ApprovalGateGrant, ApprovalGateInput, require_approval_decision
+from .approval_scope_support import resolve_request_workspace_scope, supported_request_scopes
 from .cli.connect_flow import (
     connect_retry_refresh_race_from_reason,
     resolve_guard_cloud_repair_detail,
@@ -313,7 +314,9 @@ def queue_blocked_approvals(
         if created_new_request:
             _record_created_event(store, request, timestamp)
         _notify_pending_approval(store=store, request=request)
-        queued.append(request.to_dict())
+        request_payload = request.to_dict()
+        request_payload["allowed_scopes"] = list(supported_request_scopes(request_payload))
+        queued.append(request_payload)
     return queued
 
 
@@ -339,10 +342,9 @@ def apply_approval_resolution(
         raise ApprovalRequestAlreadyResolvedError(f"Approval request already resolved: {request_id}")
     if not _is_decision_scope(scope):
         raise ValueError(f"Unsupported approval scope: {scope}")
-    if scope == "workspace" and not workspace:
-        raise ValueError(f"Approval request {request_id} requires --workspace for workspace scope.")
-    if scope == "publisher" and _string_or_none(request.get("publisher")) is None:
-        raise ValueError(f"Approval request {request_id} has no publisher scope to approve.")
+    if scope not in supported_request_scopes(request):
+        raise ValueError("unsupported_request_scope")
+    resolved_workspace = resolve_request_workspace_scope(request, workspace) if scope == "workspace" else None
     workspace_artifact_id, workspace_artifact_hash = _workspace_policy_artifact_keys(request, scope)
     request_artifact_id = _string_or_none(request.get("artifact_id"))
     request_artifact_hash = _string_or_none(request.get("artifact_hash"))
@@ -361,7 +363,7 @@ def apply_approval_resolution(
         action="allow" if action == "allow" else "block",
         artifact_id=scoped_artifact_id,
         artifact_hash=scoped_artifact_hash,
-        workspace=workspace if scope == "workspace" else None,
+        workspace=resolved_workspace if scope == "workspace" else None,
         publisher=request_publisher if scope == "publisher" else None,
         reason=reason,
         source="approval-gate",
@@ -408,7 +410,7 @@ def apply_approval_resolution(
                 harness=resolution_harness,
                 scope=scope,
                 artifact_id=scoped_artifact_id,
-                workspace=workspace if scope == "workspace" else None,
+                workspace=resolved_workspace if scope == "workspace" else None,
                 publisher=(
                     str(request["publisher"])
                     if scope == "publisher" and isinstance(request.get("publisher"), str)
@@ -437,7 +439,7 @@ def apply_approval_resolution(
             harness=resolution_harness,
             scope=scope,
             artifact_id=scoped_artifact_id,
-            workspace=workspace if scope == "workspace" else None,
+            workspace=resolved_workspace if scope == "workspace" else None,
             publisher=(
                 str(request["publisher"])
                 if scope == "publisher" and isinstance(request.get("publisher"), str)

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -65,7 +65,7 @@ def add_approval_parser(
 
     clear_history_parser = approvals_subparsers.add_parser(
         "clear-history",
-        help="Clear saved allow/deny history so flows can be re-tested",
+        help="Clear remembered rules and resolved approval history so flows can be re-tested",
     )
     clear_history_parser.add_argument(
         "--harness",

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -8,6 +8,7 @@ import json
 import re
 import sqlite3
 
+from .approval_scope_support import supported_request_scopes
 from .models import GuardApprovalRequest
 from .runtime.action_identity import normalize_command_identity
 
@@ -532,7 +533,7 @@ def count_approval_requests(
 
 
 def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
-    return {
+    payload = {
         "request_id": str(row["request_id"]),
         "harness": str(row["harness"]),
         "artifact_id": str(row["artifact_id"]),
@@ -576,6 +577,8 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "created_at": str(row["created_at"]),
         "resolved_at": row["resolved_at"],
     }
+    payload["allowed_scopes"] = list(supported_request_scopes(payload))
+    return payload
 
 
 def _safe_json_list(value: object) -> list[object]:

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -533,7 +533,7 @@ def count_approval_requests(
 
 
 def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
-    payload = {
+    payload: dict[str, object] = {
         "request_id": str(row["request_id"]),
         "harness": str(row["harness"]),
         "artifact_id": str(row["artifact_id"]),

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -430,6 +430,40 @@ def test_approval_gate_rejects_unsupported_broad_scope_for_unscoped_request(tmp_
         )
 
 
+def test_approval_gate_rejects_unsupported_workspace_scope_without_bound_workspace(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    store.add_approval_request(
+        GuardApprovalRequest(
+            request_id="req-workspace-unsupported",
+            harness="codex",
+            artifact_id="codex:project:req-workspace-unsupported",
+            artifact_name="Shell command",
+            artifact_hash="hash-workspace-unsupported",
+            policy_action="require-reapproval",
+            recommended_scope="artifact",
+            changed_fields=("shell_command",),
+            source_scope="project",
+            config_path="",
+            review_command="hol-guard approvals approve req-workspace-unsupported",
+            approval_url="http://127.0.0.1:5474/requests/req-workspace-unsupported",
+        ),
+        "2026-04-11T00:00:00+00:00",
+    )
+
+    with pytest.raises(ValueError, match="unsupported_request_scope"):
+        apply_approval_resolution(
+            store=store,
+            request_id="req-workspace-unsupported",
+            action="allow",
+            scope="workspace",
+            workspace=None,
+            reason="too broad",
+            now="2026-04-11T00:01:00+00:00",
+            approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        )
+
+
 def test_approval_gate_cooldown_works_expires_and_revokes(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store, cooldown_seconds=900)

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -324,6 +324,112 @@ def test_approval_gate_artifact_remember_persists_policy(
     assert any(event["payload"]["request_id"] == "req-remember" for event in remembered_events)
 
 
+def test_approval_gate_workspace_scope_uses_request_workspace_without_cli_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _trust_local_policy_rows(monkeypatch)
+    store = _store(tmp_path)
+    _enable_gate(store)
+    workspace = tmp_path / "workspace"
+    request = GuardApprovalRequest(
+        request_id="req-workspace",
+        harness="codex",
+        artifact_id="codex:project:tool-action:req-workspace",
+        artifact_name="Shell command",
+        artifact_type="tool_action_request",
+        artifact_hash="hash-req-workspace",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("shell_command",),
+        source_scope="project",
+        config_path=str(workspace / ".codex" / "config.toml"),
+        workspace=str(workspace),
+        review_command="hol-guard approvals approve req-workspace",
+        approval_url="http://127.0.0.1:5474/requests/req-workspace",
+    )
+    store.add_approval_request(request, "2026-04-11T00:00:00+00:00")
+
+    resolved = apply_approval_resolution(
+        store=store,
+        request_id="req-workspace",
+        action="allow",
+        scope="workspace",
+        workspace=None,
+        reason="remember this project",
+        now="2026-04-11T00:01:00+00:00",
+        approval_gate_input=ApprovalGateInput(password=PASSWORD),
+    )
+
+    assert resolved["status"] == "resolved"
+    assert (
+        store.resolve_policy_decision(
+            "codex",
+            "codex:project:tool-action:req-workspace",
+            "hash-req-workspace",
+            workspace=str(workspace),
+            now="2026-04-11T00:02:00+00:00",
+        )["action"]
+        == "allow"
+    )
+
+
+def test_approval_gate_workspace_scope_rejects_tampered_workspace_override(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _trust_local_policy_rows(monkeypatch)
+    store = _store(tmp_path)
+    _enable_gate(store)
+    request = GuardApprovalRequest(
+        request_id="req-workspace-mismatch",
+        harness="codex",
+        artifact_id="codex:project:tool-action:req-workspace-mismatch",
+        artifact_name="Shell command",
+        artifact_type="tool_action_request",
+        artifact_hash="hash-req-workspace-mismatch",
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("shell_command",),
+        source_scope="project",
+        config_path=str(tmp_path / "workspace-a" / ".codex" / "config.toml"),
+        workspace=str(tmp_path / "workspace-a"),
+        review_command="hol-guard approvals approve req-workspace-mismatch",
+        approval_url="http://127.0.0.1:5474/requests/req-workspace-mismatch",
+    )
+    store.add_approval_request(request, "2026-04-11T00:00:00+00:00")
+
+    with pytest.raises(ValueError, match="workspace_scope_mismatch"):
+        apply_approval_resolution(
+            store=store,
+            request_id="req-workspace-mismatch",
+            action="allow",
+            scope="workspace",
+            workspace=str(tmp_path / "workspace-b"),
+            reason="tampered project scope",
+            now="2026-04-11T00:01:00+00:00",
+            approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        )
+
+
+def test_approval_gate_rejects_unsupported_broad_scope_for_unscoped_request(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _enable_gate(store)
+    _add_request(store, "req-global")
+
+    with pytest.raises(ValueError, match="unsupported_request_scope"):
+        apply_approval_resolution(
+            store=store,
+            request_id="req-global",
+            action="allow",
+            scope="global",
+            workspace=None,
+            reason="too broad",
+            now="2026-04-11T00:01:00+00:00",
+            approval_gate_input=ApprovalGateInput(password=PASSWORD),
+        )
+
+
 def test_approval_gate_cooldown_works_expires_and_revokes(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store, cooldown_seconds=900)
@@ -1275,6 +1381,32 @@ def test_daemon_approval_defaults_artifact_scope_to_one_time(tmp_path: Path) -> 
     assert body["resolved"] is True
     assert store.get_approval_request("req-daemon-once")["status"] == "resolved"
     assert store.list_policy_decisions("codex") == []
+
+
+def test_daemon_approval_rejects_unsupported_request_scope(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    _add_request(store, "req-daemon-global")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/requests/req-daemon-global/approve",
+            data=json.dumps({"scope": "global"}).encode("utf-8"),
+            headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
+            method="POST",
+        )
+        try:
+            urllib.request.urlopen(request, timeout=5)
+        except urllib.error.HTTPError as error:
+            payload = json.loads(error.read().decode("utf-8"))
+            status = error.code
+        else:
+            raise AssertionError("expected HTTPError for unsupported request scope")
+    finally:
+        daemon.stop()
+
+    assert status == 400
+    assert payload["error"] == "unsupported_request_scope"
 
 
 @pytest.mark.parametrize("field_name", ["remember", "persist_policy"])

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -903,8 +903,8 @@ class TestGuardApprovals:
     def test_guard_broad_scope_resolution_clears_matching_pending_requests(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         for request_id, artifact_id in (
-            ("req-a", "codex:project:first"),
-            ("req-b", "codex:project:second"),
+            ("req-a", "codex:project:mcp:first"),
+            ("req-b", "codex:project:mcp:second"),
         ):
             store.add_approval_request(
                 GuardApprovalRequest(
@@ -944,7 +944,7 @@ class TestGuardApprovals:
                 GuardApprovalRequest(
                     request_id=request_id,
                     harness=harness,
-                    artifact_id=f"{harness}:project:item",
+                    artifact_id=f"{harness}:project:mcp:item",
                     artifact_name=f"{harness}-item",
                     artifact_hash=f"hash-{request_id}",
                     policy_action="require-reapproval",
@@ -982,7 +982,7 @@ class TestGuardApprovals:
                 GuardApprovalRequest(
                     request_id=f"req-{index}",
                     harness="codex",
-                    artifact_id=f"codex:project:item-{index}",
+                    artifact_id=f"codex:project:mcp:item-{index}",
                     artifact_name=f"item-{index}",
                     artifact_hash=f"hash-{index}",
                     policy_action="require-reapproval",
@@ -1043,6 +1043,35 @@ class TestGuardApprovals:
         assert after_expiry is None
         assert decisions[0]["expires_at"] == "2026-04-11T01:00:00+00:00"
         assert decisions[0]["source"] == "local"
+
+    def test_guard_pending_request_payload_lists_supported_scopes(self, tmp_path):
+        store = GuardStore(tmp_path / "guard-home")
+        workspace = tmp_path / "workspace"
+        store.add_approval_request(
+            GuardApprovalRequest(
+                request_id="req-supported-scopes",
+                harness="codex",
+                artifact_id="codex:project:tool-action:req-supported-scopes",
+                artifact_name="Shell command",
+                artifact_type="tool_action_request",
+                artifact_hash="hash-supported-scopes",
+                policy_action="require-reapproval",
+                recommended_scope="publisher",
+                changed_fields=("shell_command",),
+                source_scope="project",
+                config_path=str(workspace / ".codex" / "config.toml"),
+                workspace=str(workspace),
+                publisher="hashgraph-online",
+                review_command="hol-guard approvals approve req-supported-scopes",
+                approval_url="http://127.0.0.1:5474/requests/req-supported-scopes",
+            ),
+            "2026-04-11T00:00:00+00:00",
+        )
+
+        request = store.get_approval_request("req-supported-scopes")
+
+        assert request is not None
+        assert request["allowed_scopes"] == ["artifact", "publisher", "workspace", "harness", "global"]
 
     def test_guard_store_ignores_expired_policy_decisions_without_explicit_now(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
@@ -1887,7 +1916,7 @@ class TestGuardApprovals:
         assert status == 400
         assert payload["error"] == "missing_required_fields"
 
-    def test_guard_daemon_approve_route_requires_workspace_for_workspace_scope(self, tmp_path):
+    def test_guard_daemon_approve_route_derives_workspace_scope_from_request(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")
         store.add_approval_request(
             GuardApprovalRequest(
@@ -1916,18 +1945,15 @@ class TestGuardApprovals:
                 headers=_guard_json_headers(daemon._server.auth_token),
                 method="POST",
             )
-            try:
-                urllib.request.urlopen(request, timeout=5)
-            except urllib.error.HTTPError as error:
-                payload = json.loads(error.read().decode("utf-8"))
-                status = error.code
-            else:
-                raise AssertionError("expected HTTPError for missing workspace path")
+            with urllib.request.urlopen(request, timeout=5) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+                status = response.status
         finally:
             daemon.stop()
 
-        assert status == 400
-        assert "requires --workspace" in payload["error"]
+        assert status == 200
+        assert payload["resolved"] is True
+        assert payload["resolved_request"]["resolution_scope"] == "workspace"
 
     @pytest.mark.parametrize("action", ["approve", "block"])
     @pytest.mark.parametrize("scope", ["artifact", "workspace", "publisher", "harness", "global"])
@@ -1937,11 +1963,20 @@ class TestGuardApprovals:
         store = GuardStore(tmp_path / "guard-home")
         workspace = tmp_path / "workspace"
         request_id = f"req-{action}-{scope}"
+        artifact_family = "tool-action" if scope in {"harness", "global"} else scope
+        artifact_id = (
+            f"codex:project:{artifact_family}:{scope}" if scope in {"harness", "global"} else f"codex:project:{scope}"
+        )
+        other_artifact_id = (
+            f"codex:project:{artifact_family}:{scope}-other"
+            if scope in {"harness", "global"}
+            else f"codex:project:{scope}-other"
+        )
         store.add_approval_request(
             GuardApprovalRequest(
                 request_id=request_id,
                 harness="codex",
-                artifact_id=f"codex:project:{scope}",
+                artifact_id=artifact_id,
                 artifact_name=f"{scope} action",
                 artifact_hash=f"hash-{action}-{scope}",
                 publisher="codex-local",
@@ -1960,7 +1995,7 @@ class TestGuardApprovals:
             GuardApprovalRequest(
                 request_id=f"{request_id}-other",
                 harness="codex",
-                artifact_id=f"codex:project:{scope}-other",
+                artifact_id=other_artifact_id,
                 artifact_name=f"{scope} other action",
                 artifact_hash=f"hash-{action}-{scope}-other",
                 publisher="codex-local",
@@ -2980,7 +3015,7 @@ class TestGuardApprovals:
             )
         ]
 
-    def test_guard_approvals_cli_rejects_workspace_scope_without_workspace(self, tmp_path, capsys):
+    def test_guard_approvals_cli_derives_workspace_scope_without_workspace_override(self, tmp_path, capsys):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         store.add_approval_request(
@@ -3018,13 +3053,16 @@ class TestGuardApprovals:
         except SystemExit as error:
             rc = error.code
         else:
-            raise AssertionError("expected argparse failure for missing workspace scope target")
+            rc = 0
 
         captured = capsys.readouterr()
+        payload = json.loads(captured.out)
 
-        assert rc == 2
-        assert "requires --workspace" in captured.err
-        assert store.get_approval_request("req-workspace")["status"] == "pending"
+        assert rc == 0
+        assert captured.err == ""
+        assert payload["resolved"] is True
+        assert payload["item"]["resolution_scope"] == "workspace"
+        assert store.get_approval_request("req-workspace")["status"] == "resolved"
 
     def test_guard_workspace_resolution_does_not_match_sibling_workspace(self, tmp_path):
         store = GuardStore(tmp_path / "guard-home")

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -1116,7 +1116,7 @@ def test_gr119_publisher_scope_rejects_blank_publisher_identity(tmp_path: Path) 
     request = _request("req-no-publisher", publisher="")
     store.add_approval_request(request, "2026-05-13T00:00:00+00:00")
 
-    with pytest.raises(ValueError, match="no publisher scope"):
+    with pytest.raises(ValueError, match="unsupported_request_scope"):
         apply_approval_resolution(
             store=store,
             request_id="req-no-publisher",

--- a/tests/test_guard_queue_api_contract.py
+++ b/tests/test_guard_queue_api_contract.py
@@ -657,7 +657,13 @@ def test_resolving_duplicate_group_reports_collapsed_ids(tmp_path: Path) -> None
 
 def test_broad_scope_resolution_keeps_other_reviews_pending(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
-    _populate(store, [_request("req-active"), _request("req-covered", command="cat ~/.pypirc")])
+    _populate(
+        store,
+        [
+            _request("req-active", artifact_id="codex:project:mcp:req-active"),
+            _request("req-covered", command="cat ~/.pypirc", artifact_id="codex:project:mcp:req-covered"),
+        ],
+    )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
 


### PR DESCRIPTION
## Summary\n- derive supported approval scopes from each pending request and expose them in request payloads\n- bind workspace approvals to the original request workspace and reject unsupported broad-scope resolutions\n- rename CLI approval-history copy to remembered-rule language and add regression coverage for the new scope contract\n\n## Testing\n- python3 -m ruff check src/codex_plugin_scanner/guard/approval_scope_support.py src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/store_approvals.py tests/test_guard_approval_gate.py tests/test_guard_approvals.py\n- python3 -m ruff format --check src/codex_plugin_scanner/guard/approval_scope_support.py src/codex_plugin_scanner/guard/approvals.py src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/store_approvals.py tests/test_guard_approval_gate.py tests/test_guard_approvals.py\n- python3 -m pytest tests/test_guard_approval_gate.py -k 'workspace_scope or unsupported_request_scope' -q\n- python3 -m pytest tests/test_guard_approvals.py -k 'broad_scope_resolution or daemon_resolution_route_accepts_all_scope_kinds_without_clearing_queue or derives_workspace_scope_without_workspace_override or pending_request_payload_lists_supported_scopes or derive_workspace_scope_from_request' -q