### PR TITLE
test: make approval gate suite host-platform agnostic

### DIFF
--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -15,6 +15,7 @@ from urllib.parse import parse_qs, urlparse
 import pytest
 from rich.console import Console
 
+from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import (
     ApprovalGateError,
@@ -47,6 +48,11 @@ from codex_plugin_scanner.guard.proxy.runtime_mcp import RuntimeMcpGuardProxy
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
 from codex_plugin_scanner.guard.totp import TotpSecretStore, _temporary_atomic_path, totp_code_at_counter
+
+
+@pytest.fixture(autouse=True)
+def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux")
 
 
 def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):


### PR DESCRIPTION
## Summary
- pin `tests/test_guard_approval_gate.py` to the Linux store platform so its OAuth seeding helper does not depend on the host macOS credential-store behavior
- keep approval-gate coverage focused on gate behavior instead of local keychain semantics that are already covered in the store migration suite

## Testing
- python3 -m pytest tests/test_guard_approval_gate.py -k "background_remote_policy_sync_fails_closed_without_crashing" -q
- python3 -m pytest tests/test_guard_policy_integrity.py tests/test_guard_trust_cli_passive_backend.py tests/test_guard_store_migrations.py tests/test_guard_approval_gate.py -q
- python3 -m ruff check tests/test_guard_approval_gate.py