### PR TITLE
fix(guard): verify trust doctor install surface

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -17,7 +17,7 @@ from ..local_trust_controller import macos_native_backend_supported, resolve_pas
 from ..policy_integrity import is_remote_policy_source
 from ..store import GuardStore
 from .commands_support_interaction import _emit
-from .update_commands import build_guard_update_status_payload
+from .update_commands import build_guard_install_surface_payload
 
 
 def _now() -> str:
@@ -87,8 +87,8 @@ def _installed_trust_cli_payload() -> dict[str, object]:
     installation_mode = "unknown"
     editable_install = False
     official_install = False
-    update_status = build_guard_update_status_payload()
-    binary_diagnostics = update_status.get("binary_diagnostics")
+    install_surface = build_guard_install_surface_payload()
+    binary_diagnostics = install_surface.get("binary_diagnostics")
     if not isinstance(binary_diagnostics, dict):
         binary_diagnostics = {}
     try:
@@ -131,7 +131,7 @@ def _installed_trust_cli_payload() -> dict[str, object]:
         "official_install": official_install,
         "official_install_verified": official_install and active_command_status == "pipx_shim_detected",
         "editable_install": editable_install,
-        "installer": update_status.get("installer"),
+        "installer": install_surface.get("installer"),
         "active_command_path": binary_diagnostics.get("resolved_hol_guard"),
         "active_command_status": active_command_status,
         "active_command_verified": active_command_verified,
@@ -225,9 +225,15 @@ def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> d
             "Use the official pipx install before relying on packaged update and daemon lifecycle checks."
         )
     if not bool(install_info.get("active_command_verified")):
-        payload["recommended_actions"].append(
-            "Run `command -v hol-guard` and `hol-guard --version` to confirm the active command matches this install."
-        )
+        if install_info.get("active_command_status") == "not_on_path":
+            payload["recommended_actions"].append(
+                "hol-guard is not on PATH. Reinstall it or add the install script directory to PATH."
+            )
+        else:
+            payload["recommended_actions"].append(
+                "Run `command -v hol-guard` and `hol-guard --version` "
+                "to confirm the active command matches this install."
+            )
     payload["approval_center"] = approval_center
     payload["approval_url_base"] = approval_center.get("approval_url_base")
     payload["passive_read_guarantee"] = _passive_read_guarantee()

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -17,6 +17,7 @@ from ..local_trust_controller import macos_native_backend_supported, resolve_pas
 from ..policy_integrity import is_remote_policy_source
 from ..store import GuardStore
 from .commands_support_interaction import _emit
+from .update_commands import build_guard_update_status_payload
 
 
 def _now() -> str:
@@ -86,6 +87,10 @@ def _installed_trust_cli_payload() -> dict[str, object]:
     installation_mode = "unknown"
     editable_install = False
     official_install = False
+    update_status = build_guard_update_status_payload()
+    binary_diagnostics = update_status.get("binary_diagnostics")
+    if not isinstance(binary_diagnostics, dict):
+        binary_diagnostics = {}
     try:
         distribution = importlib.metadata.distribution("hol-guard")
     except importlib.metadata.PackageNotFoundError:
@@ -113,12 +118,25 @@ def _installed_trust_cli_payload() -> dict[str, object]:
             installation_mode = "editable"
         else:
             installation_mode = "packaged"
+    active_command_status = str(binary_diagnostics.get("path_status") or "unknown")
+    active_command_verified = active_command_status in {
+        "pipx_shim_detected",
+        "uv_tool_shim_detected",
+        "matches_installer",
+    }
     return {
         "package": "hol-guard",
         "version": version,
         "installation_mode": installation_mode,
         "official_install": official_install,
+        "official_install_verified": official_install and active_command_status == "pipx_shim_detected",
         "editable_install": editable_install,
+        "installer": update_status.get("installer"),
+        "active_command_path": binary_diagnostics.get("resolved_hol_guard"),
+        "active_command_status": active_command_status,
+        "active_command_verified": active_command_verified,
+        "expected_script_dir": binary_diagnostics.get("expected_script_dir"),
+        "self_check_command": "command -v hol-guard && hol-guard --version",
         "update_command": "hol-guard update",
         "dry_run_command": "hol-guard update --dry-run --json",
     }
@@ -184,6 +202,7 @@ def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> d
         "local_rules_protected": remembered_rules == "enforced",
         "cloud_policy_available": payload.get("cloud_policy_status") == "available",
         "approval_center_active": bool(approval_center.get("active")),
+        "official_install_verified": bool(install_info.get("official_install_verified")),
     }
     payload["recommended_actions"] = (
         [
@@ -204,6 +223,10 @@ def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> d
     if bool(install_info.get("editable_install")):
         payload["recommended_actions"].append(
             "Use the official pipx install before relying on packaged update and daemon lifecycle checks."
+        )
+    if not bool(install_info.get("active_command_verified")):
+        payload["recommended_actions"].append(
+            "Run `command -v hol-guard` and `hol-guard --version` to confirm the active command matches this install."
         )
     payload["approval_center"] = approval_center
     payload["approval_url_base"] = approval_center.get("approval_url_base")

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -753,6 +753,10 @@ def _build_trust_doctor_panel(trust: dict[str, object]) -> Panel:
         update_command = official_install.get("update_command") or "hol-guard update"
         body.add_row("Installed package", f"hol-guard {version}")
         body.add_row("Install mode", str(official_install.get("installation_mode") or "unknown"))
+        body.add_row("Install check", str(official_install.get("active_command_status") or "unknown"))
+        active_command_path = official_install.get("active_command_path")
+        if isinstance(active_command_path, str) and active_command_path.strip():
+            body.add_row("Active command", active_command_path.strip())
         body.add_row("Update", str(update_command))
     summary = trust.get("summary")
     if isinstance(summary, str) and summary.strip():

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -1158,7 +1158,7 @@ def _codex_backup_repair_contexts(context: HarnessContext) -> tuple[HarnessConte
 def build_guard_update_status_payload() -> dict[str, object]:
     current_version = _current_version()
     install_surface = build_guard_install_surface_payload()
-    installer = str(install_surface.get("installer") or _installer_kind())
+    installer = str(install_surface.get("installer") or "")
     binary_diagnostics = install_surface.get("binary_diagnostics")
     if not isinstance(binary_diagnostics, dict):
         binary_diagnostics = {}

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -354,7 +354,10 @@ def _binary_diagnostics(command: list[str], installer: str) -> dict[str, object]
 def _expected_script_dir(installer_binary: str, installer: str) -> Path | None:
     if installer != "pip" or not installer_binary:
         return None
-    scripts_dir = sysconfig.get_path("scripts")
+    try:
+        scripts_dir = sysconfig.get_path("scripts")
+    except Exception:
+        scripts_dir = None
     if scripts_dir:
         return _directory_path(scripts_dir)
     return _script_dir(installer_binary)
@@ -1147,6 +1150,7 @@ def _codex_backup_repair_contexts(context: HarnessContext) -> tuple[HarnessConte
 def build_guard_update_status_payload() -> dict[str, object]:
     current_version = _current_version()
     installer = _installer_kind()
+    binary_diagnostics = _binary_diagnostics(_update_command(installer, use_pypi=False), installer)
     direct_url = _direct_url_payload()
     local_source_install = _local_source_install_payload(direct_url)
     version_check = _version_check_payload(current_version)
@@ -1180,6 +1184,7 @@ def build_guard_update_status_payload() -> dict[str, object]:
         "current_version": current_version,
         "latest_version": latest_version if isinstance(latest_version, str) else None,
         "installer": installer,
+        "binary_diagnostics": binary_diagnostics,
         "version_check": version_check,
         "auto_updatable": auto_updatable,
         "update_available": update_available,

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -1205,4 +1205,5 @@ def build_guard_update_status_payload() -> dict[str, object]:
         "recovery_reinstall_command": recovery_reinstall_command,
     }
 
+
 __all__ = ["build_guard_install_surface_payload", "build_guard_update_status_payload", "run_guard_update"]

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -363,6 +363,14 @@ def _expected_script_dir(installer_binary: str, installer: str) -> Path | None:
     return _script_dir(installer_binary)
 
 
+def build_guard_install_surface_payload() -> dict[str, object]:
+    installer = _installer_kind()
+    return {
+        "installer": installer,
+        "binary_diagnostics": _binary_diagnostics(_update_command(installer, use_pypi=False), installer),
+    }
+
+
 def _script_dir(path: str) -> Path:
     return _directory_path(Path(path).expanduser().parent)
 
@@ -1149,8 +1157,11 @@ def _codex_backup_repair_contexts(context: HarnessContext) -> tuple[HarnessConte
 
 def build_guard_update_status_payload() -> dict[str, object]:
     current_version = _current_version()
-    installer = _installer_kind()
-    binary_diagnostics = _binary_diagnostics(_update_command(installer, use_pypi=False), installer)
+    install_surface = build_guard_install_surface_payload()
+    installer = str(install_surface.get("installer") or _installer_kind())
+    binary_diagnostics = install_surface.get("binary_diagnostics")
+    if not isinstance(binary_diagnostics, dict):
+        binary_diagnostics = {}
     direct_url = _direct_url_payload()
     local_source_install = _local_source_install_payload(direct_url)
     version_check = _version_check_payload(current_version)
@@ -1194,5 +1205,4 @@ def build_guard_update_status_payload() -> dict[str, object]:
         "recovery_reinstall_command": recovery_reinstall_command,
     }
 
-
-__all__ = ["build_guard_update_status_payload", "run_guard_update"]
+__all__ = ["build_guard_install_surface_payload", "build_guard_update_status_payload", "run_guard_update"]

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -133,7 +133,6 @@ def test_update_binary_diagnostics_treats_pipx_shim_as_healthy(monkeypatch: pyte
     assert payload["binary_diagnostics"]["path_status"] == "pipx_shim_detected"
     assert payload["binary_diagnostics"]["expected_script_dir"] is None
 
-
 def test_update_uses_real_pipx_binary_when_guard_package_shims_are_installed(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -177,6 +176,25 @@ def test_update_uses_real_pipx_binary_when_guard_package_shims_are_installed(
     assert exit_code == 0
     assert payload["status"] == "updated"
     assert payload["command"] == ["pipx", "upgrade", "hol-guard"]
+
+
+def test_build_guard_install_surface_payload_stays_local(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+    monkeypatch.setattr(
+        update_commands.shutil,
+        "which",
+        lambda name: "/mock-home/.local/bin/hol-guard" if name == "hol-guard" else None,
+    )
+    monkeypatch.setattr(
+        update_commands,
+        "_version_check_payload",
+        lambda _current_version: (_ for _ in ()).throw(AssertionError("network version check should not run")),
+    )
+
+    payload = update_commands.build_guard_install_surface_payload()
+
+    assert payload["installer"] == "pipx"
+    assert payload["binary_diagnostics"]["path_status"] == "pipx_shim_detected"
 
 
 def test_version_check_reports_python_incompatible_latest_release(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1548,7 +1548,7 @@ def test_build_trust_doctor_payload_detects_editable_install(tmp_path: Path, mon
     monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
     monkeypatch.setattr(
         trust_dispatch_module,
-        "build_guard_update_status_payload",
+        "build_guard_install_surface_payload",
         lambda: {
             "installer": "pipx",
             "binary_diagnostics": {
@@ -1588,7 +1588,7 @@ def test_build_trust_doctor_payload_tolerates_distribution_path_error(
     monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
     monkeypatch.setattr(
         trust_dispatch_module,
-        "build_guard_update_status_payload",
+        "build_guard_install_surface_payload",
         lambda: {
             "installer": "pipx",
             "binary_diagnostics": {
@@ -1607,6 +1607,44 @@ def test_build_trust_doctor_payload_tolerates_distribution_path_error(
     assert payload["official_install"]["active_command_status"] == "path_mismatch"
     assert payload["official_install"]["active_command_verified"] is False
     assert any("command -v hol-guard" in action for action in payload["recommended_actions"])
+
+
+def test_build_trust_doctor_payload_reports_missing_command_path_help(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+
+    class _FakeDistribution:
+        version = "9.9.9"
+
+        def read_text(self, _filename: str) -> str | None:
+            return None
+
+        def locate_file(self, _path: str) -> Path:
+            return Path("/mock-home/.local/pipx/venvs/hol-guard/lib/python3.12/site-packages")
+
+    monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "build_guard_install_surface_payload",
+        lambda: {
+            "installer": "pipx",
+            "binary_diagnostics": {
+                "resolved_hol_guard": None,
+                "expected_script_dir": None,
+                "path_status": "not_on_path",
+            },
+        },
+    )
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["official_install"]["active_command_status"] == "not_on_path"
+    assert payload["official_install"]["active_command_verified"] is False
+    assert any("not on PATH" in action for action in payload["recommended_actions"])
+    assert not any("command -v hol-guard" in action for action in payload["recommended_actions"])
 
 
 def test_build_trust_doctor_payload_verifies_official_pipx_command_path(
@@ -1628,7 +1666,7 @@ def test_build_trust_doctor_payload_verifies_official_pipx_command_path(
     monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
     monkeypatch.setattr(
         trust_dispatch_module,
-        "build_guard_update_status_payload",
+        "build_guard_install_surface_payload",
         lambda: {
             "installer": "pipx",
             "binary_diagnostics": {

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1461,6 +1461,8 @@ def test_guard_doctor_includes_safe_trust_diagnostics(tmp_path: Path, capsys) ->
     assert trust_payload["checks"]["runtime_protection"] is (trust_payload["runtime_protection"] == "protected")
     assert trust_payload["official_install"]["package"] == "hol-guard"
     assert trust_payload["official_install"]["update_command"] == "hol-guard update"
+    assert "active_command_status" in trust_payload["official_install"]
+    assert "self_check_command" in trust_payload["official_install"]
     assert trust_payload["approval_center"]["active"] is False
     assert trust_payload["approval_url_base"] is None
     assert trust_payload["passive_read_guarantee"]
@@ -1480,6 +1482,7 @@ def test_guard_doctor_human_output_includes_trust_diagnostics(tmp_path: Path, ca
     assert rc == 0
     assert "Local trust" in output
     assert "Passive OS prompts" in output
+    assert "Install check" in output
     assert "hol-guard update" in output
     assert "Guard Cloud policies" in output
     assert "trust test --no-ui --json" in output
@@ -1496,6 +1499,7 @@ def test_trust_cli_doctor_human_output_uses_trust_renderer(tmp_path: Path, capsy
     assert "Mode" in output
     assert "Passive OS prompts" in output
     assert "Install mode" in output
+    assert "Install check" in output
     assert "hol-guard update" in output
     assert '"runtime_protection"' not in output
 
@@ -1542,6 +1546,18 @@ def test_build_trust_doctor_payload_detects_editable_install(tmp_path: Path, mon
             return Path("editable/hol-guard/src")
 
     monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "build_guard_update_status_payload",
+        lambda: {
+            "installer": "pipx",
+            "binary_diagnostics": {
+                "resolved_hol_guard": "/mock-home/.local/bin/hol-guard",
+                "expected_script_dir": None,
+                "path_status": "pipx_shim_detected",
+            },
+        },
+    )
 
     payload = trust_dispatch_module.build_trust_doctor_payload(store)
 
@@ -1549,6 +1565,7 @@ def test_build_trust_doctor_payload_detects_editable_install(tmp_path: Path, mon
     assert payload["official_install"]["installation_mode"] == "editable"
     assert payload["official_install"]["editable_install"] is True
     assert payload["official_install"]["official_install"] is False
+    assert payload["official_install"]["official_install_verified"] is False
     assert any("official pipx install" in action for action in payload["recommended_actions"])
 
 
@@ -1569,12 +1586,65 @@ def test_build_trust_doctor_payload_tolerates_distribution_path_error(
             raise RuntimeError("bad metadata")
 
     monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "build_guard_update_status_payload",
+        lambda: {
+            "installer": "pipx",
+            "binary_diagnostics": {
+                "resolved_hol_guard": "/usr/local/bin/hol-guard",
+                "expected_script_dir": None,
+                "path_status": "path_mismatch",
+            },
+        },
+    )
 
     payload = trust_dispatch_module.build_trust_doctor_payload(store)
 
     assert payload["official_install"]["version"] == "9.9.9"
     assert payload["official_install"]["installation_mode"] == "packaged"
     assert payload["official_install"]["official_install"] is False
+    assert payload["official_install"]["active_command_status"] == "path_mismatch"
+    assert payload["official_install"]["active_command_verified"] is False
+    assert any("command -v hol-guard" in action for action in payload["recommended_actions"])
+
+
+def test_build_trust_doctor_payload_verifies_official_pipx_command_path(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+
+    class _FakeDistribution:
+        version = "9.9.9"
+
+        def read_text(self, _filename: str) -> str | None:
+            return None
+
+        def locate_file(self, _path: str) -> Path:
+            return Path("/mock-home/.local/pipx/venvs/hol-guard/lib/python3.12/site-packages")
+
+    monkeypatch.setattr(trust_dispatch_module.importlib.metadata, "distribution", lambda _name: _FakeDistribution())
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "build_guard_update_status_payload",
+        lambda: {
+            "installer": "pipx",
+            "binary_diagnostics": {
+                "resolved_hol_guard": "/mock-home/.local/bin/hol-guard",
+                "expected_script_dir": None,
+                "path_status": "pipx_shim_detected",
+            },
+        },
+    )
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["official_install"]["installation_mode"] == "official-pipx"
+    assert payload["official_install"]["official_install"] is True
+    assert payload["official_install"]["official_install_verified"] is True
+    assert payload["checks"]["official_install_verified"] is True
 
 
 def test_trust_cli_doctor_reports_macos_no_prompt_copy(


### PR DESCRIPTION
## Summary
- surface the active `hol-guard` command path and install health inside `guard trust doctor`
- add trust-doctor regression coverage and a safe `sysconfig` fallback for pip install path checks

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/update_commands.py src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_policy_integrity.py`
- `python3 -m pytest tests/test_guard_policy_integrity.py -k "guard_doctor_includes_safe_trust_diagnostics or guard_doctor_human_output_includes_trust_diagnostics or trust_cli_doctor_human_output_uses_trust_renderer or build_trust_doctor_payload_detects_editable_install or build_trust_doctor_payload_tolerates_distribution_path_error or build_trust_doctor_payload_verifies_official_pipx_command_path" -q`
- `python3 -m pytest tests/test_guard_phase03_local_install.py tests/test_guard_phase03_remainder.py -q`
- `python3 -m pytest tests/test_dashboard_update.py -k "build_guard_update_status_payload_shape or build_guard_update_status_payload" -q`
