### PR TITLE
feat(cli): add guard test-eval command for test-safe artifact evaluation

### DIFF
--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -245,6 +245,7 @@ def _resolve_legacy_args(
         "protect",
         "preflight",
         "diff",
+        "test-eval",
         "receipts",
         "history",
         "inventory",

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_records.py
@@ -51,6 +51,72 @@ def _run_guard_diff_command(
     return 0
 
 
+def _run_guard_test_eval_command(
+    args: argparse.Namespace,
+    *,
+    guard_home: Path | None = None,
+    workspace: Path | None = None,
+    context: HarnessContext | None = None,
+    store: GuardStore | None = None,
+    config: GuardConfig | None = None,
+    input_text: str | None = None,
+    output_stream: TextIO | None = None,
+) -> int:
+    """Evaluate a single artifact description against local policy without persisting.
+
+    Reads a JSON file with artifact fields (artifactType, artifactId, artifactName,
+    artifactHash, capabilities) and calls evaluate_detection(persist=False).
+    """
+    import json
+    import sys
+    from pathlib import Path as _Path
+
+    context = _require_guard_context(context)
+    store = _require_guard_store(store)
+    config = _require_guard_config(config)
+
+    input_file = getattr(args, "input_file", None)
+    if input_file:
+        raw = _Path(input_file).read_text(encoding="utf-8")
+    elif input_text:
+        raw = input_text
+    else:
+        raw = sys.stdin.read()
+
+    artifact_desc = json.loads(raw)
+    harness = getattr(args, "harness", artifact_desc.get("harness", "codex"))
+
+    artifact_metadata = artifact_desc.get("metadata", {})
+    if artifact_hash := artifact_desc.get("artifactHash", artifact_desc.get("artifact_hash")):
+        artifact_metadata["artifactHash"] = artifact_hash
+    if capabilities := artifact_desc.get("capabilities"):
+        artifact_metadata["capabilities"] = capabilities
+    if device_id := artifact_desc.get("deviceId"):
+        artifact_metadata["deviceId"] = device_id
+
+    artifact = GuardArtifact(
+        artifact_id=artifact_desc.get("artifactId", artifact_desc.get("artifact_id", "test-artifact")),
+        name=artifact_desc.get("artifactName", artifact_desc.get("artifact_name", "test-artifact")),
+        harness=harness,
+        artifact_type=artifact_desc.get("artifactType", artifact_desc.get("artifact_type", "tool_action_request")),
+        source_scope=artifact_desc.get("sourceScope", artifact_desc.get("source_scope", "test")),
+        config_path=artifact_desc.get("configPath", artifact_desc.get("config_path", "/test")),
+        publisher=artifact_desc.get("publisher"),
+        metadata=artifact_metadata,
+    )
+
+    detection = HarnessDetection(
+        harness=harness,
+        installed=True,
+        command_available=True,
+        config_paths=("/test",),
+        artifacts=(artifact,),
+    )
+
+    payload = evaluate_detection(detection, store, config, default_action="allow", persist=False)
+    _emit("test-eval", payload, getattr(args, "json", False))
+    return 0
+
 def _run_guard_receipts_command(
     args: argparse.Namespace,
     *,

--- a/src/codex_plugin_scanner/guard/cli/commands_parser.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser.py
@@ -51,6 +51,7 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         parser_class=FriendlyArgumentParser,
         metavar=(
             "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
+            "test-eval,"
             "receipts,inventory,abom,aibom,approvals,explain,allow,deny,policies,trust,exceptions,advisories,events,doctor,connect,"
             "remote-pair,disconnect,"
             "login,sync,device,commands,bridge}"

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_local.py
@@ -191,6 +191,18 @@ def _configure_guard_local_parsers(
     _add_guard_common_args(diff_parser)
     diff_parser.add_argument("--json", action="store_true")
 
+    test_eval_parser = guard_subparsers.add_parser(
+        "test-eval",
+        help="Evaluate a single artifact description against local policy without persisting (test-safe)",
+    )
+    _add_guard_common_args(test_eval_parser)
+    test_eval_parser.add_argument("harness", help="Harness name (e.g. codex)")
+    test_eval_parser.add_argument(
+        "--input",
+        dest="input_file",
+        help="Path to JSON file with artifact description",
+    )
+    test_eval_parser.add_argument("--json", action="store_true")
     receipts_parser = guard_subparsers.add_parser("receipts", help="List local Guard receipts")
     _add_guard_common_args(receipts_parser)
     receipts_parser.add_argument("--json", action="store_true")

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -44,6 +44,7 @@ _COMMON_HANDLERS = {
     "package-shims": "_run_guard_package_shims_command",
     "run": "_run_guard_run_command",
     "diff": "_run_guard_diff_command",
+    "test-eval": "_run_guard_test_eval_command",
     "receipts": "_run_guard_receipts_command",
     "history": "_run_guard_history_command",
     "inventory": "_run_guard_inventory_command",


### PR DESCRIPTION
## Summary

Adds `guard test-eval <harness> --input <file> --json` — a production-safe CLI subcommand that evaluates a single artifact description against local policy without persisting.

## Why

The Policy Routing E2E test harness needs to evaluate custom artifact descriptions (shell commands, package installs, file reads, tool invocations) against the locally synced policy bundle. The existing commands don't support this:

- `guard policies verify` checks policy *integrity* (tamper detection), not artifact evaluation
- `guard diff` scans real harness config, not custom artifact descriptions
- `guard run --dry-run` requires a real harness installation

`test-eval` is the smallest production-safe helper that bridges this gap — it calls `evaluate_detection(persist=False)` directly with a synthetic `HarnessDetection`.

## Changes

- **commands_parser_local.py**: Add `test-eval` subparser with `--input` and `--json` args
- **commands_parser.py**: Add `test-eval` to metavar list
- **commands_router.py**: Add `test-eval` → `_run_guard_test_eval_command` to dispatch table
- **commands_dispatch_records.py**: Add `_run_guard_test_eval_command` handler
- **cli.py**: Add `test-eval` to `_guard_subcommands` for legacy arg resolution

## Test plan

```bash
echo '{"artifactType":"tool-action","artifactId":"test","artifactName":"test","artifactHash":"sha256:test"}' > /tmp/eval.json
PYTHONPATH=src python3 -m codex_plugin_scanner guard test-eval codex --input /tmp/eval.json --json
```