### PR TITLE
fix(guard): restore password+TOTP two-factor and reviewed Pi tool output

### DIFF
--- a/dashboard/src/approval-gate.test.ts
+++ b/dashboard/src/approval-gate.test.ts
@@ -232,7 +232,7 @@ function testBulkApproveGateCredentialsPayload(): void {
   assert(!("approval_gate_use_cooldown" in withoutGate), "bulk payload should not include approval_gate_use_cooldown when no gate credentials");
 }
 
-function testApprovalProofTotpOverridesPassword(): void {
+function testApprovalProofTotpRequiresPassword(): void {
   const totpGate: GuardApprovalGatePublicConfig = {
     enabled: true,
     configured: true,
@@ -245,13 +245,23 @@ function testApprovalProofTotpOverridesPassword(): void {
     totp_enabled: true,
     totp_pending: false,
   };
+  // With TOTP enabled, the password is still the primary factor: a TOTP code
+  // alone does not enable submit.
   assert(
-    isApprovalProofSubmitDisabled(totpGate, { approvalPassword: "", approvalTotpCode: "123456" }, false) === false,
-    "totp approval proof should not require password",
+    isApprovalProofSubmitDisabled(totpGate, { approvalPassword: "", approvalTotpCode: "123456" }, false) === true,
+    "totp approval proof should still require password",
   );
-  const credentials = buildApprovalProofCredentials(totpGate, { approvalPassword: "ignored", approvalTotpCode: "123456" });
+  assert(
+    isApprovalProofSubmitDisabled(totpGate, { approvalPassword: "pw", approvalTotpCode: "" }, false) === true,
+    "totp approval proof should require the authenticator code",
+  );
+  assert(
+    isApprovalProofSubmitDisabled(totpGate, { approvalPassword: "pw", approvalTotpCode: "123456" }, false) === false,
+    "totp approval proof should accept both factors",
+  );
+  const credentials = buildApprovalProofCredentials(totpGate, { approvalPassword: "pw", approvalTotpCode: "123456" });
+  assert(credentials.approval_password === "pw", "totp approval proof should include password");
   assert(credentials.approval_totp_code === "123456", "totp approval proof should include authenticator code");
-  assert(!("approval_password" in credentials), "totp approval proof should omit password");
 }
 
 const tests: Array<[string, () => void]> = [
@@ -263,7 +273,7 @@ const tests: Array<[string, () => void]> = [
   ["testApprovalGateToggleReflectedInDraftApprovalGate", testApprovalGateToggleReflectedInDraftApprovalGate],
   ["testApprovalGateCooldownReflectedInDraftApprovalGate", testApprovalGateCooldownReflectedInDraftApprovalGate],
   ["testBulkApproveGateCredentialsPayload", testBulkApproveGateCredentialsPayload],
-  ["testApprovalProofTotpOverridesPassword", testApprovalProofTotpOverridesPassword],
+  ["testApprovalProofTotpRequiresPassword", testApprovalProofTotpRequiresPassword],
 ];
 
 let passed = 0;

--- a/dashboard/src/approval-proof-inline.tsx
+++ b/dashboard/src/approval-proof-inline.tsx
@@ -13,9 +13,10 @@ type ApprovalProofFieldInputsProps = {
   onApprovalTotpCodeChange: (event: ChangeEvent<HTMLInputElement>) => void;
 };
 
-export function approvalProofRequiresPassword(gate: GuardApprovalGatePublicConfig | null | undefined): boolean {
+export function approvalProofRequiresPassword(_gate: GuardApprovalGatePublicConfig | null | undefined): boolean {
   // The approval password is always the primary factor. TOTP, when enabled,
-  // is an additional second factor rather than a replacement for it.
+  // is an additional second factor rather than a replacement for it. The gate
+  // argument is retained so call sites keep passing the resolved gate config.
   return true;
 }
 

--- a/dashboard/src/approval-proof-inline.tsx
+++ b/dashboard/src/approval-proof-inline.tsx
@@ -14,7 +14,9 @@ type ApprovalProofFieldInputsProps = {
 };
 
 export function approvalProofRequiresPassword(gate: GuardApprovalGatePublicConfig | null | undefined): boolean {
-  return gate?.totp_enabled !== true;
+  // The approval password is always the primary factor. TOTP, when enabled,
+  // is an additional second factor rather than a replacement for it.
+  return true;
 }
 
 export function isApprovalProofSubmitDisabled(
@@ -25,39 +27,44 @@ export function isApprovalProofSubmitDisabled(
   if (busy) {
     return true;
   }
-  if (approvalProofRequiresPassword(gate)) {
-    return credentials.approvalPassword.trim() === "";
+  if (credentials.approvalPassword.trim() === "") {
+    return true;
   }
-  return credentials.approvalTotpCode.trim() === "";
+  if (gate?.totp_enabled === true && credentials.approvalTotpCode.trim() === "") {
+    return true;
+  }
+  return false;
 }
 
 export function buildApprovalProofCredentials(
   gate: GuardApprovalGatePublicConfig | null | undefined,
   credentials: { approvalPassword: string; approvalTotpCode: string },
-): { approval_password?: string; approval_totp_code?: string } {
-  if (approvalProofRequiresPassword(gate)) {
-    return { approval_password: credentials.approvalPassword };
+): { approval_password: string; approval_totp_code?: string } {
+  const payload: { approval_password: string; approval_totp_code?: string } = {
+    approval_password: credentials.approvalPassword,
+  };
+  if (gate?.totp_enabled === true) {
+    payload.approval_totp_code = credentials.approvalTotpCode;
   }
-  return { approval_totp_code: credentials.approvalTotpCode };
+  return payload;
 }
 
 export function ApprovalProofFieldInputs(props: ApprovalProofFieldInputsProps) {
-  const needsPassword = approvalProofRequiresPassword(props.approvalGate);
+  const needsTotp = props.approvalGate?.totp_enabled === true;
   return (
     <div className="space-y-3">
-      {needsPassword ? (
-        <label className="block">
-          <span className="text-sm font-semibold text-brand-dark">Approval password</span>
-          <input
-            ref={props.passwordRef}
-            type="password"
-            autoComplete="current-password"
-            value={props.approvalPassword}
-            onChange={props.onApprovalPasswordChange}
-            className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
-          />
-        </label>
-      ) : (
+      <label className="block">
+        <span className="text-sm font-semibold text-brand-dark">Approval password</span>
+        <input
+          ref={props.passwordRef}
+          type="password"
+          autoComplete="current-password"
+          value={props.approvalPassword}
+          onChange={props.onApprovalPasswordChange}
+          className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
+        />
+      </label>
+      {needsTotp ? (
         <label className="block">
           <span className="text-sm font-semibold text-brand-dark">Authenticator code</span>
           <input
@@ -70,7 +77,7 @@ export function ApprovalProofFieldInputs(props: ApprovalProofFieldInputsProps) {
             className="mt-1 min-h-11 w-full rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm text-brand-dark focus:border-brand-blue focus:outline-none focus:ring-2 focus:ring-brand-blue/20"
           />
         </label>
-      )}
+      ) : null}
     </div>
   );
 }

--- a/dashboard/src/settings-save-proof-modal.test.ts
+++ b/dashboard/src/settings-save-proof-modal.test.ts
@@ -77,16 +77,28 @@ assert(
 );
 
 assert(
-  isSettingsSaveProofSubmitDisabled("verify-save", { totpCode: "123456" }, true) === false,
-  "save-proof: verify accepts totp without password when enabled",
+  isSettingsSaveProofSubmitDisabled("verify-save", { totpCode: "123456" }, true) === true,
+  "save-proof: verify rejects totp without password when enabled",
+);
+assert(
+  isSettingsSaveProofSubmitDisabled("verify-save", { currentPassword: "secret", totpCode: "123456" }, true) === false,
+  "save-proof: verify accepts password and totp together when enabled",
 );
 assert(
   isSettingsSaveProofSubmitDisabled(
     "change-password",
     { newPassword: "next-secret", confirmPassword: "next-secret", totpCode: "123456" },
     true,
+  ) === true,
+  "save-proof: change-password rejects totp without current password when enabled",
+);
+assert(
+  isSettingsSaveProofSubmitDisabled(
+    "change-password",
+    { currentPassword: "secret", newPassword: "next-secret", confirmPassword: "next-secret", totpCode: "123456" },
+    true,
   ) === false,
-  "save-proof: change-password accepts totp without current password when enabled",
+  "save-proof: change-password accepts current password and totp together when enabled",
 );
 assert(
   isSettingsSaveProofSubmitDisabled("setup-gate", { newPassword: "alpha", confirmPassword: "beta" }, false) === true,

--- a/dashboard/src/settings-save-proof-modal.tsx
+++ b/dashboard/src/settings-save-proof-modal.tsx
@@ -161,13 +161,16 @@ export function isSettingsSaveProofSubmitDisabled(
     if (next.length === 0 || confirm.length === 0 || next !== confirm) {
       return true;
     }
-    return totpRequired ? totp.length === 0 : current.length === 0;
-  }
-  if (totpRequired) {
-    return totp.length === 0;
+    if (current.length === 0) {
+      return true;
+    }
+    return totpRequired ? totp.length === 0 : false;
   }
   if (current.length === 0) {
     return true;
+  }
+  if (totpRequired) {
+    return totp.length === 0;
   }
   return false;
 }
@@ -192,17 +195,10 @@ export function SettingsSaveProofModal(props: SettingsSaveProofModalProps) {
       return;
     }
     const timer = setTimeout(() => {
-      if (
-        props.gate?.totp_enabled === true
-        && (props.mode === "verify-save" || props.mode === "change-password" || props.mode === "maintenance")
-      ) {
-        totpRef.current?.focus();
-      } else {
-        passwordRef.current?.focus();
-      }
+      passwordRef.current?.focus();
     }, 50);
     return () => clearTimeout(timer);
-  }, [props.gate?.totp_enabled, props.open, props.mode]);
+  }, [props.open]);
 
   useEffect(() => {
     if (props.open) {
@@ -223,7 +219,9 @@ export function SettingsSaveProofModal(props: SettingsSaveProofModalProps) {
 
   const totpRequired = props.gate?.totp_enabled === true
     && (props.mode === "verify-save" || props.mode === "change-password" || props.mode === "maintenance");
-  const needsCurrentPassword = props.mode !== "setup-gate" && !totpRequired;
+  // The approval password is always the primary factor; TOTP adds a second
+  // factor rather than replacing the password prompt.
+  const needsCurrentPassword = props.mode !== "setup-gate";
 
   const handleCurrentPasswordChange = useCallback((event: ChangeEvent<HTMLInputElement>) => {
     setCurrentPassword(event.target.value);

--- a/src/codex_plugin_scanner/guard/adapters/pi_support.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_support.py
@@ -388,6 +388,23 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "  };\n"
         "}\n"
         "\n"
+        "function reviewedToolResult(content: unknown, details: unknown, isError?: boolean) {\n"
+        "  let body = '';\n"
+        "  if (Array.isArray(content)) {\n"
+        "    body = boundedOutputText(content).value as string;\n"
+        "  } else if (typeof content === 'string') {\n"
+        "    body = content;\n"
+        "  } else if (content !== undefined && content !== null) {\n"
+        "    try { body = JSON.stringify(content); } catch {}\n"
+        "  }\n"
+        "  const result = {\n"
+        '    content: body.length > 0 ? [{ type: "text", text: body }] : [],\n'
+        "    details,\n"
+        "  } as { content: unknown[]; details: unknown; isError?: boolean };\n"
+        "  if (isError) result.isError = true;\n"
+        "  return result;\n"
+        "}\n"
+        "\n"
         "export default function (pi: ExtensionAPI) {\n"
         "  const blockedToolResults = new Map<string, string>();\n"
         '  pi.on("input", async (event, ctx) => {\n'
@@ -447,10 +464,13 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    );\n"
         "    const boundedContent = boundValue(event.content);\n"
         "    const boundedStdout = boundedOutputText(event.content);\n"
-        "    const oversizeNotice =\n"
-        "      boundedToolInput.truncated || boundedContent.truncated || boundedStdout.truncated\n"
+        "    // Only the reviewed *output* content determines whether the result is\n"
+        "    // replaced with the bounded excerpt. A truncated tool input alone does\n"
+        "    // not mean the output reached the model unreviewed.\n"
+        "    const outputTruncated = boundedContent.truncated || boundedStdout.truncated;\n"
+        "    const oversizeNotice = outputTruncated\n"
         '        ? "HOL Guard reviewed a size-bounded excerpt of a large Pi tool result; "\n'
-        '          + "the full output was truncated before review."\n'
+        '          + "the model receives the reviewed excerpt, not the full output."\n'
         "        : null;\n"
         '    if (oversizeNotice) ctx.ui.notify(oversizeNotice, "info");\n'
         "    const toolInput =\n"
@@ -477,7 +497,12 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         '      ctx.ui.notify(reason, "warning");\n'
         "      return blockedToolResult(reason, event.details);\n"
         "    }\n"
-        "    return undefined;\n"
+        "    if (!outputTruncated) return undefined;\n"
+        "    // The full tool result was larger than the review window. Returning\n"
+        "    // undefined would leave Pi's original full event.content intact, so the\n"
+        "    // unreviewed tail would still reach the model. Instead, replace the\n"
+        "    // result with the bounded excerpt Guard actually reviewed.\n"
+        "    return reviewedToolResult(limitedContent, event.details, event.isError === true);\n"
         "  });\n"
         "}\n"
     )

--- a/src/codex_plugin_scanner/guard/approval_gate.py
+++ b/src/codex_plugin_scanner/guard/approval_gate.py
@@ -384,11 +384,22 @@ def disable_totp(
     state = _load_state(guard_home)
     if not _enabled(state):
         raise ApprovalGateError("approval_gate_required", "Approval password is required.")
+    if _verifier(state) is None:
+        raise ApprovalGateError(
+            "approval_gate_recovery_required",
+            "Approval gate is enabled but no verifier is configured.",
+            status=423,
+        )
     now_epoch = _epoch(now)
     locked_until = _optional_string(state.get("locked_until"))
     if _is_future(locked_until, now_epoch):
         raise ApprovalGateError("approval_gate_locked", "Approval gate is temporarily locked.", status=423)
     gate_input = approval_gate_input or ApprovalGateInput()
+    if gate_input.password is None:
+        raise ApprovalGateError("approval_gate_required", "Approval password is required.")
+    if not _verify_password(gate_input.password, _verifier(state)):
+        _record_failed_attempt(guard_home, state, now=now)
+        raise ApprovalGateError("approval_gate_invalid_password", "Approval password is invalid.")
     secret_id = _optional_string(state.get("totp_secret_id"))
     if secret_id is None:
         if _totp_enabled(state):
@@ -575,8 +586,6 @@ def validate_grant(
 ) -> None:
     state = _load_state(guard_home)
     if approval_gate_grant is None:
-        if _totp_enabled(state):
-            raise ApprovalGateError("approval_gate_totp_required", "TOTP code is required.")
         raise ApprovalGateError("approval_gate_required", "Approval password is required.")
     metadata = _ACTIVE_GRANTS.get(approval_gate_grant.grant_id)
     if metadata is None:
@@ -627,10 +636,35 @@ def _verify_or_raise(
     now: str | None,
 ) -> ApprovalGateGrant:
     now_epoch = _epoch(now)
+    if _verifier(state) is None:
+        raise ApprovalGateError(
+            "approval_gate_recovery_required",
+            "Approval gate is enabled but no verifier is configured.",
+            status=423,
+        )
     locked_until = _optional_string(state.get("locked_until"))
     if _is_future(locked_until, now_epoch):
         raise ApprovalGateError("approval_gate_locked", "Approval gate is temporarily locked.", status=423)
+    # Cooldown can satisfy ordinary (non-strict) actions only when TOTP is not
+    # enabled. With TOTP enabled every protected action requires both the
+    # current password and a current authenticator code.
+    if not strict and _cooldown_active(state, now_epoch) and not _totp_enabled(state):
+        return _register_grant(
+            guard_home,
+            purpose=purpose,
+            strict=False,
+            used_cooldown=True,
+            cooldown_expires_at=_optional_string(state.get("cooldown_expires_at")),
+            totp_verified=False,
+            now=now,
+        )
     gate_input = approval_gate_input or ApprovalGateInput()
+    if gate_input.password is None:
+        raise ApprovalGateError("approval_gate_required", "Approval password is required.")
+    if not _verify_password(gate_input.password, _verifier(state)):
+        _record_failed_attempt(guard_home, state, now=now)
+        raise ApprovalGateError("approval_gate_invalid_password", "Approval password is invalid.")
+    totp_verified = False
     if _totp_enabled(state):
         if gate_input.totp_code is None:
             raise ApprovalGateError("approval_gate_totp_required", "TOTP code is required.")
@@ -641,44 +675,16 @@ def _verify_or_raise(
             now_epoch=now_epoch,
         )
         state["totp_last_counter"] = accepted_counter
-        state["failed_attempts"] = 0
-        state.pop("locked_until", None)
-        state.pop("cooldown_expires_at", None)
-        _write_state(guard_home, state, now=now)
-        return _register_grant(
-            guard_home,
-            purpose=purpose,
-            strict=strict,
-            used_cooldown=False,
-            cooldown_expires_at=None,
-            totp_verified=True,
-            now=now,
-        )
-    if _verifier(state) is None:
-        raise ApprovalGateError(
-            "approval_gate_recovery_required",
-            "Approval gate is enabled but no verifier is configured.",
-            status=423,
-        )
-    if not strict and _cooldown_active(state, now_epoch):
-        return _register_grant(
-            guard_home,
-            purpose=purpose,
-            strict=False,
-            used_cooldown=True,
-            cooldown_expires_at=_optional_string(state.get("cooldown_expires_at")),
-            totp_verified=False,
-            now=now,
-        )
-    if gate_input.password is None:
-        raise ApprovalGateError("approval_gate_required", "Approval password is required.")
-    if not _verify_password(gate_input.password, _verifier(state)):
-        _record_failed_attempt(guard_home, state, now=now)
-        raise ApprovalGateError("approval_gate_invalid_password", "Approval password is invalid.")
+        totp_verified = True
     state["failed_attempts"] = 0
     state.pop("locked_until", None)
     cooldown_expires_at: str | None = None
-    if not strict and _cooldown_seconds(state) > 0 and gate_input.use_cooldown is not False:
+    if (
+        not strict
+        and not _totp_enabled(state)
+        and _cooldown_seconds(state) > 0
+        and gate_input.use_cooldown is not False
+    ):
         cooldown_expires_at = _iso_from_epoch(now_epoch + _cooldown_seconds(state))
         state["cooldown_expires_at"] = cooldown_expires_at
     _write_state(guard_home, state, now=now)
@@ -688,7 +694,7 @@ def _verify_or_raise(
         strict=strict,
         used_cooldown=False,
         cooldown_expires_at=cooldown_expires_at,
-        totp_verified=False,
+        totp_verified=totp_verified,
         now=now,
     )
 

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -923,34 +923,52 @@ def test_approval_gate_totp_manual_key_accepts_readability_dashes(tmp_path: Path
     assert totp_code_at_counter(secret=dashed_secret, counter=_counter("2026-04-11T00:01:00+00:00"))
 
 
-def test_approval_gate_disable_totp_requires_totp_only_when_enabled(tmp_path: Path) -> None:
+def test_approval_gate_disable_totp_requires_password_and_totp_when_enabled(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store)
     secret = _enable_totp(store, now="2026-04-11T00:00:00+00:00")
 
-    with pytest.raises(ApprovalGateError) as missing_totp:
+    # Disabling TOTP is a strict action: the approval password is required first,
+    # and a current authenticator code is required as the second factor.
+    with pytest.raises(ApprovalGateError) as missing_password:
         disable_totp(store.guard_home, approval_gate_input=ApprovalGateInput(), now="2026-04-11T00:00:31+00:00")
+    assert missing_password.value.code == "approval_gate_required"
+
+    with pytest.raises(ApprovalGateError) as wrong_password:
+        disable_totp(
+            store.guard_home,
+            approval_gate_input=ApprovalGateInput(password=WRONG_PASSWORD),
+            now="2026-04-11T00:00:31+00:00",
+        )
+    assert wrong_password.value.code == "approval_gate_invalid_password"
+
+    disable_now = "2026-04-11T00:01:31+00:00"
+    disable_code = totp_code_at_counter(secret=secret, counter=_counter(disable_now))
+    with pytest.raises(ApprovalGateError) as missing_totp:
+        disable_totp(
+            store.guard_home,
+            approval_gate_input=ApprovalGateInput(password=PASSWORD),
+            now=disable_now,
+        )
     assert missing_totp.value.code == "approval_gate_totp_required"
 
     with pytest.raises(ApprovalGateError) as invalid_totp:
         disable_totp(
             store.guard_home,
-            approval_gate_input=ApprovalGateInput(totp_code="000000"),
-            now="2026-04-11T00:00:31+00:00",
+            approval_gate_input=ApprovalGateInput(password=PASSWORD, totp_code="000000"),
+            now=disable_now,
         )
     assert invalid_totp.value.code == "approval_gate_totp_invalid"
 
-    disable_now = "2026-04-11T00:01:31+00:00"
-    disable_code = totp_code_at_counter(secret=secret, counter=_counter(disable_now))
     gate = disable_totp(
         store.guard_home,
-        approval_gate_input=ApprovalGateInput(totp_code=disable_code),
+        approval_gate_input=ApprovalGateInput(password=PASSWORD, totp_code=disable_code),
         now=disable_now,
     )
     assert gate.totp_enabled is False
 
 
-def test_approval_gate_password_disable_uses_totp_only_when_enabled(tmp_path: Path) -> None:
+def test_approval_gate_password_disable_requires_password_and_totp_when_enabled(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store)
     workspace = tmp_path / "workspace"
@@ -958,7 +976,7 @@ def test_approval_gate_password_disable_uses_totp_only_when_enabled(tmp_path: Pa
     home_dir = tmp_path / "home"
     secret = _enable_totp(store, now="2026-04-11T00:00:00+00:00")
 
-    disable_without_totp = run_guard_command(
+    disable_without_password = run_guard_command(
         SimpleNamespace(
             guard_command="settings",
             settings_command="approval-password",
@@ -973,11 +991,12 @@ def test_approval_gate_password_disable_uses_totp_only_when_enabled(tmp_path: Pa
         ),
         output_stream=io.StringIO(),
     )
-    assert disable_without_totp == 4
+    assert disable_without_password == 4
 
     disable_now = datetime.now(timezone.utc).isoformat()
     disable_code = totp_code_at_counter(secret=secret, counter=_counter(disable_now))
-    disable_with_totp = run_guard_command(
+    # TOTP alone is no longer sufficient; the password is the primary factor.
+    disable_with_totp_only = run_guard_command(
         SimpleNamespace(
             guard_command="settings",
             settings_command="approval-password",
@@ -992,11 +1011,28 @@ def test_approval_gate_password_disable_uses_totp_only_when_enabled(tmp_path: Pa
         ),
         output_stream=io.StringIO(),
     )
-    assert disable_with_totp == 0
+    assert disable_with_totp_only == 4
+
+    disable_with_both = run_guard_command(
+        SimpleNamespace(
+            guard_command="settings",
+            settings_command="approval-password",
+            settings_approval_password_command="disable",
+            current_password=PASSWORD,
+            totp_code=disable_code,
+            guard_home=str(store.guard_home),
+            home=str(home_dir),
+            workspace=str(workspace),
+            json=True,
+            cisco_mode="off",
+        ),
+        output_stream=io.StringIO(),
+    )
+    assert disable_with_both == 0
     assert public_config(store.guard_home).enabled is False
 
 
-def test_approval_gate_totp_overrides_password_for_reviews(tmp_path: Path) -> None:
+def test_approval_gate_totp_requires_password_for_reviews(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store)
     secret = _enable_totp(store, now="2026-04-11T00:00:00+00:00")
@@ -1004,10 +1040,31 @@ def test_approval_gate_totp_overrides_password_for_reviews(tmp_path: Path) -> No
     approve_code = totp_code_at_counter(secret=secret, counter=_counter(approve_now))
     _add_request(store, "req-totp-only")
 
+    # With TOTP enabled the approval password is still the primary factor: a
+    # wrong password is rejected even when a valid authenticator code is present.
+    with pytest.raises(ApprovalGateError) as wrong_password:
+        _approve(
+            store,
+            "req-totp-only",
+            gate_input=ApprovalGateInput(password=WRONG_PASSWORD, totp_code=approve_code),
+            now=approve_now,
+        )
+    assert wrong_password.value.code == "approval_gate_invalid_password"
+
+    # TOTP alone (no password) is also rejected.
+    with pytest.raises(ApprovalGateError) as missing_password:
+        _approve(
+            store,
+            "req-totp-only",
+            gate_input=ApprovalGateInput(totp_code=approve_code),
+            now=approve_now,
+        )
+    assert missing_password.value.code == "approval_gate_required"
+
     _approve(
         store,
         "req-totp-only",
-        gate_input=ApprovalGateInput(password=WRONG_PASSWORD, totp_code=approve_code),
+        gate_input=ApprovalGateInput(password=PASSWORD, totp_code=approve_code),
         now=approve_now,
     )
 
@@ -1166,7 +1223,7 @@ def test_approval_gate_settings_import_and_reset_require_totp_when_enabled(tmp_p
     assert reset_body["error"] == "approval_gate_totp_required"
 
 
-def test_approval_gate_settings_update_accepts_totp_without_password(tmp_path: Path) -> None:
+def test_approval_gate_settings_update_requires_password_and_totp_when_enabled(tmp_path: Path) -> None:
     store = _store(tmp_path)
     _enable_gate(store)
     secret = _enable_totp(store, now="2026-04-11T00:00:00+00:00")
@@ -1175,11 +1232,28 @@ def test_approval_gate_settings_update_accepts_totp_without_password(tmp_path: P
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
     try:
+        # TOTP alone is not sufficient; the approval password is required.
+        totp_only_request = urllib.request.Request(
+            f"http://127.0.0.1:{daemon.port}/v1/settings",
+            data=json.dumps(
+                {
+                    "settings": {"approval_wait_timeout_seconds": 90},
+                    "approval_totp_code": settings_code,
+                }
+            ).encode("utf-8"),
+            headers={"Content-Type": "application/json", "X-Guard-Token": daemon._server.auth_token},
+            method="POST",
+        )
+        with pytest.raises(urllib.error.HTTPError) as totp_only_error:
+            urllib.request.urlopen(totp_only_request, timeout=5)
+        totp_only_body = json.loads(totp_only_error.value.read().decode("utf-8"))
+
         update_request = urllib.request.Request(
             f"http://127.0.0.1:{daemon.port}/v1/settings",
             data=json.dumps(
                 {
                     "settings": {"approval_wait_timeout_seconds": 90},
+                    "approval_gate": {"password": PASSWORD},
                     "approval_totp_code": settings_code,
                 }
             ).encode("utf-8"),
@@ -1191,6 +1265,8 @@ def test_approval_gate_settings_update_accepts_totp_without_password(tmp_path: P
     finally:
         daemon.stop()
 
+    assert totp_only_error.value.code == 403
+    assert totp_only_body["error"] == "approval_gate_required"
     assert update_body["settings"]["approval_wait_timeout_seconds"] == 90
 
 

--- a/tests/test_guard_package_support_matrix.py
+++ b/tests/test_guard_package_support_matrix.py
@@ -14,8 +14,8 @@ so the portal support matrix can accurately report interceptTest=False.
 
 from __future__ import annotations
 
-from codex_plugin_scanner.guard.shims import package_shim_supported_managers
 from codex_plugin_scanner.guard.shim_probe import _PACKAGE_SHIM_PROBE_ARGS
+from codex_plugin_scanner.guard.shims import package_shim_supported_managers
 
 
 def test_supported_managers_are_sorted() -> None:

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -253,7 +253,10 @@ class TestPiInstall:
         assert "[deep object omitted by HOL Guard]" in text
         assert "const boundedContent = boundValue(event.content);" in text
         assert "const boundedStdout = boundedOutputText(event.content);" in text
-        assert "boundedToolInput.truncated || boundedContent.truncated || boundedStdout.truncated" in text
+        # Only output truncation gates the reviewed-result replacement; a
+        # truncated tool input alone must not replace the result.
+        assert "boundedContent.truncated || boundedStdout.truncated" in text
+        assert "boundedToolInput.truncated || boundedContent.truncated" not in text
         assert "const blockedToolResults = new Map<string, string>();" in text
         assert 'pi.on("message_end"' in text
         assert "const toolCallId = toolCallIdKey(event.toolCallId);" in text
@@ -261,9 +264,13 @@ class TestPiInstall:
         assert "blockedToolResults.delete(toolCallId);" in text
         # Oversized tool results are truncated and reviewed, not pre-emptively blocked.
         assert "HOL Guard blocked oversized Pi tool output before review" not in text
-        assert 'oversizeNotice' in text
+        assert "oversizeNotice" in text
         assert 'ctx.ui.notify(oversizeNotice, "info")' in text
-        assert 'const response = runGuard(' in text
+        assert "const response = runGuard(" in text
+        # When truncated, the reviewed excerpt (not the full unreviewed output) is
+        # returned to Pi so omitted content never reaches the model.
+        assert "function reviewedToolResult(" in text
+        assert "return reviewedToolResult(limitedContent, event.details, event.isError === true);" in text
         assert "tool_response: limitedContent" in text
         assert "stdout: toolOutput" in text
         assert "contentText(event.content)" not in text


### PR DESCRIPTION
## Summary
- Restore the two-factor approval model: when TOTP is enabled, protected actions require the approval password **and** a current authenticator code, rather than the authenticator code alone.
- `disable_totp`, `_verify_or_raise`, and grant validation re-require the password as the primary factor before the TOTP code is accepted. The dashboard approval and settings-save proof prompts now show and require the password field alongside the authenticator code when TOTP is enabled.
- When a Pi tool result is larger than the review window, return the size-bounded excerpt Guard actually reviewed to the harness instead of leaving the full unreviewed output in place. Large results are no longer blocked outright, but content past the review window no longer reaches the model.

## Testing
- `uv run --no-sync pytest tests/test_guard_approval_gate.py tests/test_pi_adapter.py -q`
- `uv run --no-sync ruff check src/ tests/ && uv run --no-sync basedpyright --level error`
- `cd dashboard && npm run build`
- Emitted the Pi managed extension and exercised `tool_result` under Node: a result with credentials placed after the review window is reviewed on the bounded prefix, allowed when clean, and the returned content is the bounded excerpt (the credential tail is absent).

## Notes
- Behavior change: TOTP no longer replaces the password prompt. Users with TOTP enabled will enter both factors for protected actions, matching the documented security model.
- Also sorts an import in `tests/test_guard_package_support_matrix.py` to keep repo-wide `ruff check` green.
