### PR TITLE
fix(release): sync repository version through protected main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -361,6 +361,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10
         with:
@@ -380,17 +381,48 @@ jobs:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           python3 scripts/sync_repo_version.py --version "$VERSION"
-      - name: Commit repository version
+      - name: Open repository version sync PR
         env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           if git diff --quiet -- pyproject.toml src/codex_plugin_scanner/version.py uv.lock; then
             echo "Repository version already synced."
             exit 0
           fi
+          if [[ "$(gh api repos/${{ github.repository }} --jq .allow_auto_merge)" != "true" ]]; then
+            echo "Repository auto-merge is disabled; enable it so release version sync PRs can merge after checks." >&2
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          branch="release/sync-repository-version-v${VERSION}"
+          head_ref="${{ github.repository_owner }}:${branch}"
+          title="chore(release): sync repository version to ${VERSION}"
+          body_file="$(mktemp)"
+          trap 'rm -f "$body_file"' EXIT
+          cat > "$body_file" <<EOF
+          ## Summary
+          - sync repository version files to ${VERSION} after publish
+          - keep repo-visible version metadata aligned with the released package artifacts
+
+          ## Testing
+          - \`python3 scripts/sync_repo_version.py --version "${VERSION}"\`
+          EOF
+          git checkout -B "$branch"
           git add pyproject.toml src/codex_plugin_scanner/version.py uv.lock
           git commit -m "chore(release): sync repository version to ${VERSION} [skip release publish]"
-          git pull --rebase origin main
-          git push origin HEAD:main
+          git push --force-with-lease --set-upstream origin "$branch"
+          head_sha="$(git rev-parse HEAD)"
+          pr_number="$(gh pr list --repo ${{ github.repository }} --base main --head "$head_ref" --state open --json number --jq '.[0].number // empty')"
+          if [[ -n "$pr_number" ]]; then
+            gh pr edit "$pr_number" --repo ${{ github.repository }} --title "$title" --body-file "$body_file"
+          else
+            gh pr create --repo ${{ github.repository }} --base main --head "$head_ref" --title "$title" --body-file "$body_file"
+            pr_number="$(gh pr list --repo ${{ github.repository }} --base main --head "$head_ref" --state open --json number --jq '.[0].number // empty')"
+          fi
+          if [[ -z "$pr_number" ]]; then
+            echo "Failed to create or locate repository version sync PR." >&2
+            exit 1
+          fi
+          gh pr merge "$pr_number" --repo ${{ github.repository }} --auto --squash --delete-branch --match-head-commit "$head_sha" --subject "chore(release): sync repository version to ${VERSION} [skip release publish]" --body ""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -383,19 +383,21 @@ jobs:
           python3 scripts/sync_repo_version.py --version "$VERSION"
       - name: Open repository version sync PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ACTION_REPO_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
+          GH_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
           VERSION: ${{ needs.build.outputs.version }}
         run: |
           if git diff --quiet -- pyproject.toml src/codex_plugin_scanner/version.py uv.lock; then
             echo "Repository version already synced."
             exit 0
           fi
-          if [[ "$(gh api repos/${{ github.repository }} --jq .allow_auto_merge)" != "true" ]]; then
-            echo "Repository auto-merge is disabled; enable it so release version sync PRs can merge after checks." >&2
+          if [[ -z "$ACTION_REPO_TOKEN" ]]; then
+            echo "ACTION_REPO_TOKEN must be configured to sync repository version files after publish." >&2
             exit 1
           fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${{ github.repository }}.git"
           branch="release/sync-repository-version-v${VERSION}"
           head_ref="${{ github.repository_owner }}:${branch}"
           title="chore(release): sync repository version to ${VERSION}"
@@ -411,6 +413,13 @@ jobs:
           EOF
           git checkout -B "$branch"
           git add pyproject.toml src/codex_plugin_scanner/version.py uv.lock
+          expected_files="$(printf '%s\n' pyproject.toml src/codex_plugin_scanner/version.py uv.lock | sort)"
+          changed_files="$(git diff --cached --name-only | sort)"
+          if [[ "$changed_files" != "$expected_files" ]]; then
+            echo "Unexpected files staged for repository version sync:" >&2
+            printf '%s\n' "$changed_files" >&2
+            exit 1
+          fi
           git commit -m "chore(release): sync repository version to ${VERSION} [skip release publish]"
           git push --force-with-lease --set-upstream origin "$branch"
           head_sha="$(git rev-parse HEAD)"
@@ -425,4 +434,4 @@ jobs:
             echo "Failed to create or locate repository version sync PR." >&2
             exit 1
           fi
-          gh pr merge "$pr_number" --repo ${{ github.repository }} --auto --squash --delete-branch --match-head-commit "$head_sha" --subject "chore(release): sync repository version to ${VERSION} [skip release publish]" --body ""
+          gh pr merge "$pr_number" --repo ${{ github.repository }} --admin --squash --delete-branch --match-head-commit "$head_sha" --subject "chore(release): sync repository version to ${VERSION} [skip release publish]" --body ""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -400,7 +400,7 @@ jobs:
           git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${{ github.repository }}.git"
           branch="release/sync-repository-version-v${VERSION}"
           head_ref="${{ github.repository_owner }}:${branch}"
-          title="chore(release): sync repository version to ${VERSION}"
+          title="chore(release): sync repository version to ${VERSION} [skip release publish]"
           body_file="$(mktemp)"
           trap 'rm -f "$body_file"' EXIT
           cat > "$body_file" <<EOF
@@ -436,6 +436,6 @@ jobs:
           fi
           if [[ "$(gh api repos/${{ github.repository }} --jq .allow_auto_merge)" != "true" ]]; then
             echo "Repository auto-merge is disabled; leaving PR #${pr_number} open for manual merge after checks." >&2
-            exit 0
+            exit 1
           fi
           gh pr merge "$pr_number" --repo ${{ github.repository }} --auto --squash --delete-branch --match-head-commit "$head_sha" --subject "chore(release): sync repository version to ${VERSION} [skip release publish]" --body ""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -395,6 +395,10 @@ jobs:
             echo "ACTION_REPO_TOKEN must be configured to sync repository version files after publish." >&2
             exit 1
           fi
+          if [[ "$(gh api repos/${{ github.repository }} --jq .allow_auto_merge)" != "true" ]]; then
+            echo "Repository auto-merge must stay enabled so the version sync PR can merge after required checks." >&2
+            exit 1
+          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${{ github.repository }}.git"
@@ -413,11 +417,11 @@ jobs:
           EOF
           git checkout -B "$branch"
           git add pyproject.toml src/codex_plugin_scanner/version.py uv.lock
-          expected_files="$(printf '%s\n' pyproject.toml src/codex_plugin_scanner/version.py uv.lock | sort)"
-          changed_files="$(git diff --cached --name-only | sort)"
-          if [[ "$changed_files" != "$expected_files" ]]; then
+          changed_files="$(git diff --cached --name-only)"
+          unexpected_files="$(printf '%s\n' "$changed_files" | rg -vx 'pyproject.toml|src/codex_plugin_scanner/version.py|uv.lock' || true)"
+          if [[ -n "$unexpected_files" ]]; then
             echo "Unexpected files staged for repository version sync:" >&2
-            printf '%s\n' "$changed_files" >&2
+            printf '%s\n' "$unexpected_files" >&2
             exit 1
           fi
           git commit -m "chore(release): sync repository version to ${VERSION} [skip release publish]"
@@ -434,4 +438,4 @@ jobs:
             echo "Failed to create or locate repository version sync PR." >&2
             exit 1
           fi
-          gh pr merge "$pr_number" --repo ${{ github.repository }} --admin --squash --delete-branch --match-head-commit "$head_sha" --subject "chore(release): sync repository version to ${VERSION} [skip release publish]" --body ""
+          gh pr merge "$pr_number" --repo ${{ github.repository }} --auto --squash --delete-branch --match-head-commit "$head_sha" --subject "chore(release): sync repository version to ${VERSION} [skip release publish]" --body ""

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -395,10 +395,6 @@ jobs:
             echo "ACTION_REPO_TOKEN must be configured to sync repository version files after publish." >&2
             exit 1
           fi
-          if [[ "$(gh api repos/${{ github.repository }} --jq .allow_auto_merge)" != "true" ]]; then
-            echo "Repository auto-merge must stay enabled so the version sync PR can merge after required checks." >&2
-            exit 1
-          fi
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git remote set-url origin "https://x-access-token:${ACTION_REPO_TOKEN}@github.com/${{ github.repository }}.git"
@@ -437,5 +433,9 @@ jobs:
           if [[ -z "$pr_number" ]]; then
             echo "Failed to create or locate repository version sync PR." >&2
             exit 1
+          fi
+          if [[ "$(gh api repos/${{ github.repository }} --jq .allow_auto_merge)" != "true" ]]; then
+            echo "Repository auto-merge is disabled; leaving PR #${pr_number} open for manual merge after checks." >&2
+            exit 0
           fi
           gh pr merge "$pr_number" --repo ${{ github.repository }} --auto --squash --delete-branch --match-head-commit "$head_sha" --subject "chore(release): sync repository version to ${VERSION} [skip release publish]" --body ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.844"
+version = "2.0.847"
 description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, OpenCode, and Pi."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.844"
+__version__ = "2.0.847"

--- a/uv.lock
+++ b/uv.lock
@@ -1162,7 +1162,7 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "2.0.844"
+version = "2.0.847"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner", marker = "python_full_version < '3.14'" },


### PR DESCRIPTION
## Summary
- sync repository version files through protected `main` by opening a post-publish version PR instead of pushing directly from the workflow
- bump repo version metadata to `2.0.847` so the repository matches the next published release

## Testing
- `python3 scripts/sync_repo_version.py --check`
- `python3 -m pytest tests/test_sync_repo_version.py tests/test_versioning.py`
