### PR TITLE
fix: rewrite stale approval links to the active daemon

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py
@@ -59,7 +59,7 @@ def _approval_center_locator_is_fresh(
     locator_port = _guard_daemon_url_port(locator_url)
     if isinstance(state_pid, int) and state_pid != locator_pid:
         return False
-    if isinstance(state_port, int) and locator_port != state_port:
+    if isinstance(state_port, int) and isinstance(locator_port, int) and locator_port != state_port:
         return False
     raw_started_at = state.get("started_at")
     state_started_at = _parse_iso8601(raw_started_at if isinstance(raw_started_at, str) else None)

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -802,7 +802,7 @@ class RuntimeMcpGuardProxy:
                 now=_now(),
             )
         request_id = str(queued[0]["request_id"]) if queued else "stored-block"
-        review_url = first_approval_url(queued) or approval_center_url
+        review_url = first_approval_url(queued, approval_center_url=approval_center_url) or approval_center_url
         self._maybe_open_approval_center(
             approval_center_url=approval_center_url,
             review_url=review_url,
@@ -1169,7 +1169,7 @@ class RuntimeMcpGuardProxy:
             risk_categories=tool_call_risk_categories(artifact, params.get("arguments")),
         )
         request_id = str(queued[0]["request_id"]) if queued else "unknown"
-        review_url = first_approval_url(queued) or approval_center_url
+        review_url = first_approval_url(queued, approval_center_url=approval_center_url) or approval_center_url
         self._maybe_open_approval_center(
             approval_center_url=approval_center_url,
             review_url=review_url,

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -466,7 +466,13 @@ class StdioGuardProxy:
                         )
                         event["approval_center_url"] = self.approval_center_url
                         event["approval_delivery"] = approval_delivery_payload(approval_flow)
-                        review_url = first_approval_url(event["approval_requests"]) or self.approval_center_url
+                        review_url = (
+                            first_approval_url(
+                                event["approval_requests"],
+                                approval_center_url=self.approval_center_url,
+                            )
+                            or self.approval_center_url
+                        )
                         request_id = next(
                             (
                                 str(item["request_id"])

--- a/tests/test_guard_opencode_proxy.py
+++ b/tests/test_guard_opencode_proxy.py
@@ -141,6 +141,56 @@ def test_runtime_guard_proxy_queue_block_includes_request_url(tmp_path, monkeypa
     assert opened_urls == []
 
 
+def test_runtime_guard_proxy_rewrites_stale_request_url_to_active_approval_center(tmp_path, monkeypatch):
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    config = GuardConfig(guard_home=context.guard_home, workspace=context.workspace_dir)
+    marker_path = tmp_path / "dangerous-call.json"
+    monkeypatch.setattr(runtime_mcp_module, "ensure_guard_daemon", lambda _guard_home: "http://127.0.0.1:4455")
+    monkeypatch.setattr(runtime_mcp_module, "load_guard_daemon_auth_token", lambda _guard_home: "secret-token")
+    monkeypatch.setattr(runtime_mcp_module.webbrowser, "open", lambda _url: True)
+    monkeypatch.setattr(
+        runtime_mcp_module,
+        "queue_blocked_approvals",
+        lambda **_kwargs: [
+            {
+                "request_id": "stale-port-request",
+                "approval_url": "http://127.0.0.1:4833/requests/stale-port-request",
+            }
+        ],
+    )
+    proxy = RuntimeMcpGuardProxy(
+        harness="hermes",
+        server_name="danger_lab",
+        command=_child_command(marker_path),
+        context=context,
+        store=store,
+        config=config,
+        source_scope="project",
+        config_path=str(context.workspace_dir / "hermes.json"),
+        transport="local",
+    )
+
+    result = proxy.run_session(
+        [
+            {"jsonrpc": "2.0", "id": 1, "method": "initialize", "params": {"capabilities": {}}},
+            {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {"name": "dangerous_delete", "arguments": {"target": ".env.guard-proof"}},
+            },
+        ]
+    )
+
+    error = result["responses"][1]["error"]
+
+    assert error["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
+    assert error["data"]["approvalRequests"][0]["approval_url"] == "http://127.0.0.1:4833/requests/stale-port-request"
+    assert error["data"]["reviewUrl"] == "http://127.0.0.1:4455/requests/stale-port-request"
+    assert error["data"]["reviewUrl"] in error["message"]
+
+
 def test_runtime_guard_proxy_respects_native_only_approval_surface_policy(tmp_path, monkeypatch):
     context = _context(tmp_path)
     store = GuardStore(context.guard_home)

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -1599,6 +1599,40 @@ def test_build_trust_doctor_payload_tolerates_mixed_naive_and_aware_locator_time
     assert payload["approval_center"]["approval_url_base"] == "http://127.0.0.1:5481"
 
 
+def test_build_trust_doctor_payload_tolerates_missing_locator_daemon_port(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    home_dir = tmp_path / "home"
+    store = GuardStore(home_dir)
+    locator = ApprovalCenterLocator(
+        guard_home=home_dir,
+        daemon_url="http://127.0.0.1",
+        approval_url_base="http://127.0.0.1:5481",
+        pid=1234,
+        started_at="2026-06-19T12:01:00+00:00",
+        state_path=home_dir / "guard-daemon-state.json",
+    )
+    monkeypatch.setattr(trust_dispatch_module, "read_approval_center_locator", lambda _home: locator)
+    monkeypatch.setattr(trust_dispatch_module, "load_guard_daemon_url", lambda _home: locator.daemon_url)
+    monkeypatch.setattr(
+        trust_dispatch_module,
+        "_load_state",
+        lambda _home: {
+            "pid": 1234,
+            "port": 5481,
+            "package_version": trust_dispatch_module.__version__,
+            "started_at": "2026-06-19T12:00:00+00:00",
+        },
+    )
+
+    payload = trust_dispatch_module.build_trust_doctor_payload(store)
+
+    assert payload["approval_center"]["snapshot_fresh"] is True
+    assert payload["approval_center"]["approval_url_base"] == "http://127.0.0.1:5481"
+    assert payload["approval_center"]["port"] == 5481
+
+
 def test_build_trust_doctor_payload_detects_editable_install(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     home_dir = tmp_path / "home"
     store = GuardStore(home_dir)

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -16376,6 +16376,62 @@ def test_stdio_proxy_respects_native_only_approval_surface_policy(tmp_path, monk
     assert blocked["responses"][0]["error"]["data"]["reviewHint"]
 
 
+def test_stdio_proxy_rewrites_stale_request_url_to_active_approval_center(tmp_path, monkeypatch):
+    store = GuardStore(tmp_path / "guard-home")
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=workspace_dir)
+    monkeypatch.setattr(
+        stdio_proxy_module,
+        "queue_blocked_approvals",
+        lambda **_kwargs: [
+            {
+                "request_id": "stale-read-request",
+                "approval_url": "http://127.0.0.1:4833/requests/stale-read-request",
+            }
+        ],
+    )
+    proxy = StdioGuardProxy(
+        command=[
+            sys.executable,
+            "-u",
+            "-c",
+            "\n".join(
+                [
+                    "import json, sys",
+                    "for line in sys.stdin:",
+                    "    message = json.loads(line)",
+                    "    print(json.dumps({'jsonrpc': '2.0', 'id': message.get('id'), 'result': {'ok': True}}))",
+                    "    sys.stdout.flush()",
+                ]
+            ),
+        ],
+        cwd=workspace_dir,
+        guard_store=store,
+        guard_config=config,
+        approval_center_url="http://127.0.0.1:4455",
+        harness="codex",
+    )
+
+    blocked = proxy.run_session(
+        [
+            {
+                "jsonrpc": "2.0",
+                "id": 1,
+                "method": "tools/call",
+                "params": {"name": "read_file", "arguments": {"path": ".env"}},
+            }
+        ]
+    )
+
+    error = blocked["responses"][0]["error"]
+
+    assert error["data"]["approvalCenterUrl"] == "http://127.0.0.1:4455"
+    assert error["data"]["approvalRequests"][0]["approval_url"] == "http://127.0.0.1:4833/requests/stale-read-request"
+    assert error["data"]["reviewUrl"] == "http://127.0.0.1:4455/requests/stale-read-request"
+    assert "http://127.0.0.1:4455/requests/stale-read-request" in error["data"]["reviewHint"]
+
+
 def test_stdio_proxy_respects_adapter_no_browser_flow(tmp_path, monkeypatch):
     store = GuardStore(tmp_path / "guard-home")
     workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- rewrite queued approval review URLs against the active daemon URL in the runtime MCP and stdio proxy block paths
- keep trust doctor from discarding a fresh locator just because the daemon URL snapshot omits an explicit port
- add regression tests for stale request ports and the trust freshness edge case

## Testing
- python3 -m pytest tests/test_guard_opencode_proxy.py -k "stale_request_url or queue_block_includes_request_url or native_only_approval_surface_policy" -q
- python3 -m pytest tests/test_guard_runtime.py -k "stale_request_url_to_active_approval_center or stdio_proxy_respects_native_only_approval_surface_policy" -q
- python3 -m pytest tests/test_guard_policy_integrity.py -k "missing_locator_daemon_port or active_approval_center_port or prefers_live_daemon_port_when_locator_is_stale or mixed_naive_and_aware_locator_timestamps" -q
- python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_dispatch_trust.py src/codex_plugin_scanner/guard/proxy/runtime_mcp.py src/codex_plugin_scanner/guard/proxy/stdio.py tests/test_guard_opencode_proxy.py tests/test_guard_runtime.py tests/test_guard_policy_integrity.py