### PR TITLE
fix(release): sync repository version after publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -356,7 +356,7 @@ jobs:
 
   sync-repository-version:
     name: Sync repository version
-    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip release publish]') && needs.build.result == 'success' && needs.publish-pypi.result == 'success'
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip release publish]') && needs.build.result == 'success' && needs.publish-pypi.result == 'success' && contains(fromJSON('["success","skipped"]'), needs.release.result) && contains(fromJSON('["success","skipped"]'), needs.publish-container.result)
     needs: [build, publish-pypi, release, publish-container]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -350,7 +350,7 @@ jobs:
 
   sync-repository-version:
     name: Sync repository version
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip release publish]')
+    if: always() && github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip release publish]') && needs.build.result == 'success' && needs.publish-pypi.result == 'success'
     needs: [build, publish-pypi, release, publish-container]
     runs-on: ubuntu-latest
     permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ concurrency:
 jobs:
   build:
     name: Build + Verify
+    if: github.event_name != 'push' || github.ref != 'refs/heads/main' || !contains(github.event.head_commit.message, '[skip release publish]')
     runs-on: ubuntu-latest
     outputs:
       version: ${{ steps.version.outputs.version }}
@@ -48,7 +49,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BASE_VERSION=$(python3 -c "import tomllib; p=tomllib.load(open('pyproject.toml','rb')); print(p['project']['version'])")
+          BASE_VERSION=$(python3 scripts/sync_repo_version.py --check)
           VERSION="$BASE_VERSION"
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
@@ -91,8 +92,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          sed -i "1,/^version = /{s/^version = .*/version = \"$VERSION\"/}" pyproject.toml
-          sed -i "1,/^__version__ = /{s/^__version__ = .*/__version__ = \"$VERSION\"/}" src/codex_plugin_scanner/version.py
+          python3 scripts/sync_repo_version.py --version "$VERSION"
       - name: Build Guard package (hol-guard)
         run: |
           cp pyproject.toml pyproject.toml.bak
@@ -319,8 +319,7 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          sed -i "1,/^version = /{s/^version = .*/version = \"$VERSION\"/}" pyproject.toml
-          sed -i "1,/^__version__ = /{s/^__version__ = .*/__version__ = \"$VERSION\"/}" src/codex_plugin_scanner/version.py
+          python3 scripts/sync_repo_version.py --version "$VERSION"
       - name: Prepare image tags
         id: tags
         env:
@@ -348,3 +347,41 @@ jobs:
             org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
             org.opencontainers.image.version=${{ needs.build.outputs.version }}
             org.opencontainers.image.revision=${{ github.sha }}
+
+  sync-repository-version:
+    name: Sync repository version
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' && !contains(github.event.head_commit.message, '[skip release publish]')
+    needs: [build, publish-pypi, release, publish-container]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+        with:
+          ref: main
+          fetch-depth: 0
+      - name: Prepare main branch
+        run: |
+          git checkout -B main origin/main
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - name: Sync repository version files
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          python3 scripts/sync_repo_version.py --version "$VERSION"
+      - name: Commit repository version
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          if git diff --quiet -- pyproject.toml src/codex_plugin_scanner/version.py; then
+            echo "Repository version already synced."
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add pyproject.toml src/codex_plugin_scanner/version.py
+          git commit -m "chore(release): sync repository version to ${VERSION} [skip release publish]"
+          git pull --rebase origin main
+          git push origin HEAD:main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -375,13 +375,13 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          if git diff --quiet -- pyproject.toml src/codex_plugin_scanner/version.py; then
+          if git diff --quiet -- pyproject.toml src/codex_plugin_scanner/version.py uv.lock; then
             echo "Repository version already synced."
             exit 0
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add pyproject.toml src/codex_plugin_scanner/version.py
+          git add pyproject.toml src/codex_plugin_scanner/version.py uv.lock
           git commit -m "chore(release): sync repository version to ${VERSION} [skip release publish]"
           git pull --rebase origin main
           git push origin HEAD:main

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -366,6 +366,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
+      - name: Install packaging
+        run: |
+          python3 -m pip install packaging
       - name: Sync repository version files
         env:
           VERSION: ${{ needs.build.outputs.version }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
           GITHUB_EVENT_NAME: ${{ github.event_name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          BASE_VERSION=$(python3 scripts/sync_repo_version.py --check)
+          BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
           VERSION="$BASE_VERSION"
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
@@ -92,7 +92,7 @@ jobs:
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
-          python3 scripts/sync_repo_version.py --version "$VERSION"
+          uv run --no-sync python scripts/sync_repo_version.py --version "$VERSION"
       - name: Build Guard package (hol-guard)
         run: |
           cp pyproject.toml pyproject.toml.bak
@@ -315,6 +315,12 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
+        with:
+          python-version: "3.12"
+      - name: Install packaging
+        run: |
+          python3 -m pip install packaging
       - name: Stamp package version
         env:
           VERSION: ${{ needs.build.outputs.version }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.764"
+version = "2.0.844"
 description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, OpenCode, and Pi."
 readme = "README.md"
 license = "Apache-2.0"

--- a/scripts/sync_repo_version.py
+++ b/scripts/sync_repo_version.py
@@ -105,7 +105,7 @@ def _replace_matching_line(line: str, pattern: re.Pattern[str], version: str) ->
     return f'{match.group("prefix")}{version}{match.group("suffix")}{line_ending}'
 
 
-def _replace_project_version(path: Path, version: str) -> bool:
+def _replace_project_version(path: Path, version: str) -> tuple[str, bool]:
     text = _read_text(path)
     lines = text.splitlines(keepends=True)
     in_project_table = False
@@ -130,13 +130,10 @@ def _replace_project_version(path: Path, version: str) -> bool:
         raise ValueError(f"Could not update [project].version in {path}")
 
     updated_text = "".join(lines)
-    if updated_text == text:
-        return False
-    path.write_text(updated_text, encoding="utf-8")
-    return True
+    return updated_text, updated_text != text
 
 
-def _replace_module_version(path: Path, version: str) -> bool:
+def _replace_module_version(path: Path, version: str) -> tuple[str, bool]:
     text = _read_text(path)
     lines = text.splitlines(keepends=True)
     module_version_index: int | None = None
@@ -152,14 +149,10 @@ def _replace_module_version(path: Path, version: str) -> bool:
         raise ValueError(f"Could not update module version line in {path}")
 
     updated_text = "".join(lines)
-    if updated_text == text:
-        return False
-    path.write_text(updated_text, encoding="utf-8")
-    return True
+    return updated_text, updated_text != text
 
 
-def _find_lockfile_version_index(path: Path) -> int:
-    lines = _read_text(path).splitlines(keepends=True)
+def _find_lockfile_version_index(lines: list[str], path: Path) -> int:
     in_package_block = False
     package_name_matches = False
     editable_source_matches = False
@@ -193,7 +186,7 @@ def _find_lockfile_version_index(path: Path) -> int:
 
 def _read_lockfile_version(path: Path) -> str:
     lines = _read_text(path).splitlines(keepends=True)
-    version_index = _find_lockfile_version_index(path)
+    version_index = _find_lockfile_version_index(lines, path)
     version_line = lines[version_index].rstrip("\r\n")
     match = PYPROJECT_VERSION_LINE_PATTERN.match(version_line)
     if match is None:
@@ -201,31 +194,33 @@ def _read_lockfile_version(path: Path) -> str:
     return match.group("version")
 
 
-def _replace_lockfile_version(path: Path, version: str) -> bool:
+def _replace_lockfile_version(path: Path, version: str) -> tuple[str, bool]:
     lines = _read_text(path).splitlines(keepends=True)
-    version_index = _find_lockfile_version_index(path)
+    version_index = _find_lockfile_version_index(lines, path)
     replaced_line = _replace_matching_line(lines[version_index], PYPROJECT_VERSION_LINE_PATTERN, version)
     if replaced_line == lines[version_index]:
-        return False
+        return "".join(lines), False
     lines[version_index] = replaced_line
-    path.write_text("".join(lines), encoding="utf-8")
-    return True
+    return "".join(lines), True
 
 
 def sync_repo_version(repo_root: Path, version: str) -> bool:
     normalized_version = _validate_version_token(version)
-    pyproject_changed = _replace_project_version(
-        repo_root / PYPROJECT_RELATIVE_PATH,
-        normalized_version,
-    )
-    module_changed = _replace_module_version(
-        repo_root / MODULE_RELATIVE_PATH,
-        normalized_version,
-    )
-    lockfile_changed = _replace_lockfile_version(
-        repo_root / LOCKFILE_RELATIVE_PATH,
-        normalized_version,
-    )
+    pyproject_path = repo_root / PYPROJECT_RELATIVE_PATH
+    module_path = repo_root / MODULE_RELATIVE_PATH
+    lockfile_path = repo_root / LOCKFILE_RELATIVE_PATH
+
+    pyproject_text, pyproject_changed = _replace_project_version(pyproject_path, normalized_version)
+    module_text, module_changed = _replace_module_version(module_path, normalized_version)
+    lockfile_text, lockfile_changed = _replace_lockfile_version(lockfile_path, normalized_version)
+
+    if pyproject_changed:
+        pyproject_path.write_text(pyproject_text, encoding="utf-8")
+    if module_changed:
+        module_path.write_text(module_text, encoding="utf-8")
+    if lockfile_changed:
+        lockfile_path.write_text(lockfile_text, encoding="utf-8")
+
     assert_repo_version(repo_root, normalized_version)
     return pyproject_changed or module_changed or lockfile_changed
 

--- a/scripts/sync_repo_version.py
+++ b/scripts/sync_repo_version.py
@@ -9,6 +9,8 @@ import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+from packaging.version import InvalidVersion, Version
+
 try:
     import tomllib
 except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
@@ -17,12 +19,11 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 PYPROJECT_RELATIVE_PATH = Path("pyproject.toml")
 MODULE_RELATIVE_PATH = Path("src/codex_plugin_scanner/version.py")
 LOCKFILE_RELATIVE_PATH = Path("uv.lock")
-VERSION_TOKEN_PATTERN = re.compile(r"^\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?$")
 PYPROJECT_VERSION_LINE_PATTERN = re.compile(
-    r'^(?P<prefix>\s*version\s*=\s*["\'])(?P<version>[^"\']+)(?P<suffix>["\']\s*)$'
+    r'^(?P<prefix>\s*version\s*=\s*["\'])(?P<version>[^"\']+)(?P<suffix>["\'](?:\s+#.*)?\s*)$'
 )
 MODULE_VERSION_LINE_PATTERN = re.compile(
-    r'^(?P<prefix>\s*__version__\s*=\s*["\'])(?P<version>[^"\']+)(?P<suffix>["\']\s*)$',
+    r'^(?P<prefix>\s*__version__\s*=\s*["\'])(?P<version>[^"\']+)(?P<suffix>["\'](?:\s+#.*)?\s*)$',
     re.MULTILINE,
 )
 
@@ -39,7 +40,9 @@ def _default_repo_root() -> Path:
 
 
 def _validate_version_token(version: str) -> str:
-    if not VERSION_TOKEN_PATTERN.fullmatch(version):
+    try:
+        Version(version)
+    except InvalidVersion:
         raise ValueError(f"Unsupported version format: {version}")
     return version
 

--- a/scripts/sync_repo_version.py
+++ b/scripts/sync_repo_version.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Keep repository version files aligned."""
+
+from __future__ import annotations
+
+import argparse
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+PYPROJECT_RELATIVE_PATH = Path("pyproject.toml")
+MODULE_RELATIVE_PATH = Path("src/codex_plugin_scanner/version.py")
+SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
+PYPROJECT_VERSION_PATTERN = re.compile(r'(?m)^version = "[^"]+"$')
+MODULE_VERSION_PATTERN = re.compile(r'(?m)^__version__ = "[^"]+"$')
+
+
+@dataclass(frozen=True)
+class RepoVersionState:
+    pyproject: str
+    module: str
+
+
+def _default_repo_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def _validate_semver(version: str) -> str:
+    if not SEMVER_PATTERN.fullmatch(version):
+        raise ValueError(f"Unsupported version format: {version}")
+    return version
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _extract_version(path: Path, pattern: re.Pattern[str], label: str) -> str:
+    match = pattern.search(_read_text(path))
+    if match is None:
+        raise ValueError(f"Could not find {label} version in {path}")
+    return match.group(0).split('"')[1]
+
+
+def read_repo_version_state(repo_root: Path) -> RepoVersionState:
+    return RepoVersionState(
+        pyproject=_extract_version(
+            repo_root / PYPROJECT_RELATIVE_PATH,
+            PYPROJECT_VERSION_PATTERN,
+            "pyproject",
+        ),
+        module=_extract_version(
+            repo_root / MODULE_RELATIVE_PATH,
+            MODULE_VERSION_PATTERN,
+            "module",
+        ),
+    )
+
+
+def assert_repo_version(repo_root: Path, expected_version: str | None = None) -> str:
+    if expected_version is not None:
+        _validate_semver(expected_version)
+    state = read_repo_version_state(repo_root)
+    if state.pyproject != state.module:
+        raise ValueError(
+            "Repository version mismatch: "
+            f"{PYPROJECT_RELATIVE_PATH} has {state.pyproject}, "
+            f"{MODULE_RELATIVE_PATH} has {state.module}"
+        )
+    if expected_version is not None and state.pyproject != expected_version:
+        raise ValueError(
+            "Repository version mismatch: "
+            f"expected {expected_version}, found {state.pyproject}"
+        )
+    return state.pyproject
+
+
+def _replace_single_line(path: Path, pattern: re.Pattern[str], replacement: str) -> bool:
+    text = _read_text(path)
+    updated_text, count = pattern.subn(replacement, text, count=1)
+    if count != 1:
+        raise ValueError(f"Could not update version line in {path}")
+    if updated_text == text:
+        return False
+    path.write_text(updated_text, encoding="utf-8")
+    return True
+
+
+def sync_repo_version(repo_root: Path, version: str) -> bool:
+    normalized_version = _validate_semver(version)
+    pyproject_changed = _replace_single_line(
+        repo_root / PYPROJECT_RELATIVE_PATH,
+        PYPROJECT_VERSION_PATTERN,
+        f'version = "{normalized_version}"',
+    )
+    module_changed = _replace_single_line(
+        repo_root / MODULE_RELATIVE_PATH,
+        MODULE_VERSION_PATTERN,
+        f'__version__ = "{normalized_version}"',
+    )
+    assert_repo_version(repo_root, normalized_version)
+    return pyproject_changed or module_changed
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--check",
+        action="store_true",
+        help="Validate that repository version files match and print the current version.",
+    )
+    mode.add_argument(
+        "--version",
+        help="Sync both repository version files to the supplied semantic version.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=_default_repo_root(),
+        help="Repository root to inspect. Defaults to the current hol-guard checkout.",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = _build_parser()
+    args = parser.parse_args()
+    repo_root = args.repo_root.resolve()
+    if args.version is not None:
+        sync_repo_version(repo_root, args.version)
+        print(_validate_semver(args.version))
+        return 0
+    current_version = assert_repo_version(repo_root)
+    print(current_version)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/sync_repo_version.py
+++ b/scripts/sync_repo_version.py
@@ -19,6 +19,7 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 PYPROJECT_RELATIVE_PATH = Path("pyproject.toml")
 MODULE_RELATIVE_PATH = Path("src/codex_plugin_scanner/version.py")
 LOCKFILE_RELATIVE_PATH = Path("uv.lock")
+TOML_TABLE_HEADER_PATTERN = re.compile(r"^\[[A-Za-z0-9_.-]+\]$")
 PYPROJECT_VERSION_LINE_PATTERN = re.compile(
     r'^(?P<prefix>\s*version\s*=\s*["\'])(?P<version>[^"\']+)(?P<suffix>["\'](?:\s+#.*)?\s*)$'
 )
@@ -119,7 +120,7 @@ def _replace_project_version(path: Path, version: str) -> tuple[str, bool]:
         if stripped == "[project]":
             in_project_table = True
             continue
-        if in_project_table and stripped.startswith("[") and stripped.endswith("]"):
+        if in_project_table and TOML_TABLE_HEADER_PATTERN.fullmatch(stripped):
             break
         if not in_project_table:
             continue

--- a/scripts/sync_repo_version.py
+++ b/scripts/sync_repo_version.py
@@ -5,14 +5,25 @@ from __future__ import annotations
 
 import argparse
 import re
+import sys
 from dataclasses import dataclass
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
+    import tomli as tomllib
+
 PYPROJECT_RELATIVE_PATH = Path("pyproject.toml")
 MODULE_RELATIVE_PATH = Path("src/codex_plugin_scanner/version.py")
-SEMVER_PATTERN = re.compile(r"^\d+\.\d+\.\d+$")
-PYPROJECT_VERSION_PATTERN = re.compile(r'(?m)^version = "[^"]+"$')
-MODULE_VERSION_PATTERN = re.compile(r'(?m)^__version__ = "[^"]+"$')
+VERSION_TOKEN_PATTERN = re.compile(r"^[0-9][0-9A-Za-z.+_-]*$")
+PYPROJECT_VERSION_LINE_PATTERN = re.compile(
+    r'^(?P<prefix>\s*version\s*=\s*["\'])(?P<version>[^"\']+)(?P<suffix>["\']\s*)$'
+)
+MODULE_VERSION_LINE_PATTERN = re.compile(
+    r'^(?P<prefix>\s*__version__\s*=\s*["\'])(?P<version>[^"\']+)(?P<suffix>["\']\s*)$',
+    re.MULTILINE,
+)
 
 
 @dataclass(frozen=True)
@@ -25,8 +36,8 @@ def _default_repo_root() -> Path:
     return Path(__file__).resolve().parents[1]
 
 
-def _validate_semver(version: str) -> str:
-    if not SEMVER_PATTERN.fullmatch(version):
+def _validate_version_token(version: str) -> str:
+    if not VERSION_TOKEN_PATTERN.fullmatch(version):
         raise ValueError(f"Unsupported version format: {version}")
     return version
 
@@ -35,23 +46,29 @@ def _read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
+def _read_pyproject_version(path: Path) -> str:
+    project = tomllib.loads(_read_text(path)).get("project")
+    if not isinstance(project, dict):
+        raise ValueError(f"Could not find [project] table in {path}")
+    version = project.get("version")
+    if not isinstance(version, str):
+        raise ValueError(f"Could not find [project].version in {path}")
+    return version
+
+
 def _extract_version(path: Path, pattern: re.Pattern[str], label: str) -> str:
     match = pattern.search(_read_text(path))
     if match is None:
         raise ValueError(f"Could not find {label} version in {path}")
-    return match.group(0).split('"')[1]
+    return match.group("version")
 
 
 def read_repo_version_state(repo_root: Path) -> RepoVersionState:
     return RepoVersionState(
-        pyproject=_extract_version(
-            repo_root / PYPROJECT_RELATIVE_PATH,
-            PYPROJECT_VERSION_PATTERN,
-            "pyproject",
-        ),
+        pyproject=_read_pyproject_version(repo_root / PYPROJECT_RELATIVE_PATH),
         module=_extract_version(
             repo_root / MODULE_RELATIVE_PATH,
-            MODULE_VERSION_PATTERN,
+            MODULE_VERSION_LINE_PATTERN,
             "module",
         ),
     )
@@ -59,7 +76,7 @@ def read_repo_version_state(repo_root: Path) -> RepoVersionState:
 
 def assert_repo_version(repo_root: Path, expected_version: str | None = None) -> str:
     if expected_version is not None:
-        _validate_semver(expected_version)
+        _validate_version_token(expected_version)
     state = read_repo_version_state(repo_root)
     if state.pyproject != state.module:
         raise ValueError(
@@ -75,11 +92,62 @@ def assert_repo_version(repo_root: Path, expected_version: str | None = None) ->
     return state.pyproject
 
 
-def _replace_single_line(path: Path, pattern: re.Pattern[str], replacement: str) -> bool:
+def _replace_matching_line(line: str, pattern: re.Pattern[str], version: str) -> str:
+    line_body = line.rstrip("\r\n")
+    line_ending = line[len(line_body) :]
+    match = pattern.match(line_body)
+    if match is None:
+        return line
+    return f'{match.group("prefix")}{version}{match.group("suffix")}{line_ending}'
+
+
+def _replace_project_version(path: Path, version: str) -> bool:
     text = _read_text(path)
-    updated_text, count = pattern.subn(replacement, text, count=1)
-    if count != 1:
-        raise ValueError(f"Could not update version line in {path}")
+    lines = text.splitlines(keepends=True)
+    in_project_table = False
+    project_version_index: int | None = None
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "[project]":
+            in_project_table = True
+            continue
+        if in_project_table and stripped.startswith("[") and stripped.endswith("]"):
+            break
+        if not in_project_table:
+            continue
+        replaced_line = _replace_matching_line(line, PYPROJECT_VERSION_LINE_PATTERN, version)
+        if replaced_line != line:
+            lines[index] = replaced_line
+            project_version_index = index
+            break
+
+    if project_version_index is None:
+        raise ValueError(f"Could not update [project].version in {path}")
+
+    updated_text = "".join(lines)
+    if updated_text == text:
+        return False
+    path.write_text(updated_text, encoding="utf-8")
+    return True
+
+
+def _replace_module_version(path: Path, version: str) -> bool:
+    text = _read_text(path)
+    lines = text.splitlines(keepends=True)
+    module_version_index: int | None = None
+
+    for index, line in enumerate(lines):
+        replaced_line = _replace_matching_line(line, MODULE_VERSION_LINE_PATTERN, version)
+        if replaced_line != line:
+            lines[index] = replaced_line
+            module_version_index = index
+            break
+
+    if module_version_index is None:
+        raise ValueError(f"Could not update module version line in {path}")
+
+    updated_text = "".join(lines)
     if updated_text == text:
         return False
     path.write_text(updated_text, encoding="utf-8")
@@ -87,16 +155,14 @@ def _replace_single_line(path: Path, pattern: re.Pattern[str], replacement: str)
 
 
 def sync_repo_version(repo_root: Path, version: str) -> bool:
-    normalized_version = _validate_semver(version)
-    pyproject_changed = _replace_single_line(
+    normalized_version = _validate_version_token(version)
+    pyproject_changed = _replace_project_version(
         repo_root / PYPROJECT_RELATIVE_PATH,
-        PYPROJECT_VERSION_PATTERN,
-        f'version = "{normalized_version}"',
+        normalized_version,
     )
-    module_changed = _replace_single_line(
+    module_changed = _replace_module_version(
         repo_root / MODULE_RELATIVE_PATH,
-        MODULE_VERSION_PATTERN,
-        f'__version__ = "{normalized_version}"',
+        normalized_version,
     )
     assert_repo_version(repo_root, normalized_version)
     return pyproject_changed or module_changed
@@ -127,13 +193,17 @@ def main() -> int:
     parser = _build_parser()
     args = parser.parse_args()
     repo_root = args.repo_root.resolve()
-    if args.version is not None:
-        sync_repo_version(repo_root, args.version)
-        print(_validate_semver(args.version))
+    try:
+        if args.version is not None:
+            sync_repo_version(repo_root, args.version)
+            print(_validate_version_token(args.version))
+            return 0
+        current_version = assert_repo_version(repo_root)
+        print(current_version)
         return 0
-    current_version = assert_repo_version(repo_root)
-    print(current_version)
-    return 0
+    except ValueError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 1
 
 
 if __name__ == "__main__":

--- a/scripts/sync_repo_version.py
+++ b/scripts/sync_repo_version.py
@@ -16,7 +16,8 @@ except ModuleNotFoundError:  # pragma: no cover - Python 3.10 fallback
 
 PYPROJECT_RELATIVE_PATH = Path("pyproject.toml")
 MODULE_RELATIVE_PATH = Path("src/codex_plugin_scanner/version.py")
-VERSION_TOKEN_PATTERN = re.compile(r"^[0-9][0-9A-Za-z.+_-]*$")
+LOCKFILE_RELATIVE_PATH = Path("uv.lock")
+VERSION_TOKEN_PATTERN = re.compile(r"^\d+(?:\.\d+)*(?:(?:a|b|rc)\d+)?(?:\.post\d+)?(?:\.dev\d+)?$")
 PYPROJECT_VERSION_LINE_PATTERN = re.compile(
     r'^(?P<prefix>\s*version\s*=\s*["\'])(?P<version>[^"\']+)(?P<suffix>["\']\s*)$'
 )
@@ -30,6 +31,7 @@ MODULE_VERSION_LINE_PATTERN = re.compile(
 class RepoVersionState:
     pyproject: str
     module: str
+    lockfile: str
 
 
 def _default_repo_root() -> Path:
@@ -71,6 +73,7 @@ def read_repo_version_state(repo_root: Path) -> RepoVersionState:
             MODULE_VERSION_LINE_PATTERN,
             "module",
         ),
+        lockfile=_read_lockfile_version(repo_root / LOCKFILE_RELATIVE_PATH),
     )
 
 
@@ -78,11 +81,12 @@ def assert_repo_version(repo_root: Path, expected_version: str | None = None) ->
     if expected_version is not None:
         _validate_version_token(expected_version)
     state = read_repo_version_state(repo_root)
-    if state.pyproject != state.module:
+    if state.pyproject != state.module or state.pyproject != state.lockfile:
         raise ValueError(
             "Repository version mismatch: "
             f"{PYPROJECT_RELATIVE_PATH} has {state.pyproject}, "
-            f"{MODULE_RELATIVE_PATH} has {state.module}"
+            f"{MODULE_RELATIVE_PATH} has {state.module}, "
+            f"{LOCKFILE_RELATIVE_PATH} has {state.lockfile}"
         )
     if expected_version is not None and state.pyproject != expected_version:
         raise ValueError(
@@ -154,6 +158,60 @@ def _replace_module_version(path: Path, version: str) -> bool:
     return True
 
 
+def _find_lockfile_version_index(path: Path) -> int:
+    lines = _read_text(path).splitlines(keepends=True)
+    in_package_block = False
+    package_name_matches = False
+    editable_source_matches = False
+    version_index: int | None = None
+
+    for index, line in enumerate(lines):
+        stripped = line.strip()
+        if stripped == "[[package]]":
+            if in_package_block and package_name_matches and editable_source_matches and version_index is not None:
+                return version_index
+            in_package_block = True
+            package_name_matches = False
+            editable_source_matches = False
+            version_index = None
+            continue
+        if not in_package_block:
+            continue
+        if stripped.startswith("name = "):
+            package_name_matches = stripped == 'name = "hol-guard"'
+            continue
+        if stripped.startswith("version = ") and version_index is None:
+            version_index = index
+            continue
+        if stripped.startswith("source = "):
+            editable_source_matches = stripped == 'source = { editable = "." }'
+
+    if in_package_block and package_name_matches and editable_source_matches and version_index is not None:
+        return version_index
+    raise ValueError(f"Could not find editable hol-guard package version in {path}")
+
+
+def _read_lockfile_version(path: Path) -> str:
+    lines = _read_text(path).splitlines(keepends=True)
+    version_index = _find_lockfile_version_index(path)
+    version_line = lines[version_index].rstrip("\r\n")
+    match = PYPROJECT_VERSION_LINE_PATTERN.match(version_line)
+    if match is None:
+        raise ValueError(f"Could not parse lockfile version in {path}")
+    return match.group("version")
+
+
+def _replace_lockfile_version(path: Path, version: str) -> bool:
+    lines = _read_text(path).splitlines(keepends=True)
+    version_index = _find_lockfile_version_index(path)
+    replaced_line = _replace_matching_line(lines[version_index], PYPROJECT_VERSION_LINE_PATTERN, version)
+    if replaced_line == lines[version_index]:
+        return False
+    lines[version_index] = replaced_line
+    path.write_text("".join(lines), encoding="utf-8")
+    return True
+
+
 def sync_repo_version(repo_root: Path, version: str) -> bool:
     normalized_version = _validate_version_token(version)
     pyproject_changed = _replace_project_version(
@@ -164,8 +222,12 @@ def sync_repo_version(repo_root: Path, version: str) -> bool:
         repo_root / MODULE_RELATIVE_PATH,
         normalized_version,
     )
+    lockfile_changed = _replace_lockfile_version(
+        repo_root / LOCKFILE_RELATIVE_PATH,
+        normalized_version,
+    )
     assert_repo_version(repo_root, normalized_version)
-    return pyproject_changed or module_changed
+    return pyproject_changed or module_changed or lockfile_changed
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.764"
+__version__ = "2.0.844"

--- a/tests/test_sync_repo_version.py
+++ b/tests/test_sync_repo_version.py
@@ -188,6 +188,29 @@ def test_sync_repo_version_preserves_inline_version_comments(tmp_path: Path) -> 
     assert 'version = "2.0.845"  # current release' in pyproject_text
 
 
+def test_sync_repo_version_handles_multiline_arrays_before_version(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
+    (tmp_path / "pyproject.toml").write_text(
+        '\n'.join(
+            [
+                "[project]",
+                'name = "hol-guard"',
+                "authors = [",
+                '  { name = "HOL", email = "support@hol.org" },',
+                "]",
+                'version = "2.0.844"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845")
+
+    pyproject_text = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "2.0.845"' in pyproject_text
+
+
 def test_sync_repo_version_avoids_partial_writes_when_lockfile_is_invalid(tmp_path: Path) -> None:
     _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
     (tmp_path / "uv.lock").write_text(

--- a/tests/test_sync_repo_version.py
+++ b/tests/test_sync_repo_version.py
@@ -1,0 +1,67 @@
+"""Tests for repository version synchronization."""
+
+from importlib.util import module_from_spec, spec_from_file_location
+from pathlib import Path
+import sys
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT_PATH = REPO_ROOT / "scripts" / "sync_repo_version.py"
+SCRIPT_SPEC = spec_from_file_location("sync_repo_version", SCRIPT_PATH)
+assert SCRIPT_SPEC is not None
+assert SCRIPT_SPEC.loader is not None
+SYNC_REPO_VERSION = module_from_spec(SCRIPT_SPEC)
+sys.modules[SCRIPT_SPEC.name] = SYNC_REPO_VERSION
+SCRIPT_SPEC.loader.exec_module(SYNC_REPO_VERSION)
+
+
+def _write_repo_files(tmp_path: Path, *, pyproject_version: str, module_version: str) -> None:
+    (tmp_path / "src" / "codex_plugin_scanner").mkdir(parents=True)
+    (tmp_path / "pyproject.toml").write_text(
+        '\n'.join(
+            [
+                "[project]",
+                'name = "hol-guard"',
+                f'version = "{pyproject_version}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "codex_plugin_scanner" / "version.py").write_text(
+        '\n'.join(
+            [
+                '"""Single source of truth for tool version."""',
+                "",
+                f'__version__ = "{module_version}"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_sync_repo_version_updates_both_files(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.764", module_version="2.0.764")
+
+    changed = SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.844")
+
+    assert changed is True
+    state = SYNC_REPO_VERSION.read_repo_version_state(tmp_path)
+    assert state.pyproject == "2.0.844"
+    assert state.module == "2.0.844"
+
+
+def test_assert_repo_version_detects_mismatch(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.764")
+
+    with pytest.raises(ValueError, match="Repository version mismatch"):
+        SYNC_REPO_VERSION.assert_repo_version(tmp_path)
+
+
+def test_sync_repo_version_rejects_non_semver(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
+
+    with pytest.raises(ValueError, match="Unsupported version format"):
+        SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845rc1")

--- a/tests/test_sync_repo_version.py
+++ b/tests/test_sync_repo_version.py
@@ -29,6 +29,26 @@ def _write_repo_files(tmp_path: Path, *, pyproject_version: str, module_version:
         ),
         encoding="utf-8",
     )
+    (tmp_path / "uv.lock").write_text(
+        '\n'.join(
+            [
+                "[[package]]",
+                'name = "hol-guard"',
+                f'version = "{pyproject_version}"',
+                'source = { editable = "." }',
+                "dependencies = [",
+                '    { name = "cisco-ai-skill-scanner", marker = "python_full_version < \'3.14\'" },',
+                "]",
+                "",
+                "[package.optional-dependencies]",
+                "cisco = [",
+                '    { name = "litellm", marker = "python_full_version >= \'3.11\' and python_full_version < \'3.14\'" },',
+                "]",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
     (tmp_path / "src" / "codex_plugin_scanner" / "version.py").write_text(
         '\n'.join(
             [
@@ -51,6 +71,7 @@ def test_sync_repo_version_updates_both_files(tmp_path: Path) -> None:
     state = SYNC_REPO_VERSION.read_repo_version_state(tmp_path)
     assert state.pyproject == "2.0.844"
     assert state.module == "2.0.844"
+    assert state.lockfile == "2.0.844"
 
 
 def test_assert_repo_version_detects_mismatch(tmp_path: Path) -> None:
@@ -104,9 +125,33 @@ def test_sync_repo_version_targets_project_version_only(tmp_path: Path) -> None:
         ),
         encoding="utf-8",
     )
+    (tmp_path / "uv.lock").write_text(
+        '\n'.join(
+            [
+                "[[package]]",
+                'name = "hol-guard"',
+                'version = "2.0.844"',
+                'source = { editable = "." }',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
 
     SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845")
 
     pyproject_text = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    lockfile_text = (tmp_path / "uv.lock").read_text(encoding="utf-8")
     assert 'version = "0.1.0"' in pyproject_text
     assert pyproject_text.count('version = "2.0.845"') == 1
+    assert lockfile_text.count('version = "2.0.845"') == 1
+
+
+def test_sync_repo_version_preserves_lockfile_markers(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
+
+    SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845")
+
+    lockfile_text = (tmp_path / "uv.lock").read_text(encoding="utf-8")
+    assert 'marker = "python_full_version < \'3.14\'"' in lockfile_text
+    assert 'marker = "python_full_version >= \'3.11\' and python_full_version < \'3.14\'"' in lockfile_text

--- a/tests/test_sync_repo_version.py
+++ b/tests/test_sync_repo_version.py
@@ -91,6 +91,17 @@ def test_sync_repo_version_accepts_prerelease_versions(tmp_path: Path) -> None:
     assert state.module == "2.0.845rc1"
 
 
+def test_sync_repo_version_accepts_epoch_and_local_versions(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
+
+    SYNC_REPO_VERSION.sync_repo_version(tmp_path, "1!2.0.845+abc")
+
+    state = SYNC_REPO_VERSION.read_repo_version_state(tmp_path)
+    assert state.pyproject == "1!2.0.845+abc"
+    assert state.module == "1!2.0.845+abc"
+    assert state.lockfile == "1!2.0.845+abc"
+
+
 def test_sync_repo_version_rejects_invalid_version_tokens(tmp_path: Path) -> None:
     _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
 
@@ -155,6 +166,26 @@ def test_sync_repo_version_preserves_lockfile_markers(tmp_path: Path) -> None:
     lockfile_text = (tmp_path / "uv.lock").read_text(encoding="utf-8")
     assert 'marker = "python_full_version < \'3.14\'"' in lockfile_text
     assert 'marker = "python_full_version >= \'3.11\' and python_full_version < \'3.14\'"' in lockfile_text
+
+
+def test_sync_repo_version_preserves_inline_version_comments(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
+    (tmp_path / "pyproject.toml").write_text(
+        '\n'.join(
+            [
+                "[project]",
+                'name = "hol-guard"',
+                'version = "2.0.844"  # current release',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845")
+
+    pyproject_text = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "2.0.845"  # current release' in pyproject_text
 
 
 def test_sync_repo_version_avoids_partial_writes_when_lockfile_is_invalid(tmp_path: Path) -> None:

--- a/tests/test_sync_repo_version.py
+++ b/tests/test_sync_repo_version.py
@@ -1,8 +1,8 @@
 """Tests for repository version synchronization."""
 
+import sys
 from importlib.util import module_from_spec, spec_from_file_location
 from pathlib import Path
-import sys
 
 import pytest
 
@@ -17,7 +17,7 @@ SCRIPT_SPEC.loader.exec_module(SYNC_REPO_VERSION)
 
 
 def _write_repo_files(tmp_path: Path, *, pyproject_version: str, module_version: str) -> None:
-    (tmp_path / "src" / "codex_plugin_scanner").mkdir(parents=True)
+    (tmp_path / "src" / "codex_plugin_scanner").mkdir(parents=True, exist_ok=True)
     (tmp_path / "pyproject.toml").write_text(
         '\n'.join(
             [
@@ -60,8 +60,53 @@ def test_assert_repo_version_detects_mismatch(tmp_path: Path) -> None:
         SYNC_REPO_VERSION.assert_repo_version(tmp_path)
 
 
-def test_sync_repo_version_rejects_non_semver(tmp_path: Path) -> None:
+def test_sync_repo_version_accepts_prerelease_versions(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
+
+    SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845rc1")
+
+    state = SYNC_REPO_VERSION.read_repo_version_state(tmp_path)
+    assert state.pyproject == "2.0.845rc1"
+    assert state.module == "2.0.845rc1"
+
+
+def test_sync_repo_version_rejects_invalid_version_tokens(tmp_path: Path) -> None:
     _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
 
     with pytest.raises(ValueError, match="Unsupported version format"):
-        SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845rc1")
+        SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845 rc1")
+
+
+def test_sync_repo_version_targets_project_version_only(tmp_path: Path) -> None:
+    (tmp_path / "src" / "codex_plugin_scanner").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "pyproject.toml").write_text(
+        '\n'.join(
+            [
+                "[tool.demo]",
+                'version = "0.1.0"',
+                "",
+                "[project]",
+                'name = "hol-guard"',
+                'version = "2.0.844"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "src" / "codex_plugin_scanner" / "version.py").write_text(
+        '\n'.join(
+            [
+                '"""Single source of truth for tool version."""',
+                "",
+                '__version__ = "2.0.844"',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845")
+
+    pyproject_text = (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'version = "0.1.0"' in pyproject_text
+    assert pyproject_text.count('version = "2.0.845"') == 1

--- a/tests/test_sync_repo_version.py
+++ b/tests/test_sync_repo_version.py
@@ -155,3 +155,27 @@ def test_sync_repo_version_preserves_lockfile_markers(tmp_path: Path) -> None:
     lockfile_text = (tmp_path / "uv.lock").read_text(encoding="utf-8")
     assert 'marker = "python_full_version < \'3.14\'"' in lockfile_text
     assert 'marker = "python_full_version >= \'3.11\' and python_full_version < \'3.14\'"' in lockfile_text
+
+
+def test_sync_repo_version_avoids_partial_writes_when_lockfile_is_invalid(tmp_path: Path) -> None:
+    _write_repo_files(tmp_path, pyproject_version="2.0.844", module_version="2.0.844")
+    (tmp_path / "uv.lock").write_text(
+        '\n'.join(
+            [
+                "[[package]]",
+                'name = "hol-guard"',
+                'version = "2.0.844"',
+                'source = { editable = "./elsewhere" }',
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="Could not find editable hol-guard package version"):
+        SYNC_REPO_VERSION.sync_repo_version(tmp_path, "2.0.845")
+
+    assert 'version = "2.0.844"' in (tmp_path / "pyproject.toml").read_text(encoding="utf-8")
+    assert '__version__ = "2.0.844"' in (tmp_path / "src" / "codex_plugin_scanner" / "version.py").read_text(
+        encoding="utf-8"
+    )

--- a/uv.lock
+++ b/uv.lock
@@ -1165,7 +1165,7 @@ name = "hol-guard"
 version = "2.0.844"
 source = { editable = "." }
 dependencies = [
-    { name = "cisco-ai-skill-scanner" },
+    { name = "cisco-ai-skill-scanner", marker = "python_full_version < '3.14'" },
     { name = "cryptography" },
     { name = "keyring" },
     { name = "packaging" },
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [package.optional-dependencies]
 cisco = [
-    { name = "litellm" },
+    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
 ]
 dev = [
     { name = "basedpyright" },

--- a/uv.lock
+++ b/uv.lock
@@ -1162,10 +1162,10 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "2.0.764"
+version = "2.0.844"
 source = { editable = "." }
 dependencies = [
-    { name = "cisco-ai-skill-scanner", marker = "python_full_version < '3.14'" },
+    { name = "cisco-ai-skill-scanner" },
     { name = "cryptography" },
     { name = "keyring" },
     { name = "packaging" },
@@ -1176,7 +1176,7 @@ dependencies = [
 
 [package.optional-dependencies]
 cisco = [
-    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14'" },
+    { name = "litellm" },
 ]
 dev = [
     { name = "basedpyright" },
@@ -3312,8 +3312,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
## Summary
- keep `pyproject.toml` and `src/codex_plugin_scanner/version.py` aligned with a shared repo-version sync script
- sync the repository version back to `main` after successful publishes so release metadata stops drifting

## Testing
- `python3 scripts/sync_repo_version.py --check`
- `python3 -m pytest tests/test_versioning.py tests/test_sync_repo_version.py`
