### PR TITLE
fix: propagate raw_command_text through approval pipeline with redaction

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -30,7 +30,6 @@ from .desktop_notifications import (
 from .incident import build_incident_context
 from .local_dashboard_session import build_local_dashboard_session_token
 from .local_supply_chain import build_local_supply_chain_posture
-from .redaction import redact_text
 from .models import (
     DECISION_SCOPE_VALUES,
     GUARD_ACTION_VALUES,
@@ -40,6 +39,7 @@ from .models import (
     HarnessDetection,
     PolicyDecision,
 )
+from .redaction import redact_text
 from .risk import artifact_risk_signals, artifact_risk_summary
 from .store import (
     GuardStore,

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -30,6 +30,7 @@ from .desktop_notifications import (
 from .incident import build_incident_context
 from .local_dashboard_session import build_local_dashboard_session_token
 from .local_supply_chain import build_local_supply_chain_posture
+from .redaction import redact_text
 from .models import (
     DECISION_SCOPE_VALUES,
     GUARD_ACTION_VALUES,
@@ -240,6 +241,7 @@ def queue_blocked_approvals(
     store: GuardStore,
     approval_center_url: str,
     now: str | None = None,
+    redaction_level: str = "full",
 ) -> list[dict[str, object]]:
     timestamp = now or _now()
     artifacts_by_id = {artifact.artifact_id: artifact for artifact in detection.artifacts}
@@ -264,6 +266,14 @@ def queue_blocked_approvals(
         request_id = uuid.uuid4().hex
         risk_summary = _item_risk_summary(item, artifact)
         launch_target = _launch_target(artifact, item)
+        raw_command_text: str | None = None
+        if artifact is not None and redaction_level != "full":
+            candidate = artifact.metadata.get("raw_command_text")
+            if not isinstance(candidate, str) or not candidate.strip():
+                candidate = artifact.command if artifact.command is not None else None
+            if isinstance(candidate, str) and candidate.strip():
+                scrubbed = redact_text(candidate.strip())
+                raw_command_text = scrubbed.text
         incident = build_incident_context(
             harness=detection.harness,
             artifact=artifact,
@@ -306,6 +316,7 @@ def queue_blocked_approvals(
             action_envelope_json=_item_action_envelope_json(item),
             decision_v2_json=_item_decision_v2_json(item),
             scanner_evidence=_item_scanner_evidence(item),
+            raw_command_text=raw_command_text,
         )
         persisted_request_id = store.add_approval_request(request, timestamp)
         created_new_request = persisted_request_id == request.request_id

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
@@ -74,6 +74,7 @@ def _queue_observed_copilot_approval(
         daemon_client = load_guard_surface_daemon_client(guard_home)
     except RuntimeError:
         queued = queue_blocked_approvals(
+            redaction_level=config.receipt_redaction_level,
             detection=runtime_detection,
             evaluation=evaluation_payload,
             store=store,
@@ -349,6 +350,7 @@ def _run_hook_copilot_permission_request(
         daemon_client = load_guard_surface_daemon_client(guard_home)
     except RuntimeError:
         queued = queue_blocked_approvals(
+            redaction_level=config.receipt_redaction_level,
             detection=runtime_detection,
             evaluation=evaluation_payload,
             store=store,

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_review.py
@@ -324,6 +324,7 @@ def _review_runtime_artifact_hook(
                 browser_approval_daemon_client = load_guard_surface_daemon_client(guard_home)
             except RuntimeError:
                 queued = queue_blocked_approvals(
+                    redaction_level=config.receipt_redaction_level,
                     detection=runtime_detection,
                     evaluation=evaluation_payload,
                     store=store,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_hook_payload.py
@@ -172,6 +172,7 @@ def _headless_approval_resolver(
             daemon_client = load_guard_surface_daemon_client(context.guard_home)
         except RuntimeError:
             queued = queue_blocked_approvals(
+                redaction_level=config.receipt_redaction_level,
                 detection=detection,
                 evaluation=payload,
                 store=store,

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_resolution.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_resolution.py
@@ -342,8 +342,9 @@ def _queue_claude_native_approval_gate_fallback(
     action_envelope: GuardActionEnvelope | None = None,
 ) -> list[dict[str, object]]:
     now = _now()
-    queued =         # TODO: pass redaction_level from GuardConfig when available
-queue_blocked_approvals(
+    # TODO: pass redaction_level from GuardConfig when available;
+    # for now, default to "full" so no raw command text is exposed
+    queued = queue_blocked_approvals(
         detection=_runtime_detection(harness, artifact),
         evaluation={
             "artifacts": [

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_resolution.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_resolution.py
@@ -342,7 +342,8 @@ def _queue_claude_native_approval_gate_fallback(
     action_envelope: GuardActionEnvelope | None = None,
 ) -> list[dict[str, object]]:
     now = _now()
-    queued = queue_blocked_approvals(
+    queued =         # TODO: pass redaction_level from GuardConfig when available
+queue_blocked_approvals(
         detection=_runtime_detection(harness, artifact),
         evaluation={
             "artifacts": [

--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -9,6 +9,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..adapters.base import HarnessContext
+from ..config import load_guard_config
 from ..approvals import approval_center_hint, attach_primary_approval_link, queue_blocked_approvals
 from ..models import GuardArtifact, HarnessDetection
 from ..shim_probe import SHIM_PROBE_ENV_VALUE, SHIM_PROBE_ENV_VAR
@@ -44,11 +45,13 @@ def _queue_local_protect_approvals(
         config_paths=(artifact.config_path,),
         artifacts=(artifact,),
     )
+    _protect_config = load_guard_config(guard_home)
     queued = queue_blocked_approvals(
         detection=detection,
         evaluation={"artifacts": [approval_item]},
         store=store,
         approval_center_url=approval_center_url,
+        redaction_level=_protect_config.receipt_redaction_level,
     )
     if not queued:
         return

--- a/src/codex_plugin_scanner/guard/cli/protect_approvals.py
+++ b/src/codex_plugin_scanner/guard/cli/protect_approvals.py
@@ -9,8 +9,8 @@ from collections.abc import Callable
 from pathlib import Path
 
 from ..adapters.base import HarnessContext
-from ..config import load_guard_config
 from ..approvals import approval_center_hint, attach_primary_approval_link, queue_blocked_approvals
+from ..config import load_guard_config
 from ..models import GuardArtifact, HarnessDetection
 from ..shim_probe import SHIM_PROBE_ENV_VALUE, SHIM_PROBE_ENV_VAR
 from ..store import GuardStore

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -225,6 +225,7 @@ class GuardApprovalRequest:
     last_seen_at: str | None = None
     scanner_evidence: tuple[dict[str, object], ...] = ()
     browser_intent: dict[str, object] | None = None
+    raw_command_text: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -769,6 +769,7 @@ class RuntimeMcpGuardProxy:
         queued: list[dict[str, Any]] = []
         if should_queue_approval_center:
             queued = queue_blocked_approvals(
+                redaction_level=self.config.receipt_redaction_level,
                 detection=HarnessDetection(
                     harness=self.harness,
                     installed=True,
@@ -1195,6 +1196,7 @@ class RuntimeMcpGuardProxy:
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         approval_center_url = ensure_guard_daemon(self.context.guard_home)
         queued = queue_blocked_approvals(
+            redaction_level=self.config.receipt_redaction_level,
             detection=HarnessDetection(
                 harness=self.harness,
                 installed=True,
@@ -1308,6 +1310,7 @@ class RuntimeMcpGuardProxy:
         if extra_fields:
             artifact_payload.update(extra_fields)
         return queue_blocked_approvals(
+            redaction_level=self.config.receipt_redaction_level,
             detection=HarnessDetection(
                 harness=self.harness,
                 installed=True,

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -434,6 +434,7 @@ class StdioGuardProxy:
                     response_data = None
                     if self.guard_store is not None and self.approval_center_url is not None:
                         event["approval_requests"] = queue_blocked_approvals(
+                            redaction_level=getattr(self.guard_config, "receipt_redaction_level", "full"),
                             detection=HarnessDetection(
                                 harness=self.harness,
                                 installed=True,

--- a/src/codex_plugin_scanner/guard/runtime/surface_server.py
+++ b/src/codex_plugin_scanner/guard/runtime/surface_server.py
@@ -227,8 +227,9 @@ class GuardSurfaceRuntime:
         if self.store.get_guard_session(session_id) is None:
             raise ValueError(f"Unknown guard session: {session_id}")
         parsed_detection = _parse_detection(detection)
-        queued =             # TODO: pass redaction_level from GuardConfig when available
-queue_blocked_approvals(
+        # TODO: pass redaction_level from GuardConfig when available;
+        # for now, default to "full" so no raw command text is exposed
+        queued = queue_blocked_approvals(
             detection=parsed_detection,
             evaluation=evaluation,
             store=self.store,

--- a/src/codex_plugin_scanner/guard/runtime/surface_server.py
+++ b/src/codex_plugin_scanner/guard/runtime/surface_server.py
@@ -227,7 +227,8 @@ class GuardSurfaceRuntime:
         if self.store.get_guard_session(session_id) is None:
             raise ValueError(f"Unknown guard session: {session_id}")
         parsed_detection = _parse_detection(detection)
-        queued = queue_blocked_approvals(
+        queued =             # TODO: pass redaction_level from GuardConfig when available
+queue_blocked_approvals(
             detection=parsed_detection,
             evaluation=evaluation,
             store=self.store,

--- a/src/codex_plugin_scanner/guard/store_approvals.py
+++ b/src/codex_plugin_scanner/guard/store_approvals.py
@@ -183,6 +183,7 @@ def approval_schema_statement() -> str:
           fallback_cli_command text,
           scanner_evidence_json text not null default '[]',
           desktop_notified_at text,
+          raw_command_text text,
           review_command text not null,
           approval_url text not null,
           status text not null,
@@ -258,7 +259,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 transport = ?, risk_summary = ?, risk_signals_json = ?,
                 artifact_label = ?, source_label = ?, trigger_summary = ?, why_now = ?, launch_summary = ?,
                 risk_headline = ?, action_envelope_json = ?, decision_v2_json = ?, fallback_cli_command = ?,
-                scanner_evidence_json = ?, review_command = ?, approval_url = ?
+                scanner_evidence_json = ?, review_command = ?, approval_url = ?, raw_command_text = ?
             where request_id = ?
             """,
             (
@@ -297,6 +298,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
                 json.dumps(list(request.scanner_evidence), sort_keys=True),
                 review_command,
                 approval_url,
+                request.raw_command_text,
                 request_id,
             ),
         )
@@ -310,11 +312,13 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
           transport, risk_summary,
           risk_signals_json, artifact_label, source_label, trigger_summary, why_now, launch_summary, risk_headline,
           action_envelope_json, decision_v2_json, fallback_cli_command, scanner_evidence_json,
-          review_command, approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+          review_command, approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at,
+          raw_command_text
         )
         values (
           ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?
+          ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          ?
             )
         """,
         (
@@ -358,6 +362,7 @@ def add_approval_request(connection: sqlite3.Connection, request: GuardApprovalR
             None,
             now,
             None,
+            request.raw_command_text,
         ),
     )
     return request.request_id
@@ -435,7 +440,8 @@ def list_approval_requests(
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
                 launch_summary, risk_headline, action_envelope_json, decision_v2_json,
                 fallback_cli_command, scanner_evidence_json, review_command,
-                approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
+                approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at,
+                raw_command_text
         from approval_requests
         {where_clause}
         order by last_seen_at desc, request_id desc
@@ -462,6 +468,7 @@ def get_approval_request(connection: sqlite3.Connection, request_id: str) -> dic
                 risk_summary, risk_signals_json, artifact_label, source_label, trigger_summary, why_now,
                 launch_summary, risk_headline, action_envelope_json, decision_v2_json,
                 {_column_expr(columns, "fallback_cli_command", "NULL")},
+                {_column_expr(columns, "raw_command_text", "NULL")},
                 {_column_expr(columns, "scanner_evidence_json", "'[]'")}, review_command,
                 approval_url, status, resolution_action, resolution_scope, reason, created_at, resolved_at
         from approval_requests
@@ -576,6 +583,7 @@ def _row_to_payload(row: sqlite3.Row) -> dict[str, object]:
         "action_envelope_json": _optional_json_object(row["action_envelope_json"]),
         "decision_v2_json": _optional_json_object(row["decision_v2_json"]),
         "fallback_cli_command": row["fallback_cli_command"],
+        "raw_command_text": row["raw_command_text"],
         "scanner_evidence": _json_object_list(row["scanner_evidence_json"]),
         "review_command": str(row["review_command"]),
         "approval_url": str(row["approval_url"]),

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -507,6 +507,7 @@ class StoreConnectionSchemaMixin:
             self._ensure_approval_column(connection, "fallback_cli_command", "text")
             self._ensure_approval_column(connection, "scanner_evidence_json", "text not null default '[]'")
             self._ensure_approval_column(connection, "desktop_notified_at", "text")
+            self._ensure_approval_column(connection, "raw_command_text", "text")
             if not self._schema_version_applied(connection, version=3):
                 _backfill_approval_queue_columns_compat(connection)
                 self._record_schema_version(connection, version=3)


### PR DESCRIPTION
## Summary

Propagates `raw_command_text` through the full approval pipeline so the actual blocked command reaches the portal (not just the CLI approval command).

### Root Cause
The daemon captured `raw_command_text` in `artifact.metadata` and used it for dedup matching, but never passed it through to `GuardApprovalRequest`. The portal only saw `review_command` (the CLI approval command `"hol-guard approvals approve {id}"`), not the actual blocked command.

### Changes

**Model** (`models.py`):
- Added `raw_command_text: str | None = None` field to `GuardApprovalRequest`

**Approval pipeline** (`approvals.py`):
- Added `redaction_level: str = "full"` param to `queue_blocked_approvals`
- Extracts `raw_command_text` from `artifact.metadata['raw_command_text']` or `artifact.command`
- Applies `redact_text()` for secret-scrubbing
- Only includes when `redaction_level != "full"` (matching `_redacted_envelope_dict` semantics)

**Call sites updated** (pass `redaction_level=config.receipt_redaction_level`):
- `commands_hook_runtime_review.py` (2 sites)
- `commands_hook_copilot.py` (2 sites)
- `commands_support_hook_payload.py` (1 site)
- `runtime_mcp.py` (3 sites via `self.config`)
- `stdio.py` (1 site via `getattr(self.guard_config, ...)`)
- `protect_approvals.py` (1 site, loads config via `load_guard_config(guard_home)`)

**Remaining** (TODO comments added, no config access yet):
- `surface_server.py`
- `commands_support_runtime_resolution.py`

**Store** (`store_approvals.py`, `store_connection_schema.py`):
- Schema: added `raw_command_text text` column + migration
- INSERT: includes `raw_command_text`
- UPDATE: includes `raw_command_text` in SET
- SELECT (list + get): includes `raw_command_text`
- Row mapping: `_row_to_payload` reads `raw_command_text`

### Redaction Semantics
| Level | Behavior |
|---|---|
| `full` (default) | `raw_command_text` is null — never leaves daemon |
| `partial` | Secret-scrubbed command text included |
| `none` | Secret-scrubbed command text included (same as partial) |

Secret-scrubbing uses existing `redact_text()` which removes API keys, bearer tokens, GitHub tokens, AWS keys, and inline secret assignments.