### PR TITLE
fix(pi): review size-bounded tool results instead of blocking them

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_support.py
@@ -447,14 +447,12 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    );\n"
         "    const boundedContent = boundValue(event.content);\n"
         "    const boundedStdout = boundedOutputText(event.content);\n"
-        "    if (boundedToolInput.truncated || boundedContent.truncated || boundedStdout.truncated) {\n"
-        '      const reason = "HOL Guard blocked oversized Pi tool output before review because "\n'
-        '        + "the result exceeded the safe hook limit.";\n'
-        "      const toolCallId = toolCallIdKey(event.toolCallId);\n"
-        "      if (toolCallId) blockedToolResults.set(toolCallId, reason);\n"
-        '      ctx.ui.notify(reason, "warning");\n'
-        "      return blockedToolResult(reason, event.details);\n"
-        "    }\n"
+        "    const oversizeNotice =\n"
+        "      boundedToolInput.truncated || boundedContent.truncated || boundedStdout.truncated\n"
+        '        ? "HOL Guard reviewed a size-bounded excerpt of a large Pi tool result; "\n'
+        '          + "the full output was truncated before review."\n'
+        "        : null;\n"
+        "    if (oversizeNotice) ctx.ui.notify(oversizeNotice, \"info\");\n"
         "    const toolInput =\n"
         "      boundedToolInput.value as Record<string, unknown>;\n"
         "    const limitedContent = boundedContent.value;\n"

--- a/src/codex_plugin_scanner/guard/adapters/pi_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_support.py
@@ -452,7 +452,7 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         '        ? "HOL Guard reviewed a size-bounded excerpt of a large Pi tool result; "\n'
         '          + "the full output was truncated before review."\n'
         "        : null;\n"
-        "    if (oversizeNotice) ctx.ui.notify(oversizeNotice, \"info\");\n"
+        '    if (oversizeNotice) ctx.ui.notify(oversizeNotice, "info");\n'
         "    const toolInput =\n"
         "      boundedToolInput.value as Record<string, unknown>;\n"
         "    const limitedContent = boundedContent.value;\n"

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -259,8 +259,11 @@ class TestPiInstall:
         assert "const toolCallId = toolCallIdKey(event.toolCallId);" in text
         assert "if (toolCallId) blockedToolResults.set(toolCallId, reason);" in text
         assert "blockedToolResults.delete(toolCallId);" in text
-        assert "HOL Guard blocked oversized Pi tool output before review" in text
-        assert "return blockedToolResult(reason, event.details);" in text
+        # Oversized tool results are truncated and reviewed, not pre-emptively blocked.
+        assert "HOL Guard blocked oversized Pi tool output before review" not in text
+        assert 'oversizeNotice' in text
+        assert 'ctx.ui.notify(oversizeNotice, "info")' in text
+        assert 'const response = runGuard(' in text
         assert "tool_response: limitedContent" in text
         assert "stdout: toolOutput" in text
         assert "contentText(event.content)" not in text


### PR DESCRIPTION
## Summary
- The Pi `tool_result` hook previously denied any tool result whose content exceeded the per-field size limit, emitting "HOL Guard blocked oversized Pi tool output before review because the result exceeded the safe hook limit." before the guard ever reviewed it. Benign large reads (e.g. a sizeable source file) were blocked outright.
- Oversized tool results are now size-bounded and submitted to the guard for review; the full result is no longer denied solely for being large. A non-blocking info notice replaces the warning when truncation occurs.
- The guard still denies results when a PostToolUse heuristic actually flags them, and `runGuard`'s existing `enforceSizeCap` path still denies payloads that are genuinely too large to review even after best-effort truncation.
- Fixes a repo-wide `ruff` (I001) import-sort error and a `basedpyright` type error in the support-matrix dispatch path that were already failing on `main`.

## Testing
- `uv run --no-sync pytest tests/test_pi_adapter.py tests/test_action_runner.py -q`
- `uv run --no-sync ruff check src/ && uv run --no-sync ruff format --check src/`
- `uv run --no-sync basedpyright --level error`
- Emitted the generated extension, loaded it under Node with `--experimental-strip-types`, and exercised the `tool_result` handler: a 2MB file read now passes through with only an info notice (reviewed on a ~12k-char bounded excerpt), a small read produces no notice, and an oversized result still denies when the guard returns `deny`.

## Notes
- Behavior change for the Pi adapter only; other harnesses are unaffected. The lint/typecheck fixes keep CI green alongside this change.
