### PR TITLE
fix(disconnect): clear expired oauth grants locally

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -762,15 +762,55 @@ def refresh_guard_access_token(
                 dpop_nonce = challenge_nonce
                 nonce_retry_count += 1
                 continue
-            message = (
-                str(payload.get("error_description") or payload.get("error") or error.reason)
-                if isinstance(payload, dict)
-                else str(error.reason)
-            )
-            raise RuntimeError(f"Guard OAuth token exchange failed: {message}") from error
+            raise _guard_oauth_token_exchange_error_from_http_error(error, payload) from error
         if not isinstance(payload, dict):
             raise RuntimeError("Guard OAuth token exchange failed: invalid response.")
         return _parse_guard_token_exchange_payload(payload)
+
+
+class GuardOAuthTokenExchangeError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        oauth_error: str | None,
+        oauth_error_description: str | None,
+        status_code: int | None,
+        reason: str | None,
+    ) -> None:
+        self.oauth_error = oauth_error
+        self.oauth_error_description = oauth_error_description
+        self.status_code = status_code
+        self.reason = reason
+        message = oauth_error_description or oauth_error or reason or "token exchange failed."
+        super().__init__(f"Guard OAuth token exchange failed: {message}")
+
+
+def _guard_oauth_token_exchange_error_from_http_error(
+    error: urllib.error.HTTPError,
+    payload: object,
+) -> GuardOAuthTokenExchangeError:
+    oauth_error = payload.get("error") if isinstance(payload, dict) else None
+    oauth_error_description = payload.get("error_description") if isinstance(payload, dict) else None
+    return GuardOAuthTokenExchangeError(
+        oauth_error=str(oauth_error).strip() if isinstance(oauth_error, str) and oauth_error.strip() else None,
+        oauth_error_description=(
+            str(oauth_error_description).strip()
+            if isinstance(oauth_error_description, str) and oauth_error_description.strip()
+            else None
+        ),
+        status_code=error.code,
+        reason=str(error.reason).strip() if str(error.reason).strip() else None,
+    )
+
+
+def _oauth_refresh_error_means_grant_inactive(error: Exception) -> bool:
+    if isinstance(error, GuardOAuthTokenExchangeError):
+        oauth_error = (error.oauth_error or "").strip().lower()
+        if error.status_code not in {400, 401, 403}:
+            return False
+        return oauth_error == "invalid_grant"
+    message = str(error).strip().lower()
+    return "missing, expired, or already consumed" in message
 
 
 def revoke_guard_self_oauth_grant(
@@ -923,14 +963,26 @@ def run_guard_disconnect_command(
     oauth_client = resolve_guard_oauth_client_config(issuer)
     exchange_now = datetime.fromisoformat(now) if isinstance(now, str) else datetime.now(timezone.utc)
     timestamp = now or exchange_now.isoformat()
-    token_result = refresh_guard_access_token(
-        token_endpoint=oauth_client.token_endpoint,
-        client_id=client_id,
-        refresh_token=refresh_token,
-        dpop_key_material=dpop_key_material,
-        urlopen=urlopen,
-        now=exchange_now,
-    )
+    try:
+        token_result = refresh_guard_access_token(
+            token_endpoint=oauth_client.token_endpoint,
+            client_id=client_id,
+            refresh_token=refresh_token,
+            dpop_key_material=dpop_key_material,
+            urlopen=urlopen,
+            now=exchange_now,
+        )
+    except RuntimeError as error:
+        if not _oauth_refresh_error_means_grant_inactive(error):
+            raise
+        store.clear_oauth_local_credentials()
+        return {
+            "status": "disconnected",
+            "cloud_grant_revoked": False,
+            "cloud_grant_status": "already_inactive",
+            "detail": "Guard Cloud grant was already expired. Cleared local sign-in on this machine.",
+            "reconnect_command": CONNECT_COMMAND,
+        }
     rotated_refresh_token = token_result.refresh_token
     if rotated_refresh_token and rotated_refresh_token != refresh_token:
         _persist_oauth_local_credentials(

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -56,6 +56,10 @@ def _install_fake_system_keyring(monkeypatch) -> _FakeSystemKeyringModule:
     return module
 
 
+def _disable_oauth_persistence_assert(monkeypatch) -> None:
+    monkeypatch.setattr(GuardStore, "_assert_oauth_secret_persisted", lambda self, secret_id, value: None)
+
+
 class _Args:
     guard_command = "login"
     token = None
@@ -404,8 +408,11 @@ def test_headless_connect_ci_safe_uses_explicit_label_and_restricted_scopes(tmp_
 
 def test_disconnect_revokes_cloud_grant_with_runtime_access_token_and_clears_local_oauth_credentials(
     tmp_path: Path,
+    monkeypatch,
 ) -> None:
     guard_home = tmp_path / "guard-home"
+    _install_fake_system_keyring(monkeypatch)
+    _disable_oauth_persistence_assert(monkeypatch)
     store = GuardStore(guard_home)
     dpop_key_material = generate_dpop_key_pair()
     store.set_oauth_local_credentials(
@@ -502,8 +509,13 @@ def test_disconnect_revokes_cloud_grant_with_runtime_access_token_and_clears_loc
     assert "refresh-123" not in str(requests[1]["body"])
 
 
-def test_disconnect_keeps_local_oauth_credentials_when_self_revoke_fails(tmp_path: Path) -> None:
+def test_disconnect_keeps_local_oauth_credentials_when_self_revoke_fails(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
     guard_home = tmp_path / "guard-home"
+    _install_fake_system_keyring(monkeypatch)
+    _disable_oauth_persistence_assert(monkeypatch)
     store = GuardStore(guard_home)
     dpop_key_material = generate_dpop_key_pair()
     store.set_oauth_local_credentials(
@@ -577,6 +589,241 @@ def test_disconnect_keeps_local_oauth_credentials_when_self_revoke_fails(tmp_pat
     credentials = store.get_oauth_local_credentials()
     assert credentials is not None
     assert credentials["refresh_token"] == "refresh-rotated"
+
+
+def test_disconnect_clears_local_oauth_credentials_when_refresh_grant_is_already_expired(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _install_fake_system_keyring(monkeypatch)
+    _disable_oauth_persistence_assert(monkeypatch)
+    store = GuardStore(guard_home)
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-123",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        runtime_id="hol-guard",
+        runtime_label="HOL Guard CLI",
+        now="2026-06-01T12:00:00+00:00",
+    )
+    requests: list[str] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        requests.append(request.full_url)
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "invalid_grant",
+            hdrs={"Content-Type": "application/json"},
+            fp=io.BytesIO(
+                json.dumps(
+                    {
+                        "error": "invalid_grant",
+                        "error_description": "The grant is missing, expired, or already consumed.",
+                    }
+                ).encode("utf-8")
+            ),
+        )
+
+    payload = connect_flow.run_guard_disconnect_command(
+        store=store,
+        revoke_cloud_grant=True,
+        urlopen=fake_urlopen,
+        now="2026-06-01T12:05:00+00:00",
+    )
+
+    assert payload == {
+        "status": "disconnected",
+        "cloud_grant_revoked": False,
+        "cloud_grant_status": "already_inactive",
+        "detail": "Guard Cloud grant was already expired. Cleared local sign-in on this machine.",
+        "reconnect_command": "hol-guard connect",
+    }
+    assert requests == ["https://hol.org/api/guard/oauth/token"]
+    assert store.get_oauth_local_credentials() is None
+
+
+def test_disconnect_keeps_local_oauth_credentials_when_refresh_error_is_not_invalid_grant(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _install_fake_system_keyring(monkeypatch)
+    _disable_oauth_persistence_assert(monkeypatch)
+    store = GuardStore(guard_home)
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-123",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        runtime_id="hol-guard",
+        runtime_label="HOL Guard CLI",
+        now="2026-06-01T12:00:00+00:00",
+    )
+    requests: list[str] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        requests.append(request.full_url)
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "invalid_grant_type",
+            hdrs={"Content-Type": "application/json"},
+            fp=io.BytesIO(
+                json.dumps(
+                    {
+                        "error": "invalid_grant_type",
+                        "error_description": "unsupported refresh flow",
+                    }
+                ).encode("utf-8")
+            ),
+        )
+
+    with pytest.raises(RuntimeError, match="Guard OAuth token exchange failed: unsupported refresh flow"):
+        connect_flow.run_guard_disconnect_command(
+            store=store,
+            revoke_cloud_grant=True,
+            urlopen=fake_urlopen,
+            now="2026-06-01T12:05:00+00:00",
+        )
+
+    assert requests == ["https://hol.org/api/guard/oauth/token"]
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-123"
+
+
+def test_disconnect_keeps_local_oauth_credentials_when_invalid_grant_comes_from_server_error(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _install_fake_system_keyring(monkeypatch)
+    _disable_oauth_persistence_assert(monkeypatch)
+    store = GuardStore(guard_home)
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-123",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        runtime_id="hol-guard",
+        runtime_label="HOL Guard CLI",
+        now="2026-06-01T12:00:00+00:00",
+    )
+    requests: list[str] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        requests.append(request.full_url)
+        raise urllib.error.HTTPError(
+            request.full_url,
+            500,
+            "server_error",
+            hdrs={"Content-Type": "application/json"},
+            fp=io.BytesIO(
+                json.dumps(
+                    {
+                        "error": "invalid_grant",
+                        "error_description": "temporary upstream mismatch",
+                    }
+                ).encode("utf-8")
+            ),
+        )
+
+    with pytest.raises(RuntimeError, match="Guard OAuth token exchange failed: temporary upstream mismatch"):
+        connect_flow.run_guard_disconnect_command(
+            store=store,
+            revoke_cloud_grant=True,
+            urlopen=fake_urlopen,
+            now="2026-06-01T12:05:00+00:00",
+        )
+
+    assert requests == ["https://hol.org/api/guard/oauth/token"]
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-123"
+
+
+def test_disconnect_keeps_local_oauth_credentials_when_description_matches_but_oauth_error_does_not(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    _install_fake_system_keyring(monkeypatch)
+    _disable_oauth_persistence_assert(monkeypatch)
+    store = GuardStore(guard_home)
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-123",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        runtime_id="hol-guard",
+        runtime_label="HOL Guard CLI",
+        now="2026-06-01T12:00:00+00:00",
+    )
+    requests: list[str] = []
+
+    def fake_urlopen(request: urllib.request.Request, timeout: int):
+        del timeout
+        requests.append(request.full_url)
+        raise urllib.error.HTTPError(
+            request.full_url,
+            400,
+            "invalid_request",
+            hdrs={"Content-Type": "application/json"},
+            fp=io.BytesIO(
+                json.dumps(
+                    {
+                        "error": "invalid_request",
+                        "error_description": "The grant is missing, expired, or already consumed.",
+                    }
+                ).encode("utf-8")
+            ),
+        )
+
+    with pytest.raises(
+        RuntimeError,
+        match="Guard OAuth token exchange failed: The grant is missing, expired, or already consumed.",
+    ):
+        connect_flow.run_guard_disconnect_command(
+            store=store,
+            revoke_cloud_grant=True,
+            urlopen=fake_urlopen,
+            now="2026-06-01T12:05:00+00:00",
+        )
+
+    assert requests == ["https://hol.org/api/guard/oauth/token"]
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-123"
 
 
 def test_headless_connect_polls_until_success_and_persists_oauth_credentials(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- clear local Guard Cloud sign-in when disconnect hits an already expired or consumed OAuth grant
- add disconnect regression coverage for revoke success, revoke failure retention, and invalid-grant cleanup

## Testing
- `uv run pytest tests/test_guard_oauth_device_connect.py -k 'disconnect'`
