### PR TITLE
fix(dashboard): use package firewall connect route

### DIFF
--- a/dashboard/src/guard-api.test.ts
+++ b/dashboard/src/guard-api.test.ts
@@ -1035,7 +1035,7 @@ globalThis.fetch = async (input: RequestInfo | URL, init?: RequestInit): Promise
   const url = input instanceof Request ? input.url : String(input);
   connectCalls.push({ url, init });
   const path = new URL(url, "http://127.0.0.1:4174").pathname;
-  if (path === "/v1/cloud/connect") {
+  if (path === "/v1/supply-chain/package-shims/connect") {
     return new Response(JSON.stringify({ error: "unauthorized", message: "Guard session missing." }), {
       status: 401,
       headers: { "Content-Type": "application/json" }
@@ -1052,8 +1052,8 @@ try {
 }
 assert(connectCalls.length === 1, "L079dc: connect flow does not mint local session from unauthenticated initialize");
 assert(
-  new URL(connectCalls[0].url).pathname === "/v1/cloud/connect",
-  "L079dc: connect flow posts to shared Guard Cloud connect route"
+  new URL(connectCalls[0].url).pathname === "/v1/supply-chain/package-shims/connect",
+  "L079dc: connect flow posts to package firewall connect route"
 );
 assert(
   connectFlowError instanceof Error && connectFlowError.message.includes("Guard session missing"),

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2646,8 +2646,13 @@ export async function fetchPackageFirewallStatus(): Promise<PackageFirewallStatu
 }
 
 export async function startPackageFirewallConnect(): Promise<PackageFirewallStatusResponse["connect_flow"]> {
-  const status = await startGuardCloudConnect();
-  return status.connect_flow;
+  return normalizePackageFirewallConnectFlow(
+    await readJson<unknown>("/v1/supply-chain/package-shims/connect", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({}),
+    }),
+  );
 }
 
 export async function fetchSupplyChainBundle(): Promise<SupplyChainBundle | null> {

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -4492,6 +4492,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/receipts/analytics",
             "/v1/insights/share",
             "/v1/cloud/connect",
+            "/v1/supply-chain/package-shims/connect",
             "/v1/receipts/latest",
             "/v1/runtime",
             "/v1/settings",

--- a/src/codex_plugin_scanner/guard/product_model.py
+++ b/src/codex_plugin_scanner/guard/product_model.py
@@ -239,6 +239,13 @@ LOCAL_API_OWNERSHIP = (
     ApiOwnership(path="/v1/runtime", method="GET", category="config", auth_required=True, writes_state=False),
     ApiOwnership(path="/v1/cloud/connect", method="GET", category="config", auth_required=True, writes_state=False),
     ApiOwnership(path="/v1/cloud/connect", method="POST", category="config", auth_required=True, writes_state=True),
+    ApiOwnership(
+        path="/v1/supply-chain/package-shims/connect",
+        method="POST",
+        category="supply_chain",
+        auth_required=True,
+        writes_state=True,
+    ),
     ApiOwnership(path="/v1/harnesses", method="GET", category="config", auth_required=True, writes_state=False),
     ApiOwnership(
         path="/v1/harnesses/{harness}/install",

--- a/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
+++ b/src/codex_plugin_scanner/guard/schemas/guard_product_model_v1.json
@@ -435,6 +435,13 @@
             "writes_state": true
         },
         {
+            "path": "/v1/supply-chain/package-shims/connect",
+            "method": "POST",
+            "category": "supply_chain",
+            "auth_required": true,
+            "writes_state": true
+        },
+        {
             "path": "/v1/harnesses",
             "method": "GET",
             "category": "config",

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -694,6 +694,75 @@ def test_guard_cloud_connect_starts_local_browser_flow_for_insights_share(
     assert store.get_cloud_sync_profile() is not None
 
 
+def test_package_firewall_connect_accepts_hosted_dashboard_origin(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+    try:
+        token = _dashboard_token_for(store)
+
+        class _FakeSession:
+            authorize_url = "https://hol.org/mock-authorize"
+            redirect_uri = "http://127.0.0.1:53112/oauth/callback"
+            pkce_verifier = "pkce-verifier"
+            dpop_key_material = type(
+                "KeyMaterial",
+                (),
+                {
+                    "private_key_pem": "private-key-new",
+                    "public_jwk": {"kty": "EC", "crv": "P-256", "x": "x-value-new", "y": "y-value-new"},
+                    "public_jwk_thumbprint": "thumbprint-new",
+                },
+            )()
+
+            def wait_for_callback(self, _timeout_seconds: float):
+                return type("Callback", (), {"code": "auth-code-1"})()
+
+            def close(self) -> None:
+                return None
+
+        monkeypatch.setattr(daemon_server, "start_guard_browser_session", lambda **_kwargs: _FakeSession())
+        monkeypatch.setattr(daemon_server.webbrowser, "open", lambda _url: True)
+        monkeypatch.setattr(
+            daemon_server,
+            "exchange_guard_authorization_code",
+            lambda **_kwargs: GuardOAuthTokenExchangeResult(
+                access_token="access-token-1",
+                refresh_token="refresh-token-new",
+                expires_in=300,
+                scope="guard:runtime.sync guard:offline_access",
+                token_type="Bearer",
+                grant_id="grant-new",
+                machine_id="machine-new",
+                supply_chain_entitlement={
+                    "supply_chain_entitlement_expires_at": "2026-07-05T01:39:51+00:00",
+                    "supply_chain_firewall": True,
+                    "supply_chain_plan_id": "team",
+                },
+                workspace_id="workspace-1",
+            ),
+        )
+
+        status, payload = _read_json_response(
+            _request(
+                daemon.port,
+                "/v1/supply-chain/package-shims/connect",
+                token=token,
+                payload={},
+                origin="https://hol.org",
+            ),
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 202
+    assert payload["state"] == "running"
+    assert payload["authorize_url"] == "https://hol.org/mock-authorize"
+
+
 def _assert_connect_endpoint_coalesces_concurrent_browser_starts(
     *,
     endpoint: str,

--- a/tests/test_guard_product_model_contracts.py
+++ b/tests/test_guard_product_model_contracts.py
@@ -206,6 +206,8 @@ def test_local_route_and_api_ownership_contracts_are_explicit() -> None:
     assert apis_by_method[("POST", "/v1/connect/complete")].writes_state is False
     assert apis_by_method[("POST", "/v1/connect/result")].writes_state is False
     assert apis_by_method[("GET", "/v1/runtime")].writes_state is False
+    assert apis_by_method[("POST", "/v1/supply-chain/package-shims/connect")].category == "supply_chain"
+    assert apis_by_method[("POST", "/v1/supply-chain/package-shims/connect")].writes_state is True
     assert apis_by_method[("GET", "/v1/harnesses")].writes_state is False
     assert apis_by_method[("POST", "/v1/harnesses/{harness}/install")].writes_state is True
     assert apis_by_method[("POST", "/v1/harnesses/{harness}/verify")].writes_state is False


### PR DESCRIPTION
## Summary
- route supply-chain connect actions to the dedicated package-firewall daemon endpoint instead of the generic cloud-connect endpoint
- cover the dashboard API helper with a regression test for the package-firewall connect route

## Testing
- `/Users/michaelkantor/CascadeProjects/hashgraph-online/hol-guard/dashboard/node_modules/.bin/tsx src/guard-api.test.ts`
