### PR TITLE
fix(guard): refresh DPoP proof on timeout and rate-limit retries

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3088,6 +3088,8 @@ def _refresh_guard_sync_request(
 
     Reusing the same DPoP proof after a timeout triggers server-side replay
     detection because the original request may have already been consumed.
+    Preserves any server-provided DPoP nonce from the current request so
+    nonce-challenged endpoints do not lose their nonce state across retries.
     """
     request_context = _resolve_guard_dpop_retry_context(request)
     if request_context is None:
@@ -3096,6 +3098,7 @@ def _refresh_guard_sync_request(
     request_url = request_context.get("request_url")
     method = request_context.get("method")
     extra_headers = request_context.get("extra_headers")
+    current_dpop_nonce = request_context.get("dpop_nonce")
     if not isinstance(auth_context, dict) or not isinstance(request_url, str) or not isinstance(method, str):
         return None
     if extra_headers is not None and not isinstance(extra_headers, dict):
@@ -3106,7 +3109,7 @@ def _refresh_guard_sync_request(
         method=method,
         data=_request_data_bytes(request.data),
         extra_headers=None if extra_headers is None else {str(key): str(value) for key, value in extra_headers.items()},
-        dpop_nonce=None,
+        dpop_nonce=current_dpop_nonce if isinstance(current_dpop_nonce, str) else None,
     )
 
 
@@ -3237,8 +3240,9 @@ def _urlopen_json_with_timeout_retry(
                 time.sleep(min(retry_after, 120))
                 rate_limit_retry_count += 1
                 refreshed_request = _refresh_guard_sync_request(current_request)
-                if refreshed_request is not None:
-                    current_request = refreshed_request
+                if refreshed_request is None:
+                    raise
+                current_request = refreshed_request
                 current_timeout_seconds = timeout_seconds
                 retried_timeout = False
                 continue
@@ -3259,8 +3263,9 @@ def _urlopen_json_with_timeout_retry(
         except OSError as error:
             if not retried_timeout and _is_timeout_error(error):
                 refreshed_request = _refresh_guard_sync_request(current_request)
-                if refreshed_request is not None:
-                    current_request = refreshed_request
+                if refreshed_request is None:
+                    raise
+                current_request = refreshed_request
                 current_timeout_seconds = retry_timeout_seconds
                 retried_timeout = True
                 continue
@@ -3291,8 +3296,9 @@ def _urlopen_with_timeout_retry(
                 time.sleep(min(retry_after, 120))
                 rate_limit_retry_count += 1
                 refreshed_request = _refresh_guard_sync_request(current_request)
-                if refreshed_request is not None:
-                    current_request = refreshed_request
+                if refreshed_request is None:
+                    raise
+                current_request = refreshed_request
                 current_timeout_seconds = timeout_seconds
                 retried_timeout = False
                 continue
@@ -3313,8 +3319,9 @@ def _urlopen_with_timeout_retry(
         except OSError as error:
             if not retried_timeout and _is_timeout_error(error):
                 refreshed_request = _refresh_guard_sync_request(current_request)
-                if refreshed_request is not None:
-                    current_request = refreshed_request
+                if refreshed_request is None:
+                    raise
+                current_request = refreshed_request
                 current_timeout_seconds = retry_timeout_seconds
                 retried_timeout = True
                 continue

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3037,19 +3037,9 @@ def _guard_sync_request_with_nonce(
     request: urllib.request.Request,
     dpop_nonce: str,
 ) -> urllib.request.Request | None:
-    request_context = getattr(request, "_guard_dpop_retry_context", None)
-    if not isinstance(request_context, dict):
-        current_dpop = request.get_header("DPoP")
-        if not isinstance(current_dpop, str):
-            for header_name, header_value in request.header_items():
-                if header_name.lower() == "dpop":
-                    current_dpop = header_value
-                    break
-        if not isinstance(current_dpop, str):
-            return None
-        request_context = _GUARD_DPOP_REQUEST_CONTEXTS.get(current_dpop)
-        if not isinstance(request_context, dict):
-            return None
+    request_context = _resolve_guard_dpop_retry_context(request)
+    if request_context is None:
+        return None
     auth_context = request_context.get("auth_context")
     request_url = request_context.get("request_url")
     method = request_context.get("method")
@@ -3068,6 +3058,55 @@ def _guard_sync_request_with_nonce(
         data=_request_data_bytes(request.data),
         extra_headers=None if extra_headers is None else {str(key): str(value) for key, value in extra_headers.items()},
         dpop_nonce=dpop_nonce,
+    )
+
+
+def _resolve_guard_dpop_retry_context(
+    request: urllib.request.Request,
+) -> dict[str, object] | None:
+    request_context = getattr(request, "_guard_dpop_retry_context", None)
+    if isinstance(request_context, dict):
+        return request_context
+    current_dpop = request.get_header("DPoP")
+    if not isinstance(current_dpop, str):
+        for header_name, header_value in request.header_items():
+            if header_name.lower() == "dpop":
+                current_dpop = header_value
+                break
+    if not isinstance(current_dpop, str):
+        return None
+    request_context = _GUARD_DPOP_REQUEST_CONTEXTS.get(current_dpop)
+    if not isinstance(request_context, dict):
+        return None
+    return request_context
+
+
+def _refresh_guard_sync_request(
+    request: urllib.request.Request,
+) -> urllib.request.Request | None:
+    """Build a new request with a fresh DPoP proof for timeout retries.
+
+    Reusing the same DPoP proof after a timeout triggers server-side replay
+    detection because the original request may have already been consumed.
+    """
+    request_context = _resolve_guard_dpop_retry_context(request)
+    if request_context is None:
+        return None
+    auth_context = request_context.get("auth_context")
+    request_url = request_context.get("request_url")
+    method = request_context.get("method")
+    extra_headers = request_context.get("extra_headers")
+    if not isinstance(auth_context, dict) or not isinstance(request_url, str) or not isinstance(method, str):
+        return None
+    if extra_headers is not None and not isinstance(extra_headers, dict):
+        return None
+    return _guard_sync_request(
+        auth_context,
+        request_url=request_url,
+        method=method,
+        data=_request_data_bytes(request.data),
+        extra_headers=None if extra_headers is None else {str(key): str(value) for key, value in extra_headers.items()},
+        dpop_nonce=None,
     )
 
 
@@ -3197,6 +3236,9 @@ def _urlopen_json_with_timeout_retry(
                 retry_after = _parse_retry_after_header(error)
                 time.sleep(min(retry_after, 120))
                 rate_limit_retry_count += 1
+                refreshed_request = _refresh_guard_sync_request(current_request)
+                if refreshed_request is not None:
+                    current_request = refreshed_request
                 current_timeout_seconds = timeout_seconds
                 retried_timeout = False
                 continue
@@ -3216,6 +3258,9 @@ def _urlopen_json_with_timeout_retry(
             raise
         except OSError as error:
             if not retried_timeout and _is_timeout_error(error):
+                refreshed_request = _refresh_guard_sync_request(current_request)
+                if refreshed_request is not None:
+                    current_request = refreshed_request
                 current_timeout_seconds = retry_timeout_seconds
                 retried_timeout = True
                 continue
@@ -3245,6 +3290,9 @@ def _urlopen_with_timeout_retry(
                 retry_after = _parse_retry_after_header(error)
                 time.sleep(min(retry_after, 120))
                 rate_limit_retry_count += 1
+                refreshed_request = _refresh_guard_sync_request(current_request)
+                if refreshed_request is not None:
+                    current_request = refreshed_request
                 current_timeout_seconds = timeout_seconds
                 retried_timeout = False
                 continue
@@ -3264,6 +3312,9 @@ def _urlopen_with_timeout_retry(
             raise
         except OSError as error:
             if not retried_timeout and _is_timeout_error(error):
+                refreshed_request = _refresh_guard_sync_request(current_request)
+                if refreshed_request is not None:
+                    current_request = refreshed_request
                 current_timeout_seconds = retry_timeout_seconds
                 retried_timeout = True
                 continue


### PR DESCRIPTION
## Summary

- Fix DPoP replay detection on timeout and rate-limit retries in Guard Cloud sync
- When a sync request times out or gets 429, the retry reused the same DPoP proof (same `jti`), which the server rejected as `auth_dpop_replay_detected`
- This caused AIBOM inventory sync to fail when the payload exceeded the default 30s timeout

## Changes

- Extract `_resolve_guard_dpop_retry_context` helper from `_guard_sync_request_with_nonce` to reduce duplication
- Add `_refresh_guard_sync_request` that builds a new request with a fresh DPoP proof (new `jti`) for the same auth context, URL, method, and body
- Update both `_urlopen_json_with_timeout_retry` and `_urlopen_with_timeout_retry` to call `_refresh_guard_sync_request` on timeout retries and rate-limit (429) retries

## Root Cause

The AIBOM inventory sync sends a ~1.4MB payload to `/api/v1/guard/events`. This exceeds the default 30s read timeout, triggering a retry. The retry reused the same `urllib.request.Request` object, which contained the same DPoP JWT with the same `jti` claim. Since the server had already consumed the DPoP proof from the original (timed-out) request into its replay store, the retry was rejected with HTTP 401 `auth_dpop_replay_detected`.