### PR TITLE
fix(update): refresh package shims after upgrade

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -41,6 +41,7 @@ _ALREADY_CURRENT_HINTS = (
 )
 _PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
 _PYPI_TIMEOUT_SECONDS = 3.0
+_PACKAGE_SHIM_REFRESH_TIMEOUT_SECONDS = 30.0
 _last_pypi_payload: dict[str, object] | None = None
 _PACKAGE_SHIM_REFRESH_SCRIPT = """
 from __future__ import annotations
@@ -59,7 +60,7 @@ def _resolve_path(value: object) -> Path | None:
     return Path(value).expanduser().resolve()
 
 
-payload = json.loads(sys.argv[1])
+payload = json.loads(sys.stdin.read())
 home_dir = _resolve_path(payload.get("home_dir")) or Path.home().resolve()
 guard_home = _resolve_path(payload.get("guard_home")) or (home_dir / ".hol-guard")
 context = HarnessContext(
@@ -260,13 +261,14 @@ def run_guard_update(
         notes = [*notes, nonzero_success_note]
     if notes:
         payload["notes"] = notes
-    package_shims, package_shim_note = _refresh_package_shims_after_update(
-        context=context,
-        dry_run=dry_run,
-    )
-    if package_shims is not None:
-        payload["package_shims"] = package_shims
-    _append_payload_note(payload, package_shim_note)
+    if payload.get("changed") is True or payload.get("status") == "current":
+        package_shims, package_shim_note = _refresh_package_shims_after_update(
+            context=context,
+            dry_run=dry_run,
+        )
+        if package_shims is not None:
+            payload["package_shims"] = package_shims
+        _append_payload_note(payload, package_shim_note)
     repaired_installs, repair_notes = _repair_supported_harnesses(
         context=context,
         store=store,
@@ -867,7 +869,7 @@ def _refresh_package_shims_after_update(
     context: HarnessContext | None,
     dry_run: bool,
 ) -> tuple[dict[str, object] | None, str | None]:
-    if dry_run or context is None:
+    if dry_run or context is None or not _package_shim_manifest_has_installed_managers(context):
         return None, None
     refresh_context = {
         "home_dir": str(context.home_dir),
@@ -876,12 +878,14 @@ def _refresh_package_shims_after_update(
     }
     try:
         result = subprocess.run(
-            [sys.executable, "-c", _PACKAGE_SHIM_REFRESH_SCRIPT, json.dumps(refresh_context)],
+            [sys.executable, "-c", _PACKAGE_SHIM_REFRESH_SCRIPT],
+            input=json.dumps(refresh_context),
             capture_output=True,
             check=False,
             text=True,
+            timeout=_PACKAGE_SHIM_REFRESH_TIMEOUT_SECONDS,
         )
-    except OSError as error:
+    except (OSError, subprocess.SubprocessError) as error:
         return None, f"Could not refresh package firewall shims during update: {redact_sensitive_text(str(error))}"
     stdout = _normalize_output_text(result.stdout)
     stderr = _normalize_output_text(result.stderr)
@@ -901,6 +905,21 @@ def _refresh_package_shims_after_update(
     if not installed_managers:
         return None, None
     return refresh_payload, _package_shim_refresh_note(refresh_payload)
+
+
+def _package_shim_manifest_has_installed_managers(context: HarnessContext) -> bool:
+    manifest_path = context.guard_home / "package-shims" / "manifest.json"
+    try:
+        raw_manifest = manifest_path.read_text(encoding="utf-8")
+    except OSError:
+        return False
+    try:
+        manifest = json.loads(raw_manifest)
+    except json.JSONDecodeError:
+        return False
+    if not isinstance(manifest, dict):
+        return False
+    return bool(_string_list(manifest.get("installed_managers")))
 
 
 def _package_shim_refresh_note(refresh_payload: dict[str, object]) -> str | None:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -42,6 +42,38 @@ _ALREADY_CURRENT_HINTS = (
 _PYPI_JSON_URL = "https://pypi.org/pypi/hol-guard/json"
 _PYPI_TIMEOUT_SECONDS = 3.0
 _last_pypi_payload: dict[str, object] | None = None
+_PACKAGE_SHIM_REFRESH_SCRIPT = """
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.shims import package_shim_status, repair_package_shims
+
+
+def _resolve_path(value: object) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return Path(value).expanduser().resolve()
+
+
+payload = json.loads(sys.argv[1])
+home_dir = _resolve_path(payload.get("home_dir")) or Path.home().resolve()
+guard_home = _resolve_path(payload.get("guard_home")) or (home_dir / ".hol-guard")
+context = HarnessContext(
+    home_dir=home_dir,
+    workspace_dir=_resolve_path(payload.get("workspace_dir")),
+    guard_home=guard_home,
+)
+before = package_shim_status(context)
+repair = None
+if before.get("installed_managers"):
+    repair = repair_package_shims(context)
+after = package_shim_status(context)
+print(json.dumps({"before": before, "repair": repair, "after": after}))
+""".strip()
 
 
 def _read_direct_url_dir_info(direct_url: dict[str, object] | None) -> dict[str, object]:
@@ -228,6 +260,13 @@ def run_guard_update(
         notes = [*notes, nonzero_success_note]
     if notes:
         payload["notes"] = notes
+    package_shims, package_shim_note = _refresh_package_shims_after_update(
+        context=context,
+        dry_run=dry_run,
+    )
+    if package_shims is not None:
+        payload["package_shims"] = package_shims
+    _append_payload_note(payload, package_shim_note)
     repaired_installs, repair_notes = _repair_supported_harnesses(
         context=context,
         store=store,
@@ -236,7 +275,7 @@ def run_guard_update(
         dry_run=dry_run,
     )
     if repair_notes:
-        payload["notes"] = [*notes, *repair_notes]
+        payload["notes"] = [*_payload_notes(payload), *repair_notes]
     if repaired_installs:
         payload["managed_installs"] = repaired_installs
         if len(repaired_installs) == 1:
@@ -256,6 +295,22 @@ def run_guard_update(
 
 def _normalize_output_text(value: str) -> str:
     return redact_sensitive_text(value.strip())
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [item for item in value if isinstance(item, str)]
+
+
+def _payload_notes(payload: dict[str, object]) -> list[str]:
+    return _string_list(payload.get("notes"))
+
+
+def _append_payload_note(payload: dict[str, object], note: str | None) -> None:
+    if note is None or not note.strip():
+        return
+    payload["notes"] = [*_payload_notes(payload), note]
 
 
 def _shell_command(command: list[str]) -> str:
@@ -805,6 +860,79 @@ def _current_version_from_subprocess() -> str:
         return _current_version()
     version = result.stdout.strip()
     return version or _current_version()
+
+
+def _refresh_package_shims_after_update(
+    *,
+    context: HarnessContext | None,
+    dry_run: bool,
+) -> tuple[dict[str, object] | None, str | None]:
+    if dry_run or context is None:
+        return None, None
+    refresh_context = {
+        "home_dir": str(context.home_dir),
+        "workspace_dir": str(context.workspace_dir) if context.workspace_dir is not None else None,
+        "guard_home": str(context.guard_home),
+    }
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", _PACKAGE_SHIM_REFRESH_SCRIPT, json.dumps(refresh_context)],
+            capture_output=True,
+            check=False,
+            text=True,
+        )
+    except OSError as error:
+        return None, f"Could not refresh package firewall shims during update: {redact_sensitive_text(str(error))}"
+    stdout = _normalize_output_text(result.stdout)
+    stderr = _normalize_output_text(result.stderr)
+    if result.returncode != 0:
+        details = stderr or stdout or f"exit code {result.returncode}"
+        return None, f"Could not refresh package firewall shims during update: {details}"
+    try:
+        refresh_payload = json.loads(stdout) if stdout else {}
+    except json.JSONDecodeError as error:
+        return None, f"Could not parse package firewall refresh output during update: {error}"
+    if not isinstance(refresh_payload, dict):
+        return None, "Could not parse package firewall refresh output during update: invalid payload"
+    after_status = refresh_payload.get("after")
+    if not isinstance(after_status, dict):
+        return None, "Could not parse package firewall refresh output during update: missing status"
+    installed_managers = _string_list(after_status.get("installed_managers"))
+    if not installed_managers:
+        return None, None
+    return refresh_payload, _package_shim_refresh_note(refresh_payload)
+
+
+def _package_shim_refresh_note(refresh_payload: dict[str, object]) -> str | None:
+    after_status = refresh_payload.get("after")
+    if not isinstance(after_status, dict):
+        return None
+    manager_details = after_status.get("manager_details")
+    detail_items = manager_details if isinstance(manager_details, list) else []
+    unhealthy_managers = [
+        str(detail.get("manager"))
+        for detail in detail_items
+        if isinstance(detail, dict) and detail.get("integrity") in {"missing", "stale", "tampered"}
+    ]
+    path_repair_required = _string_list(after_status.get("path_repair_required"))
+    if unhealthy_managers:
+        return (
+            "Package firewall shims still need repair after update for "
+            f"{', '.join(unhealthy_managers)}."
+        )
+    repair_result = refresh_payload.get("repair")
+    repaired = _string_list(repair_result.get("repaired")) if isinstance(repair_result, dict) else []
+    if repaired:
+        note = f"Refreshed package firewall shims during update for {', '.join(repaired)}."
+        if path_repair_required:
+            note += f" Restart your shell to reactivate {', '.join(path_repair_required)}."
+        return note
+    if path_repair_required:
+        return (
+            "Package firewall shims are current, but PATH repair is still required for "
+            f"{', '.join(path_repair_required)}."
+        )
+    return None
 
 
 def _repair_supported_harnesses(

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -935,10 +935,7 @@ def _package_shim_refresh_note(refresh_payload: dict[str, object]) -> str | None
     ]
     path_repair_required = _string_list(after_status.get("path_repair_required"))
     if unhealthy_managers:
-        return (
-            "Package firewall shims still need repair after update for "
-            f"{', '.join(unhealthy_managers)}."
-        )
+        return f"Package firewall shims still need repair after update for {', '.join(unhealthy_managers)}."
     repair_result = refresh_payload.get("repair")
     repaired = _string_list(repair_result.get("repaired")) if isinstance(repair_result, dict) else []
     if repaired:

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -476,6 +476,122 @@ def test_update_syncs_dashboard_assets_after_partial_stale_upgrade(monkeypatch: 
     assert "synced dashboard" in payload["notes"]
 
 
+def test_refresh_package_shims_after_update_uses_fresh_python_process(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command[0] == update_commands.sys.executable
+        assert command[1] == "-c"
+        assert "repair_package_shims" in command[2]
+        refresh_context = json.loads(command[3])
+        assert refresh_context == {
+            "home_dir": str(context.home_dir),
+            "workspace_dir": str(context.workspace_dir),
+            "guard_home": str(context.guard_home),
+        }
+        refresh_payload = {
+            "before": {"installed_managers": ["pnpm"]},
+            "repair": {"repaired": ["pnpm"], "repaired_count": 1},
+            "after": {
+                "installed_managers": ["pnpm"],
+                "manager_details": [{"manager": "pnpm", "integrity": "ok"}],
+                "path_repair_required": [],
+            },
+        }
+        return subprocess.CompletedProcess(command, 0, json.dumps(refresh_payload), "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, note = update_commands._refresh_package_shims_after_update(context=context, dry_run=False)
+
+    assert payload is not None
+    assert payload["repair"] == {"repaired": ["pnpm"], "repaired_count": 1}
+    assert note == "Refreshed package firewall shims during update for pnpm."
+
+
+def test_update_records_package_shim_refresh_after_successful_update(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.826")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.830")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.830")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+    monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: None)
+    monkeypatch.setattr(
+        update_commands,
+        "_refresh_package_shims_after_update",
+        lambda **_: (
+            {
+                "before": {"installed_managers": ["pnpm"]},
+                "repair": {"repaired": ["pnpm"], "repaired_count": 1},
+                "after": {
+                    "installed_managers": ["pnpm"],
+                    "manager_details": [{"manager": "pnpm", "integrity": "ok"}],
+                    "path_repair_required": [],
+                },
+            },
+            "Refreshed package firewall shims during update for pnpm.",
+        ),
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["pipx", "upgrade", "hol-guard"]
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, context=_context(tmp_path))
+
+    assert exit_code == 0
+    assert payload["status"] == "updated"
+    assert payload["package_shims"]["repair"] == {"repaired": ["pnpm"], "repaired_count": 1}
+    assert "Refreshed package firewall shims during update for pnpm." in payload["notes"]
+
+
+def test_update_keeps_success_when_package_shim_refresh_warns(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.826")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.830")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.830")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+    monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: None)
+    monkeypatch.setattr(
+        update_commands,
+        "_refresh_package_shims_after_update",
+        lambda **_: (None, "Could not refresh package firewall shims during update: import failed"),
+    )
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["pipx", "upgrade", "hol-guard"]
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, context=_context(tmp_path))
+
+    assert exit_code == 0
+    assert payload["status"] == "updated"
+    assert "Could not refresh package firewall shims during update: import failed" in payload["notes"]
+
+
 def test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -481,17 +481,19 @@ def test_refresh_package_shims_after_update_uses_fresh_python_process(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     context = _context(tmp_path)
+    manifest_path = context.guard_home / "package-shims" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps({"installed_managers": ["pnpm"]}), encoding="utf-8")
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command[0] == update_commands.sys.executable
-        assert command[1] == "-c"
-        assert "repair_package_shims" in command[2]
-        refresh_context = json.loads(command[3])
+        assert command == [update_commands.sys.executable, "-c", update_commands._PACKAGE_SHIM_REFRESH_SCRIPT]
+        refresh_context = json.loads(str(kwargs.get("input")))
         assert refresh_context == {
             "home_dir": str(context.home_dir),
             "workspace_dir": str(context.workspace_dir),
             "guard_home": str(context.guard_home),
         }
+        assert kwargs.get("timeout") == update_commands._PACKAGE_SHIM_REFRESH_TIMEOUT_SECONDS
         refresh_payload = {
             "before": {"installed_managers": ["pnpm"]},
             "repair": {"repaired": ["pnpm"], "repaired_count": 1},
@@ -590,6 +592,54 @@ def test_update_keeps_success_when_package_shim_refresh_warns(
     assert exit_code == 0
     assert payload["status"] == "updated"
     assert "Could not refresh package firewall shims during update: import failed" in payload["notes"]
+
+
+def test_update_skips_package_shim_refresh_for_stale_no_change(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.584")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.584")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.585")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+    monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: None)
+
+    refresh_attempted = False
+
+    def fake_refresh(**_: object) -> tuple[dict[str, object] | None, str | None]:
+        nonlocal refresh_attempted
+        refresh_attempted = True
+        return None, None
+
+    monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", fake_refresh)
+
+    captured_commands: list[list[str]] = []
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        captured_commands.append(command)
+        return subprocess.CompletedProcess(
+            command,
+            0,
+            "hol-guard is already at latest version 2.0.584",
+            "upgrading shared libraries...\nupgrading hol-guard...\n",
+        )
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False)
+
+    assert exit_code == 0
+    assert captured_commands == [
+        ["pipx", "upgrade", "hol-guard"],
+        ["pipx", "install", "--force", "hol-guard==2.0.585"],
+    ]
+    assert payload["status"] == "stale"
+    assert refresh_attempted is False
 
 
 def test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change(


### PR DESCRIPTION
## Summary
- refresh installed package-manager shims from a fresh Python process after `hol-guard update`
- surface package-shim refresh results in the update payload so stale wrappers are visible during rollout

## Testing
- `pytest tests/test_guard_phase03_local_install.py -k 'refresh_package_shims_after_update_uses_fresh_python_process or update_records_package_shim_refresh_after_successful_update or update_keeps_success_when_package_shim_refresh_warns'`

## Notes
- Post-merge verification will rerun `hol-guard update` locally to confirm existing shims regenerate cleanly.
