### PR TITLE
fix(guard): reuse oauth access tokens for cloud sync

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -13,7 +13,7 @@ import urllib.parse
 import urllib.request
 from collections.abc import Iterable, Mapping
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 
 from cryptography.hazmat.primitives import hashes, serialization
@@ -100,6 +100,20 @@ class GuardOAuthTokenExchangeResult:
     machine_id: str | None
     supply_chain_entitlement: dict[str, object] | None
     workspace_id: str | None
+    access_token_expires_at: str | None = None
+
+    def __post_init__(self) -> None:
+        if self.access_token_expires_at is not None:
+            return
+        object.__setattr__(
+            self,
+            "access_token_expires_at",
+            _guard_access_token_expires_at(
+                access_token=self.access_token,
+                expires_in=self.expires_in,
+                now=datetime.now(timezone.utc),
+            ),
+        )
 
 
 @dataclass
@@ -160,6 +174,21 @@ def _read_nested_string(payload: dict[str, object], *path: str) -> str | None:
             return None
         current = current.get(segment)
     return current if isinstance(current, str) and current else None
+
+
+def _guard_access_token_expires_at(
+    *,
+    access_token: str,
+    expires_in: int,
+    now: datetime,
+) -> str | None:
+    claims = _decode_access_token_claims(access_token)
+    exp = claims.get("exp")
+    if isinstance(exp, (int, float)) and float(exp) > 0:
+        return datetime.fromtimestamp(float(exp), tz=timezone.utc).isoformat()
+    if expires_in <= 0:
+        return None
+    return (now + timedelta(seconds=expires_in)).isoformat()
 
 
 def _encode_jwt_segment(payload: dict[str, object]) -> str:
@@ -486,18 +515,25 @@ def _parse_guard_token_exchange_payload(payload: dict[str, object]) -> GuardOAut
     token_type = _require_string(payload, "token_type")
     if token_type.lower() != "bearer":
         raise RuntimeError("Guard OAuth token exchange failed: missing access token.")
+    now = datetime.now(timezone.utc)
     claims = _decode_access_token_claims(access_token)
+    expires_in = _int_payload_value(payload, "expires_in", 0)
     return GuardOAuthTokenExchangeResult(
         access_token=access_token,
+        access_token_expires_at=_guard_access_token_expires_at(
+            access_token=access_token,
+            expires_in=expires_in,
+            now=now,
+        ),
         refresh_token=str(payload.get("refresh_token") or "").strip() or None,
-        expires_in=_int_payload_value(payload, "expires_in", 0),
+        expires_in=expires_in,
         scope=str(payload.get("scope") or "").strip(),
         token_type=token_type,
         grant_id=_read_nested_string(claims, "grant", "grantId"),
         machine_id=_read_nested_string(claims, "machine", "machineId"),
         supply_chain_entitlement=build_oauth_package_firewall_entitlement(
             payload,
-            now=datetime.now(timezone.utc),
+            now=now,
         ),
         workspace_id=_read_nested_string(claims, "workspace", "workspaceId"),
     )
@@ -903,6 +939,8 @@ def _persist_oauth_local_credentials(
     workspace_id: str | None = None,
     runtime_id: str | None = None,
     runtime_label: str | None = None,
+    access_token: str | None = None,
+    access_token_expires_at: str | None = None,
 ) -> None:
     store.set_oauth_local_credentials(
         issuer=issuer,
@@ -934,6 +972,8 @@ def _persist_oauth_local_credentials(
         workspace_id=workspace_id,
         runtime_id=runtime_id,
         runtime_label=runtime_label,
+        access_token=access_token,
+        access_token_expires_at=access_token_expires_at,
         now=now,
     )
     reconcile_connect_state_with_oauth_entitlement(store, now=now)
@@ -997,6 +1037,8 @@ def run_guard_disconnect_command(
             workspace_id=workspace_id,
             runtime_id=_read_nested_string(credentials, "runtime_id"),
             runtime_label=_read_nested_string(credentials, "runtime_label"),
+            access_token=token_result.access_token,
+            access_token_expires_at=token_result.access_token_expires_at,
             now=timestamp,
         )
     revoke_guard_self_oauth_grant(
@@ -1116,6 +1158,8 @@ def run_guard_device_connect_command(
         workspace_id=token_result.workspace_id,
         runtime_id=HEADLESS_RUNTIME_ID,
         runtime_label=HEADLESS_RUNTIME_LABEL,
+        access_token=token_result.access_token,
+        access_token_expires_at=token_result.access_token_expires_at,
         now=timestamp,
     )
     sync_url = _oauth_sync_url_from_issuer(oauth_client.issuer)
@@ -1190,6 +1234,8 @@ def run_guard_browser_connect_command(
         workspace_id=token_result.workspace_id,
         runtime_id=HEADLESS_RUNTIME_ID,
         runtime_label=HEADLESS_RUNTIME_LABEL,
+        access_token=token_result.access_token,
+        access_token_expires_at=token_result.access_token_expires_at,
         now=timestamp,
     )
     sync_url = _oauth_sync_url_from_issuer(oauth_client.issuer)

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2740,6 +2740,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     workspace_id=token_result.workspace_id,
                     runtime_id="hol-guard",
                     runtime_label="HOL Guard CLI",
+                    access_token=token_result.access_token,
+                    access_token_expires_at=token_result.access_token_expires_at,
                     now=timestamp,
                 )
                 payload = _finalize_daemon_guard_connect_payload(
@@ -2923,6 +2925,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     workspace_id=token_result.workspace_id,
                     runtime_id="hol-guard",
                     runtime_label="HOL Guard CLI",
+                    access_token=token_result.access_token,
+                    access_token_expires_at=token_result.access_token_expires_at,
                     now=timestamp,
                 )
                 payload = _finalize_daemon_guard_connect_payload(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -13,7 +13,7 @@ import threading
 import urllib.error
 import urllib.parse
 import urllib.request
-from base64 import urlsafe_b64encode
+from base64 import urlsafe_b64decode, urlsafe_b64encode
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from contextlib import contextmanager, suppress
 from datetime import datetime, timedelta, timezone
@@ -2601,11 +2601,10 @@ def _refresh_guard_oauth_access_token(
         token_type = _optional_string(payload.get("token_type"))
         if access_token is None or token_type is None or token_type.lower() not in {"bearer", "dpop"}:
             raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
-        expires_in = _int_value(payload.get("expires_in"))
-        access_token_expires_at = (
-            (datetime.now(timezone.utc) + timedelta(seconds=expires_in)).isoformat()
-            if isinstance(expires_in, int) and expires_in > 0
-            else None
+        access_token_expires_at = _oauth_access_token_expires_at(
+            access_token,
+            payload=payload,
+            now=datetime.now(timezone.utc),
         )
         return {
             "access_token": access_token,
@@ -2638,6 +2637,44 @@ def _oauth_dpop_key_material(credentials: dict[str, object]) -> GuardDpopKeyMate
 
 
 _OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
+
+
+def _decode_oauth_access_token_claims(access_token: str) -> dict[str, object]:
+    parts = access_token.split(".")
+    if len(parts) != 3:
+        return {}
+    try:
+        padding = "=" * (-len(parts[1]) % 4)
+        payload = json.loads(urlsafe_b64decode(parts[1] + padding).decode("utf-8"))
+    except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
+        return {}
+    return payload if isinstance(payload, dict) else {}
+
+
+def _oauth_access_token_expires_at(
+    access_token: str,
+    *,
+    payload: dict[str, object],
+    now: datetime,
+) -> str | None:
+    claims = _decode_oauth_access_token_claims(access_token)
+    exp = claims.get("exp")
+    if isinstance(exp, (int, float)) and not isinstance(exp, bool) and float(exp) > 0:
+        return datetime.fromtimestamp(float(exp), tz=timezone.utc).isoformat()
+    expires_in = payload.get("expires_in")
+    parsed_expires_in: int | None
+    if isinstance(expires_in, (int, float)) and not isinstance(expires_in, bool):
+        parsed_expires_in = int(expires_in)
+    elif isinstance(expires_in, str):
+        try:
+            parsed_expires_in = int(expires_in)
+        except ValueError:
+            parsed_expires_in = None
+    else:
+        parsed_expires_in = None
+    if parsed_expires_in is None or parsed_expires_in <= 0:
+        return None
+    return (now + timedelta(seconds=parsed_expires_in)).isoformat()
 
 
 def _cached_oauth_access_token(credentials: dict[str, object], *, now: datetime) -> str | None:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2601,8 +2601,15 @@ def _refresh_guard_oauth_access_token(
         token_type = _optional_string(payload.get("token_type"))
         if access_token is None or token_type is None or token_type.lower() not in {"bearer", "dpop"}:
             raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
+        expires_in = _int_value(payload.get("expires_in"))
+        access_token_expires_at = (
+            (datetime.now(timezone.utc) + timedelta(seconds=expires_in)).isoformat()
+            if isinstance(expires_in, int) and expires_in > 0
+            else None
+        )
         return {
             "access_token": access_token,
+            "access_token_expires_at": access_token_expires_at,
             "package_firewall_entitlement": build_oauth_package_firewall_entitlement(
                 payload,
                 now=datetime.now(timezone.utc),
@@ -2630,12 +2637,34 @@ def _oauth_dpop_key_material(credentials: dict[str, object]) -> GuardDpopKeyMate
     )
 
 
+_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS = 60
+
+
+def _cached_oauth_access_token(credentials: dict[str, object], *, now: datetime) -> str | None:
+    access_token = _optional_string(credentials.get("access_token"))
+    access_token_expires_at = _optional_string(credentials.get("access_token_expires_at"))
+    if access_token is None or access_token_expires_at is None:
+        return None
+    try:
+        expires_at = datetime.fromisoformat(access_token_expires_at)
+    except ValueError:
+        return None
+    if expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=timezone.utc)
+    expires_at = expires_at.astimezone(timezone.utc)
+    if expires_at <= now + timedelta(seconds=_OAUTH_ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
+        return None
+    return access_token
+
+
 def _persist_rotated_oauth_refresh_token(
     *,
     store: GuardStore,
     credentials: dict[str, object],
     package_firewall_entitlement: dict[str, object] | None = None,
     refresh_token: str,
+    access_token: str | None = None,
+    access_token_expires_at: str | None = None,
 ) -> None:
     issuer = _optional_string(credentials.get("issuer"))
     client_id = _optional_string(credentials.get("client_id"))
@@ -2681,6 +2710,10 @@ def _persist_rotated_oauth_refresh_token(
             else _optional_string(credentials.get("supply_chain_plan_id"))
         ),
         workspace_id=_optional_string(credentials.get("workspace_id")),
+        runtime_id=_optional_string(credentials.get("runtime_id")),
+        runtime_label=_optional_string(credentials.get("runtime_label")),
+        access_token=access_token,
+        access_token_expires_at=access_token_expires_at,
         now=_now(),
     )
 
@@ -2701,6 +2734,17 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
         oauth_client = resolve_guard_oauth_client_config(issuer)
     except ValueError as error:
         raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
+    cached_access_token = _cached_oauth_access_token(oauth_credentials, now=datetime.now(timezone.utc))
+    if cached_access_token is not None and not persist_recovered_secret:
+        sync_url = _validate_guard_sync_url(
+            _oauth_sync_url_from_issuer(oauth_client.issuer),
+            issuer=oauth_client.issuer,
+        )
+        return {
+            "sync_url": sync_url,
+            "access_token": cached_access_token,
+            "dpop_key_material": dpop_key_material,
+        }
     refreshed = _refresh_guard_oauth_access_token(
         token_endpoint=oauth_client.token_endpoint,
         client_id=client_id,
@@ -2718,6 +2762,8 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
             credentials=oauth_credentials,
             package_firewall_entitlement=package_firewall_entitlement,
             refresh_token=rotated_refresh_token,
+            access_token=_optional_string(refreshed.get("access_token")),
+            access_token_expires_at=_optional_string(refreshed.get("access_token_expires_at")),
         )
     sync_url = _validate_guard_sync_url(
         _oauth_sync_url_from_issuer(oauth_client.issuer),

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -195,6 +195,8 @@ class _RecoveredOAuthLocalCredentialInputs(TypedDict):
     workspace_id: str | None
     runtime_id: str | None
     runtime_label: str | None
+    access_token: str | None
+    access_token_expires_at: str | None
 
 
 class PolicyDecisionLookupResult(TypedDict):

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -51,6 +51,8 @@ class StoreOAuthConnectMixin:
         workspace_id: str | None = None,
         runtime_id: str | None = None,
         runtime_label: str | None = None,
+        access_token: str | None = None,
+        access_token_expires_at: str | None = None,
     ) -> None:
         with self.hold_oauth_credential_lock():
             self._set_oauth_local_credentials_unlocked(
@@ -69,6 +71,8 @@ class StoreOAuthConnectMixin:
                 workspace_id=workspace_id,
                 runtime_id=runtime_id,
                 runtime_label=runtime_label,
+                access_token=access_token,
+                access_token_expires_at=access_token_expires_at,
             )
 
     def _set_oauth_local_credentials_unlocked(
@@ -89,6 +93,8 @@ class StoreOAuthConnectMixin:
         workspace_id: str | None = None,
         runtime_id: str | None = None,
         runtime_label: str | None = None,
+        access_token: str | None = None,
+        access_token_expires_at: str | None = None,
     ) -> None:
         normalized_issuer = resolve_guard_oauth_client_config(issuer).issuer
         secret_payload = {
@@ -97,6 +103,10 @@ class StoreOAuthConnectMixin:
             "dpop_public_jwk": dpop_public_jwk,
             "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
         }
+        if isinstance(access_token, str) and access_token:
+            secret_payload["access_token"] = access_token
+        if isinstance(access_token_expires_at, str) and access_token_expires_at:
+            secret_payload["access_token_expires_at"] = access_token_expires_at
         secret_json = json.dumps(secret_payload, sort_keys=True, separators=(",", ":"))
         secret_hash = _secret_fingerprint(secret_json)
         payload: dict[str, object] = {
@@ -392,6 +402,8 @@ class StoreOAuthConnectMixin:
             "workspace_id": _string_value(credentials.get("workspace_id")),
             "runtime_id": _string_value(credentials.get("runtime_id")),
             "runtime_label": _string_value(credentials.get("runtime_label")),
+            "access_token": _string_value(credentials.get("access_token")),
+            "access_token_expires_at": _string_value(credentials.get("access_token_expires_at")),
         }
         return recovered_inputs
 
@@ -587,6 +599,12 @@ class StoreOAuthConnectMixin:
             "dpop_public_jwk": {str(key): str(value) for key, value in dpop_public_jwk.items()},
             "dpop_public_jwk_thumbprint": dpop_public_jwk_thumbprint,
         }
+        access_token = secret_payload.get("access_token")
+        if isinstance(access_token, str) and access_token:
+            result["access_token"] = access_token
+        access_token_expires_at = secret_payload.get("access_token_expires_at")
+        if isinstance(access_token_expires_at, str) and access_token_expires_at:
+            result["access_token_expires_at"] = access_token_expires_at
         for key in ("grant_id", "machine_id", "workspace_id", "runtime_id", "runtime_label"):
             value = metadata.get(key)
             if isinstance(value, str) and value:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -873,7 +873,7 @@ def test_poll_once_retries_pending_result_before_leasing(tmp_path: Path, monkeyp
     assert status["pending_result"] is None
 
 
-def test_poll_once_continues_across_oauth_refresh_token_rotation(
+def test_poll_once_reuses_cached_access_token_across_oauth_polls(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
@@ -893,6 +893,7 @@ def test_poll_once_continues_across_oauth_refresh_token_rotation(
         current_index = len(observed_refresh_tokens)
         return {
             "access_token": f"access-token-{current_index}",
+            "access_token_expires_at": "2099-07-05T00:00:00+00:00",
             "refresh_token": f"refresh-token-{current_index + 1}",
             "package_firewall_entitlement": {
                 "supply_chain_entitlement_expires_at": "2026-07-05T00:00:00+00:00",
@@ -921,11 +922,13 @@ def test_poll_once_continues_across_oauth_refresh_token_rotation(
 
     assert first_status["last_poll_was_empty"] is True
     assert second_status["last_poll_was_empty"] is True
-    assert observed_refresh_tokens == ["refresh-token-1", "refresh-token-2"]
-    assert observed_access_tokens == ["access-token-1", "access-token-2"]
+    assert observed_refresh_tokens == ["refresh-token-1"]
+    assert observed_access_tokens == ["access-token-1", "access-token-1"]
     credentials = store.get_oauth_local_credentials()
     assert credentials is not None
-    assert credentials["refresh_token"] == "refresh-token-3"
+    assert credentials["refresh_token"] == "refresh-token-2"
+    assert credentials["access_token"] == "access-token-1"
+    assert credentials["access_token_expires_at"] == "2099-07-05T00:00:00+00:00"
 
 
 def test_poll_once_clears_active_job_for_malformed_pending_result(tmp_path: Path, monkeypatch) -> None:

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -14,7 +14,12 @@ from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
 
 
-def _store_with_oauth_credentials(tmp_path) -> GuardStore:
+def _store_with_oauth_credentials(
+    tmp_path,
+    *,
+    access_token: str | None = None,
+    access_token_expires_at: str | None = None,
+) -> GuardStore:
     store = GuardStore(tmp_path / "guard-home")
     dpop_key_material = generate_dpop_key_pair()
     store.set_oauth_local_credentials(
@@ -27,6 +32,8 @@ def _store_with_oauth_credentials(tmp_path) -> GuardStore:
         grant_id="grant-1",
         machine_id="machine-1",
         workspace_id="workspace-1",
+        access_token=access_token,
+        access_token_expires_at=access_token_expires_at,
         now="2026-06-01T00:00:00+00:00",
     )
     return store
@@ -154,6 +161,24 @@ def test_prepare_guard_cloud_connect_authorization_refreshes_under_lock(tmp_path
     assert result["cleared_stale_sign_in"] is False
     assert result["existing_sign_in_valid"] is True
     assert store.get_oauth_local_credentials(allow_primary=True) is not None
+
+
+def test_resolve_guard_sync_auth_context_reuses_cached_access_token(tmp_path, monkeypatch) -> None:
+    store = _store_with_oauth_credentials(
+        tmp_path,
+        access_token="cached-access-token",
+        access_token_expires_at="2099-01-01T00:00:00+00:00",
+    )
+
+    def _unexpected_refresh(**_kwargs):
+        raise AssertionError("refresh should not run while cached access token is still valid")
+
+    monkeypatch.setattr(guard_runner_module, "_refresh_guard_oauth_access_token", _unexpected_refresh)
+
+    auth_context = guard_runner_module._resolve_guard_sync_auth_context(store)
+
+    assert auth_context["access_token"] == "cached-access-token"
+    assert auth_context["sync_url"] == "https://hol.org/api/guard/receipts/sync"
 
 
 def test_prepare_guard_cloud_connect_authorization_tolerates_refresh_lock_timeout(

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import urllib.error
 from contextlib import contextmanager
+from datetime import datetime, timezone
 
 import pytest
 
@@ -179,6 +180,49 @@ def test_resolve_guard_sync_auth_context_reuses_cached_access_token(tmp_path, mo
 
     assert auth_context["access_token"] == "cached-access-token"
     assert auth_context["sync_url"] == "https://hol.org/api/guard/receipts/sync"
+
+
+def test_refresh_guard_oauth_access_token_prefers_jwt_expiry_claim(monkeypatch) -> None:
+    expiry = datetime(2099, 1, 1, tzinfo=timezone.utc)
+    access_token = ".".join(
+        (
+            guard_runner_module._encode_jwt_segment({"alg": "ES256"}),
+            guard_runner_module._encode_jwt_segment({"exp": int(expiry.timestamp())}),
+            "signature",
+        )
+    )
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": access_token,
+                    "refresh_token": "refresh-token-2",
+                    "token_type": "Bearer",
+                }
+            ).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        guard_runner_module.urllib.request,
+        "urlopen",
+        lambda request, timeout: _Response(),
+    )
+
+    refreshed = guard_runner_module._refresh_guard_oauth_access_token(
+        token_endpoint="https://hol.org/api/guard/oauth/token",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_key_material=generate_dpop_key_pair(),
+    )
+
+    assert refreshed["access_token"] == access_token
+    assert refreshed["access_token_expires_at"] == expiry.isoformat()
 
 
 def test_prepare_guard_cloud_connect_authorization_tolerates_refresh_lock_timeout(

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -19272,10 +19272,11 @@ def test_sync_local_guard_cloud_proof_serializes_concurrent_oauth_refresh(tmp_pa
 
     assert sync_errors == []
     assert len(sync_results) == 2
-    assert token_refreshes == ["refresh-token-1", "refresh-token-2"]
+    assert token_refreshes == ["refresh-token-1"]
     stored_credentials = store.get_oauth_local_credentials()
     assert isinstance(stored_credentials, dict)
-    assert stored_credentials["refresh_token"] == "refresh-token-3"
+    assert stored_credentials["refresh_token"] == "refresh-token-2"
+    assert stored_credentials["access_token"] == "oauth-access-token-for-refresh-token-1"
 
 
 def test_sync_pain_signals_raises_when_oauth_refresh_is_revoked(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- cache the Guard Cloud OAuth access token in local encrypted credentials and reuse it until expiry instead of refreshing on every cloud poll
- persist access token expiry metadata across connect flows so command queue and review sync can keep using the same grant safely
- cover the cached-token path with OAuth reconnect and command queue regression tests

## Testing
- `pytest tests/test_guard_oauth_reconnect.py tests/test_guard_command_queue.py tests/test_guard_connect_flow.py -q`
- `pytest tests/test_guard_connect_flow.py::test_daemon_guard_cloud_connect_persists_oauth_state_for_dashboard tests/test_guard_connect_flow.py::test_browser_connect_persists_oauth_state_when_macos_keychain_readback_succeeds tests/test_guard_headless_daemon_api.py::test_supply_chain_package_firewall_connect_repairs_local_auth_and_unlocks_paid_access -q`
