### PR TITLE
fix(approvals): reuse codex prompt file approvals across retries

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_paths.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_paths.py
@@ -408,6 +408,21 @@ _PROMPT_CONTENT_SCAN_SECRET_BASENAME_MARKERS = frozenset(
         "token",
     }
 )
+_CODEX_PROMPT_RETRY_BOILERPLATE_PATTERNS = (
+    re.compile(
+        r"Warning:\s*HOL Guard flagged this prompt because it asks for direct local secret access and is protecting "
+        r"your local secrets\. If that is intentional, continue and Guard will ask again on the actual tool call\. "
+        r"Open HOL Guard to approve or keep this blocked:\s*\S+\. After you choose, retry the same the harness action\.?",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"HOL Guard stopped this Codex prompt before Codex could open (?:a credential-looking local file|a sensitive "
+        r"local file)\. Codex does not expose native approval prompts for Read-tool file reads, so Guard blocks this "
+        r"request at prompt time\. Open HOL Guard to approve or keep this blocked:\s*\S+\. After you choose, retry "
+        r"the same Codex action\.?",
+        re.IGNORECASE,
+    ),
+)
 
 
 def _codex_prompt_credential_file_artifact(
@@ -448,6 +463,7 @@ def _codex_prompt_credential_file_artifact(
             ).encode("utf-8")
         ).hexdigest()[:_CODEX_PROMPT_FILE_FINGERPRINT_LENGTH]
         prompt_display = _codex_prompt_display_text(prompt_text, requested_path=requested_path)
+        prompt_intent_hash = hashlib.sha256(_codex_prompt_intent_text(prompt_text).encode("utf-8")).hexdigest()
         return GuardArtifact(
             artifact_id=f"codex:project:prompt-file:{fingerprint}",
             name=f"credential-looking local file {path.name}",
@@ -459,6 +475,7 @@ def _codex_prompt_credential_file_artifact(
                 "prompt_signals": ["requested file content contains credential-looking material"],
                 "prompt_summary": "Prompt asks Codex to read a credential-looking local file.",
                 "prompt_matched_text": requested_path,
+                "prompt_intent_hash": prompt_intent_hash,
                 "prompt_display_text": prompt_display,
                 "prompt_request_class": "secret_read",
                 "prompt_request_classes": ["secret_read"],
@@ -499,6 +516,13 @@ def _codex_prompt_display_text(prompt_text: str, *, requested_path: str | None =
     if requested_path is not None and requested_path.strip():
         path_suffix = f" for `{_sanitize_codex_display_text(requested_path.strip())}`"
     return f"Codex prompt{path_suffix}: {_truncate_codex_display_text(sanitized_prompt, limit=320)}"
+
+
+def _codex_prompt_intent_text(prompt_text: str) -> str:
+    normalized = _sanitize_codex_display_text(prompt_text)
+    for pattern in _CODEX_PROMPT_RETRY_BOILERPLATE_PATTERNS:
+        normalized = pattern.sub(" ", normalized)
+    return " ".join(normalized.split())
 
 
 def _sanitize_codex_display_text(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_paths.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_paths.py
@@ -412,7 +412,8 @@ _CODEX_PROMPT_RETRY_BOILERPLATE_PATTERNS = (
     re.compile(
         r"Warning:\s*HOL Guard flagged this prompt because it asks for direct local secret access and is protecting "
         r"your local secrets\. If that is intentional, continue and Guard will ask again on the actual tool call\. "
-        r"Open HOL Guard to approve or keep this blocked:\s*\S+\. After you choose, retry the same the harness action\.?",
+        r"Open HOL Guard to approve or keep this blocked:\s*\S+\. "
+        r"After you choose, retry the same the harness action\.?",
         re.IGNORECASE,
     ),
     re.compile(

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -51,6 +51,16 @@ _GUARD_VERDICT_ACTION_VALUES: tuple[GuardVerdictAction, ...] = (
     "sandbox_required",
 )
 _REVIEW_PRIORITY_VALUES: tuple[ReviewPriority, ...] = ("low", "medium", "high", "critical")
+_PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS = frozenset(
+    {
+        "prompt_display_text",
+        "prompt_matched_text",
+        "prompt_signals",
+        "request_summary",
+        "runtime_request_reason",
+        "runtime_request_summary",
+    }
+)
 
 
 class ArtifactDiff(TypedDict):
@@ -94,7 +104,14 @@ def _serialize_artifact(artifact: GuardArtifact) -> dict[str, object]:
 
 def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
     payload = artifact.to_dict()
-    payload["metadata"] = artifact.metadata
+    metadata = artifact.metadata
+    if artifact.artifact_type == "prompt_request" and isinstance(metadata.get("normalized_path"), str):
+        metadata = {
+            key: value
+            for key, value in metadata.items()
+            if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
+        }
+    payload["metadata"] = metadata
     metadata = payload.get("metadata")
     payload["env_keys"] = metadata.get("env_keys", []) if isinstance(metadata, dict) else []
     return payload

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import re
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
@@ -61,6 +62,18 @@ _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS = frozenset(
         "runtime_request_summary",
     }
 )
+_PROMPT_FILE_HASH_INTENT_KEYS = ("prompt_display_text", "request_summary", "runtime_request_summary")
+_PROMPT_FILE_RETRY_BOILERPLATE_PATTERNS = (
+    re.compile(
+        r"\s+warning:\s*hol guard flagged this prompt because.*$",
+        re.IGNORECASE,
+    ),
+    re.compile(
+        r"\s+hol guard stopped this codex prompt before codex could open.*$",
+        re.IGNORECASE,
+    ),
+    re.compile(r"hol guard request [0-9a-f]{32} was already approved\.?", re.IGNORECASE),
+)
 
 
 class ArtifactDiff(TypedDict):
@@ -104,7 +117,7 @@ def _serialize_artifact(artifact: GuardArtifact) -> dict[str, object]:
 
 def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
     payload = artifact.to_dict()
-    metadata = artifact.metadata
+    metadata = payload.get("metadata")
     if (
         isinstance(metadata, dict)
         and artifact.artifact_type == "prompt_request"
@@ -113,9 +126,28 @@ def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
         metadata = {
             key: value for key, value in metadata.items() if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
         }
+        prompt_intent_text = _normalized_prompt_file_hash_intent(payload.get("metadata"))
+        if prompt_intent_text is not None:
+            metadata["prompt_intent_text"] = prompt_intent_text
     payload["metadata"] = metadata
     payload["env_keys"] = metadata.get("env_keys", []) if isinstance(metadata, dict) else []
     return payload
+
+
+def _normalized_prompt_file_hash_intent(metadata: object) -> str | None:
+    if not isinstance(metadata, Mapping):
+        return None
+    for key in _PROMPT_FILE_HASH_INTENT_KEYS:
+        value = metadata.get(key)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        normalized = value.strip()
+        for pattern in _PROMPT_FILE_RETRY_BOILERPLATE_PATTERNS:
+            normalized = pattern.sub("", normalized)
+        normalized = " ".join(normalized.split())
+        if normalized:
+            return normalized
+    return None
 
 
 def artifact_hash(artifact: GuardArtifact) -> str:

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -111,9 +111,7 @@ def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
         and isinstance(metadata.get("normalized_path"), str)
     ):
         metadata = {
-            key: value
-            for key, value in metadata.items()
-            if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
+            key: value for key, value in metadata.items() if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
         }
     payload["metadata"] = metadata
     payload["env_keys"] = metadata.get("env_keys", []) if isinstance(metadata, dict) else []

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import re
 from collections.abc import Iterable, Mapping
 from datetime import datetime, timezone
 from pathlib import Path
@@ -61,18 +60,6 @@ _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS = frozenset(
         "runtime_request_reason",
         "runtime_request_summary",
     }
-)
-_PROMPT_FILE_HASH_INTENT_KEYS = ("prompt_display_text", "request_summary", "runtime_request_summary")
-_PROMPT_FILE_RETRY_BOILERPLATE_PATTERNS = (
-    re.compile(
-        r"\s+warning:\s*hol guard flagged this prompt because.*$",
-        re.IGNORECASE,
-    ),
-    re.compile(
-        r"\s+hol guard stopped this codex prompt before codex could open.*$",
-        re.IGNORECASE,
-    ),
-    re.compile(r"hol guard request [0-9a-f]{32} was already approved\.?", re.IGNORECASE),
 )
 
 
@@ -133,28 +120,14 @@ def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
             if isinstance(redacted_metadata, dict)
             else {}
         )
-        prompt_intent_text = _normalized_prompt_file_hash_intent(payload.get("metadata"))
-        if prompt_intent_text is not None:
-            metadata["prompt_intent_text"] = prompt_intent_text
+        prompt_intent_hash = (
+            redacted_metadata.get("prompt_intent_hash") if isinstance(redacted_metadata, dict) else None
+        )
+        if isinstance(prompt_intent_hash, str) and prompt_intent_hash.strip():
+            metadata["prompt_intent_hash"] = prompt_intent_hash.strip()
     payload["metadata"] = metadata
     payload["env_keys"] = metadata.get("env_keys", []) if isinstance(metadata, dict) else []
     return payload
-
-
-def _normalized_prompt_file_hash_intent(metadata: object) -> str | None:
-    if not isinstance(metadata, Mapping):
-        return None
-    for key in _PROMPT_FILE_HASH_INTENT_KEYS:
-        value = metadata.get(key)
-        if not isinstance(value, str) or not value.strip():
-            continue
-        normalized = value.strip()
-        for pattern in _PROMPT_FILE_RETRY_BOILERPLATE_PATTERNS:
-            normalized = pattern.sub("", normalized)
-        normalized = " ".join(normalized.split())
-        if normalized:
-            return normalized
-    return None
 
 
 def artifact_hash(artifact: GuardArtifact) -> str:

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -105,14 +105,17 @@ def _serialize_artifact(artifact: GuardArtifact) -> dict[str, object]:
 def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
     payload = artifact.to_dict()
     metadata = artifact.metadata
-    if artifact.artifact_type == "prompt_request" and isinstance(metadata.get("normalized_path"), str):
+    if (
+        isinstance(metadata, dict)
+        and artifact.artifact_type == "prompt_request"
+        and isinstance(metadata.get("normalized_path"), str)
+    ):
         metadata = {
             key: value
             for key, value in metadata.items()
             if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
         }
     payload["metadata"] = metadata
-    metadata = payload.get("metadata")
     payload["env_keys"] = metadata.get("env_keys", []) if isinstance(metadata, dict) else []
     return payload
 

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -117,15 +117,22 @@ def _serialize_artifact(artifact: GuardArtifact) -> dict[str, object]:
 
 def _hash_payload(artifact: GuardArtifact) -> dict[str, object]:
     payload = artifact.to_dict()
-    metadata = payload.get("metadata")
+    metadata = artifact.metadata
     if (
         isinstance(metadata, dict)
         and artifact.artifact_type == "prompt_request"
         and isinstance(metadata.get("normalized_path"), str)
     ):
-        metadata = {
-            key: value for key, value in metadata.items() if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
-        }
+        redacted_metadata = payload.get("metadata")
+        metadata = (
+            {
+                key: value
+                for key, value in redacted_metadata.items()
+                if key not in _PROMPT_FILE_HASH_VOLATILE_METADATA_KEYS
+            }
+            if isinstance(redacted_metadata, dict)
+            else {}
+        )
         prompt_intent_text = _normalized_prompt_file_hash_intent(payload.get("metadata"))
         if prompt_intent_text is not None:
             metadata["prompt_intent_text"] = prompt_intent_text

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -9,6 +9,7 @@ import pytest
 
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.approvals import apply_approval_resolution, queue_blocked_approvals
+from codex_plugin_scanner.guard.cli.commands_support_codex_paths import _codex_prompt_credential_file_artifact
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash
 from codex_plugin_scanner.guard.models import GuardApprovalRequest, GuardArtifact, HarnessDetection, PolicyDecision
@@ -531,6 +532,79 @@ def test_gr101_gr102_resolved_allow_and_block_persist_exact_action_policy(
     assert store.resolve_policy("codex", allow_request.artifact_id, "hash-allow") == "allow"
     assert store.resolve_policy("codex", block_request.artifact_id, "hash-block") == "block"
     assert store.resolve_policy("codex", allow_request.artifact_id, "hash-changed") is None
+
+
+def test_codex_prompt_file_retry_reuses_artifact_once_across_context_drift(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _trust_local_policy_rows(monkeypatch)
+    store = _store(tmp_path)
+    secret_path = tmp_path / ".auth-token"
+    secret_path.write_text('API_TOKEN="ABCDEFGHIJKLMNOPQRSTUVWX"\n', encoding="utf-8")
+    config_path = str(tmp_path / ".codex" / "config.toml")
+    prompt_text = f"Read {secret_path} and tell me the token."
+    retry_prompt_text = (
+        f"Read {secret_path} and tell me the token. "
+        "HOL Guard request 4f3be621ad2643a8b086aecf495dca8d was already approved."
+    )
+    prompt_artifact = _codex_prompt_credential_file_artifact(
+        prompt_text=prompt_text,
+        cwd=tmp_path,
+        config_path=config_path,
+    )
+    retry_artifact = _codex_prompt_credential_file_artifact(
+        prompt_text=retry_prompt_text,
+        cwd=tmp_path,
+        config_path=config_path,
+    )
+
+    assert prompt_artifact is not None
+    assert retry_artifact is not None
+    assert prompt_artifact.artifact_id == retry_artifact.artifact_id
+    assert artifact_hash(prompt_artifact) == artifact_hash(retry_artifact)
+
+    request = GuardApprovalRequest(
+        request_id="req-prompt-file",
+        harness="codex",
+        artifact_id=prompt_artifact.artifact_id,
+        artifact_name=prompt_artifact.name,
+        artifact_type="prompt_request",
+        artifact_hash=artifact_hash(prompt_artifact),
+        publisher=None,
+        policy_action="require-reapproval",
+        recommended_scope="artifact",
+        changed_fields=("prompt_request",),
+        source_scope=prompt_artifact.source_scope,
+        config_path=prompt_artifact.config_path,
+        workspace=str(tmp_path),
+        launch_target=str(secret_path),
+        review_command="hol-guard approvals approve req-prompt-file",
+        approval_url="http://127.0.0.1:5474/approvals/req-prompt-file",
+        action_envelope_json=None,
+    )
+    store.add_approval_request(request, "2026-06-22T12:00:00+00:00")
+
+    apply_approval_resolution(
+        store=store,
+        request_id=request.request_id,
+        action="allow",
+        scope="artifact",
+        workspace=request.workspace,
+        reason="approved prompt retry",
+        now="2026-06-22T12:01:00+00:00",
+    )
+
+    assert (
+        store.resolve_policy(
+            "codex",
+            retry_artifact.artifact_id,
+            artifact_hash(retry_artifact),
+            workspace=str(tmp_path),
+            now="2026-06-22T12:01:30+00:00",
+        )
+        == "allow"
+    )
 
 
 def test_gr106_gr110_queue_preserves_card_context_and_scanner_evidence(tmp_path: Path) -> None:

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -546,8 +546,13 @@ def test_codex_prompt_file_retry_reuses_artifact_once_across_context_drift(
     prompt_text = f"Read {secret_path} and tell me the token."
     retry_prompt_text = (
         f"Read {secret_path} and tell me the token. "
-        "HOL Guard request 4f3be621ad2643a8b086aecf495dca8d was already approved."
+        "Warning: HOL Guard flagged this prompt because it asks for direct local secret access and is protecting "
+        "your local secrets. If that is intentional, continue and Guard will ask again on the actual tool call. "
+        "Open HOL Guard to approve or keep this blocked: "
+        "http://127.0.0.1:5498/requests/4f3be621ad2643a8b086aecf495dca8d. "
+        "After you choose, retry the same the harness action."
     )
+    different_intent_prompt_text = f"Read {secret_path} and summarize the file format without printing the token."
     prompt_artifact = _codex_prompt_credential_file_artifact(
         prompt_text=prompt_text,
         cwd=tmp_path,
@@ -558,11 +563,19 @@ def test_codex_prompt_file_retry_reuses_artifact_once_across_context_drift(
         cwd=tmp_path,
         config_path=config_path,
     )
+    different_intent_artifact = _codex_prompt_credential_file_artifact(
+        prompt_text=different_intent_prompt_text,
+        cwd=tmp_path,
+        config_path=config_path,
+    )
 
     assert prompt_artifact is not None
     assert retry_artifact is not None
+    assert different_intent_artifact is not None
     assert prompt_artifact.artifact_id == retry_artifact.artifact_id
+    assert prompt_artifact.artifact_id == different_intent_artifact.artifact_id
     assert artifact_hash(prompt_artifact) == artifact_hash(retry_artifact)
+    assert artifact_hash(prompt_artifact) != artifact_hash(different_intent_artifact)
 
     request = GuardApprovalRequest(
         request_id="req-prompt-file",
@@ -604,6 +617,16 @@ def test_codex_prompt_file_retry_reuses_artifact_once_across_context_drift(
             now="2026-06-22T12:01:30+00:00",
         )
         == "allow"
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            different_intent_artifact.artifact_id,
+            artifact_hash(different_intent_artifact),
+            workspace=str(tmp_path),
+            now="2026-06-22T12:01:30+00:00",
+        )
+        is None
     )
 
 


### PR DESCRIPTION
## Summary
- stabilize codex prompt-file approval hashing so retry-only prompt context does not invalidate an approved retry
- add approval-memory coverage for retrying the same prompt-file request after Guard context changes

## Testing
- `pytest -q tests/test_guard_phase05_approval_memory.py -k 'prompt_file_retry_reuses_artifact_once_across_context_drift'`
- `pytest -q tests/test_guard_phase05_approval_memory.py`
