### PR TITLE
fix(guard): surface package approval links in protect output

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_policy.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 
 
 from ..store import _runtime_scoped_exact_match_key, runtime_tool_action_exact_match_context
+from ..text import ensure_terminal_punctuation as _ensure_terminal_punctuation
 from ._commands_shared import *
 from .commands_parser_helpers import *
 
@@ -83,12 +84,6 @@ def _native_hook_reason(*values: object | None) -> str:
     if messages:
         return " ".join(messages)
     return "HOL Guard flagged this tool call for review."
-
-def _ensure_terminal_punctuation(message: str) -> str:
-    trimmed = message.strip()
-    if trimmed.endswith((".", "!", "?")):
-        return trimmed
-    return f"{trimmed}."
 
 def _native_hook_reason_for_harness(harness: str, *values: object | None) -> str:
     reason = _native_hook_reason(*values)

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1959,7 +1959,13 @@ def _render_protect(console: Console, payload: dict[str, object]) -> None:
         if isinstance(user_copy, dict):
             harness_message = str(user_copy.get("harness_message") or "").strip()
             if harness_message:
-                console.print(Panel(Text(harness_message), title="Guard guidance", border_style="magenta"))
+                console.print(
+                    Panel(
+                        Text(harness_message, no_wrap=False, overflow="fold"),
+                        title="Guard guidance",
+                        border_style="magenta",
+                    )
+                )
     supply_chain = payload.get("supply_chain")
     if isinstance(supply_chain, dict):
         console.print(_build_supply_chain_posture_panel(supply_chain))

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -553,7 +553,7 @@ def _finalize_evaluation(
             summary = f"{summary} Also flagged: {others}."
     harness_parts = [risk_summary]
     if reason_message:
-        harness_parts.append(f"Reason: {reason_message}.")
+        harness_parts.append(f"Reason: {_ensure_terminal_punctuation(reason_message)}")
     if fix_command:
         harness_parts.append(f"Fix: install `{fix_command}` or choose a team exception.")
     user_copy = _normalize_package_user_copy(
@@ -871,6 +871,13 @@ def _normalize_package_user_copy(user_copy: SupplyChainUserCopy, *, policy_actio
     if needs_local_review and _LOCAL_REVIEW_INSTRUCTION.lower() not in harness_message.lower():
         harness_message = f"{harness_message} {_LOCAL_REVIEW_INSTRUCTION}".strip()
     return replace(user_copy, dashboard_url=dashboard_url, harness_message=harness_message)
+
+
+def _ensure_terminal_punctuation(message: str) -> str:
+    trimmed = message.strip()
+    if trimmed.endswith((".", "!", "?")):
+        return trimmed
+    return f"{trimmed}."
 
 
 def _strip_review_evidence_tail(message: str) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -32,6 +32,7 @@ from ..models import GuardArtifact
 from ..stable_digest import stable_digest_hex
 from ..store import GuardStore
 from ..store_evidence import EvidenceRecord
+from ..text import ensure_terminal_punctuation as _ensure_terminal_punctuation
 from .js_semver import highest_js_version_for_selector, version_matches_js_selector
 from .manifest_dependency_targets import evaluation_targets as _manifest_evaluation_targets
 from .package_intent_common import split_python_extras
@@ -871,13 +872,6 @@ def _normalize_package_user_copy(user_copy: SupplyChainUserCopy, *, policy_actio
     if needs_local_review and _LOCAL_REVIEW_INSTRUCTION.lower() not in harness_message.lower():
         harness_message = f"{harness_message} {_LOCAL_REVIEW_INSTRUCTION}".strip()
     return replace(user_copy, dashboard_url=dashboard_url, harness_message=harness_message)
-
-
-def _ensure_terminal_punctuation(message: str) -> str:
-    trimmed = message.strip()
-    if trimmed.endswith((".", "!", "?")):
-        return trimmed
-    return f"{trimmed}."
 
 
 def _strip_review_evidence_tail(message: str) -> str:

--- a/src/codex_plugin_scanner/guard/text.py
+++ b/src/codex_plugin_scanner/guard/text.py
@@ -1,0 +1,16 @@
+"""Shared text-formatting helpers for Guard surfaces."""
+
+from __future__ import annotations
+
+
+def ensure_terminal_punctuation(message: str | None) -> str:
+    """Normalize trailing terminal punctuation for user-facing copy."""
+
+    if not message:
+        return ""
+    trimmed = message.strip()
+    if not trimmed:
+        return ""
+    if trimmed.endswith((".", "!", "?")):
+        return trimmed
+    return f"{trimmed}."

--- a/src/codex_plugin_scanner/guard/text.py
+++ b/src/codex_plugin_scanner/guard/text.py
@@ -6,9 +6,7 @@ from __future__ import annotations
 def ensure_terminal_punctuation(message: str | None) -> str:
     """Normalize trailing terminal punctuation for user-facing copy."""
 
-    if not message:
-        return ""
-    trimmed = message.strip()
+    trimmed = (message or "").strip()
     if not trimmed:
         return ""
     if trimmed.endswith((".", "!", "?")):

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -1108,6 +1108,71 @@ def test_guard_protect_probe_skips_local_approval_queue_on_block(
     assert store.list_approval_requests(limit=None) == []
 
 
+def test_guard_protect_pnpm_install_alias_renders_wrapped_review_link_for_cloud_validation_error(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    (workspace_dir / "package.json").write_text(
+        json.dumps({"name": "demo", "dependencies": {"lodash": "^4.17.21"}}),
+        encoding="utf-8",
+    )
+    (workspace_dir / "pnpm-lock.yaml").write_text(
+        "\n".join(
+            [
+                "lockfileVersion: '9.0'",
+                "packages:",
+                "  lodash@4.17.21:",
+                "    resolution: {integrity: sha256-demo}",
+                "importers:",
+                "  .:",
+                "    dependencies:",
+                "      lodash: 4.17.21",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    server, thread, sync_url = _start_cloud_eval_server(
+        decision="allow",
+        package_name="lodash",
+        evaluate_status=400,
+    )
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    try:
+        _seed_bundle(
+            home_dir=home_dir,
+            ecosystem="npm",
+            package_name="lodash",
+            package_version="4.17.21",
+            action="allow",
+        )
+        _seed_workspace_sync_credentials(home_dir, sync_url)
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "pnpm",
+                "i",
+            ]
+        )
+    finally:
+        _stop_cloud_eval_server(server, thread)
+
+    output = capsys.readouterr().out
+
+    assert rc == 2
+    assert "approve or keep this blocked" in output
+    assert "http://127.0.0.1:5474/requests/" in output
+    assert "review.. Open HOL Guard" not in output
+
+
 def test_guard_protect_retry_runs_after_local_package_approval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- wrap the install-protection guidance panel so long approval-center links stay visible in non-TTY `guard protect` output
- preserve review-copy punctuation and add regression coverage for `pnpm i` failing closed on cloud validation

## Testing

- `uv run pytest -q tests/test_guard_package_shims.py -k 'pnpm_install_alias_renders_wrapped_review_link_for_cloud_validation_error or test_guard_protect_block_payload_links_local_approval_to_primary_request or test_guard_protect_probe_skips_local_approval_queue_on_block'`
- `uv run pytest -q tests/test_guard_render.py -k 'guard_protect_render'`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/render.py src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py tests/test_guard_package_shims.py`

<!-- capy-pr-badge:start -->
<a href="https://capy.ai/project/b259de13-c7a7-4faa-95ee-6bfe66724093/thread/343f08c7-01bd-4724-a3be-6629863f4703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/open.svg?theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/open.svg"><img alt="Open POINT-013" src="https://capy.ai/api/badge/open.svg"></picture></a> <a href="https://capy.ai/project/b259de13-c7a7-4faa-95ee-6bfe66724093/thread/343f08c7-01bd-4724-a3be-6629863f4703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://capy.ai/api/badge/thread.svg?label=POINT-013&theme=dark"><source media="(prefers-color-scheme: light)" srcset="https://capy.ai/api/badge/thread.svg?label=POINT-013"><img alt="POINT-013" src="https://capy.ai/api/badge/thread.svg?label=POINT-013"></picture></a>
<!-- capy-pr-badge:end -->