### PR TITLE
fix(guard): skip browser-scoped policy bundle rules in decision builder

### DIFF
--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -39,7 +39,17 @@ _POLICY_BUNDLE_RULE_ACTIONS = frozenset({"allow", "block", "review", "ignore"})
 _POLICY_BUNDLE_ROLLOUT_STATES = frozenset(
     {"draft", "simulated", "pending_approval", "enforcing", "enforced", "rollback_available"}
 )
-_POLICY_BUNDLE_SCOPE_KEYS = frozenset(
+_POLICY_BUNDLE_BROWSER_SCOPE_KEYS = frozenset(
+    {
+        "browserIntent",
+        "browserOperation",
+        "browserProfile",
+        "origin",
+        "pathPrefix",
+        "sensitiveSurface",
+    }
+)
+_POLICY_BUNDLE_SCOPE_KEYS = _POLICY_BUNDLE_BROWSER_SCOPE_KEYS | frozenset(
     {
         "agents",
         "devices",
@@ -47,12 +57,6 @@ _POLICY_BUNDLE_SCOPE_KEYS = frozenset(
         "environments",
         "harnesses",
         "locations",
-        "browserIntent",
-        "browserOperation",
-        "browserProfile",
-        "origin",
-        "pathPrefix",
-        "sensitiveSurface",
     }
 )
 _VALID_BROWSER_INTENTS = frozenset(
@@ -370,3 +374,4 @@ non_empty_string = _non_empty_string
 POLICY_BUNDLE_DEFAULT_ENVIRONMENTS = _POLICY_BUNDLE_DEFAULT_ENVIRONMENTS
 POLICY_BUNDLE_RULE_ACTIONS = _POLICY_BUNDLE_RULE_ACTIONS
 POLICY_BUNDLE_RULE_MATCHER_FAMILIES = _POLICY_BUNDLE_RULE_MATCHER_FAMILIES
+POLICY_BUNDLE_BROWSER_SCOPE_KEYS = _POLICY_BUNDLE_BROWSER_SCOPE_KEYS

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1022,18 +1022,30 @@ def _policy_bundle_rule_harnesses(rule: dict[str, object]) -> list[str]:
     if not normalized:
         return ["*"]
     return ["*" if value == "custom" else value for value in dict.fromkeys(normalized)]
+
+
 def _policy_bundle_rule_has_browser_scope(rule: dict[str, object]) -> bool:
-    """Check if a rule has any browser-specific scope keys.
+    """Check if a rule has any non-empty browser-specific scope constraints.
 
     Browser scope keys (browserIntent, origin, pathPrefix, browserProfile,
     sensitiveSurface) cannot be safely represented as harness-scoped family
     decisions because the runtime resolution would match all browser tool calls
     in that family, ignoring the narrow constraints the rule author specified.
+
+    The Guard Cloud bundle compiler may emit these fields at the top level of
+    the rule or nested under ``scope``. Empty lists are treated as no
+    constraint (matching how other scope keys behave).
     """
-    scope = rule.get("scope")
-    if not isinstance(scope, dict):
-        return False
-    return any(key in scope for key in POLICY_BUNDLE_BROWSER_SCOPE_KEYS)
+    for source in (rule, rule.get("scope")):
+        if not isinstance(source, dict):
+            continue
+        for key in POLICY_BUNDLE_BROWSER_SCOPE_KEYS:
+            value = source.get(key)
+            if isinstance(value, list) and value:
+                return True
+            if isinstance(value, str) and value.strip():
+                return True
+    return False
 
 
 def _build_policy_bundle_decisions(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -49,6 +49,7 @@ from ..package_firewall_entitlement import (
     reconcile_connect_state_with_oauth_entitlement,
 )
 from ..policy_bundle_parser import (
+    POLICY_BUNDLE_BROWSER_SCOPE_KEYS,
     POLICY_BUNDLE_DEFAULT_ENVIRONMENTS,
     POLICY_BUNDLE_RULE_ACTIONS,
     POLICY_BUNDLE_RULE_MATCHER_FAMILIES,
@@ -1021,6 +1022,18 @@ def _policy_bundle_rule_harnesses(rule: dict[str, object]) -> list[str]:
     if not normalized:
         return ["*"]
     return ["*" if value == "custom" else value for value in dict.fromkeys(normalized)]
+def _policy_bundle_rule_has_browser_scope(rule: dict[str, object]) -> bool:
+    """Check if a rule has any browser-specific scope keys.
+
+    Browser scope keys (browserIntent, origin, pathPrefix, browserProfile,
+    sensitiveSurface) cannot be safely represented as harness-scoped family
+    decisions because the runtime resolution would match all browser tool calls
+    in that family, ignoring the narrow constraints the rule author specified.
+    """
+    scope = rule.get("scope")
+    if not isinstance(scope, dict):
+        return False
+    return any(key in scope for key in POLICY_BUNDLE_BROWSER_SCOPE_KEYS)
 
 
 def _build_policy_bundle_decisions(
@@ -1040,6 +1053,8 @@ def _build_policy_bundle_decisions(
             continue
         action = item.get("action")
         if action == "ignore" or action not in POLICY_BUNDLE_RULE_ACTIONS:
+            continue
+        if _policy_bundle_rule_has_browser_scope(item):
             continue
         matcher_families = _policy_bundle_rule_matcher_families(item)
         if not matcher_families:

--- a/tests/test_guard_policy_bundle_browser_scopes.py
+++ b/tests/test_guard_policy_bundle_browser_scopes.py
@@ -267,3 +267,36 @@ class TestBrowserScopeDecisionNarrowing:
         assert "origin" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS
         assert "pathPrefix" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS
         assert "sensitiveSurface" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS
+
+    def test_empty_browser_scope_list_does_not_skip_rule(self) -> None:
+        """Empty browser scope lists are no-ops, not constraints."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        rule = self._local_match_rule()
+        rule["scope"]["browserIntent"] = []
+        rule["scope"]["origin"] = []
+        bundle = _valid_bundle_with_rules([rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert len(decisions) > 0
+
+    def test_top_level_browser_fields_skip_rule(self) -> None:
+        """Browser fields at the top level of the rule (not under scope) also skip."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        rule = self._local_match_rule()
+        rule["browserIntent"] = ["browser.navigation"]
+        rule["origin"] = ["http://127.0.0.1:3000"]
+        bundle = _valid_bundle_with_rules([rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert decisions == []
+
+    def test_empty_top_level_browser_fields_do_not_skip_rule(self) -> None:
+        """Empty top-level browser fields are no-ops, not constraints."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        rule = self._local_match_rule()
+        rule["browserIntent"] = []
+        rule["origin"] = []
+        bundle = _valid_bundle_with_rules([rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert len(decisions) > 0

--- a/tests/test_guard_policy_bundle_browser_scopes.py
+++ b/tests/test_guard_policy_bundle_browser_scopes.py
@@ -145,3 +145,125 @@ class TestBrowserScopeValidation:
         payload, error = validated_policy_bundle_payload(bundle)
         assert payload is not None
         assert error is None
+
+
+
+def _valid_bundle_with_rules(rules: list[dict[str, object]]) -> dict[str, object]:
+    bundle = {
+        "contractVersion": "guard-policy-bundle.v1",
+        "bundleVersion": "1.0",
+        "issuedAt": "2026-01-01T00:00:00Z",
+        "expiresAt": "2027-01-01T00:00:00Z",
+        "verifier": {"algorithm": "sha256", "keyId": "key-1", "signature": "sig"},
+        "rolloutState": "enforced",
+        "policyDefaults": {
+            "mode": "enforce",
+            "defaultAction": "block",
+            "unknownPublisherAction": "review",
+            "changedHashAction": "require-reapproval",
+            "newNetworkDomainAction": "block",
+            "subprocessAction": "block",
+            "telemetryEnabled": False,
+            "syncEnabled": False,
+        },
+        "rules": rules,
+        "acknowledgements": [],
+    }
+    bundle["bundleHash"] = computed_policy_bundle_hash(bundle)
+    return bundle
+
+
+class TestBrowserScopeDecisionNarrowing:
+    """Regression: browser-scoped bundle rules must not produce broad family decisions."""
+
+    @staticmethod
+    def _local_match_rule() -> dict[str, object]:
+        rule = _valid_base_rule()
+        rule["scope"]["locations"] = []
+        return rule
+
+    def test_browser_scoped_rule_produces_no_decisions(self) -> None:
+        """A rule with browserIntent must not generate a harness-scoped family decision."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        rule = self._local_match_rule()
+        rule["scope"]["browserIntent"] = ["browser.navigation"]
+        rule["scope"]["origin"] = ["http://127.0.0.1:3000"]
+        rule["scope"]["pathPrefix"] = ["/guard"]
+        bundle = _valid_bundle_with_rules([rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert decisions == []
+
+    def test_non_browser_scoped_rule_still_produces_decisions(self) -> None:
+        """A rule without browser scope keys still generates harness-scoped family decisions."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        rule = self._local_match_rule()
+        bundle = _valid_bundle_with_rules([rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert len(decisions) > 0
+        for decision in decisions:
+            assert decision.scope == "harness"
+            assert decision.artifact_id is not None
+            assert decision.artifact_id.startswith("family:")
+
+    def test_rule_with_only_sensitive_surface_skipped(self) -> None:
+        """A rule with only sensitiveSurface scope is skipped (no broad allow)."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        rule = self._local_match_rule()
+        rule["scope"]["sensitiveSurface"] = ["cookies"]
+        bundle = _valid_bundle_with_rules([rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert decisions == []
+
+    def test_rule_with_only_browser_profile_skipped(self) -> None:
+        """A rule with only browserProfile scope is skipped (no broad allow)."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        rule = self._local_match_rule()
+        rule["scope"]["browserProfile"] = ["isolated"]
+        bundle = _valid_bundle_with_rules([rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert decisions == []
+
+    def test_rule_with_only_origin_skipped(self) -> None:
+        """A rule with only origin scope is skipped (no broad allow)."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        rule = self._local_match_rule()
+        rule["scope"]["origin"] = ["http://127.0.0.1:3000"]
+        bundle = _valid_bundle_with_rules([rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert decisions == []
+
+    def test_mixed_browser_and_non_browser_rules(self) -> None:
+        """Only the non-browser rule produces a decision; the browser rule is skipped."""
+        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+
+        browser_rule = self._local_match_rule()
+        browser_rule["ruleId"] = "browser-rule"
+        browser_rule["scope"]["browserIntent"] = ["browser.navigation"]
+        browser_rule["scope"]["origin"] = ["http://127.0.0.1:3000"]
+
+        plain_rule = self._local_match_rule()
+        plain_rule["ruleId"] = "plain-rule"
+
+        bundle = _valid_bundle_with_rules([browser_rule, plain_rule])
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
+        assert len(decisions) > 0
+        for decision in decisions:
+            assert decision.owner == "plain-rule"
+
+    def test_browser_scope_constant_exported(self) -> None:
+        """POLICY_BUNDLE_BROWSER_SCOPE_KEYS is exported and contains the expected keys."""
+        from codex_plugin_scanner.guard.policy_bundle_parser import (
+            POLICY_BUNDLE_BROWSER_SCOPE_KEYS,
+        )
+
+        assert "browserIntent" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS
+        assert "browserOperation" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS
+        assert "browserProfile" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS
+        assert "origin" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS
+        assert "pathPrefix" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS
+        assert "sensitiveSurface" in POLICY_BUNDLE_BROWSER_SCOPE_KEYS


### PR DESCRIPTION
## Summary
- Skip policy bundle rules with browser scope keys (browserIntent, origin, pathPrefix, browserProfile, sensitiveSurface) in `_build_policy_bundle_decisions` instead of emitting over-broad harness-scoped family decisions that ignore those constraints
- Export `POLICY_BUNDLE_BROWSER_SCOPE_KEYS` from `policy_bundle_parser` for reuse in the runner
- Add regression tests proving browser-scoped rules produce no decisions while non-browser rules are unaffected

## Testing
- `python3 -m pytest tests/test_guard_policy_bundle_browser_scopes.py -v` (18 passed)
- `python3 -m pytest tests/test_policy_bundle_parser.py tests/test_guard_policy_integrity.py tests/test_policy.py -v` (all passed)
