### PR TITLE
feat(guard): add package support matrix drift test and CLI command

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -328,6 +328,26 @@ def _run_guard_supply_chain_command(
     store = _require_guard_store(store)
     config = _require_guard_config(config)
     supply_chain_command = getattr(args, "supply_chain_command", None)
+    if supply_chain_command == "support-matrix":
+        from ..shims import package_shim_supported_managers
+        from ..shim_probe import _PACKAGE_SHIM_PROBE_ARGS
+
+        managers = package_shim_supported_managers()
+        probe_managers = set(_PACKAGE_SHIM_PROBE_ARGS.keys())
+        entries = [
+            {
+                "manager": manager,
+                "has_probe_args": manager in probe_managers,
+            }
+            for manager in managers
+        ]
+        payload = {
+            "managers": list(managers),
+            "entries": entries,
+            "source": "hol-guard/src/codex_plugin_scanner/guard/shims.py::_PACKAGE_SHIM_COMMANDS",
+        }
+        _emit("supply-chain-support-matrix", payload, getattr(args, "json", False))
+        return 0
     workspace_dir = workspace or Path.cwd()
     if supply_chain_command == "scan":
         payload, exit_code = build_workspace_scan_payload(

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
@@ -189,6 +189,13 @@ def _configure_guard_cloud_parsers(
     _add_guard_common_args(supply_chain_explain_parser)
     supply_chain_explain_parser.add_argument("--json", action="store_true")
 
+    supply_chain_matrix_parser = supply_chain_subparsers.add_parser(
+        "support-matrix",
+        help="Print supported package managers and probe coverage as JSON",
+    )
+    _add_guard_common_args(supply_chain_matrix_parser)
+    supply_chain_matrix_parser.add_argument("--json", action="store_true")
+
     service_parser = guard_subparsers.add_parser(
         "service",
         help="Manage headless hosted-runtime Guard Cloud login, sync, and status",

--- a/tests/test_guard_package_support_matrix.py
+++ b/tests/test_guard_package_support_matrix.py
@@ -1,0 +1,95 @@
+"""Drift test: _PACKAGE_SHIM_COMMANDS keys match _PACKAGE_SHIM_PROBE_ARGS keys.
+
+This test documents the relationship between the two source-of-truth dicts
+that define package manager support in hol-guard:
+
+  - _PACKAGE_SHIM_COMMANDS (shims.py): managers that can have shims installed
+  - _PACKAGE_SHIM_PROBE_ARGS (shim_probe.py): managers with dedicated probe commands
+
+Managers in _PACKAGE_SHIM_COMMANDS but NOT in _PACKAGE_SHIM_PROBE_ARGS fall
+back to `--version` for probe testing, which proves the shim exists on PATH
+but does not prove install interception. These managers are documented here
+so the portal support matrix can accurately report interceptTest=False.
+"""
+
+from __future__ import annotations
+
+from codex_plugin_scanner.guard.shims import package_shim_supported_managers
+from codex_plugin_scanner.guard.shim_probe import _PACKAGE_SHIM_PROBE_ARGS
+
+
+def test_supported_managers_are_sorted() -> None:
+    """package_shim_supported_managers() returns sorted tuple."""
+    managers = package_shim_supported_managers()
+    assert managers == tuple(sorted(managers))
+
+
+def test_supported_managers_match_shim_commands() -> None:
+    """_PACKAGE_SHIM_COMMANDS keys produce the supported managers list."""
+    from codex_plugin_scanner.guard.shims import _PACKAGE_SHIM_COMMANDS
+
+    expected = tuple(sorted(_PACKAGE_SHIM_COMMANDS.keys()))
+    assert package_shim_supported_managers() == expected
+
+
+def test_probe_args_cover_protected_managers() -> None:
+    """Managers without dedicated probe args are documented.
+
+    gradle, mvn, and uvx are in _PACKAGE_SHIM_COMMANDS but not in
+    _PACKAGE_SHIM_PROBE_ARGS. They fall back to `--version` which
+    proves the shim is on PATH but does not prove install interception.
+    """
+    managers = set(package_shim_supported_managers())
+    probe_managers = set(_PACKAGE_SHIM_PROBE_ARGS.keys())
+
+    missing_probes = managers - probe_managers
+    # These are the known gaps. If a new manager is added without a probe,
+    # this test will fail and the developer must either add probe args
+    # or add the manager to KNOWN_NO_PROBE_MANAGERS.
+    known_no_probe = {"gradle", "mvn", "uvx"}
+    assert missing_probes == known_no_probe, (
+        f"Managers without probe args changed: {missing_probes}. "
+        f"Expected: {known_no_probe}. Either add probe args to "
+        f"_PACKAGE_SHIM_PROBE_ARGS or update KNOWN_NO_PROBE_MANAGERS."
+    )
+
+
+def test_probe_args_only_reference_supported_managers() -> None:
+    """Every probe arg key must be a supported manager."""
+    managers = set(package_shim_supported_managers())
+    probe_managers = set(_PACKAGE_SHIM_PROBE_ARGS.keys())
+
+    unknown_probes = probe_managers - managers
+    assert unknown_probes == set(), (
+        f"Probe args reference unknown managers: {unknown_probes}. "
+        f"Add them to _PACKAGE_SHIM_COMMANDS or remove the probe args."
+    )
+
+
+def test_supported_managers_snapshot() -> None:
+    """Snapshot of supported managers for portal drift detection.
+
+    The portal's package-shim-supported-managers.snapshot.json must match
+    this list. If managers change, update the snapshot in the portal.
+    """
+    expected = (
+        "bun",
+        "bundle",
+        "cargo",
+        "composer",
+        "go",
+        "gradle",
+        "mvn",
+        "npm",
+        "npx",
+        "pip",
+        "pip3",
+        "pipenv",
+        "pipx",
+        "pnpm",
+        "poetry",
+        "uv",
+        "uvx",
+        "yarn",
+    )
+    assert package_shim_supported_managers() == expected


### PR DESCRIPTION
## Summary

Add a drift test and CLI command for the package manager support matrix.

## Changes

### New: `tests/test_guard_package_support_matrix.py`
5 drift tests:
- `package_shim_supported_managers()` returns sorted tuple
- Supported managers match `_PACKAGE_SHIM_COMMANDS` keys
- Probe args cover protected managers — documents intentional gaps (gradle, mvn, uvx have no dedicated probe args, fall back to `--version`)
- Probe args only reference supported managers (no orphan probes)
- Snapshot of supported managers for portal drift detection

### Updated: `commands_parser_cloud.py`
Add `support-matrix` subcommand to `supply-chain` parser.

### Updated: `commands_dispatch_cloud.py`
`hol-guard guard supply-chain support-matrix --json` emits:
```json
{
  "managers": ["bun", "bundle", "cargo", ...],
  "entries": [{"manager": "bun", "has_probe_args": true}, ...],
  "source": "hol-guard/src/codex_plugin_scanner/guard/shims.py::_PACKAGE_SHIM_COMMANDS"
}
```

The portal can use this to sync the support matrix without hardcoding manager names.

## Verification

```
✓ 5 tests passed (test_guard_package_support_matrix.py)
✓ CLI command outputs correct JSON with 18 managers and probe flags
```