### PR TITLE
fix(dashboard): suppress repeated local-install recovery prompt

### DIFF
--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -36,8 +36,8 @@ function updateStatusLabel(status: GuardUpdateStatus | null | undefined): string
 function shouldPromptRecoveryReinstall(status: GuardUpdateStatus | null | undefined): boolean {
   return (
     status?.recovery_reinstall_available === true &&
-    status.auto_updatable !== true &&
-    status.version_check.update_available === true
+    status?.auto_updatable !== true &&
+    status?.version_check?.update_available === true
   );
 }
 

--- a/dashboard/src/guard-update-panel.tsx
+++ b/dashboard/src/guard-update-panel.tsx
@@ -33,6 +33,28 @@ function updateStatusLabel(status: GuardUpdateStatus | null | undefined): string
   return `Version ${status.current_version}`;
 }
 
+function shouldPromptRecoveryReinstall(status: GuardUpdateStatus | null | undefined): boolean {
+  return (
+    status?.recovery_reinstall_available === true &&
+    status.auto_updatable !== true &&
+    status.version_check.update_available === true
+  );
+}
+
+function recoveryReinstallHelpCopy(status: GuardUpdateStatus | null | undefined): string | null {
+  if (!shouldPromptRecoveryReinstall(status)) {
+    return null;
+  }
+  const blockedReason = status?.blocked_reason ?? "";
+  if (blockedReason.includes("local wheel whose source file is no longer available")) {
+    return "This install came from a local wheel whose source file is no longer available, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
+  if (blockedReason.includes("local wheel")) {
+    return "This install came from a local wheel, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
+  return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+}
+
 function updateHelpCopy(status: GuardUpdateStatus | null | undefined, phase: GuardUpdatePhase): string | null {
   if (phase === "updating") {
     return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
@@ -55,9 +77,8 @@ function updateHelpCopy(status: GuardUpdateStatus | null | undefined, phase: Gua
   if (status?.update_available) {
     return "This restarts Guard for a moment. Open approvals will stay saved.";
   }
-  // Recovery case gets calmer copy that frames the fix instead of the dead end.
   if (status && !status.auto_updatable && status.recovery_reinstall_available) {
-    return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+    return recoveryReinstallHelpCopy(status);
   }
   if (status && !status.auto_updatable && status.blocked_reason) {
     return status.blocked_reason;
@@ -75,11 +96,7 @@ export function GuardUpdatePanel(props: GuardUpdatePanelProps) {
     props.updateStatus.update_suppressed !== true &&
     phase !== "updating" &&
     phase !== "reconnecting";
-  const showReinstallButton =
-    props.updateStatus?.recovery_reinstall_available === true &&
-    props.updateStatus.auto_updatable !== true &&
-    phase !== "updating" &&
-    phase !== "reconnecting";
+  const showReinstallButton = shouldPromptRecoveryReinstall(props.updateStatus) && phase !== "updating" && phase !== "reconnecting";
   const busy = phase === "updating" || phase === "reconnecting";
 
   return (

--- a/dashboard/src/guard-update.test.ts
+++ b/dashboard/src/guard-update.test.ts
@@ -1,4 +1,8 @@
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
 import { buildGuardDaemonCandidatePorts, normalizeGuardUpdateStatus, updateReconnectSucceeded } from "./guard-api";
+import { GuardUpdatePanel } from "./guard-update-panel";
 
 function assert(condition: boolean, message: string): void {
   if (!condition) {
@@ -53,6 +57,95 @@ assert(recovery.recovery_reinstall_available === true, "recovery_reinstall_avail
 assert(
   recovery.recovery_reinstall_command === "pipx install --force hol-guard",
   "recovery_reinstall_command should pass through",
+);
+
+const currentLocalWheelMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updateStatus: normalizeGuardUpdateStatus({
+      current_version: "2.0.855",
+      latest_version: "2.0.855",
+      auto_updatable: false,
+      update_available: false,
+      version_check: {
+        source: "pypi",
+        status: "current",
+        current_version: "2.0.855",
+        latest_version: "2.0.855",
+        update_available: false,
+      },
+      blocked_reason:
+        "This install was set up from a local wheel. Re-run `hol-guard update --wheel <wheel-or-directory>` or your usual local install command instead.",
+      recovery_reinstall_available: true,
+    }),
+    onReinstallGuard: () => undefined,
+  }),
+);
+
+assert(
+  !currentLocalWheelMarkup.includes("Reinstall from PyPI"),
+  "current local wheel installs should not keep showing the PyPI recovery CTA",
+);
+assert(
+  !currentLocalWheelMarkup.includes("automatic updates are off"),
+  "current local wheel installs should not keep showing the recovery warning",
+);
+
+const staleLocalWheelMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updateStatus: normalizeGuardUpdateStatus({
+      current_version: "2.0.855",
+      latest_version: "2.0.856",
+      auto_updatable: false,
+      update_available: false,
+      version_check: {
+        source: "pypi",
+        status: "stale",
+        current_version: "2.0.855",
+        latest_version: "2.0.856",
+        update_available: true,
+      },
+      blocked_reason:
+        "This install was set up from a local wheel. Re-run `hol-guard update --wheel <wheel-or-directory>` or your usual local install command instead.",
+      recovery_reinstall_available: true,
+    }),
+    onReinstallGuard: () => undefined,
+  }),
+);
+
+assert(
+  staleLocalWheelMarkup.includes("This install came from a local wheel"),
+  "stale local wheel installs should explain the real install source",
+);
+assert(
+  staleLocalWheelMarkup.includes("Reinstall from PyPI"),
+  "stale local wheel installs should keep the PyPI recovery CTA",
+);
+
+const staleLocalFolderMarkup = renderToStaticMarkup(
+  createElement(GuardUpdatePanel, {
+    updateStatus: normalizeGuardUpdateStatus({
+      current_version: "2.0.855",
+      latest_version: "2.0.856",
+      auto_updatable: false,
+      update_available: false,
+      version_check: {
+        source: "pypi",
+        status: "stale",
+        current_version: "2.0.855",
+        latest_version: "2.0.856",
+        update_available: true,
+      },
+      blocked_reason:
+        "This install was set up from a local folder. Re-run your usual local install command instead.",
+      recovery_reinstall_available: true,
+    }),
+    onReinstallGuard: () => undefined,
+  }),
+);
+
+assert(
+  staleLocalFolderMarkup.includes("This install came from a local folder"),
+  "stale local folder installs should keep the folder-specific recovery copy",
 );
 
 const noRecovery = normalizeGuardUpdateStatus({

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16978,6 +16978,22 @@ function updateStatusLabel(status) {
   }
   return `Version ${status.current_version}`;
 }
+function shouldPromptRecoveryReinstall(status) {
+  return status?.recovery_reinstall_available === true && status.auto_updatable !== true && status.version_check.update_available === true;
+}
+function recoveryReinstallHelpCopy(status) {
+  if (!shouldPromptRecoveryReinstall(status)) {
+    return null;
+  }
+  const blockedReason = status?.blocked_reason ?? "";
+  if (blockedReason.includes("local wheel whose source file is no longer available")) {
+    return "This install came from a local wheel whose source file is no longer available, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
+  if (blockedReason.includes("local wheel")) {
+    return "This install came from a local wheel, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+  }
+  return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+}
 function updateHelpCopy(status, phase) {
   if (phase === "updating") {
     return "Guard is installing the update. The dashboard will pause briefly and reopen when ready.";
@@ -17001,7 +17017,7 @@ function updateHelpCopy(status, phase) {
     return "This restarts Guard for a moment. Open approvals will stay saved.";
   }
   if (status && !status.auto_updatable && status.recovery_reinstall_available) {
-    return "This install came from a local folder, so automatic updates are off. Reinstall from PyPI to switch it back to a normal package; Guard restarts briefly and saved approvals stay.";
+    return recoveryReinstallHelpCopy(status);
   }
   if (status && !status.auto_updatable && status.blocked_reason) {
     return status.blocked_reason;
@@ -17013,7 +17029,7 @@ function GuardUpdatePanel(props) {
   const phase = props.updatePhase ?? "idle";
   const helpCopy = updateHelpCopy(props.updateStatus, phase);
   const showUpdateButton = props.updateStatus?.update_available === true && props.updateStatus.auto_updatable && props.updateStatus.update_suppressed !== true && phase !== "updating" && phase !== "reconnecting";
-  const showReinstallButton = props.updateStatus?.recovery_reinstall_available === true && props.updateStatus.auto_updatable !== true && phase !== "updating" && phase !== "reconnecting";
+  const showReinstallButton = shouldPromptRecoveryReinstall(props.updateStatus) && phase !== "updating" && phase !== "reconnecting";
   const busy = phase === "updating" || phase === "reconnecting";
   return /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: props.compact ? "space-y-1" : "space-y-2", children: [
     version ? /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: "font-mono text-[10px] text-brand-dark/60", "aria-label": `Guard version ${version}`, children: [

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -16979,7 +16979,7 @@ function updateStatusLabel(status) {
   return `Version ${status.current_version}`;
 }
 function shouldPromptRecoveryReinstall(status) {
-  return status?.recovery_reinstall_available === true && status.auto_updatable !== true && status.version_check.update_available === true;
+  return status?.recovery_reinstall_available === true && status?.auto_updatable !== true && status?.version_check?.update_available === true;
 }
 function recoveryReinstallHelpCopy(status) {
   if (!shouldPromptRecoveryReinstall(status)) {


### PR DESCRIPTION
## Summary
- stop showing the local-install recovery warning when a local wheel or folder install is already current on PyPI
- keep the recovery CTA when PyPI is actually newer and show the correct local wheel vs local folder copy
- cover the dashboard behavior with focused update panel assertions and rebuild the shipped dashboard asset

## Testing
- `pnpm exec tsx src/guard-update.test.ts`
- `pnpm build`
