### PR TITLE
chore(release): sync repository version to 2.0.913 [skip release publish]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.893"
+version = "2.0.913"
 description = "Protect local AI harnesses with HOL Guard and run scanner checks for Codex, Claude, Cursor, Gemini, OpenCode, and Pi."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.893"
+__version__ = "2.0.913"

--- a/uv.lock
+++ b/uv.lock
@@ -1162,7 +1162,7 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "2.0.893"
+version = "2.0.913"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner", marker = "python_full_version < '3.14'" },


### PR DESCRIPTION
## Summary
- sync repository version files to 2.0.913 after publish
- keep repo-visible version metadata aligned with the released package artifacts

## Testing
- `uv sync --frozen && uv run --no-sync python scripts/sync_repo_version.py --version "2.0.913"`
