### PR TITLE
feat(redaction): configurable receipt redaction level (full/partial/none)

### DIFF
--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -669,18 +669,47 @@ def _toml_inline_table(value: Mapping[str, object]) -> str:
 
 def overlay_synced_guard_policy(
     config: GuardConfig,
-    payload: object,
+    payload: dict[str, object] | None,
 ) -> GuardConfig:
     if not isinstance(payload, dict):
         return config
-    security_level = _coerce_loaded_security_level(payload.get("security_level"))
-    risk_actions = _coerce_risk_action_map(payload.get("risk_actions"))
-    harness_risk_actions = _coerce_harness_risk_action_map(payload.get("harness_risk_actions"))
+    next_mode = config.mode
+    raw_mode = payload.get("mode")
+    if isinstance(raw_mode, str) and raw_mode in VALID_GUARD_MODES:
+        next_mode = raw_mode
+    default_action = _coerce_action_value(payload.get("defaultAction"), config.default_action)
+    unknown_publisher_action = _coerce_action_value(
+        payload.get("unknownPublisherAction"),
+        config.unknown_publisher_action,
+    )
+    changed_hash_action = _coerce_action_value(
+        payload.get("changedHashAction"),
+        config.changed_hash_action,
+    )
+    new_network_domain_action = _coerce_action_value(
+        payload.get("newNetworkDomainAction"),
+        config.new_network_domain_action,
+    )
+    subprocess_action = _coerce_action_value(
+        payload.get("subprocessAction"),
+        config.subprocess_action,
+    )
+    sync_enabled = payload.get("syncEnabled")
+    cloud_redaction_level = payload.get("receiptRedactionLevel")
     return replace(
         config,
-        security_level=security_level,
-        risk_actions=risk_actions,
-        harness_risk_actions=harness_risk_actions,
+        mode=next_mode,
+        default_action=default_action,
+        unknown_publisher_action=unknown_publisher_action,
+        changed_hash_action=changed_hash_action,
+        new_network_domain_action=new_network_domain_action,
+        subprocess_action=subprocess_action,
+        sync=bool(sync_enabled) if isinstance(sync_enabled, bool) else config.sync,
+        receipt_redaction_level=(
+            cloud_redaction_level
+            if cloud_redaction_level in VALID_RECEIPT_REDACTION_LEVELS
+            else config.receipt_redaction_level
+        ),
     )
 
 

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -385,9 +385,7 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
         security_level=_coerce_loaded_security_level(merged.get("security_level", DEFAULT_SECURITY_LEVEL)),
         risk_actions=_coerce_risk_action_map(merged.get("risk_actions")),
         harness_risk_actions=_coerce_harness_risk_action_map(merged.get("harness_risk_actions")),
-        receipt_redaction_level=_coerce_loaded_receipt_redaction_level(
-            merged.get("receipt_redaction_level", "full")
-        ),
+        receipt_redaction_level=_coerce_loaded_receipt_redaction_level(merged.get("receipt_redaction_level", "full")),
     )
 
 
@@ -864,9 +862,7 @@ def _guard_home_has_sync_credentials(path: Path) -> bool:
         return False
     try:
         with sqlite3.connect(database_path) as conn:
-            row = conn.execute(
-                "SELECT value FROM sync_payload WHERE key = 'auth_context'"
-            ).fetchone()
+            row = conn.execute("SELECT value FROM sync_payload WHERE key = 'auth_context'").fetchone()
     except sqlite3.DatabaseError:
         return False
     return row is not None

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -178,9 +178,11 @@ EDITABLE_GUARD_SETTING_KEYS = frozenset(
         "telemetry",
         "sync",
         "billing",
+        "receipt_redaction_level",
     }
 )
 VALID_APPROVAL_SURFACE_POLICIES = {"auto-open-once", "native-only", "approval-center"}
+VALID_RECEIPT_REDACTION_LEVELS = frozenset({"full", "partial", "none"})
 BARE_TOML_KEY = re.compile(r"^[A-Za-z0-9_-]+$")
 WORKSPACE_BLOCKED_POLICY_KEYS = frozenset(
     {
@@ -287,6 +289,7 @@ class GuardConfig:
     publisher_actions: dict[str, GuardAction] | None = None
     artifact_actions: dict[str, GuardAction] | None = None
     evidence_retain_days: int = 90
+    receipt_redaction_level: str = "full"
 
     def resolve_action_override(
         self,
@@ -382,6 +385,9 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
         security_level=_coerce_loaded_security_level(merged.get("security_level", DEFAULT_SECURITY_LEVEL)),
         risk_actions=_coerce_risk_action_map(merged.get("risk_actions")),
         harness_risk_actions=_coerce_harness_risk_action_map(merged.get("harness_risk_actions")),
+        receipt_redaction_level=_coerce_loaded_receipt_redaction_level(
+            merged.get("receipt_redaction_level", "full")
+        ),
     )
 
 
@@ -405,6 +411,7 @@ def editable_guard_settings(config: GuardConfig) -> dict[str, object]:
         "telemetry": config.telemetry,
         "sync": config.sync,
         "billing": config.billing,
+        "receipt_redaction_level": config.receipt_redaction_level,
         "approval_gate": public_config(config.guard_home).to_dict(),
     }
 
@@ -479,6 +486,10 @@ def _coerce_editable_setting(key: str, value: object) -> object:
         if isinstance(value, bool):
             return value
         raise ValueError(f"{key} must be true or false.")
+    if key == "receipt_redaction_level":
+        if isinstance(value, str) and value in VALID_RECEIPT_REDACTION_LEVELS:
+            return value
+        raise ValueError("Invalid receipt redaction level. Must be 'full', 'partial', or 'none'.")
     raise ValueError(f"Unsupported Guard setting: {key}")
 
 
@@ -556,17 +567,22 @@ def _coerce_sandbox_analysis(value: object) -> str:
     return "off"
 
 
+def _coerce_loaded_receipt_redaction_level(value: object) -> str:
+    if isinstance(value, str) and value in VALID_RECEIPT_REDACTION_LEVELS:
+        return value
+    return "full"
+
+
 def _coerce_risk_action_payload(value: object) -> dict[str, GuardAction]:
     if not isinstance(value, dict):
         raise ValueError("Risk actions must be a table.")
     action_map: dict[str, GuardAction] = {}
     for key, action in value.items():
         if not isinstance(key, str) or key not in VALID_RISK_ACTION_KEYS:
-            raise ValueError("Invalid Guard risk action.")
+            continue
         resolved_action = _coerce_loaded_guard_action(action, None)
-        if resolved_action is None:
-            raise ValueError("Invalid Guard risk action.")
-        action_map[key] = resolved_action
+        if resolved_action is not None:
+            action_map[key] = resolved_action
     return action_map
 
 
@@ -574,33 +590,34 @@ def _coerce_harness_risk_action_payload(value: object) -> dict[str, dict[str, Gu
     if not isinstance(value, dict):
         raise ValueError("Harness risk actions must be a table.")
     harness_actions: dict[str, dict[str, GuardAction]] = {}
-    for harness, risk_payload in value.items():
+    for harness, actions in value.items():
         if not isinstance(harness, str) or not harness.strip():
-            raise ValueError("Invalid Guard harness.")
-        harness_actions[harness] = _coerce_risk_action_payload(risk_payload)
+            continue
+        harness_actions[harness] = _coerce_risk_action_payload(actions)
     return harness_actions
 
 
 def _effective_risk_actions(config: GuardConfig) -> dict[str, GuardAction]:
     defaults = SECURITY_LEVEL_RISK_ACTIONS.get(
-        config.security_level, SECURITY_LEVEL_RISK_ACTIONS[DEFAULT_SECURITY_LEVEL]
+        config.security_level,
+        SECURITY_LEVEL_RISK_ACTIONS[DEFAULT_SECURITY_LEVEL],
     )
     return {**defaults, **dict(config.risk_actions or {})}
 
 
 def resolve_risk_action(config: GuardConfig, risk_class: str | None, *, harness: str | None) -> GuardAction | None:
     """Resolve the configured action for a concrete runtime risk class."""
-
-    if not isinstance(risk_class, str) or risk_class not in VALID_RISK_ACTION_KEYS:
+    if risk_class is None:
         return None
-    if isinstance(harness, str) and config.harness_risk_actions is not None:
-        harness_actions = config.harness_risk_actions.get(harness)
-        if harness_actions is not None and risk_class in harness_actions:
-            return harness_actions[risk_class]
-    if config.risk_actions is not None and risk_class in config.risk_actions:
+    if harness is not None and config.harness_risk_actions:
+        harness_map = config.harness_risk_actions.get(harness)
+        if harness_map is not None and risk_class in harness_map:
+            return harness_map[risk_class]
+    if config.risk_actions and risk_class in config.risk_actions:
         return config.risk_actions[risk_class]
     defaults = SECURITY_LEVEL_RISK_ACTIONS.get(
-        config.security_level, SECURITY_LEVEL_RISK_ACTIONS[DEFAULT_SECURITY_LEVEL]
+        config.security_level,
+        SECURITY_LEVEL_RISK_ACTIONS[DEFAULT_SECURITY_LEVEL],
     )
     return defaults.get(risk_class)
 
@@ -613,23 +630,13 @@ def _write_guard_config(path: Path, payload: dict[str, object]) -> None:
 
 def _toml_lines_for_table(payload: Mapping[str, object], path: tuple[str, ...]) -> list[str]:
     lines: list[str] = []
-    scalar_items: list[tuple[str, object]] = []
-    table_items: list[tuple[str, dict[str, object]]] = []
-    for key, value in sorted(payload.items(), key=lambda item: item[0]):
-        nested_table = _string_object_table(value)
-        if nested_table is not None:
-            table_items.append((key, nested_table))
-            continue
-        scalar_items.append((key, value))
-    if path:
-        lines.append(f"[{'.'.join(_toml_key(item) for item in path)}]")
-    for key, value in scalar_items:
-        lines.append(f"{_toml_key(key)} = {_toml_literal(value)}")
-    for key, value in table_items:
-        nested_lines = _toml_lines_for_table(value, (*path, key))
-        if lines and nested_lines:
-            lines.append("")
-        lines.extend(nested_lines)
+    for key, value in payload.items():
+        if isinstance(value, Mapping):
+            child_path = (*path, key)
+            lines.append(f"[{'.'.join(child_path)}]")
+            lines.extend(_toml_lines_for_table(value, child_path))
+        else:
+            lines.append(f"{_toml_key(key)} = {_toml_literal(value)}")
     return lines
 
 
@@ -642,64 +649,38 @@ def _toml_key(value: str) -> str:
 def _toml_literal(value: object) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, int):
+    if isinstance(value, int) and not isinstance(value, bool):
         return str(value)
     if isinstance(value, float):
         return repr(value)
-    if isinstance(value, str):
-        return json.dumps(value)
-    if isinstance(value, list):
+    if isinstance(value, tuple | list):
         return "[" + ", ".join(_toml_literal(item) for item in value) + "]"
-    nested_table = _string_object_table(value)
-    if nested_table is not None:
-        return _toml_inline_table(nested_table)
+    if isinstance(value, Mapping):
+        return _toml_inline_table(value)
     return json.dumps(str(value))
 
 
 def _toml_inline_table(value: Mapping[str, object]) -> str:
     items: list[str] = []
-    for key, item in sorted(value.items(), key=lambda entry: entry[0]):
+    for key, item in value.items():
         items.append(f"{_toml_key(key)} = {_toml_literal(item)}")
     return "{ " + ", ".join(items) + " }"
 
 
 def overlay_synced_guard_policy(
     config: GuardConfig,
-    payload: dict[str, object] | None,
+    payload: object,
 ) -> GuardConfig:
     if not isinstance(payload, dict):
         return config
-    next_mode = config.mode
-    raw_mode = payload.get("mode")
-    if isinstance(raw_mode, str) and raw_mode in VALID_GUARD_MODES:
-        next_mode = raw_mode
-    default_action = _coerce_action_value(payload.get("defaultAction"), config.default_action)
-    unknown_publisher_action = _coerce_action_value(
-        payload.get("unknownPublisherAction"),
-        config.unknown_publisher_action,
-    )
-    changed_hash_action = _coerce_action_value(
-        payload.get("changedHashAction"),
-        config.changed_hash_action,
-    )
-    new_network_domain_action = _coerce_action_value(
-        payload.get("newNetworkDomainAction"),
-        config.new_network_domain_action,
-    )
-    subprocess_action = _coerce_action_value(
-        payload.get("subprocessAction"),
-        config.subprocess_action,
-    )
-    sync_enabled = payload.get("syncEnabled")
+    security_level = _coerce_loaded_security_level(payload.get("security_level"))
+    risk_actions = _coerce_risk_action_map(payload.get("risk_actions"))
+    harness_risk_actions = _coerce_harness_risk_action_map(payload.get("harness_risk_actions"))
     return replace(
         config,
-        mode=next_mode,
-        default_action=default_action,
-        unknown_publisher_action=unknown_publisher_action,
-        changed_hash_action=changed_hash_action,
-        new_network_domain_action=new_network_domain_action,
-        subprocess_action=subprocess_action,
-        sync=bool(sync_enabled) if isinstance(sync_enabled, bool) else config.sync,
+        security_level=security_level,
+        risk_actions=risk_actions,
+        harness_risk_actions=harness_risk_actions,
     )
 
 
@@ -716,7 +697,7 @@ def _string_object_table(value: object) -> dict[str, object] | None:
 def _existing_legacy_guard_home() -> Path | None:
     for relative_path in LEGACY_GUARD_DIRNAMES:
         candidate = Path.home() / relative_path
-        if candidate.exists():
+        if candidate.is_dir():
             return candidate
     return None
 
@@ -724,41 +705,26 @@ def _existing_legacy_guard_home() -> Path | None:
 def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
     if not source.exists():
         return
-    destination.mkdir(parents=True, exist_ok=True)
-    replace_database = not _guard_home_has_sync_credentials(destination) and not _guard_home_has_state(destination)
     for entry in source.iterdir():
-        if entry.name in NON_MIGRATED_GUARD_RUNTIME_FILES:
+        if entry.name.startswith("."):
             continue
         target = destination / entry.name
-        if target.exists():
-            if replace_database and entry.name == "secrets" and entry.is_dir() and target.is_dir():
-                shutil.rmtree(target)
-                shutil.copytree(entry, target)
-                continue
-            if entry.is_dir() and target.is_dir():
-                _migrate_guard_home_state(source=entry, destination=target)
-                continue
-            if replace_database and entry.name == "guard.db" and entry.is_file():
-                _copy_guard_database(source=entry, destination=target)
-            continue
         if entry.is_dir():
-            shutil.copytree(entry, target)
-            continue
-        if entry.name == "guard.db" and entry.is_file():
-            _copy_guard_database(source=entry, destination=target)
-            continue
-        shutil.copy2(entry, target)
+            shutil.copytree(entry, target, dirs_exist_ok=True)
+        else:
+            shutil.copy2(entry, target)
 
 
 def _migrate_guard_home_transactionally(*, source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with tempfile.TemporaryDirectory(dir=destination.parent, prefix=f"{destination.name}-migration-") as temp_dir:
-            staging_root = Path(temp_dir) / destination.name
-            _migrate_guard_home_state(source=source, destination=staging_root)
-            if destination.exists():
-                _remove_guard_home_destination(destination)
-            shutil.move(str(staging_root), str(destination))
+        with tempfile.TemporaryDirectory(prefix="guard-home-migration-") as staging:
+            staging_path = Path(staging)
+            _migrate_guard_home_state(source=source, destination=staging_path)
+            _copy_guard_database(source=source, destination=staging_path)
+            _prune_retired_guard_db_sync_state(staging_path / "guard.db")
+            _remove_guard_home_destination(destination)
+            shutil.move(str(staging_path), str(destination))
     except OSError:
         raise GuardHomeMigrationError("guard home migration failed") from None
 
@@ -767,39 +733,39 @@ def _remove_guard_home_destination(path: Path) -> None:
     for entry in path.iterdir():
         if entry.is_dir():
             shutil.rmtree(entry)
-            continue
-        entry.unlink()
+        else:
+            entry.unlink()
     path.rmdir()
 
 
 def _copy_guard_database(*, source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    temporary_destination = destination.with_name(f"{destination.name}.migrating")
+    source_db = source / "guard.db"
+    if not source_db.is_file():
+        return
     deadline = time.monotonic() + GUARD_DB_BACKUP_TIMEOUT_SECONDS
+    backup_path = destination / "guard.db"
+    while True:
+        _raise_when_backup_deadline_elapsed(deadline)
+        try:
+            shutil.copy2(source_db, backup_path)
+            break
+        except OSError:
+            time.sleep(GUARD_DB_BACKUP_SLEEP_SECONDS)
     try:
-        with (
-            sqlite3.connect(f"file:{source}?mode=ro", uri=True) as source_connection,
-            sqlite3.connect(temporary_destination) as destination_connection,
-        ):
-            source_connection.backup(
-                destination_connection,
-                pages=128,
-                progress=lambda *_: _raise_when_backup_deadline_elapsed(deadline),
-                sleep=GUARD_DB_BACKUP_SLEEP_SECONDS,
-            )
-        _prune_retired_guard_db_sync_state(temporary_destination)
-        temporary_destination.replace(destination)
-    except (TimeoutError, sqlite3.Error):
-        if temporary_destination.exists():
-            temporary_destination.unlink()
+        with sqlite3.connect(backup_path) as conn:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    except sqlite3.DatabaseError:
+        backup_path.unlink(missing_ok=True)
         raise GuardHomeMigrationError("guard.db migration failed") from None
 
 
 def _prune_retired_guard_db_sync_state(database_path: Path) -> None:
     try:
-        with sqlite3.connect(database_path) as connection:
-            connection.execute("delete from sync_state where state_key = 'credentials'")
-    except sqlite3.Error:
+        with sqlite3.connect(database_path) as conn:
+            conn.execute("DELETE FROM sync_payload WHERE key LIKE 'retired_%'")
+    except sqlite3.DatabaseError:
         return
 
 
@@ -813,7 +779,8 @@ def _load_workspace_guard_config(workspace: Path | None) -> dict[str, object]:
         return {}
     merged: dict[str, object] = {}
     for filename in WORKSPACE_CONFIG_FILENAMES:
-        merged = _merge_config_payload(merged, _sanitize_workspace_guard_config(_read_toml(workspace / filename)))
+        payload = _sanitize_workspace_guard_config(_read_toml(workspace / filename))
+        merged.update(payload)
     return merged
 
 
@@ -824,57 +791,39 @@ def _sanitize_workspace_guard_config(payload: dict[str, object]) -> dict[str, ob
 def _merge_config_payload(base: dict[str, object], override: dict[str, object]) -> dict[str, object]:
     merged = dict(base)
     for key, value in override.items():
-        existing = merged.get(key)
-        if isinstance(existing, dict) and isinstance(value, dict):
-            nested_existing = {name: nested_value for name, nested_value in existing.items() if isinstance(name, str)}
-            nested_override = {name: nested_value for name, nested_value in value.items() if isinstance(name, str)}
-            if "action" in nested_override or "default_action" in nested_override:
-                nested_existing.pop("action", None)
-                nested_existing.pop("default_action", None)
-            merged[key] = _merge_config_payload(nested_existing, nested_override)
-            continue
-        merged[key] = value
+        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
+            merged_child = dict(merged[key])
+            merged_child.update(value)
+            merged[key] = merged_child
+        else:
+            merged[key] = value
     return merged
 
 
 def _guard_home_has_state(path: Path) -> bool:
     if not path.exists():
         return False
-    entries = list(path.iterdir())
-    if not entries:
-        return False
-    if any(entry.name not in {"guard.db", *GUARD_HOME_METADATA_FILES} for entry in entries):
+    for entry in path.iterdir():
+        if entry.name.startswith("."):
+            continue
+        if entry.is_dir():
+            continue
+        if entry.name in GUARD_HOME_METADATA_FILES:
+            continue
+        if entry.name == "guard.db":
+            continue
+        if entry.suffix in {".json", ".toml"}:
+            continue
         return True
-    database_path = path / "guard.db"
-    if not database_path.is_file():
-        return True
-    try:
-        with sqlite3.connect(f"file:{database_path}?mode=ro", uri=True) as connection:
-            tables = {str(row[0]) for row in connection.execute("select name from sqlite_master where type = 'table'")}
-            for table_name in (
-                "harness_installations",
-                "artifact_snapshots",
-                "artifact_hashes",
-                "artifact_diffs",
-                "artifact_inventory",
-                "policy_decisions",
-                "runtime_receipts",
-                "publisher_cache",
-                "guard_events",
-                "managed_installs",
-                "guard_sessions",
-                "guard_operations",
-                "guard_operation_items",
-                "guard_client_attachments",
-                "guard_surface_opens",
-                "approval_requests",
-            ):
-                if table_name not in tables:
-                    continue
-                if connection.execute(f"select 1 from {table_name} limit 1").fetchone() is not None:
+    db_path = path / "guard.db"
+    if db_path.is_file():
+        try:
+            with sqlite3.connect(db_path) as conn:
+                row = conn.execute("SELECT COUNT(*) FROM runtime_receipts").fetchone()
+                if row is not None and row[0] > 0:
                     return True
-    except sqlite3.Error:
-        return True
+        except sqlite3.DatabaseError:
+            pass
     return False
 
 
@@ -883,15 +832,10 @@ def _guard_home_has_sync_credentials(path: Path) -> bool:
     if not database_path.is_file():
         return False
     try:
-        with sqlite3.connect(f"file:{database_path}?mode=ro", uri=True) as connection:
-            row = connection.execute(
-                """
-                select 1
-                from sync_state
-                where state_key = 'oauth_local_credentials'
-                limit 1
-                """
+        with sqlite3.connect(database_path) as conn:
+            row = conn.execute(
+                "SELECT value FROM sync_payload WHERE key = 'auth_context'"
             ).fetchone()
-    except sqlite3.Error:
+    except sqlite3.DatabaseError:
         return False
     return row is not None

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -181,8 +181,9 @@ EDITABLE_GUARD_SETTING_KEYS = frozenset(
         "receipt_redaction_level",
     }
 )
-VALID_APPROVAL_SURFACE_POLICIES = {"auto-open-once", "native-only", "approval-center"}
 VALID_RECEIPT_REDACTION_LEVELS = frozenset({"full", "partial", "none"})
+
+VALID_APPROVAL_SURFACE_POLICIES = {"auto-open-once", "native-only", "approval-center"}
 BARE_TOML_KEY = re.compile(r"^[A-Za-z0-9_-]+$")
 WORKSPACE_BLOCKED_POLICY_KEYS = frozenset(
     {
@@ -277,6 +278,7 @@ class GuardConfig:
     desktop_notifications: bool = True
     telemetry: bool = False
     sync: bool = False
+    receipt_redaction_level: str = "full"
     billing: bool = False
     runtime_detector_registry: bool = False
     runtime_detector_timeout_ms: int = 50
@@ -289,7 +291,6 @@ class GuardConfig:
     publisher_actions: dict[str, GuardAction] | None = None
     artifact_actions: dict[str, GuardAction] | None = None
     evidence_retain_days: int = 90
-    receipt_redaction_level: str = "full"
 
     def resolve_action_override(
         self,
@@ -339,6 +340,12 @@ def _read_toml(path: Path) -> dict[str, object]:
         return {}
 
 
+def _coerce_loaded_receipt_redaction_level(value: object) -> str:
+    if isinstance(value, str) and value in VALID_RECEIPT_REDACTION_LEVELS:
+        return value
+    return "full"
+
+
 def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardConfig:
     """Load Guard config from home and workspace overrides."""
 
@@ -385,7 +392,6 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
         security_level=_coerce_loaded_security_level(merged.get("security_level", DEFAULT_SECURITY_LEVEL)),
         risk_actions=_coerce_risk_action_map(merged.get("risk_actions")),
         harness_risk_actions=_coerce_harness_risk_action_map(merged.get("harness_risk_actions")),
-        receipt_redaction_level=_coerce_loaded_receipt_redaction_level(merged.get("receipt_redaction_level", "full")),
     )
 
 
@@ -408,8 +414,8 @@ def editable_guard_settings(config: GuardConfig) -> dict[str, object]:
         "desktop_notifications": config.desktop_notifications,
         "telemetry": config.telemetry,
         "sync": config.sync,
-        "billing": config.billing,
         "receipt_redaction_level": config.receipt_redaction_level,
+        "billing": config.billing,
         "approval_gate": public_config(config.guard_home).to_dict(),
     }
 
@@ -487,7 +493,7 @@ def _coerce_editable_setting(key: str, value: object) -> object:
     if key == "receipt_redaction_level":
         if isinstance(value, str) and value in VALID_RECEIPT_REDACTION_LEVELS:
             return value
-        raise ValueError("Invalid receipt redaction level. Must be 'full', 'partial', or 'none'.")
+        raise ValueError(f"Invalid receipt redaction level: {value!r}")
     raise ValueError(f"Unsupported Guard setting: {key}")
 
 
@@ -565,22 +571,17 @@ def _coerce_sandbox_analysis(value: object) -> str:
     return "off"
 
 
-def _coerce_loaded_receipt_redaction_level(value: object) -> str:
-    if isinstance(value, str) and value in VALID_RECEIPT_REDACTION_LEVELS:
-        return value
-    return "full"
-
-
 def _coerce_risk_action_payload(value: object) -> dict[str, GuardAction]:
     if not isinstance(value, dict):
         raise ValueError("Risk actions must be a table.")
     action_map: dict[str, GuardAction] = {}
     for key, action in value.items():
         if not isinstance(key, str) or key not in VALID_RISK_ACTION_KEYS:
-            continue
+            raise ValueError("Invalid Guard risk action.")
         resolved_action = _coerce_loaded_guard_action(action, None)
-        if resolved_action is not None:
-            action_map[key] = resolved_action
+        if resolved_action is None:
+            raise ValueError("Invalid Guard risk action.")
+        action_map[key] = resolved_action
     return action_map
 
 
@@ -588,34 +589,33 @@ def _coerce_harness_risk_action_payload(value: object) -> dict[str, dict[str, Gu
     if not isinstance(value, dict):
         raise ValueError("Harness risk actions must be a table.")
     harness_actions: dict[str, dict[str, GuardAction]] = {}
-    for harness, actions in value.items():
+    for harness, risk_payload in value.items():
         if not isinstance(harness, str) or not harness.strip():
-            continue
-        harness_actions[harness] = _coerce_risk_action_payload(actions)
+            raise ValueError("Invalid Guard harness.")
+        harness_actions[harness] = _coerce_risk_action_payload(risk_payload)
     return harness_actions
 
 
 def _effective_risk_actions(config: GuardConfig) -> dict[str, GuardAction]:
     defaults = SECURITY_LEVEL_RISK_ACTIONS.get(
-        config.security_level,
-        SECURITY_LEVEL_RISK_ACTIONS[DEFAULT_SECURITY_LEVEL],
+        config.security_level, SECURITY_LEVEL_RISK_ACTIONS[DEFAULT_SECURITY_LEVEL]
     )
     return {**defaults, **dict(config.risk_actions or {})}
 
 
 def resolve_risk_action(config: GuardConfig, risk_class: str | None, *, harness: str | None) -> GuardAction | None:
     """Resolve the configured action for a concrete runtime risk class."""
-    if risk_class is None:
+
+    if not isinstance(risk_class, str) or risk_class not in VALID_RISK_ACTION_KEYS:
         return None
-    if harness is not None and config.harness_risk_actions:
-        harness_map = config.harness_risk_actions.get(harness)
-        if harness_map is not None and risk_class in harness_map:
-            return harness_map[risk_class]
-    if config.risk_actions and risk_class in config.risk_actions:
+    if isinstance(harness, str) and config.harness_risk_actions is not None:
+        harness_actions = config.harness_risk_actions.get(harness)
+        if harness_actions is not None and risk_class in harness_actions:
+            return harness_actions[risk_class]
+    if config.risk_actions is not None and risk_class in config.risk_actions:
         return config.risk_actions[risk_class]
     defaults = SECURITY_LEVEL_RISK_ACTIONS.get(
-        config.security_level,
-        SECURITY_LEVEL_RISK_ACTIONS[DEFAULT_SECURITY_LEVEL],
+        config.security_level, SECURITY_LEVEL_RISK_ACTIONS[DEFAULT_SECURITY_LEVEL]
     )
     return defaults.get(risk_class)
 
@@ -628,13 +628,23 @@ def _write_guard_config(path: Path, payload: dict[str, object]) -> None:
 
 def _toml_lines_for_table(payload: Mapping[str, object], path: tuple[str, ...]) -> list[str]:
     lines: list[str] = []
-    for key, value in payload.items():
-        if isinstance(value, Mapping):
-            child_path = (*path, key)
-            lines.append(f"[{'.'.join(child_path)}]")
-            lines.extend(_toml_lines_for_table(value, child_path))
-        else:
-            lines.append(f"{_toml_key(key)} = {_toml_literal(value)}")
+    scalar_items: list[tuple[str, object]] = []
+    table_items: list[tuple[str, dict[str, object]]] = []
+    for key, value in sorted(payload.items(), key=lambda item: item[0]):
+        nested_table = _string_object_table(value)
+        if nested_table is not None:
+            table_items.append((key, nested_table))
+            continue
+        scalar_items.append((key, value))
+    if path:
+        lines.append(f"[{'.'.join(_toml_key(item) for item in path)}]")
+    for key, value in scalar_items:
+        lines.append(f"{_toml_key(key)} = {_toml_literal(value)}")
+    for key, value in table_items:
+        nested_lines = _toml_lines_for_table(value, (*path, key))
+        if lines and nested_lines:
+            lines.append("")
+        lines.extend(nested_lines)
     return lines
 
 
@@ -647,20 +657,23 @@ def _toml_key(value: str) -> str:
 def _toml_literal(value: object) -> str:
     if isinstance(value, bool):
         return "true" if value else "false"
-    if isinstance(value, int) and not isinstance(value, bool):
+    if isinstance(value, int):
         return str(value)
     if isinstance(value, float):
         return repr(value)
-    if isinstance(value, tuple | list):
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, list):
         return "[" + ", ".join(_toml_literal(item) for item in value) + "]"
-    if isinstance(value, Mapping):
-        return _toml_inline_table(value)
+    nested_table = _string_object_table(value)
+    if nested_table is not None:
+        return _toml_inline_table(nested_table)
     return json.dumps(str(value))
 
 
 def _toml_inline_table(value: Mapping[str, object]) -> str:
     items: list[str] = []
-    for key, item in value.items():
+    for key, item in sorted(value.items(), key=lambda entry: entry[0]):
         items.append(f"{_toml_key(key)} = {_toml_literal(item)}")
     return "{ " + ", ".join(items) + " }"
 
@@ -724,7 +737,7 @@ def _string_object_table(value: object) -> dict[str, object] | None:
 def _existing_legacy_guard_home() -> Path | None:
     for relative_path in LEGACY_GUARD_DIRNAMES:
         candidate = Path.home() / relative_path
-        if candidate.is_dir():
+        if candidate.exists():
             return candidate
     return None
 
@@ -732,69 +745,82 @@ def _existing_legacy_guard_home() -> Path | None:
 def _migrate_guard_home_state(*, source: Path, destination: Path) -> None:
     if not source.exists():
         return
+    destination.mkdir(parents=True, exist_ok=True)
+    replace_database = not _guard_home_has_sync_credentials(destination) and not _guard_home_has_state(destination)
     for entry in source.iterdir():
-        if entry.name.startswith("."):
+        if entry.name in NON_MIGRATED_GUARD_RUNTIME_FILES:
             continue
         target = destination / entry.name
+        if target.exists():
+            if replace_database and entry.name == "secrets" and entry.is_dir() and target.is_dir():
+                shutil.rmtree(target)
+                shutil.copytree(entry, target)
+                continue
+            if entry.is_dir() and target.is_dir():
+                _migrate_guard_home_state(source=entry, destination=target)
+                continue
+            if replace_database and entry.name == "guard.db" and entry.is_file():
+                _copy_guard_database(source=entry, destination=target)
+            continue
         if entry.is_dir():
-            shutil.copytree(entry, target, dirs_exist_ok=True)
-        else:
-            shutil.copy2(entry, target)
+            shutil.copytree(entry, target)
+            continue
+        if entry.name == "guard.db" and entry.is_file():
+            _copy_guard_database(source=entry, destination=target)
+            continue
+        shutil.copy2(entry, target)
 
 
 def _migrate_guard_home_transactionally(*, source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
     try:
-        with tempfile.TemporaryDirectory(prefix="guard-home-migration-") as staging:
-            staging_path = Path(staging)
-            _migrate_guard_home_state(source=source, destination=staging_path)
-            _copy_guard_database(source=source, destination=staging_path)
-            _prune_retired_guard_db_sync_state(staging_path / "guard.db")
-            _remove_guard_home_destination(destination)
-            shutil.move(str(staging_path), str(destination))
+        with tempfile.TemporaryDirectory(dir=destination.parent, prefix=f"{destination.name}-migration-") as temp_dir:
+            staging_root = Path(temp_dir) / destination.name
+            _migrate_guard_home_state(source=source, destination=staging_root)
+            if destination.exists():
+                _remove_guard_home_destination(destination)
+            shutil.move(str(staging_root), str(destination))
     except OSError:
         raise GuardHomeMigrationError("guard home migration failed") from None
 
 
 def _remove_guard_home_destination(path: Path) -> None:
-    if not path.exists():
-        return
     for entry in path.iterdir():
         if entry.is_dir():
             shutil.rmtree(entry)
-        else:
-            entry.unlink()
+            continue
+        entry.unlink()
     path.rmdir()
 
 
 def _copy_guard_database(*, source: Path, destination: Path) -> None:
     destination.parent.mkdir(parents=True, exist_ok=True)
-    source_db = source / "guard.db"
-    if not source_db.is_file():
-        return
+    temporary_destination = destination.with_name(f"{destination.name}.migrating")
     deadline = time.monotonic() + GUARD_DB_BACKUP_TIMEOUT_SECONDS
-    backup_path = destination / "guard.db"
-    while True:
-        _raise_when_backup_deadline_elapsed(deadline)
-        try:
-            shutil.copy2(source_db, backup_path)
-            break
-        except OSError:
-            time.sleep(GUARD_DB_BACKUP_SLEEP_SECONDS)
     try:
-        with sqlite3.connect(backup_path) as conn:
-            conn.execute("PRAGMA journal_mode=WAL")
-            conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-    except sqlite3.DatabaseError:
-        backup_path.unlink(missing_ok=True)
+        with (
+            sqlite3.connect(f"file:{source}?mode=ro", uri=True) as source_connection,
+            sqlite3.connect(temporary_destination) as destination_connection,
+        ):
+            source_connection.backup(
+                destination_connection,
+                pages=128,
+                progress=lambda *_: _raise_when_backup_deadline_elapsed(deadline),
+                sleep=GUARD_DB_BACKUP_SLEEP_SECONDS,
+            )
+        _prune_retired_guard_db_sync_state(temporary_destination)
+        temporary_destination.replace(destination)
+    except (TimeoutError, sqlite3.Error):
+        if temporary_destination.exists():
+            temporary_destination.unlink()
         raise GuardHomeMigrationError("guard.db migration failed") from None
 
 
 def _prune_retired_guard_db_sync_state(database_path: Path) -> None:
     try:
-        with sqlite3.connect(database_path) as conn:
-            conn.execute("DELETE FROM sync_payload WHERE key LIKE 'retired_%'")
-    except sqlite3.DatabaseError:
+        with sqlite3.connect(database_path) as connection:
+            connection.execute("delete from sync_state where state_key = 'credentials'")
+    except sqlite3.Error:
         return
 
 
@@ -808,8 +834,7 @@ def _load_workspace_guard_config(workspace: Path | None) -> dict[str, object]:
         return {}
     merged: dict[str, object] = {}
     for filename in WORKSPACE_CONFIG_FILENAMES:
-        payload = _sanitize_workspace_guard_config(_read_toml(workspace / filename))
-        merged.update(payload)
+        merged = _merge_config_payload(merged, _sanitize_workspace_guard_config(_read_toml(workspace / filename)))
     return merged
 
 
@@ -820,39 +845,57 @@ def _sanitize_workspace_guard_config(payload: dict[str, object]) -> dict[str, ob
 def _merge_config_payload(base: dict[str, object], override: dict[str, object]) -> dict[str, object]:
     merged = dict(base)
     for key, value in override.items():
-        if isinstance(value, Mapping) and isinstance(merged.get(key), Mapping):
-            merged_child = dict(merged[key])
-            merged_child.update(value)
-            merged[key] = merged_child
-        else:
-            merged[key] = value
+        existing = merged.get(key)
+        if isinstance(existing, dict) and isinstance(value, dict):
+            nested_existing = {name: nested_value for name, nested_value in existing.items() if isinstance(name, str)}
+            nested_override = {name: nested_value for name, nested_value in value.items() if isinstance(name, str)}
+            if "action" in nested_override or "default_action" in nested_override:
+                nested_existing.pop("action", None)
+                nested_existing.pop("default_action", None)
+            merged[key] = _merge_config_payload(nested_existing, nested_override)
+            continue
+        merged[key] = value
     return merged
 
 
 def _guard_home_has_state(path: Path) -> bool:
     if not path.exists():
         return False
-    for entry in path.iterdir():
-        if entry.name.startswith("."):
-            continue
-        if entry.is_dir():
-            continue
-        if entry.name in GUARD_HOME_METADATA_FILES:
-            continue
-        if entry.name == "guard.db":
-            continue
-        if entry.suffix in {".json", ".toml"}:
-            continue
+    entries = list(path.iterdir())
+    if not entries:
+        return False
+    if any(entry.name not in {"guard.db", *GUARD_HOME_METADATA_FILES} for entry in entries):
         return True
-    db_path = path / "guard.db"
-    if db_path.is_file():
-        try:
-            with sqlite3.connect(db_path) as conn:
-                row = conn.execute("SELECT COUNT(*) FROM runtime_receipts").fetchone()
-                if row is not None and row[0] > 0:
+    database_path = path / "guard.db"
+    if not database_path.is_file():
+        return True
+    try:
+        with sqlite3.connect(f"file:{database_path}?mode=ro", uri=True) as connection:
+            tables = {str(row[0]) for row in connection.execute("select name from sqlite_master where type = 'table'")}
+            for table_name in (
+                "harness_installations",
+                "artifact_snapshots",
+                "artifact_hashes",
+                "artifact_diffs",
+                "artifact_inventory",
+                "policy_decisions",
+                "runtime_receipts",
+                "publisher_cache",
+                "guard_events",
+                "managed_installs",
+                "guard_sessions",
+                "guard_operations",
+                "guard_operation_items",
+                "guard_client_attachments",
+                "guard_surface_opens",
+                "approval_requests",
+            ):
+                if table_name not in tables:
+                    continue
+                if connection.execute(f"select 1 from {table_name} limit 1").fetchone() is not None:
                     return True
-        except sqlite3.DatabaseError:
-            pass
+    except sqlite3.Error:
+        return True
     return False
 
 
@@ -861,8 +904,15 @@ def _guard_home_has_sync_credentials(path: Path) -> bool:
     if not database_path.is_file():
         return False
     try:
-        with sqlite3.connect(database_path) as conn:
-            row = conn.execute("SELECT value FROM sync_payload WHERE key = 'auth_context'").fetchone()
-    except sqlite3.DatabaseError:
+        with sqlite3.connect(f"file:{database_path}?mode=ro", uri=True) as connection:
+            row = connection.execute(
+                """
+                select 1
+                from sync_state
+                where state_key = 'oauth_local_credentials'
+                limit 1
+                """
+            ).fetchone()
+    except sqlite3.Error:
         return False
     return row is not None

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -759,6 +759,8 @@ def _migrate_guard_home_transactionally(*, source: Path, destination: Path) -> N
 
 
 def _remove_guard_home_destination(path: Path) -> None:
+    if not path.exists():
+        return
     for entry in path.iterdir():
         if entry.is_dir():
             shutil.rmtree(entry)

--- a/src/codex_plugin_scanner/guard/receipts/manager.py
+++ b/src/codex_plugin_scanner/guard/receipts/manager.py
@@ -11,9 +11,19 @@ from ..models import GUARD_ACTION_VALUES, GuardAction, GuardReceipt
 from ..runtime.actions import GuardActionEnvelope
 
 
-def _redacted_envelope_dict(envelope: GuardActionEnvelope) -> dict[str, object]:
-    """Return a cloud-safe redacted view of the action envelope."""
-    return {
+def _redacted_envelope_dict(
+    envelope: GuardActionEnvelope,
+    *,
+    redaction_level: str = "full",
+) -> dict[str, object]:
+    """Return a cloud-safe redacted view of the action envelope.
+
+    ``redaction_level`` controls how much command detail is included:
+    - ``full`` (default): command text never leaves the daemon (counts/booleans only)
+    - ``partial``: command text included (already secret-scrubbed via redact_text at source)
+    - ``none``: command text, target paths, network hosts, package name included
+    """
+    base: dict[str, object] = {
         "schema_version": envelope.schema_version,
         "action_id": envelope.action_id,
         "harness": envelope.harness,
@@ -33,6 +43,21 @@ def _redacted_envelope_dict(envelope: GuardActionEnvelope) -> dict[str, object]:
         "pre_execution_result": envelope.pre_execution_result,
         "script_name": envelope.script_name,
     }
+
+    if redaction_level == "none":
+        if envelope.command is not None:
+            base["command"] = envelope.command
+        if envelope.target_paths:
+            base["target_paths"] = list(envelope.target_paths)
+        if envelope.network_hosts:
+            base["network_hosts"] = list(envelope.network_hosts)
+        if envelope.package_name is not None and len(envelope.package_name) > 0:
+            base["package_name"] = envelope.package_name
+    elif redaction_level == "partial":
+        if envelope.command is not None:
+            base["command"] = envelope.command
+
+    return base
 
 
 def _auto_diff_summary(changed_capabilities: list[str]) -> str:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -42,7 +42,7 @@ from ..cloud_exceptions import (
     dedupe_cloud_exceptions,
     stored_receipt_sync_cloud_exceptions,
 )
-from ..config import VALID_RECEIPT_REDACTION_LEVELS, GuardConfig
+from ..config import VALID_RECEIPT_REDACTION_LEVELS, GuardConfig, load_guard_config
 from ..edge_events import build_runtime_session_event
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..package_firewall_entitlement import (
@@ -3711,15 +3711,22 @@ def _persist_receipt_sync_cursor(
 
 
 def _resolve_cloud_receipt_redaction_level(store: GuardStore) -> str:
-    """Read the cloud-configured receipt redaction level from sync payload.
+    """Resolve the receipt redaction level for cloud sync.
 
-    Falls back to 'full' (safest) when not set.
+    Priority: cloud-configured level (from policy bundle downlink) >
+    local GuardConfig.receipt_redaction_level > 'full' (safest).
     """
     payload = store.get_sync_payload("cloud_receipt_redaction_level")
     if isinstance(payload, dict):
         level = payload.get("level")
         if isinstance(level, str) and level in VALID_RECEIPT_REDACTION_LEVELS:
             return level
+    try:
+        config = load_guard_config(store.guard_home)
+        if config.receipt_redaction_level in VALID_RECEIPT_REDACTION_LEVELS:
+            return config.receipt_redaction_level
+    except Exception:
+        pass
     return "full"
 
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -42,7 +42,7 @@ from ..cloud_exceptions import (
     dedupe_cloud_exceptions,
     stored_receipt_sync_cloud_exceptions,
 )
-from ..config import GuardConfig
+from ..config import GuardConfig, VALID_RECEIPT_REDACTION_LEVELS
 from ..edge_events import build_runtime_session_event
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..package_firewall_entitlement import (
@@ -1213,6 +1213,7 @@ def sync_receipts(
     team_policy_pack_payload: dict[str, object] | None = None
     remote_decisions: set[PolicyDecision] = set()
     device_id, device_name = _guard_device_metadata(store)
+    redaction_level = _resolve_cloud_receipt_redaction_level(store)
     local_guard_online_at = _now()
     sync_context = _receipt_sync_context(
         store=store,
@@ -1228,6 +1229,7 @@ def sync_receipts(
                     receipt_batch,
                     device_id=device_id,
                     device_name=device_name,
+                    redaction_level=redaction_level,
                 ),
                 "syncContext": sync_context,
             }
@@ -1361,6 +1363,18 @@ def sync_receipts(
                 now,
             )
             store.set_sync_payload("policy_bundle_last_error", {}, now)
+            # Extract cloud-configured receipt redaction level from policy bundle
+            cloud_redaction_level = non_empty_string(
+                validated_policy_bundle.get("receiptRedactionLevel")
+                if isinstance(validated_policy_bundle, dict)
+                else None
+            )
+            if cloud_redaction_level and cloud_redaction_level in VALID_RECEIPT_REDACTION_LEVELS:
+                store.set_sync_payload(
+                    "cloud_receipt_redaction_level",
+                    {"level": cloud_redaction_level, "updated_at": now},
+                    now,
+                )
             remote_decisions.update(
                 _build_policy_bundle_decisions(
                     validated_policy_bundle,
@@ -3585,8 +3599,17 @@ def _cloud_sync_receipts_payload(
     *,
     device_id: str,
     device_name: str,
+    redaction_level: str = "full",
 ) -> list[dict[str, object]]:
-    return [_cloud_sync_receipt_payload(receipt, device_id=device_id, device_name=device_name) for receipt in receipts]
+    return [
+        _cloud_sync_receipt_payload(
+            receipt,
+            device_id=device_id,
+            device_name=device_name,
+            redaction_level=redaction_level,
+        )
+        for receipt in receipts
+    ]
 
 
 def _dedupe_sync_payload_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
@@ -3687,11 +3710,25 @@ def _persist_receipt_sync_cursor(
     store.set_sync_payload("receipt_sync_cursor", payload, synced_at)
 
 
+def _resolve_cloud_receipt_redaction_level(store: GuardStore) -> str:
+    """Read the cloud-configured receipt redaction level from sync payload.
+
+    Falls back to 'full' (safest) when not set.
+    """
+    payload = store.get_sync_payload("cloud_receipt_redaction_level")
+    if isinstance(payload, dict):
+        level = payload.get("level")
+        if isinstance(level, str) and level in VALID_RECEIPT_REDACTION_LEVELS:
+            return level
+    return "full"
+
+
 def _cloud_sync_receipt_payload(
     receipt: dict[str, object],
     *,
     device_id: str,
     device_name: str,
+    redaction_level: str = "full",
 ) -> dict[str, object]:
     receipt_fingerprint = _cloud_sync_receipt_fingerprint(receipt)
     artifact_id = _optional_string(receipt.get("artifact_id")) or f"guard:local-receipt:{receipt_fingerprint[:24]}"
@@ -3743,7 +3780,30 @@ def _cloud_sync_receipt_payload(
         payload["publisher"] = publisher
     redacted_envelope = receipt.get("envelope_redacted_json")
     if isinstance(redacted_envelope, dict) and redacted_envelope:
-        payload["envelopeRedacted"] = redacted_envelope
+        # When redaction level is not "full", enrich the envelope with command text
+        # from the full envelope (already secret-scrubbed at source via redact_text)
+        if redaction_level != "full":
+            full_envelope = receipt.get("action_envelope_json")
+            if isinstance(full_envelope, dict):
+                enriched = dict(redacted_envelope)
+                command = full_envelope.get("command")
+                if isinstance(command, str) and command:
+                    enriched["command"] = command
+                if redaction_level == "none":
+                    target_paths = full_envelope.get("target_paths")
+                    if isinstance(target_paths, list):
+                        enriched["target_paths"] = target_paths
+                    network_hosts = full_envelope.get("network_hosts")
+                    if isinstance(network_hosts, list):
+                        enriched["network_hosts"] = network_hosts
+                    package_name = full_envelope.get("package_name")
+                    if isinstance(package_name, str) and package_name:
+                        enriched["package_name"] = package_name
+                payload["envelopeRedacted"] = enriched
+            else:
+                payload["envelopeRedacted"] = redacted_envelope
+        else:
+            payload["envelopeRedacted"] = redacted_envelope
     return payload
 
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -42,7 +42,7 @@ from ..cloud_exceptions import (
     dedupe_cloud_exceptions,
     stored_receipt_sync_cloud_exceptions,
 )
-from ..config import GuardConfig, VALID_RECEIPT_REDACTION_LEVELS
+from ..config import VALID_RECEIPT_REDACTION_LEVELS, GuardConfig
 from ..edge_events import build_runtime_session_event
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..package_firewall_entitlement import (

--- a/tests/test_guard_receipt_redaction_level.py
+++ b/tests/test_guard_receipt_redaction_level.py
@@ -1,0 +1,185 @@
+"""Tests for configurable receipt redaction levels."""
+
+from __future__ import annotations
+
+from codex_plugin_scanner.guard.config import (
+    VALID_RECEIPT_REDACTION_LEVELS,
+    _coerce_editable_setting,
+    _coerce_loaded_receipt_redaction_level,
+)
+from codex_plugin_scanner.guard.receipts.manager import _redacted_envelope_dict
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
+
+
+def _make_envelope(
+    *,
+    command: str | None = "rm -rf /important-dir",
+    target_paths: tuple[str, ...] = ("/important-dir",),
+    network_hosts: tuple[str, ...] = ("example.com",),
+    package_name: str | None = "evil-package",
+) -> GuardActionEnvelope:
+    """Build a minimal envelope for testing."""
+    return GuardActionEnvelope(
+        schema_version=1,
+        action_id="test-action-001",
+        harness="test-harness",
+        event_name="tool_call",
+        action_type="command-write",
+        workspace="/test",
+        workspace_hash="abc123",
+        tool_name="bash",
+        command=command,
+        prompt_excerpt=None,
+        prompt_text=None,
+        target_paths=target_paths,
+        network_hosts=network_hosts,
+        mcp_server=None,
+        mcp_tool=None,
+        package_manager=None,
+        package_name=package_name,
+        package_intent_kind=None,
+        package_targets=(),
+        pre_execution_result=None,
+        script_name=None,
+    )
+
+
+class TestRedactionLevelConfig:
+    def test_valid_levels(self):
+        assert VALID_RECEIPT_REDACTION_LEVELS == frozenset({"full", "partial", "none"})
+
+    def test_coerce_loaded_default(self):
+        assert _coerce_loaded_receipt_redaction_level(None) == "full"
+        assert _coerce_loaded_receipt_redaction_level("invalid") == "full"
+
+    def test_coerce_loaded_valid(self):
+        assert _coerce_loaded_receipt_redaction_level("full") == "full"
+        assert _coerce_loaded_receipt_redaction_level("partial") == "partial"
+        assert _coerce_loaded_receipt_redaction_level("none") == "none"
+
+    def test_coerce_editable_valid(self):
+        assert _coerce_editable_setting("receipt_redaction_level", "full") == "full"
+        assert _coerce_editable_setting("receipt_redaction_level", "partial") == "partial"
+        assert _coerce_editable_setting("receipt_redaction_level", "none") == "none"
+
+    def test_coerce_editable_invalid(self):
+        try:
+            _coerce_editable_setting("receipt_redaction_level", "invalid")
+            assert False, "Should have raised ValueError"
+        except ValueError as e:
+            assert "receipt redaction level" in str(e).lower()
+
+
+class TestRedactedEnvelopeDictFull:
+    def test_full_level_excludes_command(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="full")
+        assert "command" not in result
+        assert result["command_length"] == len("rm -rf /important-dir")
+
+    def test_full_level_excludes_target_paths(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="full")
+        assert "target_paths" not in result
+        assert result["target_paths_count"] == 1
+
+    def test_full_level_excludes_network_hosts(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="full")
+        assert "network_hosts" not in result
+        assert result["network_hosts_count"] == 1
+
+    def test_full_level_excludes_package_name(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="full")
+        assert "package_name" not in result
+        assert result["has_package_name"] is True
+
+    def test_full_level_default(self):
+        """Default redaction level is 'full'."""
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope)
+        assert "command" not in result
+
+
+class TestRedactedEnvelopeDictPartial:
+    def test_partial_level_includes_command(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="partial")
+        assert result.get("command") == "rm -rf /important-dir"
+
+    def test_partial_level_excludes_target_paths(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="partial")
+        assert "target_paths" not in result
+
+    def test_partial_level_excludes_network_hosts(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="partial")
+        assert "network_hosts" not in result
+
+    def test_partial_level_excludes_package_name(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="partial")
+        assert "package_name" not in result
+
+    def test_partial_level_includes_metadata(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="partial")
+        assert result["command_length"] == len("rm -rf /important-dir")
+        assert result["tool_name"] == "bash"
+        assert result["has_package_name"] is True
+
+
+class TestRedactedEnvelopeDictNone:
+    def test_none_level_includes_command(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="none")
+        assert result.get("command") == "rm -rf /important-dir"
+
+    def test_none_level_includes_target_paths(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="none")
+        assert result.get("target_paths") == ["/important-dir"]
+
+    def test_none_level_includes_network_hosts(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="none")
+        assert result.get("network_hosts") == ["example.com"]
+
+    def test_none_level_includes_package_name(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="none")
+        assert result.get("package_name") == "evil-package"
+
+    def test_none_level_includes_metadata(self):
+        envelope = _make_envelope()
+        result = _redacted_envelope_dict(envelope, redaction_level="none")
+        assert result["command_length"] == len("rm -rf /important-dir")
+        assert result["tool_name"] == "bash"
+
+
+class TestRedactedEnvelopeDictEdgeCases:
+    def test_none_command_with_partial(self):
+        envelope = _make_envelope(command=None)
+        result = _redacted_envelope_dict(envelope, redaction_level="partial")
+        assert "command" not in result
+        assert result["command_length"] == 0
+
+    def test_empty_package_name_with_none(self):
+        envelope = _make_envelope(package_name="")
+        result = _redacted_envelope_dict(envelope, redaction_level="none")
+        assert "package_name" not in result
+        assert result["has_package_name"] is False
+
+    def test_empty_target_paths_with_none(self):
+        envelope = _make_envelope(target_paths=())
+        result = _redacted_envelope_dict(envelope, redaction_level="none")
+        assert "target_paths" not in result
+        assert result["target_paths_count"] == 0
+
+    def test_empty_network_hosts_with_none(self):
+        envelope = _make_envelope(network_hosts=())
+        result = _redacted_envelope_dict(envelope, redaction_level="none")
+        assert "network_hosts" not in result
+        assert result["network_hosts_count"] == 0


### PR DESCRIPTION
## Summary

Add configurable receipt redaction levels to the Guard daemon so cloud users can control how much command detail is sent to the cloud when syncing receipts.

## Changes

- **config.py**: Added `receipt_redaction_level` field to `GuardConfig`, `VALID_RECEIPT_REDACTION_LEVELS` frozenset, `EDITABLE_GUARD_SETTING_KEYS` entry, `_coerce_loaded_receipt_redaction_level` helper, and coercion in `_coerce_editable_setting`.
- **receipts/manager.py**: Parameterized `_redacted_envelope_dict` to accept `redaction_level`. `full` = counts/booleans only, `partial` = +command text, `none` = +target_paths/network_hosts/package_name.
- **runtime/runner.py**: Added `_resolve_cloud_receipt_redaction_level` helper (reads `cloud_receipt_redaction_level` from sync_payload KV). Updated `_cloud_sync_receipt_payload` and `_cloud_sync_receipts_payload` to accept `redaction_level`. Enriches `envelopeRedacted` with command text from `action_envelope_json` when level ≠ full. Extracts `receiptRedactionLevel` from validated policy bundle downlink → stores as `cloud_receipt_redaction_level` sync_payload.

## Security

`redact_text()` in `redaction.py` ALWAYS runs on `envelope.command` at source — strips `sk-*`, `ghp_*`, `AKIA*`, bearer tokens, npm tokens — regardless of redaction level. The level only controls whether the (already-sanitized) command text is included in the cloud sync payload.

## Tests

24 tests in `tests/test_guard_receipt_redaction_level.py` covering all 3 levels + edge cases (null command, empty package name, empty paths).