### PR TITLE
fix(daemon): accept hol-guard console-script pids

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -806,7 +806,7 @@ def _running_ephemeral_guard_daemon_processes() -> list[tuple[int, Path, float]]
         pid = int(match.group(1))
         elapsed_seconds = _elapsed_seconds_from_ps(match.group(2))
         command = match.group(3).strip()
-        if "codex_plugin_scanner.cli guard daemon --serve" not in command:
+        if not _guard_daemon_command_matches(command):
             continue
         guard_home = _guard_home_from_command(command)
         if guard_home is None or not _guard_home_is_ephemeral(guard_home):
@@ -871,6 +871,25 @@ def _guard_daemon_port_from_command(command: str) -> int | None:
     return None
 
 
+def _guard_daemon_command_matches(command: str) -> bool:
+    try:
+        parts = shlex.split(command)
+    except ValueError:
+        return False
+    for index in range(len(parts) - 2):
+        if parts[index : index + 3] != ["guard", "daemon", "--serve"]:
+            continue
+        prefix = parts[:index]
+        if any(part == "codex_plugin_scanner.cli" for part in prefix):
+            return True
+        if index == 0:
+            continue
+        launcher_name = Path(parts[index - 1]).name.lower()
+        if launcher_name in {"hol-guard", "hol-guard.exe"}:
+            return True
+    return False
+
+
 def _running_guard_daemon_processes_for_guard_home(guard_home: Path) -> list[tuple[int, int]]:
     if os.name == "nt":
         return []
@@ -891,7 +910,7 @@ def _running_guard_daemon_processes_for_guard_home(guard_home: Path) -> list[tup
             continue
         pid = int(match.group(1))
         command = match.group(2).strip()
-        if "codex_plugin_scanner.cli" not in command or "guard daemon --serve" not in command:
+        if not _guard_daemon_command_matches(command):
             continue
         command_guard_home = _guard_home_from_command(command)
         port = _guard_daemon_port_from_command(command)
@@ -972,7 +991,7 @@ def _guard_daemon_pid_matches_command(pid: int, expected_guard_home: Path | None
     command = _guard_daemon_command_for_pid(pid)
     if command is None:
         return False
-    if "codex_plugin_scanner.cli" not in command or "guard daemon --serve" not in command:
+    if not _guard_daemon_command_matches(command):
         return False
     if expected_guard_home is None:
         return True

--- a/src/codex_plugin_scanner/guard/daemon/manager.py
+++ b/src/codex_plugin_scanner/guard/daemon/manager.py
@@ -876,16 +876,34 @@ def _guard_daemon_command_matches(command: str) -> bool:
         parts = shlex.split(command)
     except ValueError:
         return False
-    for index in range(len(parts) - 2):
+    for index in range(len(parts) - 1):
+        prefix = parts[:index]
+        if parts[index : index + 2] == ["daemon", "--serve"]:
+            if any(part == "codex_plugin_scanner.cli" for part in prefix):
+                return True
+            if index > 0:
+                launcher_name = Path(parts[index - 1]).name.lower()
+                if launcher_name in {
+                    "hol-guard",
+                    "hol-guard.exe",
+                    "plugin-guard",
+                    "plugin-guard.exe",
+                }:
+                    return True
+            continue
         if parts[index : index + 3] != ["guard", "daemon", "--serve"]:
             continue
-        prefix = parts[:index]
         if any(part == "codex_plugin_scanner.cli" for part in prefix):
             return True
         if index == 0:
             continue
         launcher_name = Path(parts[index - 1]).name.lower()
-        if launcher_name in {"hol-guard", "hol-guard.exe"}:
+        if launcher_name in {
+            "hol-guard",
+            "hol-guard.exe",
+            "plugin-guard",
+            "plugin-guard.exe",
+        }:
             return True
     return False
 

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -191,6 +191,26 @@ def test_running_guard_daemon_processes_for_guard_home_returns_empty_on_ps_timeo
     assert daemon_manager_module._running_guard_daemon_processes_for_guard_home(guard_home) == []
 
 
+def test_running_guard_daemon_processes_for_guard_home_accepts_console_script_launch(
+    tmp_path,
+    monkeypatch,
+):
+    guard_home = tmp_path / "guard-home"
+    command = (
+        "/Users/test/.local/pipx/venvs/hol-guard/bin/python "
+        "/Users/test/.local/bin/hol-guard guard daemon --serve "
+        f"--guard-home {guard_home} --port 5474"
+    )
+
+    monkeypatch.setattr(
+        daemon_manager_module.subprocess,
+        "run",
+        lambda *_args, **_kwargs: SimpleNamespace(stdout=f"12345 {command}\n"),
+    )
+
+    assert daemon_manager_module._running_guard_daemon_processes_for_guard_home(guard_home) == [(12345, 5474)]
+
+
 def test_ensure_guard_daemon_reuses_inflight_pid_before_respawning(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     responses = iter((None, None, "http://127.0.0.1:5409"))
@@ -805,6 +825,30 @@ def test_guard_daemon_pid_matches_command_validates_guard_home_on_windows(tmp_pa
         daemon_manager_module,
         "_guard_home_from_command",
         lambda _command: expected_guard_home,
+    )
+
+    assert daemon_manager_module._guard_daemon_pid_matches_command(
+        12345,
+        expected_guard_home=expected_guard_home,
+    )
+    assert not daemon_manager_module._guard_daemon_pid_matches_command(
+        12345,
+        expected_guard_home=tmp_path / "other-home",
+    )
+
+
+def test_guard_daemon_pid_matches_command_accepts_console_script_launch(tmp_path, monkeypatch):
+    expected_guard_home = tmp_path / "guard-home"
+    command = (
+        "/Users/test/.local/pipx/venvs/hol-guard/bin/python "
+        "/Users/test/.local/bin/hol-guard guard daemon --serve "
+        f"--guard-home {expected_guard_home} --port 5474"
+    )
+
+    monkeypatch.setattr(
+        daemon_manager_module,
+        "_guard_daemon_command_for_pid",
+        lambda _pid: command,
     )
 
     assert daemon_manager_module._guard_daemon_pid_matches_command(

--- a/tests/test_guard_daemon_manager.py
+++ b/tests/test_guard_daemon_manager.py
@@ -211,6 +211,15 @@ def test_running_guard_daemon_processes_for_guard_home_accepts_console_script_la
     assert daemon_manager_module._running_guard_daemon_processes_for_guard_home(guard_home) == [(12345, 5474)]
 
 
+def test_guard_daemon_command_matches_accepts_console_script_shortcuts() -> None:
+    assert daemon_manager_module._guard_daemon_command_matches(
+        "/Users/test/.local/bin/hol-guard daemon --serve --guard-home /tmp/guard-home --port 5474"
+    )
+    assert daemon_manager_module._guard_daemon_command_matches(
+        "/Users/test/.local/bin/plugin-guard daemon --serve --guard-home /tmp/guard-home --port 5474"
+    )
+
+
 def test_ensure_guard_daemon_reuses_inflight_pid_before_respawning(tmp_path, monkeypatch):
     guard_home = tmp_path / "guard-home"
     responses = iter((None, None, "http://127.0.0.1:5409"))


### PR DESCRIPTION
## Summary
- accept live Guard daemon processes launched through the `hol-guard` console script, not just the module entrypoint
- cover console-script daemon detection in focused manager tests so daemon status and liveness checks stay aligned with pipx installs

## Testing
- `pytest tests/test_guard_daemon_manager.py -q -k 'console_script_launch or pid_matches_command_validates_guard_home_on_windows or returns_empty_on_ps_timeout'`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard daemon status --guard-home ~/.hol-guard --json`
