### PR TITLE
fix(guard): speed up approval integrity self-heal

### DIFF
--- a/docs/guard/harness-support.md
+++ b/docs/guard/harness-support.md
@@ -150,8 +150,8 @@ Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
 
 | Harness | Install Aliases | Native Approval | Browser Fallback | Resume | Event Surfaces |
 |---------|-----------------|-----------------|------------------|--------|----------------|
-| `codex` | `codex` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read |
-| `claude-code` | `claude-code`, `claude` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read |
+| `codex` | `codex` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read, tool_result |
+| `claude-code` | `claude-code`, `claude` | ✅ | ✅ | ✅ | shell, prompt, mcp_tool, file_read, tool_result |
 | `opencode` | `opencode` | ❌ | ✅ | ❌ | shell, mcp_tool |
 | `copilot` | `copilot` | ✅ | ✅ | ✅ | shell, prompt |
 | `cursor` | `cursor` | ❌ | ✅ | ❌ | shell, mcp_tool, file_read |
@@ -161,5 +161,5 @@ Generated from `src/codex_plugin_scanner/guard/adapters/contracts.py`.
 | `antigravity` | `antigravity` | ❌ | ✅ | ❌ | mcp_tool, prompt |
 | `kimi` | `kimi`, `kimi-code`, `kimi-cli` | ❌ | ✅ | ❌ | shell, prompt |
 | `grok` | `grok`, `grok-build`, `grok-build-cli`, `xai-grok` | ❌ | ✅ | ❌ | shell, prompt, mcp_tool, file_read |
-| `pi` | `pi`, `pi-agent`, `pi-coding-agent` | ✅ | ✅ | ❌ | shell, prompt, mcp_tool, file_read |
+| `pi` | `pi`, `pi-agent`, `pi-coding-agent` | ✅ | ✅ | ❌ | shell, prompt, mcp_tool, file_read, tool_result |
 | `zcode` | `zcode`, `zai`, `z-code`, `zai-zcode` | ❌ | ✅ | ❌ | shell, prompt, mcp_tool, file_read |

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -339,7 +339,7 @@ def _codex_post_tool_output_artifact(
     canonical_harness = _canonical_harness_name(harness)
     harness_label = "Pi" if canonical_harness == "pi" else "Codex"
     response_text = _collect_codex_tool_response_text(payload.get("tool_response"))
-    stdout_text = _coalesce_string(payload.get("stdout"))
+    stdout_text = _optional_string(payload.get("stdout"))
     if stdout_text:
         response_text = f"{response_text}\n{stdout_text}".strip() if response_text else stdout_text
     tool_name = _coalesce_string(payload.get("tool_name"), "Bash")

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -1320,7 +1320,29 @@ def _policy_integrity_ready_for_local_write(payload: Mapping[str, object]) -> bo
     trust = payload.get("trust_status")
     if not isinstance(trust, Mapping):
         return False
-    return payload.get("mode") == "protected" and trust.get("remembered_rules") == "enforced"
+    counts = payload.get("counts")
+    if not isinstance(counts, Mapping):
+        return False
+    invalid_rows = 0
+    for status in _POLICY_INTEGRITY_STATUSES:
+        if status == "valid":
+            continue
+        count = counts.get(status)
+        if isinstance(count, int) and count > 0:
+            invalid_rows += count
+    return payload.get("mode") == "protected" and trust.get("remembered_rules") == "enforced" and invalid_rows == 0
+
+
+def _policy_integrity_setup_safe_for_local_write(payload: Mapping[str, object]) -> bool:
+    counts = payload.get("counts")
+    if not isinstance(counts, Mapping):
+        return False
+    eligible_invalid_rows = 0
+    for status in _POLICY_INTEGRITY_MIGRATION_ELIGIBLE_STATUSES:
+        count = counts.get(status)
+        if isinstance(count, int) and count > 0:
+            eligible_invalid_rows += count
+    return eligible_invalid_rows > 0
 
 
 def _family_key_value(family_key: str) -> str:

--- a/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
+++ b/src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py
@@ -17,6 +17,29 @@ def _set_private_mode_compat(path: Path, mode: int) -> None:
 
 
 class StorePolicyIntegrityAdminMixin:
+    @staticmethod
+    def _policy_integrity_summary_payload(
+        *,
+        generated_at: str,
+        harness: str | None,
+        state: Mapping[str, object],
+        counts: Mapping[str, int],
+    ) -> dict[str, object]:
+        return {
+            "generated_at": generated_at,
+            "harness": harness,
+            "backend": state.get("backend"),
+            "cutover_complete": state.get("cutover_complete"),
+            "mode": state.get("mode"),
+            "enforcement": state.get("enforcement"),
+            "generation": state.get("generation"),
+            "key_id": state.get("key_id"),
+            "degraded_reasons": state.get("degraded_reasons", []),
+            "trust_status": TrustStatus.from_policy_integrity_state(dict(state)).to_dict(),
+            "counts": dict(counts),
+            "local_rows_scanned": sum(counts.values()),
+        }
+
     def list_policy_decisions(self, harness: str | None = None) -> list[dict[str, object]]:
         query = """
             select decision_id, harness, scope, artifact_id, artifact_hash, workspace, publisher,
@@ -212,20 +235,12 @@ class StorePolicyIntegrityAdminMixin:
                 create_key=False,
                 include_items=False,
             )
-        return {
-            "generated_at": now,
-            "harness": harness,
-            "backend": state.get("backend"),
-            "cutover_complete": state.get("cutover_complete"),
-            "mode": state.get("mode"),
-            "enforcement": state.get("enforcement"),
-            "generation": state.get("generation"),
-            "key_id": state.get("key_id"),
-            "degraded_reasons": state.get("degraded_reasons", []),
-            "trust_status": TrustStatus.from_policy_integrity_state(state).to_dict(),
-            "counts": counts,
-            "local_rows_scanned": sum(counts.values()),
-        }
+        return self._policy_integrity_summary_payload(
+            generated_at=now,
+            harness=harness,
+            state=state,
+            counts=counts,
+        )
 
     def get_cached_policy_trust_status(self) -> dict[str, object]:
         with self._connect() as connection:
@@ -273,15 +288,16 @@ class StorePolicyIntegrityAdminMixin:
             return before
 
         attempts: list[dict[str, object]] = []
-        try:
-            setup = self.setup_policy_integrity(harness=harness, now=current_time)
-            attempts.append({"step": "setup", "mode": setup.get("mode"), "counts": setup.get("counts")})
-            if _policy_integrity_ready_for_local_write(setup):
-                setup["autorepair"] = {"attempted": True, "cleared": 0, "steps": attempts}
-                self.add_event("policy_integrity.autorepaired", {"steps": attempts}, current_time)
-                return setup
-        except Exception as error:  # pragma: no cover - exercised through final degraded status assertions.
-            attempts.append({"step": "setup", "error": type(error).__name__})
+        if _policy_integrity_setup_safe_for_local_write(before):
+            try:
+                setup = self.setup_policy_integrity(harness=harness, now=current_time, include_items=False)
+                attempts.append({"step": "setup", "mode": setup.get("mode"), "counts": setup.get("counts")})
+                if _policy_integrity_ready_for_local_write(setup):
+                    setup["autorepair"] = {"attempted": True, "cleared": 0, "steps": attempts}
+                    self.add_event("policy_integrity.autorepaired", {"steps": attempts}, current_time)
+                    return setup
+            except Exception as error:  # pragma: no cover - exercised through final degraded status assertions.
+                attempts.append({"step": "setup", "error": type(error).__name__})
 
         try:
             repair = self.repair_policy_integrity(
@@ -289,6 +305,7 @@ class StorePolicyIntegrityAdminMixin:
                 harness=harness,
                 approval_gate_grant=approval_gate_grant,
                 now=current_time,
+                include_items=False,
             )
             attempts.append(
                 {
@@ -321,25 +338,28 @@ class StorePolicyIntegrityAdminMixin:
         harness: str | None = None,
         approval_gate_grant: ApprovalGateGrant | None = None,
         now: str | None = None,
+        include_items: bool = True,
     ) -> dict[str, object]:
         current_time = now or _now()
         if clear_invalid:
             require_policy_clear(self.guard_home, approval_gate_grant=approval_gate_grant, now=current_time)
         next_control_state: dict[str, object] | None = None
         with self._connect() as connection:
-            state, _counts, items = self._policy_integrity_scan(
-                connection,
-                now=current_time,
-                harness=harness,
-                create_key=True,
-                include_items=True,
-            )
-            invalid_ids = [
-                decision_id
-                for item in items
-                if item.get("integrity_status") != "valid"
-                and (decision_id := _int_value(item.get("decision_id"))) is not None
-            ]
+            state = self._refresh_policy_integrity_state(connection, now=current_time, create_key=True)
+            state = self._load_policy_integrity_state(connection) or state
+            key, key_id = self._policy_integrity_secret_material(create=True)
+            trusted_generation = _mapping_int(state, "generation")
+            invalid_ids: list[int] = []
+            for row in self._load_local_policy_rows(connection, harness=harness):
+                integrity_result = self._policy_integrity_result_for_row(
+                    row,
+                    mode=str(state.get("mode") or "degraded"),
+                    key=key,
+                    key_id=key_id,
+                    trusted_generation=trusted_generation,
+                )
+                if integrity_result.status != "valid" and (decision_id := _int_value(row["decision_id"])) is not None:
+                    invalid_ids.append(decision_id)
             cleared = 0
             if clear_invalid and invalid_ids:
                 for chunk in _chunks(invalid_ids, _SQLITE_ID_BATCH_SIZE):
@@ -350,7 +370,6 @@ class StorePolicyIntegrityAdminMixin:
                     )
                     cleared += int(cursor.rowcount if cursor.rowcount is not None else 0)
                 if cleared > 0 and state.get("mode") == "protected":
-                    key, key_id = self._policy_integrity_secret_material(create=True)
                     trusted_state = self._load_policy_integrity_control_state(create=True)
                     if key is not None and key_id is not None and trusted_state is not None:
                         next_control_state = self._advance_policy_integrity_generation(
@@ -368,24 +387,19 @@ class StorePolicyIntegrityAdminMixin:
                 now=current_time,
                 harness=harness,
                 create_key=True,
-                include_items=True,
+                include_items=include_items,
             )
+            invalid_items = [item for item in remaining_items if item.get("integrity_status") != "valid"]
         return {
-            "generated_at": current_time,
-            "harness": harness,
-            "backend": state.get("backend"),
-            "cutover_complete": state.get("cutover_complete"),
-            "mode": state.get("mode"),
-            "enforcement": state.get("enforcement"),
-            "generation": state.get("generation"),
-            "key_id": state.get("key_id"),
-            "degraded_reasons": state.get("degraded_reasons", []),
-            "trust_status": TrustStatus.from_policy_integrity_state(state).to_dict(),
-            "counts": counts,
-            "local_rows_scanned": sum(counts.values()),
+            **self._policy_integrity_summary_payload(
+                generated_at=current_time,
+                harness=harness,
+                state=state,
+                counts=counts,
+            ),
             "cleared": cleared,
             "clear_invalid": clear_invalid,
-            "items": [item for item in remaining_items if item.get("integrity_status") != "valid"],
+            **({"items": invalid_items} if include_items else {}),
         }
 
     def migrate_local_policy_integrity(
@@ -503,6 +517,7 @@ class StorePolicyIntegrityAdminMixin:
         *,
         harness: str | None = None,
         now: str,
+        include_items: bool = True,
     ) -> dict[str, object]:
         next_control_state: dict[str, object] | None = None
         with self._connect() as connection:
@@ -522,8 +537,18 @@ class StorePolicyIntegrityAdminMixin:
             ):
                 connection.rollback()
             else:
-                local_ids = {
-                    int(row["decision_id"]) for row in self._load_local_policy_rows(connection, harness=harness)
+                trusted_generation = _mapping_int(state, "generation")
+                force_sign_ids = {
+                    int(row["decision_id"])
+                    for row in self._load_local_policy_rows(connection)
+                    if self._policy_integrity_result_for_row(
+                        row,
+                        mode=str(state.get("mode") or "degraded"),
+                        key=key,
+                        key_id=key_id,
+                        trusted_generation=trusted_generation,
+                    ).status
+                    in _POLICY_INTEGRITY_MIGRATION_ELIGIBLE_STATUSES
                 }
                 next_control_state = self._advance_policy_integrity_generation(
                     connection,
@@ -531,13 +556,14 @@ class StorePolicyIntegrityAdminMixin:
                     key=key,
                     key_id=key_id,
                     trusted_state=trusted_state,
-                    force_sign_decision_ids=local_ids,
-                    harness=harness,
+                    force_sign_decision_ids=force_sign_ids,
                 )
                 connection.commit()
         if next_control_state is not None:
             self._finalize_policy_integrity_control_state(next_control_state)
-        return self.verify_policy_integrity(harness=harness)
+        if include_items:
+            return self.verify_policy_integrity(harness=harness)
+        return self.get_policy_integrity_status(harness=harness)
 
     def reset_policy_integrity(
         self,

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -10,7 +10,7 @@ import json
 import pickle
 import sqlite3
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import cast
 
@@ -20,6 +20,7 @@ from codex_plugin_scanner.cli import _resolve_legacy_args, main
 from codex_plugin_scanner.guard import local_trust_contract as local_trust_contract_module
 from codex_plugin_scanner.guard import policy_integrity as policy_integrity_module
 from codex_plugin_scanner.guard import store as guard_store_module
+from codex_plugin_scanner.guard import store_policy_integrity_runtime as policy_integrity_runtime_module
 from codex_plugin_scanner.guard.cli import commands_dispatch_trust as trust_dispatch_module
 from codex_plugin_scanner.guard.daemon.manager import ApprovalCenterLocator
 from codex_plugin_scanner.guard.local_trust_contract import (
@@ -967,6 +968,220 @@ def test_policy_integrity_status_skips_item_context_expansion(
     status = store.get_policy_integrity_status()
 
     assert status["local_rows_scanned"] == 1
+
+
+def test_ensure_policy_integrity_ready_for_write_skips_item_context_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:approval-memory", artifact_hash="hash-approval-memory"),
+        "2026-06-14T00:00:00Z",
+    )
+    _rotate_policy_integrity_key(store, raw_key=b"2" * 32)
+    monkeypatch.setattr(
+        store,
+        "_policy_decision_dict_from_row",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("approval self-heal should not build per-row item payloads")
+        ),
+    )
+
+    payload = store.ensure_policy_integrity_ready_for_write(now="2026-06-14T00:05:00Z")
+
+    assert payload["mode"] == "protected"
+    assert payload["counts"]["valid"] == 1
+    assert payload["autorepair"]["attempted"] is True
+    assert payload["autorepair"]["steps"][0]["step"] == "setup"
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:approval-memory",
+            "hash-approval-memory",
+            now="2026-06-14T00:06:00Z",
+        )
+        == "allow"
+    )
+
+
+def test_setup_policy_integrity_repairs_all_harnesses_when_called_with_scope(tmp_path: Path) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:codex", artifact_hash="hash-codex"),
+        "2026-06-14T00:00:00Z",
+    )
+    store.upsert_policy(
+        replace(
+            _decision(artifact_id="cursor:project:cursor", artifact_hash="hash-cursor"),
+            harness="cursor",
+        ),
+        "2026-06-14T00:00:00Z",
+    )
+    _rotate_policy_integrity_key(store, raw_key=b"2" * 32)
+
+    payload = store.setup_policy_integrity(harness="codex", now="2026-06-14T00:05:00Z", include_items=False)
+    global_status = store.get_policy_integrity_status()
+
+    assert payload["counts"]["valid"] == 1
+    assert global_status["counts"]["valid"] == 2
+    assert store.resolve_policy("codex", "codex:project:codex", "hash-codex", now="2026-06-14T00:06:00Z") == "allow"
+    assert store.resolve_policy("cursor", "cursor:project:cursor", "hash-cursor", now="2026-06-14T00:06:00Z") == "allow"
+
+
+def test_ensure_policy_integrity_ready_for_write_clears_tampered_rows_without_item_expansion(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:tampered-repair", artifact_hash="hash-tampered-repair"),
+        "2026-06-14T00:00:00Z",
+    )
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where artifact_id = ?",
+            ("deadbeef", "codex:project:tampered-repair"),
+        )
+    monkeypatch.setattr(policy_integrity_runtime_module, "require_policy_clear", lambda *args, **kwargs: None)
+    monkeypatch.setattr(
+        store,
+        "_policy_decision_dict_from_row",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("approval repair should not build per-row item payloads")
+        ),
+    )
+
+    payload = store.ensure_policy_integrity_ready_for_write(now="2026-06-14T00:05:00Z")
+
+    assert payload["counts"]["valid"] == 0
+    assert payload["local_rows_scanned"] == 0
+    assert payload["cleared"] == 1
+    assert payload["autorepair"]["steps"][0]["step"] == "clear_invalid"
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:tampered-repair",
+            "hash-tampered-repair",
+            now="2026-06-14T00:06:00Z",
+        )
+        is None
+    )
+
+
+def test_ensure_policy_integrity_ready_for_write_preserves_unknown_key_rows_while_clearing_tampered_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:unknown-key", artifact_hash="hash-unknown-key"),
+        "2026-06-14T00:00:00Z",
+    )
+    _rotate_policy_integrity_key(store, raw_key=b"2" * 32)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:tampered-mixed", artifact_hash="hash-tampered-mixed"),
+        "2026-06-14T00:01:00Z",
+    )
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where artifact_id = ?",
+            ("deadbeef", "codex:project:tampered-mixed"),
+        )
+    monkeypatch.setattr(policy_integrity_runtime_module, "require_policy_clear", lambda *args, **kwargs: None)
+
+    payload = store.ensure_policy_integrity_ready_for_write(now="2026-06-14T00:05:00Z")
+
+    assert payload["counts"]["valid"] == 1
+    assert payload["cleared"] == 1
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:unknown-key",
+            "hash-unknown-key",
+            now="2026-06-14T00:06:00Z",
+        )
+        == "allow"
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:tampered-mixed",
+            "hash-tampered-mixed",
+            now="2026-06-14T00:06:00Z",
+        )
+        is None
+    )
+
+
+def test_ensure_policy_integrity_ready_for_write_repairs_only_requested_harness(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:tampered-local", artifact_hash="hash-tampered-local"),
+        "2026-06-14T00:00:00Z",
+    )
+    store.upsert_policy(
+        replace(
+            _decision(artifact_id="cursor:project:tampered-foreign", artifact_hash="hash-tampered-foreign"),
+            harness="cursor",
+        ),
+        "2026-06-14T00:00:00Z",
+    )
+    with sqlite3.connect(store.guard_home / "guard.db") as connection:
+        connection.execute(
+            "update policy_decisions set payload_mac = ? where artifact_id in (?, ?)",
+            ("deadbeef", "codex:project:tampered-local", "cursor:project:tampered-foreign"),
+        )
+    monkeypatch.setattr(policy_integrity_runtime_module, "require_policy_clear", lambda *args, **kwargs: None)
+
+    payload = store.ensure_policy_integrity_ready_for_write(harness="codex", now="2026-06-14T00:05:00Z")
+
+    assert payload["cleared"] == 1
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:project:tampered-local",
+            "hash-tampered-local",
+            now="2026-06-14T00:06:00Z",
+        )
+        is None
+    )
+    foreign_rows = [
+        item
+        for item in store.list_policy_decisions(harness="cursor")
+        if item.get("artifact_id") == "cursor:project:tampered-foreign"
+    ]
+    assert len(foreign_rows) == 1
+    assert foreign_rows[0]["integrity_status"] == "tampered"
+
+
+def test_repair_policy_integrity_uses_reconciled_generation_before_fast_scan(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _store(tmp_path)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:baseline", artifact_hash="hash-baseline"),
+        "2026-06-14T00:00:00Z",
+    )
+    monkeypatch.setattr(store, "_finalize_policy_integrity_control_state", lambda payload: None)
+    store.upsert_policy(
+        _decision(artifact_id="codex:project:pending", artifact_hash="hash-pending"),
+        "2026-06-14T00:01:00Z",
+    )
+    monkeypatch.setattr(policy_integrity_runtime_module, "require_policy_clear", lambda *args, **kwargs: None)
+
+    payload = store.repair_policy_integrity(clear_invalid=True, now="2026-06-14T00:02:00Z", include_items=False)
+
+    assert payload["counts"]["valid"] == 2
+    assert payload["cleared"] == 0
+    assert (
+        store.resolve_policy("codex", "codex:project:baseline", "hash-baseline", now="2026-06-14T00:03:00Z") == "allow"
+    )
+    assert store.resolve_policy("codex", "codex:project:pending", "hash-pending", now="2026-06-14T00:03:00Z") == "allow"
 
 
 def test_tampered_signed_row_is_ignored_and_event_emitted(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- auto-repair unknown-key local approval rules before writing new remembered approvals
- avoid the slow per-row verify payload path during approval integrity self-heal

## Testing
- `python3 -m pytest tests/test_guard_policy_integrity.py -k 'status_skips_item_context_expansion or ensure_policy_integrity_ready_for_write_skips_item_context_expansion or migrate_local_policy_integrity_re_signs_unknown_key_rows or policies_cli_migrate_preserve_all_local_re_signs_unknown_key_rows or upsert_policy_signs_local_row_and_resolve_honors_it' -q`
- `python3 -m pytest tests/test_guard_package_shims.py::test_guard_protect_retry_runs_after_cached_advisory_package_approval tests/test_guard_policy_integrity.py::test_ensure_policy_integrity_ready_for_write_skips_item_context_expansion tests/test_guard_policy_integrity.py::test_migrate_local_policy_integrity_re_signs_unknown_key_rows -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/store_base.py src/codex_plugin_scanner/guard/store_policy_integrity_runtime.py tests/test_guard_policy_integrity.py`
