### PR TITLE
feat(guard): add unidentified_package reason code for unresolved registry packages

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2043,7 +2043,7 @@ def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
                 "code": "unidentified_package",
                 "message": (
                     f"Guard could not resolve registry metadata for {target['name']} "
-                    f"in the {ecosystem} ecosystem; approval is required before install."
+                    f"in the {target['ecosystem']} ecosystem; approval is required before install."
                 ),
                 "severity": "medium",
                 "source": "guard-local",

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -2027,6 +2027,28 @@ def _package_from_cloud_result(item: dict[str, object]) -> dict[str, object]:
 
 
 def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
+    ecosystem = _optional_string(target.get("ecosystem")) or "npm"
+    is_supported = ecosystem not in {"unsupported", "system"}
+    reasons: list[dict[str, object]] = [
+        {
+            "code": "no_cached_match",
+            "message": "Guard recorded this package request and will keep watching for new intelligence.",
+            "severity": "unknown",
+            "source": "guard-local",
+        },
+    ]
+    if is_supported:
+        reasons.append(
+            {
+                "code": "unidentified_package",
+                "message": (
+                    f"Guard could not resolve registry metadata for {target['name']} "
+                    f"in the {ecosystem} ecosystem; approval is required before install."
+                ),
+                "severity": "medium",
+                "source": "guard-local",
+            }
+        )
     return {
         "decision": "monitor",
         "ecosystem": target["ecosystem"],
@@ -2041,14 +2063,7 @@ def _unknown_package_result(target: dict[str, object]) -> dict[str, object]:
         "packageManager": _optional_string(target.get("package_manager")) or "npm",
         "redactedCommand": _optional_string(target.get("redacted_command")),
         "alias": _optional_string(target.get("alias")),
-        "reasons": (
-            {
-                "code": "no_cached_match",
-                "message": "Guard recorded this package request and will keep watching for new intelligence.",
-                "severity": "unknown",
-                "source": "guard-local",
-            },
-        ),
+        "reasons": tuple(reasons),
     }
 
 

--- a/tests/test_guard_supply_chain_disclosure_reasons.py
+++ b/tests/test_guard_supply_chain_disclosure_reasons.py
@@ -221,6 +221,29 @@ def test_unidentified_package_reason_absent_for_unsupported_ecosystem(tmp_path: 
         for package in result.packages
         for reason in package["reasons"]
     )
+
+
+def test_unknown_package_result_directly_skips_unidentified_for_unsupported() -> None:
+    """Directly test _unknown_package_result does not emit unidentified_package for unsupported ecosystem."""
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import _unknown_package_result
+
+    target = {"ecosystem": "unsupported", "name": "some-pkg", "namespace": None}
+    result = _unknown_package_result(target)
+    codes = [reason["code"] for reason in result["reasons"]]
+    assert "no_cached_match" in codes
+    assert "unidentified_package" not in codes
+
+
+def test_unknown_package_result_directly_skips_unidentified_for_system() -> None:
+    """Directly test _unknown_package_result does not emit unidentified_package for system ecosystem."""
+    from codex_plugin_scanner.guard.runtime.supply_chain_package_eval import _unknown_package_result
+
+    target = {"ecosystem": "system", "name": "some-pkg", "namespace": None}
+    result = _unknown_package_result(target)
+    codes = [reason["code"] for reason in result["reasons"]]
+    assert "unidentified_package" not in codes
+
+
 def test_known_package_does_not_emit_unidentified_package(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_supply_chain_disclosure_reasons.py
+++ b/tests/test_guard_supply_chain_disclosure_reasons.py
@@ -178,7 +178,79 @@ def test_unknown_package_disclosure_reason(tmp_path: Path, monkeypatch: pytest.M
     )
 
     assert any(reason["code"] == "no_cached_match" for package in result.packages for reason in package["reasons"])
+    assert any(
+        reason["code"] == "unidentified_package"
+        for package in result.packages
+        for reason in package["reasons"]
+    )
 
+
+def test_unidentified_package_reason_fires_for_supported_ecosystem(tmp_path: Path) -> None:
+    """A supported-ecosystem package with no registry match emits unidentified_package."""
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("unresolved-npm-pkg@1.0.0"),
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+    assert result.decision == "monitor"
+    assert len(result.packages) == 1
+    codes = [reason["code"] for reason in result.packages[0]["reasons"]]
+    assert "no_cached_match" in codes
+    assert "unidentified_package" in codes
+    unidentified = next(r for r in result.packages[0]["reasons"] if r["code"] == "unidentified_package")
+    assert unidentified["severity"] == "medium"
+
+
+def test_unidentified_package_reason_absent_for_unsupported_ecosystem(tmp_path: Path) -> None:
+    """Unsupported-ecosystem packages get unsupported_ecosystem codes, not unidentified_package."""
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    artifact = artifact_from_command_fixture(
+        "helm install ingress ingress-nginx/ingress-nginx",
+        workspace=workspace_dir,
+    )
+    result = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=GuardStore(tmp_path / "home"),
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:00:00Z",
+    )
+    assert all(
+        reason["code"] != "unidentified_package"
+        for package in result.packages
+        for reason in package["reasons"]
+    )
+def test_known_package_does_not_emit_unidentified_package(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A package with a bundle match should not emit unidentified_package."""
+    monkeypatch.setattr(GuardStore, "_assert_oauth_secret_persisted", lambda self, secret_id, value: None)
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
+    bundle_response = _bundle_response(
+        packages=[
+            _package(
+                ecosystem="npm",
+                name="left-pad",
+                version="1.0.0",
+                default_action="monitor",
+            )
+        ]
+    )
+    store.cache_supply_chain_bundle(WORKSPACE_ID, bundle_response, "2026-05-19T00:00:00Z")
+    result = evaluate_package_request_artifact(
+        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        store=store,
+        workspace_dir=tmp_path / "workspace",
+        now="2026-05-19T00:00:00Z",
+    )
+    assert all(
+        reason["code"] != "unidentified_package"
+        for package in result.packages
+        for reason in package["reasons"]
+    )
 
 def test_policy_version_hash_consistency_between_cloud_request_and_local_evaluation(
     tmp_path: Path,


### PR DESCRIPTION
## Summary
- Add `unidentified_package` reason code to `_unknown_package_result` for supported-ecosystem packages that have no registry metadata match
- The new reason code has medium severity and explains which lookup failed, complementing the existing `no_cached_match` reason
- Unsupported and system ecosystem packages do not emit this code

## Testing
- `python3 -m pytest tests/test_guard_supply_chain_disclosure_reasons.py -k "unidentified or unknown_package or unsupported_ecosystem" -x -q`
