### PR TITLE
fix: extract raw_command_text from metadata command_text fallback

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -270,6 +270,8 @@ def queue_blocked_approvals(
         if artifact is not None and redaction_level != "full":
             candidate = artifact.metadata.get("raw_command_text")
             if not isinstance(candidate, str) or not candidate.strip():
+                candidate = artifact.metadata.get("command_text")
+            if not isinstance(candidate, str) or not candidate.strip():
                 candidate = artifact.command if artifact.command is not None else None
             if isinstance(candidate, str) and candidate.strip():
                 scrubbed = redact_text(candidate.strip())

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -234,6 +234,28 @@ def _parsed_url_host(parsed: ParseResult) -> str:
     return host_port
 
 
+_GENERIC_TOOL_LABELS = frozenset(
+    {
+        "Bash",
+        "Shell",
+        "shell_command",
+        "Read",
+        "Write",
+        "Edit",
+        "MultiEdit",
+        "Glob",
+        "Grep",
+        "WebFetch",
+        "TodoWrite",
+    }
+)
+
+
+def _is_generic_tool_label(value: str) -> bool:
+    """Return True if the value is a generic tool name, not an actual command."""
+    return value in _GENERIC_TOOL_LABELS
+
+
 def queue_blocked_approvals(
     *,
     detection: HarnessDetection,
@@ -274,8 +296,10 @@ def queue_blocked_approvals(
             if not isinstance(candidate, str) or not candidate.strip():
                 candidate = artifact.command if artifact.command is not None else None
             if isinstance(candidate, str) and candidate.strip():
-                scrubbed = redact_text(candidate.strip())
-                raw_command_text = scrubbed.text
+                stripped = candidate.strip()
+                if not _is_generic_tool_label(stripped):
+                    scrubbed = redact_text(stripped)
+                    raw_command_text = scrubbed.text
         incident = build_incident_context(
             harness=detection.harness,
             artifact=artifact,

--- a/tests/test_raw_command_text.py
+++ b/tests/test_raw_command_text.py
@@ -305,4 +305,28 @@ class TestRawCommandTextPropagation:
         raw = queued[0]["raw_command_text"]
         assert raw is not None
         assert "grep" in raw
-        assert "password" in raw
+
+    def test_generic_tool_label_not_promoted_to_raw_command_text(self, tmp_path):
+        """Generic tool labels like 'Bash' or 'Read' should not become raw_command_text."""
+        store = GuardStore(tmp_path / "guard-home")
+        artifact = GuardArtifact(
+            artifact_id="codex:project:tool-output:generic",
+            name="Bash credential-looking output",
+            harness="codex",
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(tmp_path / "config.toml"),
+            command=None,
+            metadata={"command_text": "Bash"},
+        )
+        detection = _make_detection(artifact, tmp_path)
+        evaluation = _make_evaluation("codex:project:tool-output:generic", tmp_path)
+        queued = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1/pending",
+            redaction_level="none",
+        )
+        assert len(queued) == 1
+        assert queued[0]["raw_command_text"] is None

--- a/tests/test_raw_command_text.py
+++ b/tests/test_raw_command_text.py
@@ -277,3 +277,32 @@ class TestRawCommandTextPropagation:
         queued = response.get("approval_requests", [])
         assert len(queued) == 1
         assert queued[0]["raw_command_text"] is None
+
+    def test_raw_command_text_falls_back_to_metadata_command_text(self, tmp_path):
+        """tool_action_request artifacts store command as metadata['command_text'],
+        not metadata['raw_command_text']. The extraction should fall back to it."""
+        store = GuardStore(tmp_path / "guard-home")
+        artifact = GuardArtifact(
+            artifact_id="pi:project:tool-output:test",
+            name="grep credential-looking output",
+            harness="pi",
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(tmp_path / "config.toml"),
+            command=None,
+            metadata={"command_text": "grep -r 'password' ~/secrets"},
+        )
+        detection = _make_detection(artifact, tmp_path)
+        evaluation = _make_evaluation("pi:project:tool-output:test", tmp_path)
+        queued = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1/pending",
+            redaction_level="none",
+        )
+        assert len(queued) == 1
+        raw = queued[0]["raw_command_text"]
+        assert raw is not None
+        assert "grep" in raw
+        assert "password" in raw


### PR DESCRIPTION
## Summary
- `tool_action_request` artifacts (Pi/Codex tool output blocks) store command text as `metadata['command_text']`, not `metadata['raw_command_text']`
- The approval extraction only checked `raw_command_text` and `artifact.command`, so these approvals had `raw_command_text=None` even with redaction disabled
- Extends the fallback chain: `metadata['raw_command_text']` → `metadata['command_text']` → `artifact.command`

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_raw_command_text.py -v` — 8/8 pass
- New test `test_raw_command_text_falls_back_to_metadata_command_text` proves a `tool_action_request` artifact with `metadata['command_text']` produces `raw_command_text` in the queued approval
