### PR TITLE
fix(redaction): include receiptRedactionLevel in policy bundle hash

### DIFF
--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -31,6 +31,11 @@ _POLICY_BUNDLE_CORE_KEYS = (
     "rules",
 )
 
+# receiptRedactionLevel is included in the policy bundle signing payload by the
+# portal (buildPolicyBundleCore), so it must be part of the canonical hash.
+# Older bundles may not have it, so treat it as optional in hash computation.
+_POLICY_BUNDLE_OPTIONAL_CORE_KEYS = ("receiptRedactionLevel",)
+
 _POLICY_BUNDLE_DEFAULT_ACTIONS = frozenset({"allow", "warn", "block"})
 _POLICY_BUNDLE_MODE_VALUES = frozenset({"observe", "prompt", "enforce"})
 _POLICY_BUNDLE_REVIEW_ACTIONS = frozenset({"allow", "review", "block"})
@@ -96,6 +101,9 @@ def computed_policy_bundle_hash(policy_bundle: dict[str, object]) -> str:
         if key not in policy_bundle:
             raise ValueError(f"missing_policy_bundle_key:{key}")
         bundle_core[key] = policy_bundle[key]
+    for key in _POLICY_BUNDLE_OPTIONAL_CORE_KEYS:
+        if key in policy_bundle:
+            bundle_core[key] = policy_bundle[key]
     verifier = bundle_core.get("verifier")
     if isinstance(verifier, dict):
         normalized_verifier = dict(verifier)
@@ -188,9 +196,14 @@ def canonical_policy_bundle_payload(policy_bundle: dict[str, object]) -> bytes:
         if key not in policy_bundle:
             raise ValueError(f"missing_policy_bundle_key:{key}")
         bundle_core[key] = policy_bundle[key]
+    for key in _POLICY_BUNDLE_OPTIONAL_CORE_KEYS:
+        if key in policy_bundle:
+            bundle_core[key] = policy_bundle[key]
     verifier = bundle_core.get("verifier")
     if isinstance(verifier, dict):
         normalized_verifier = dict(verifier)
+        if verifier.get("algorithm") == "rsa-pss-sha256":
+            normalized_verifier["publicKeyPem"] = None
         normalized_verifier["signature"] = None
         bundle_core["verifier"] = normalized_verifier
     workspace_id = policy_bundle.get("workspaceId")
@@ -360,6 +373,9 @@ def validated_policy_bundle_payload(
         "rules": rules,
         "acknowledgements": acknowledgements,
     }
+    receipt_redaction_level = _non_empty_string(policy_bundle.get("receiptRedactionLevel"))
+    if receipt_redaction_level is not None:
+        payload["receiptRedactionLevel"] = receipt_redaction_level
     cloud_exceptions = policy_bundle.get("cloudExceptions")
     if isinstance(cloud_exceptions, list) and cloud_exceptions:
         payload["cloudExceptions"] = cloud_exceptions


### PR DESCRIPTION
## Summary

Fixes a `payload_hash_mismatch` error that caused the daemon to reject every policy bundle containing `receiptRedactionLevel`, blocking the entire redaction feature.

## Root Cause

The portal includes `receiptRedactionLevel` in the policy bundle signing payload (via `buildPolicyBundleCore` → `policyBundleCoreForIntegrity` → `buildPolicyBundleSigningPayload`), but the daemon's `policy_bundle_parser.py` had three issues:

1. **Missing optional key in hash computation**: `_POLICY_BUNDLE_CORE_KEYS` didn't include `receiptRedactionLevel`, so `canonical_policy_bundle_payload` and `computed_policy_bundle_hash` didn't include it when computing hashes — but the portal DID include it when signing. Result: hash mismatch.

2. **Verifier normalization mismatch** (the actual root cause): `canonical_policy_bundle_payload` only nulled `signature` for the verifier, while `computed_policy_bundle_hash` nulled BOTH `publicKeyPem` AND `signature` for RSA bundles. The portal's `normalizeBundleVerifierForIntegrity` nulls both. This bug predates the redaction feature but only manifests with RSA-signed bundles (production) — not sha256 (local/test).

3. **Missing field in validated return**: `validated_policy_bundle_payload` didn't include `receiptRedactionLevel` in the returned payload, so even when validation passed, the stored bundle didn't have the field — preventing the daemon from extracting it for receipt sync.

## Changes

`src/codex_plugin_scanner/guard/policy_bundle_parser.py`:
- Add `_POLICY_BUNDLE_OPTIONAL_CORE_KEYS = ("receiptRedactionLevel",)` 
- Include optional keys in `canonical_policy_bundle_payload` and `computed_policy_bundle_hash`
- Fix verifier normalization in `canonical_policy_bundle_payload` to null `publicKeyPem` for RSA (matching `computed_policy_bundle_hash`)
- Include `receiptRedactionLevel` in `validated_policy_bundle_payload` return value

## Verification

- 49 existing tests pass (test_policy_bundle_parser.py, test_guard_policy_bundle_browser_scopes.py, test_cloud_exception_sync_proof.py)
- Tested against production: daemon successfully validated the policy bundle with `receiptRedactionLevel: "partial"`, extracted the cloud redaction level, and synced receipts with command text in `envelopeRedacted`