### PR TITLE
fix(release): lock version sync workflow tooling

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -412,7 +412,7 @@ jobs:
           - keep repo-visible version metadata aligned with the released package artifacts
 
           ## Testing
-          - \`uv run --no-sync python scripts/sync_repo_version.py --version "${VERSION}"\`
+          - \`uv sync --frozen && uv run --no-sync python scripts/sync_repo_version.py --version "${VERSION}"\`
           EOF
           git checkout -B "$branch"
           git add pyproject.toml src/codex_plugin_scanner/version.py uv.lock

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -318,14 +318,15 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
-      - name: Install packaging
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+      - name: Sync locked release tooling
         run: |
-          python3 -m pip install packaging
+          uv sync --frozen
       - name: Stamp package version
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          python3 scripts/sync_repo_version.py --version "$VERSION"
+          uv run --no-sync python scripts/sync_repo_version.py --version "$VERSION"
       - name: Prepare image tags
         id: tags
         env:
@@ -367,20 +368,22 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
+          persist-credentials: false
       - name: Prepare main branch
         run: |
           git checkout -B main origin/main
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405
         with:
           python-version: "3.12"
-      - name: Install packaging
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+      - name: Sync locked release tooling
         run: |
-          python3 -m pip install packaging
+          uv sync --frozen
       - name: Sync repository version files
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          python3 scripts/sync_repo_version.py --version "$VERSION"
+          uv run --no-sync python scripts/sync_repo_version.py --version "$VERSION"
       - name: Open repository version sync PR
         env:
           ACTION_REPO_TOKEN: ${{ secrets.ACTION_REPO_TOKEN }}
@@ -409,7 +412,7 @@ jobs:
           - keep repo-visible version metadata aligned with the released package artifacts
 
           ## Testing
-          - \`python3 scripts/sync_repo_version.py --version "${VERSION}"\`
+          - \`uv run --no-sync python scripts/sync_repo_version.py --version "${VERSION}"\`
           EOF
           git checkout -B "$branch"
           git add pyproject.toml src/codex_plugin_scanner/version.py uv.lock

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,7 +40,6 @@ jobs:
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
           uv-version: "0.9.26"
-        with:
           enable-cache: true
       - name: Install dependencies
         run: uv sync --frozen --extra dev --extra publish --extra cisco

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,6 +39,8 @@ jobs:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
         with:
+          uv-version: "0.9.26"
+        with:
           enable-cache: true
       - name: Install dependencies
         run: uv sync --frozen --extra dev --extra publish --extra cisco
@@ -319,6 +321,8 @@ jobs:
         with:
           python-version: "3.12"
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39
+        with:
+          uv-version: "0.9.26"
       - name: Sync locked release tooling
         run: |
           uv sync --frozen


### PR DESCRIPTION
## Summary
- replace unpinned `pip install packaging` in release publish jobs with locked `uv sync --frozen`
- disable persisted checkout credentials in the repository version sync job and keep its generated testing command aligned with the locked workflow path

## Testing
- `python3 -m pytest tests/test_sync_repo_version.py -q`
- `yq e '.jobs["sync-repository-version"].steps | length' .github/workflows/publish.yml >/dev/null && yq e '.jobs["publish-container"].steps | length' .github/workflows/publish.yml >/dev/null`
- `git diff --check`
