### PR TITLE
fix(update): bypass package shims during self-update

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -797,9 +797,13 @@ def _execution_update_command(
     installer: str,
     context: HarnessContext | None,
 ) -> list[str]:
-    if installer == "pipx" and context is not None and _package_shim_manifest_has_installed_managers(context):
-        if real_binary := _resolve_unshimmed_binary(command[0], context):
-            return [real_binary, *command[1:]]
+    if (
+        installer == "pipx"
+        and context is not None
+        and _package_shim_manifest_has_installed_managers(context)
+        and (real_binary := _resolve_unshimmed_binary(command[0], context))
+    ):
+        return [real_binary, *command[1:]]
     return command
 
 

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -797,12 +797,10 @@ def _execution_update_command(
     installer: str,
     context: HarnessContext | None,
 ) -> list[str]:
-    if installer != "pipx" or context is None or not _package_shim_manifest_has_installed_managers(context):
-        return command
-    real_binary = _resolve_unshimmed_binary(command[0], context)
-    if real_binary is None:
-        return command
-    return [real_binary, *command[1:]]
+    if installer == "pipx" and context is not None and _package_shim_manifest_has_installed_managers(context):
+        if real_binary := _resolve_unshimmed_binary(command[0], context):
+            return [real_binary, *command[1:]]
+    return command
 
 
 def _vcs_install_payload(direct_url: dict[str, object] | None) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -150,6 +150,7 @@ def run_guard_update(
         local_source_install=local_source_install,
     )
     command = _update_command(installer, use_pypi=use_pypi)
+    execution_command = _execution_update_command(command, installer=installer, context=context)
     if force_pypi_reinstall:
         payload["recovery_reinstall"] = True
     payload.update(
@@ -167,7 +168,8 @@ def run_guard_update(
         payload["changed"] = False
         payload["message"] = _planned_update_message(version_check=version_check, use_pypi=use_pypi)
         return payload, 0
-    active_command = command
+    active_command = execution_command
+    active_display_command = command
     attempted_force_retry = False
     nonzero_success_note: str | None = None
     while True:
@@ -184,7 +186,7 @@ def run_guard_update(
             payload["error"] = redact_sensitive_text(str(error))
             payload["message"] = "HOL Guard update failed before the installer started."
             return payload, 1
-        payload["command"] = active_command
+        payload["command"] = active_display_command
         payload["stdout"] = _normalize_output_text(result.stdout)
         payload["stderr"] = _normalize_output_text(result.stderr)
         payload["return_code"] = result.returncode
@@ -231,9 +233,14 @@ def run_guard_update(
                 if isinstance(latest, str) and latest.strip():
                     target_version = latest.strip()
             retry_command = _update_command(installer, use_pypi=True, target_version=target_version)
-            if retry_command != active_command:
+            if retry_command != active_display_command:
                 attempted_force_retry = True
-                active_command = retry_command
+                active_display_command = retry_command
+                active_command = _execution_update_command(
+                    retry_command,
+                    installer=installer,
+                    context=context,
+                )
                 payload["upgrade_source"] = "pypi"
                 continue
         break
@@ -784,6 +791,20 @@ def _update_command(installer: str, *, use_pypi: bool = False, target_version: s
     return [sys.executable, "-m", "pip", "install", "--upgrade", "hol-guard"]
 
 
+def _execution_update_command(
+    command: list[str],
+    *,
+    installer: str,
+    context: HarnessContext | None,
+) -> list[str]:
+    if installer != "pipx" or context is None or not _package_shim_manifest_has_installed_managers(context):
+        return command
+    real_binary = _resolve_unshimmed_binary(command[0], context)
+    if real_binary is None:
+        return command
+    return [real_binary, *command[1:]]
+
+
 def _vcs_install_payload(direct_url: dict[str, object] | None) -> dict[str, object] | None:
     if not isinstance(direct_url, dict):
         return None
@@ -862,6 +883,28 @@ def _current_version_from_subprocess() -> str:
         return _current_version()
     version = result.stdout.strip()
     return version or _current_version()
+
+
+def _resolve_unshimmed_binary(command_name: str, context: HarnessContext) -> str | None:
+    filtered_path = _path_without_guard_package_shims(context)
+    if not filtered_path:
+        return None
+    return shutil.which(command_name, path=filtered_path)
+
+
+def _path_without_guard_package_shims(context: HarnessContext) -> str:
+    shim_dir = (context.guard_home / "package-shims" / "bin").expanduser().resolve()
+    filtered_entries = []
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        try:
+            if Path(entry).expanduser().resolve() == shim_dir:
+                continue
+        except OSError:
+            pass
+        filtered_entries.append(entry)
+    return os.pathsep.join(filtered_entries)
 
 
 def _refresh_package_shims_after_update(

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -150,14 +150,18 @@ def test_update_uses_real_pipx_binary_when_guard_package_shims_are_installed(
     monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.830")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
     monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+
+    def fake_which(name: str, path: str | None = None) -> str | None:
+        if name == "pipx" and isinstance(path, str) and "/package-shims/bin" not in path:
+            return "/opt/homebrew/bin/pipx"
+        if name == "hol-guard":
+            return "/mock-home/.local/bin/hol-guard"
+        return None
+
     monkeypatch.setattr(
         update_commands.shutil,
         "which",
-        lambda name, path=None: (
-            "/opt/homebrew/bin/pipx"
-            if name == "pipx" and isinstance(path, str) and "/package-shims/bin" not in path
-            else ("/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None)
-        ),
+        fake_which,
     )
     monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: None)
     monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", lambda **_: (None, None))

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -131,6 +132,47 @@ def test_update_binary_diagnostics_treats_pipx_shim_as_healthy(monkeypatch: pyte
     assert exit_code == 0
     assert payload["binary_diagnostics"]["path_status"] == "pipx_shim_detected"
     assert payload["binary_diagnostics"]["expected_script_dir"] is None
+
+
+def test_update_uses_real_pipx_binary_when_guard_package_shims_are_installed(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    context = _context(tmp_path)
+    manifest_path = context.guard_home / "package-shims" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True, exist_ok=True)
+    manifest_path.write_text(json.dumps({"installed_managers": ["pipx"]}), encoding="utf-8")
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    shim_dir.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("PATH", f"{shim_dir}{os.pathsep}/opt/homebrew/bin")
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.829")
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.830")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.830")
+    monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name, path=None: (
+            "/opt/homebrew/bin/pipx"
+            if name == "pipx" and isinstance(path, str) and "/package-shims/bin" not in path
+            else ("/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None)
+        ),
+    )
+    monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: None)
+    monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", lambda **_: (None, None))
+
+    def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        assert command == ["/opt/homebrew/bin/pipx", "upgrade", "hol-guard"]
+        return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
+
+    monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=False, context=context)
+
+    assert exit_code == 0
+    assert payload["status"] == "updated"
+    assert payload["command"] == ["pipx", "upgrade", "hol-guard"]
 
 
 def test_version_check_reports_python_incompatible_latest_release(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
- resolve the real `pipx` binary outside Guard-managed package shims before running `hol-guard update`
- keep the displayed update command unchanged while exercising the unshimmed binary only for the actual self-update subprocess

## Testing
- `pytest tests/test_guard_phase03_local_install.py -k 'update_uses_real_pipx_binary_when_guard_package_shims_are_installed or refresh_package_shims_after_update_uses_fresh_python_process or update_records_package_shim_refresh_after_successful_update or update_keeps_success_when_package_shim_refresh_warns or update_skips_package_shim_refresh_for_stale_no_change'`
- `python3 -m ruff format --check src/`
