### PR TITLE
fix(trust): harden doctor daemon diagnostics

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -66,7 +66,10 @@ def _approval_center_locator_is_fresh(
     locator_started_at_dt = _parse_iso8601(locator_started_at)
     if state_started_at is None or locator_started_at_dt is None:
         return True
-    return locator_started_at_dt >= state_started_at
+    try:
+        return locator_started_at_dt >= state_started_at
+    except TypeError:
+        return True
 
 
 def _sanitize_trust_text(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -5,19 +5,88 @@ from __future__ import annotations
 import argparse
 import importlib.metadata
 import json
+import re
 import sys
+from datetime import datetime
 from pathlib import Path
 from typing import TextIO
 
+from ...version import __version__
 from ..adapters.base import HarnessContext
 from ..config import GuardConfig
-from ..daemon.manager import _guard_daemon_url_port, load_guard_daemon_url, read_approval_center_locator
+from ..daemon.manager import _guard_daemon_url_port, _load_state, load_guard_daemon_url, read_approval_center_locator
 from ..local_trust_contract import TrustStatus
 from ..local_trust_controller import macos_native_backend_supported, resolve_passive_trust_state
 from ..policy_integrity import is_remote_policy_source
 from ..store import GuardStore
 from .commands_support_interaction import _emit
 from .update_commands import build_guard_install_surface_payload
+
+_TRUST_SECRET_ASSIGNMENT_PATTERNS: tuple[re.Pattern[str], ...] = (
+    re.compile(
+        r"(?i)\b[a-z0-9_.-]*(?:token|secret|api[-_]?key|password|credential)[a-z0-9_.-]*\s*=\s*"
+        r"(?:'[^']*'|\"[^\"]*\"|[^\s]+)"
+    ),
+    re.compile(
+        r"(?i)\b[a-z0-9_.-]*(?:token|secret|api[-_]?key|password|credential)[a-z0-9_.-]*\s*:\s*"
+        r"(?:bearer\s+)?[^\s,;]+"
+    ),
+)
+
+
+def _parse_iso8601(value: str | None) -> datetime | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        return datetime.fromisoformat(normalized)
+    except ValueError:
+        return None
+
+
+def _approval_center_locator_is_fresh(
+    locator_pid: int,
+    locator_url: str,
+    locator_started_at: str,
+    state: dict[str, object] | None,
+) -> bool:
+    if not isinstance(state, dict):
+        return True
+    state_pid = state.get("pid")
+    state_port = state.get("port")
+    locator_port = _guard_daemon_url_port(locator_url)
+    if isinstance(state_pid, int) and state_pid != locator_pid:
+        return False
+    if isinstance(state_port, int) and locator_port != state_port:
+        return False
+    state_started_at = _parse_iso8601(state.get("started_at") if isinstance(state.get("started_at"), str) else None)
+    locator_started_at_dt = _parse_iso8601(locator_started_at)
+    if state_started_at is None or locator_started_at_dt is None:
+        return True
+    return locator_started_at_dt >= state_started_at
+
+
+def _sanitize_trust_text(value: str) -> str:
+    sanitized = value
+    for pattern in _TRUST_SECRET_ASSIGNMENT_PATTERNS:
+        sanitized = pattern.sub("credential redacted", sanitized)
+    return sanitized
+
+
+def _sanitize_trust_payload(value: object) -> object:
+    if isinstance(value, dict):
+        return {key: _sanitize_trust_payload(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_sanitize_trust_payload(item) for item in value]
+    if isinstance(value, str):
+        return _sanitize_trust_text(value)
+    return value
+
+
+def _emit_trust_payload(command: str, payload: dict[str, object], as_json: bool) -> None:
+    _emit(command, _sanitize_trust_payload(payload), as_json)
 
 
 def _now() -> str:
@@ -143,8 +212,22 @@ def _installed_trust_cli_payload() -> dict[str, object]:
 
 
 def _approval_center_status_payload(guard_home: Path) -> dict[str, object]:
+    state = _load_state(guard_home)
+    daemon_package_version = state.get("package_version") if isinstance(state, dict) else None
+    restart_required = isinstance(daemon_package_version, str) and daemon_package_version != __version__
     locator = read_approval_center_locator(guard_home)
-    if locator is not None:
+    if locator is not None and _approval_center_locator_is_fresh(
+        locator.pid,
+        locator.daemon_url,
+        locator.started_at,
+        state,
+    ):
+        detail = None
+        if restart_required:
+            detail = (
+                f"Guard daemon is still serving hol-guard {daemon_package_version}. "
+                f"Restart it so browser approvals use hol-guard {__version__}."
+            )
         return {
             "active": True,
             "approval_url_base": locator.approval_url_base,
@@ -156,19 +239,35 @@ def _approval_center_status_payload(guard_home: Path) -> dict[str, object]:
             ),
             "started_at": locator.started_at,
             "pid": locator.pid,
+            "snapshot_fresh": True,
+            "restart_required": restart_required,
+            "daemon_package_version": daemon_package_version,
+            "detail": detail,
         }
     daemon_url = load_guard_daemon_url(guard_home)
     if isinstance(daemon_url, str) and daemon_url.strip():
+        detail = "Guard daemon is healthy, but the browser approval locator has not been refreshed yet."
+        if restart_required:
+            detail = (
+                f"Guard daemon is still serving hol-guard {daemon_package_version}. "
+                f"Restart it so browser approvals use hol-guard {__version__}."
+            )
         return {
             "active": True,
             "approval_url_base": daemon_url,
             "daemon_url": daemon_url,
             "port": _guard_daemon_url_port(daemon_url),
-            "detail": "Guard daemon is healthy, but the browser approval locator has not been refreshed yet.",
+            "detail": detail,
+            "snapshot_fresh": False,
+            "restart_required": restart_required,
+            "daemon_package_version": daemon_package_version,
         }
     return {
         "active": False,
         "detail": "No active Guard approval center daemon detected.",
+        "snapshot_fresh": False,
+        "restart_required": False,
+        "daemon_package_version": daemon_package_version,
     }
 
 
@@ -202,6 +301,7 @@ def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> d
         "local_rules_protected": remembered_rules == "enforced",
         "cloud_policy_available": payload.get("cloud_policy_status") == "available",
         "approval_center_active": bool(approval_center.get("active")),
+        "approval_center_route_current": bool(approval_center.get("snapshot_fresh")),
         "official_install_verified": bool(install_info.get("official_install_verified")),
     }
     payload["recommended_actions"] = (
@@ -219,6 +319,14 @@ def build_trust_doctor_payload(store: GuardStore, *, backend: str = "auto") -> d
     if not bool(approval_center.get("active")):
         payload["recommended_actions"].append(
             "Run `hol-guard dashboard` if browser approvals are unavailable and Guard needs a fresh local route."
+        )
+    elif bool(approval_center.get("restart_required")):
+        payload["recommended_actions"].append(
+            "Run `hol-guard daemon repair` or restart the Guard daemon so browser approvals reconnect to this install."
+        )
+    elif not bool(approval_center.get("snapshot_fresh")):
+        payload["recommended_actions"].append(
+            "Run `hol-guard dashboard` once to refresh the local browser approval route for the active daemon."
         )
     if bool(install_info.get("editable_install")):
         payload["recommended_actions"].append(
@@ -330,22 +438,22 @@ def _run_guard_trust_command(
         else _trust_status_payload(store, command=trust_command, backend=backend)
     )
     if trust_command in {"status", "doctor"}:
-        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+        _emit_trust_payload(f"trust.{trust_command}", payload, getattr(args, "json", False))
         return 0
     if trust_command == "test":
         if not bool(getattr(args, "no_ui", False)):
             payload["error"] = "Use --no-ui so Guard can prove this probe will not open an OS credential prompt."
-            _emit("trust.test", payload, getattr(args, "json", False))
+            _emit_trust_payload("trust.test", payload, getattr(args, "json", False))
             return 2
         payload["probe"] = "passive_no_ui"
         payload["ok"] = payload["passive_prompt_allowed"] is False and payload.get("mode") != "unsupported"
         payload["trust_health"] = str(payload.get("mode") or "degraded_safe")
-        _emit("trust.test", payload, getattr(args, "json", False))
+        _emit_trust_payload("trust.test", payload, getattr(args, "json", False))
         return 0
     if trust_command == "explain":
         rule_id = getattr(args, "rule", None)
         if not isinstance(rule_id, int) or isinstance(rule_id, bool):
-            _emit(
+            _emit_trust_payload(
                 "trust.explain",
                 {
                     "generated_at": _now(),
@@ -356,7 +464,7 @@ def _run_guard_trust_command(
             )
             return 2
         payload = build_trust_explain_payload(store, rule_id=rule_id, backend=backend)
-        _emit("trust.explain", payload, getattr(args, "json", False))
+        _emit_trust_payload("trust.explain", payload, getattr(args, "json", False))
         return 0 if "error" not in payload else 2
     if trust_command in {"setup", "reset"}:
         if backend == "degraded-safe":
@@ -370,7 +478,7 @@ def _run_guard_trust_command(
                 if trust_command == "setup"
                 else "Nothing changed."
             )
-            _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+            _emit_trust_payload(f"trust.{trust_command}", payload, getattr(args, "json", False))
             return 2
         if sys.platform != "darwin":
             payload["error"] = (
@@ -383,7 +491,7 @@ def _run_guard_trust_command(
                 if trust_command == "setup"
                 else "Nothing changed."
             )
-            _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+            _emit_trust_payload(f"trust.{trust_command}", payload, getattr(args, "json", False))
             return 2
         if not macos_native_backend_supported(store):
             payload["error"] = (
@@ -391,7 +499,7 @@ def _run_guard_trust_command(
                 "Guard will not fall back to a prompt-capable backend."
             )
             payload["next_action"] = "Use one-time approvals or Guard Cloud policies until native setup is available."
-            _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+            _emit_trust_payload(f"trust.{trust_command}", payload, getattr(args, "json", False))
             return 2
         result = (
             store.setup_policy_integrity(now=_now())
@@ -425,7 +533,7 @@ def _run_guard_trust_command(
             )
             if not payload["ok"]:
                 payload["next_action"] = "Keep using one-time approvals, then run trust doctor for the degraded reason."
-                _emit("trust.setup", payload, getattr(args, "json", False))
+                _emit_trust_payload("trust.setup", payload, getattr(args, "json", False))
                 return 2
         else:
             payload["message"] = (
@@ -435,9 +543,13 @@ def _run_guard_trust_command(
             payload["next_action"] = (
                 "Run `hol-guard guard trust setup --backend macos-native --json` to protect local rules again."
             )
-        _emit(f"trust.{trust_command}", payload, getattr(args, "json", False))
+        _emit_trust_payload(f"trust.{trust_command}", payload, getattr(args, "json", False))
         return 0
-    _emit("trust", {"error": "Use: hol-guard guard trust status|doctor|test|setup|reset"}, getattr(args, "json", False))
+    _emit_trust_payload(
+        "trust",
+        {"error": "Use: hol-guard guard trust status|doctor|test|setup|reset"},
+        getattr(args, "json", False),
+    )
     return 2
 
 

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -29,7 +29,7 @@ _TRUST_SECRET_ASSIGNMENT_PATTERNS: tuple[re.Pattern[str], ...] = (
     ),
     re.compile(
         r"(?i)\b[a-z0-9_.-]*(?:token|secret|api[-_]?key|password|credential)[a-z0-9_.-]*\s*:\s*"
-        r"(?:bearer\s+)?[^\s,;]+"
+        r"(?:bearer\s+[^\s,;]+|[a-f0-9]{16,}|[a-z0-9._-]{24,})"
     ),
 )
 
@@ -76,14 +76,18 @@ def _sanitize_trust_text(value: str) -> str:
     return sanitized
 
 
-def _sanitize_trust_payload(value: object) -> object:
+def _sanitize_trust_value(value: object) -> object:
     if isinstance(value, dict):
-        return {key: _sanitize_trust_payload(item) for key, item in value.items()}
+        return {key: _sanitize_trust_value(item) for key, item in value.items()}
     if isinstance(value, list):
-        return [_sanitize_trust_payload(item) for item in value]
+        return [_sanitize_trust_value(item) for item in value]
     if isinstance(value, str):
         return _sanitize_trust_text(value)
     return value
+
+
+def _sanitize_trust_payload(payload: dict[str, object]) -> dict[str, object]:
+    return {key: _sanitize_trust_value(value) for key, value in payload.items()}
 
 
 def _emit_trust_payload(command: str, payload: dict[str, object], as_json: bool) -> None:

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -61,7 +61,8 @@ def _approval_center_locator_is_fresh(
         return False
     if isinstance(state_port, int) and locator_port != state_port:
         return False
-    state_started_at = _parse_iso8601(state.get("started_at") if isinstance(state.get("started_at"), str) else None)
+    raw_started_at = state.get("started_at")
+    state_started_at = _parse_iso8601(raw_started_at if isinstance(raw_started_at, str) else None)
     locator_started_at_dt = _parse_iso8601(locator_started_at)
     if state_started_at is None or locator_started_at_dt is None:
         return True

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -288,10 +288,7 @@ def _render_redacted_json_payload(redacted_payload: object) -> str:
 def _safe_json_output_text(command: str, payload: PayloadDict) -> str:
     json_payload = _json_payload_for_command(command, payload)
     sanitized_payload = _coerce_object_dict(_sanitize_payload_for_output(json_payload, command=command))
-    rendered = _render_redacted_json_payload(sanitized_payload)
-    if command.startswith("trust."):
-        return rendered
-    return redact_text(rendered).text
+    return _render_redacted_json_payload(sanitized_payload)
 
 
 def _plain_text_protect(payload: PayloadDict) -> str:

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -224,7 +224,8 @@ def emit_guard_payload(command: str, payload: PayloadDict, as_json: bool) -> Non
     """Render Guard payloads as JSON or human-friendly rich output."""
 
     if as_json:
-        sys.stdout.write(_safe_json_output_text(command, payload))
+        redacted_output = redact_text(_safe_json_output_text(command, payload))
+        sys.stdout.write(redacted_output.text)
         sys.stdout.write("\n")
         return
 
@@ -232,7 +233,8 @@ def emit_guard_payload(command: str, payload: PayloadDict, as_json: bool) -> Non
     if not _RICH_AVAILABLE:
         plain_renderer = _PLAIN_TEXT_RENDERERS.get(command)
         if plain_renderer is None:
-            sys.stdout.write(_safe_json_output_text(command, payload))
+            redacted_output = redact_text(_safe_json_output_text(command, payload))
+            sys.stdout.write(redacted_output.text)
         else:
             sys.stdout.write(plain_renderer(redacted_payload))
         sys.stdout.write("\n")

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -215,23 +215,24 @@ _SENSITIVE_STRING_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
         r"\1*****",
     ),
 )
+_TRUST_SENSITIVE_STRING_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = tuple(
+    item for item in _SENSITIVE_STRING_PATTERNS if item[0].pattern != r"(?i)(api[-_ ]?key:\s*)[^\s,;]+"
+)
 
 
 def emit_guard_payload(command: str, payload: PayloadDict, as_json: bool) -> None:
     """Render Guard payloads as JSON or human-friendly rich output."""
 
     if as_json:
-        redacted_output = redact_text(_safe_json_output_text(command, payload))
-        sys.stdout.write(redacted_output.text)
+        sys.stdout.write(_safe_json_output_text(command, payload))
         sys.stdout.write("\n")
         return
 
-    redacted_payload = _coerce_object_dict(_redact_payload(payload))
+    redacted_payload = _coerce_object_dict(_sanitize_payload_for_output(payload, command=command))
     if not _RICH_AVAILABLE:
         plain_renderer = _PLAIN_TEXT_RENDERERS.get(command)
         if plain_renderer is None:
-            redacted_output = redact_text(_safe_json_output_text(command, payload))
-            sys.stdout.write(redacted_output.text)
+            sys.stdout.write(_safe_json_output_text(command, payload))
         else:
             sys.stdout.write(plain_renderer(redacted_payload))
         sys.stdout.write("\n")
@@ -242,9 +243,12 @@ def emit_guard_payload(command: str, payload: PayloadDict, as_json: bool) -> Non
     renderer(console, redacted_payload)
 
 
-def _redact_payload(value: object, *, key: str | None = None) -> object:
+def _redact_payload(value: object, *, key: str | None = None, command: str | None = None) -> object:
     if key in _NON_SECRET_STRUCTURED_KEYS and isinstance(value, dict):
-        return {item_key: _redact_payload(item_value, key=item_key) for item_key, item_value in value.items()}
+        return {
+            item_key: _redact_payload(item_value, key=item_key, command=command)
+            for item_key, item_value in value.items()
+        }
     if (
         key is not None
         and key not in _NON_SECRET_STRUCTURED_KEYS
@@ -254,12 +258,20 @@ def _redact_payload(value: object, *, key: str | None = None) -> object:
             return value
         return "*****"
     if isinstance(value, dict):
-        return {item_key: _redact_payload(item_value, key=item_key) for item_key, item_value in value.items()}
+        return {
+            item_key: _redact_payload(item_value, key=item_key, command=command)
+            for item_key, item_value in value.items()
+        }
     if isinstance(value, list):
-        return [_redact_payload(item) for item in value]
+        return [_redact_payload(item, command=command) for item in value]
     if isinstance(value, str):
         redacted = value
-        for pattern, replacement in _SENSITIVE_STRING_PATTERNS:
+        patterns = (
+            _TRUST_SENSITIVE_STRING_PATTERNS
+            if isinstance(command, str) and command.startswith("trust.")
+            else _SENSITIVE_STRING_PATTERNS
+        )
+        for pattern, replacement in patterns:
             redacted = pattern.sub(replacement, redacted)
         return redact_local_path(redacted)
     return value
@@ -273,8 +285,11 @@ def _render_redacted_json_payload(redacted_payload: object) -> str:
 
 def _safe_json_output_text(command: str, payload: PayloadDict) -> str:
     json_payload = _json_payload_for_command(command, payload)
-    sanitized_payload = _sanitize_payload_for_output(json_payload)
-    return _render_redacted_json_payload(sanitized_payload)
+    sanitized_payload = _coerce_object_dict(_sanitize_payload_for_output(json_payload, command=command))
+    rendered = _render_redacted_json_payload(sanitized_payload)
+    if command.startswith("trust."):
+        return rendered
+    return redact_text(rendered).text
 
 
 def _plain_text_protect(payload: PayloadDict) -> str:
@@ -330,8 +345,8 @@ def _plain_text_protect(payload: PayloadDict) -> str:
     return "\n".join(lines)
 
 
-def _sanitize_payload_for_output(value: object) -> object:
-    return _redact_payload(value)
+def _sanitize_payload_for_output(value: object, *, command: str | None = None) -> object:
+    return _redact_payload(value, command=command)
 
 
 def _json_payload_for_command(command: str, payload: PayloadDict) -> PayloadDict:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1530,6 +1530,42 @@ def test_build_trust_doctor_payload_reports_active_approval_center_port(
     assert payload["approval_url_base"] == "http://127.0.0.1:5481"
 
 
+def test_build_trust_doctor_payload_prefers_live_daemon_port_when_locator_is_stale(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    stale_locator = ApprovalCenterLocator(
+        guard_home=home_dir,
+        daemon_url="http://127.0.0.1:5481",
+        approval_url_base="http://127.0.0.1:5481",
+        pid=1234,
+        started_at="2026-06-19T12:00:00+00:00",
+        state_path=home_dir / "guard-daemon-state.json",
+    )
+    monkeypatch.setattr(trust_dispatch_module, "read_approval_center_locator", lambda _home: stale_locator)
+    monkeypatch.setattr(trust_dispatch_module, "load_guard_daemon_url", lambda _home: "http://127.0.0.1:5499")
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "_load_state",
+        lambda _home: {
+            "pid": 7777,
+            "port": 5499,
+            "package_version": trust_dispatch_module.__version__,
+            "started_at": "2026-06-19T12:01:00+00:00",
+        },
+    )
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["approval_center"]["approval_url_base"] == "http://127.0.0.1:5499"
+    assert payload["approval_center"]["port"] == 5499
+    assert payload["approval_center"]["snapshot_fresh"] is False
+    assert payload["checks"]["approval_center_route_current"] is False
+    assert any("refresh the local browser approval route" in action for action in payload["recommended_actions"])
+
+
 def test_build_trust_doctor_payload_detects_editable_install(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)
@@ -1685,6 +1721,74 @@ def test_build_trust_doctor_payload_verifies_official_pipx_command_path(
     assert payload["checks"]["official_install_verified"] is True
 
 
+def test_build_trust_doctor_payload_recommends_daemon_restart_only_for_version_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    locator = ApprovalCenterLocator(
+        guard_home=home_dir,
+        daemon_url="http://127.0.0.1:5481",
+        approval_url_base="http://127.0.0.1:5481",
+        pid=1234,
+        started_at="2026-06-19T12:01:00+00:00",
+        state_path=home_dir / "guard-daemon-state.json",
+    )
+    monkeypatch.setattr(trust_dispatch_module, "read_approval_center_locator", lambda _home: locator)
+    monkeypatch.setattr(trust_dispatch_module, "load_guard_daemon_url", lambda _home: locator.daemon_url)
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "_load_state",
+        lambda _home: {
+            "pid": 1234,
+            "port": 5481,
+            "package_version": "0.0.1",
+            "started_at": "2026-06-19T12:00:00+00:00",
+        },
+    )
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["approval_center"]["snapshot_fresh"] is True
+    assert payload["approval_center"]["restart_required"] is True
+    assert any("restart the Guard daemon" in action for action in payload["recommended_actions"])
+
+
+def test_build_trust_doctor_payload_skips_daemon_restart_when_current(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    locator = ApprovalCenterLocator(
+        guard_home=home_dir,
+        daemon_url="http://127.0.0.1:5481",
+        approval_url_base="http://127.0.0.1:5481",
+        pid=1234,
+        started_at="2026-06-19T12:01:00+00:00",
+        state_path=home_dir / "guard-daemon-state.json",
+    )
+    monkeypatch.setattr(trust_dispatch_module, "read_approval_center_locator", lambda _home: locator)
+    monkeypatch.setattr(trust_dispatch_module, "load_guard_daemon_url", lambda _home: locator.daemon_url)
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "_load_state",
+        lambda _home: {
+            "pid": 1234,
+            "port": 5481,
+            "package_version": trust_dispatch_module.__version__,
+            "started_at": "2026-06-19T12:00:00+00:00",
+        },
+    )
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["approval_center"]["snapshot_fresh"] is True
+    assert payload["approval_center"]["restart_required"] is False
+    assert not any("restart the Guard daemon" in action for action in payload["recommended_actions"])
+
+
 def test_trust_cli_doctor_reports_macos_no_prompt_copy(
     tmp_path: Path,
     capsys,
@@ -1698,6 +1802,48 @@ def test_trust_cli_doctor_reports_macos_no_prompt_copy(
 
     assert rc == 0
     assert "No passive macOS Keychain access" in output
+
+
+def test_trust_cli_doctor_redacts_secret_like_assignments_in_json_output(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    original_trust_payload = trust_dispatch_module._trust_status_payload
+
+    def fake_trust_payload(store: GuardStore, *, command: str, backend: str) -> dict[str, object]:
+        payload = original_trust_payload(store, command=command, backend=backend)
+        payload["summary"] = (
+            "Guard saw MY_SECRET_TOKEN=super-secret-value and "
+            "guard-oauth-local-credentials:8126370c0eb65a02 while checking trust."
+        )
+        return payload
+
+    monkeypatch.setattr(trust_dispatch_module, "_trust_status_payload", fake_trust_payload)
+
+    rc = main(
+        [
+            "guard",
+            "trust",
+            "doctor",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    output = capsys.readouterr().out
+    payload = json.loads(output)
+    summary = str(payload.get("summary") or "")
+
+    assert rc == 0
+    assert "MY_SECRET_TOKEN" not in output
+    assert "super-secret-value" not in output
+    assert "8126370c0eb65a02" not in output
+    assert "MY_SECRET_TOKEN" not in summary
+    assert "super-secret-value" not in summary
+    assert "8126370c0eb65a02" not in summary
+    assert summary
 
 
 def test_trust_cli_bare_combined_command_routes_to_guard() -> None:

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1846,6 +1846,26 @@ def test_trust_cli_doctor_redacts_secret_like_assignments_in_json_output(
     assert summary
 
 
+def test_trust_cli_explain_preserves_non_secret_colon_rule_text(capsys) -> None:
+    trust_dispatch_module._emit_trust_payload(
+        "trust.explain",
+        {
+            "rule": {
+                "pattern": "api_key: forbidden_pattern",
+                "description": "credential: oauth-style",
+                "status": "token: active",
+            }
+        },
+        True,
+    )
+    payload = json.loads(capsys.readouterr().out)
+    rule = payload["rule"]
+
+    assert rule["pattern"] == "api_key: forbidden_pattern"
+    assert rule["description"] == "credential: oauth-style"
+    assert rule["status"] == "token: active"
+
+
 def test_trust_cli_bare_combined_command_routes_to_guard() -> None:
     assert _resolve_legacy_args(["trust", "status", "--json"], program_mode="combined") == [
         "guard",

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1566,6 +1566,39 @@ def test_build_trust_doctor_payload_prefers_live_daemon_port_when_locator_is_sta
     assert any("refresh the local browser approval route" in action for action in payload["recommended_actions"])
 
 
+def test_build_trust_doctor_payload_tolerates_mixed_naive_and_aware_locator_timestamps(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    locator = ApprovalCenterLocator(
+        guard_home=home_dir,
+        daemon_url="http://127.0.0.1:5481",
+        approval_url_base="http://127.0.0.1:5481",
+        pid=1234,
+        started_at="2026-06-19T12:01:00",
+        state_path=home_dir / "guard-daemon-state.json",
+    )
+    monkeypatch.setattr(trust_dispatch_module, "read_approval_center_locator", lambda _home: locator)
+    monkeypatch.setattr(trust_dispatch_module, "load_guard_daemon_url", lambda _home: locator.daemon_url)
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "_load_state",
+        lambda _home: {
+            "pid": 1234,
+            "port": 5481,
+            "package_version": trust_dispatch_module.__version__,
+            "started_at": "2026-06-19T12:00:00+00:00",
+        },
+    )
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["approval_center"]["snapshot_fresh"] is True
+    assert payload["approval_center"]["approval_url_base"] == "http://127.0.0.1:5481"
+
+
 def test_build_trust_doctor_payload_detects_editable_install(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)


### PR DESCRIPTION
## Summary
- harden `guard trust doctor` so it ignores stale approval-center locator ports and only recommends a daemon restart when the running daemon version is actually stale
- scrub trust-command output for secret-like assignment text before emit and add regression coverage for live-port fallback, daemon freshness, and trust-output redaction

## Testing
- `python3 -m pytest tests/test_guard_policy_integrity.py -k "guard_doctor_includes_safe_trust_diagnostics or active_approval_center_port or live_daemon_port_when_locator_is_stale or daemon_restart_only_for_version_drift or skips_daemon_restart_when_current or detects_editable_install or tolerates_distribution_path_error or reports_missing_command_path_help or verifies_official_pipx_command_path or doctor_reports_macos_no_prompt_copy or redacts_secret_like_assignments_in_json_output" -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py tests/test_guard_policy_integrity.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py tests/test_guard_policy_integrity.py`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard trust doctor --home <guard-home> --json`
