### PR TITLE
fix(guard): block agent approval self-authorization

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/base.py
+++ b/src/codex_plugin_scanner/guard/adapters/base.py
@@ -105,7 +105,7 @@ class HarnessAdapter:
     legacy_launcher_names: tuple[str, ...] = ()
     approval_tier = "approval-center"
     approval_summary = "Guard pauses the launch and routes approval through the local approval center."
-    fallback_hint = "Use `hol-guard approvals` if you want to resolve it from the terminal."
+    fallback_hint = "Use the Guard approval center or native harness prompt to resolve pending requests."
     approval_prompt_channel = "browser"
     approval_auto_open_browser = True
 

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -1025,7 +1025,7 @@ def main() -> int:
                     "permission": "deny",
                     "user_message": (
                         f"HOL Guard hook timed out after {GUARD_HOOK_TIMEOUT_SECONDS}s. "
-                        "Run `hol-guard status`, approve pending requests, then retry."
+                        "Open the Guard approval center or native Cursor prompt, resolve pending requests, then retry."
                     ),
                 }
             )

--- a/src/codex_plugin_scanner/guard/adapters/grok.py
+++ b/src/codex_plugin_scanner/guard/adapters/grok.py
@@ -66,7 +66,7 @@ class GrokHarnessAdapter(HarnessAdapter):
     )
     fallback_hint = (
         "Grok receives plain-language allow or deny responses from Guard hooks. "
-        "Use `hol-guard approvals` if you want to resolve pending requests from the terminal."
+        "Use the Guard approval center when native prompting is unavailable."
     )
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -205,7 +205,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         return {
             "tier": "approval-center",
             "summary": "Guard keeps Hermes approvals in the local approval center without forcing a browser open.",
-            "fallback_hint": "Resolve pending Hermes requests from the Guard approval center or `hol-guard approvals`.",
+            "fallback_hint": "Resolve pending Hermes requests from the Guard approval center.",
             "prompt_channel": "native-fallback",
             "auto_open_browser": False,
         }

--- a/src/codex_plugin_scanner/guard/adapters/openclaw.py
+++ b/src/codex_plugin_scanner/guard/adapters/openclaw.py
@@ -220,9 +220,7 @@ class OpenClawHarnessAdapter(HarnessAdapter):
         return {
             "tier": "approval-center",
             "summary": "Guard keeps OpenClaw approvals in the local approval center without forcing a browser open.",
-            "fallback_hint": (
-                "Resolve pending OpenClaw requests from the Guard approval center or `hol-guard approvals`."
-            ),
+            "fallback_hint": "Resolve pending OpenClaw requests from the Guard approval center.",
             "prompt_channel": "native-fallback",
             "auto_open_browser": False,
         }

--- a/src/codex_plugin_scanner/guard/adapters/zcode.py
+++ b/src/codex_plugin_scanner/guard/adapters/zcode.py
@@ -70,7 +70,7 @@ class ZCodeHarnessAdapter(HarnessAdapter):
     )
     fallback_hint = (
         "ZCode gets preflight approval through Guard until it exposes a richer native approval surface. "
-        "Use `hol-guard approvals` to resolve pending requests from the terminal."
+        "Use the Guard approval center when native prompting is unavailable."
     )
 
     @staticmethod

--- a/src/codex_plugin_scanner/guard/cli/approval_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/approval_commands.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import os
 import urllib.parse
 import webbrowser
 from datetime import datetime, timezone
@@ -14,6 +15,7 @@ from ..approvals import apply_approval_resolution, build_runtime_snapshot
 from ..codex_resume import retry_request_resume
 from ..config import load_guard_config
 from ..daemon import load_guard_daemon_url
+from ..runtime.self_approval import SELF_APPROVAL_REASON, approval_resolution_invoked_from_agent
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
 from .approval_gate_prompt import approval_gate_cli_payload, prompt_for_approval_gate
@@ -221,6 +223,14 @@ def run_approval_command(
             "cooldown_active": gate.cooldown_active,
             "cooldown_expires_at": gate.cooldown_expires_at,
             "exit_code": 0,
+        }
+    if command in {"approve", "deny"} and approval_resolution_invoked_from_agent(os.environ):
+        return {
+            "resolved": False,
+            "error": "approval_cli_blocked_in_agent_context",
+            "message": SELF_APPROVAL_REASON,
+            "next_action": "Open the original Guard request in the local approval center or native harness prompt.",
+            "exit_code": 4,
         }
     try:
         gate_input = (

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -32,6 +32,11 @@ from .false_positive_rules import (
 from .secret_sensitivity import SecretPathMatch as SensitivePathMatch
 from .secret_sensitivity import classify_secret_path
 from .sed_scripts import sed_script_is_bounded_print
+from .self_approval import (
+    SELF_APPROVAL_ACTION_CLASS,
+    SELF_APPROVAL_REASON,
+    is_guard_approval_mutation_command,
+)
 from .shell_command_wrappers import normalize_transparent_shell_command
 
 _FILE_READ_TOOL_NAMES = frozenset(
@@ -859,6 +864,14 @@ def _destructive_shell_tool_action_request(
 ) -> ToolActionRequestMatch | None:
     if normalized_tool_name not in _SHELL_TOOL_NAMES:
         return None
+    if is_guard_approval_mutation_command(command_text):
+        return ToolActionRequestMatch(
+            tool_name=tool_name,
+            normalized_tool_name=normalized_tool_name,
+            command_text=command_text,
+            action_class=SELF_APPROVAL_ACTION_CLASS,
+            reason=SELF_APPROVAL_REASON,
+        )
     if _contains_encoded_or_encrypted_shell_command(command_text, cwd=cwd, home_dir=home_dir):
         return ToolActionRequestMatch(
             tool_name=tool_name,

--- a/src/codex_plugin_scanner/guard/runtime/self_approval.py
+++ b/src/codex_plugin_scanner/guard/runtime/self_approval.py
@@ -113,7 +113,11 @@ def _looks_env_assignment(token: str) -> bool:
 
 
 def _is_python_interpreter(command_name: str) -> bool:
-    return command_name == "python" or command_name.startswith("python")
+    return (
+        command_name in {"python", "py"}
+        or command_name.startswith("python")
+        or command_name.startswith("py3")
+    )
 
 
 def _python_module_args_mutate_approvals(args: list[str]) -> bool:
@@ -144,7 +148,9 @@ def _runner_wrapper_tail(command_name: str, args: list[str]) -> list[str] | None
     if command_name not in _RUN_WRAPPERS:
         return None
     if command_name == "uv":
-        return _tail_after_subcommand(args, {"run", "tool"})
+        if args and args[0] == "tool":
+            return _tail_after_subcommand(args[1:], {"run"})
+        return _tail_after_subcommand(args, {"run"})
     if command_name == "uvx":
         return args
     if command_name in {"pipx", "poetry", "hatch"}:
@@ -158,23 +164,26 @@ def _runner_wrapper_tail(command_name: str, args: list[str]) -> list[str] | None
 
 def _tail_after_subcommand(args: list[str], subcommands: set[str]) -> list[str] | None:
     for index, token in enumerate(args):
+        if token == "--":
+            break
         if token in subcommands:
             tail = args[index + 1 :]
             if tail and tail[0] == "--":
                 tail = tail[1:]
             return tail
-        if token == "--":
-            continue
-        if token.startswith("-"):
-            continue
-        return None
     return None
 
 
 def _tail_after_flag(args: list[str], flag: str) -> list[str] | None:
     for index, token in enumerate(args):
         if token == flag:
-            return args[index + 1 :]
+            remaining = args[index + 1 :]
+            if not remaining:
+                return []
+            try:
+                return shlex.split(" ".join(remaining))
+            except ValueError:
+                return remaining
         if token.startswith(f"{flag}="):
             try:
                 return shlex.split(token.split("=", 1)[1])

--- a/src/codex_plugin_scanner/guard/runtime/self_approval.py
+++ b/src/codex_plugin_scanner/guard/runtime/self_approval.py
@@ -107,17 +107,15 @@ def _looks_env_assignment(token: str) -> bool:
         return False
     if name.endswith("+"):
         name = name[:-1]
-    return bool(name) and (name[0].isalpha() or name[0] == "_") and all(
-        character.isalnum() or character == "_" for character in name[1:]
+    return (
+        bool(name)
+        and (name[0].isalpha() or name[0] == "_")
+        and all(character.isalnum() or character == "_" for character in name[1:])
     )
 
 
 def _is_python_interpreter(command_name: str) -> bool:
-    return (
-        command_name in {"python", "py"}
-        or command_name.startswith("python")
-        or command_name.startswith("py3")
-    )
+    return command_name in {"python", "py"} or command_name.startswith("python") or command_name.startswith("py3")
 
 
 def _python_module_args_mutate_approvals(args: list[str]) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/self_approval.py
+++ b/src/codex_plugin_scanner/guard/runtime/self_approval.py
@@ -1,0 +1,209 @@
+"""Detect Guard approval mutation attempts from agent-controlled shells."""
+
+from __future__ import annotations
+
+import os
+import shlex
+from collections.abc import Mapping
+from pathlib import Path
+
+SELF_APPROVAL_ACTION_CLASS = "Guard approval self-authorization command"
+SELF_APPROVAL_REASON = (
+    "Guard blocks AI agents from approving or weakening Guard approval state from inside a protected shell. "
+    "Review the original request in the local approval center or native harness prompt."
+)
+
+_APPROVAL_ROOTS = frozenset({"approvals", "requests"})
+_APPROVAL_MUTATION_COMMANDS = frozenset({"approve", "allow", "deny", "block", "clear-history", "unlock"})
+_GUARD_BINARIES = frozenset({"hol-guard", "plugin-guard"})
+_PYTHON_MODULES = frozenset({"codex_plugin_scanner", "codex_plugin_scanner.cli"})
+_PYTHON_OPTIONS_WITH_VALUES = frozenset({"-W", "-X", "--check-hash-based-pycs"})
+_RUN_WRAPPERS = frozenset({"hatch", "mise", "nix", "pipx", "poetry", "uv", "uvx"})
+_SHELL_SEPARATORS = frozenset({";", "&&", "||", "|", "|&", "&"})
+_AGENT_ENV_MARKERS = frozenset(
+    {
+        "HOL_GUARD_HOOK_ARGV",
+        "HOL_GUARD_MANAGED_CURSOR_HOOK",
+        "HOL_GUARD_CURSOR_APPROVAL_BINDING",
+        "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF",
+        "CURSOR_SESSION_ID",
+        "CURSOR_TRACE_ID",
+        "CURSOR_TRANSCRIPT_PATH",
+        "CLAUDECODE",
+        "OPENCODE_CONFIG_CONTENT",
+        "CODEX_SANDBOX",
+    }
+)
+
+
+def is_guard_approval_mutation_command(command_text: str) -> bool:
+    """Return True for commands that let an agent mutate Guard approval state."""
+
+    parts = _split_shell_parts(command_text)
+    if not parts:
+        return False
+    return any(_segment_is_guard_approval_mutation(segment) for segment in _shell_segments(parts))
+
+
+def approval_resolution_invoked_from_agent(env: Mapping[str, str] | None = None) -> bool:
+    """Detect known AI harness hook contexts for approval CLI mutation defense-in-depth."""
+
+    source = env if env is not None else os.environ
+    return any(str(source.get(key) or "").strip() for key in _AGENT_ENV_MARKERS)
+
+
+def _split_shell_parts(command_text: str) -> list[str]:
+    try:
+        lexer = shlex.shlex(command_text.replace("\n", " ; "), posix=True, punctuation_chars=";&|")
+        lexer.whitespace_split = True
+        return list(lexer)
+    except ValueError:
+        return command_text.split()
+
+
+def _shell_segments(parts: list[str]) -> list[list[str]]:
+    segments: list[list[str]] = []
+    current: list[str] = []
+    for part in parts:
+        if part in _SHELL_SEPARATORS:
+            if current:
+                segments.append(current)
+                current = []
+            continue
+        current.append(part)
+    if current:
+        segments.append(current)
+    return segments
+
+
+def _segment_is_guard_approval_mutation(segment: list[str], *, depth: int = 0) -> bool:
+    if depth > 3:
+        return False
+    index = _first_executable_index(segment)
+    if index is None:
+        return False
+    command_name = Path(segment[index]).name.lower()
+    if command_name in _GUARD_BINARIES:
+        return _guard_args_mutate_approvals(segment[index + 1 :])
+    if _is_python_interpreter(command_name):
+        return _python_module_args_mutate_approvals(segment[index + 1 :])
+    wrapper_tail = _runner_wrapper_tail(command_name, segment[index + 1 :])
+    if wrapper_tail is not None:
+        return _segment_is_guard_approval_mutation(wrapper_tail, depth=depth + 1)
+    return False
+
+
+def _first_executable_index(segment: list[str]) -> int | None:
+    for index, token in enumerate(segment):
+        if not token or _looks_env_assignment(token):
+            continue
+        return index
+    return None
+
+
+def _looks_env_assignment(token: str) -> bool:
+    name, separator, _ = token.partition("=")
+    if separator != "=" or not name:
+        return False
+    if name.endswith("+"):
+        name = name[:-1]
+    return bool(name) and (name[0].isalpha() or name[0] == "_") and all(
+        character.isalnum() or character == "_" for character in name[1:]
+    )
+
+
+def _is_python_interpreter(command_name: str) -> bool:
+    return command_name == "python" or command_name.startswith("python")
+
+
+def _python_module_args_mutate_approvals(args: list[str]) -> bool:
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if token == "-m" and index + 1 < len(args):
+            module_name = args[index + 1].strip()
+            if module_name in _PYTHON_MODULES:
+                return _guard_args_mutate_approvals(args[index + 2 :])
+            return False
+        if token == "-c":
+            return False
+        if token in _PYTHON_OPTIONS_WITH_VALUES:
+            index += 2
+            continue
+        if any(token.startswith(f"{option}=") for option in _PYTHON_OPTIONS_WITH_VALUES):
+            index += 1
+            continue
+        if token.startswith("-"):
+            index += 1
+            continue
+        return False
+    return False
+
+
+def _runner_wrapper_tail(command_name: str, args: list[str]) -> list[str] | None:
+    if command_name not in _RUN_WRAPPERS:
+        return None
+    if command_name == "uv":
+        return _tail_after_subcommand(args, {"run", "tool"})
+    if command_name == "uvx":
+        return args
+    if command_name in {"pipx", "poetry", "hatch"}:
+        return _tail_after_subcommand(args, {"run"})
+    if command_name == "mise":
+        return _tail_after_subcommand(args, {"exec"})
+    if command_name == "nix":
+        return _tail_after_flag(args, "--command")
+    return None
+
+
+def _tail_after_subcommand(args: list[str], subcommands: set[str]) -> list[str] | None:
+    for index, token in enumerate(args):
+        if token in subcommands:
+            tail = args[index + 1 :]
+            if tail and tail[0] == "--":
+                tail = tail[1:]
+            return tail
+        if token == "--":
+            continue
+        if token.startswith("-"):
+            continue
+        return None
+    return None
+
+
+def _tail_after_flag(args: list[str], flag: str) -> list[str] | None:
+    for index, token in enumerate(args):
+        if token == flag:
+            return args[index + 1 :]
+        if token.startswith(f"{flag}="):
+            try:
+                return shlex.split(token.split("=", 1)[1])
+            except ValueError:
+                return []
+    return None
+
+
+def _guard_args_mutate_approvals(args: list[str]) -> bool:
+    if args and args[0] == "guard":
+        args = args[1:]
+    for index, token in enumerate(args):
+        if token not in _APPROVAL_ROOTS:
+            continue
+        return _approval_tail_has_mutation(args[index + 1 :])
+    return False
+
+
+def _approval_tail_has_mutation(args: list[str]) -> bool:
+    for token in args:
+        if token.startswith("-"):
+            continue
+        return token in _APPROVAL_MUTATION_COMMANDS
+    return False
+
+
+__all__ = [
+    "SELF_APPROVAL_ACTION_CLASS",
+    "SELF_APPROVAL_REASON",
+    "approval_resolution_invoked_from_agent",
+    "is_guard_approval_mutation_command",
+]

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -542,6 +542,32 @@ def test_approval_gate_cli_noninteractive_fails_closed(tmp_path: Path, monkeypat
     assert store.get_approval_request("req-cli")["status"] == "pending"
 
 
+def test_approval_cli_refuses_agent_managed_self_authorization(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    _add_request(store, "req-agent-cli")
+    monkeypatch.setenv("HOL_GUARD_HOOK_ARGV", "codex-pretool")
+
+    payload = run_approval_command(
+        SimpleNamespace(
+            approvals_command="approve",
+            request_id="req-agent-cli",
+            approval_action="allow",
+            scope="artifact",
+            reason=None,
+        ),
+        store=store,
+        workspace=None,
+    )
+
+    assert payload["resolved"] is False
+    assert payload["error"] == "approval_cli_blocked_in_agent_context"
+    assert payload["exit_code"] == 4
+    assert store.get_approval_request("req-agent-cli")["status"] == "pending"
+
+
 def test_approval_gate_cli_noninteractive_uses_active_cooldown(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -2950,6 +2950,57 @@ def test_tool_action_request_classifier_does_not_promote_echoed_interpreter_text
     assert request is None
 
 
+def test_tool_action_request_classifier_blocks_guard_approval_self_authorization():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "cd app && hol-guard approvals approve req-123 --scope global"},
+    )
+
+    assert request is not None
+    assert request.action_class == "Guard approval self-authorization command"
+    assert "AI agents" in request.reason
+
+
+def test_tool_action_request_classifier_blocks_python_module_guard_approval_mutation():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "python3 -m codex_plugin_scanner.cli guard approvals deny req-123"},
+    )
+
+    assert request is not None
+    assert request.action_class == "Guard approval self-authorization command"
+
+
+def test_tool_action_request_classifier_blocks_runner_wrapped_guard_approval_mutation():
+    request = extract_sensitive_tool_action_request(
+        "bash",
+        {"command": "uv run hol-guard approvals approve req-123"},
+    )
+
+    assert request is not None
+    assert request.action_class == "Guard approval self-authorization command"
+
+
+def test_tool_action_request_classifier_allows_guard_approval_read_only_commands():
+    assert (
+        extract_sensitive_tool_action_request(
+            "bash",
+            {"command": "hol-guard approvals open req-123 && hol-guard --version"},
+        )
+        is None
+    )
+
+
+def test_tool_action_request_classifier_does_not_block_quoted_guard_approval_text():
+    assert (
+        extract_sensitive_tool_action_request(
+            "bash",
+            {"command": "printf '%s\\n' 'hol-guard approvals approve req-123'"},
+        )
+        is None
+    )
+
+
 def test_explicitly_benign_tool_action_request_requires_all_command_variants_to_be_benign():
     assert not is_explicitly_benign_tool_action_request(
         "bash",

--- a/tests/test_guard_risk.py
+++ b/tests/test_guard_risk.py
@@ -2981,6 +2981,21 @@ def test_tool_action_request_classifier_blocks_runner_wrapped_guard_approval_mut
     assert request.action_class == "Guard approval self-authorization command"
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "poetry -C project run hol-guard approvals approve req-123",
+        "nix develop --command 'hol-guard approvals approve req-123'",
+        "py -m codex_plugin_scanner.cli guard approvals approve req-123",
+    ],
+)
+def test_tool_action_request_classifier_blocks_wrapped_guard_approval_variants(command: str):
+    request = extract_sensitive_tool_action_request("bash", {"command": command})
+
+    assert request is not None
+    assert request.action_class == "Guard approval self-authorization command"
+
+
 def test_tool_action_request_classifier_allows_guard_approval_read_only_commands():
     assert (
         extract_sensitive_tool_action_request(


### PR DESCRIPTION
## Summary
- Block agent-controlled shell commands that try to approve, deny, clear, or unlock Guard approvals through the Guard CLI
- Refuse direct approval CLI mutation when invoked from known Guard-managed agent hook contexts
- Update harness fallback copy to direct users to the approval center or native prompts instead of terminal approval mutation

## Testing
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/self_approval.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py src/codex_plugin_scanner/guard/cli/approval_commands.py src/codex_plugin_scanner/guard/adapters/base.py src/codex_plugin_scanner/guard/adapters/grok.py src/codex_plugin_scanner/guard/adapters/zcode.py src/codex_plugin_scanner/guard/adapters/hermes.py src/codex_plugin_scanner/guard/adapters/openclaw.py src/codex_plugin_scanner/guard/adapters/cursor_hooks.py tests/test_guard_risk.py tests/test_guard_approval_gate.py`
- `python3 -m pytest tests/test_guard_risk.py tests/test_guard_approval_gate.py -q`
