### PR TITLE
fix(guard): retry command queue after oauth expiry

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -40,6 +40,7 @@ COMMAND_QUEUE_ERROR_BACKOFF_ENV = "GUARD_CLOUD_COMMAND_QUEUE_ERROR_BACKOFF_SECON
 _DEFAULT_LEASE_WAIT_MS = 25_000
 _DEFAULT_POLL_INTERVAL_SECONDS = 2.0
 _DEFAULT_ERROR_BACKOFF_SECONDS = 30.0
+_MIN_RETRY_WAIT_SECONDS = 0.1
 _REQUEST_TIMEOUT_SECONDS = 35
 _RETRY_TIMEOUT_SECONDS = 60
 _LOGGER = logging.getLogger(__name__)
@@ -131,6 +132,17 @@ def _load_state(store: GuardStore) -> dict[str, object]:
 
 def _save_state(store: GuardStore, payload: dict[str, object]) -> None:
     store.set_sync_payload(COMMAND_QUEUE_STATE_KEY, payload, _now())
+
+
+def _retry_wait_seconds(
+    poll_interval: float,
+    error_backoff: float,
+    error_streak: int,
+) -> float:
+    retry_base = max(poll_interval, _MIN_RETRY_WAIT_SECONDS)
+    retry_cap = max(error_backoff, _MIN_RETRY_WAIT_SECONDS)
+    retry_exponent = min(max(0, error_streak - 1), 30)
+    return min(retry_cap, retry_base * (2**retry_exponent))
 
 
 def _parse_iso8601_timestamp(value: object) -> datetime | None:
@@ -443,7 +455,7 @@ def command_queue_loop(
             error_streak = 0
             if status.get("last_poll_was_empty") is True:
                 empty_streak += 1
-                wait_seconds = min(error_backoff, poll_interval * (2 ** max(0, empty_streak - 1)))
+                wait_seconds = _retry_wait_seconds(poll_interval, error_backoff, empty_streak)
             else:
                 empty_streak = 0
         except GuardSyncAuthorizationExpiredError as error:
@@ -458,7 +470,7 @@ def command_queue_loop(
                     "last_poll_at": _now(),
                 },
             )
-            wait_seconds = min(error_backoff, poll_interval * (2 ** max(0, error_streak - 1)))
+            wait_seconds = _retry_wait_seconds(poll_interval, error_backoff, error_streak)
         except GuardSyncNotConfiguredError as error:
             empty_streak = 0
             error_streak += 1
@@ -471,7 +483,7 @@ def command_queue_loop(
                     "last_poll_at": _now(),
                 },
             )
-            wait_seconds = min(error_backoff, poll_interval * (2 ** max(0, error_streak - 1)))
+            wait_seconds = _retry_wait_seconds(poll_interval, error_backoff, error_streak)
         except Exception as error:
             empty_streak = 0
             error_streak += 1
@@ -484,7 +496,7 @@ def command_queue_loop(
                     "last_poll_at": _now(),
                 },
             )
-            wait_seconds = min(error_backoff, poll_interval * (2 ** max(0, error_streak - 1)))
+            wait_seconds = _retry_wait_seconds(poll_interval, error_backoff, error_streak)
         if stop_event.wait(wait_seconds):
             return
 

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -447,6 +447,8 @@ def command_queue_loop(
             else:
                 empty_streak = 0
         except GuardSyncAuthorizationExpiredError as error:
+            empty_streak = 0
+            error_streak += 1
             _save_state(
                 store,
                 {
@@ -456,7 +458,7 @@ def command_queue_loop(
                     "last_poll_at": _now(),
                 },
             )
-            return
+            wait_seconds = min(error_backoff, poll_interval * (2 ** max(0, error_streak - 1)))
         except GuardSyncNotConfiguredError as error:
             empty_streak = 0
             error_streak += 1

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1117,6 +1117,11 @@ def test_command_queue_loop_retries_revoked_oauth_auth_and_records_reconnect_sta
     assert waits == [1, 2, 4]
 
 
+def test_command_queue_retry_wait_clamps_zero_poll_interval_and_large_backoff_exponent() -> None:
+    assert command_queue._retry_wait_seconds(0.0, 8.0, 1) == 0.1
+    assert command_queue._retry_wait_seconds(1.0, 8.0, 10_000) == 8.0
+
+
 def test_commands_status_outputs_command_queue_state(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1122,6 +1122,36 @@ def test_command_queue_retry_wait_clamps_zero_poll_interval_and_large_backoff_ex
     assert command_queue._retry_wait_seconds(1.0, 8.0, 10_000) == 8.0
 
 
+def test_poll_once_keeps_auth_expired_state_when_auth_refresh_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = _oauth_store(tmp_path)
+    existing_error = "Guard authorization expired. Run `hol-guard connect` to sign in again."
+    store.set_sync_payload(
+        command_queue.COMMAND_QUEUE_STATE_KEY,
+        {
+            "state": "auth_expired",
+            "last_error": existing_error,
+            "last_poll_at": "2026-06-23T10:00:00+00:00",
+        },
+        "2026-06-23T10:00:00+00:00",
+    )
+
+    def fake_auth_context(current_store, *, allow_primary_repair: bool = True):
+        del current_store, allow_primary_repair
+        raise guard_runner_module.GuardSyncAuthorizationExpiredError(existing_error)
+
+    monkeypatch.setattr(command_queue, "_resolve_guard_sync_auth_context", fake_auth_context)
+
+    with pytest.raises(guard_runner_module.GuardSyncAuthorizationExpiredError, match="hol-guard connect"):
+        command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    status = command_queue.command_queue_status(store)
+    assert status["state"] == "auth_expired"
+    assert status["last_error"] == existing_error
+
+
 def test_commands_status_outputs_command_queue_state(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1075,23 +1075,21 @@ def test_command_queue_loop_backs_off_after_errors(tmp_path: Path, monkeypatch) 
     assert waits == [1, 2, 4]
 
 
-def test_command_queue_loop_stops_on_revoked_oauth_auth_and_records_reconnect_state(
+def test_command_queue_loop_retries_revoked_oauth_auth_and_records_reconnect_state(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
     store = _oauth_store(tmp_path)
 
-    class FailIfWaitCalled:
-        def __init__(self) -> None:
-            self.wait_called = False
+    waits: list[float] = []
 
+    class StopAfterThreeWaits:
         def is_set(self) -> bool:
             return False
 
         def wait(self, seconds: float) -> bool:
-            del seconds
-            self.wait_called = True
-            return True
+            waits.append(seconds)
+            return len(waits) >= 3
 
     def fake_refresh(
         *,
@@ -1105,8 +1103,10 @@ def test_command_queue_loop_stops_on_revoked_oauth_auth_and_records_reconnect_st
             "Guard authorization expired. Run `hol-guard connect` to sign in again."
         )
 
-    stop_event = FailIfWaitCalled()
+    stop_event = StopAfterThreeWaits()
     monkeypatch.setenv(command_queue.COMMAND_QUEUE_ENABLED_ENV, "1")
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_POLL_INTERVAL_ENV, "1")
+    monkeypatch.setenv(command_queue.COMMAND_QUEUE_ERROR_BACKOFF_ENV, "8")
     monkeypatch.setattr(guard_runner_module, "_refresh_guard_oauth_access_token", fake_refresh)
 
     command_queue.command_queue_loop(store, _context(tmp_path), stop_event=stop_event)
@@ -1114,7 +1114,7 @@ def test_command_queue_loop_stops_on_revoked_oauth_auth_and_records_reconnect_st
     status = command_queue.command_queue_status(store)
     assert status["state"] == "auth_expired"
     assert "hol-guard connect" in str(status["last_error"])
-    assert stop_event.wait_called is False
+    assert waits == [1, 2, 4]
 
 
 def test_commands_status_outputs_command_queue_state(tmp_path: Path, capsys, monkeypatch) -> None:


### PR DESCRIPTION
## Summary
- retry the local Guard command queue after OAuth expiry instead of exiting the daemon worker
- keep the command queue status in `auth_expired` with backoff until the machine is reconnected or refresh recovers

## Testing
- `uv run pytest tests/test_guard_command_queue.py -k 'revoked_oauth_auth or backs_off_after_errors or backs_off_after_empty_polls'`
