### PR TITLE
test: isolate headless daemon host platform

### DIFF
--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -16,6 +16,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard import local_supply_chain as local_supply_chain_module
+from codex_plugin_scanner.guard import store as guard_store_module
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
 from codex_plugin_scanner.guard.approval_gate import ApprovalGateError
 from codex_plugin_scanner.guard.approval_gate import update_settings as update_approval_gate_settings
@@ -34,6 +35,11 @@ from codex_plugin_scanner.guard.runtime.runner import (
 from codex_plugin_scanner.guard.shims import install_package_shims
 from codex_plugin_scanner.guard.store import GuardStore
 from tests.test_guard_supply_chain_evaluator import WORKSPACE_ID, _bundle_response, _package
+
+
+@pytest.fixture(autouse=True)
+def _default_store_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(guard_store_module.sys, "platform", "linux")
 
 
 def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-token", now="2026-05-19T00:00:00Z"):


### PR DESCRIPTION
## Summary
- pin the headless daemon API suite to a Linux store platform so OAuth and Cloud-action tests stay host-platform agnostic
- keep the suite focused on daemon and approval behavior instead of local macOS credential-store semantics

## Testing
- `python3 -m pytest tests/test_guard_headless_daemon_api.py -k "supply_chain_package_firewall or guard_cloud_connect_starts_local_browser_flow_for_insights_share or headless_app_scan or supply_chain_audit_scans_workspace_manifests or supply_chain_dashboard_session_claims_scope_action_and_managers" -q`
- `python3 -m pytest tests/test_guard_policy_integrity.py tests/test_guard_trust_cli_passive_backend.py tests/test_guard_approval_gate.py tests/test_guard_headless_daemon_api.py tests/test_guard_approval_continuity.py tests/test_opencode_pretool.py -q`
- `python3 -m ruff check tests/test_guard_headless_daemon_api.py`
