### PR TITLE
fix(connect): repair missing oauth metadata state

### DIFF
--- a/src/codex_plugin_scanner/guard/package_firewall_defaults.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_defaults.py
@@ -1,0 +1,38 @@
+"""Shared package-firewall entitlement defaults with no GuardStore dependency."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+PACKAGE_FIREWALL_PAID_TIERS = frozenset({"paid", "premium", "pro", "team", "enterprise", "guard_cloud", "guard-cloud"})
+_OAUTH_ENTITLEMENT_FALLBACK_TTL = timedelta(days=30)
+
+
+def _optional_string(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip()
+    return normalized or None
+
+
+def build_guard_local_entitlement_defaults(
+    record: dict[str, object],
+    *,
+    now: datetime | None = None,
+) -> dict[str, object] | None:
+    plan_id = _optional_string(record.get("plan_id")) or _optional_string(record.get("tier"))
+    if plan_id is None:
+        return None
+    normalized_tier = plan_id.lower()
+    allowed_value = record.get("supply_chain_firewall")
+    allowed = allowed_value if isinstance(allowed_value, bool) else normalized_tier in PACKAGE_FIREWALL_PAID_TIERS
+    expires_at = _optional_string(record.get("expires_at"))
+    if expires_at is None:
+        resolved_now = now or datetime.now(timezone.utc)
+        expires_at = (resolved_now + _OAUTH_ENTITLEMENT_FALLBACK_TTL).isoformat()
+    return {
+        "plan_id": normalized_tier,
+        "supply_chain_entitlement_expires_at": expires_at,
+        "supply_chain_firewall": allowed,
+        "supply_chain_plan_id": normalized_tier,
+    }

--- a/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_entitlement.py
@@ -2,17 +2,19 @@
 
 from __future__ import annotations
 
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 
+from .package_firewall_defaults import (
+    PACKAGE_FIREWALL_PAID_TIERS,
+    build_guard_local_entitlement_defaults,
+)
 from .store import GuardStore
 
-PACKAGE_FIREWALL_PAID_TIERS = frozenset({"paid", "premium", "pro", "team", "enterprise", "guard_cloud", "guard-cloud"})
 PACKAGE_FIREWALL_CONNECT_CTA = (
     "Connect HOL Guard Cloud to check package firewall access and run package firewall actions."
 )
 PACKAGE_FIREWALL_RECONNECT_CTA = "Reconnect HOL Guard Cloud to refresh package firewall access."
 PACKAGE_FIREWALL_UPGRADE_CTA = "Upgrade to HOL Guard Cloud to run package firewall actions."
-_OAUTH_ENTITLEMENT_FALLBACK_TTL = timedelta(days=30)
 
 
 def _optional_string(value: object) -> str | None:
@@ -44,22 +46,7 @@ def build_oauth_package_firewall_entitlement(
     record = payload.get("guard_local_entitlement")
     if not isinstance(record, dict):
         return None
-    plan_id = _optional_string(record.get("plan_id")) or _optional_string(record.get("tier"))
-    if plan_id is None:
-        return None
-    normalized_tier = plan_id.lower()
-    allowed_value = record.get("supply_chain_firewall")
-    allowed = allowed_value if isinstance(allowed_value, bool) else normalized_tier in PACKAGE_FIREWALL_PAID_TIERS
-    expires_at = _optional_string(record.get("expires_at"))
-    if expires_at is None:
-        resolved_now = now or datetime.now(timezone.utc)
-        expires_at = (resolved_now + _OAUTH_ENTITLEMENT_FALLBACK_TTL).isoformat()
-    return {
-        "plan_id": normalized_tier,
-        "supply_chain_entitlement_expires_at": expires_at,
-        "supply_chain_firewall": allowed,
-        "supply_chain_plan_id": normalized_tier,
-    }
+    return build_guard_local_entitlement_defaults(record, now=now)
 
 
 def _bundle_entitlement(payload: object) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -399,7 +399,7 @@ class StoreOAuthConnectMixin:
         installation_id = device.get("installation_id")
         if isinstance(installation_id, str) and installation_id:
             recovered_payload["machine_id"] = installation_id
-        for key in ("workspace_id", "supply_chain_plan_id"):
+        for key in ("workspace_id", "supply_chain_plan_id", "supply_chain_entitlement_expires_at"):
             value = workspace_metadata.get(key)
             if isinstance(value, str) and value:
                 recovered_payload[key] = value
@@ -423,18 +423,21 @@ class StoreOAuthConnectMixin:
         return recovered_payload
 
     def _load_oauth_secret_json_without_payload(self, secret_ref: str) -> str | None:
+        primary_secret_json = None
+        secret_store = self._oauth_secret_store
+        if isinstance(secret_store, FallbackSecretStore):
+            primary_secret_json = self._get_secret_from_primary_store(secret_store.primary, secret_ref)
+        else:
+            primary_secret_json = self._get_secret_from_store(secret_store, secret_ref)
+        if isinstance(primary_secret_json, str) and self._parse_oauth_secret_payload(primary_secret_json) is not None:
+            return primary_secret_json
+        if not self._oauth_fallback_recovery_allowed():
+            return None
+        if self._oauth_primary_repair_available() and not self._oauth_primary_secret_definitely_missing(secret_ref):
+            return None
         fallback_secret_json = self._load_oauth_fallback_secret_json(secret_ref)
         if isinstance(fallback_secret_json, str) and self._parse_oauth_secret_payload(fallback_secret_json) is not None:
             return fallback_secret_json
-        for candidate in self._get_secret_candidates(
-            self._oauth_secret_store,
-            secret_ref,
-            None,
-            prefer_fallback_first=True,
-            fallback_token_hint=fallback_secret_json,
-        ):
-            if self._parse_oauth_secret_payload(candidate) is not None:
-                return candidate
         return None
 
     @staticmethod
@@ -450,19 +453,23 @@ class StoreOAuthConnectMixin:
         return None
 
     def _recover_oauth_workspace_metadata(self) -> dict[str, object]:
+        from .package_firewall_entitlement import build_oauth_package_firewall_entitlement
+
         payload = self.get_sync_payload("supply_chain_bundle_entitlement")
         workspace_id = None
-        plan_id = None
-        supply_chain_firewall = None
+        entitlement_fields: dict[str, object] = {}
         if isinstance(payload, dict):
             raw_workspace_id = payload.get("workspace_id")
             if isinstance(raw_workspace_id, str) and raw_workspace_id.strip():
                 workspace_id = raw_workspace_id.strip()
             raw_tier = payload.get("tier")
             if isinstance(raw_tier, str) and raw_tier.strip():
-                normalized_tier = raw_tier.strip().lower()
-                plan_id = normalized_tier
-                supply_chain_firewall = normalized_tier in {"premium", "pro", "team"}
+                recovered_entitlement = build_oauth_package_firewall_entitlement(
+                    {"guard_local_entitlement": {"tier": raw_tier.strip()}},
+                    now=datetime.now(timezone.utc),
+                )
+                if isinstance(recovered_entitlement, dict):
+                    entitlement_fields.update(recovered_entitlement)
         if workspace_id is None:
             with self._connect() as connection:
                 row = connection.execute(
@@ -480,8 +487,11 @@ class StoreOAuthConnectMixin:
         metadata: dict[str, object] = {}
         if workspace_id is not None:
             metadata["workspace_id"] = workspace_id
-        if plan_id is not None:
-            metadata["supply_chain_plan_id"] = plan_id
+        for key in ("supply_chain_plan_id", "supply_chain_entitlement_expires_at"):
+            value = entitlement_fields.get(key)
+            if isinstance(value, str) and value:
+                metadata[key] = value
+        supply_chain_firewall = entitlement_fields.get("supply_chain_firewall")
         if isinstance(supply_chain_firewall, bool):
             metadata["supply_chain_firewall"] = supply_chain_firewall
         return metadata

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -4,9 +4,10 @@
 
 from __future__ import annotations
 
+from .package_firewall_defaults import build_guard_local_entitlement_defaults
+
 # ruff: noqa: F403,F405
 from .store_base import *
-from .package_firewall_defaults import build_guard_local_entitlement_defaults
 
 
 class StoreOAuthConnectMixin:

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -11,6 +11,8 @@ from .store_base import *
 class StoreOAuthConnectMixin:
     def get_cloud_sync_profile(self) -> dict[str, str] | None:
         oauth_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        if not isinstance(oauth_payload, dict) and self.repair_oauth_local_credential_storage_from_primary():
+            oauth_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         if isinstance(oauth_payload, dict):
             oauth_health = self.get_oauth_local_credential_health()
             if not isinstance(oauth_health, dict) or oauth_health.get("state") != "healthy":
@@ -201,6 +203,8 @@ class StoreOAuthConnectMixin:
 
     def get_oauth_local_credential_health(self) -> dict[str, object]:
         payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        if not isinstance(payload, dict) and self.repair_oauth_local_credential_storage_from_primary():
+            payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
         health: dict[str, object] = {
             "configured": isinstance(payload, dict),
             "state": "not_configured",
@@ -330,7 +334,11 @@ class StoreOAuthConnectMixin:
         with self.hold_oauth_credential_lock():
             payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
             if not isinstance(payload, dict):
-                return False
+                recovered_payload = self._recover_missing_oauth_local_credentials_payload(now=_now())
+                if recovered_payload is None:
+                    return False
+                self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, recovered_payload, _now())
+                return True
             repaired_payload = None
             if self._should_attempt_oauth_storage_repair():
                 self._mark_oauth_storage_repair_attempt()
@@ -363,6 +371,117 @@ class StoreOAuthConnectMixin:
             if cache_key is not None:
                 _OAUTH_HEALTH_RESULT_PROCESS_CACHE.pop(cache_key, None)
             return True
+
+    def _recover_missing_oauth_local_credentials_payload(self, *, now: str) -> dict[str, object] | None:
+        secret_ref = self._oauth_local_credentials_ref
+        secret_json = self._load_oauth_secret_json_without_payload(secret_ref)
+        if secret_json is None:
+            return None
+        secret_payload = self._parse_oauth_secret_payload(secret_json)
+        if secret_payload is None:
+            return None
+        latest_state = self.get_latest_guard_connect_state(now=now)
+        issuer = self._recover_oauth_issuer_for_missing_metadata(latest_state)
+        if issuer is None:
+            return None
+        try:
+            oauth_client = resolve_guard_oauth_client_config(issuer)
+        except ValueError:
+            return None
+        workspace_metadata = self._recover_oauth_workspace_metadata()
+        recovered_payload: dict[str, object] = {
+            "issuer": oauth_client.issuer,
+            "client_id": oauth_client.client_id,
+            _OAUTH_LOCAL_CREDENTIALS_REF_KEY: secret_ref,
+            _OAUTH_LOCAL_CREDENTIALS_HASH_KEY: _secret_fingerprint(secret_json),
+        }
+        device = self.get_device_metadata()
+        installation_id = device.get("installation_id")
+        if isinstance(installation_id, str) and installation_id:
+            recovered_payload["machine_id"] = installation_id
+        for key in ("workspace_id", "supply_chain_plan_id"):
+            value = workspace_metadata.get(key)
+            if isinstance(value, str) and value:
+                recovered_payload[key] = value
+        supply_chain_firewall = workspace_metadata.get("supply_chain_firewall")
+        if isinstance(supply_chain_firewall, bool):
+            recovered_payload["supply_chain_firewall"] = supply_chain_firewall
+        if self._build_oauth_local_credentials_result(
+            metadata=self._oauth_local_credentials_metadata(recovered_payload) or {},
+            secret_payload=secret_payload,
+        ) is None:
+            return None
+        self._mirror_oauth_secret_to_fallback(secret_ref, secret_json)
+        self._remember_oauth_secret_payload(
+            secret_ref,
+            str(recovered_payload[_OAUTH_LOCAL_CREDENTIALS_HASH_KEY]),
+            secret_json,
+        )
+        return recovered_payload
+
+    def _load_oauth_secret_json_without_payload(self, secret_ref: str) -> str | None:
+        fallback_secret_json = self._load_oauth_fallback_secret_json(secret_ref)
+        if isinstance(fallback_secret_json, str) and self._parse_oauth_secret_payload(fallback_secret_json) is not None:
+            return fallback_secret_json
+        for candidate in self._get_secret_candidates(
+            self._oauth_secret_store,
+            secret_ref,
+            None,
+            prefer_fallback_first=True,
+            fallback_token_hint=fallback_secret_json,
+        ):
+            if self._parse_oauth_secret_payload(candidate) is not None:
+                return candidate
+        return None
+
+    @staticmethod
+    def _recover_oauth_issuer_for_missing_metadata(latest_state: dict[str, object] | None) -> str | None:
+        if not isinstance(latest_state, dict):
+            return None
+        allowed_origin = latest_state.get("allowed_origin")
+        if isinstance(allowed_origin, str) and allowed_origin.strip():
+            return allowed_origin.strip()
+        sync_url = latest_state.get("sync_url")
+        if isinstance(sync_url, str) and sync_url.strip():
+            return _allowed_origin_from_sync_url(sync_url.strip())
+        return None
+
+    def _recover_oauth_workspace_metadata(self) -> dict[str, object]:
+        payload = self.get_sync_payload("supply_chain_bundle_entitlement")
+        workspace_id = None
+        plan_id = None
+        supply_chain_firewall = None
+        if isinstance(payload, dict):
+            raw_workspace_id = payload.get("workspace_id")
+            if isinstance(raw_workspace_id, str) and raw_workspace_id.strip():
+                workspace_id = raw_workspace_id.strip()
+            raw_tier = payload.get("tier")
+            if isinstance(raw_tier, str) and raw_tier.strip():
+                normalized_tier = raw_tier.strip().lower()
+                plan_id = normalized_tier
+                supply_chain_firewall = normalized_tier in {"premium", "pro", "team"}
+        if workspace_id is None:
+            with self._connect() as connection:
+                row = connection.execute(
+                    """
+                    select workspace_id
+                    from guard_supply_chain_bundle_cache
+                    order by cached_at desc
+                    limit 1
+                    """
+                ).fetchone()
+            if row is not None:
+                raw_workspace_id = row["workspace_id"]
+                if isinstance(raw_workspace_id, str) and raw_workspace_id.strip():
+                    workspace_id = raw_workspace_id.strip()
+        metadata: dict[str, object] = {}
+        if workspace_id is not None:
+            metadata["workspace_id"] = workspace_id
+        if plan_id is not None:
+            metadata["supply_chain_plan_id"] = plan_id
+        if isinstance(supply_chain_firewall, bool):
+            metadata["supply_chain_firewall"] = supply_chain_firewall
+        return metadata
 
     @staticmethod
     def _build_recovered_oauth_local_credentials_inputs(

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -406,10 +406,13 @@ class StoreOAuthConnectMixin:
         supply_chain_firewall = workspace_metadata.get("supply_chain_firewall")
         if isinstance(supply_chain_firewall, bool):
             recovered_payload["supply_chain_firewall"] = supply_chain_firewall
-        if self._build_oauth_local_credentials_result(
-            metadata=self._oauth_local_credentials_metadata(recovered_payload) or {},
-            secret_payload=secret_payload,
-        ) is None:
+        if (
+            self._build_oauth_local_credentials_result(
+                metadata=self._oauth_local_credentials_metadata(recovered_payload) or {},
+                secret_payload=secret_payload,
+            )
+            is None
+        ):
             return None
         self._mirror_oauth_secret_to_fallback(secret_ref, secret_json)
         self._remember_oauth_secret_payload(

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 # ruff: noqa: F403,F405
 from .store_base import *
+from .package_firewall_defaults import build_guard_local_entitlement_defaults
 
 
 class StoreOAuthConnectMixin:
@@ -453,8 +454,6 @@ class StoreOAuthConnectMixin:
         return None
 
     def _recover_oauth_workspace_metadata(self) -> dict[str, object]:
-        from .package_firewall_entitlement import build_oauth_package_firewall_entitlement
-
         payload = self.get_sync_payload("supply_chain_bundle_entitlement")
         workspace_id = None
         entitlement_fields: dict[str, object] = {}
@@ -464,8 +463,8 @@ class StoreOAuthConnectMixin:
                 workspace_id = raw_workspace_id.strip()
             raw_tier = payload.get("tier")
             if isinstance(raw_tier, str) and raw_tier.strip():
-                recovered_entitlement = build_oauth_package_firewall_entitlement(
-                    {"guard_local_entitlement": {"tier": raw_tier.strip()}},
+                recovered_entitlement = build_guard_local_entitlement_defaults(
+                    {"tier": raw_tier.strip()},
                     now=datetime.now(timezone.utc),
                 )
                 if isinstance(recovered_entitlement, dict):

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -23,6 +23,7 @@ from codex_plugin_scanner.guard.daemon import server as daemon_server_module
 from codex_plugin_scanner.guard.package_firewall_entitlement import resolve_package_firewall_entitlement
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_base import SystemKeyringSecretStore
 from tests.test_guard_store_migrations import _install_fake_system_keyring
 
 
@@ -774,6 +775,11 @@ def test_connect_status_recovers_missing_oauth_metadata_from_surviving_secret(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "get_secret_with_timeout",
+        lambda self, secret_id, timeout_seconds=0.0: self.get_secret(secret_id),
+    )
     store = GuardStore(tmp_path / "guard-home")
     store.set_oauth_local_credentials(
         issuer="https://hol.org",
@@ -840,12 +846,79 @@ def test_connect_status_recovers_missing_oauth_metadata_from_surviving_secret(
     assert repaired_payload["workspace_id"] == "workspace-1"
     assert repaired_payload["supply_chain_plan_id"] == "premium"
     assert repaired_payload["supply_chain_firewall"] is True
+    assert isinstance(repaired_payload["supply_chain_entitlement_expires_at"], str)
     assert store.get_oauth_local_credential_health()["state"] == "healthy"
     assert store.get_cloud_sync_profile() == {
         "auth_mode": "oauth",
         "sync_url": "https://hol.org/api/guard/receipts/sync",
         "workspace_id": "workspace-1",
     }
+    entitlement = resolve_package_firewall_entitlement(store)
+    assert entitlement["allowed"] is True
+    assert entitlement["tier"] == "premium"
+    assert entitlement["upgrade_cta"] is None
+
+
+def test_connect_status_does_not_recover_missing_oauth_metadata_from_fallback_only_secret_on_macos(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    keyring_module = _install_fake_system_keyring(monkeypatch)
+    monkeypatch.setattr(
+        SystemKeyringSecretStore,
+        "get_secret_with_timeout",
+        lambda self, secret_id, timeout_seconds=0.0: self.get_secret(secret_id),
+    )
+    store = GuardStore(tmp_path / "guard-home")
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-24T18:20:00+00:00",
+        request_id="connect-1",
+    )
+    store.record_latest_guard_connect_sync_success(
+        sync_payload={
+            "synced_at": "2026-06-24T18:21:00+00:00",
+            "receipts_stored": 5,
+            "inventory_items": 3,
+        },
+        now="2026-06-24T18:21:00+00:00",
+        request_id="connect-1",
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {
+            "workspace_id": "workspace-1",
+            "tier": "premium",
+        },
+        "2026-06-24T18:20:00+00:00",
+    )
+    fallback_store = store._resolve_oauth_fallback_store()
+    assert fallback_store is not None
+    fallback_store.set_secret(
+        store._oauth_local_credentials_ref,
+        json.dumps(
+            {
+                "refresh_token": "refresh-token-1",
+                "dpop_private_key_pem": "private-key-1",
+                "dpop_public_jwk": {"kty": "EC", "crv": "P-256", "x": "x-value-1", "y": "y-value-1"},
+                "dpop_public_jwk_thumbprint": "thumbprint-1",
+            },
+            sort_keys=True,
+            separators=(",", ":"),
+        ),
+    )
+    keyring_module.delete_password("hol-guard.oauth", store._oauth_local_credentials_ref)
+
+    payload = build_connect_status_payload(
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+    )
+
+    assert payload["status"] == "retry_required"
+    assert payload["milestone"] == "first_sync_failed"
+    assert store.get_sync_payload("oauth_local_credentials") is None
 
 
 def test_retry_required_connect_state_prefers_reconnect_over_false_paywall(tmp_path: Path) -> None:

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import sys
 import time
 import urllib.error
 import urllib.request
@@ -863,6 +864,7 @@ def test_connect_status_does_not_recover_missing_oauth_metadata_from_fallback_on
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    monkeypatch.setattr(sys, "platform", "darwin")
     keyring_module = _install_fake_system_keyring(monkeypatch)
     monkeypatch.setattr(
         SystemKeyringSecretStore,

--- a/tests/test_guard_connect_flow.py
+++ b/tests/test_guard_connect_flow.py
@@ -769,6 +769,85 @@ def test_sync_local_guard_cloud_proof_repairs_degraded_oauth_from_encrypted_fall
     assert latest_state["milestone"] == "first_sync_succeeded"
 
 
+def test_connect_status_recovers_missing_oauth_metadata_from_surviving_secret(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_fake_system_keyring(monkeypatch)
+    store = GuardStore(tmp_path / "guard-home")
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem="private-key-1",
+        dpop_public_jwk={"kty": "EC", "crv": "P-256", "x": "x-value-1", "y": "y-value-1"},
+        dpop_public_jwk_thumbprint="thumbprint-1",
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        supply_chain_plan_id="premium",
+        supply_chain_firewall=True,
+        now="2026-06-24T18:20:00+00:00",
+    )
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {
+            "workspace_id": "workspace-1",
+            "tier": "premium",
+        },
+        "2026-06-24T18:20:00+00:00",
+    )
+    store.set_sync_payload(
+        "sync_summary",
+        {
+            "synced_at": "2026-06-24T18:21:00+00:00",
+            "receipts_stored": 5,
+            "inventory_tracked": 3,
+        },
+        "2026-06-24T18:21:00+00:00",
+    )
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now="2026-06-24T18:20:00+00:00",
+        request_id="connect-1",
+    )
+    store.record_latest_guard_connect_sync_success(
+        sync_payload={
+            "synced_at": "2026-06-24T18:21:00+00:00",
+            "receipts_stored": 5,
+            "inventory_items": 3,
+        },
+        now="2026-06-24T18:21:00+00:00",
+        request_id="connect-1",
+    )
+    store.delete_sync_payload("oauth_local_credentials")
+
+    payload = build_connect_status_payload(
+        store=store,
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        connect_url="https://hol.org/guard/connect",
+    )
+
+    assert payload["status"] == "connected"
+    assert payload["milestone"] == "first_sync_succeeded"
+    latest_state = payload["latest_connect_state"]
+    assert isinstance(latest_state, dict)
+    assert latest_state["status"] == "connected"
+    assert latest_state["milestone"] == "first_sync_succeeded"
+    repaired_payload = store.get_sync_payload("oauth_local_credentials")
+    assert isinstance(repaired_payload, dict)
+    assert repaired_payload["workspace_id"] == "workspace-1"
+    assert repaired_payload["supply_chain_plan_id"] == "premium"
+    assert repaired_payload["supply_chain_firewall"] is True
+    assert store.get_oauth_local_credential_health()["state"] == "healthy"
+    assert store.get_cloud_sync_profile() == {
+        "auth_mode": "oauth",
+        "sync_url": "https://hol.org/api/guard/receipts/sync",
+        "workspace_id": "workspace-1",
+    }
+
+
 def test_retry_required_connect_state_prefers_reconnect_over_false_paywall(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     store.set_oauth_local_credentials(


### PR DESCRIPTION
## Summary
- repair local Guard Cloud auth metadata when the `oauth_local_credentials` row disappears but the stored secret and bundle state still exist
- cover the stale-connect recovery path with a focused regression test so status/connect flows heal instead of forcing an unnecessary reconnect

## Testing
- `python3 -m pytest tests/test_guard_connect_flow.py -k 'missing_oauth_metadata_from_surviving_secret or cached_paid_bundle_does_not_hide_missing_oauth_after_success or sync_local_guard_cloud_proof_repairs_degraded_oauth_from_encrypted_fallback'`

## Notes
- fully missing local OAuth secrets still require a fresh `hol-guard connect`; this change repairs the broken metadata-only state that can strand an otherwise valid sign-in
