### PR TITLE
feat: add named connection profiles for multi-environment CLI usage

### DIFF
--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -322,7 +322,7 @@ def run_bridge(
     """Run the Guard Bridge daemon."""
     config = BridgeConfig(guard_url=guard_url, poll_interval=poll_interval, dry_run=dry_run)
     if store is None:
-        store = GuardStore(resolve_guard_home())
+        store = GuardStore(resolve_guard_home())  # source defaults to "default"
 
     bridge = GuardBridge(config=config, store=store, backend=backend)
     bridge.run()

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -119,6 +119,10 @@ def _run_guard_connect_command(
         )
         _emit("connect", payload, getattr(args, "json", False))
         return 0
+    if connect_subcommand == "sources":
+        sources = store.list_oauth_sources()
+        _emit("connect", {"sources": sources}, getattr(args, "json", False))
+        return 0
     if connect_subcommand in {"status", "re-pair"}:
         payload = build_connect_status_payload(
             store=store,

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
@@ -97,7 +97,7 @@ def _run_guard_update_command(
         store = None
     else:
         try:
-            store = GuardStore(guard_home)
+            store = GuardStore(guard_home, source=getattr(args, "source", "default"))
         except (OSError, RuntimeError, sqlite3.Error) as error:
             store = None
             update_store_error = error

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
@@ -97,7 +97,7 @@ def _run_guard_update_command(
         store = None
     else:
         try:
-            store = GuardStore(guard_home, source=getattr(args, "source", "default"))
+            store = GuardStore(guard_home)
         except (OSError, RuntimeError, sqlite3.Error) as error:
             store = None
             update_store_error = error

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
@@ -29,13 +29,18 @@ def _configure_guard_cloud_parsers(
     login_parser.add_argument("--wait-timeout-seconds", type=int, default=180)
     login_parser.add_argument("--home")
     login_parser.add_argument("--guard-home")
+    login_parser.add_argument(
+        "--source",
+        default="default",
+        help="Named connection profile for multi-environment usage.",
+    )
     login_parser.add_argument("--json", action="store_true")
 
     connect_parser = guard_subparsers.add_parser(
         "connect",
         help="Open browser OAuth, pair this runtime to HOL Guard, and send the first sync",
     )
-    connect_parser.add_argument("connect_command", nargs="?", choices=("status", "repair", "re-pair"))
+    connect_parser.add_argument("connect_command", nargs="?", choices=("status", "repair", "re-pair", "sources"))
     _add_guard_common_args(connect_parser)
     connect_parser.add_argument("--sync-url", default=DEFAULT_GUARD_SYNC_URL, type=_guard_http_url)
     connect_parser.add_argument("--connect-url", default=DEFAULT_GUARD_CONNECT_URL, type=_guard_http_url)
@@ -63,6 +68,11 @@ def _configure_guard_cloud_parsers(
         action="store_true",
         dest="headless",
         help="Alias for --headless. Start Device Code approval without opening a browser.",
+    )
+    connect_parser.add_argument(
+        "--source",
+        default="default",
+        help="Named connection profile for multi-environment usage (e.g. 'staging'). Defaults to 'default'.",
     )
     connect_parser.add_argument("--json", action="store_true")
 
@@ -103,11 +113,21 @@ def _configure_guard_cloud_parsers(
         action="store_true",
         help="Also revoke the machine and runtime grant state in Guard Cloud.",
     )
+    disconnect_parser.add_argument(
+        "--source",
+        default="default",
+        help="Named connection profile to disconnect. Defaults to 'default'.",
+    )
     disconnect_parser.add_argument("--json", action="store_true")
 
     sync_parser = guard_subparsers.add_parser("sync", help="Sync receipts to the configured Guard endpoint")
     sync_parser.add_argument("--home")
     sync_parser.add_argument("--guard-home")
+    sync_parser.add_argument(
+        "--source",
+        default="default",
+        help="Named connection profile to sync from. Defaults to 'default'.",
+    )
     sync_parser.add_argument("--json", action="store_true")
 
     commands_parser = guard_subparsers.add_parser(

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -122,7 +122,12 @@ def run_guard_command(
         )
         return _normalize_guard_handler_result(result)
 
-    store = GuardStore(guard_home, prime_policy_integrity=args.guard_command != "hook")
+    source = getattr(args, "source", "default")
+    try:
+        store = GuardStore(guard_home, source=source, prime_policy_integrity=args.guard_command != "hook")
+    except ValueError as error:
+        print(f"Error: {error}", file=sys.stderr)
+        return 2
     config = load_guard_config(guard_home, workspace=workspace)
     config = overlay_synced_guard_policy(config, _synced_policy_payload(store))
 

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -10,6 +10,7 @@ import importlib
 import json
 import logging
 import os
+import re
 import sqlite3
 import subprocess
 import sys
@@ -241,6 +242,31 @@ _SQLITE_ID_BATCH_SIZE = 500
 _WORKSPACE_POLICY_KEY_PREFIX = "workspace:"
 _POLICY_INTEGRITY_STATE_KEY = "policy_integrity"
 _POLICY_INTEGRITY_CONTROL_VERSION = 1
+
+_SOURCE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
+
+
+def _normalize_source_name(source: str) -> str:
+    """Normalize a connection source name.
+
+    The default source is 'default'. Source names are used to namespace
+    OAuth credentials in the local store, allowing multiple simultaneous
+    connections (e.g. production + staging).
+    """
+    normalized = source.strip().lower()
+    if not normalized:
+        return "default"
+    if not _SOURCE_NAME_PATTERN.match(normalized):
+        raise ValueError(
+            f"Invalid source name: {source!r}. "
+            "Source names must match [a-zA-Z0-9][a-zA-Z0-9_-]*"
+        )
+    if len(normalized) > 64:
+        raise ValueError(
+            f"Invalid source name: {source!r}. "
+            "Source names must be 64 characters or fewer."
+        )
+    return normalized
 _POLICY_INTEGRITY_ENFORCEMENTS = frozenset({"warn", "enforce"})
 _POLICY_INTEGRITY_STATUSES = (
     "valid",

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -246,13 +246,15 @@ _POLICY_INTEGRITY_CONTROL_VERSION = 1
 _SOURCE_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]*$")
 
 
-def _normalize_source_name(source: str) -> str:
+def _normalize_source_name(source: str | None) -> str:
     """Normalize a connection source name.
 
     The default source is 'default'. Source names are used to namespace
     OAuth credentials in the local store, allowing multiple simultaneous
     connections (e.g. production + staging).
     """
+    if source is None:
+        return "default"
     normalized = source.strip().lower()
     if not normalized:
         return "default"

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -257,16 +257,12 @@ def _normalize_source_name(source: str) -> str:
     if not normalized:
         return "default"
     if not _SOURCE_NAME_PATTERN.match(normalized):
-        raise ValueError(
-            f"Invalid source name: {source!r}. "
-            "Source names must match [a-zA-Z0-9][a-zA-Z0-9_-]*"
-        )
+        raise ValueError(f"Invalid source name: {source!r}. Source names must match [a-zA-Z0-9][a-zA-Z0-9_-]*")
     if len(normalized) > 64:
-        raise ValueError(
-            f"Invalid source name: {source!r}. "
-            "Source names must be 64 characters or fewer."
-        )
+        raise ValueError(f"Invalid source name: {source!r}. Source names must be 64 characters or fewer.")
     return normalized
+
+
 _POLICY_INTEGRITY_ENFORCEMENTS = frozenset({"warn", "enforce"})
 _POLICY_INTEGRITY_STATUSES = (
     "valid",

--- a/src/codex_plugin_scanner/guard/store_cloud_events.py
+++ b/src/codex_plugin_scanner/guard/store_cloud_events.py
@@ -184,7 +184,9 @@ class StoreCloudEventsMixin:
             )
 
     def set_sync_payload(self, state_key: str, payload: Mapping[str, object] | Sequence[object], now: str) -> None:
-        if state_key == _OAUTH_LOCAL_CREDENTIALS_STATE_KEY:
+        if state_key == _OAUTH_LOCAL_CREDENTIALS_STATE_KEY or state_key.startswith(
+            _OAUTH_LOCAL_CREDENTIALS_STATE_KEY + ":"
+        ):
             self._clear_oauth_secret_payload_cache()
         with self._connect() as connection:
             connection.execute(

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -37,8 +37,8 @@ class StoreOAuthConnectMixin:
     def list_oauth_sources(self) -> list[dict[str, object]]:
         """List all configured connection source profiles.
 
-        Returns a list of dicts with 'source', 'issuer', 'workspace_id',
-        and 'connected' fields for each source that has OAuth credentials.
+        Returns a list of dicts with 'source', 'issuer', and 'workspace_id'
+        fields for each source that has OAuth credentials.
         """
         sources: list[dict[str, object]] = []
         prefix = _OAUTH_LOCAL_CREDENTIALS_STATE_KEY + ":"

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -52,7 +52,7 @@ class StoreOAuthConnectMixin:
             if key == _OAUTH_LOCAL_CREDENTIALS_STATE_KEY:
                 source_name = "default"
             elif key.startswith(prefix):
-                source_name = key[len(prefix):]
+                source_name = key[len(prefix) :]
             else:
                 continue
             payload = json.loads(str(row["payload_json"]))
@@ -60,11 +60,13 @@ class StoreOAuthConnectMixin:
                 continue
             issuer = payload.get("issuer")
             workspace_id = payload.get("workspace_id")
-            sources.append({
-                "source": source_name,
-                "issuer": issuer if isinstance(issuer, str) else None,
-                "workspace_id": workspace_id if isinstance(workspace_id, str) else None,
-            })
+            sources.append(
+                {
+                    "source": source_name,
+                    "issuer": issuer if isinstance(issuer, str) else None,
+                    "workspace_id": workspace_id if isinstance(workspace_id, str) else None,
+                }
+            )
         return sources
 
     def clear_cloud_sync_state_for_reconnect(self) -> None:

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -12,9 +12,9 @@ from .store_base import *
 
 class StoreOAuthConnectMixin:
     def get_cloud_sync_profile(self) -> dict[str, str] | None:
-        oauth_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        oauth_payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
         if not isinstance(oauth_payload, dict) and self.repair_oauth_local_credential_storage_from_primary():
-            oauth_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+            oauth_payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
         if isinstance(oauth_payload, dict):
             oauth_health = self.get_oauth_local_credential_health()
             if not isinstance(oauth_health, dict) or oauth_health.get("state") != "healthy":
@@ -33,6 +33,39 @@ class StoreOAuthConnectMixin:
                     profile["workspace_id"] = workspace_id.strip()
                 return profile
         return None
+
+    def list_oauth_sources(self) -> list[dict[str, object]]:
+        """List all configured connection source profiles.
+
+        Returns a list of dicts with 'source', 'issuer', 'workspace_id',
+        and 'connected' fields for each source that has OAuth credentials.
+        """
+        sources: list[dict[str, object]] = []
+        prefix = _OAUTH_LOCAL_CREDENTIALS_STATE_KEY + ":"
+        with self._connect() as connection:
+            rows = connection.execute(
+                "select state_key, payload_json from sync_state where state_key = ? or state_key like ?",
+                (_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, prefix + "%"),
+            ).fetchall()
+        for row in rows:
+            key = str(row["state_key"])
+            if key == _OAUTH_LOCAL_CREDENTIALS_STATE_KEY:
+                source_name = "default"
+            elif key.startswith(prefix):
+                source_name = key[len(prefix):]
+            else:
+                continue
+            payload = json.loads(str(row["payload_json"]))
+            if not isinstance(payload, dict):
+                continue
+            issuer = payload.get("issuer")
+            workspace_id = payload.get("workspace_id")
+            sources.append({
+                "source": source_name,
+                "issuer": issuer if isinstance(issuer, str) else None,
+                "workspace_id": workspace_id if isinstance(workspace_id, str) else None,
+            })
+        return sources
 
     def clear_cloud_sync_state_for_reconnect(self) -> None:
         self.delete_sync_payloads(list(_GUARD_CLOUD_RESET_STATE_KEYS))
@@ -135,7 +168,7 @@ class StoreOAuthConnectMixin:
             payload["runtime_id"] = runtime_id
         if runtime_label:
             payload["runtime_label"] = runtime_label
-        existing_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        existing_payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
         existing_secret_ref = (
             existing_payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY) if isinstance(existing_payload, dict) else None
         )
@@ -160,10 +193,10 @@ class StoreOAuthConnectMixin:
         self._mirror_oauth_secret_to_fallback(self._oauth_local_credentials_ref, secret_json)
         self._assert_oauth_secret_persisted(self._oauth_local_credentials_ref, secret_json)
         self._remember_oauth_secret_payload(self._oauth_local_credentials_ref, secret_hash, secret_json)
-        self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, payload, now)
+        self.set_sync_payload(self._oauth_local_credentials_state_key, payload, now)
 
     def get_oauth_local_credentials(self, *, allow_primary: bool = False) -> dict[str, object] | None:
-        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
         if not isinstance(payload, dict):
             return None
         metadata = self._oauth_local_credentials_metadata(payload)
@@ -178,7 +211,7 @@ class StoreOAuthConnectMixin:
         return self._build_oauth_local_credentials_result(metadata=metadata, secret_payload=secret_payload)
 
     def get_recoverable_oauth_local_credentials(self) -> dict[str, object] | None:
-        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
         if not isinstance(payload, dict):
             return None
         metadata = self._oauth_local_credentials_metadata(payload)
@@ -191,7 +224,7 @@ class StoreOAuthConnectMixin:
 
     def clear_oauth_local_credentials(self) -> None:
         self._clear_oauth_secret_payload_cache()
-        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
         if isinstance(payload, dict):
             secret_ref = payload.get(_OAUTH_LOCAL_CREDENTIALS_REF_KEY)
             if isinstance(secret_ref, str) and secret_ref:
@@ -201,12 +234,12 @@ class StoreOAuthConnectMixin:
                     legacy_path = legacy_fallback._path_for(secret_ref)
                     with suppress(OSError):
                         legacy_path.unlink()
-        self.delete_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        self.delete_sync_payload(self._oauth_local_credentials_state_key)
 
     def get_oauth_local_credential_health(self) -> dict[str, object]:
-        payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+        payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
         if not isinstance(payload, dict) and self.repair_oauth_local_credential_storage_from_primary():
-            payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+            payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
         health: dict[str, object] = {
             "configured": isinstance(payload, dict),
             "state": "not_configured",
@@ -235,7 +268,7 @@ class StoreOAuthConnectMixin:
             and can_repair_from_primary
             and self.repair_oauth_local_credential_storage_from_primary()
         ):
-            refreshed_payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+            refreshed_payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
             if isinstance(refreshed_payload, dict):
                 payload = refreshed_payload
                 secret_hash = payload.get(_OAUTH_LOCAL_CREDENTIALS_HASH_KEY)
@@ -334,12 +367,12 @@ class StoreOAuthConnectMixin:
     def repair_oauth_local_credential_storage_from_primary(self) -> bool:
         """Rebuild OAuth credential storage from primary or recoverable fallback state."""
         with self.hold_oauth_credential_lock():
-            payload = self.get_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY)
+            payload = self.get_sync_payload(self._oauth_local_credentials_state_key)
             if not isinstance(payload, dict):
                 recovered_payload = self._recover_missing_oauth_local_credentials_payload(now=_now())
                 if recovered_payload is None:
                     return False
-                self.set_sync_payload(_OAUTH_LOCAL_CREDENTIALS_STATE_KEY, recovered_payload, _now())
+                self.set_sync_payload(self._oauth_local_credentials_state_key, recovered_payload, _now())
                 return True
             repaired_payload = None
             if self._should_attempt_oauth_storage_repair():

--- a/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
@@ -57,6 +57,7 @@ class StoreSecretPolicyIntegrityMixin:
         *,
         guard_event_queue_limit: int = 1000,
         prime_policy_integrity: bool = True,
+        source: str = "default",
     ) -> None:
         self.guard_home = guard_home
         self.guard_home.mkdir(parents=True, exist_ok=True)
@@ -75,7 +76,15 @@ class StoreSecretPolicyIntegrityMixin:
         self._startup_prefetched_policy_integrity_repair_failed = False
         self._policy_integrity_key_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_KEY_REF)
         self._policy_integrity_control_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_CONTROL_REF)
-        self._oauth_local_credentials_ref = self._build_scoped_secret_ref(_OAUTH_LOCAL_CREDENTIALS_REF)
+        self._guard_source = _normalize_source_name(source)
+        self._oauth_local_credentials_ref = self._build_scoped_secret_ref(
+            _OAUTH_LOCAL_CREDENTIALS_REF if self._guard_source == "default"
+            else f"{_OAUTH_LOCAL_CREDENTIALS_REF}:{self._guard_source}"
+        )
+        self._oauth_local_credentials_state_key = (
+            _OAUTH_LOCAL_CREDENTIALS_STATE_KEY if self._guard_source == "default"
+            else f"{_OAUTH_LOCAL_CREDENTIALS_STATE_KEY}:{self._guard_source}"
+        )
         self._guard_event_queue_limit = max(1, guard_event_queue_limit)
         self._prime_policy_integrity_on_initialize = prime_policy_integrity
         self.path = self.guard_home / "guard.db"

--- a/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
+++ b/src/codex_plugin_scanner/guard/store_secret_policy_integrity.py
@@ -77,14 +77,14 @@ class StoreSecretPolicyIntegrityMixin:
         self._policy_integrity_key_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_KEY_REF)
         self._policy_integrity_control_ref = self._build_scoped_secret_ref(_POLICY_INTEGRITY_CONTROL_REF)
         self._guard_source = _normalize_source_name(source)
-        self._oauth_local_credentials_ref = self._build_scoped_secret_ref(
-            _OAUTH_LOCAL_CREDENTIALS_REF if self._guard_source == "default"
-            else f"{_OAUTH_LOCAL_CREDENTIALS_REF}:{self._guard_source}"
-        )
-        self._oauth_local_credentials_state_key = (
-            _OAUTH_LOCAL_CREDENTIALS_STATE_KEY if self._guard_source == "default"
-            else f"{_OAUTH_LOCAL_CREDENTIALS_STATE_KEY}:{self._guard_source}"
-        )
+        if self._guard_source == "default":
+            oauth_ref_prefix = _OAUTH_LOCAL_CREDENTIALS_REF
+            oauth_state_key = _OAUTH_LOCAL_CREDENTIALS_STATE_KEY
+        else:
+            oauth_ref_prefix = f"{_OAUTH_LOCAL_CREDENTIALS_REF}:{self._guard_source}"
+            oauth_state_key = f"{_OAUTH_LOCAL_CREDENTIALS_STATE_KEY}:{self._guard_source}"
+        self._oauth_local_credentials_ref = self._build_scoped_secret_ref(oauth_ref_prefix)
+        self._oauth_local_credentials_state_key = oauth_state_key
         self._guard_event_queue_limit = max(1, guard_event_queue_limit)
         self._prime_policy_integrity_on_initialize = prime_policy_integrity
         self.path = self.guard_home / "guard.db"

--- a/tests/test_multi_source_connect.py
+++ b/tests/test_multi_source_connect.py
@@ -1,0 +1,154 @@
+"""Tests for multi-source connection profile support."""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.store import GuardStore
+from codex_plugin_scanner.guard.store_base import _normalize_source_name
+
+
+class TestNormalizeSourceName:
+    def test_default_returns_default(self):
+        assert _normalize_source_name("default") == "default"
+
+    def test_empty_returns_default(self):
+        assert _normalize_source_name("") == "default"
+        assert _normalize_source_name("   ") == "default"
+
+    def test_lowercases(self):
+        assert _normalize_source_name("Staging") == "staging"
+        assert _normalize_source_name("PROD") == "prod"
+
+    def test_strips_whitespace(self):
+        assert _normalize_source_name("  staging  ") == "staging"
+
+    def test_allows_hyphens_and_underscores(self):
+        assert _normalize_source_name("my-staging") == "my-staging"
+        assert _normalize_source_name("test_env") == "test_env"
+
+    def test_rejects_spaces(self):
+        with pytest.raises(ValueError, match="Invalid source name"):
+            _normalize_source_name("staging env")
+
+    def test_rejects_special_chars(self):
+        with pytest.raises(ValueError, match="Invalid source name"):
+            _normalize_source_name("staging!")
+
+    def test_rejects_leading_hyphen(self):
+        with pytest.raises(ValueError, match="Invalid source name"):
+            _normalize_source_name("-staging")
+
+    def test_rejects_too_long(self):
+        with pytest.raises(ValueError, match="64 characters"):
+            _normalize_source_name("a" * 65)
+
+
+class TestGuardStoreSourceNamespacing:
+    """Verify that different source names produce isolated credential storage."""
+
+    def test_default_source_uses_unnamespaced_keys(self, tmp_path):
+        store = GuardStore(tmp_path / "default")
+        assert store._oauth_local_credentials_state_key == "oauth_local_credentials"
+        assert store._guard_source == "default"
+
+    def test_named_source_uses_namespaced_keys(self, tmp_path):
+        store = GuardStore(tmp_path / "staging", source="staging")
+        assert store._oauth_local_credentials_state_key == "oauth_local_credentials:staging"
+        assert store._guard_source == "staging"
+
+    def test_different_sources_have_different_state_keys(self, tmp_path):
+        store_a = GuardStore(tmp_path / "a", source="production")
+        store_b = GuardStore(tmp_path / "b", source="staging")
+        assert store_a._oauth_local_credentials_state_key != store_b._oauth_local_credentials_state_key
+
+    def test_different_sources_have_different_secret_refs(self, tmp_path):
+        store_a = GuardStore(tmp_path / "a", source="production")
+        store_b = GuardStore(tmp_path / "b", source="staging")
+        assert store_a._oauth_local_credentials_ref != store_b._oauth_local_credentials_ref
+
+    def test_same_source_same_guard_home_produces_same_ref(self, tmp_path):
+        store_a = GuardStore(tmp_path / "shared", source="staging")
+        store_b = GuardStore(tmp_path / "shared", source="staging")
+        assert store_a._oauth_local_credentials_ref == store_b._oauth_local_credentials_ref
+
+    def test_invalid_source_raises(self, tmp_path):
+        with pytest.raises(ValueError, match="Invalid source name"):
+            GuardStore(tmp_path / "bad", source="invalid name!")
+
+
+class TestMultiSourceCredentials:
+    """Verify that credentials stored under one source are isolated from another."""
+
+    @staticmethod
+    def _store_credentials(store: GuardStore, issuer: str, client_id: str) -> None:
+        from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
+
+        dpop = generate_dpop_key_pair()
+        store.set_oauth_local_credentials(
+            issuer=issuer,
+            client_id=client_id,
+            refresh_token=f"refresh-{client_id}",
+            dpop_private_key_pem=dpop.private_key_pem,
+            dpop_public_jwk=dpop.public_jwk,
+            dpop_public_jwk_thumbprint=dpop.public_jwk_thumbprint,
+            now="2026-01-01T00:00:00+00:00",
+        )
+
+    def test_default_and_staging_are_isolated(self, tmp_path):
+        store_default = GuardStore(tmp_path / "shared")
+        store_staging = GuardStore(tmp_path / "shared", source="staging")
+
+        # Store credentials under default
+        self._store_credentials(store_default, "https://hol.org", "client-default")
+
+        # Store credentials under staging
+        self._store_credentials(store_staging, "https://hol.org", "client-staging")
+
+        # Verify isolation
+        default_creds = store_default.get_oauth_local_credentials()
+        staging_creds = store_staging.get_oauth_local_credentials()
+
+        assert default_creds is not None
+        assert staging_creds is not None
+        assert default_creds["client_id"] == "client-default"
+        assert staging_creds["client_id"] == "client-staging"
+        assert default_creds["issuer"] == "https://hol.org"
+        assert staging_creds["issuer"] == "https://hol.org"
+
+    def test_list_oauth_sources_returns_all(self, tmp_path):
+        store_default = GuardStore(tmp_path / "shared")
+        store_staging = GuardStore(tmp_path / "shared", source="staging")
+
+        self._store_credentials(store_default, "https://hol.org", "client-default")
+        self._store_credentials(store_staging, "https://hol.org", "client-staging")
+
+        # Use a third store to list all sources (source param doesn't matter for listing)
+        store_list = GuardStore(tmp_path / "shared")
+        sources = store_list.list_oauth_sources()
+
+        assert len(sources) == 2
+        source_names = {s["source"] for s in sources}
+        assert source_names == {"default", "staging"}
+
+    def test_disconnect_only_clears_one_source(self, tmp_path):
+        store_default = GuardStore(tmp_path / "shared")
+        store_staging = GuardStore(tmp_path / "shared", source="staging")
+
+        self._store_credentials(store_default, "https://hol.org", "client-default")
+        self._store_credentials(store_staging, "https://hol.org", "client-staging")
+
+        # Clear staging
+        store_staging.delete_sync_payload(store_staging._oauth_local_credentials_state_key)
+
+        # Default should still be there
+        default_creds = store_default.get_oauth_local_credentials()
+        assert default_creds is not None
+        assert default_creds["client_id"] == "client-default"
+
+        # Staging should be gone
+        staging_creds = store_staging.get_oauth_local_credentials()
+        assert staging_creds is None

--- a/tests/test_multi_source_connect.py
+++ b/tests/test_multi_source_connect.py
@@ -152,3 +152,4 @@ class TestMultiSourceCredentials:
         # Staging should be gone
         staging_creds = store_staging.get_oauth_local_credentials()
         assert staging_creds is None
+


### PR DESCRIPTION
## Summary
- Add `--source` flag to `connect`, `sync`, `disconnect`, and `login` commands for named connection profiles
- Each source stores OAuth credentials under a separate state key, enabling simultaneous connections to multiple environments from one device
- New `hol-guard connect sources` subcommand lists all configured connection profiles
- Default source is `default` — fully backward compatible

## Testing
- `python3 -m pytest tests/test_multi_source_connect.py -q` (18/18 pass)
- `python3 -m pytest tests/test_guard_oauth_client.py tests/test_guard_connect_flow.py tests/test_guard_oauth_device_connect.py tests/test_guard_oauth_reconnect.py tests/test_multi_source_connect.py -q` (107/107 pass)
