### PR TITLE
fix(sync): preserve Guard Cloud OAuth pairing state

### DIFF
--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -792,7 +792,7 @@ def _copy_guard_database(*, source: Path, destination: Path) -> None:
 def _prune_retired_guard_db_sync_state(database_path: Path) -> None:
     try:
         with sqlite3.connect(database_path) as connection:
-            connection.execute("delete from sync_state where state_key in ('credentials', 'oauth_local_credentials')")
+            connection.execute("delete from sync_state where state_key = 'credentials'")
     except sqlite3.Error:
         return
 

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -33,6 +33,12 @@ NON_MIGRATED_GUARD_RUNTIME_FILES = frozenset(
         "guard.db-wal",
     }
 )
+GUARD_HOME_METADATA_FILES = frozenset(
+    {
+        "oauth-keychain-access.json",
+        "system-keyring-availability.json",
+    }
+)
 GUARD_DB_BACKUP_TIMEOUT_SECONDS = 5.0
 GUARD_DB_BACKUP_SLEEP_SECONDS = 0.05
 WORKSPACE_CONFIG_FILENAMES = (".ai-plugin-scanner-guard.toml", ".hol-guard.toml")
@@ -837,7 +843,7 @@ def _guard_home_has_state(path: Path) -> bool:
     entries = list(path.iterdir())
     if not entries:
         return False
-    if any(entry.name != "guard.db" for entry in entries):
+    if any(entry.name not in {"guard.db", *GUARD_HOME_METADATA_FILES} for entry in entries):
         return True
     database_path = path / "guard.db"
     if not database_path.is_file():
@@ -882,7 +888,7 @@ def _guard_home_has_sync_credentials(path: Path) -> bool:
                 """
                 select 1
                 from sync_state
-                where state_key in ('credentials', 'oauth_local_credentials')
+                where state_key = 'oauth_local_credentials'
                 limit 1
                 """
             ).fetchone()

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -417,14 +417,13 @@ class StoreOAuthConnectMixin:
             and isinstance(self._oauth_secret_store, FallbackSecretStore)
             and isinstance(self._oauth_secret_store.primary, SystemKeyringSecretStore)
         )
-        if not skip_fallback_first:
-            fallback_secret_payload = self._load_validated_oauth_fallback_secret_payload(
-                fallback_secret_json,
-                secret_hash,
-            )
-            if fallback_secret_payload is not None:
-                self._remember_oauth_secret_payload(secret_ref, secret_hash, fallback_secret_json)
-                return fallback_secret_payload
+        fallback_secret_payload = self._load_validated_oauth_fallback_secret_payload(
+            fallback_secret_json,
+            secret_hash,
+        )
+        if fallback_secret_payload is not None and (not skip_fallback_first or not allow_primary):
+            self._remember_oauth_secret_payload(secret_ref, secret_hash, fallback_secret_json)
+            return fallback_secret_payload
         if not allow_primary:
             return None
         for candidate in self._get_secret_candidates(

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -421,7 +421,8 @@ class StoreOAuthConnectMixin:
             fallback_secret_json,
             secret_hash,
         )
-        if fallback_secret_payload is not None and (not skip_fallback_first or not allow_primary):
+        prefer_primary_over_fallback = skip_fallback_first and allow_primary
+        if fallback_secret_payload is not None and not prefer_primary_over_fallback:
             self._remember_oauth_secret_payload(secret_ref, secret_hash, fallback_secret_json)
             return fallback_secret_payload
         if not allow_primary:

--- a/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
@@ -116,6 +116,10 @@ class StoreSecretPolicyIntegrityMixin:
                     return
                 if self._oauth_primary_direct_test_reads_are_safe() and primary.get_secret(secret_id) == value:
                     return
+                if isinstance(secret_store.fallback, EncryptedFileSecretStore):
+                    fallback_value = self._get_secret_from_store(secret_store.fallback, secret_id)
+                    if fallback_value == value:
+                        return
                 raise RuntimeError("Guard could not persist local Guard Cloud authorization securely.")
         if isinstance(secret_store, UnavailableSecretStore):
             raise RuntimeError(

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -9095,12 +9095,12 @@ url = http://127.0.0.1:8787/guard-canary
         store = GuardStore(home_dir)
         _seed_guard_cloud(store)
 
-        def _fail_auth(_store: GuardStore) -> dict[str, object]:
+        def _fail_auth(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
             raise guard_commands_module.GuardSyncAuthorizationExpiredError(
                 "Guard authorization expired. Run `hol-guard connect` to sign in again."
             )
 
-        monkeypatch.setattr(guard_commands_module, "_resolve_guard_sync_auth_context", _fail_auth)
+        monkeypatch.setattr(guard_commands_module, "sync_supply_chain_bundle", _fail_auth)
 
         guard_commands_module._refresh_cloud_policy_bundle(store, bundle_only=True)
 

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -409,6 +409,31 @@ def test_migrate_guard_home_state_preserves_oauth_local_credentials(tmp_path):
     assert canonical_store.get_cloud_workspace_id() == "workspace-123"
 
 
+def test_migrate_guard_home_state_replaces_retired_credentials_only_destination(tmp_path):
+    canonical_home = tmp_path / ".hol-guard"
+    legacy_home = tmp_path / ".config" / ".ai-plugin-scanner-guard"
+    canonical_store = GuardStore(canonical_home)
+    canonical_store.set_sync_payload(
+        "credentials",
+        {
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "demo-token",
+        },
+        "2026-05-19T00:00:00Z",
+    )
+    legacy_store = GuardStore(legacy_home)
+    _seed_guard_cloud(legacy_store, workspace_id="workspace-123")
+
+    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+
+    migrated_store = GuardStore(canonical_home)
+    oauth_payload = migrated_store.get_sync_payload("oauth_local_credentials")
+
+    assert isinstance(oauth_payload, dict)
+    assert migrated_store.get_cloud_workspace_id() == "workspace-123"
+    assert migrated_store.get_sync_payload("credentials") is None
+
+
 def test_resolve_guard_home_does_not_migrate_retired_legacy_credentials(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     canonical_home = home_dir / ".hol-guard"

--- a/tests/test_guard_config_paths.py
+++ b/tests/test_guard_config_paths.py
@@ -394,6 +394,21 @@ def test_migrate_guard_home_state_copies_guard_db_with_sqlite_backup(tmp_path):
     assert row == ("legacy",)
 
 
+def test_migrate_guard_home_state_preserves_oauth_local_credentials(tmp_path):
+    canonical_home = tmp_path / ".hol-guard"
+    legacy_home = tmp_path / ".config" / ".ai-plugin-scanner-guard"
+    legacy_store = GuardStore(legacy_home)
+    _seed_guard_cloud(legacy_store, workspace_id="workspace-123")
+
+    _migrate_guard_home_state(source=legacy_home, destination=canonical_home)
+
+    canonical_store = GuardStore(canonical_home)
+    oauth_payload = canonical_store.get_sync_payload("oauth_local_credentials")
+
+    assert isinstance(oauth_payload, dict)
+    assert canonical_store.get_cloud_workspace_id() == "workspace-123"
+
+
 def test_resolve_guard_home_does_not_migrate_retired_legacy_credentials(tmp_path, monkeypatch):
     home_dir = tmp_path / "home"
     canonical_home = home_dir / ".hol-guard"

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1035,7 +1035,7 @@ def test_headless_connect_slows_down_polling_when_server_requests_it(tmp_path: P
     assert sleeps == [7]
 
 
-def test_headless_connect_rejects_macos_keychain_readback_failure(
+def test_headless_connect_uses_encrypted_fallback_when_macos_keychain_readback_fails(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -1074,28 +1074,30 @@ def test_headless_connect_rejects_macos_keychain_readback_failure(
         def read(self) -> bytes:
             return json.dumps(self._payload).encode("utf-8")
 
-    with pytest.raises(RuntimeError, match="persist local Guard Cloud authorization securely"):
-        connect_flow.run_guard_device_connect_command(
-            store=store,
-            connect_url="https://hol.org/guard/connect",
-            request_device_authorization=fake_request,
-            token_urlopen=lambda request, timeout: _Response(
-                {
-                    "access_token": _fake_access_token(
-                        grant_id="grant-123",
-                        machine_id="machine-123",
-                        workspace_id="workspace-123",
-                    ),
-                    "refresh_token": "refresh-123",
-                    "expires_in": 3600,
-                    "scope": "guard:runtime.sync guard:offline_access",
-                    "token_type": "Bearer",
-                }
-            ),
-            now="2026-06-01T12:00:00+00:00",
-        )
+    payload = connect_flow.run_guard_device_connect_command(
+        store=store,
+        connect_url="https://hol.org/guard/connect",
+        request_device_authorization=fake_request,
+        token_urlopen=lambda request, timeout: _Response(
+            {
+                "access_token": _fake_access_token(
+                    grant_id="grant-123",
+                    machine_id="machine-123",
+                    workspace_id="workspace-123",
+                ),
+                "refresh_token": "refresh-123",
+                "expires_in": 3600,
+                "scope": "guard:runtime.sync guard:offline_access",
+                "token_type": "Bearer",
+            }
+        ),
+        now="2026-06-01T12:00:00+00:00",
+    )
 
-    assert store.get_oauth_local_credentials() is None
+    assert payload["status"] == "connected"
+    credentials = store.get_oauth_local_credentials(allow_primary=False)
+    assert credentials is not None
+    assert credentials["workspace_id"] == "workspace-123"
 
 
 def test_headless_connect_expired_code_surfaces_retry_command(tmp_path: Path) -> None:

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -1565,6 +1565,38 @@ def test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_key
     assert headless_store.get_oauth_local_credentials(allow_primary=False) is not None
 
 
+def test_get_oauth_local_credentials_uses_encrypted_fallback_on_macos_when_primary_reads_are_blocked(
+    tmp_path,
+    monkeypatch,
+):
+    fake_keyring = _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(guard_store_module.sys, "platform", "darwin", raising=False)
+    monkeypatch.setattr(SystemKeyringSecretStore, "_macos_default_keychain_is_usable", classmethod(lambda cls: True))
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----[REDACTED:Private key block]\\n",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value", "y": "y-value", "alg": "ES256", "use": "sig"},
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        grant_id="grant-123",
+        machine_id="machine-123",
+        workspace_id="workspace-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
+    assert isinstance(store._oauth_secret_store, FallbackSecretStore)
+    secret_id = store._oauth_local_credentials_ref
+    assert isinstance(store._oauth_secret_store.fallback.get_secret(secret_id), str)
+    fake_keyring.delete_password("hol-guard.oauth", secret_id)
+    monkeypatch.setattr(store._oauth_secret_store.primary, "get_secret_with_timeout", lambda *_args, **_kwargs: None)
+
+    credentials = store.get_oauth_local_credentials(allow_primary=False)
+
+    assert credentials is not None
+    assert credentials["workspace_id"] == "workspace-123"
+
+
 def test_get_oauth_local_credential_health_avoids_primary_keychain_reads(tmp_path, monkeypatch):
     _install_fake_system_keyring(monkeypatch)
     monkeypatch.setattr(guard_store_module.sys, "platform", "linux", raising=False)

--- a/tests/test_guard_store_migrations.py
+++ b/tests/test_guard_store_migrations.py
@@ -681,7 +681,7 @@ def test_oauth_secret_store_rechecks_stale_macos_health_cache_for_login(tmp_path
     assert isinstance(secret_store.fallback, EncryptedFileSecretStore)
 
 
-def test_macos_oauth_write_rejects_unreadable_keychain_secret(
+def test_macos_oauth_write_accepts_encrypted_fallback_when_keychain_readback_fails(
     tmp_path,
     monkeypatch,
 ):
@@ -691,26 +691,28 @@ def test_macos_oauth_write_rejects_unreadable_keychain_secret(
     monkeypatch.setattr(SystemKeyringSecretStore, "get_secret_with_timeout", lambda *args, **kwargs: None)
     store = GuardStore(guard_home)
 
-    with pytest.raises(RuntimeError, match="persist local Guard Cloud authorization securely"):
-        store.set_oauth_local_credentials(
-            issuer="https://hol.org",
-            client_id="guard-local-daemon",
-            refresh_token="refresh-secret-value",
-            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
-            dpop_public_jwk={
-                "kty": "EC",
-                "crv": "P-256",
-                "x": "x-value",
-                "y": "y-value",
-                "alg": "ES256",
-                "use": "sig",
-            },
-            dpop_public_jwk_thumbprint="thumbprint-123",
-            now="2026-06-01T00:00:00+00:00",
-        )
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-secret-value",
+        dpop_private_key_pem="-----BEGIN PRIVATE KEY-----[REDACTED:Private key block]\n",
+        dpop_public_jwk={
+            "kty": "EC",
+            "crv": "P-256",
+            "x": "x-value",
+            "y": "y-value",
+            "alg": "ES256",
+            "use": "sig",
+        },
+        dpop_public_jwk_thumbprint="thumbprint-123",
+        now="2026-06-01T00:00:00+00:00",
+    )
 
-    assert store.get_sync_payload(guard_store_module._OAUTH_LOCAL_CREDENTIALS_STATE_KEY) is None
-    assert store.get_oauth_local_credentials() is None
+    payload = store.get_sync_payload(guard_store_module._OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+    assert isinstance(payload, dict)
+    credentials = store.get_oauth_local_credentials()
+    assert credentials is not None
+    assert credentials["refresh_token"] == "refresh-secret-value"
 
 
 def test_oauth_health_uses_no_ui_primary_read_for_macos_keychain_only_store(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- allow Guard Cloud OAuth connect to persist through the encrypted fallback store when macOS keychain readback is unavailable
- preserve fallback-only OAuth reads for headless paths and keep `oauth_local_credentials` during guard home migration

## Testing
- `pytest tests/test_guard_oauth_device_connect.py::test_headless_connect_uses_encrypted_fallback_when_macos_keychain_readback_fails tests/test_guard_store_migrations.py::test_get_oauth_local_credentials_uses_encrypted_fallback_on_macos_when_primary_reads_are_blocked tests/test_guard_config_paths.py::test_migrate_guard_home_state_preserves_oauth_local_credentials`
- `pytest tests/test_guard_headless_daemon_api.py::test_supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_paid_access`
- `pytest tests/test_guard_oauth_device_connect.py::test_headless_connect_polls_until_success_and_persists_oauth_credentials tests/test_guard_store_migrations.py::test_get_oauth_local_credentials_backfills_encrypted_fallback_for_legacy_keyring_only_state tests/test_guard_config_paths.py::test_migrate_guard_home_state_copies_guard_db_with_sqlite_backup`
