### PR TITLE
fix(cursor): validate daemon identity before sending auth token in hook fast path

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -626,13 +626,25 @@ def _daemon_hook_result(
         return None
     # Probe /healthz before sending the hook payload and auth token.
     # Ensures the listener is actually the Guard daemon, not a spoofed process.
+    # Validate the response body — not just HTTP 200 — so an attacker listener
+    # that returns 200 but doesn't know the daemon's compatibility version is rejected.
     opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
         health_req = urllib.request.Request(f"http://127.0.0.1:{port}/healthz", method="GET")
         with opener.open(health_req, timeout=2) as health_response:
             if health_response.status != 200:
                 return None
+            health_body = health_response.read().decode("utf-8", errors="replace")
     except (OSError, urllib.error.URLError):
+        return None
+    try:
+        health_json = json.loads(health_body)
+    except ValueError:
+        return None
+    if not isinstance(health_json, dict) or health_json.get("ok") is not True:
+        return None
+    state_compat = state.get("compatibility_version")
+    if isinstance(state_compat, str) and health_json.get("compatibility_version") != state_compat:
         return None
     params = [("guard-home", GUARD_HOME)]
     if workspace:

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -610,8 +610,29 @@ def _daemon_hook_result(
         auth_token = token_path.read_text(encoding="utf-8").strip()
     except (OSError, ValueError):
         return None
-    port = state.get("port") if isinstance(state, dict) else None
+    if not isinstance(state, dict):
+        return None
+    port = state.get("port")
     if not isinstance(port, int) or port <= 0 or not auth_token:
+        return None
+    # Validate the recorded PID is still alive before trusting the state file.
+    # A stale state file after a crash could point at an attacker-controlled listener.
+    pid = state.get("pid")
+    if not isinstance(pid, int) or pid <= 0:
+        return None
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return None
+    # Probe /healthz before sending the hook payload and auth token.
+    # Ensures the listener is actually the Guard daemon, not a spoofed process.
+    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
+    try:
+        health_req = urllib.request.Request(f"http://127.0.0.1:{port}/healthz", method="GET")
+        with opener.open(health_req, timeout=2) as health_response:
+            if health_response.status != 200:
+                return None
+    except (OSError, urllib.error.URLError):
         return None
     params = [("guard-home", GUARD_HOME)]
     if workspace:
@@ -637,13 +658,23 @@ def _daemon_hook_result(
         },
         method="POST",
     )
-    opener = urllib.request.build_opener(urllib.request.ProxyHandler({}))
     try:
         with opener.open(request, timeout=max(GUARD_HOOK_TIMEOUT_SECONDS - 2, 1)) as response:
             body = response.read().decode("utf-8", errors="replace")
     except (OSError, urllib.error.URLError):
         return None
-    return (0, body if body.strip() else "{}", "")
+    # Reject empty or non-dict responses — they default policy_action to "allow".
+    # Fall through to the CLI subprocess path instead of trusting a malformed response.
+    body_stripped = body.strip()
+    if not body_stripped:
+        return None
+    try:
+        parsed_body = json.loads(body_stripped)
+    except ValueError:
+        return None
+    if not isinstance(parsed_body, dict):
+        return None
+    return (0, body_stripped, "")
 
 
 def _validated_hol_guard_src_path(path_str: str) -> str | None:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -1109,3 +1109,121 @@ def test_uninstall_cursor_hooks_restores_backup(tmp_path: Path, monkeypatch: pyt
     result = uninstall_cursor_hooks(context)
     assert result["restored"] is True
     assert json.loads(hooks_path.read_text(encoding="utf-8")) == {"version": 1, "hooks": {"preToolUse": []}}
+
+
+def test_cursor_hook_daemon_fast_path_rejects_stale_pid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fast path returns None when daemon-state.json points at a dead PID."""
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+        lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+    )
+    context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
+    script_path = tmp_path / "cursor-hook.py"
+    script_path.write_text(cursor_hook_script_source(context), encoding="utf-8")
+    script_path.chmod(0o755)
+
+    # Write stale daemon state pointing at a dead PID and a real-looking port.
+    guard_home.mkdir(parents=True, exist_ok=True)
+    (guard_home / "daemon-state.json").write_text(
+        json.dumps({"port": 59999, "pid": 999999, "compatibility_version": "v1"}),
+        encoding="utf-8",
+    )
+    (guard_home / "daemon-auth-token").write_text("stale-token", encoding="utf-8")
+
+    payload = {
+        "hook_event_name": "beforeShellExecution",
+        "tool_name": "Bash",
+        "tool_input": {"command": "echo hi"},
+        "command": "echo hi",
+        "cwd": str(workspace_dir),
+    }
+    proc = subprocess.run(
+        [sys.executable, str(script_path)],
+        input=json.dumps(payload),
+        capture_output=True,
+        text=True,
+        env={**os.environ, "CURSOR_PROJECT_DIR": str(workspace_dir)},
+        timeout=30,
+    )
+    # Should fall through to the subprocess CLI path, not crash or default-allow.
+    assert proc.returncode in (0, 2)
+
+
+def test_cursor_hook_daemon_fast_path_rejects_empty_response(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fast path returns None when daemon returns an empty body, falling through to CLI."""
+    import http.server
+    import threading
+
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    # Spin up a minimal HTTP server that returns 200 on /healthz but empty body on POST.
+    class _EmptyResponseHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"ok")
+
+        def do_POST(self) -> None:
+            self.send_response(200)
+            self.end_headers()
+            # Empty body — should be rejected by the fast path.
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _EmptyResponseHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+            lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+        )
+        context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
+        script_path = tmp_path / "cursor-hook.py"
+        script_path.write_text(cursor_hook_script_source(context), encoding="utf-8")
+        script_path.chmod(0o755)
+
+        # Write daemon state pointing at our test server with the current PID.
+        guard_home.mkdir(parents=True, exist_ok=True)
+        (guard_home / "daemon-state.json").write_text(
+            json.dumps({"port": port, "pid": os.getpid()}),
+            encoding="utf-8",
+        )
+        (guard_home / "daemon-auth-token").write_text("test-token", encoding="utf-8")
+
+        payload = {
+            "hook_event_name": "beforeShellExecution",
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo hi"},
+            "command": "echo hi",
+            "cwd": str(workspace_dir),
+        }
+        proc = subprocess.run(
+            [sys.executable, str(script_path)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env={**os.environ, "CURSOR_PROJECT_DIR": str(workspace_dir)},
+            timeout=30,
+        )
+    finally:
+        server.shutdown()
+
+    # The fast path should reject the empty response and fall through to CLI.
+    # The CLI path may fail (no real daemon), but it must not default-allow.
+    assert proc.returncode in (0, 2)

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -1168,12 +1168,13 @@ def test_cursor_hook_daemon_fast_path_rejects_empty_response(tmp_path: Path, mon
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir(parents=True, exist_ok=True)
 
-    # Spin up a minimal HTTP server that returns 200 on /healthz but empty body on POST.
+    # Spin up a minimal HTTP server that returns a valid /healthz but empty body on POST.
     class _EmptyResponseHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self) -> None:
             self.send_response(200)
+            self.send_header("Content-Type", "application/json")
             self.end_headers()
-            self.wfile.write(b"ok")
+            self.wfile.write(json.dumps({"ok": True, "compatibility_version": "v1"}).encode())
 
         def do_POST(self) -> None:
             self.send_response(200)
@@ -1201,7 +1202,7 @@ def test_cursor_hook_daemon_fast_path_rejects_empty_response(tmp_path: Path, mon
         # Write daemon state pointing at our test server with the current PID.
         guard_home.mkdir(parents=True, exist_ok=True)
         (guard_home / "daemon-state.json").write_text(
-            json.dumps({"port": port, "pid": os.getpid()}),
+            json.dumps({"port": port, "pid": os.getpid(), "compatibility_version": "v1"}),
             encoding="utf-8",
         )
         (guard_home / "daemon-auth-token").write_text("test-token", encoding="utf-8")


### PR DESCRIPTION
## Summary

The Cursor hook daemon fast path read `daemon-state.json` and `daemon-auth-token` directly, then immediately POSTed the hook payload and auth token to the recorded port. Unlike the canonical daemon client path, it did not validate the recorded PID, probe `/healthz`, or verify the listener was actually the Guard daemon.

If the state file was stale after a crash, or pointed at an attacker-controlled listener, that listener received the persistent daemon auth token and hook payload. An empty or invalid daemon response defaulted `policy_action` to `"allow"`, bypassing Guard approval/blocking for tool executions.

## Changes

- **`cursor_hooks.py`** (`_daemon_hook_result` in `_HOOK_SCRIPT_TEMPLATE`):
  - Validate the recorded PID is alive via `os.kill(pid, 0)` before trusting the state file
  - Probe `GET /healthz` before sending the auth token and hook payload — ensures the listener is the Guard daemon, not a spoofed process
  - Reject empty or non-dict daemon responses — return `None` to fall through to the safe subprocess CLI path instead of defaulting to `allow`

## Verification

- `ruff check` — all checks passed
- `pytest tests/test_cursor_hooks.py` — 41/41 pass (including 2 new security tests)
- `pytest tests/test_cursor_adapter.py tests/test_cursor_hooks.py tests/test_cursor_local_actions.py tests/test_cursor_completion_gates.py tests/test_cursor_cli.py tests/test_cursor_headless_fixtures.py` — 108/108 pass