### PR TITLE
fix(oauth): allow additional pre-production origin with path prefix

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/_commands_shared.py
+++ b/src/codex_plugin_scanner/guard/cli/_commands_shared.py
@@ -200,6 +200,7 @@ from .connect_flow import (
     build_connect_status_payload,
     connect_recovery_command,
     connect_state_requires_oauth,
+    guard_api_base_path,
     normalize_connect_state_for_missing_oauth,
     resolve_connect_url,
     run_guard_browser_connect_command,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -191,10 +191,12 @@ def _refresh_cloud_policy_bundle(store: GuardStore, *, bundle_only: bool = False
 
 def _guard_cloud_urls_for_connect(connect_url: str) -> dict[str, str]:
     normalized_connect_url, allowed_origin = resolve_connect_url(connect_url)
-    dashboard_url = f"{allowed_origin}/guard"
+    prefix = guard_api_base_path(allowed_origin)
+    dashboard_url = f"{allowed_origin}{prefix}/guard"
+    api_base = f"{allowed_origin}{prefix}/api/guard"
     return {
         "connect_url": normalized_connect_url,
-        "sync_url": f"{allowed_origin}/api/guard/receipts/sync",
+        "sync_url": f"{api_base}/receipts/sync",
         "dashboard_url": dashboard_url,
         "inbox_url": f"{dashboard_url}/inbox",
         "fleet_url": f"{dashboard_url}/protect",

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -34,6 +34,7 @@ from .oauth_client import (
     build_pkce_s256_challenge,
     generate_dpop_key_pair,
     generate_pkce_verifier,
+    guard_api_base_path,
     resolve_guard_oauth_client_config,
 )
 
@@ -449,7 +450,8 @@ def resolve_connect_url(connect_url: str) -> tuple[str, str]:
 
 def _oauth_sync_url_from_issuer(issuer: str) -> str:
     oauth_client = resolve_guard_oauth_client_config(issuer)
-    return f"{oauth_client.issuer}/api/guard/receipts/sync"
+    prefix = guard_api_base_path(issuer)
+    return f"{oauth_client.issuer}{prefix}/api/guard/receipts/sync"
 
 
 def _build_sync_auth_context(

--- a/src/codex_plugin_scanner/guard/cli/oauth_client.py
+++ b/src/codex_plugin_scanner/guard/cli/oauth_client.py
@@ -19,12 +19,17 @@ LOCAL_GUARD_OAUTH_CLIENT_ID = "guard-local-daemon-local"
 
 PRODUCTION_GUARD_ISSUER = "https://hol.org"
 STAGING_GUARD_ISSUER = "https://staging.hol.org"
+REGISTRY_STAGING_GUARD_ISSUER = "https://registry-staging.hol.org"
 LOCAL_GUARD_ISSUER = "http://127.0.0.1:3000"
 
 _ALLOWED_PRODUCTION_GUARD_ORIGINS = frozenset({PRODUCTION_GUARD_ISSUER})
-_ALLOWED_STAGING_GUARD_ORIGINS = frozenset({STAGING_GUARD_ISSUER})
+_ALLOWED_STAGING_GUARD_ORIGINS = frozenset({STAGING_GUARD_ISSUER, REGISTRY_STAGING_GUARD_ISSUER})
 _LOOPBACK_GUARD_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
 _DOCKER_LAB_GUARD_HOSTS = frozenset({"host.docker.internal"})
+
+_GUARD_OAUTH_PATH_PREFIXES: dict[str, str] = {
+    REGISTRY_STAGING_GUARD_ISSUER: "/points",
+}
 
 _PKCE_ALLOWED_CHARACTERS = frozenset("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._~")
 
@@ -101,12 +106,13 @@ def _oauth_endpoints(origin: str) -> GuardOAuthClientConfig:
         "staging": STAGING_GUARD_OAUTH_CLIENT_ID,
         "local": LOCAL_GUARD_OAUTH_CLIENT_ID,
     }[environment]
+    prefix = _GUARD_OAUTH_PATH_PREFIXES.get(origin.lower(), "")
     return GuardOAuthClientConfig(
         issuer=origin,
-        authorize_endpoint=f"{origin}/api/guard/oauth/authorize",
-        token_endpoint=f"{origin}/api/guard/oauth/token",
-        device_authorization_endpoint=f"{origin}/api/guard/oauth/device/authorize",
-        jwks_endpoint=f"{origin}/api/guard/oauth/jwks",
+        authorize_endpoint=f"{origin}{prefix}/api/guard/oauth/authorize",
+        token_endpoint=f"{origin}{prefix}/api/guard/oauth/token",
+        device_authorization_endpoint=f"{origin}{prefix}/api/guard/oauth/device/authorize",
+        jwks_endpoint=f"{origin}{prefix}/api/guard/oauth/jwks",
         client_id=client_id,
     )
 
@@ -118,6 +124,12 @@ def detect_guard_oauth_environment(issuer: str) -> str:
     if origin in _ALLOWED_STAGING_GUARD_ORIGINS:
         return "staging"
     return "production"
+
+
+def guard_api_base_path(issuer: str) -> str:
+    """Return the API path prefix for a given issuer (e.g. '/points' for registry-staging)."""
+    origin = _require_allowlisted_guard_oauth_origin(issuer)
+    return _GUARD_OAUTH_PATH_PREFIXES.get(origin.lower(), "")
 
 
 def resolve_guard_oauth_client_config(issuer: str) -> GuardOAuthClientConfig:

--- a/tests/test_guard_oauth_client.py
+++ b/tests/test_guard_oauth_client.py
@@ -9,6 +9,7 @@ from codex_plugin_scanner.guard.cli.oauth_client import (
     detect_guard_oauth_environment,
     generate_dpop_key_pair,
     generate_pkce_verifier,
+    guard_api_base_path,
     resolve_guard_oauth_client_config,
     validate_guard_sync_endpoint,
 )
@@ -31,6 +32,32 @@ def test_resolve_guard_oauth_client_config_for_staging() -> None:
     assert config.client_id == STAGING_GUARD_OAUTH_CLIENT_ID
     assert config.token_endpoint == "https://staging.hol.org/api/guard/oauth/token"
     assert detect_guard_oauth_environment(config.issuer) == "staging"
+
+
+def test_resolve_guard_oauth_client_config_for_registry_staging() -> None:
+    config = resolve_guard_oauth_client_config("https://registry-staging.hol.org")
+
+    assert config.client_id == STAGING_GUARD_OAUTH_CLIENT_ID
+    assert config.issuer == "https://registry-staging.hol.org"
+    assert config.authorize_endpoint == "https://registry-staging.hol.org/points/api/guard/oauth/authorize"
+    assert config.token_endpoint == "https://registry-staging.hol.org/points/api/guard/oauth/token"
+    assert config.device_authorization_endpoint == "https://registry-staging.hol.org/points/api/guard/oauth/device/authorize"
+    assert config.jwks_endpoint == "https://registry-staging.hol.org/points/api/guard/oauth/jwks"
+    assert detect_guard_oauth_environment(config.issuer) == "staging"
+    assert guard_api_base_path(config.issuer) == "/points"
+
+
+def test_guard_api_base_path_is_empty_for_non_registry_origins() -> None:
+    assert guard_api_base_path("https://hol.org") == ""
+    assert guard_api_base_path("https://staging.hol.org") == ""
+    assert guard_api_base_path("http://127.0.0.1:3000") == ""
+
+
+def test_validate_guard_sync_endpoint_allows_registry_staging() -> None:
+    issuer = "https://registry-staging.hol.org"
+    sync_url = "https://registry-staging.hol.org/points/api/guard/receipts/sync"
+
+    assert validate_guard_sync_endpoint(sync_url, issuer=issuer) == sync_url
 
 
 def test_resolve_guard_oauth_client_config_for_local_loopback() -> None:


### PR DESCRIPTION
## Summary
- Add a second pre-production OAuth origin to the CLI allowlist with a path prefix for portal-served OAuth endpoints
- Add `guard_api_base_path()` helper to resolve path prefixes for any issuer
- Update OAuth endpoint construction, sync URL, and dashboard/inbox/fleet URLs to use the prefix

## Testing
- 14 OAuth client tests pass (11 existing + 3 new)
- 18 connect flow tests pass
- 88 total relevant tests pass
