### PR TITLE
fix: avoid degrading passive macOS trust on shimmed keyring installs

### DIFF
--- a/src/codex_plugin_scanner/guard/store.py
+++ b/src/codex_plugin_scanner/guard/store.py
@@ -396,7 +396,7 @@ class SystemKeyringSecretStore:
 
     _MACOS_KEYCHAIN_HEALTH_CACHE_TTL_SECONDS = 5.0
     _macos_keychain_health_cache: tuple[float, bool] | None = None
-    _native_macos_security_reads_cache: tuple[int, bool] | None = None
+    _native_macos_security_reads_cache: tuple[tuple[int, int], bool] | None = None
 
     def __init__(self, service_name: str) -> None:
         self.service_name = service_name
@@ -639,20 +639,25 @@ class SystemKeyringSecretStore:
         if cls._test_keyring_module() is not None:
             return True
         loader_ref = cls._load_keyring_module
-        loader_id = id(loader_ref)
+        api_loader_ref = cls._load_macos_keyring_api_module
+        cache_key = (id(loader_ref), id(api_loader_ref))
         cached = cls._native_macos_security_reads_cache
-        if cached is not None and cached[0] == loader_id:
+        if cached is not None and cached[0] == cache_key:
             return cached[1]
         try:
             keyring_module = loader_ref()
         except Exception:
             keyring_module = None
         if keyring_module is None:
-            cls._native_macos_security_reads_cache = (loader_id, False)
+            cls._native_macos_security_reads_cache = (cache_key, False)
             return False
-        module_name = getattr(keyring_module, "__name__", "")
-        supported = module_name == "keyring"
-        cls._native_macos_security_reads_cache = (loader_id, supported)
+        try:
+            api_loader_ref()
+        except Exception:
+            supported = False
+        else:
+            supported = True
+        cls._native_macos_security_reads_cache = (cache_key, supported)
         return supported
 
     def _get_secret_without_macos_ui(self, secret_id: str) -> str | None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -239,6 +239,50 @@ def test_system_keyring_native_macos_read_uses_cfstr_decoder(
     assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "native-secret"
 
 
+def test_system_keyring_supports_native_macos_reads_with_nonstandard_keyring_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    module = _FakeSystemKeyringModule()
+    SystemKeyringSecretStore._native_macos_security_reads_cache = None
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_load_macos_keyring_api_module",
+        staticmethod(lambda: types.SimpleNamespace()),
+    )
+
+    assert SystemKeyringSecretStore._supports_native_macos_security_reads() is True
+
+
+def test_policy_integrity_timeout_uses_native_no_ui_path_with_nonstandard_keyring_module(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    module = _FakeSystemKeyringModule()
+    module._secrets[("hol-guard.policy-integrity", "policy-key")] = "native-secret"
+    SystemKeyringSecretStore._native_macos_security_reads_cache = None
+    monkeypatch.setattr(SystemKeyringSecretStore, "_load_keyring_module", staticmethod(lambda: module))
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_load_macos_keyring_api_module",
+        staticmethod(lambda: types.SimpleNamespace()),
+    )
+    secret_store = SystemKeyringSecretStore(service_name="hol-guard.policy-integrity")
+    monkeypatch.setattr(
+        secret_store,
+        "_get_secret_without_macos_ui",
+        lambda _secret_id: module.get_password("hol-guard.policy-integrity", _secret_id),
+    )
+    monkeypatch.setattr(
+        secret_store,
+        "get_secret",
+        lambda _secret_id: (_ for _ in ()).throw(AssertionError("Python keyring reads should not run")),
+    )
+
+    assert secret_store.get_secret_with_timeout("policy-key", timeout_seconds=1.0) == "native-secret"
+
+
 def test_system_keyring_timeout_blocks_non_policy_macos_prompt_fallback(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_guard_trust_cli_passive_backend.py
+++ b/tests/test_guard_trust_cli_passive_backend.py
@@ -121,6 +121,49 @@ def test_trust_cli_macos_native_status_reports_setup_required_when_passive_backe
     assert payload["passive_prompt_allowed"] is False
 
 
+def test_trust_cli_macos_native_status_uses_native_api_even_when_keyring_module_is_shimmed(
+    tmp_path: Path,
+    capsys,
+    monkeypatch: pytest.MonkeyPatch,
+    install_fake_system_keyring,
+) -> None:
+    fake_keyring = install_fake_system_keyring()
+    home_dir = tmp_path / "home"
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    SystemKeyringSecretStore._native_macos_security_reads_cache = None
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_load_macos_keyring_api_module",
+        staticmethod(lambda: object()),
+    )
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "_get_secret_without_macos_ui",
+        lambda self, secret_id: fake_keyring.get_password(self.service_name, secret_id),
+    )
+
+    rc = main(
+        [
+            "guard",
+            "trust",
+            "status",
+            "--backend",
+            "macos-native",
+            "--home",
+            str(home_dir),
+            "--json",
+        ]
+    )
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert payload["mode"] == "setup_required"
+    assert payload["backend_requested"] == "macos-native"
+    assert payload["backend_selected"] == "macos-native"
+    assert payload["setup_available"] is True
+    assert payload["passive_prompt_allowed"] is False
+
+
 def test_trust_cli_macos_native_test_stays_prompt_free_when_backend_is_unavailable(
     tmp_path: Path,
     capsys,


### PR DESCRIPTION
## Summary
- detect passive macOS native no-UI support by probing the native Security API loader instead of requiring the top-level module name to equal `keyring`
- keep the passive native-read capability cache keyed to both loader call sites
- add regressions for shimmed keyring modules in store and trust CLI coverage

## Testing
- python3 -m pytest tests/test_guard_store_migrations.py -k "nonstandard_keyring_module or native_macos_read_uses_cfstr_decoder or timeout_skips_all_passive_macos_reads" -q
- python3 -m pytest tests/test_guard_trust_cli_passive_backend.py -k "shimmed or setup_required_when_passive_backend_is_ready or unsupported_backend_status_without_prompt_error" -q
- python3 -m pytest tests/test_guard_policy_integrity.py -k "trust_cli_macos_native_setup_and_reset_work" -q
- python3 -m ruff check src/codex_plugin_scanner/guard/store.py tests/test_guard_store_migrations.py tests/test_guard_trust_cli_passive_backend.py