### PR TITLE
fix: persist full prompt_text in action envelope to_dict

### DIFF
--- a/dashboard/src/evidence/plain-english.ts
+++ b/dashboard/src/evidence/plain-english.ts
@@ -73,10 +73,10 @@ export function resolveActionTitle(receipt: GuardReceipt): string {
     return truncate(targetPath, 80);
   }
 
-  // Prompt: show excerpt
-  const promptExcerpt = envelope?.prompt_excerpt?.trim();
-  if (type === "Prompt" && promptExcerpt && promptExcerpt.length > 0) {
-    return truncate(promptExcerpt, 80);
+  // Prompt: show full text (prefer prompt_text, fall back to excerpt)
+  const promptText = (envelope?.prompt_text ?? envelope?.prompt_excerpt)?.trim();
+  if (type === "Prompt" && promptText && promptText.length > 0) {
+    return truncate(promptText, 80);
   }
 
   // Network: show host

--- a/dashboard/src/queue-state.test.ts
+++ b/dashboard/src/queue-state.test.ts
@@ -421,6 +421,21 @@ const mcpItem: GuardApprovalRequest = {
 const mcpResults = searchQueue([BASE_REQUEST, shellItem, mcpItem], "filesystem");
 assert(mcpResults.length === 1, "T-QS-37: searchQueue matches MCP server name");
 assert(mcpResults[0].request_id === "req-mcp", "T-QS-38: searchQueue returns correct item for MCP server search");
+const longPromptItem: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "req-long-prompt",
+  action_envelope_json: {
+    ...shellEnvelope,
+    action_type: "prompt",
+    command: null,
+    prompt_excerpt: "Short excerpt that is truncated",
+    prompt_text: "The full prompt contains unique searchable text like zigzag-xylophone that is not in the excerpt",
+  },
+};
+
+const promptTextResults = searchQueue([BASE_REQUEST, longPromptItem], "zigzag-xylophone");
+assert(promptTextResults.length === 1, "T-QS-38a: searchQueue matches full prompt_text not just prompt_excerpt");
+assert(promptTextResults[0].request_id === "req-long-prompt", "T-QS-38b: searchQueue returns correct item for prompt_text search");
 
 assert(
   resolveStaleRequestRecovery("req-1", [BASE_REQUEST, req2]) === "req-1",

--- a/dashboard/src/queue-state.ts
+++ b/dashboard/src/queue-state.ts
@@ -748,7 +748,7 @@ function queueCategoryText(item: GuardApprovalRequest): string {
     envelope?.action_type ?? "",
     envelope?.command ?? "",
     envelope?.tool_name ?? "",
-    envelope?.prompt_excerpt ?? "",
+    (envelope?.prompt_text ?? envelope?.prompt_excerpt) ?? "",
     envelope?.mcp_server ?? "",
     envelope?.mcp_tool ?? "",
     envelope?.package_manager ?? "",
@@ -1125,7 +1125,7 @@ export function searchQueue(items: GuardApprovalRequest[], term: string): GuardA
       item.launch_summary ?? "",
       item.why_now ?? "",
       envelope?.command ?? "",
-      envelope?.prompt_excerpt ?? "",
+      (envelope?.prompt_text ?? envelope?.prompt_excerpt) ?? "",
       envelope?.mcp_server ?? "",
       envelope?.mcp_tool ?? "",
       envelope?.package_name ?? "",
@@ -1170,7 +1170,7 @@ export function buildNextUpChipText(item: GuardApprovalRequest): string {
   const preview =
     envelope?.command?.slice(0, 40) ??
     envelope?.mcp_tool ??
-    envelope?.prompt_excerpt?.slice(0, 40) ??
+    (envelope?.prompt_text ?? envelope?.prompt_excerpt)?.slice(0, 40) ??
     item.artifact_type;
   return `${item.harness} — ${preview}`;
 }

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -954,7 +954,7 @@ function queueItemPreview(item: GuardApprovalRequest): string {
   return (
     envelope?.command ??
     envelope?.mcp_tool ??
-    envelope?.prompt_excerpt ??
+    (envelope?.prompt_text ?? envelope?.prompt_excerpt) ??
     envelope?.package_name ??
     displayArtifactName(item)
   );

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -176,6 +176,7 @@ class GuardActionEnvelope:
             "tool_name": self.tool_name,
             "command": self.command,
             "prompt_excerpt": self.prompt_excerpt,
+            "prompt_text": self.prompt_text,
             "target_paths": list(self.target_paths),
             "network_hosts": list(self.network_hosts),
             "mcp_server": self.mcp_server,

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -51,6 +51,7 @@ def test_guard_action_envelope_round_trips_to_dict() -> None:
         "tool_name": "Bash",
         "command": "printf ok",
         "prompt_excerpt": None,
+        "prompt_text": None,
         "target_paths": ["package.json"],
         "network_hosts": ["example.com"],
         "mcp_server": None,
@@ -63,6 +64,37 @@ def test_guard_action_envelope_round_trips_to_dict() -> None:
         "script_name": None,
         "raw_payload_redacted": {"tool_name": "Bash"},
     }
+    assert restored == envelope
+
+
+def test_guard_action_envelope_persists_full_prompt_text() -> None:
+    """prompt_text must be persisted in to_dict so the UI can show the full prompt."""
+    long_prompt = "A" * 500
+    envelope = GuardActionEnvelope(
+        schema_version=1,
+        action_id="action-prompt",
+        harness="codex",
+        event_name="UserPromptSubmit",
+        action_type="prompt",
+        workspace=None,
+        workspace_hash=None,
+        tool_name=None,
+        command=None,
+        prompt_excerpt=long_prompt[:240],
+        prompt_text=long_prompt,
+        target_paths=(),
+        network_hosts=(),
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=None,
+        script_name=None,
+        raw_payload_redacted={},
+    )
+    payload = envelope.to_dict()
+    restored = GuardActionEnvelope.from_dict(payload)
+    assert payload["prompt_text"] == long_prompt
+    assert payload["prompt_excerpt"] == long_prompt[:240]
     assert restored == envelope
 
 


### PR DESCRIPTION
## Problem

`GuardActionEnvelope.to_dict()` serialized `prompt_excerpt` (truncated to 240 chars via `_PROMPT_EXCERPT_LIMIT`) but **dropped `prompt_text`** (the full prompt). This meant the approval center UI only displayed a truncated prompt — users could not see or search the full content of what they were approving.

When a user pasted a long prompt and approved it in the approval center, the displayed text was truncated. The user could not verify the full prompt content before approving, and searching the queue by prompt content only matched the first 240 characters.

## Root Cause

In `src/codex_plugin_scanner/guard/runtime/actions.py`, `GuardActionEnvelope.to_dict()` (line 165) builds the dict that gets stored as `action_envelope_json` in the SQLite approval_requests table. It included `prompt_excerpt` but omitted `prompt_text`. The `from_dict()` method already parsed `prompt_text`, and the UI code already preferred `prompt_text ?? prompt_excerpt` in `resolveEnvelopeDisplayText` and `resolveActionEnvelopeDetailText` — but `prompt_text` was always `null` when loaded from the DB because it was never persisted.

The `LoggedActionPanel` component already had expand/collapse behavior (`EXPAND_CHAR_THRESHOLD = 180`), so the UI was ready to display full prompts — it just never received them.

## Fix

**Backend** (`src/codex_plugin_scanner/guard/runtime/actions.py`):
- Added `prompt_text` to `GuardActionEnvelope.to_dict()` so the full prompt is persisted in `action_envelope_json`

**Frontend** (dashboard):
- `queue-state.ts`: `queueCategoryText` and `searchQueue` now use `prompt_text ?? prompt_excerpt` (full prompt with excerpt fallback) so search and category matching work on the full prompt text
- `queue-state.ts`: `buildNextUpChipText` prefers `prompt_text` for the chip preview (still truncated to 40 chars for the chip)
- `review-workspace.tsx`: `queueItemPreview` prefers `prompt_text ?? prompt_excerpt`
- `evidence/plain-english.ts`: Prompt display prefers `prompt_text ?? prompt_excerpt`

**Tests**:
- `test_guard_runtime_actions.py`: Updated `test_guard_action_envelope_round_trips_to_dict` to include `prompt_text` in expected dict
- `test_guard_runtime_actions.py`: Added `test_guard_action_envelope_persists_full_prompt_text` verifying a 500-char prompt round-trips correctly with both `prompt_text` (full) and `prompt_excerpt` (240 chars) preserved
- `queue-state.test.ts`: Added test verifying `searchQueue` matches content found only in `prompt_text` (not in `prompt_excerpt`)

## Verification

- Python: `uv run pytest tests/test_guard_runtime_actions.py tests/test_guard_runtime_actions_phase14.py tests/test_guard_receipt_p5_fields.py` — 83 passed
- Python: `uv run pytest tests/test_guard_phase05_approval_memory.py tests/test_guard_red_team_e2e.py tests/test_guard_harness_smoke.py tests/test_guard_bypass_detector.py tests/test_guard_mcp_detectors.py tests/test_guard_data_flow.py` — 233 passed, 10 skipped
- Python: `uv run ruff check src/codex_plugin_scanner/guard/runtime/actions.py` — OK
- Dashboard: `pnpm test` — all tests passed (including new `T-QS-38a/38b` for prompt_text search)
- Dashboard: `tsc --noEmit` — 13 pre-existing errors, 0 new errors from this change

## What's NOT changed (intentional)

- `stable_action_hash()` — still uses `prompt_excerpt` for identity hashing. Changing it would alter identity semantics and break existing stored data. The hash is used for `action_id`, not for approval matching.
- `_build_action_identity()` in `store_approvals.py` — still uses `prompt_excerpt` for queue deduplication. This is the dedup key, not the approval match key.
- `_PROMPT_EXCERPT_LIMIT = 240` — unchanged. The excerpt is still used for identity/dedup; the full text is now persisted alongside it for display.