### PR TITLE
fix(guard-review): validate signed review commands

### DIFF
--- a/docs/guard-review-backend-contract.md
+++ b/docs/guard-review-backend-contract.md
@@ -1,0 +1,114 @@
+# Guard Review Backend Contract
+
+Date: 2026-06-19
+Scope: local Guard daemon and command runtime
+
+## Local ownership
+
+Guard Local remains the live interrupt owner.
+
+Local owns:
+
+- pending approval queue creation
+- exact live request resolution
+- local policy persistence
+- bundle validation
+- signed/verified remote approval acceptance
+- signed memory acknowledgement generation
+
+Cloud must not bypass the local queue by posting loose metadata.
+
+## Accepted command payloads
+
+### `guard.approval.resolve` for one live request
+
+Required payload:
+
+- `action=allow_once` or `action=block`
+- `localRequestId`
+- signed `remoteApproval`
+
+Local validates:
+
+- request id
+- approval id
+- workspace id
+- machine installation id
+- machine id
+- device id
+- harness id
+- action envelope hash
+- source claim hash
+- policy version
+- expiry
+- signature and trusted verification key
+- replay receipt
+
+If any check fails, the request is rejected and no policy is written.
+
+### `guard.approval.resolve` for reusable memory
+
+Required payload:
+
+- `action=policy_sync`
+- signed `decisionMemoryBundle`
+
+Rejected payloads:
+
+- loose `policyMemory`
+- unsigned bundle
+- tampered bundle hash / payload hash
+- expired bundle
+- downgraded policy version
+- wrong workspace
+- wrong target machine for machine-scoped bundle
+- malformed or unsupported rule
+- overbroad allow rule local runtime cannot safely enforce
+
+## Local persistence behavior
+
+Remote once:
+
+- resolves exactly one pending queue item
+- records claimed remote receipt
+- does not upsert reusable policy
+
+Signed memory bundle:
+
+- updates only `cloud-signed-memory` policy rows derived from accepted rules
+- preserves unrelated remote policies
+- records bundle version and last ack payload
+- supports signed revocation bundle replay through bundle `revocations`
+
+## Acknowledgement contract
+
+After bundle processing, local emits `GuardDecisionMemoryAckV1` with:
+
+- `workspaceId`
+- `machineInstallationId`
+- `machineId`
+- `deviceId`
+- `bundleVersion`
+- `bundleHash`
+- `policyVersion`
+- `status`
+- `reason`
+- `appliedRuleCount`
+- `rejectedRuleIds`
+- `acknowledgedAt`
+
+Accepted ack means the machine now enforces the bundle. Rejected/stale/expired
+acks must not be treated as synced.
+
+## Runtime and daemon touchpoints
+
+- `src/codex_plugin_scanner/guard/review_contracts.py`
+- `src/codex_plugin_scanner/guard/runtime/command_executors.py`
+- `src/codex_plugin_scanner/guard/daemon/server.py`
+- `src/codex_plugin_scanner/guard/store.py`
+
+## Proof suites
+
+- `tests/test_guard_command_queue.py`
+- `tests/test_guard_headless_daemon_api.py`
+- `tests/test_guard_command_queue_stale_pending_result.py`

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2261,14 +2261,19 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "remote_once_replayed"}, status=409)
             return
         resolution_action = "block" if self._optional_string(envelope.get("decision")) == "block" else "allow"
-        result = self.server.store.resolve_request_with_signed_remote_result(  # type: ignore[attr-defined]
-            request_id,
-            resolution_action=resolution_action,
-            resolution_scope="artifact",
-            reason="Guard Cloud signed remote approval",
-            resolved_at=_now(),
-        )
+        try:
+            result = self.server.store.resolve_request_with_signed_remote_result(  # type: ignore[attr-defined]
+                request_id,
+                resolution_action=resolution_action,
+                resolution_scope="artifact",
+                reason="Guard Cloud signed remote approval",
+                resolved_at=_now(),
+            )
+        except Exception:
+            self.server.store.release_remote_once_receipt(receipt_id)  # type: ignore[attr-defined]
+            raise
         if result.get("resolved") is not True:
+            self.server.store.release_remote_once_receipt(receipt_id)  # type: ignore[attr-defined]
             self._write_json({"error": "remote_once_apply_failed"}, status=409)
             return
         resolved_request_value = result.get("resolved_request")

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2077,6 +2077,15 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError:
             self._write_json({"error": "unknown_harness"}, status=404)
             return
+        try:
+            require_high_risk(
+                self.server.store.guard_home,  # type: ignore[attr-defined]
+                purpose="policy_write",
+                approval_gate_input=approval_gate_input_from_mapping(payload),
+            )
+        except ApprovalGateError as error:
+            self._write_approval_gate_error(error)
+            return
         policy_memory = self._policy_memory_payload(payload.get("policy_memory"))
         policy_bundle = self._policy_memory_payload(payload.get("policy_bundle") or payload.get("policyBundle"))
         validated_policy_bundle: dict[str, object] | None = None

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2196,7 +2196,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "missing_remote_approval"}, status=400)
             return
         try:
-            envelope = validated_remote_approval_envelope(remote_approval)
+            envelope = validated_remote_approval_envelope(
+                remote_approval,
+                store=self.server.store,  # type: ignore[attr-defined]
+            )
             oauth = guard_review_oauth_metadata(self.server.store)  # type: ignore[attr-defined]
         except GuardReviewContractError as error:
             self._write_json({"error": str(error)}, status=400)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -120,13 +120,13 @@ from ..policy_bundle_trusted_keys import (
     policy_bundle_keyring_payload,
     validate_synced_policy_bundle,
 )
+from ..receipts.manager import build_receipt
 from ..review_contracts import (
     GuardReviewContractError,
     guard_review_oauth_metadata,
     validate_remote_approval_request_binding,
     validated_remote_approval_envelope,
 )
-from ..receipts.manager import build_receipt
 from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
     GuardSyncNotAvailableError,
@@ -2190,7 +2190,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "unknown_harness"}, status=404)
             return
         remote_approval = self._policy_memory_payload(
-            payload.get("remoteApproval") or payload.get("remote_approval") or payload.get("remote_once") or payload.get("remoteOnce")
+            payload.get("remoteApproval")
+            or payload.get("remote_approval")
+            or payload.get("remote_once")
+            or payload.get("remoteOnce")
         )
         if not remote_approval:
             self._write_json({"error": "missing_remote_approval"}, status=400)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -120,6 +120,12 @@ from ..policy_bundle_trusted_keys import (
     policy_bundle_keyring_payload,
     validate_synced_policy_bundle,
 )
+from ..review_contracts import (
+    GuardReviewContractError,
+    guard_review_oauth_metadata,
+    validate_remote_approval_request_binding,
+    validated_remote_approval_envelope,
+)
 from ..receipts.manager import build_receipt
 from ..runtime.runner import (
     GuardSyncAuthorizationExpiredError,
@@ -2079,6 +2085,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if not policy_memory and not policy_bundle:
             self._write_json({"error": "missing_policy_memory"}, status=400)
             return
+        if policy_memory:
+            self._write_json({"error": "unsupported_policy_memory_contract"}, status=400)
+            return
         if policy_bundle:
             validated_policy_bundle, rejection_reason, trusted_policy_bundle_keys = validate_synced_policy_bundle(
                 policy_bundle,
@@ -2160,84 +2169,12 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             )
             applied_bundle_hash = str(validated_policy_bundle["bundleHash"])
             applied_bundle_version = str(validated_policy_bundle["bundleVersion"])
-        if not policy_memory:
-            self._write_json(
-                {
-                    "bundle_hash": applied_bundle_hash,
-                    "bundle_version": applied_bundle_version,
-                    "harness": adapter.harness,
-                    "operation": "policy_sync",
-                    "status": "completed",
-                }
-            )
-            return
-        scope = self._optional_string(policy_memory.get("scope"))
-        action = self._optional_string(policy_memory.get("action"))
-        if scope is None or action is None:
-            self._write_json({"error": "missing_policy_fields"}, status=400)
-            return
-        if scope not in DECISION_SCOPE_VALUES or action not in GUARD_ACTION_VALUES:
-            self._write_json({"error": "unsupported_policy_value"}, status=400)
-            return
-        if scope == "global" and action == "allow":
-            self._write_json({"error": "broad_allow_requires_narrow_scope"}, status=400)
-            return
-        artifact_id = self._optional_string(policy_memory.get("artifact_id"))
-        workspace = self._optional_string(policy_memory.get("workspace"))
-        publisher = self._optional_string(policy_memory.get("publisher"))
-        if not self._scope_target_is_valid(
-            scope,
-            artifact_id=artifact_id,
-            workspace=workspace,
-            publisher=publisher,
-        ):
-            self._write_json({"error": "missing_scope_target"}, status=400)
-            return
-        expires_at = _normalized_iso_timestamp_string(policy_memory.get("expires_at"))
-        if policy_memory.get("expires_at") is not None and expires_at is None:
-            self._write_json({"error": "invalid_policy_expiry"}, status=400)
-            return
-        decision = PolicyDecision(
-            harness=adapter.harness,
-            scope=scope,  # type: ignore[arg-type]
-            action=action,  # type: ignore[arg-type]
-            artifact_id=artifact_id,
-            artifact_hash=self._optional_string(policy_memory.get("artifact_hash")),
-            workspace=workspace,
-            publisher=publisher,
-            reason=self._optional_string(policy_memory.get("reason")) or "Guard Cloud policy memory sync",
-            source="cloud-sync",
-            expires_at=expires_at,
-        )
-        try:
-            approval_gate_grant = require_high_risk(
-                self.server.store.guard_home,  # type: ignore[attr-defined]
-                purpose="headless_policy_sync",
-                approval_gate_input=approval_gate_input_from_mapping(payload),
-            )
-            self.server.store.upsert_policy(  # type: ignore[attr-defined]
-                decision,
-                _now(),
-                approval_gate_grant=approval_gate_grant,
-                remote_write_authorized=True,
-            )
-        except ApprovalGateError as error:
-            self._write_approval_gate_error(error)
-            return
-        receipt = self._record_headless_receipt(
-            harness=adapter.harness,
-            operation="policy_sync",
-            payload=payload,
-            result={"decision": decision.to_dict()},
-            workspace_id=decision.workspace,
-        )
         self._write_json(
             {
                 "bundle_hash": applied_bundle_hash,
                 "bundle_version": applied_bundle_version,
                 "harness": adapter.harness,
                 "operation": "policy_sync",
-                "receipt": receipt,
                 "status": "completed",
             }
         )
@@ -2252,11 +2189,21 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         except ValueError:
             self._write_json({"error": "unknown_harness"}, status=404)
             return
-        remote_once = self._policy_memory_payload(payload.get("remote_once") or payload.get("remoteOnce"))
-        request_id = self._coalesce_string(remote_once, "request_id", "requestId")
-        request_last_seen_at = self._coalesce_string(remote_once, "request_last_seen_at", "requestLastSeenAt")
-        receipt_id = self._coalesce_string(remote_once, "receipt_id", "receiptId")
-        if request_id is None or request_last_seen_at is None or receipt_id is None:
+        remote_approval = self._policy_memory_payload(
+            payload.get("remoteApproval") or payload.get("remote_approval") or payload.get("remote_once") or payload.get("remoteOnce")
+        )
+        if not remote_approval:
+            self._write_json({"error": "missing_remote_approval"}, status=400)
+            return
+        try:
+            envelope = validated_remote_approval_envelope(remote_approval)
+            oauth = guard_review_oauth_metadata(self.server.store)  # type: ignore[attr-defined]
+        except GuardReviewContractError as error:
+            self._write_json({"error": str(error)}, status=400)
+            return
+        request_id = self._coalesce_string(envelope, "localRequestId", "requestId")
+        receipt_id = self._coalesce_string(envelope, "receiptId")
+        if request_id is None or receipt_id is None:
             self._write_json({"error": "missing_remote_once_fields"}, status=400)
             return
         if self._remote_once_receipt_replayed(receipt_id):
@@ -2271,8 +2218,34 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if request_policy_action not in {"review", "require-reapproval"} or request_recommended_scope != "artifact":
             self._write_json({"error": "remote_once_not_permitted"}, status=409)
             return
-        if self._optional_string(request_row.get("last_seen_at")) != request_last_seen_at:
-            self._write_json({"error": "remote_once_request_stale"}, status=409)
+        try:
+            validate_remote_approval_request_binding(
+                envelope=envelope,
+                request_row=request_row,
+                oauth=oauth,
+                store=self.server.store,  # type: ignore[attr-defined]
+            )
+        except GuardReviewContractError as error:
+            error_code = str(error)
+            if error_code in {
+                "remote_approval_request_id_mismatch",
+                "remote_approval_approval_id_mismatch",
+                "remote_approval_harness_mismatch",
+                "remote_approval_action_hash_mismatch",
+                "remote_approval_claim_hash_mismatch",
+                "remote_approval_policy_version_mismatch",
+            }:
+                self._write_json({"error": "remote_once_request_stale"}, status=409)
+                return
+            if error_code in {
+                "remote_approval_workspace_mismatch",
+                "remote_approval_installation_mismatch",
+                "remote_approval_machine_mismatch",
+                "remote_approval_device_mismatch",
+            }:
+                self._write_json({"error": "remote_once_wrong_target"}, status=409)
+                return
+            self._write_json({"error": error_code}, status=400)
             return
         if not self.server.store.claim_remote_once_receipt(  # type: ignore[attr-defined]
             receipt_id,
@@ -2281,33 +2254,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         ):
             self._write_json({"error": "remote_once_replayed"}, status=409)
             return
-        try:
-            result = apply_approval_resolution(
-                store=self.server.store,  # type: ignore[attr-defined]
-                request_id=request_id,
-                action="allow",
-                scope="artifact",
-                workspace=self._optional_string(request_row.get("workspace")),
-                reason=self._optional_string(remote_once.get("reason")) or "Guard Cloud remote once approval",
-                return_queue_result=True,
-                resolve_scope_matches=False,
-                approval_gate_input=approval_gate_input_from_mapping(payload),
-                persist_policy=False,
-            )
-        except ApprovalRequestNotFoundError:
-            self.server.store.release_remote_once_receipt(receipt_id)  # type: ignore[attr-defined]
-            self._write_json({"error": "remote_once_request_expired"}, status=409)
-            return
-        except ApprovalRequestAlreadyResolvedError:
-            self.server.store.release_remote_once_receipt(receipt_id)  # type: ignore[attr-defined]
-            self._write_json({"error": "remote_once_request_expired"}, status=409)
-            return
-        except ApprovalGateError as error:
-            self._write_approval_gate_error(error)
-            return
-        except ValueError as error:
-            self._write_json({"error": str(error)}, status=400)
-            return
+        resolution_action = "block" if self._optional_string(envelope.get("decision")) == "block" else "allow"
+        result = self.server.store.resolve_request_with_signed_remote_result(  # type: ignore[attr-defined]
+            request_id,
+            resolution_action=resolution_action,
+            resolution_scope="artifact",
+            reason="Guard Cloud signed remote approval",
+            resolved_at=_now(),
+        )
         if result.get("resolved") is not True:
             self._write_json({"error": "remote_once_apply_failed"}, status=409)
             return

--- a/src/codex_plugin_scanner/guard/policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/policy_integrity.py
@@ -13,7 +13,7 @@ POLICY_INTEGRITY_VERSION = 2
 POLICY_INTEGRITY_MAC_ALGORITHM = "hmac-sha256"
 _LEGACY_POLICY_INTEGRITY_VERSION = 1
 _SUPPORTED_POLICY_INTEGRITY_VERSIONS = frozenset({_LEGACY_POLICY_INTEGRITY_VERSION, POLICY_INTEGRITY_VERSION})
-REMOTE_POLICY_SOURCES = frozenset({"cloud-sync", "team-policy", "policy-bundle"})
+REMOTE_POLICY_SOURCES = frozenset({"cloud-sync", "team-policy", "policy-bundle", "cloud-signed-memory"})
 
 PolicyIntegrityStatus = Literal[
     "valid",

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -1,0 +1,466 @@
+"""Guard Review backend contracts shared by local daemon and command queue."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+from copy import deepcopy
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+
+from cryptography.exceptions import InvalidSignature, UnsupportedAlgorithm
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
+
+from .policy_bundle_trusted_keys import PolicyBundleVerificationKey
+
+_LOCAL_REVIEW_REQUEST_CONTRACT_VERSION = "guard.local-review-request.v1"
+_REMOTE_APPROVAL_CONTRACT_VERSION = "guard.remote-approval.v1"
+_DECISION_MEMORY_BUNDLE_CONTRACT_VERSION = "guard.decision-memory-bundle.v1"
+_DECISION_MEMORY_ACK_CONTRACT_VERSION = "guard.decision-memory-ack.v1"
+_REMOTE_APPROVAL_REQUIRED_SCOPE = "artifact"
+_REMOTE_APPROVAL_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
+_DECISION_MEMORY_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
+_CLAIM_HASH_KEYS = ("claimHash",)
+_SIGNED_PAYLOAD_STRIP_KEYS = ("payloadHash", "signature", "signatureAlgorithm", "verificationKeys", "bundleHash")
+
+
+class GuardReviewContractError(ValueError):
+    """Raised when a Guard Review backend contract is malformed or unsafe."""
+
+
+@dataclass(frozen=True, slots=True)
+class GuardReviewOAuthMetadata:
+    device_id: str
+    grant_id: str | None
+    installation_id: str
+    machine_id: str
+    runtime_id: str | None
+    workspace_id: str
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _stable_serialize(value: object) -> str:
+    if isinstance(value, list):
+        return f"[{','.join(_stable_serialize(item) for item in value)}]"
+    if isinstance(value, dict):
+        return (
+            "{"
+            + ",".join(
+                f"{json.dumps(key, separators=(',', ':'), ensure_ascii=False)}:{_stable_serialize(value[key])}"
+                for key in sorted(value)
+            )
+            + "}"
+        )
+    return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+
+
+def _sha256_hex(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _non_empty_string(value: object) -> str | None:
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _read_json_mapping(value: object) -> dict[str, object] | None:
+    if isinstance(value, dict):
+        return {str(key): item for key, item in value.items()}
+    if value is None:
+        return None
+    try:
+        parsed = json.loads(str(value))
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    return {str(key): item for key, item in parsed.items()}
+
+
+def _strip_keys(value: dict[str, object], keys: tuple[str, ...]) -> dict[str, object]:
+    clone = deepcopy(value)
+    for key in keys:
+        clone.pop(key, None)
+    return clone
+
+
+def _parse_iso_timestamp(value: object, *, field_name: str) -> datetime:
+    normalized = _non_empty_string(value)
+    if normalized is None:
+        raise GuardReviewContractError(f"invalid_{field_name}")
+    candidate = normalized[:-1] + "+00:00" if normalized.endswith(("Z", "z")) else normalized
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError as error:
+        raise GuardReviewContractError(f"invalid_{field_name}") from error
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _canonical_signed_payload(value: dict[str, object]) -> str:
+    return _stable_serialize(_strip_keys(value, _SIGNED_PAYLOAD_STRIP_KEYS))
+
+
+def _verification_keys_from_payload(value: object) -> tuple[PolicyBundleVerificationKey, ...]:
+    if not isinstance(value, list) or not value:
+        raise GuardReviewContractError("missing_verification_keys")
+    parsed: list[PolicyBundleVerificationKey] = []
+    for item in value:
+        if not isinstance(item, dict):
+            raise GuardReviewContractError("invalid_verification_key")
+        parsed.append(PolicyBundleVerificationKey.from_dict(item))
+    return tuple(parsed)
+
+
+def _resolve_signing_key(
+    *,
+    key_id: str,
+    verification_keys: tuple[PolicyBundleVerificationKey, ...],
+) -> PolicyBundleVerificationKey:
+    for key in verification_keys:
+        if key.key_id == key_id:
+            return key
+    raise GuardReviewContractError("unknown_signing_key")
+
+
+def _verify_signed_payload(
+    payload: dict[str, object],
+    *,
+    signature_algorithm: str,
+) -> None:
+    if signature_algorithm not in {
+        _REMOTE_APPROVAL_SIGNATURE_ALGORITHM,
+        _DECISION_MEMORY_SIGNATURE_ALGORITHM,
+    }:
+        raise GuardReviewContractError("invalid_signature_algorithm")
+    signature = _non_empty_string(payload.get("signature"))
+    if signature is None:
+        raise GuardReviewContractError("missing_signature")
+    key_id = _non_empty_string(payload.get("issuerKeyId")) or _non_empty_string(payload.get("keyId"))
+    if key_id is None:
+        verifier = payload.get("verifier")
+        if isinstance(verifier, dict):
+            key_id = _non_empty_string(verifier.get("keyId"))
+    if key_id is None:
+        raise GuardReviewContractError("missing_signing_key_id")
+    verification_keys = _verification_keys_from_payload(payload.get("verificationKeys"))
+    signing_key = _resolve_signing_key(key_id=key_id, verification_keys=verification_keys)
+    try:
+        public_key = serialization.load_pem_public_key(signing_key.public_key_pem.encode("utf-8"))
+    except (UnsupportedAlgorithm, ValueError, TypeError) as error:
+        raise GuardReviewContractError("invalid_signing_key") from error
+    if not isinstance(public_key, RSAPublicKey):
+        raise GuardReviewContractError("invalid_signing_key")
+    try:
+        signature_bytes = base64.b64decode(signature)
+    except Exception as error:  # pragma: no cover - defensive
+        raise GuardReviewContractError("invalid_signature") from error
+    canonical_payload = _canonical_signed_payload(payload).encode("utf-8")
+    try:
+        public_key.verify(
+            signature_bytes,
+            canonical_payload,
+            padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.AUTO),
+            hashes.SHA256(),
+        )
+    except (InvalidSignature, ValueError, TypeError) as error:
+        raise GuardReviewContractError("signature_mismatch") from error
+
+
+def guard_review_oauth_metadata(store) -> GuardReviewOAuthMetadata:
+    credentials = store.get_oauth_local_credentials(allow_primary=False)
+    if not isinstance(credentials, dict):
+        raise GuardReviewContractError("missing_oauth_credentials")
+    installation_id = _non_empty_string(store.get_or_create_installation_id())
+    machine_id = _non_empty_string(credentials.get("machine_id"))
+    workspace_id = _non_empty_string(credentials.get("workspace_id"))
+    if installation_id is None or machine_id is None or workspace_id is None:
+        raise GuardReviewContractError("missing_oauth_binding")
+    return GuardReviewOAuthMetadata(
+        device_id=machine_id,
+        grant_id=_non_empty_string(credentials.get("grant_id")),
+        installation_id=installation_id,
+        machine_id=machine_id,
+        runtime_id=_non_empty_string(credentials.get("runtime_id")),
+        workspace_id=workspace_id,
+    )
+
+
+def _action_envelope_hash(request_row: dict[str, object]) -> str:
+    envelope = _read_json_mapping(request_row.get("action_envelope_json")) or {}
+    return _sha256_hex(_stable_serialize(envelope))
+
+
+def _project_identity(request_row: dict[str, object], store) -> str | None:
+    operation = store.get_guard_operation_for_approval_request(str(request_row["request_id"]))
+    if not isinstance(operation, dict):
+        return None
+    metadata = operation.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("project_id", "projectId", "workspace_path", "workspacePath"):
+            value = _non_empty_string(metadata.get(key))
+            if value is not None:
+                return value
+    return _non_empty_string(operation.get("operation_id"))
+
+
+def _capability_category(request_row: dict[str, object]) -> str:
+    harness = (_non_empty_string(request_row.get("harness")) or "").lower()
+    artifact_id = (_non_empty_string(request_row.get("artifact_id")) or "").lower()
+    action_envelope = _read_json_mapping(request_row.get("action_envelope_json")) or {}
+    action_type = (_non_empty_string(action_envelope.get("action_type")) or "").lower()
+    risk_signals = request_row.get("risk_signals")
+    normalized_signals = {
+        str(item).lower()
+        for item in risk_signals
+    } if isinstance(risk_signals, list) else set()
+    if artifact_id.startswith("pkg:") or "package" in artifact_id or "package" in harness:
+        return "package-install"
+    if any(token in artifact_id for token in ("mcp", "modelcontextprotocol")) or "mcp" in harness:
+        return "mcp-server"
+    if any(token in harness for token in ("bash", "shell")) or action_type == "shell_command":
+        return "shell-command"
+    if any(token in normalized_signals for token in ("secret", "credential", "token")):
+        return "secret-read"
+    if "skill" in artifact_id:
+        return "skill-action"
+    return "tool-call"
+
+
+def _risk_category(request_row: dict[str, object]) -> str:
+    for key in ("risk_headline", "risk_summary", "policy_action"):
+        value = (_non_empty_string(request_row.get(key)) or "").lower()
+        if any(token in value for token in ("critical", "high", "block", "destructive")):
+            return "high"
+        if any(token in value for token in ("medium", "review", "reapproval")):
+            return "medium"
+        if any(token in value for token in ("low", "allow")):
+            return "low"
+    return "unknown"
+
+
+def _policy_version(request_row: dict[str, object]) -> str:
+    decision_v2 = _read_json_mapping(request_row.get("decision_v2_json")) or {}
+    value = _non_empty_string(decision_v2.get("policyVersion"))
+    if value is not None:
+        return value
+    last_seen_at = _non_empty_string(request_row.get("last_seen_at")) or _non_empty_string(request_row.get("created_at"))
+    return f"request:{last_seen_at or request_row['request_id']}"
+
+
+def _claim_expiry(request_row: dict[str, object]) -> str:
+    created_at = _parse_iso_timestamp(request_row.get("created_at"), field_name="created_at")
+    last_seen_at = _parse_iso_timestamp(
+        request_row.get("last_seen_at") or request_row.get("created_at"),
+        field_name="last_seen_at",
+    )
+    baseline = max(created_at, last_seen_at)
+    return (baseline + timedelta(minutes=10)).astimezone(timezone.utc).isoformat()
+
+
+def build_local_review_request_claim(
+    *,
+    request_row: dict[str, object],
+    oauth: GuardReviewOAuthMetadata,
+    store,
+) -> dict[str, object]:
+    local_request_id = _non_empty_string(request_row.get("request_id"))
+    approval_id = _non_empty_string(request_row.get("request_id"))
+    artifact_id = _non_empty_string(request_row.get("artifact_id"))
+    harness_id = _non_empty_string(request_row.get("harness"))
+    policy_action = _non_empty_string(request_row.get("policy_action"))
+    recommended_scope = _non_empty_string(request_row.get("recommended_scope"))
+    created_at = _non_empty_string(request_row.get("created_at"))
+    last_seen_at = _non_empty_string(request_row.get("last_seen_at")) or created_at
+    if None in {
+        local_request_id,
+        approval_id,
+        artifact_id,
+        harness_id,
+        policy_action,
+        recommended_scope,
+        created_at,
+        last_seen_at,
+    }:
+        raise GuardReviewContractError("invalid_request_row")
+    claim = {
+        "contractVersion": _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION,
+        "actionEnvelopeHash": _action_envelope_hash(request_row),
+        "actionIdentity": _non_empty_string(request_row.get("action_identity")) or local_request_id,
+        "approvalId": approval_id,
+        "artifactHash": _non_empty_string(request_row.get("artifact_hash")),
+        "artifactId": artifact_id,
+        "capabilityCategory": _capability_category(request_row),
+        "createdAt": created_at,
+        "deviceId": oauth.device_id,
+        "expiresAt": _claim_expiry(request_row),
+        "harnessId": harness_id,
+        "lastSeenAt": last_seen_at,
+        "localRequestId": local_request_id,
+        "machineId": oauth.machine_id,
+        "machineInstallationId": oauth.installation_id,
+        "nonce": _non_empty_string(request_row.get("queue_group_id")) or local_request_id,
+        "policyAction": policy_action,
+        "policyVersion": _policy_version(request_row),
+        "projectIdentity": _project_identity(request_row, store),
+        "queueGroupId": _non_empty_string(request_row.get("queue_group_id")),
+        "recommendedScope": recommended_scope,
+        "riskCategory": _risk_category(request_row),
+        "runtimeGrantId": oauth.runtime_id,
+        "workspaceId": oauth.workspace_id,
+    }
+    claim["claimHash"] = compute_local_review_request_claim_hash(claim)
+    return claim
+
+
+def compute_local_review_request_claim_hash(claim: dict[str, object]) -> str:
+    return _sha256_hex(_stable_serialize(_strip_keys(claim, _CLAIM_HASH_KEYS)))
+
+
+def validate_local_review_request_claim(claim: dict[str, object]) -> dict[str, object]:
+    if claim.get("contractVersion") != _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION:
+        raise GuardReviewContractError("unsupported_claim_contract_version")
+    expected_hash = compute_local_review_request_claim_hash(claim)
+    if _non_empty_string(claim.get("claimHash")) != expected_hash:
+        raise GuardReviewContractError("claim_hash_mismatch")
+    return claim
+
+
+def payload_hash_for_remote_approval_envelope(envelope: dict[str, object]) -> str:
+    return _sha256_hex(_canonical_signed_payload(envelope))
+
+
+def validated_remote_approval_envelope(envelope: dict[str, object]) -> dict[str, object]:
+    if envelope.get("contractVersion") != _REMOTE_APPROVAL_CONTRACT_VERSION:
+        raise GuardReviewContractError("unsupported_remote_approval_contract")
+    if envelope.get("scope") != _REMOTE_APPROVAL_REQUIRED_SCOPE:
+        raise GuardReviewContractError("invalid_remote_approval_scope")
+    issued_at = _parse_iso_timestamp(envelope.get("issuedAt"), field_name="issued_at")
+    expires_at = _parse_iso_timestamp(envelope.get("expiresAt"), field_name="expires_at")
+    if expires_at <= issued_at or expires_at <= _now():
+        raise GuardReviewContractError("remote_approval_expired")
+    payload_hash = _non_empty_string(envelope.get("payloadHash"))
+    if payload_hash is None or payload_hash != payload_hash_for_remote_approval_envelope(envelope):
+        raise GuardReviewContractError("remote_approval_payload_hash_mismatch")
+    _verify_signed_payload(
+        envelope,
+        signature_algorithm=_non_empty_string(envelope.get("signatureAlgorithm")) or "",
+    )
+    return envelope
+
+
+def validate_remote_approval_request_binding(
+    *,
+    envelope: dict[str, object],
+    request_row: dict[str, object],
+    oauth: GuardReviewOAuthMetadata,
+    store,
+) -> None:
+    if _non_empty_string(envelope.get("localRequestId")) != _non_empty_string(request_row.get("request_id")):
+        raise GuardReviewContractError("remote_approval_request_id_mismatch")
+    if _non_empty_string(envelope.get("approvalId")) != _non_empty_string(request_row.get("request_id")):
+        raise GuardReviewContractError("remote_approval_approval_id_mismatch")
+    if _non_empty_string(envelope.get("workspaceId")) != oauth.workspace_id:
+        raise GuardReviewContractError("remote_approval_workspace_mismatch")
+    if _non_empty_string(envelope.get("machineInstallationId")) != oauth.installation_id:
+        raise GuardReviewContractError("remote_approval_installation_mismatch")
+    if _non_empty_string(envelope.get("machineId")) != oauth.machine_id:
+        raise GuardReviewContractError("remote_approval_machine_mismatch")
+    if _non_empty_string(envelope.get("deviceId")) != oauth.device_id:
+        raise GuardReviewContractError("remote_approval_device_mismatch")
+    if _non_empty_string(envelope.get("harnessId")) != _non_empty_string(request_row.get("harness")):
+        raise GuardReviewContractError("remote_approval_harness_mismatch")
+    if _non_empty_string(envelope.get("actionEnvelopeHash")) != _action_envelope_hash(request_row):
+        raise GuardReviewContractError("remote_approval_action_hash_mismatch")
+    if _non_empty_string(envelope.get("policyVersion")) != _policy_version(request_row):
+        raise GuardReviewContractError("remote_approval_policy_version_mismatch")
+    expected_claim = build_local_review_request_claim(request_row=request_row, oauth=oauth, store=store)
+    if _non_empty_string(envelope.get("sourceClaimHash")) != _non_empty_string(expected_claim.get("claimHash")):
+        raise GuardReviewContractError("remote_approval_claim_hash_mismatch")
+
+
+def payload_hash_for_decision_memory_bundle(bundle: dict[str, object]) -> str:
+    return _sha256_hex(_canonical_signed_payload(bundle))
+
+
+def validated_decision_memory_bundle(bundle: dict[str, object]) -> dict[str, object]:
+    if bundle.get("contractVersion") != _DECISION_MEMORY_BUNDLE_CONTRACT_VERSION:
+        raise GuardReviewContractError("unsupported_memory_bundle_contract")
+    issued_at = _parse_iso_timestamp(bundle.get("issuedAt"), field_name="issued_at")
+    expires_at = _parse_iso_timestamp(bundle.get("expiresAt"), field_name="expires_at")
+    if expires_at <= issued_at or expires_at <= _now():
+        raise GuardReviewContractError("decision_memory_bundle_expired")
+    bundle_hash = _non_empty_string(bundle.get("bundleHash"))
+    payload_hash = payload_hash_for_decision_memory_bundle(bundle)
+    if bundle_hash is None or bundle_hash != payload_hash:
+        raise GuardReviewContractError("decision_memory_bundle_hash_mismatch")
+    if _non_empty_string(bundle.get("payloadHash")) != payload_hash:
+        raise GuardReviewContractError("decision_memory_payload_hash_mismatch")
+    _verify_signed_payload(
+        bundle,
+        signature_algorithm=_non_empty_string(bundle.get("signatureAlgorithm")) or "",
+    )
+    return bundle
+
+
+def validate_decision_memory_bundle_target(
+    *,
+    bundle: dict[str, object],
+    oauth: GuardReviewOAuthMetadata,
+    last_policy_version: str | None = None,
+) -> None:
+    if _non_empty_string(bundle.get("workspaceId")) != oauth.workspace_id:
+        raise GuardReviewContractError("decision_memory_workspace_mismatch")
+    if last_policy_version is not None:
+        current = _non_empty_string(bundle.get("policyVersion"))
+        if current is not None and current <= last_policy_version:
+            raise GuardReviewContractError("decision_memory_policy_version_stale")
+    rules = bundle.get("memoryRules")
+    revocations = bundle.get("revocations")
+    if not isinstance(rules, list):
+        raise GuardReviewContractError("decision_memory_rules_missing")
+    if not rules and not (isinstance(revocations, list) and revocations):
+        raise GuardReviewContractError("decision_memory_rules_missing")
+    for rule in rules:
+        if not isinstance(rule, dict):
+            raise GuardReviewContractError("decision_memory_rule_invalid")
+        target = rule.get("target")
+        if not isinstance(target, dict):
+            raise GuardReviewContractError("decision_memory_target_invalid")
+        machine_ids = target.get("machineIds")
+        if (
+            isinstance(machine_ids, list)
+            and machine_ids
+            and oauth.installation_id not in {str(item) for item in machine_ids}
+        ):
+            raise GuardReviewContractError("decision_memory_machine_mismatch")
+
+
+def build_decision_memory_ack(
+    *,
+    bundle: dict[str, object],
+    oauth: GuardReviewOAuthMetadata,
+    status: str,
+    applied_rule_count: int,
+    reason: str | None = None,
+    rejected_rule_ids: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "acknowledgedAt": _now().isoformat(),
+        "appliedRuleCount": max(0, applied_rule_count),
+        "bundleHash": _non_empty_string(bundle.get("bundleHash")),
+        "bundleVersion": _non_empty_string(bundle.get("bundleVersion")),
+        "contractVersion": _DECISION_MEMORY_ACK_CONTRACT_VERSION,
+        "deviceId": oauth.device_id,
+        "machineId": oauth.machine_id,
+        "machineInstallationId": oauth.installation_id,
+        "policyVersion": _non_empty_string(bundle.get("policyVersion")),
+        "reason": reason,
+        "rejectedRuleIds": rejected_rule_ids or [],
+        "status": status,
+        "workspaceId": oauth.workspace_id,
+    }

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -316,7 +316,7 @@ def build_local_review_request_claim(
         last_seen_at,
     }:
         raise GuardReviewContractError("invalid_request_row")
-    claim = {
+    claim: dict[str, object] = {
         "contractVersion": _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION,
         "actionEnvelopeHash": _action_envelope_hash(request_row),
         "actionIdentity": _non_empty_string(request_row.get("action_identity")) or local_request_id,

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -51,27 +51,19 @@ class GuardReviewOAuthMetadata:
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
-
-
 def _stable_serialize(value: object) -> str:
     if isinstance(value, list):
         return f"[{','.join(_stable_serialize(item) for item in value)}]"
     if isinstance(value, dict):
-        return (
-            "{"
-            + ",".join(
-                f"{json.dumps(key, separators=(',', ':'), ensure_ascii=False)}:{_stable_serialize(value[key])}"
-                for key in sorted(value)
-            )
-            + "}"
-        )
+        return "{" + ",".join(
+            f"{json.dumps(key, separators=(',', ':'), ensure_ascii=False)}:{_stable_serialize(value[key])}"
+            for key in sorted(value)
+        ) + "}"
     return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
 
 
 def _sha256_hex(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
-
-
 def _non_empty_string(value: object) -> str | None:
     return value if isinstance(value, str) and value.strip() else None
 
@@ -157,10 +149,7 @@ def _verify_signed_payload(
     signature_algorithm: str,
     store,
 ) -> None:
-    if signature_algorithm not in {
-        _REMOTE_APPROVAL_SIGNATURE_ALGORITHM,
-        _DECISION_MEMORY_SIGNATURE_ALGORITHM,
-    }:
+    if signature_algorithm not in {_REMOTE_APPROVAL_SIGNATURE_ALGORITHM, _DECISION_MEMORY_SIGNATURE_ALGORITHM}:
         raise GuardReviewContractError("invalid_signature_algorithm")
     signature = _non_empty_string(payload.get("signature"))
     if signature is None:
@@ -279,8 +268,6 @@ def _policy_version(request_row: dict[str, object]) -> str:
         request_row.get("created_at")
     )
     return f"request:{last_seen_at or request_row['request_id']}"
-
-
 def _claim_expiry(request_row: dict[str, object]) -> str:
     created_at = _parse_iso_timestamp(request_row.get("created_at"), field_name="created_at")
     last_seen_at = _parse_iso_timestamp(
@@ -305,7 +292,7 @@ def build_local_review_request_claim(
     recommended_scope = _non_empty_string(request_row.get("recommended_scope"))
     created_at = _non_empty_string(request_row.get("created_at"))
     last_seen_at = _non_empty_string(request_row.get("last_seen_at")) or created_at
-    if None in {
+    required_fields = (
         local_request_id,
         approval_id,
         artifact_id,
@@ -314,7 +301,8 @@ def build_local_review_request_claim(
         recommended_scope,
         created_at,
         last_seen_at,
-    }:
+    )
+    if None in required_fields:
         raise GuardReviewContractError("invalid_request_row")
     claim: dict[str, object] = {
         "contractVersion": _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION,
@@ -348,8 +336,6 @@ def build_local_review_request_claim(
 
 def compute_local_review_request_claim_hash(claim: dict[str, object]) -> str:
     return _sha256_hex(_stable_serialize(_strip_keys(claim, _CLAIM_HASH_KEYS)))
-
-
 def validate_local_review_request_claim(claim: dict[str, object]) -> dict[str, object]:
     if claim.get("contractVersion") != _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION:
         raise GuardReviewContractError("unsupported_claim_contract_version")
@@ -361,8 +347,6 @@ def validate_local_review_request_claim(claim: dict[str, object]) -> dict[str, o
 
 def payload_hash_for_remote_approval_envelope(envelope: dict[str, object]) -> str:
     return _sha256_hex(_canonical_signed_payload(envelope))
-
-
 def validated_remote_approval_envelope(envelope: dict[str, object], *, store) -> dict[str, object]:
     if envelope.get("contractVersion") != _REMOTE_APPROVAL_CONTRACT_VERSION:
         raise GuardReviewContractError("unsupported_remote_approval_contract")
@@ -411,8 +395,6 @@ def validate_remote_approval_request_binding(
     expected_claim = build_local_review_request_claim(request_row=request_row, oauth=oauth, store=store)
     if _non_empty_string(envelope.get("sourceClaimHash")) != _non_empty_string(expected_claim.get("claimHash")):
         raise GuardReviewContractError("remote_approval_claim_hash_mismatch")
-
-
 def payload_hash_for_decision_memory_bundle(bundle: dict[str, object]) -> str:
     return _sha256_hex(_canonical_signed_payload(bundle))
 
@@ -454,8 +436,6 @@ def _policy_version_is_stale(current: str, previous: str) -> bool:
     if current_key is not None and previous_key is not None:
         return current_key <= previous_key
     return current <= previous
-
-
 def validate_decision_memory_bundle_target(
     *,
     bundle: dict[str, object],
@@ -487,8 +467,6 @@ def validate_decision_memory_bundle_target(
             and oauth.installation_id not in {str(item) for item in machine_ids}
         ):
             raise GuardReviewContractError("decision_memory_machine_mismatch")
-
-
 def build_decision_memory_ack(
     *,
     bundle: dict[str, object],

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -126,13 +126,9 @@ def _verification_keys_from_payload(value: object) -> tuple[PolicyBundleVerifica
 
 def _anchored_review_verification_keys(store) -> tuple[PolicyBundleVerificationKey, ...]:
     return merge_policy_bundle_trusted_keys(
-        safe_load_policy_bundle_verification_keys(
-            store.get_sync_payload(_GUARD_REVIEW_VERIFICATION_KEYRING_SYNC_KEY)
-        ),
+        safe_load_policy_bundle_verification_keys(store.get_sync_payload(_GUARD_REVIEW_VERIFICATION_KEYRING_SYNC_KEY)),
         safe_load_policy_bundle_verification_keys(store.get_sync_payload("policy_bundle_keyring")),
-        policy_bundle_keys_from_supply_chain_keyring(
-            store.get_sync_payload("supply_chain_bundle_keyring")
-        ),
+        policy_bundle_keys_from_supply_chain_keyring(store.get_sync_payload("supply_chain_bundle_keyring")),
     )
 
 
@@ -248,10 +244,7 @@ def _capability_category(request_row: dict[str, object]) -> str:
     action_envelope = _read_json_mapping(request_row.get("action_envelope_json")) or {}
     action_type = (_non_empty_string(action_envelope.get("action_type")) or "").lower()
     risk_signals = request_row.get("risk_signals")
-    normalized_signals = {
-        str(item).lower()
-        for item in risk_signals
-    } if isinstance(risk_signals, list) else set()
+    normalized_signals = {str(item).lower() for item in risk_signals} if isinstance(risk_signals, list) else set()
     if artifact_id.startswith("pkg:") or "package" in artifact_id or "package" in harness:
         return "package-install"
     if any(token in artifact_id for token in ("mcp", "modelcontextprotocol")) or "mcp" in harness:

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -282,7 +282,9 @@ def _policy_version(request_row: dict[str, object]) -> str:
     value = _non_empty_string(decision_v2.get("policyVersion"))
     if value is not None:
         return value
-    last_seen_at = _non_empty_string(request_row.get("last_seen_at")) or _non_empty_string(request_row.get("created_at"))
+    last_seen_at = _non_empty_string(request_row.get("last_seen_at")) or _non_empty_string(
+        request_row.get("created_at")
+    )
     return f"request:{last_seen_at or request_row['request_id']}"
 
 

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -26,7 +26,6 @@ from .policy_bundle_trusted_keys import (
 _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION = "guard.local-review-request.v1"
 _REMOTE_APPROVAL_CONTRACT_VERSION = "guard.remote-approval.v1"
 _DECISION_MEMORY_BUNDLE_CONTRACT_VERSION = "guard.decision-memory-bundle.v1"
-_DECISION_MEMORY_ACK_CONTRACT_VERSION = "guard.decision-memory-ack.v1"
 _REMOTE_APPROVAL_REQUIRED_SCOPE = "artifact"
 _REMOTE_APPROVAL_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
 _DECISION_MEMORY_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
@@ -51,19 +50,27 @@ class GuardReviewOAuthMetadata:
 
 def _now() -> datetime:
     return datetime.now(timezone.utc)
+
+
 def _stable_serialize(value: object) -> str:
     if isinstance(value, list):
         return f"[{','.join(_stable_serialize(item) for item in value)}]"
     if isinstance(value, dict):
-        return "{" + ",".join(
-            f"{json.dumps(key, separators=(',', ':'), ensure_ascii=False)}:{_stable_serialize(value[key])}"
-            for key in sorted(value)
-        ) + "}"
+        return (
+            "{"
+            + ",".join(
+                f"{json.dumps(key, separators=(',', ':'), ensure_ascii=False)}:{_stable_serialize(value[key])}"
+                for key in sorted(value)
+            )
+            + "}"
+        )
     return json.dumps(value, separators=(",", ":"), ensure_ascii=False)
 
 
 def _sha256_hex(value: str) -> str:
     return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
 def _non_empty_string(value: object) -> str | None:
     return value if isinstance(value, str) and value.strip() else None
 
@@ -268,6 +275,8 @@ def _policy_version(request_row: dict[str, object]) -> str:
         request_row.get("created_at")
     )
     return f"request:{last_seen_at or request_row['request_id']}"
+
+
 def _claim_expiry(request_row: dict[str, object]) -> str:
     created_at = _parse_iso_timestamp(request_row.get("created_at"), field_name="created_at")
     last_seen_at = _parse_iso_timestamp(
@@ -336,6 +345,8 @@ def build_local_review_request_claim(
 
 def compute_local_review_request_claim_hash(claim: dict[str, object]) -> str:
     return _sha256_hex(_stable_serialize(_strip_keys(claim, _CLAIM_HASH_KEYS)))
+
+
 def validate_local_review_request_claim(claim: dict[str, object]) -> dict[str, object]:
     if claim.get("contractVersion") != _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION:
         raise GuardReviewContractError("unsupported_claim_contract_version")
@@ -347,6 +358,8 @@ def validate_local_review_request_claim(claim: dict[str, object]) -> dict[str, o
 
 def payload_hash_for_remote_approval_envelope(envelope: dict[str, object]) -> str:
     return _sha256_hex(_canonical_signed_payload(envelope))
+
+
 def validated_remote_approval_envelope(envelope: dict[str, object], *, store) -> dict[str, object]:
     if envelope.get("contractVersion") != _REMOTE_APPROVAL_CONTRACT_VERSION:
         raise GuardReviewContractError("unsupported_remote_approval_contract")
@@ -395,6 +408,8 @@ def validate_remote_approval_request_binding(
     expected_claim = build_local_review_request_claim(request_row=request_row, oauth=oauth, store=store)
     if _non_empty_string(envelope.get("sourceClaimHash")) != _non_empty_string(expected_claim.get("claimHash")):
         raise GuardReviewContractError("remote_approval_claim_hash_mismatch")
+
+
 def payload_hash_for_decision_memory_bundle(bundle: dict[str, object]) -> str:
     return _sha256_hex(_canonical_signed_payload(bundle))
 
@@ -436,6 +451,8 @@ def _policy_version_is_stale(current: str, previous: str) -> bool:
     if current_key is not None and previous_key is not None:
         return current_key <= previous_key
     return current <= previous
+
+
 def validate_decision_memory_bundle_target(
     *,
     bundle: dict[str, object],
@@ -467,27 +484,3 @@ def validate_decision_memory_bundle_target(
             and oauth.installation_id not in {str(item) for item in machine_ids}
         ):
             raise GuardReviewContractError("decision_memory_machine_mismatch")
-def build_decision_memory_ack(
-    *,
-    bundle: dict[str, object],
-    oauth: GuardReviewOAuthMetadata,
-    status: str,
-    applied_rule_count: int,
-    reason: str | None = None,
-    rejected_rule_ids: list[str] | None = None,
-) -> dict[str, object]:
-    return {
-        "acknowledgedAt": _now().isoformat(),
-        "appliedRuleCount": max(0, applied_rule_count),
-        "bundleHash": _non_empty_string(bundle.get("bundleHash")),
-        "bundleVersion": _non_empty_string(bundle.get("bundleVersion")),
-        "contractVersion": _DECISION_MEMORY_ACK_CONTRACT_VERSION,
-        "deviceId": oauth.device_id,
-        "machineId": oauth.machine_id,
-        "machineInstallationId": oauth.installation_id,
-        "policyVersion": _non_empty_string(bundle.get("policyVersion")),
-        "reason": reason,
-        "rejectedRuleIds": rejected_rule_ids or [],
-        "status": status,
-        "workspaceId": oauth.workspace_id,
-    }

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -14,7 +14,14 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
-from .policy_bundle_trusted_keys import PolicyBundleVerificationKey
+from .policy_bundle_trusted_keys import (
+    PolicyBundleVerificationKey,
+    merge_policy_bundle_trusted_keys,
+    policy_bundle_keys_from_supply_chain_keyring,
+    resolve_policy_bundle_signing_key,
+    safe_load_policy_bundle_verification_keys,
+    signing_key_is_current,
+)
 
 _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION = "guard.local-review-request.v1"
 _REMOTE_APPROVAL_CONTRACT_VERSION = "guard.remote-approval.v1"
@@ -25,6 +32,7 @@ _REMOTE_APPROVAL_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
 _DECISION_MEMORY_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
 _CLAIM_HASH_KEYS = ("claimHash",)
 _SIGNED_PAYLOAD_STRIP_KEYS = ("payloadHash", "signature", "signatureAlgorithm", "verificationKeys", "bundleHash")
+_GUARD_REVIEW_VERIFICATION_KEYRING_SYNC_KEY = "guard_review_verification_keyring"
 
 
 class GuardReviewContractError(ValueError):
@@ -116,21 +124,42 @@ def _verification_keys_from_payload(value: object) -> tuple[PolicyBundleVerifica
     return tuple(parsed)
 
 
-def _resolve_signing_key(
+def _anchored_review_verification_keys(store) -> tuple[PolicyBundleVerificationKey, ...]:
+    return merge_policy_bundle_trusted_keys(
+        safe_load_policy_bundle_verification_keys(
+            store.get_sync_payload(_GUARD_REVIEW_VERIFICATION_KEYRING_SYNC_KEY)
+        ),
+        safe_load_policy_bundle_verification_keys(store.get_sync_payload("policy_bundle_keyring")),
+        policy_bundle_keys_from_supply_chain_keyring(
+            store.get_sync_payload("supply_chain_bundle_keyring")
+        ),
+    )
+
+
+def _resolve_anchored_signing_key(
     *,
+    advertised_keys: tuple[PolicyBundleVerificationKey, ...],
+    anchored_keys: tuple[PolicyBundleVerificationKey, ...],
     key_id: str,
-    verification_keys: tuple[PolicyBundleVerificationKey, ...],
 ) -> PolicyBundleVerificationKey:
-    for key in verification_keys:
-        if key.key_id == key_id:
-            return key
-    raise GuardReviewContractError("unknown_signing_key")
+    signing_key = resolve_policy_bundle_signing_key(key_id, anchored_keys)
+    if signing_key is None:
+        raise GuardReviewContractError("unknown_signing_key")
+    advertised_key = resolve_policy_bundle_signing_key(key_id, advertised_keys)
+    if advertised_key is None:
+        raise GuardReviewContractError("missing_signing_key")
+    if advertised_key.fingerprint_sha256 != signing_key.fingerprint_sha256:
+        raise GuardReviewContractError("untrusted_signing_key")
+    if not signing_key_is_current(signing_key):
+        raise GuardReviewContractError("expired_signing_key")
+    return signing_key
 
 
 def _verify_signed_payload(
     payload: dict[str, object],
     *,
     signature_algorithm: str,
+    store,
 ) -> None:
     if signature_algorithm not in {
         _REMOTE_APPROVAL_SIGNATURE_ALGORITHM,
@@ -147,8 +176,12 @@ def _verify_signed_payload(
             key_id = _non_empty_string(verifier.get("keyId"))
     if key_id is None:
         raise GuardReviewContractError("missing_signing_key_id")
-    verification_keys = _verification_keys_from_payload(payload.get("verificationKeys"))
-    signing_key = _resolve_signing_key(key_id=key_id, verification_keys=verification_keys)
+    advertised_keys = _verification_keys_from_payload(payload.get("verificationKeys"))
+    signing_key = _resolve_anchored_signing_key(
+        advertised_keys=advertised_keys,
+        anchored_keys=_anchored_review_verification_keys(store),
+        key_id=key_id,
+    )
     try:
         public_key = serialization.load_pem_public_key(signing_key.public_key_pem.encode("utf-8"))
     except (UnsupportedAlgorithm, ValueError, TypeError) as error:
@@ -180,8 +213,9 @@ def guard_review_oauth_metadata(store) -> GuardReviewOAuthMetadata:
     workspace_id = _non_empty_string(credentials.get("workspace_id"))
     if installation_id is None or machine_id is None or workspace_id is None:
         raise GuardReviewContractError("missing_oauth_binding")
+    device_id = _non_empty_string(credentials.get("device_id")) or machine_id
     return GuardReviewOAuthMetadata(
-        device_id=machine_id,
+        device_id=device_id,
         grant_id=_non_empty_string(credentials.get("grant_id")),
         installation_id=installation_id,
         machine_id=machine_id,
@@ -334,7 +368,7 @@ def payload_hash_for_remote_approval_envelope(envelope: dict[str, object]) -> st
     return _sha256_hex(_canonical_signed_payload(envelope))
 
 
-def validated_remote_approval_envelope(envelope: dict[str, object]) -> dict[str, object]:
+def validated_remote_approval_envelope(envelope: dict[str, object], *, store) -> dict[str, object]:
     if envelope.get("contractVersion") != _REMOTE_APPROVAL_CONTRACT_VERSION:
         raise GuardReviewContractError("unsupported_remote_approval_contract")
     if envelope.get("scope") != _REMOTE_APPROVAL_REQUIRED_SCOPE:
@@ -349,6 +383,7 @@ def validated_remote_approval_envelope(envelope: dict[str, object]) -> dict[str,
     _verify_signed_payload(
         envelope,
         signature_algorithm=_non_empty_string(envelope.get("signatureAlgorithm")) or "",
+        store=store,
     )
     return envelope
 
@@ -387,7 +422,7 @@ def payload_hash_for_decision_memory_bundle(bundle: dict[str, object]) -> str:
     return _sha256_hex(_canonical_signed_payload(bundle))
 
 
-def validated_decision_memory_bundle(bundle: dict[str, object]) -> dict[str, object]:
+def validated_decision_memory_bundle(bundle: dict[str, object], *, store) -> dict[str, object]:
     if bundle.get("contractVersion") != _DECISION_MEMORY_BUNDLE_CONTRACT_VERSION:
         raise GuardReviewContractError("unsupported_memory_bundle_contract")
     issued_at = _parse_iso_timestamp(bundle.get("issuedAt"), field_name="issued_at")
@@ -403,8 +438,27 @@ def validated_decision_memory_bundle(bundle: dict[str, object]) -> dict[str, obj
     _verify_signed_payload(
         bundle,
         signature_algorithm=_non_empty_string(bundle.get("signatureAlgorithm")) or "",
+        store=store,
     )
     return bundle
+
+
+def _policy_version_ordering_key(value: str) -> tuple[datetime, str] | None:
+    prefix, separator, suffix = value.partition(":")
+    if not separator:
+        return None
+    try:
+        return (_parse_iso_timestamp(prefix, field_name="policy_version"), suffix)
+    except GuardReviewContractError:
+        return None
+
+
+def _policy_version_is_stale(current: str, previous: str) -> bool:
+    current_key = _policy_version_ordering_key(current)
+    previous_key = _policy_version_ordering_key(previous)
+    if current_key is not None and previous_key is not None:
+        return current_key <= previous_key
+    return current <= previous
 
 
 def validate_decision_memory_bundle_target(
@@ -417,7 +471,7 @@ def validate_decision_memory_bundle_target(
         raise GuardReviewContractError("decision_memory_workspace_mismatch")
     if last_policy_version is not None:
         current = _non_empty_string(bundle.get("policyVersion"))
-        if current is not None and current <= last_policy_version:
+        if current is not None and _policy_version_is_stale(current, last_policy_version):
             raise GuardReviewContractError("decision_memory_policy_version_stale")
     rules = bundle.get("memoryRules")
     revocations = bundle.get("revocations")

--- a/src/codex_plugin_scanner/guard/review_memory_ack.py
+++ b/src/codex_plugin_scanner/guard/review_memory_ack.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from .review_contracts import GuardReviewOAuthMetadata
+
+_DECISION_MEMORY_ACK_CONTRACT_VERSION = "guard.decision-memory-ack.v1"
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def build_decision_memory_ack(
+    *,
+    bundle: dict[str, object],
+    oauth: GuardReviewOAuthMetadata,
+    status: str,
+    applied_rule_count: int,
+    reason: str | None = None,
+    rejected_rule_ids: list[str] | None = None,
+) -> dict[str, object]:
+    return {
+        "acknowledgedAt": _now().isoformat(),
+        "appliedRuleCount": max(0, applied_rule_count),
+        "bundleHash": bundle.get("bundleHash"),
+        "bundleVersion": bundle.get("bundleVersion"),
+        "contractVersion": _DECISION_MEMORY_ACK_CONTRACT_VERSION,
+        "deviceId": oauth.device_id,
+        "machineId": oauth.machine_id,
+        "machineInstallationId": oauth.installation_id,
+        "policyVersion": bundle.get("policyVersion"),
+        "reason": reason,
+        "rejectedRuleIds": rejected_rule_ids or [],
+        "status": status,
+        "workspaceId": oauth.workspace_id,
+    }

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -269,7 +269,7 @@ def _execute_approval_operation(
             generated_at=generated_at,
         )
     oauth = guard_review_oauth_metadata(store)
-    envelope = validated_remote_approval_envelope(remote_approval)
+    envelope = validated_remote_approval_envelope(remote_approval, store=store)
     validate_remote_approval_request_binding(
         envelope=envelope,
         request_row=request_row,
@@ -315,7 +315,7 @@ def _execute_policy_sync(
     if not bundle_payload:
         raise ValueError("missing_decision_memory_bundle")
     oauth = guard_review_oauth_metadata(store)
-    bundle = validated_decision_memory_bundle(bundle_payload)
+    bundle = validated_decision_memory_bundle(bundle_payload, store=store)
     validate_decision_memory_bundle_target(
         bundle=bundle,
         oauth=oauth,
@@ -399,7 +399,10 @@ def _local_policy_scope(scope: str | None) -> DecisionScope:
 
 def _local_request_snapshot_items(store: GuardStore) -> list[dict[str, object]]:
     items: list[dict[str, object]] = []
-    oauth = guard_review_oauth_metadata(store)
+    try:
+        oauth = guard_review_oauth_metadata(store)
+    except GuardReviewContractError:
+        oauth = None
     for status in ("pending", "resolved"):
         for item in store.list_approval_requests(status=status, limit=100):
             request_id = item.get("request_id")
@@ -408,11 +411,16 @@ def _local_request_snapshot_items(store: GuardStore) -> list[dict[str, object]]:
             created_at = str(item.get("created_at") or _now())
             last_seen_at = str(item.get("last_seen_at") or created_at)
             resolved_at = item.get("resolved_at")
-            claim = build_local_review_request_claim(
-                request_row=item,
-                oauth=oauth,
-                store=store,
-            )
+            claim = None
+            if oauth is not None:
+                try:
+                    claim = build_local_review_request_claim(
+                        request_row=item,
+                        oauth=oauth,
+                        store=store,
+                    )
+                except GuardReviewContractError:
+                    claim = None
             items.append(
                 {
                     "claim": claim,

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -6,6 +6,7 @@ import tempfile
 from collections.abc import Callable
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import TypeGuard
 
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
@@ -22,7 +23,7 @@ from ..local_supply_chain import (
     resolve_supply_chain_audit_workspace_dir,
     sync_supply_chain_cloud_state,
 )
-from ..models import DecisionScope, PolicyDecision
+from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, DecisionScope, GuardAction, PolicyDecision
 from ..package_shim_status import record_package_shim_audit_result
 from ..review_contracts import (
     GuardReviewContractError,
@@ -328,7 +329,8 @@ def _execute_policy_sync(
         last_policy_version=_stored_review_memory_policy_version(store),
     )
     registry = _stored_review_memory_registry(store)
-    for revoked_rule_id in bundle.get("revocations", []):
+    revocations = bundle.get("revocations")
+    for revoked_rule_id in revocations if isinstance(revocations, list) else []:
         revoked_key = _optional_string(revoked_rule_id)
         if revoked_key is not None:
             registry.pop(revoked_key, None)
@@ -400,6 +402,14 @@ def _local_policy_scope(scope: str | None) -> DecisionScope:
     if scope == "item":
         return "artifact"
     return "artifact"
+
+
+def _is_decision_scope(value: object) -> TypeGuard[DecisionScope]:
+    return isinstance(value, str) and value in DECISION_SCOPE_VALUES
+
+
+def _is_guard_action(value: object) -> TypeGuard[GuardAction]:
+    return isinstance(value, str) and value in GUARD_ACTION_VALUES
 
 
 def _local_request_snapshot_items(store: GuardStore) -> list[dict[str, object]]:
@@ -506,11 +516,13 @@ def _existing_non_review_remote_policies(store: GuardStore) -> list[PolicyDecisi
         harness = _optional_string(item.get("harness"))
         if scope is None or action is None or harness is None:
             continue
+        if not _is_decision_scope(scope) or not _is_guard_action(action):
+            continue
         decisions.append(
             PolicyDecision(
                 harness=harness,
-                scope=scope,  # type: ignore[arg-type]
-                action=action,  # type: ignore[arg-type]
+                scope=scope,
+                action=action,
                 artifact_id=_optional_string(item.get("artifact_id")),
                 artifact_hash=_optional_string(item.get("artifact_hash")),
                 workspace=_optional_string(item.get("workspace")),
@@ -533,10 +545,12 @@ def _decision_from_registry_entry(entry: dict[str, object]) -> PolicyDecision:
     action = _optional_string(decision.get("action"))
     if harness is None or scope is None or action is None:
         raise ValueError("invalid_decision_memory_registry")
+    if not _is_decision_scope(scope) or not _is_guard_action(action):
+        raise ValueError("invalid_decision_memory_registry")
     return PolicyDecision(
         harness=harness,
-        scope=scope,  # type: ignore[arg-type]
-        action=action,  # type: ignore[arg-type]
+        scope=scope,
+        action=action,
         artifact_id=_optional_string(decision.get("artifact_id")),
         artifact_hash=_optional_string(decision.get("artifact_hash")),
         workspace=_optional_string(decision.get("workspace")),
@@ -559,6 +573,8 @@ def _decision_from_memory_rule(
     scope_value = _optional_string(rule.get("scope"))
     if harness is None or artifact_id is None or action is None or scope_value is None:
         raise GuardReviewContractError("invalid_decision_memory_rule")
+    if not _is_guard_action(action):
+        raise GuardReviewContractError("invalid_decision_memory_rule")
     if action == "allow" and scope_value not in {"artifact", "workspace"}:
         raise GuardReviewContractError("decision_memory_allow_scope_unsupported")
     scope = _local_policy_scope(scope_value)
@@ -574,7 +590,7 @@ def _decision_from_memory_rule(
     return PolicyDecision(
         harness=harness,
         scope=scope,
-        action=action,  # type: ignore[arg-type]
+        action=action,
         artifact_id=artifact_id,
         artifact_hash=_optional_string(rule.get("artifactHash")),
         workspace=workspace if scope == "workspace" else None,

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -288,6 +288,7 @@ def _execute_approval_operation(
         raise ValueError("remote_approval_replayed")
     envelope_decision = _optional_string(envelope.get("decision"))
     if envelope_decision not in {"allow_once", "block"}:
+        store.release_remote_once_receipt(receipt_id)
         raise ValueError("invalid_remote_approval_decision")
     resolution_action = "block" if envelope_decision == "block" else "allow"
     try:

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -27,7 +27,6 @@ from ..models import DECISION_SCOPE_VALUES, GUARD_ACTION_VALUES, DecisionScope, 
 from ..package_shim_status import record_package_shim_audit_result
 from ..review_contracts import (
     GuardReviewContractError,
-    build_decision_memory_ack,
     build_local_review_request_claim,
     guard_review_oauth_metadata,
     validate_decision_memory_bundle_target,
@@ -35,6 +34,7 @@ from ..review_contracts import (
     validated_decision_memory_bundle,
     validated_remote_approval_envelope,
 )
+from ..review_memory_ack import build_decision_memory_ack
 from ..shims import (
     activate_package_shims,
     package_shim_status,

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -286,7 +286,10 @@ def _execute_approval_operation(
         claimed_at=generated_at,
     ):
         raise ValueError("remote_approval_replayed")
-    resolution_action = "allow" if action == "allow_once" else "block"
+    envelope_decision = _optional_string(envelope.get("decision"))
+    if envelope_decision not in {"allow_once", "block"}:
+        raise ValueError("invalid_remote_approval_decision")
+    resolution_action = "block" if envelope_decision == "block" else "allow"
     try:
         result = store.resolve_request_with_signed_remote_result(
             local_request_id,

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -24,6 +24,16 @@ from ..local_supply_chain import (
 )
 from ..models import DecisionScope, PolicyDecision
 from ..package_shim_status import record_package_shim_audit_result
+from ..review_contracts import (
+    GuardReviewContractError,
+    build_decision_memory_ack,
+    build_local_review_request_claim,
+    guard_review_oauth_metadata,
+    validate_decision_memory_bundle_target,
+    validate_remote_approval_request_binding,
+    validated_decision_memory_bundle,
+    validated_remote_approval_envelope,
+)
 from ..shims import (
     activate_package_shims,
     package_shim_status,
@@ -31,6 +41,10 @@ from ..shims import (
     probe_package_shim_intercepts,
 )
 from ..store import GuardStore
+
+_GUARD_REVIEW_MEMORY_REGISTRY_SYNC_KEY = "guard_review_memory_registry"
+_GUARD_REVIEW_MEMORY_VERSION_SYNC_KEY = "guard_review_memory_policy_version"
+_GUARD_REVIEW_MEMORY_ACK_SYNC_KEY = "guard_review_memory_last_ack"
 
 PACKAGE_SHIM_OPERATIONS: tuple[str, ...] = (
     "guard.packageShims.status",
@@ -241,18 +255,49 @@ def _execute_approval_operation(
         return _execute_policy_sync(payload, store=store, generated_at=generated_at)
     if local_request_id is None:
         raise ValueError("invalid_approval_payload")
+    remote_approval = _payload_mapping(payload.get("remoteApproval") or payload.get("remote_approval"))
+    if not remote_approval:
+        raise ValueError("missing_remote_approval")
+    request_row = store.get_approval_request(local_request_id)
+    if not isinstance(request_row, dict):
+        return _result(
+            {
+                "action": action,
+                "localRequestId": local_request_id,
+                "status": "not_resolved",
+            },
+            generated_at=generated_at,
+        )
+    oauth = guard_review_oauth_metadata(store)
+    envelope = validated_remote_approval_envelope(remote_approval)
+    validate_remote_approval_request_binding(
+        envelope=envelope,
+        request_row=request_row,
+        oauth=oauth,
+        store=store,
+    )
+    receipt_id = _optional_string(envelope.get("receiptId"))
+    if receipt_id is None:
+        raise ValueError("invalid_remote_approval_receipt")
+    if not store.claim_remote_once_receipt(
+        receipt_id,
+        request_id=local_request_id,
+        claimed_at=generated_at,
+    ):
+        raise ValueError("remote_approval_replayed")
     resolution_action = "allow" if action == "allow_once" else "block"
-    result = store.resolve_request_with_queue_result(
+    result = store.resolve_request_with_signed_remote_result(
         local_request_id,
         resolution_action=resolution_action,
-        resolution_scope=_optional_string(payload.get("scope")) or "artifact",
-        reason=_optional_string(payload.get("reason")) or "Guard Cloud approval command",
+        resolution_scope="artifact",
+        reason=_optional_string(payload.get("reason")) or "Guard Cloud signed remote approval",
         resolved_at=generated_at,
     )
     return _result(
         {
             "action": action,
             "localRequestId": local_request_id,
+            "remoteApproval": envelope,
             "resolution": result,
             "status": "completed" if result.get("resolved") is True else "not_resolved",
         },
@@ -266,37 +311,78 @@ def _execute_policy_sync(
     store: GuardStore,
     generated_at: str,
 ) -> dict[str, object]:
-    policy_memory = payload.get("policyMemory") or payload.get("policy_memory")
-    if not isinstance(policy_memory, dict):
-        raise ValueError("missing_policy_memory")
-    target = policy_memory.get("target")
-    target_payload = target if isinstance(target, dict) else {}
-    harness = _optional_string(payload.get("harness")) or _optional_string(target_payload.get("harness"))
-    artifact_id = _optional_string(target_payload.get("artifactId")) or _optional_string(
-        target_payload.get("artifact_id")
+    bundle_payload = _payload_mapping(payload.get("decisionMemoryBundle") or payload.get("decision_memory_bundle"))
+    if not bundle_payload:
+        raise ValueError("missing_decision_memory_bundle")
+    oauth = guard_review_oauth_metadata(store)
+    bundle = validated_decision_memory_bundle(bundle_payload)
+    validate_decision_memory_bundle_target(
+        bundle=bundle,
+        oauth=oauth,
+        last_policy_version=_stored_review_memory_policy_version(store),
     )
-    if harness is None or artifact_id is None:
-        raise ValueError("missing_policy_target")
-    scope = _local_policy_scope(_optional_string(policy_memory.get("scope")))
-    decision = PolicyDecision(
-        harness=harness,
-        scope=scope,
-        action="allow",
-        artifact_id=artifact_id,
-        artifact_hash=None,
-        workspace=_optional_string(target_payload.get("workspaceId")) if scope == "workspace" else None,
-        publisher=None,
-        reason=_optional_string(policy_memory.get("reason")) or "Guard Cloud policy memory sync",
-        source="cloud-sync",
-        expires_at=_optional_string(policy_memory.get("expiry")),
+    registry = _stored_review_memory_registry(store)
+    for revoked_rule_id in bundle.get("revocations", []):
+        revoked_key = _optional_string(revoked_rule_id)
+        if revoked_key is not None:
+            registry.pop(revoked_key, None)
+    rejected_rule_ids: list[str] = []
+    applied_rule_count = 0
+    rules = bundle.get("memoryRules")
+    for rule in rules if isinstance(rules, list) else []:
+        if not isinstance(rule, dict):
+            raise ValueError("invalid_decision_memory_rule")
+        rule_id = _optional_string(rule.get("ruleId"))
+        if rule_id is None:
+            raise ValueError("invalid_decision_memory_rule")
+        try:
+            decision = _decision_from_memory_rule(bundle=bundle, rule=rule)
+        except GuardReviewContractError:
+            rejected_rule_ids.append(rule_id)
+            continue
+        registry[rule_id] = {
+            "decision": decision.to_dict(),
+            "ruleId": rule_id,
+        }
+        applied_rule_count += 1
+    store.replace_remote_policies(
+        [
+            *_existing_non_review_remote_policies(store),
+            *[
+                _decision_from_registry_entry(entry)
+                for entry in registry.values()
+            ],
+        ],
+        generated_at,
+        remote_write_authorized=True,
     )
-    store.upsert_policy(decision, generated_at, remote_write_authorized=True)
+    store.set_sync_payload(
+        _GUARD_REVIEW_MEMORY_REGISTRY_SYNC_KEY,
+        list(registry.values()),
+        generated_at,
+    )
+    store.set_sync_payload(
+        _GUARD_REVIEW_MEMORY_VERSION_SYNC_KEY,
+        {"policyVersion": _optional_string(bundle.get("policyVersion"))},
+        generated_at,
+    )
+    ack = build_decision_memory_ack(
+        bundle=bundle,
+        oauth=oauth,
+        status="accepted" if not rejected_rule_ids else "rejected",
+        applied_rule_count=applied_rule_count,
+        reason=None if not rejected_rule_ids else "decision_memory_rule_rejected",
+        rejected_rule_ids=rejected_rule_ids,
+    )
+    store.set_sync_payload(_GUARD_REVIEW_MEMORY_ACK_SYNC_KEY, ack, generated_at)
     return _result(
         {
             "action": "policy_sync",
-            "decision": decision.to_dict(),
+            "bundleHash": _optional_string(bundle.get("bundleHash")),
+            "bundleVersion": _optional_string(bundle.get("bundleVersion")),
+            "decisionMemoryAck": ack,
             "localRequestId": _optional_string(payload.get("localRequestId")),
-            "status": "completed",
+            "status": str(ack["status"]),
         },
         generated_at=generated_at,
     )
@@ -313,6 +399,7 @@ def _local_policy_scope(scope: str | None) -> DecisionScope:
 
 def _local_request_snapshot_items(store: GuardStore) -> list[dict[str, object]]:
     items: list[dict[str, object]] = []
+    oauth = guard_review_oauth_metadata(store)
     for status in ("pending", "resolved"):
         for item in store.list_approval_requests(status=status, limit=100):
             request_id = item.get("request_id")
@@ -321,8 +408,14 @@ def _local_request_snapshot_items(store: GuardStore) -> list[dict[str, object]]:
             created_at = str(item.get("created_at") or _now())
             last_seen_at = str(item.get("last_seen_at") or created_at)
             resolved_at = item.get("resolved_at")
+            claim = build_local_review_request_claim(
+                request_row=item,
+                oauth=oauth,
+                store=store,
+            )
             items.append(
                 {
+                    "claim": claim,
                     "localRequestId": request_id,
                     "requestKind": str(item.get("harness") or "guard-review"),
                     "requestPayload": dict(item),
@@ -358,6 +451,129 @@ def _package_shim_context(
         home_dir=base_context.home_dir,
         workspace_dir=workspace_dir or base_context.workspace_dir,
         guard_home=base_context.guard_home,
+    )
+
+
+def _payload_mapping(value: object) -> dict[str, object]:
+    return dict(value) if isinstance(value, dict) else {}
+
+
+def _stored_review_memory_policy_version(store: GuardStore) -> str | None:
+    payload = store.get_sync_payload(_GUARD_REVIEW_MEMORY_VERSION_SYNC_KEY)
+    if not isinstance(payload, dict):
+        return None
+    return _optional_string(payload.get("policyVersion"))
+
+
+def _stored_review_memory_registry(store: GuardStore) -> dict[str, dict[str, object]]:
+    payload = store.get_sync_payload(_GUARD_REVIEW_MEMORY_REGISTRY_SYNC_KEY)
+    if not isinstance(payload, list):
+        return {}
+    registry: dict[str, dict[str, object]] = {}
+    for item in payload:
+        if not isinstance(item, dict):
+            continue
+        rule_id = _optional_string(item.get("ruleId"))
+        decision = item.get("decision")
+        if rule_id is None or not isinstance(decision, dict):
+            continue
+        registry[rule_id] = {"decision": dict(decision), "ruleId": rule_id}
+    return registry
+
+
+def _existing_non_review_remote_policies(store: GuardStore) -> list[PolicyDecision]:
+    decisions: list[PolicyDecision] = []
+    for item in store.list_policy_decisions():
+        if item.get("source") in {"cloud-signed-memory"}:
+            continue
+        if item.get("source") not in {"cloud-sync", "team-policy", "policy-bundle"}:
+            continue
+        scope = _optional_string(item.get("scope"))
+        action = _optional_string(item.get("action"))
+        harness = _optional_string(item.get("harness"))
+        if scope is None or action is None or harness is None:
+            continue
+        decisions.append(
+            PolicyDecision(
+                harness=harness,
+                scope=scope,  # type: ignore[arg-type]
+                action=action,  # type: ignore[arg-type]
+                artifact_id=_optional_string(item.get("artifact_id")),
+                artifact_hash=_optional_string(item.get("artifact_hash")),
+                workspace=_optional_string(item.get("workspace")),
+                publisher=_optional_string(item.get("publisher")),
+                reason=_optional_string(item.get("reason")),
+                owner=_optional_string(item.get("owner")),
+                source=str(item.get("source") or "cloud-sync"),
+                expires_at=_optional_string(item.get("expires_at")),
+            )
+        )
+    return decisions
+
+
+def _decision_from_registry_entry(entry: dict[str, object]) -> PolicyDecision:
+    decision = entry.get("decision")
+    if not isinstance(decision, dict):
+        raise ValueError("invalid_decision_memory_registry")
+    harness = _optional_string(decision.get("harness"))
+    scope = _optional_string(decision.get("scope"))
+    action = _optional_string(decision.get("action"))
+    if harness is None or scope is None or action is None:
+        raise ValueError("invalid_decision_memory_registry")
+    return PolicyDecision(
+        harness=harness,
+        scope=scope,  # type: ignore[arg-type]
+        action=action,  # type: ignore[arg-type]
+        artifact_id=_optional_string(decision.get("artifact_id")),
+        artifact_hash=_optional_string(decision.get("artifact_hash")),
+        workspace=_optional_string(decision.get("workspace")),
+        publisher=_optional_string(decision.get("publisher")),
+        reason=_optional_string(decision.get("reason")),
+        owner=_optional_string(decision.get("owner")),
+        source=str(decision.get("source") or "cloud-signed-memory"),
+        expires_at=_optional_string(decision.get("expires_at")),
+    )
+
+
+def _decision_from_memory_rule(
+    *,
+    bundle: dict[str, object],
+    rule: dict[str, object],
+) -> PolicyDecision:
+    harness = _optional_string(rule.get("harnessId"))
+    artifact_id = _optional_string(rule.get("artifactId"))
+    action = _optional_string(rule.get("action"))
+    scope_value = _optional_string(rule.get("scope"))
+    if harness is None or artifact_id is None or action is None or scope_value is None:
+        raise GuardReviewContractError("invalid_decision_memory_rule")
+    if action == "allow" and scope_value not in {"artifact", "workspace"}:
+        raise GuardReviewContractError("decision_memory_allow_scope_unsupported")
+    scope = _local_policy_scope(scope_value)
+    target = rule.get("target")
+    target_payload = target if isinstance(target, dict) else {}
+    workspace_ids = target_payload.get("workspaceIds")
+    workspace = _optional_string(bundle.get("workspaceId"))
+    if scope == "workspace" and isinstance(workspace_ids, list):
+        workspace = next(
+            (
+                candidate
+                for candidate in (_optional_string(item) for item in workspace_ids)
+                if candidate is not None
+            ),
+            workspace,
+        )
+    return PolicyDecision(
+        harness=harness,
+        scope=scope,
+        action=action,  # type: ignore[arg-type]
+        artifact_id=artifact_id,
+        artifact_hash=_optional_string(rule.get("artifactHash")),
+        workspace=workspace if scope == "workspace" else None,
+        publisher=None,
+        reason=_optional_string(rule.get("reason")) or "Guard Cloud signed decision memory sync",
+        owner=None,
+        source="cloud-signed-memory",
+        expires_at=_optional_string(rule.get("expiresAt")),
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -286,13 +286,19 @@ def _execute_approval_operation(
     ):
         raise ValueError("remote_approval_replayed")
     resolution_action = "allow" if action == "allow_once" else "block"
-    result = store.resolve_request_with_signed_remote_result(
-        local_request_id,
-        resolution_action=resolution_action,
-        resolution_scope="artifact",
-        reason=_optional_string(payload.get("reason")) or "Guard Cloud signed remote approval",
-        resolved_at=generated_at,
-    )
+    try:
+        result = store.resolve_request_with_signed_remote_result(
+            local_request_id,
+            resolution_action=resolution_action,
+            resolution_scope="artifact",
+            reason=_optional_string(payload.get("reason")) or "Guard Cloud signed remote approval",
+            resolved_at=generated_at,
+        )
+    except Exception:
+        store.release_remote_once_receipt(receipt_id)
+        raise
+    if result.get("resolved") is not True:
+        store.release_remote_once_receipt(receipt_id)
     return _result(
         {
             "action": action,
@@ -358,15 +364,17 @@ def _execute_policy_sync(
         list(registry.values()),
         generated_at,
     )
-    store.set_sync_payload(
-        _GUARD_REVIEW_MEMORY_VERSION_SYNC_KEY,
-        {"policyVersion": _optional_string(bundle.get("policyVersion"))},
-        generated_at,
-    )
+    ack_status = "accepted" if not rejected_rule_ids else "rejected"
+    if ack_status == "accepted":
+        store.set_sync_payload(
+            _GUARD_REVIEW_MEMORY_VERSION_SYNC_KEY,
+            {"policyVersion": _optional_string(bundle.get("policyVersion"))},
+            generated_at,
+        )
     ack = build_decision_memory_ack(
         bundle=bundle,
         oauth=oauth,
-        status="accepted" if not rejected_rule_ids else "rejected",
+        status=ack_status,
         applied_rule_count=applied_rule_count,
         reason=None if not rejected_rule_ids else "decision_memory_rule_rejected",
         rejected_rule_ids=rejected_rule_ids,

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -348,10 +348,7 @@ def _execute_policy_sync(
     store.replace_remote_policies(
         [
             *_existing_non_review_remote_policies(store),
-            *[
-                _decision_from_registry_entry(entry)
-                for entry in registry.values()
-            ],
+            *[_decision_from_registry_entry(entry) for entry in registry.values()],
         ],
         generated_at,
         remote_write_authorized=True,
@@ -563,11 +560,7 @@ def _decision_from_memory_rule(
     workspace = _optional_string(bundle.get("workspaceId"))
     if scope == "workspace" and isinstance(workspace_ids, list):
         workspace = next(
-            (
-                candidate
-                for candidate in (_optional_string(item) for item in workspace_ids)
-                if candidate is not None
-            ),
+            (candidate for candidate in (_optional_string(item) for item in workspace_ids) if candidate is not None),
             workspace,
         )
     return PolicyDecision(

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -320,10 +320,7 @@ def _retry_pending_result(
         _save_state(store, state)
         return False
     if _pending_result_is_stale(job):
-        _LOGGER.warning(
-            "Guard command dropped stale pending result: job_id=%s",
-            job.get("id", "unknown"),
-        )
+        _LOGGER.warning("Guard command dropped stale pending result.")
         state.pop("pending_result", None)
         state.pop("active_job", None)
         state["state"] = "idle"

--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -3946,6 +3946,25 @@ class GuardStore:
                 resolved_at=resolved_at,
             )
 
+    def resolve_request_with_signed_remote_result(
+        self,
+        request_id: str,
+        *,
+        resolution_action: str,
+        resolution_scope: str,
+        reason: str | None,
+        resolved_at: str,
+    ) -> dict[str, object]:
+        with self._connect() as connection:
+            return persist_queue_resolution(
+                connection,
+                request_id,
+                resolution_action=resolution_action,
+                resolution_scope=resolution_scope,
+                reason=reason,
+                resolved_at=resolved_at,
+            )
+
     def resolve_matching_approval_requests(
         self,
         *,

--- a/tests/guard_review_signing_helpers.py
+++ b/tests/guard_review_signing_helpers.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import base64
+
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
+
+from codex_plugin_scanner.guard import review_contracts as review_contracts_module
+from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
+    policy_bundle_keyring_payload,
+    policy_bundle_verification_key_from_public_key,
+)
+
+REVIEW_SIGNING_KEY_ID = "guard-review-test-key"
+_REVIEW_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_REVIEW_PUBLIC_KEY_PEM = (
+    _REVIEW_PRIVATE_KEY.public_key()
+    .public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode("utf-8")
+    .strip()
+)
+
+
+def review_verification_keys() -> list[dict[str, object]]:
+    return [
+        policy_bundle_verification_key_from_public_key(
+            key_id=REVIEW_SIGNING_KEY_ID,
+            public_key_pem=_REVIEW_PUBLIC_KEY_PEM,
+        ).to_dict()
+    ]
+
+
+def review_trusted_keyring_payload(
+    *,
+    workspace_id: str | None = "workspace-1",
+) -> dict[str, object]:
+    return policy_bundle_keyring_payload(
+        tuple(
+            policy_bundle_verification_key_from_public_key(
+                key_id=item["keyId"],
+                public_key_pem=str(item["publicKeyPem"]),
+                state=str(item["state"]),
+                valid_until=str(item["validUntil"]) if item["validUntil"] is not None else None,
+            )
+            for item in review_verification_keys()
+        ),
+        workspace_id=workspace_id,
+    )
+
+
+def sign_review_payload(payload: dict[str, object]) -> str:
+    signature = _REVIEW_PRIVATE_KEY.sign(
+        review_contracts_module._canonical_signed_payload(payload).encode("utf-8"),
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.DIGEST_LENGTH),
+        hashes.SHA256(),
+    )
+    return base64.b64encode(signature).decode("ascii")

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
 import json
+import base64
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -14,9 +18,37 @@ from codex_plugin_scanner.guard.daemon.command_queue_worker import (
     CommandQueueWorker,
     start_command_queue_worker,
 )
+from codex_plugin_scanner.guard import store as guard_store_module
+from codex_plugin_scanner.guard import review_contracts as review_contracts_module
+from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
+    policy_bundle_verification_key_from_public_key,
+)
+from codex_plugin_scanner.guard.review_contracts import (
+    build_local_review_request_claim,
+    guard_review_oauth_metadata,
+    payload_hash_for_decision_memory_bundle,
+    payload_hash_for_remote_approval_envelope,
+)
 from codex_plugin_scanner.guard.runtime import command_executors, command_queue
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
+
+_REVIEW_SIGNING_KEY_ID = "guard-review-test-key"
+_REVIEW_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_REVIEW_PUBLIC_KEY_PEM = (
+    _REVIEW_PRIVATE_KEY.public_key()
+    .public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode("utf-8")
+    .strip()
+)
+
+
+@pytest.fixture(autouse=True)
+def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
 
 
 class FakeStore:
@@ -41,8 +73,204 @@ class FakeStore:
         return {
             "grant_id": "grant-1",
             "machine_id": "machine-1",
+            "runtime_id": "runtime-1",
             "workspace_id": "workspace-1",
         }
+
+    def get_or_create_installation_id(self) -> str:
+        return "22222222-2222-4222-8222-222222222222"
+
+    def get_guard_operation_for_approval_request(self, request_id: str) -> dict[str, object]:
+        return {
+            "operation_id": request_id,
+            "metadata": {"workspace_path": "/workspace/repo"},
+        }
+
+    def get_approval_request(self, request_id: str) -> dict[str, object] | None:
+        del request_id
+        return None
+
+    def claim_remote_once_receipt(
+        self,
+        receipt_id: str,
+        *,
+        request_id: str,
+        claimed_at: str,
+    ) -> bool:
+        del receipt_id, request_id, claimed_at
+        return True
+
+    def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]:
+        del harness
+        return []
+
+    def replace_remote_policies(
+        self,
+        decisions,
+        generated_at: str,
+        *,
+        remote_write_authorized: bool = False,
+    ) -> None:
+        del decisions, generated_at, remote_write_authorized
+
+
+def _review_verification_keys() -> list[dict[str, object]]:
+    return [
+        policy_bundle_verification_key_from_public_key(
+            key_id=_REVIEW_SIGNING_KEY_ID,
+            public_key_pem=_REVIEW_PUBLIC_KEY_PEM,
+        ).to_dict()
+    ]
+
+
+def _sign_review_payload(payload: dict[str, object]) -> str:
+    signature = _REVIEW_PRIVATE_KEY.sign(
+        review_contracts_module._canonical_signed_payload(payload).encode("utf-8"),
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.DIGEST_LENGTH),
+        hashes.SHA256(),
+    )
+    return base64.b64encode(signature).decode("ascii")
+
+
+def _approval_request_row(
+    request_id: str,
+    *,
+    artifact_id: str = "plugin:hol/deploy",
+    artifact_hash: str = "b" * 64,
+    harness: str = "cursor",
+    policy_action: str = "require-reapproval",
+    recommended_scope: str = "artifact",
+) -> dict[str, object]:
+    return {
+        "request_id": request_id,
+        "status": "pending",
+        "harness": harness,
+        "artifact_id": artifact_id,
+        "artifact_hash": artifact_hash,
+        "policy_action": policy_action,
+        "recommended_scope": recommended_scope,
+        "created_at": "2026-05-14T11:58:00.000Z",
+        "last_seen_at": "2026-05-14T11:59:00.000Z",
+        "queue_group_id": "queue-group-1",
+        "action_envelope_json": {
+            "action_type": "shell_command",
+            "command": "cat /workspace/repo/.npmrc",
+            "tool_name": "Bash",
+        },
+    }
+
+
+def _signed_remote_approval(
+    store: FakeStore,
+    request_row: dict[str, object],
+    *,
+    decision: str = "allow_once",
+    receipt_id: str = "cloud-receipt-1",
+) -> dict[str, object]:
+    oauth = guard_review_oauth_metadata(store)
+    claim = build_local_review_request_claim(
+        request_row=request_row,
+        oauth=oauth,
+        store=store,
+    )
+    issued_at = datetime.now(timezone.utc).replace(microsecond=0)
+    expires_at = issued_at + timedelta(minutes=5)
+    envelope = {
+        "actionEnvelopeHash": claim["actionEnvelopeHash"],
+        "approvalId": claim["approvalId"],
+        "capabilityCategory": claim["capabilityCategory"],
+        "contractVersion": "guard.remote-approval.v1",
+        "decision": decision,
+        "decisionId": receipt_id,
+        "deviceId": claim["deviceId"],
+        "expiresAt": expires_at.isoformat(),
+        "harnessId": claim["harnessId"],
+        "issuedAt": issued_at.isoformat(),
+        "localRequestId": claim["localRequestId"],
+        "machineId": claim["machineId"],
+        "machineInstallationId": claim["machineInstallationId"],
+        "nonce": f"{claim['nonce']}:{receipt_id}",
+        "policyVersion": claim["policyVersion"],
+        "projectIdentity": claim["projectIdentity"],
+        "keyId": _REVIEW_SIGNING_KEY_ID,
+        "receiptId": receipt_id,
+        "reviewerRole": "workspace-owner",
+        "reviewerUserId": "user-1",
+        "riskCategory": claim["riskCategory"],
+        "runtimeGrantId": claim["runtimeGrantId"],
+        "scope": "artifact",
+        "sourceClaimHash": claim["claimHash"],
+        "stepUpChallengeId": None,
+        "workspaceId": claim["workspaceId"],
+        "verificationKeys": _review_verification_keys(),
+        "signatureAlgorithm": "rsa-pss-sha256",
+    }
+    envelope["payloadHash"] = payload_hash_for_remote_approval_envelope(envelope)
+    envelope["signature"] = _sign_review_payload(envelope)
+    return envelope
+
+
+def _signed_decision_memory_bundle(
+    store: FakeStore,
+    *,
+    rule_scope: str = "workspace",
+    action: str = "allow",
+    rule_id: str = "review-memory:receipt-1",
+    policy_version: str = "policy-version-2",
+) -> dict[str, object]:
+    oauth = guard_review_oauth_metadata(store)
+    issued_at = datetime.now(timezone.utc).replace(microsecond=0)
+    expires_at = issued_at + timedelta(days=30)
+    bundle = {
+        "blastRadius": {
+            "artifactCount": 1,
+            "machineCount": 1,
+            "workspaceCount": 1,
+        },
+        "bundleVersion": rule_id,
+        "contractVersion": "guard.decision-memory-bundle.v1",
+        "expiresAt": expires_at.isoformat(),
+        "issuedAt": issued_at.isoformat(),
+        "issuerKeyId": _REVIEW_SIGNING_KEY_ID,
+        "memoryRules": [
+            {
+                "action": action,
+                "approvalId": "approval-1",
+                "artifactHash": "b" * 64,
+                "artifactId": "plugin:hol/deploy",
+                "capabilityCategory": "tool-call",
+                "expiresAt": expires_at.isoformat(),
+                "harnessId": "cursor",
+                "projectIdentity": "project:/workspace/repo",
+                "reason": "Approved in cloud.",
+                "recommendedScope": "artifact",
+                "riskCategory": "medium",
+                "ruleId": rule_id,
+                "scope": rule_scope,
+                "sourceReceiptIds": ["receipt-1"],
+                "target": {
+                    "machineIds": [oauth.installation_id],
+                    "workspaceIds": [oauth.workspace_id],
+                },
+            }
+        ],
+        "policyVersion": policy_version,
+        "revocations": [],
+        "scope": "workspace",
+        "scopeEvidence": {
+            "approvalIds": ["approval-1"],
+            "sourceReceiptHashes": ["c" * 64],
+            "sourceReceiptIds": ["receipt-1"],
+        },
+        "verificationKeys": _review_verification_keys(),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "workspaceId": oauth.workspace_id,
+    }
+    payload_hash = payload_hash_for_decision_memory_bundle(bundle)
+    bundle["bundleHash"] = payload_hash
+    bundle["payloadHash"] = payload_hash
+    bundle["signature"] = _sign_review_payload(bundle)
+    return bundle
 
     def list_approval_requests(
         self,
@@ -1040,8 +1268,29 @@ def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
             self.resolved: list[dict[str, object]] = []
+            self.claimed_receipts: list[dict[str, str]] = []
+            self.request_row = _approval_request_row("request-1")
 
-        def resolve_request_with_queue_result(
+        def get_approval_request(self, request_id: str) -> dict[str, object] | None:
+            return self.request_row if request_id == "request-1" else None
+
+        def claim_remote_once_receipt(
+            self,
+            receipt_id: str,
+            *,
+            request_id: str,
+            claimed_at: str,
+        ) -> bool:
+            self.claimed_receipts.append(
+                {
+                    "receipt_id": receipt_id,
+                    "request_id": request_id,
+                    "claimed_at": claimed_at,
+                }
+            )
+            return True
+
+        def resolve_request_with_signed_remote_result(
             self,
             request_id: str,
             *,
@@ -1062,10 +1311,16 @@ def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:
             return {"resolved": True, "resolved_request": {"request_id": request_id}}
 
     store = ApprovalStore(tmp_path / "guard-home")
+    remote_approval = _signed_remote_approval(store, store.request_row)
     result = command_executors.execute_guard_command_job(
         {
             "operation": "guard.approval.resolve",
-            "payload": {"localRequestId": "request-1", "action": "allow_once", "scope": "artifact"},
+            "payload": {
+                "localRequestId": "request-1",
+                "action": "allow_once",
+                "remoteApproval": remote_approval,
+                "scope": "artifact",
+            },
         },
         context=_context(tmp_path),
         store=store,  # type: ignore[arg-type]
@@ -1079,8 +1334,15 @@ def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:
             "request_id": "request-1",
             "resolution_action": "allow",
             "resolution_scope": "artifact",
-            "reason": "Guard Cloud approval command",
+            "reason": "Guard Cloud signed remote approval",
             "resolved_at": "2026-06-13T00:00:00+00:00",
+        }
+    ]
+    assert store.claimed_receipts == [
+        {
+            "receipt_id": "cloud-receipt-1",
+            "request_id": "request-1",
+            "claimed_at": "2026-06-13T00:00:00+00:00",
         }
     ]
 
@@ -1089,16 +1351,73 @@ def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
     class PolicyStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
-            self.upserts: list[tuple[dict[str, object], str, bool]] = []
+            self.policies: list[tuple[list[dict[str, object]], str, bool]] = []
 
-        def upsert_policy(
+        def replace_remote_policies(
             self,
-            decision: object,
+            decisions,
             generated_at: str,
             *,
             remote_write_authorized: bool = False,
         ) -> None:
-            self.upserts.append((decision.to_dict(), generated_at, remote_write_authorized))
+            self.policies.append(
+                ([decision.to_dict() for decision in decisions], generated_at, remote_write_authorized)
+            )
+
+    store = PolicyStore(tmp_path / "guard-home")
+    bundle = _signed_decision_memory_bundle(store)
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.approval.resolve",
+            "payload": {
+                "action": "policy_sync",
+                "decisionMemoryBundle": bundle,
+            },
+        },
+        context=_context(tmp_path),
+        store=store,  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["data"]["status"] == "accepted"
+    assert result["data"]["localRequestId"] is None
+    assert len(store.policies) == 1
+    persisted_rows, generated_at, remote_write_authorized = store.policies[0]
+    assert generated_at == "2026-06-13T00:00:00+00:00"
+    assert remote_write_authorized is True
+    assert len(persisted_rows) == 1
+    persisted = persisted_rows[0]
+    assert persisted["harness"] == "cursor"
+    assert persisted["scope"] == "workspace"
+    assert persisted["action"] == "allow"
+    assert persisted["artifact_id"] == "plugin:hol/deploy"
+    assert persisted["artifact_hash"] == "b" * 64
+    assert persisted["workspace"] == "workspace-1"
+    assert persisted["publisher"] is None
+    assert persisted["reason"] == "Approved in cloud."
+    assert persisted["owner"] is None
+    assert persisted["source"] == "cloud-signed-memory"
+    assert isinstance(persisted["expires_at"], str)
+    assert result["data"]["decisionMemoryAck"]["status"] == "accepted"
+
+
+def test_executor_rejects_overbroad_signed_allow_memory_rules(tmp_path: Path) -> None:
+    class PolicyStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.policies: list[tuple[list[dict[str, object]], str, bool]] = []
+
+        def replace_remote_policies(
+            self,
+            decisions,
+            generated_at: str,
+            *,
+            remote_write_authorized: bool = False,
+        ) -> None:
+            assert remote_write_authorized is True
+            self.policies.append(
+                ([decision.to_dict() for decision in decisions], generated_at, remote_write_authorized)
+            )
 
     store = PolicyStore(tmp_path / "guard-home")
     result = command_executors.execute_guard_command_job(
@@ -1106,15 +1425,13 @@ def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
             "operation": "guard.approval.resolve",
             "payload": {
                 "action": "policy_sync",
-                "policyMemory": {
-                    "scope": "workspace",
-                    "reason": "approved in cloud",
-                    "target": {
-                        "artifactId": "pkg:npm/react",
-                        "harness": "package-install",
-                        "workspaceId": "workspace-1",
-                    },
-                },
+                "decisionMemoryBundle": _signed_decision_memory_bundle(
+                    store,
+                    rule_scope="team",
+                    action="allow",
+                    rule_id="review-memory:receipt-team",
+                    policy_version="policy-version-3",
+                ),
             },
         },
         context=_context(tmp_path),
@@ -1122,64 +1439,6 @@ def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
         now=lambda: "2026-06-13T00:00:00+00:00",
     )
 
-    assert result["data"]["status"] == "completed"
-    assert result["data"]["localRequestId"] is None
-    assert store.upserts == [
-        (
-            {
-                "harness": "package-install",
-                "scope": "workspace",
-                "action": "allow",
-                "artifact_id": "pkg:npm/react",
-                "artifact_hash": None,
-                "workspace": "workspace-1",
-                "publisher": None,
-                "reason": "approved in cloud",
-                "owner": None,
-                "source": "cloud-sync",
-                "expires_at": None,
-            },
-            "2026-06-13T00:00:00+00:00",
-            True,
-        )
-    ]
-
-
-def test_executor_maps_unknown_cloud_policy_scope_to_artifact(tmp_path: Path) -> None:
-    class PolicyStore(FakeStore):
-        def __init__(self, guard_home: Path) -> None:
-            super().__init__(guard_home)
-            self.upserts: list[dict[str, object]] = []
-
-        def upsert_policy(
-            self,
-            decision: object,
-            generated_at: str,
-            *,
-            remote_write_authorized: bool = False,
-        ) -> None:
-            del generated_at
-            assert remote_write_authorized is True
-            self.upserts.append(decision.to_dict())
-
-    store = PolicyStore(tmp_path / "guard-home")
-    command_executors.execute_guard_command_job(
-        {
-            "operation": "guard.approval.resolve",
-            "payload": {
-                "action": "policy_sync",
-                "policyMemory": {
-                    "scope": "global",
-                    "target": {
-                        "artifactId": "pkg:npm/react",
-                        "harness": "package-install",
-                    },
-                },
-            },
-        },
-        context=_context(tmp_path),
-        store=store,  # type: ignore[arg-type]
-        now=lambda: "2026-06-13T00:00:00+00:00",
-    )
-
-    assert store.upserts[0]["scope"] == "artifact"
+    assert result["data"]["status"] == "rejected"
+    assert result["data"]["decisionMemoryAck"]["rejectedRuleIds"] == ["review-memory:receipt-team"]
+    assert store.policies == [([], "2026-06-13T00:00:00+00:00", True)]

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1532,6 +1532,80 @@ def test_executor_releases_remote_once_receipt_when_resolution_not_applied(tmp_p
     assert store.released_receipts == ["cloud-receipt-1"]
 
 
+def test_executor_uses_signed_remote_approval_decision_over_outer_payload(tmp_path: Path) -> None:
+    class ApprovalStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.resolved: list[dict[str, object]] = []
+            self.request_row = _approval_request_row("request-1")
+
+        def get_approval_request(self, request_id: str) -> dict[str, object] | None:
+            return self.request_row if request_id == "request-1" else None
+
+        def claim_remote_once_receipt(
+            self,
+            receipt_id: str,
+            *,
+            request_id: str,
+            claimed_at: str,
+        ) -> bool:
+            del receipt_id, request_id, claimed_at
+            return True
+
+        def resolve_request_with_signed_remote_result(
+            self,
+            request_id: str,
+            *,
+            resolution_action: str,
+            resolution_scope: str,
+            reason: str | None,
+            resolved_at: str,
+        ) -> dict[str, object]:
+            self.resolved.append(
+                {
+                    "request_id": request_id,
+                    "resolution_action": resolution_action,
+                    "resolution_scope": resolution_scope,
+                    "reason": reason,
+                    "resolved_at": resolved_at,
+                }
+            )
+            return {"resolved": True, "resolved_request": {"request_id": request_id}}
+
+    store = ApprovalStore(tmp_path / "guard-home")
+    remote_approval = _signed_remote_approval(
+        store,
+        store.request_row,
+        decision="block",
+        receipt_id="cloud-receipt-block",
+    )
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.approval.resolve",
+            "payload": {
+                "localRequestId": "request-1",
+                "action": "allow_once",
+                "remoteApproval": remote_approval,
+                "scope": "artifact",
+            },
+        },
+        context=_context(tmp_path),
+        store=store,  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["data"]["status"] == "completed"
+    assert store.resolved == [
+        {
+            "request_id": "request-1",
+            "resolution_action": "block",
+            "resolution_scope": "artifact",
+            "reason": "Guard Cloud signed remote approval",
+            "resolved_at": "2026-06-13T00:00:00+00:00",
+        }
+    ]
+
+
 def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
     class PolicyStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1556,6 +1556,56 @@ def test_executor_uses_signed_remote_approval_decision_over_outer_payload(tmp_pa
     ]
 
 
+def test_executor_releases_remote_once_receipt_on_invalid_signed_decision(tmp_path: Path) -> None:
+    class ApprovalStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.claimed_receipts: list[str] = []
+            self.released_receipts: list[str] = []
+            self.request_row = _approval_request_row("request-1")
+
+        def get_approval_request(self, request_id: str) -> dict[str, object] | None:
+            return self.request_row if request_id == "request-1" else None
+
+        def claim_remote_once_receipt(
+            self,
+            receipt_id: str,
+            *,
+            request_id: str,
+            claimed_at: str,
+        ) -> bool:
+            del request_id, claimed_at
+            self.claimed_receipts.append(receipt_id)
+            return True
+
+        def release_remote_once_receipt(self, receipt_id: str) -> None:
+            self.released_receipts.append(receipt_id)
+
+    store = ApprovalStore(tmp_path / "guard-home")
+    remote_approval = _signed_remote_approval(store, store.request_row)
+    remote_approval["decision"] = "future-decision"
+    remote_approval["payloadHash"] = payload_hash_for_remote_approval_envelope(remote_approval)
+    remote_approval["signature"] = sign_review_payload(remote_approval)
+
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.approval.resolve",
+            "payload": {
+                "localRequestId": "request-1",
+                "action": "allow_once",
+                "remoteApproval": remote_approval,
+            },
+        },
+        context=_context(tmp_path),
+        store=store,  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["failureCode"] == "invalid_remote_approval_decision"
+    assert store.claimed_receipts == ["cloud-receipt-1"]
+    assert store.released_receipts == ["cloud-receipt-1"]
+
+
 def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
     class PolicyStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -21,6 +21,7 @@ from codex_plugin_scanner.guard.daemon.command_queue_worker import (
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard import review_contracts as review_contracts_module
 from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
+    policy_bundle_keyring_payload,
     policy_bundle_verification_key_from_public_key,
 )
 from codex_plugin_scanner.guard.review_contracts import (
@@ -54,7 +55,9 @@ def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
 class FakeStore:
     def __init__(self, guard_home: Path) -> None:
         self.guard_home = guard_home
-        self.payloads: dict[str, dict[str, object] | list[object]] = {}
+        self.payloads: dict[str, dict[str, object] | list[object]] = {
+            "policy_bundle_keyring": _review_trusted_keyring_payload(),
+        }
 
     def get_sync_payload(self, key: str) -> dict[str, object] | list[object] | None:
         return self.payloads.get(key)
@@ -113,6 +116,18 @@ class FakeStore:
     ) -> None:
         del decisions, generated_at, remote_write_authorized
 
+    def list_approval_requests(
+        self,
+        *,
+        status: str | None = "pending",
+        harness: str | None = None,
+        limit: int | None = 50,
+        cursor: str | None = None,
+        search: str | None = None,
+    ) -> list[dict[str, object]]:
+        del status, harness, limit, cursor, search
+        return []
+
 
 def _review_verification_keys() -> list[dict[str, object]]:
     return [
@@ -121,6 +136,24 @@ def _review_verification_keys() -> list[dict[str, object]]:
             public_key_pem=_REVIEW_PUBLIC_KEY_PEM,
         ).to_dict()
     ]
+
+
+def _review_trusted_keyring_payload(
+    *,
+    workspace_id: str | None = "workspace-1",
+) -> dict[str, object]:
+    return policy_bundle_keyring_payload(
+        tuple(
+            policy_bundle_verification_key_from_public_key(
+                key_id=item["keyId"],
+                public_key_pem=str(item["publicKeyPem"]),
+                state=str(item["state"]),
+                valid_until=str(item["validUntil"]) if item["validUntil"] is not None else None,
+            )
+            for item in _review_verification_keys()
+        ),
+        workspace_id=workspace_id,
+    )
 
 
 def _sign_review_payload(payload: dict[str, object]) -> str:
@@ -272,18 +305,6 @@ def _signed_decision_memory_bundle(
     bundle["signature"] = _sign_review_payload(bundle)
     return bundle
 
-    def list_approval_requests(
-        self,
-        *,
-        status: str | None = "pending",
-        harness: str | None = None,
-        limit: int | None = 50,
-        cursor: str | None = None,
-        search: str | None = None,
-    ) -> list[dict[str, object]]:
-        del status, harness, limit, cursor, search
-        return []
-
 
 def _context(tmp_path: Path) -> HarnessContext:
     return HarnessContext(
@@ -313,6 +334,109 @@ def _oauth_store(tmp_path: Path) -> GuardStore:
         now="2026-06-13T00:00:00+00:00",
     )
     return store
+
+
+def test_guard_review_oauth_metadata_prefers_explicit_device_id(tmp_path: Path) -> None:
+    class DeviceStore(FakeStore):
+        def get_oauth_local_credentials(self, *, allow_primary: bool = False) -> dict[str, object]:
+            del allow_primary
+            return {
+                "device_id": "device-9",
+                "grant_id": "grant-1",
+                "machine_id": "machine-1",
+                "runtime_id": "runtime-1",
+                "workspace_id": "workspace-1",
+            }
+
+    oauth = guard_review_oauth_metadata(DeviceStore(tmp_path / "guard-home"))
+
+    assert oauth.device_id == "device-9"
+    assert oauth.machine_id == "machine-1"
+
+
+def test_local_request_snapshot_items_continues_without_oauth_metadata(tmp_path: Path) -> None:
+    class MissingOauthStore(FakeStore):
+        def get_oauth_local_credentials(self, *, allow_primary: bool = False) -> dict[str, object]:
+            del allow_primary
+            return {}
+
+        def list_approval_requests(
+            self,
+            *,
+            status: str | None = "pending",
+            harness: str | None = None,
+            limit: int | None = 50,
+            cursor: str | None = None,
+            search: str | None = None,
+        ) -> list[dict[str, object]]:
+            del harness, limit, cursor, search
+            if status == "pending":
+                return [_approval_request_row("req-no-oauth")]
+            return []
+
+    snapshot = command_executors._local_request_snapshot_items(MissingOauthStore(tmp_path / "guard-home"))
+
+    assert len(snapshot) == 1
+    assert snapshot[0]["localRequestId"] == "req-no-oauth"
+    assert snapshot[0]["claim"] is None
+
+
+def test_local_request_snapshot_items_continues_when_request_claim_is_invalid(tmp_path: Path) -> None:
+    class MalformedRequestStore(FakeStore):
+        def list_approval_requests(
+            self,
+            *,
+            status: str | None = "pending",
+            harness: str | None = None,
+            limit: int | None = 50,
+            cursor: str | None = None,
+            search: str | None = None,
+        ) -> list[dict[str, object]]:
+            del harness, limit, cursor, search
+            if status == "pending":
+                row = _approval_request_row("req-malformed")
+                row.pop("created_at", None)
+                return [row]
+            return []
+
+    snapshot = command_executors._local_request_snapshot_items(MalformedRequestStore(tmp_path / "guard-home"))
+
+    assert len(snapshot) == 1
+    assert snapshot[0]["localRequestId"] == "req-malformed"
+    assert snapshot[0]["claim"] is None
+
+
+def test_executor_rejects_remote_approval_without_trusted_keyring(tmp_path: Path) -> None:
+    class RequestStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.request_row = _approval_request_row("request-untrusted")
+
+        def get_approval_request(self, request_id: str) -> dict[str, object] | None:
+            return self.request_row if request_id == "request-untrusted" else None
+
+    store = RequestStore(tmp_path / "guard-home")
+    store.payloads["policy_bundle_keyring"] = {"contractVersion": "guard-policy-keyring.v1", "keys": []}
+
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.approval.resolve",
+            "payload": {
+                "action": "allow_once",
+                "localRequestId": "request-untrusted",
+                "remoteApproval": _signed_remote_approval(
+                    store,
+                    store.request_row,
+                    receipt_id="receipt-untrusted",
+                ),
+            },
+        },
+        context=_context(tmp_path),
+        store=store,  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["failureCode"] == "unknown_signing_key"
 
 
 def _block_local_daemon_client(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import json
 import base64
+import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
@@ -10,6 +10,8 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard import review_contracts as review_contracts_module
+from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.daemon import client as daemon_client_module
@@ -18,8 +20,6 @@ from codex_plugin_scanner.guard.daemon.command_queue_worker import (
     CommandQueueWorker,
     start_command_queue_worker,
 )
-from codex_plugin_scanner.guard import store as guard_store_module
-from codex_plugin_scanner.guard import review_contracts as review_contracts_module
 from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
     policy_bundle_keyring_payload,
     policy_bundle_verification_key_from_public_key,
@@ -102,6 +102,9 @@ class FakeStore:
     ) -> bool:
         del receipt_id, request_id, claimed_at
         return True
+
+    def release_remote_once_receipt(self, receipt_id: str) -> None:
+        del receipt_id
 
     def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]:
         del harness
@@ -1471,6 +1474,64 @@ def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:
     ]
 
 
+def test_executor_releases_remote_once_receipt_when_resolution_not_applied(tmp_path: Path) -> None:
+    class ApprovalStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.claimed_receipts: list[str] = []
+            self.released_receipts: list[str] = []
+            self.request_row = _approval_request_row("request-1")
+
+        def get_approval_request(self, request_id: str) -> dict[str, object] | None:
+            return self.request_row if request_id == "request-1" else None
+
+        def claim_remote_once_receipt(
+            self,
+            receipt_id: str,
+            *,
+            request_id: str,
+            claimed_at: str,
+        ) -> bool:
+            del request_id, claimed_at
+            self.claimed_receipts.append(receipt_id)
+            return True
+
+        def release_remote_once_receipt(self, receipt_id: str) -> None:
+            self.released_receipts.append(receipt_id)
+
+        def resolve_request_with_signed_remote_result(
+            self,
+            request_id: str,
+            *,
+            resolution_action: str,
+            resolution_scope: str,
+            reason: str | None,
+            resolved_at: str,
+        ) -> dict[str, object]:
+            del request_id, resolution_action, resolution_scope, reason, resolved_at
+            return {"resolved": False, "resolved_request": {}}
+
+    store = ApprovalStore(tmp_path / "guard-home")
+    remote_approval = _signed_remote_approval(store, store.request_row)
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.approval.resolve",
+            "payload": {
+                "localRequestId": "request-1",
+                "action": "allow_once",
+                "remoteApproval": remote_approval,
+            },
+        },
+        context=_context(tmp_path),
+        store=store,  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert result["data"]["status"] == "not_resolved"
+    assert store.claimed_receipts == ["cloud-receipt-1"]
+    assert store.released_receipts == ["cloud-receipt-1"]
+
+
 def test_executor_syncs_policy_without_local_request_id(tmp_path: Path) -> None:
     class PolicyStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
@@ -1566,3 +1627,4 @@ def test_executor_rejects_overbroad_signed_allow_memory_rules(tmp_path: Path) ->
     assert result["data"]["status"] == "rejected"
     assert result["data"]["decisionMemoryAck"]["rejectedRuleIds"] == ["review-memory:receipt-team"]
     assert store.policies == [([], "2026-06-13T00:00:00+00:00", True)]
+    assert store.get_sync_payload("guard_review_memory_policy_version") is None

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-import base64
 import json
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from codex_plugin_scanner.cli import main
-from codex_plugin_scanner.guard import review_contracts as review_contracts_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
@@ -19,10 +15,6 @@ from codex_plugin_scanner.guard.daemon import manager as daemon_manager_module
 from codex_plugin_scanner.guard.daemon.command_queue_worker import (
     CommandQueueWorker,
     start_command_queue_worker,
-)
-from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
-    policy_bundle_keyring_payload,
-    policy_bundle_verification_key_from_public_key,
 )
 from codex_plugin_scanner.guard.review_contracts import (
     build_local_review_request_claim,
@@ -33,17 +25,11 @@ from codex_plugin_scanner.guard.review_contracts import (
 from codex_plugin_scanner.guard.runtime import command_executors, command_queue
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
-
-_REVIEW_SIGNING_KEY_ID = "guard-review-test-key"
-_REVIEW_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-_REVIEW_PUBLIC_KEY_PEM = (
-    _REVIEW_PRIVATE_KEY.public_key()
-    .public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    .decode("utf-8")
-    .strip()
+from tests.guard_review_signing_helpers import (
+    REVIEW_SIGNING_KEY_ID,
+    review_trusted_keyring_payload,
+    review_verification_keys,
+    sign_review_payload,
 )
 
 
@@ -56,7 +42,7 @@ class FakeStore:
     def __init__(self, guard_home: Path) -> None:
         self.guard_home = guard_home
         self.payloads: dict[str, dict[str, object] | list[object]] = {
-            "policy_bundle_keyring": _review_trusted_keyring_payload(),
+            "policy_bundle_keyring": review_trusted_keyring_payload(),
         }
 
     def get_sync_payload(self, key: str) -> dict[str, object] | list[object] | None:
@@ -132,42 +118,6 @@ class FakeStore:
         return []
 
 
-def _review_verification_keys() -> list[dict[str, object]]:
-    return [
-        policy_bundle_verification_key_from_public_key(
-            key_id=_REVIEW_SIGNING_KEY_ID,
-            public_key_pem=_REVIEW_PUBLIC_KEY_PEM,
-        ).to_dict()
-    ]
-
-
-def _review_trusted_keyring_payload(
-    *,
-    workspace_id: str | None = "workspace-1",
-) -> dict[str, object]:
-    return policy_bundle_keyring_payload(
-        tuple(
-            policy_bundle_verification_key_from_public_key(
-                key_id=item["keyId"],
-                public_key_pem=str(item["publicKeyPem"]),
-                state=str(item["state"]),
-                valid_until=str(item["validUntil"]) if item["validUntil"] is not None else None,
-            )
-            for item in _review_verification_keys()
-        ),
-        workspace_id=workspace_id,
-    )
-
-
-def _sign_review_payload(payload: dict[str, object]) -> str:
-    signature = _REVIEW_PRIVATE_KEY.sign(
-        review_contracts_module._canonical_signed_payload(payload).encode("utf-8"),
-        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.DIGEST_LENGTH),
-        hashes.SHA256(),
-    )
-    return base64.b64encode(signature).decode("ascii")
-
-
 def _approval_request_row(
     request_id: str,
     *,
@@ -228,7 +178,7 @@ def _signed_remote_approval(
         "nonce": f"{claim['nonce']}:{receipt_id}",
         "policyVersion": claim["policyVersion"],
         "projectIdentity": claim["projectIdentity"],
-        "keyId": _REVIEW_SIGNING_KEY_ID,
+        "keyId": REVIEW_SIGNING_KEY_ID,
         "receiptId": receipt_id,
         "reviewerRole": "workspace-owner",
         "reviewerUserId": "user-1",
@@ -238,11 +188,11 @@ def _signed_remote_approval(
         "sourceClaimHash": claim["claimHash"],
         "stepUpChallengeId": None,
         "workspaceId": claim["workspaceId"],
-        "verificationKeys": _review_verification_keys(),
+        "verificationKeys": review_verification_keys(),
         "signatureAlgorithm": "rsa-pss-sha256",
     }
     envelope["payloadHash"] = payload_hash_for_remote_approval_envelope(envelope)
-    envelope["signature"] = _sign_review_payload(envelope)
+    envelope["signature"] = sign_review_payload(envelope)
     return envelope
 
 
@@ -267,7 +217,7 @@ def _signed_decision_memory_bundle(
         "contractVersion": "guard.decision-memory-bundle.v1",
         "expiresAt": expires_at.isoformat(),
         "issuedAt": issued_at.isoformat(),
-        "issuerKeyId": _REVIEW_SIGNING_KEY_ID,
+        "issuerKeyId": REVIEW_SIGNING_KEY_ID,
         "memoryRules": [
             {
                 "action": action,
@@ -298,14 +248,14 @@ def _signed_decision_memory_bundle(
             "sourceReceiptHashes": ["c" * 64],
             "sourceReceiptIds": ["receipt-1"],
         },
-        "verificationKeys": _review_verification_keys(),
+        "verificationKeys": review_verification_keys(),
         "signatureAlgorithm": "rsa-pss-sha256",
         "workspaceId": oauth.workspace_id,
     }
     payload_hash = payload_hash_for_decision_memory_bundle(bundle)
     bundle["bundleHash"] = payload_hash
     bundle["payloadHash"] = payload_hash
-    bundle["signature"] = _sign_review_payload(bundle)
+    bundle["signature"] = sign_review_payload(bundle)
     return bundle
 
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -10,12 +10,15 @@ import threading
 import time
 import urllib.error
 import urllib.request
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
+from codex_plugin_scanner.guard import review_contracts as review_contracts_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import ApprovalGateError
@@ -27,6 +30,15 @@ from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_tok
 from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
 from codex_plugin_scanner.guard.local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
+from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
+    policy_bundle_verification_key_from_public_key,
+)
+from codex_plugin_scanner.guard.review_contracts import (
+    build_local_review_request_claim,
+    guard_review_oauth_metadata,
+    payload_hash_for_decision_memory_bundle,
+    payload_hash_for_remote_approval_envelope,
+)
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.runtime.runner import (
     GuardSyncAuthorizationExpiredError,
@@ -35,6 +47,23 @@ from codex_plugin_scanner.guard.runtime.runner import (
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.test_guard_supply_chain_evaluator import WORKSPACE_ID, _bundle_response, _package
+
+_REVIEW_SIGNING_KEY_ID = "guard-review-test-key"
+_REVIEW_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+_REVIEW_PUBLIC_KEY_PEM = (
+    _REVIEW_PRIVATE_KEY.public_key()
+    .public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    )
+    .decode("utf-8")
+    .strip()
+)
+
+
+@pytest.fixture(autouse=True)
+def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
 
 
 @pytest.fixture(autouse=True)
@@ -218,6 +247,80 @@ def _dashboard_token_for(store: GuardStore) -> str:
     auth_token = load_guard_daemon_auth_token(store.guard_home)
     assert auth_token is not None
     return _dashboard_token(auth_token)
+
+
+def _review_verification_keys() -> list[dict[str, object]]:
+    return [
+        policy_bundle_verification_key_from_public_key(
+            key_id=_REVIEW_SIGNING_KEY_ID,
+            public_key_pem=_REVIEW_PUBLIC_KEY_PEM,
+        ).to_dict()
+    ]
+
+
+def _sign_review_payload(payload: dict[str, object]) -> str:
+    signature = _REVIEW_PRIVATE_KEY.sign(
+        review_contracts_module._canonical_signed_payload(payload).encode("utf-8"),
+        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.DIGEST_LENGTH),
+        hashes.SHA256(),
+    )
+    return base64.b64encode(signature).decode("ascii")
+
+
+def _signed_remote_approval_for_request(
+    store: GuardStore,
+    request_id: str,
+    *,
+    decision: str = "allow_once",
+    receipt_id: str = "cloud-receipt-1",
+    machine_installation_id: str | None = None,
+    machine_id: str | None = None,
+    device_id: str | None = None,
+    workspace_id: str | None = None,
+) -> dict[str, object]:
+    request_row = store.get_approval_request(request_id)
+    assert isinstance(request_row, dict)
+    oauth = guard_review_oauth_metadata(store)
+    claim = build_local_review_request_claim(
+        request_row=request_row,
+        oauth=oauth,
+        store=store,
+    )
+    issued_at = datetime.now(timezone.utc).replace(microsecond=0)
+    expires_at = issued_at + timedelta(minutes=5)
+    envelope = {
+        "actionEnvelopeHash": claim["actionEnvelopeHash"],
+        "approvalId": claim["approvalId"],
+        "capabilityCategory": claim["capabilityCategory"],
+        "contractVersion": "guard.remote-approval.v1",
+        "decision": decision,
+        "decisionId": receipt_id,
+        "deviceId": device_id or claim["deviceId"],
+        "expiresAt": expires_at.isoformat(),
+        "harnessId": claim["harnessId"],
+        "issuedAt": issued_at.isoformat(),
+        "keyId": _REVIEW_SIGNING_KEY_ID,
+        "localRequestId": claim["localRequestId"],
+        "machineId": machine_id or claim["machineId"],
+        "machineInstallationId": machine_installation_id or claim["machineInstallationId"],
+        "nonce": f"{claim['nonce']}:{receipt_id}",
+        "policyVersion": claim["policyVersion"],
+        "projectIdentity": claim["projectIdentity"],
+        "receiptId": receipt_id,
+        "reviewerRole": "workspace-owner",
+        "reviewerUserId": "user-1",
+        "riskCategory": claim["riskCategory"],
+        "runtimeGrantId": claim["runtimeGrantId"],
+        "scope": "artifact",
+        "sourceClaimHash": claim["claimHash"],
+        "stepUpChallengeId": None,
+        "verificationKeys": _review_verification_keys(),
+        "signatureAlgorithm": "rsa-pss-sha256",
+        "workspaceId": workspace_id or claim["workspaceId"],
+    }
+    envelope["payloadHash"] = payload_hash_for_remote_approval_envelope(envelope)
+    envelope["signature"] = _sign_review_payload(envelope)
+    return envelope
 
 
 def _install_local_package_shim(store: GuardStore, home_dir: Path, manager: str) -> None:
@@ -2166,13 +2269,10 @@ def test_headless_policy_sync_persists_policy_and_receipt(tmp_path: Path) -> Non
     finally:
         daemon.stop()
 
-    assert status == 200
-    assert payload["receipt"]["operation"] == "policy_sync"
-    decisions = store.list_policy_decisions(harness="codex")
-    assert decisions[0]["scope"] == "harness"
-    assert decisions[0]["action"] == "review"
-    assert decisions[0]["expires_at"] == "2099-01-01T00:00:00+00:00"
-    assert store.list_receipts(limit=5, harness="codex")
+    assert status == 400
+    assert payload["error"] == "unsupported_policy_memory_contract"
+    assert store.list_policy_decisions(harness="codex") == []
+    assert store.list_receipts(limit=5, harness="codex") == []
 
 
 def test_headless_policy_sync_accepts_policy_bundle_and_returns_bundle_metadata(tmp_path: Path) -> None:
@@ -2345,11 +2445,11 @@ def test_headless_policy_sync_rejects_global_allow_and_missing_scope_targets(
         daemon.stop()
 
     assert global_status == 400
-    assert global_payload["error"] == "broad_allow_requires_narrow_scope"
+    assert global_payload["error"] == "unsupported_policy_memory_contract"
     assert workspace_status == 400
-    assert workspace_payload["error"] == "missing_scope_target"
+    assert workspace_payload["error"] == "unsupported_policy_memory_contract"
     assert cloud_workspace_status == 400
-    assert cloud_workspace_payload["error"] == "missing_scope_target"
+    assert cloud_workspace_payload["error"] == "unsupported_policy_memory_contract"
     assert store.list_policy_decisions(harness="codex") == []
 
 
@@ -2400,7 +2500,7 @@ def test_headless_policy_sync_requires_explicit_scope_and_action(tmp_path: Path)
         daemon.stop()
 
     assert status == 400
-    assert payload["error"] == "missing_policy_fields"
+    assert payload["error"] == "unsupported_policy_memory_contract"
     assert store.list_policy_decisions(harness="codex") == []
 
 
@@ -2432,7 +2532,7 @@ def test_headless_policy_sync_rejects_malformed_expiry(tmp_path: Path) -> None:
         daemon.stop()
 
     assert status == 400
-    assert payload["error"] == "invalid_policy_expiry"
+    assert payload["error"] == "unsupported_policy_memory_contract"
     assert store.list_policy_decisions(harness="codex") == []
 
 
@@ -2471,12 +2571,18 @@ def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> No
 
 def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
     request = _remote_once_request("req-remote-once")
     store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
         token = _dashboard_token_for(store)
+        remote_approval = _signed_remote_approval_for_request(
+            store,
+            "req-remote-once",
+            receipt_id="cloud-receipt-1",
+        )
         status, payload = _read_json_response(
             _request(
                 daemon.port,
@@ -2485,15 +2591,7 @@ def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_pa
                 payload={
                     "harness": "codex",
                     "operation": "remote_once",
-                    "remote_once": json.dumps(
-                        {
-                            "receipt_id": "cloud-receipt-1",
-                            "request_id": "req-remote-once",
-                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
-                            "request_policy_action": "require-reapproval",
-                            "request_recommended_scope": "artifact",
-                        }
-                    ),
+                    "remoteApproval": json.dumps(remote_approval),
                 },
             ),
         )
@@ -2519,12 +2617,23 @@ def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_pa
 
 def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
     request = _remote_once_request("req-remote-replay")
     store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
         token = _dashboard_token_for(store)
+        stale_remote_approval = _signed_remote_approval_for_request(
+            store,
+            "req-remote-replay",
+            receipt_id="cloud-receipt-stale",
+        )
+        stale_remote_approval["actionEnvelopeHash"] = "f" * 64
+        stale_remote_approval["payloadHash"] = payload_hash_for_remote_approval_envelope(
+            stale_remote_approval
+        )
+        stale_remote_approval["signature"] = _sign_review_payload(stale_remote_approval)
         stale_status, stale_payload = _read_json_response(
             _request(
                 daemon.port,
@@ -2533,17 +2642,14 @@ def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path)
                 payload={
                     "harness": "codex",
                     "operation": "remote_once",
-                    "remote_once": json.dumps(
-                        {
-                            "receipt_id": "cloud-receipt-stale",
-                            "request_id": "req-remote-replay",
-                            "request_last_seen_at": "2026-05-14T11:58:00+00:00",
-                            "request_policy_action": "require-reapproval",
-                            "request_recommended_scope": "artifact",
-                        }
-                    ),
+                    "remoteApproval": json.dumps(stale_remote_approval),
                 },
             ),
+        )
+        valid_remote_approval = _signed_remote_approval_for_request(
+            store,
+            "req-remote-replay",
+            receipt_id="cloud-receipt-replay",
         )
         first_status, _first_payload = _read_json_response(
             _request(
@@ -2553,15 +2659,7 @@ def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path)
                 payload={
                     "harness": "codex",
                     "operation": "remote_once",
-                    "remote_once": json.dumps(
-                        {
-                            "receipt_id": "cloud-receipt-replay",
-                            "request_id": "req-remote-replay",
-                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
-                            "request_policy_action": "require-reapproval",
-                            "request_recommended_scope": "artifact",
-                        }
-                    ),
+                    "remoteApproval": json.dumps(valid_remote_approval),
                 },
             ),
         )
@@ -2573,15 +2671,7 @@ def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path)
                 payload={
                     "harness": "codex",
                     "operation": "remote_once",
-                    "remote_once": json.dumps(
-                        {
-                            "receipt_id": "cloud-receipt-replay",
-                            "request_id": "req-remote-replay",
-                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
-                            "request_policy_action": "require-reapproval",
-                            "request_recommended_scope": "artifact",
-                        }
-                    ),
+                    "remoteApproval": json.dumps(valid_remote_approval),
                 },
             ),
         )
@@ -2597,6 +2687,7 @@ def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path)
 
 def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
     request = _remote_once_request(
         "req-remote-spoof",
         policy_action="block",
@@ -2607,6 +2698,11 @@ def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> 
     daemon.start()
     try:
         token = _dashboard_token_for(store)
+        remote_approval = _signed_remote_approval_for_request(
+            store,
+            "req-remote-spoof",
+            receipt_id="cloud-receipt-spoof",
+        )
         status, payload = _read_json_response(
             _request(
                 daemon.port,
@@ -2615,15 +2711,7 @@ def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> 
                 payload={
                     "harness": "codex",
                     "operation": "remote_once",
-                    "remote_once": json.dumps(
-                        {
-                            "receipt_id": "cloud-receipt-spoof",
-                            "request_id": "req-remote-spoof",
-                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
-                            "request_policy_action": "require-reapproval",
-                            "request_recommended_scope": "artifact",
-                        }
-                    ),
+                    "remoteApproval": json.dumps(remote_approval),
                 },
             ),
         )
@@ -2634,48 +2722,24 @@ def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> 
     assert payload["error"] == "remote_once_not_permitted"
 
 
-def test_headless_remote_once_keeps_claimed_receipts_consumed_after_gate_rejection(
+def test_headless_remote_once_rejects_wrong_target_and_does_not_apply(
     tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
     request = _remote_once_request("req-remote-gate")
     store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
-    monkeypatch.setattr(
-        daemon_server,
-        "apply_approval_resolution",
-        lambda **_kwargs: (_ for _ in ()).throw(
-            ApprovalGateError(
-                "approval_gate_interactive_required",
-                "Approval password is required from an interactive terminal.",
-            )
-        ),
-    )
     try:
         token = _dashboard_token_for(store)
-        first_status, first_payload = _read_json_response(
-            _request(
-                daemon.port,
-                "/v1/requests/remote-once",
-                token=token,
-                payload={
-                    "harness": "codex",
-                    "operation": "remote_once",
-                    "remote_once": json.dumps(
-                        {
-                            "receipt_id": "cloud-receipt-gate",
-                            "request_id": "req-remote-gate",
-                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
-                            "request_policy_action": "require-reapproval",
-                            "request_recommended_scope": "artifact",
-                        }
-                    ),
-                },
-            ),
+        remote_approval = _signed_remote_approval_for_request(
+            store,
+            "req-remote-gate",
+            receipt_id="cloud-receipt-gate",
+            machine_installation_id="99999999-9999-4999-8999-999999999999",
         )
-        second_status, second_payload = _read_json_response(
+        status, payload = _read_json_response(
             _request(
                 daemon.port,
                 "/v1/requests/remote-once",
@@ -2683,25 +2747,15 @@ def test_headless_remote_once_keeps_claimed_receipts_consumed_after_gate_rejecti
                 payload={
                     "harness": "codex",
                     "operation": "remote_once",
-                    "remote_once": json.dumps(
-                        {
-                            "receipt_id": "cloud-receipt-gate",
-                            "request_id": "req-remote-gate",
-                            "request_last_seen_at": "2026-05-14T11:59:00+00:00",
-                            "request_policy_action": "require-reapproval",
-                            "request_recommended_scope": "artifact",
-                        }
-                    ),
+                    "remoteApproval": json.dumps(remote_approval),
                 },
             ),
         )
     finally:
         daemon.stop()
 
-    assert first_status == 403
-    assert first_payload["error"] == "approval_gate_interactive_required"
-    assert second_status == 409
-    assert second_payload["error"] == "remote_once_replayed"
+    assert status == 409
+    assert payload["error"] == "remote_once_wrong_target"
 
 
 def test_headless_remote_once_keeps_claimed_receipts_consumed_after_apply_failure(
@@ -2709,29 +2763,31 @@ def test_headless_remote_once_keeps_claimed_receipts_consumed_after_apply_failur
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
     request = _remote_once_request("req-remote-unresolved")
     store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     monkeypatch.setattr(
-        daemon_server,
-        "apply_approval_resolution",
-        lambda **_kwargs: {"resolved": False, "error": "unexpected"},
+        store,
+        "resolve_request_with_signed_remote_result",
+        lambda request_id, **_kwargs: {
+            "resolved": False,
+            "resolved_request": {"request_id": request_id},
+            "error": "unexpected",
+        },
     )
     try:
         token = _dashboard_token_for(store)
+        remote_approval = _signed_remote_approval_for_request(
+            store,
+            "req-remote-unresolved",
+            receipt_id="cloud-receipt-unresolved",
+        )
         payload = {
             "harness": "codex",
             "operation": "remote_once",
-            "remote_once": json.dumps(
-                {
-                    "receipt_id": "cloud-receipt-unresolved",
-                    "request_id": "req-remote-unresolved",
-                    "request_last_seen_at": "2026-05-14T11:59:00+00:00",
-                    "request_policy_action": "require-reapproval",
-                    "request_recommended_scope": "artifact",
-                }
-            ),
+            "remoteApproval": json.dumps(remote_approval),
         }
         first_status, first_payload = _read_json_response(
             _request(

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -14,11 +14,8 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
-from cryptography.hazmat.primitives import hashes, serialization
-from cryptography.hazmat.primitives.asymmetric import padding, rsa
 
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
-from codex_plugin_scanner.guard import review_contracts as review_contracts_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
@@ -29,10 +26,6 @@ from codex_plugin_scanner.guard.daemon.manager import load_guard_daemon_auth_tok
 from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payload
 from codex_plugin_scanner.guard.local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
-from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
-    policy_bundle_keyring_payload,
-    policy_bundle_verification_key_from_public_key,
-)
 from codex_plugin_scanner.guard.review_contracts import (
     build_local_review_request_claim,
     guard_review_oauth_metadata,
@@ -45,19 +38,13 @@ from codex_plugin_scanner.guard.runtime.runner import (
 )
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
-from tests.test_guard_supply_chain_evaluator import WORKSPACE_ID, _bundle_response, _package
-
-_REVIEW_SIGNING_KEY_ID = "guard-review-test-key"
-_REVIEW_PRIVATE_KEY = rsa.generate_private_key(public_exponent=65537, key_size=2048)
-_REVIEW_PUBLIC_KEY_PEM = (
-    _REVIEW_PRIVATE_KEY.public_key()
-    .public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
-    )
-    .decode("utf-8")
-    .strip()
+from tests.guard_review_signing_helpers import (
+    REVIEW_SIGNING_KEY_ID,
+    review_trusted_keyring_payload,
+    review_verification_keys,
+    sign_review_payload,
 )
+from tests.test_guard_supply_chain_evaluator import WORKSPACE_ID, _bundle_response, _package
 
 
 @pytest.fixture(autouse=True)
@@ -102,7 +89,7 @@ def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-to
     }
     store.set_sync_payload(
         "policy_bundle_keyring",
-        _review_trusted_keyring_payload(workspace_id=workspace_id),
+        review_trusted_keyring_payload(workspace_id=workspace_id),
         now,
     )
 
@@ -254,42 +241,6 @@ def _dashboard_token_for(store: GuardStore) -> str:
     return _dashboard_token(auth_token)
 
 
-def _review_verification_keys() -> list[dict[str, object]]:
-    return [
-        policy_bundle_verification_key_from_public_key(
-            key_id=_REVIEW_SIGNING_KEY_ID,
-            public_key_pem=_REVIEW_PUBLIC_KEY_PEM,
-        ).to_dict()
-    ]
-
-
-def _review_trusted_keyring_payload(
-    *,
-    workspace_id: str | None = "workspace-1",
-) -> dict[str, object]:
-    return policy_bundle_keyring_payload(
-        tuple(
-            policy_bundle_verification_key_from_public_key(
-                key_id=item["keyId"],
-                public_key_pem=str(item["publicKeyPem"]),
-                state=str(item["state"]),
-                valid_until=str(item["validUntil"]) if item["validUntil"] is not None else None,
-            )
-            for item in _review_verification_keys()
-        ),
-        workspace_id=workspace_id,
-    )
-
-
-def _sign_review_payload(payload: dict[str, object]) -> str:
-    signature = _REVIEW_PRIVATE_KEY.sign(
-        review_contracts_module._canonical_signed_payload(payload).encode("utf-8"),
-        padding.PSS(mgf=padding.MGF1(hashes.SHA256()), salt_length=padding.PSS.DIGEST_LENGTH),
-        hashes.SHA256(),
-    )
-    return base64.b64encode(signature).decode("ascii")
-
-
 def _signed_remote_approval_for_request(
     store: GuardStore,
     request_id: str,
@@ -322,7 +273,7 @@ def _signed_remote_approval_for_request(
         "expiresAt": expires_at.isoformat(),
         "harnessId": claim["harnessId"],
         "issuedAt": issued_at.isoformat(),
-        "keyId": _REVIEW_SIGNING_KEY_ID,
+        "keyId": REVIEW_SIGNING_KEY_ID,
         "localRequestId": claim["localRequestId"],
         "machineId": machine_id or claim["machineId"],
         "machineInstallationId": machine_installation_id or claim["machineInstallationId"],
@@ -337,12 +288,12 @@ def _signed_remote_approval_for_request(
         "scope": "artifact",
         "sourceClaimHash": claim["claimHash"],
         "stepUpChallengeId": None,
-        "verificationKeys": _review_verification_keys(),
+        "verificationKeys": review_verification_keys(),
         "signatureAlgorithm": "rsa-pss-sha256",
         "workspaceId": workspace_id or claim["workspaceId"],
     }
     envelope["payloadHash"] = payload_hash_for_remote_approval_envelope(envelope)
-    envelope["signature"] = _sign_review_payload(envelope)
+    envelope["signature"] = sign_review_payload(envelope)
     return envelope
 
 
@@ -2656,7 +2607,7 @@ def test_headless_remote_once_rejects_stale_requests_and_replays(tmp_path: Path)
         stale_remote_approval["payloadHash"] = payload_hash_for_remote_approval_envelope(
             stale_remote_approval
         )
-        stale_remote_approval["signature"] = _sign_review_payload(stale_remote_approval)
+        stale_remote_approval["signature"] = sign_review_payload(stale_remote_approval)
         stale_status, stale_payload = _read_json_response(
             _request(
                 daemon.port,

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -31,6 +31,7 @@ from codex_plugin_scanner.guard.daemon.server import _headless_action_error_payl
 from codex_plugin_scanner.guard.local_dashboard_session import LOCAL_DASHBOARD_SESSION_AUDIENCE
 from codex_plugin_scanner.guard.models import GuardApprovalRequest
 from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
+    policy_bundle_keyring_payload,
     policy_bundle_verification_key_from_public_key,
 )
 from codex_plugin_scanner.guard.review_contracts import (
@@ -100,6 +101,11 @@ def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-to
         "access_token": token,
         "dpop_key_material": None,
     }
+    store.set_sync_payload(
+        "policy_bundle_keyring",
+        _review_trusted_keyring_payload(workspace_id=workspace_id),
+        now,
+    )
 
 
 def _read_json_response_details(
@@ -256,6 +262,24 @@ def _review_verification_keys() -> list[dict[str, object]]:
             public_key_pem=_REVIEW_PUBLIC_KEY_PEM,
         ).to_dict()
     ]
+
+
+def _review_trusted_keyring_payload(
+    *,
+    workspace_id: str | None = "workspace-1",
+) -> dict[str, object]:
+    return policy_bundle_keyring_payload(
+        tuple(
+            policy_bundle_verification_key_from_public_key(
+                key_id=item["keyId"],
+                public_key_pem=str(item["publicKeyPem"]),
+                state=str(item["state"]),
+                valid_until=str(item["validUntil"]) if item["validUntil"] is not None else None,
+            )
+            for item in _review_verification_keys()
+        ),
+        workspace_id=workspace_id,
+    )
 
 
 def _sign_review_payload(payload: dict[str, object]) -> str:

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -71,11 +71,6 @@ def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
     )
 
 
-@pytest.fixture(autouse=True)
-def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(guard_store_module.sys, "platform", "linux")
-
-
 def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):
     """Seed OAuth credentials (replaces legacy set_sync_credentials scaffolding).
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -65,6 +65,12 @@ _REVIEW_PUBLIC_KEY_PEM = (
 @pytest.fixture(autouse=True)
 def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)
+    monkeypatch.setattr(
+        guard_runner_module,
+        "_test_sync_auth_context_override",
+        None,
+        raising=False,
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -21,7 +21,6 @@ from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_
 from codex_plugin_scanner.guard import review_contracts as review_contracts_module
 from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
-from codex_plugin_scanner.guard.approval_gate import ApprovalGateError
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
 from codex_plugin_scanner.guard.cli.connect_flow import GuardOAuthTokenExchangeResult
 from codex_plugin_scanner.guard.daemon import GuardDaemonServer
@@ -37,7 +36,6 @@ from codex_plugin_scanner.guard.policy_bundle_trusted_keys import (
 from codex_plugin_scanner.guard.review_contracts import (
     build_local_review_request_claim,
     guard_review_oauth_metadata,
-    payload_hash_for_decision_memory_bundle,
     payload_hash_for_remote_approval_envelope,
 )
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
@@ -2788,7 +2786,7 @@ def test_headless_remote_once_rejects_wrong_target_and_does_not_apply(
     assert payload["error"] == "remote_once_wrong_target"
 
 
-def test_headless_remote_once_keeps_claimed_receipts_consumed_after_apply_failure(
+def test_headless_remote_once_releases_claimed_receipts_after_apply_failure(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2840,8 +2838,9 @@ def test_headless_remote_once_keeps_claimed_receipts_consumed_after_apply_failur
 
     assert first_status == 409
     assert first_payload["error"] == "remote_once_apply_failed"
+    assert store.has_remote_once_receipt("cloud-receipt-unresolved") is False
     assert second_status == 409
-    assert second_payload["error"] == "remote_once_replayed"
+    assert second_payload["error"] == "remote_once_apply_failed"
 
 
 def test_headless_api_rejects_forged_dashboard_session_token(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- validate signed remote approval envelopes before resolving live review requests
- reject loose policy memory payloads and require signed decision memory bundles with local acknowledgements

## Testing
- `python3 -m pytest -q tests/test_guard_command_queue.py tests/test_guard_headless_daemon_api.py tests/test_guard_command_queue_stale_pending_result.py`
- `python3 -m compileall src/codex_plugin_scanner/guard`
