### PR TITLE
fix(cli): default connect to browser oauth

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -64,8 +64,8 @@ def _run_guard_login_command(
     payload, exit_code = _build_guard_device_connect_payload(
         store=store,
         connect_url=args.connect_url,
-        use_browser_oauth=False,
-        open_device_browser=True,
+        use_browser_oauth=True,
+        open_device_browser=False,
         wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
         announce_copy=None if getattr(args, "json", False) else _announce_guard_device_connect_copy,
     )
@@ -137,8 +137,8 @@ def _run_guard_connect_command(
         payload, exit_code = _build_guard_device_connect_payload(
             store=store,
             connect_url=args.connect_url,
-            use_browser_oauth=False,
-            open_device_browser=True,
+            use_browser_oauth=True,
+            open_device_browser=False,
             wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
             announce_copy=None if getattr(args, "json", False) else _announce_guard_device_connect_copy,
         )

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -329,8 +329,8 @@ def _run_guard_supply_chain_command(
     config = _require_guard_config(config)
     supply_chain_command = getattr(args, "supply_chain_command", None)
     if supply_chain_command == "support-matrix":
-        from ..shims import package_shim_supported_managers
         from ..shim_probe import _PACKAGE_SHIM_PROBE_ARGS
+        from ..shims import package_shim_supported_managers
 
         managers = package_shim_supported_managers()
         probe_managers = set(_PACKAGE_SHIM_PROBE_ARGS.keys())

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -341,7 +341,7 @@ def _run_guard_supply_chain_command(
             }
             for manager in managers
         ]
-        payload = {
+        payload: dict[str, object] = {
             "managers": list(managers),
             "entries": entries,
             "source": "hol-guard/src/codex_plugin_scanner/guard/shims.py::_PACKAGE_SHIM_COMMANDS",

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
@@ -21,7 +21,7 @@ def _configure_guard_cloud_parsers(
 ) -> None:
     login_parser = guard_subparsers.add_parser(
         "login",
-        help="Compatibility alias for Guard Cloud sign-in and pairing",
+        help="Compatibility alias for Guard Cloud browser sign-in and pairing",
     )
     login_parser.add_argument("--sync-url", type=_guard_http_url)
     login_parser.add_argument("--token")
@@ -33,7 +33,7 @@ def _configure_guard_cloud_parsers(
 
     connect_parser = guard_subparsers.add_parser(
         "connect",
-        help="Open the browser, pair this runtime to HOL Guard, and send the first sync",
+        help="Open browser OAuth, pair this runtime to HOL Guard, and send the first sync",
     )
     connect_parser.add_argument("connect_command", nargs="?", choices=("status", "repair", "re-pair"))
     _add_guard_common_args(connect_parser)

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -488,7 +488,7 @@ def _manual_guard_login_payload(
     if manual_token is None:
         return None
     print(
-        "Manual token login is retired. Run `hol-guard connect` to sign in with OAuth Device Code.",
+        "Manual token login is retired. Run `hol-guard connect` to sign in with browser OAuth.",
         file=sys.stderr,
     )
     return None, 2

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -1,4 +1,4 @@
-"""OAuth Device Code Guard connect helpers."""
+"""Guard OAuth connect helpers for browser and device-code flows."""
 
 from __future__ import annotations
 
@@ -1322,7 +1322,7 @@ def build_connect_status_payload(
     }
     if action in {"repair", "re-pair"}:
         payload["repair_action"] = "rerun_connect"
-        payload["repair_message"] = "Run hol-guard connect to start OAuth Device Code approval."
+        payload["repair_message"] = "Run hol-guard connect to start browser sign-in."
     elif (oauth_repair_required and cloud_profile is None) or (
         oauth_required and not bool(oauth_storage_health.get("configured")) and payload["status"] == "retry_required"
     ):

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3913,7 +3913,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self._write_json(
             {
                 "error": "legacy_pairing_disabled",
-                "message": "Use OAuth Device Code through hol-guard connect.",
+                "message": "Use browser OAuth through hol-guard connect, or --headless for Device Code.",
             },
             status=410,
         )
@@ -3922,7 +3922,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self._write_json(
             {
                 "error": "legacy_cloud_handoff_disabled",
-                "message": "Use OAuth Device Code through hol-guard connect.",
+                "message": "Use browser OAuth through hol-guard connect, or --headless for Device Code.",
             },
             status=410,
         )

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3913,7 +3913,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self._write_json(
             {
                 "error": "legacy_pairing_disabled",
-                "message": "Use browser OAuth through hol-guard connect, or --headless for Device Code.",
+                "message": "Use hol-guard connect for browser OAuth.",
             },
             status=410,
         )
@@ -3922,7 +3922,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         self._write_json(
             {
                 "error": "legacy_cloud_handoff_disabled",
-                "message": "Use browser OAuth through hol-guard connect, or --headless for Device Code.",
+                "message": "Use hol-guard connect for browser OAuth.",
             },
             status=410,
         )

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6742,43 +6742,33 @@ url = http://127.0.0.1:8787/guard-canary
         assert payload["cloud_state"] == "local_only"
         assert "this machine" in str(payload["cloud_state_detail"]).lower()
 
-    def test_guard_connect_opens_device_code_browser_flow_without_pairing(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_uses_browser_oauth_flow_without_pairing(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
         _build_guard_fixture(home_dir, workspace_dir)
         _write_text(home_dir / "config.toml", 'changed_hash_action = "allow"\n')
         store = GuardStore(home_dir)
-        opened: list[str] = []
 
-        def fake_device_flow(
+        def fake_browser_flow(
             *,
             store: GuardStore,
             connect_url: str,
             wait_timeout_seconds: int = 180,
-            announce_copy=None,
-            open_browser=None,
-            ci_safe: bool = False,
-            machine_label: str | None = None,
         ) -> dict[str, object]:
-            del store, announce_copy, ci_safe, machine_label
+            del store
             assert wait_timeout_seconds == 180
             assert connect_url == "https://hol.org/guard/connect"
-            assert open_browser is not None
-            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device"))
             return {
                 "status": "connected",
-                "connect_mode": "device_code",
-                "browser_opened": browser_opened,
-                "user_code": "ABCD-EFGH",
-                "verification_uri": "https://hol.org/guard/oauth/device",
-                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                "connect_mode": "browser_oauth",
+                "browser_opened": True,
+                "authorize_url": "https://hol.org/guard/oauth/authorize?request_id=req-123",
                 "grant_id": "grant-123",
                 "machine_id": "machine-123",
                 "workspace_id": "workspace-123",
             }
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda target: opened.append(target) or True)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
         run_rc = main(
             [
                 "guard",
@@ -6810,14 +6800,13 @@ url = http://127.0.0.1:8787/guard-canary
 
         assert run_rc == 0
         assert connect_rc == 0
-        assert opened == ["https://hol.org/guard/oauth/device"]
         assert connect_output["status"] == "retry_required"
         assert connect_output["milestone"] == "first_sync_failed"
-        assert connect_output["connect_mode"] == "device_code"
+        assert connect_output["connect_mode"] == "browser_oauth"
         assert connect_output["browser_opened"] is True
-        assert connect_output["user_code"] == "ABCD-EFGH"
-        assert connect_output["verification_uri"] == "https://hol.org/guard/oauth/device"
-        assert connect_output["verification_uri_complete"] == "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH"
+        assert isinstance(connect_output["authorize_url"], str)
+        assert connect_output["authorize_url"]
+        assert "user_code" not in connect_output
         assert connect_output["grant_id"] == "grant-123"
         assert connect_output["machine_id"] == "machine-123"
         assert connect_output["workspace_id"] == "workspace-123"
@@ -6833,17 +6822,13 @@ url = http://127.0.0.1:8787/guard-canary
         sync_calls: list[str] = []
         bundle_calls: list[str] = []
 
-        def fake_device_flow(
+        def fake_browser_flow(
             *,
             store: GuardStore,
             connect_url: str,
             wait_timeout_seconds: int = 180,
-            announce_copy=None,
-            open_browser=None,
-            ci_safe: bool = False,
-            machine_label: str | None = None,
         ) -> dict[str, object]:
-            del connect_url, wait_timeout_seconds, announce_copy, open_browser, ci_safe, machine_label
+            del connect_url, wait_timeout_seconds
             store.set_oauth_local_credentials(
                 issuer="https://hol.org",
                 client_id="guard-local-daemon",
@@ -6865,7 +6850,7 @@ url = http://127.0.0.1:8787/guard-canary
             )
             return {
                 "status": "connected",
-                "connect_mode": "device_code",
+                "connect_mode": "browser_oauth",
                 "browser_opened": True,
                 "workspace_id": "workspace-123",
             }
@@ -6919,7 +6904,7 @@ url = http://127.0.0.1:8787/guard-canary
                 "workspace_audits": {"status": "synced", "completed_jobs": 1},
             }
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
         monkeypatch.setattr(guard_commands_module, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof)
         monkeypatch.setattr(guard_commands_module, "sync_supply_chain_cloud_state", fake_sync_supply_chain_cloud_state)
 
@@ -6956,6 +6941,67 @@ url = http://127.0.0.1:8787/guard-canary
         assert latest_state["milestone"] == "first_sync_succeeded"
         assert latest_state["proof"]["runtime_session_id"] == "runtime-session-123"
         assert latest_state["proof"]["runtime_session_synced_at"] == "2026-06-04T18:30:59+00:00"
+
+    def test_guard_connect_headless_keeps_device_code_flow(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        opened: list[str] = []
+
+        def unexpected_browser_flow(
+            *,
+            store: GuardStore,
+            connect_url: str,
+            wait_timeout_seconds: int = 180,
+        ) -> dict[str, object]:
+            del store, connect_url, wait_timeout_seconds
+            raise AssertionError("browser flow should not run for --headless")
+
+        def fake_device_flow(
+            *,
+            store: GuardStore,
+            connect_url: str,
+            wait_timeout_seconds: int = 180,
+            announce_copy=None,
+            open_browser=None,
+            ci_safe: bool = False,
+            machine_label: str | None = None,
+        ) -> dict[str, object]:
+            del store, announce_copy, ci_safe, machine_label
+            assert connect_url == "https://hol.org/guard/connect"
+            assert wait_timeout_seconds == 180
+            assert open_browser is not None
+            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device"))
+            return {
+                "status": "connected",
+                "connect_mode": "device_code",
+                "browser_opened": browser_opened,
+                "user_code": "WXYZ-1234",
+                "verification_uri": "https://hol.org/guard/oauth/device",
+                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=WXYZ-1234",
+            }
+
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", unexpected_browser_flow)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
+        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda target: opened.append(target) or True)
+
+        connect_rc = main(
+            [
+                "guard",
+                "connect",
+                "--home",
+                str(home_dir),
+                "--connect-url",
+                "https://hol.org/guard/connect",
+                "--headless",
+                "--open-browser",
+                "--json",
+            ]
+        )
+        connect_output = json.loads(capsys.readouterr().out)
+
+        assert connect_rc == 0
+        assert opened == ["https://hol.org/guard/oauth/device"]
+        assert connect_output["connect_mode"] == "device_code"
+        assert connect_output["browser_opened"] is True
 
     def test_guard_status_reports_oauth_key_storage_health(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
@@ -7299,40 +7345,30 @@ url = http://127.0.0.1:8787/guard-canary
             "error": "<urlopen error loopback refused>",
         }
 
-    def test_guard_login_without_manual_credentials_uses_device_code_browser_flow(self, tmp_path, capsys, monkeypatch):
+    def test_guard_login_without_manual_credentials_uses_browser_oauth_flow(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
-        opened: list[str] = []
 
-        def fake_device_flow(
+        def fake_browser_flow(
             *,
             store: GuardStore,
             connect_url: str,
             wait_timeout_seconds: int = 180,
-            announce_copy=None,
-            open_browser=None,
-            ci_safe: bool = False,
-            machine_label: str | None = None,
         ) -> dict[str, object]:
-            del store, announce_copy, ci_safe, machine_label
+            del store
             assert wait_timeout_seconds == 180
             assert connect_url == "https://hol.org/guard/connect"
-            assert open_browser is not None
-            browser_opened = bool(open_browser("https://hol.org/guard/oauth/device"))
             return {
                 "status": "connected",
-                "connect_mode": "device_code",
-                "browser_opened": browser_opened,
-                "user_code": "ZXCV-BNMQ",
-                "verification_uri": "https://hol.org/guard/oauth/device",
-                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ",
+                "connect_mode": "browser_oauth",
+                "browser_opened": True,
+                "authorize_url": "https://hol.org/guard/oauth/authorize?request_id=req-456",
                 "grant_id": "grant-456",
                 "machine_id": "machine-456",
                 "workspace_id": "workspace-456",
             }
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda target: opened.append(target) or True)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
         login_rc = main(
             [
                 "guard",
@@ -7347,14 +7383,13 @@ url = http://127.0.0.1:8787/guard-canary
         login_output = json.loads(capsys.readouterr().out)
 
         assert login_rc == 0
-        assert opened == ["https://hol.org/guard/oauth/device"]
         assert login_output["status"] == "retry_required"
         assert login_output["milestone"] == "first_sync_failed"
-        assert login_output["connect_mode"] == "device_code"
+        assert login_output["connect_mode"] == "browser_oauth"
         assert login_output["browser_opened"] is True
-        assert login_output["user_code"] == "ZXCV-BNMQ"
-        assert login_output["verification_uri"] == "https://hol.org/guard/oauth/device"
-        assert login_output["verification_uri_complete"] == "https://hol.org/guard/oauth/device?user_code=ZXCV-BNMQ"
+        assert isinstance(login_output["authorize_url"], str)
+        assert login_output["authorize_url"]
+        assert "user_code" not in login_output
         assert login_output["grant_id"] == "grant-456"
         assert login_output["machine_id"] == "machine-456"
         assert login_output["workspace_id"] == "workspace-456"
@@ -7720,25 +7755,20 @@ url = http://127.0.0.1:8787/guard-canary
             "sync_url": None,
         }
 
-    def test_guard_connect_reports_device_authorization_errors_cleanly(self, tmp_path, capsys, monkeypatch):
+    def test_guard_connect_reports_browser_authorization_errors_cleanly(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
 
-        def failing_device_flow(
+        def failing_browser_flow(
             *,
             store: GuardStore,
             connect_url: str,
             wait_timeout_seconds: int = 180,
-            announce_copy=None,
-            open_browser=None,
-            ci_safe: bool = False,
-            machine_label: str | None = None,
         ) -> dict[str, object]:
-            del store, connect_url, wait_timeout_seconds, announce_copy, open_browser, ci_safe, machine_label
-            raise RuntimeError("device_code_unreachable")
+            del store, connect_url, wait_timeout_seconds
+            raise RuntimeError("browser_oauth_unreachable")
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", failing_device_flow)
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _target: True)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", failing_browser_flow)
         connect_rc = main(
             [
                 "guard",
@@ -7753,36 +7783,29 @@ url = http://127.0.0.1:8787/guard-canary
         captured = capsys.readouterr()
 
         assert connect_rc == 1
-        assert "Guard authorization failed: device_code_unreachable" in captured.err
+        assert "Guard authorization failed: browser_oauth_unreachable" in captured.err
         assert "Traceback" not in captured.err
         assert store.get_cloud_sync_profile() is None
 
     def test_guard_connect_never_exposes_legacy_pairing_fields(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"
 
-        def fake_device_flow(
+        def fake_browser_flow(
             *,
             store: GuardStore,
             connect_url: str,
             wait_timeout_seconds: int = 180,
-            announce_copy=None,
-            open_browser=None,
-            ci_safe: bool = False,
-            machine_label: str | None = None,
         ) -> dict[str, object]:
-            del store, announce_copy, open_browser, ci_safe, machine_label
+            del store
             assert wait_timeout_seconds == 180
             return {
                 "status": "connected",
-                "connect_mode": "device_code",
+                "connect_mode": "browser_oauth",
                 "browser_opened": True,
-                "user_code": "ABCD-EFGH",
-                "verification_uri": "https://hol.org/guard/oauth/device",
-                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
+                "authorize_url": "https://hol.org/guard/oauth/authorize?request_id=req-789",
             }
 
-        monkeypatch.setattr(guard_commands_module, "_run_guard_device_connect_flow", fake_device_flow)
-        monkeypatch.setattr(guard_commands_module.webbrowser, "open", lambda _target: True)
+        monkeypatch.setattr(guard_commands_module, "_run_guard_browser_connect_flow", fake_browser_flow)
         connect_rc = main(
             [
                 "guard",
@@ -7798,7 +7821,7 @@ url = http://127.0.0.1:8787/guard-canary
         rendered = json.dumps(connect_output, sort_keys=True)
 
         assert connect_rc == 0
-        assert connect_output["connect_mode"] == "device_code"
+        assert connect_output["connect_mode"] == "browser_oauth"
         assert "guardPairSecret" not in rendered
         assert "guardPairRequest" not in rendered
         assert "guardDaemon" not in rendered

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -157,10 +157,13 @@ def test_daemon_rejects_legacy_connect_pairing_endpoints(tmp_path: Path) -> None
 
     assert request_status == 410
     assert request_payload["error"] == "legacy_pairing_disabled"
+    assert request_payload["message"] == "Use hol-guard connect for browser OAuth."
     assert complete_status == 410
     assert complete_payload["error"] == "legacy_pairing_disabled"
+    assert complete_payload["message"] == "Use hol-guard connect for browser OAuth."
     assert result_status == 410
     assert result_payload["error"] == "legacy_pairing_disabled"
+    assert result_payload["message"] == "Use hol-guard connect for browser OAuth."
     assert "legacy-sync-secret" not in json.dumps([request_payload, complete_payload, result_payload])
 
 

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -275,7 +275,7 @@ def test_daemon_guard_cloud_connect_persists_oauth_state_for_dashboard(
     assert runtime["cloud_state"] in {"paired_active", "paired_waiting"}
 
 
-def test_connect_repair_copy_points_to_device_code(tmp_path: Path) -> None:
+def test_connect_repair_copy_points_to_browser_sign_in(tmp_path: Path) -> None:
     payload = build_connect_status_payload(
         store=GuardStore(tmp_path / "guard-home"),
         sync_url="https://hol.org/api/guard/receipts/sync",
@@ -285,7 +285,7 @@ def test_connect_repair_copy_points_to_device_code(tmp_path: Path) -> None:
 
     rendered = json.dumps(payload)
     assert payload["repair_action"] == "rerun_connect"
-    assert payload["repair_message"] == "Run hol-guard connect to start OAuth Device Code approval."
+    assert payload["repair_message"] == "Run hol-guard connect to start browser sign-in."
     assert "pairing" not in rendered.lower()
     assert "guardPairSecret" not in rendered
 

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -1926,6 +1926,7 @@ def test_cloud_app_handoff_start_rejects_legacy_handoff_url(tmp_path: Path) -> N
 
     assert status == 410
     assert payload["error"] == "legacy_cloud_handoff_disabled"
+    assert payload["message"] == "Use hol-guard connect for browser OAuth."
     assert auth_token not in json.dumps(payload)
 
 

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1396,15 +1396,22 @@ def test_connect_headless_open_browser_opens_device_approval_before_polling(
     assert "browser_opened" in captured.out
 
 
-def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path, capsys, monkeypatch) -> None:
+def test_connect_default_uses_browser_oauth_flow(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     args = _ConnectArgs()
     args.guard_home = str(guard_home)
     args.wait_timeout_seconds = 5
-    opened: list[str] = []
 
-    def fail_browser_flow(*, store: GuardStore, connect_url: str, wait_timeout_seconds: int) -> dict[str, object]:
-        raise AssertionError("default connect should not use browser oauth")
+    def fake_browser_flow(*, store: GuardStore, connect_url: str, wait_timeout_seconds: int) -> dict[str, object]:
+        del store
+        assert connect_url == "https://hol.org/guard/connect"
+        assert wait_timeout_seconds == 5
+        return {
+            "status": "connected",
+            "connect_mode": "browser_oauth",
+            "browser_opened": True,
+            "authorize_url": "https://hol.org/guard/oauth/authorize?request_id=req-123",
+        }
 
     def fake_device_flow(
         *,
@@ -1416,128 +1423,74 @@ def test_connect_default_uses_device_code_flow_with_browser_open(tmp_path: Path,
         ci_safe: bool = False,
         machine_label: str | None = None,
     ) -> dict[str, object]:
-        del store, ci_safe, machine_label
-        assert connect_url == "https://hol.org/guard/connect"
-        assert wait_timeout_seconds == 5
-        assert open_browser is not None
-        if announce_copy is not None:
-            announce_copy(
-                {
-                    "user_code": "ABCD-EFGH",
-                    "verification_uri": "https://hol.org/guard/oauth/device",
-                    "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
-                }
-            )
-        browser_opened = bool(open_browser("https://hol.org/guard/oauth/device"))
-        return {
-            "status": "connected",
-            "connect_mode": "device_code",
-            "browser_opened": browser_opened,
-            "user_code": "ABCD-EFGH",
-            "verification_uri": "https://hol.org/guard/oauth/device",
-            "next_action": {
-                "command": "open",
-                "target": "https://hol.org/guard/oauth/device",
-            },
-        }
+        del store, connect_url, wait_timeout_seconds, announce_copy, open_browser, ci_safe, machine_label
+        raise AssertionError("default connect should not use device code")
 
-    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", fail_browser_flow)
+    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", fake_browser_flow)
     monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_device_flow)
-    monkeypatch.setattr(guard_commands.webbrowser, "open", lambda target: opened.append(target) or True)
 
     exit_code = run_guard_command(args)
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert opened == ["https://hol.org/guard/oauth/device"]
-    assert "device_code" in captured.out
+    assert "browser_oauth" in captured.out
     assert "browser_opened" in captured.out
-    assert "ABCD-EFGH" in captured.out
-    assert "verification_uri" in captured.out
+    assert "authorize_url" in captured.out
+    assert "ABCD-EFGH" not in captured.out
     assert "guardPairSecret" not in captured.out
     assert "guardPairRequest" not in captured.out
     assert not hasattr(guard_commands, "_run_guard_connect_flow")
 
 
-def test_connect_default_device_flow_respects_wait_timeout_seconds(tmp_path: Path, capsys, monkeypatch) -> None:
+def test_connect_default_browser_flow_respects_wait_timeout_seconds(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     args = _ConnectArgs()
     args.guard_home = str(guard_home)
     args.wait_timeout_seconds = 7
 
-    def fake_device_flow(
-        *,
-        store: GuardStore,
-        connect_url: str,
-        wait_timeout_seconds: int = 180,
-        announce_copy=None,
-        open_browser=None,
-        ci_safe: bool = False,
-        machine_label: str | None = None,
-    ) -> dict[str, object]:
-        del store, announce_copy, open_browser, ci_safe, machine_label
+    def fake_browser_flow(*, store: GuardStore, connect_url: str, wait_timeout_seconds: int) -> dict[str, object]:
+        del store
         assert connect_url == "https://hol.org/guard/connect"
         assert wait_timeout_seconds == 7
         return {
             "status": "connected",
-            "connect_mode": "device_code",
-            "browser_opened": False,
-            "user_code": "ABCD-EFGH",
-            "verification_uri": "https://hol.org/guard/oauth/device",
+            "connect_mode": "browser_oauth",
+            "browser_opened": True,
+            "authorize_url": "https://hol.org/guard/oauth/authorize?request_id=req-456",
         }
 
-    monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_device_flow)
-    monkeypatch.setattr(guard_commands.webbrowser, "open", lambda _target: True)
+    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", fake_browser_flow)
 
     exit_code = run_guard_command(args)
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert "device_code" in captured.out
+    assert "browser_oauth" in captured.out
 
 
-def test_connect_default_non_json_announces_device_copy_on_stderr(tmp_path: Path, capsys, monkeypatch) -> None:
+def test_connect_default_non_json_skips_device_copy_on_stderr(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     args = _ConnectArgs()
     args.guard_home = str(guard_home)
     args.json = False
 
-    def fake_device_flow(
-        *,
-        store: GuardStore,
-        connect_url: str,
-        wait_timeout_seconds: int = 180,
-        announce_copy=None,
-        open_browser=None,
-        ci_safe: bool = False,
-        machine_label: str | None = None,
-    ) -> dict[str, object]:
-        del store, connect_url, open_browser, ci_safe, machine_label
-        assert announce_copy is not None
-        announce_copy(
-            {
-                "user_code": "ABCD-EFGH",
-                "verification_uri": "https://hol.org/guard/oauth/device",
-                "verification_uri_complete": "https://hol.org/guard/oauth/device?user_code=ABCD-EFGH",
-            }
-        )
+    def fake_browser_flow(*, store: GuardStore, connect_url: str, wait_timeout_seconds: int) -> dict[str, object]:
+        del store, connect_url, wait_timeout_seconds
         return {
             "status": "connected",
-            "connect_mode": "device_code",
-            "browser_opened": False,
-            "user_code": "ABCD-EFGH",
-            "verification_uri": "https://hol.org/guard/oauth/device",
+            "connect_mode": "browser_oauth",
+            "browser_opened": True,
+            "authorize_url": "https://hol.org/guard/oauth/authorize?request_id=req-789",
         }
 
-    monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_device_flow)
-    monkeypatch.setattr(guard_commands.webbrowser, "open", lambda _target: True)
+    monkeypatch.setattr(guard_commands, "_run_guard_browser_connect_flow", fake_browser_flow)
 
     exit_code = run_guard_command(args)
     captured = capsys.readouterr()
 
     assert exit_code == 0
-    assert "HOL Guard headless approval" in captured.err
-    assert "HOL Guard headless approval" not in captured.out
+    assert "HOL Guard headless approval" not in captured.err
+    assert "Browser opened" in captured.out
 
 
 def test_loopback_callback_listener_uses_random_high_port_and_loopback_path() -> None:


### PR DESCRIPTION
## Summary
- switch `hol-guard connect` and `hol-guard login` to the browser OAuth flow by default for local machine pairing
- keep `--headless` on the Device Code path and update repair and legacy copy to match the actual flow

## Testing
- `pytest tests/test_guard_cli.py tests/test_guard_connect_flow.py -q -k 'guard_connect_uses_browser_oauth_flow_without_pairing or guard_connect_runs_first_sync_and_surfaces_cloud_urls or guard_connect_headless_keeps_device_code_flow or guard_login_without_manual_credentials_uses_browser_oauth_flow or guard_connect_reports_browser_authorization_errors_cleanly or guard_connect_never_exposes_legacy_pairing_fields or connect_repair_copy_points_to_browser_sign_in'`
