### PR TITLE
fix: extract raw_command_text from action_envelope_json fallback

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -295,6 +295,16 @@ def queue_blocked_approvals(
                 candidate = artifact.metadata.get("command_text")
             if not isinstance(candidate, str) or not candidate.strip():
                 candidate = artifact.command if artifact.command is not None else None
+            if not isinstance(candidate, str) or not candidate.strip():
+                envelope_raw = item.get("action_envelope_json")
+                if isinstance(envelope_raw, str):
+                    try:
+                        import json as _json
+
+                        envelope = _json.loads(envelope_raw)
+                        candidate = envelope.get("command") if isinstance(envelope, dict) else None
+                    except (ValueError, TypeError):
+                        pass
             if isinstance(candidate, str) and candidate.strip():
                 stripped = candidate.strip()
                 if not _is_generic_tool_label(stripped):

--- a/tests/test_raw_command_text.py
+++ b/tests/test_raw_command_text.py
@@ -305,4 +305,28 @@ class TestRawCommandTextPropagation:
         raw = queued[0]["raw_command_text"]
         assert raw is not None
         assert "grep" in raw
-        assert "password" in raw
+
+    def test_generic_tool_label_not_promoted_to_raw_command_text(self, tmp_path):
+        """Generic tool labels like 'Bash' or 'Read' should not become raw_command_text."""
+        store = GuardStore(tmp_path / "guard-home")
+        artifact = GuardArtifact(
+            artifact_id="codex:project:tool-output:generic",
+            name="Bash credential-looking output",
+            harness="codex",
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(tmp_path / "config.toml"),
+            command=None,
+            metadata={"command_text": "Bash"},
+        )
+        detection = _make_detection(artifact, tmp_path)
+        evaluation = _make_evaluation("codex:project:tool-output:generic", tmp_path)
+        queued = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1/pending",
+            redaction_level="none",
+        )
+        assert len(queued) == 1
+        assert queued[0]["raw_command_text"] is None

--- a/tests/test_raw_command_text.py
+++ b/tests/test_raw_command_text.py
@@ -305,28 +305,4 @@ class TestRawCommandTextPropagation:
         raw = queued[0]["raw_command_text"]
         assert raw is not None
         assert "grep" in raw
-
-    def test_generic_tool_label_not_promoted_to_raw_command_text(self, tmp_path):
-        """Generic tool labels like 'Bash' or 'Read' should not become raw_command_text."""
-        store = GuardStore(tmp_path / "guard-home")
-        artifact = GuardArtifact(
-            artifact_id="codex:project:tool-output:generic",
-            name="Bash credential-looking output",
-            harness="codex",
-            artifact_type="tool_action_request",
-            source_scope="project",
-            config_path=str(tmp_path / "config.toml"),
-            command=None,
-            metadata={"command_text": "Bash"},
-        )
-        detection = _make_detection(artifact, tmp_path)
-        evaluation = _make_evaluation("codex:project:tool-output:generic", tmp_path)
-        queued = queue_blocked_approvals(
-            detection=detection,
-            evaluation=evaluation,
-            store=store,
-            approval_center_url="http://127.0.0.1/pending",
-            redaction_level="none",
-        )
-        assert len(queued) == 1
-        assert queued[0]["raw_command_text"] is None
+        assert "password" in raw

--- a/tests/test_raw_command_text.py
+++ b/tests/test_raw_command_text.py
@@ -330,3 +330,35 @@ class TestRawCommandTextPropagation:
         )
         assert len(queued) == 1
         assert queued[0]["raw_command_text"] is None
+
+    def test_raw_command_text_falls_back_to_action_envelope_command(self, tmp_path):
+        """PreToolUse shell command blocks store command in action_envelope_json,
+        not in artifact metadata. The extraction should parse it as final fallback."""
+        import json as _json
+        store = GuardStore(tmp_path / "guard-home")
+        artifact = GuardArtifact(
+            artifact_id="pi:project:pretool:test",
+            name="bash docker-sensitive command",
+            harness="pi",
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(tmp_path / "config.toml"),
+            command=None,
+            metadata={},
+        )
+        detection = _make_detection(artifact, tmp_path)
+        envelope = _json.dumps({"action_type": "shell_command", "command": "docker run --rm alpine cat /etc/passwd"})
+        evaluation = _make_evaluation("pi:project:pretool:test", tmp_path)
+        evaluation["artifacts"][0]["action_envelope_json"] = envelope
+        queued = queue_blocked_approvals(
+            detection=detection,
+            evaluation=evaluation,
+            store=store,
+            approval_center_url="http://127.0.0.1/pending",
+            redaction_level="none",
+        )
+        assert len(queued) == 1
+        raw = queued[0]["raw_command_text"]
+        assert raw is not None
+        assert "docker run" in raw
+        assert "alpine" in raw


### PR DESCRIPTION
## Summary
- PreToolUse shell command blocks (e.g. docker commands) store the command in `action_envelope_json`, not in `artifact.metadata` or `artifact.command`
- The extraction fallback chain now parses `action_envelope_json.command` as a final fallback
- Complete chain: `metadata['raw_command_text']` → `metadata['command_text']` → `artifact.command` → `action_envelope_json['command']`

## Testing
- `PYTHONPATH=src python3 -m pytest tests/test_raw_command_text.py -v` — 10/10 pass
- New test `test_raw_command_text_falls_back_to_action_envelope_command` proves a PreToolUse artifact with `action_envelope_json` containing the command produces `raw_command_text` in the queued approval
