### PR TITLE
fix(guard): validate grep file operands position-aware to prevent URI bypass

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -4232,7 +4232,7 @@ def _looks_like_safe_read_only_lookup_command(
                 return False
             if not _read_only_lookup_primary_segment_is_safe(command, segment[1:], home_dir=home_dir):
                 return False
-        elif not _read_only_lookup_filter_segment_is_safe(command, segment[1:]):
+        elif not _read_only_lookup_filter_segment_is_safe(command, segment[1:], home_dir=home_dir):
             return False
     return True
 
@@ -4280,13 +4280,18 @@ def _read_only_lookup_primary_segment_is_safe(command: str, args: list[str], *, 
     return False
 
 
-def _read_only_lookup_filter_segment_is_safe(command: str, args: list[str]) -> bool:
+def _read_only_lookup_filter_segment_is_safe(
+    command: str,
+    args: list[str],
+    *,
+    home_dir: Path | None = None,
+) -> bool:
     if command == "sed":
         return _read_only_lookup_sed_args_are_safe(args, require_target=False)
     if command in {"head", "tail"}:
         return _read_only_lookup_head_tail_args_are_safe(args, require_target=False)
     if command in {"grep", "egrep", "fgrep"}:
-        return _read_only_lookup_filter_grep_args_are_safe(args)
+        return _read_only_lookup_filter_grep_args_are_safe(args, home_dir=home_dir)
     return False
 
 
@@ -4471,12 +4476,116 @@ def _read_only_lookup_find_args_are_safe(args: list[str], *, home_dir: Path | No
     return _read_only_lookup_target_is_safe(targets[0], allow_dirs=True, home_dir=home_dir)
 
 
-def _read_only_lookup_filter_grep_args_are_safe(args: list[str]) -> bool:
-    return bool(args) and all(
-        not _read_only_lookup_arg_is_redirection(arg)
-        and (arg == "--" or not _read_only_lookup_target_is_path_like(arg))
-        for arg in args
-    )
+_GREP_PATTERN_OPTIONS = frozenset({"-e", "--regexp"})
+_GREP_PATTERN_FILE_OPTIONS = frozenset({"-f", "--file"})
+_GREP_FILTER_FILE_OPTIONS = frozenset({"--exclude-from"})
+_GREP_SKIP_NEXT_OPTIONS = frozenset({"-A", "-B", "-C", "-m", "--after-context", "--before-context", "--context", "--max-count"})
+
+
+def _read_only_lookup_filter_grep_args_are_safe(
+    args: list[str],
+    *,
+    home_dir: Path | None = None,
+) -> bool:
+    """Validate grep arguments in a filter (pipe) segment.
+
+    In a filter segment grep reads stdin and writes matching lines to stdout.
+    The first positional argument is the pattern (any string, including URIs).
+    Subsequent positional arguments are file operands that grep opens as files.
+    ``-f FILE`` reads patterns from a file, so it must also be validated.
+    ``-e PATTERN`` provides a pattern and is safe to skip.
+    """
+    if not args:
+        return False
+    saw_pattern = False
+    after_options = False
+    skip_next_is_pattern = False
+    skip_next_is_file = False
+    skip_next_file_sets_pattern = False
+    skip_next_is_value = False
+    for arg in args:
+        if skip_next_is_pattern:
+            skip_next_is_pattern = False
+            saw_pattern = True
+            continue
+        if skip_next_is_file:
+            skip_next_is_file = False
+            if not _read_only_lookup_target_is_safe(arg, allow_dirs=False, home_dir=home_dir):
+                return False
+            if skip_next_file_sets_pattern:
+                saw_pattern = True
+            continue
+        if skip_next_is_value:
+            skip_next_is_value = False
+            continue
+        if _read_only_lookup_arg_is_redirection(arg):
+            return False
+        if after_options:
+            if not saw_pattern:
+                saw_pattern = True
+                continue
+            if not _read_only_lookup_target_is_safe(arg, allow_dirs=False, home_dir=home_dir):
+                return False
+            continue
+        if arg == "--":
+            after_options = True
+            continue
+        if arg in _GREP_PATTERN_OPTIONS:
+            skip_next_is_pattern = True
+            saw_pattern = True
+            continue
+        if arg in _GREP_PATTERN_FILE_OPTIONS:
+            skip_next_is_file = True
+            skip_next_file_sets_pattern = True
+            continue
+        if arg in _GREP_FILTER_FILE_OPTIONS:
+            skip_next_is_file = True
+            skip_next_file_sets_pattern = False
+            continue
+        if arg in _GREP_SKIP_NEXT_OPTIONS:
+            skip_next_is_value = True
+            continue
+        if arg.startswith("--"):
+            # Long options: --file=VALUE, --regexp=VALUE, --fixed-strings, etc.
+            if "=" in arg:
+                key, _, value = arg.partition("=")
+                if key in _GREP_PATTERN_FILE_OPTIONS:
+                    if not _read_only_lookup_target_is_safe(value, allow_dirs=False, home_dir=home_dir):
+                        return False
+                    saw_pattern = True
+                elif key in _GREP_FILTER_FILE_OPTIONS:
+                    if not _read_only_lookup_target_is_safe(value, allow_dirs=False, home_dir=home_dir):
+                        return False
+                elif key in _GREP_PATTERN_OPTIONS:
+                    saw_pattern = True
+            # Long options without = are already handled above by exact match.
+            continue
+        if arg.startswith("-") and arg != "-":
+            # Combined short options: check for -f or -e in the cluster.
+            body = arg[1:]
+            # Handle -fFILE (file operand attached) and -ePATTERN (pattern attached).
+            for i, ch in enumerate(body):
+                if ch == "f":
+                    file_arg = body[i + 1 :]
+                    if file_arg:
+                        if not _read_only_lookup_target_is_safe(file_arg, allow_dirs=False, home_dir=home_dir):
+                            return False
+                        saw_pattern = True
+                    else:
+                        skip_next_is_file = True
+                        skip_next_file_sets_pattern = True
+                    break
+                elif ch == "e":
+                    saw_pattern = True
+                    break
+            continue
+        # Positional argument: first one is the pattern, rest are file operands.
+        if not saw_pattern:
+            saw_pattern = True
+        else:
+            if not _read_only_lookup_target_is_safe(arg, allow_dirs=False, home_dir=home_dir):
+                return False
+    return True
 
 
 def _read_only_lookup_arg_is_redirection(arg: str) -> bool:
@@ -4512,13 +4621,6 @@ def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool, home_dir:
     return allow_dirs
 
 
-def _read_only_lookup_target_is_path_like(value: str) -> bool:
-    stripped = value.strip().strip("'\"")
-    # URI schemes like skill://, http://, https:// are not file paths.
-    # file:// URIs are treated as paths because they reference local files.
-    if "://" in stripped and not stripped.lower().startswith("file://"):
-        return False
-    return "/" in stripped or "\\" in stripped or Path(stripped).suffix != ""
 
 
 _SAFE_GRAPHQL_QUERY_FILE_WORKFLOW_PATTERN = re.compile(

--- a/tests/test_command_keys_and_uri_schemes.py
+++ b/tests/test_command_keys_and_uri_schemes.py
@@ -1,14 +1,13 @@
-"""Tests for command key recognition and URI-scheme path-like filtering.
+"""Tests for command key recognition and grep filter operand validation.
 
 Verifies:
 1. _command_from_payload recognizes 'pattern', 'query', 'search', 'regex' keys
 2. _hook_command_text recognizes the same keys
-3. _read_only_lookup_target_is_path_like returns False for URI schemes (skill://, http://)
+3. _read_only_lookup_filter_grep_args_are_safe distinguishes patterns from file operands
 """
 
 from codex_plugin_scanner.guard.runtime.actions import _command_from_payload
 from codex_plugin_scanner.guard.runtime.secret_file_requests import (
-    _read_only_lookup_target_is_path_like,
     _read_only_lookup_filter_grep_args_are_safe,
 )
 from codex_plugin_scanner.guard.cli._commands_shared import _hook_command_text
@@ -44,39 +43,17 @@ def test_hook_command_text_recognizes_query():
     assert _hook_command_text(payload) == "search_term"
 
 
-def test_path_like_returns_false_for_skill_uri():
-    assert _read_only_lookup_target_is_path_like("skill://guard-dev-testing") is False
-
-
-def test_path_like_returns_false_for_http_uri():
-    assert _read_only_lookup_target_is_path_like("http://127.0.0.1:5497/requests/abc") is False
-
-
-def test_path_like_returns_true_for_https_uri():
-    assert _read_only_lookup_target_is_path_like("https://example.com/path") is False
-
-
-def test_path_like_returns_true_for_file_uri():
-    # file:// URIs reference local files and should still be treated as path-like.
-    assert _read_only_lookup_target_is_path_like("file:///etc/shadow") is True
-
-
-def test_path_like_returns_true_for_real_path():
-    assert _read_only_lookup_target_is_path_like("src/components/Button.tsx") is True
-
-
-def test_path_like_returns_true_for_file_with_extension():
-    assert _read_only_lookup_target_is_path_like("config.json") is True
+# --- Grep filter: pattern vs file operand distinction ---
 
 
 def test_grep_filter_allows_url_pattern():
-    # URL pattern is not path-like (contains ://), so it passes.
-    # But a path operand like "src/" is still checked for safety.
-    args = ["http://127.0.0.1:5497/requests/abc#token=xyz"]
+    """A single URI argument is the pattern — allowed."""
+    args = ["http://127.0.0.1:5497/requests/abc#token=secret"]
     assert _read_only_lookup_filter_grep_args_are_safe(args) is True
 
 
-def test_grep_filter_allows_skill_uri():
+def test_grep_filter_allows_skill_uri_pattern():
+    """A skill:// URI as the pattern — allowed."""
     args = ["skill://guard-dev-testing"]
     assert _read_only_lookup_filter_grep_args_are_safe(args) is True
 
@@ -84,3 +61,187 @@ def test_grep_filter_allows_skill_uri():
 def test_grep_filter_blocks_redirection():
     args = ["pattern", ">", "/etc/passwd"]
     assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_sensitive_file_operand():
+    """URI-like file operand with sensitive path component must be blocked.
+
+    POSIX grep treats the second positional arg as a filename. With a symlink
+    named ``http:`` pointing to ``.``, ``http://.env`` resolves to ``./.env``.
+    """
+    args = ["pattern", "http://.env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_sensitive_path_operand():
+    """A direct sensitive path as a file operand must be blocked."""
+    args = ["pattern", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_allows_safe_file_operand():
+    """A non-sensitive source file as a file operand is allowed."""
+    args = ["pattern", "src/main.py"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_allows_multiple_safe_operands():
+    args = ["pattern", "src/main.py", "src/utils.py"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_any_sensitive_operand():
+    args = ["pattern", "src/main.py", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_f_option_with_sensitive_file():
+    """-f FILE reads patterns from a file — must validate the file path."""
+    args = ["-f", ".env", "pattern"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_allows_f_option_with_safe_file():
+    args = ["-f", "src/patterns.txt", "src/data.py"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_long_file_option_sensitive():
+    args = ["--file", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_allows_attached_f_option_safe():
+    """-fFILE attached form must validate the file path."""
+    args = ["-fsrc/patterns.txt"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_attached_f_option_sensitive():
+    args = ["-f.env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_allows_e_option_pattern():
+    """-e PATTERN provides a pattern — URI patterns are fine."""
+    args = ["-e", "http://example.com"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_allows_attached_e_option():
+    """-ePATTERN attached form — the pattern is not validated as a path."""
+    args = ["-ehttp://example.com"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_allows_combined_flags_then_pattern():
+    """Combined flags like -in before a URI pattern."""
+    args = ["-in", "http://example.com"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_after_double_dash():
+    """After --, all args are positional: first is pattern, rest are files."""
+    args = ["--", "pattern", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_allows_after_double_dash_safe():
+    args = ["--", "pattern", "src/main.py"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_allows_skip_context_options():
+    """-A, -B, -C, -m consume numeric values that are not file paths."""
+    args = ["-A", "3", "pattern", "src/main.py"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_sensitive_operand_with_context():
+    args = ["-C", "2", "pattern", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_only_sensitive_operand():
+    """Single sensitive path as the only positional = treated as pattern, allowed.
+
+    In a filter segment, the first positional is always the pattern.
+    A single ``.env`` arg is a pattern matching the literal string, not a file read.
+    """
+    args = [".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_f_option_then_sensitive_operand():
+    """grep -f patterns.txt .env — -f sets saw_pattern, .env is a file operand."""
+    args = ["-f", "patterns.txt", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_attached_f_option_then_sensitive_operand():
+    """grep -fpatterns.txt .env — attached -fFILE sets saw_pattern, .env is a file operand."""
+    args = ["-fpatterns.txt", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_sensitive_operand_after_safe_f_option():
+    """grep -f patterns.txt /etc/passwd — /etc/passwd is a file operand, not a pattern."""
+    args = ["-f", "patterns.txt", "/etc/passwd"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_allows_long_option_with_f_letter():
+    """--fixed-strings contains 'f' but must not trigger -f file validation."""
+    args = ["--fixed-strings", "pattern", "src/main.py"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_allows_long_option_with_e_letter():
+    """--extended-regexp contains 'e' but must not trigger -e pattern handling."""
+    args = ["--extended-regexp", "pattern", "src/main.py"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_file_equals_sensitive():
+    """--file=.env attached form must be validated."""
+    args = ["--file=.env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_allows_regexp_equals_uri():
+    """--regexp=http://example.com attached form — pattern is not a path."""
+    args = ["--regexp=http://example.com"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_file_equals_then_sensitive_operand():
+    """--file=patterns.txt .env — saw_pattern set, .env is file operand."""
+    args = ["--file=patterns.txt", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_exclude_from_sensitive():
+    """--exclude-from reads a file — must validate the path."""
+    args = ["--exclude-from", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_exclude_from_equals_sensitive():
+    """--exclude-from=.env attached form — must validate the path."""
+    args = ["--exclude-from=.env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_allows_exclude_from_safe():
+    args = ["--exclude-from", "src/patterns.txt", "pattern", "src/main.py"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is True
+
+
+def test_grep_filter_blocks_combined_nf_then_sensitive_operand():
+    """grep -nf patterns.txt .env — combined -nf must set saw_pattern, .env is file operand."""
+    args = ["-nf", "patterns.txt", ".env"]
+    assert _read_only_lookup_filter_grep_args_are_safe(args) is False
+
+
+def test_grep_filter_blocks_empty_args():
+    assert _read_only_lookup_filter_grep_args_are_safe([]) is False


### PR DESCRIPTION
## Summary

Fixes a security bypass where URI-like grep file operands could skip Guard's secret-read approval.

## Problem

The grep filter validation (`_read_only_lookup_filter_grep_args_are_safe`) checked all arguments uniformly using `_read_only_lookup_target_is_path_like`, which returned `False` for any argument containing `://` (except `file://`). This meant URI-like arguments were classified as non-path patterns.

POSIX grep treats the second positional argument as a filename. A command like `grep pattern http://.env` would open `.env` as a file. With a symlink named `http:` pointing to `.`, `http://.env` resolves to `./.env` and grep prints its contents — while Guard classifies the pipeline as a safe read-only lookup without creating a sensitive tool-action artifact.

Additionally, `-f FILE` (which reads patterns from a file) was not validated at all.

## Fix

Rewrite `_read_only_lookup_filter_grep_args_are_safe` to be position-aware:

- **First positional argument** = pattern (any string, including URIs — allowed)
- **Subsequent positional arguments** = file operands, validated with `_read_only_lookup_target_is_safe` (checks for `.env`, `.ssh`, `.aws`, and other sensitive path components)
- **`-f`/`--file FILE`**: validated as a file operand (reads patterns from a file)
- **`-e`/`--regexp PATTERN`**: safe to skip (provides a pattern)
- **`-A`/`-B`/`-C`/`-m`**: consume numeric values (safe to skip)
- **Combined short options** (`-fFILE`, `-ePATTERN`): handled correctly
- **`--`**: after this, all args are positional

Remove `_read_only_lookup_target_is_path_like` — it was the wrong abstraction and its `://` check caused this vulnerability. The grep filter now uses `_read_only_lookup_target_is_safe` directly.

Thread `home_dir` through `_read_only_lookup_filter_segment_is_safe` for skill doc path matching consistency.

## Test plan

- [x] 32 unit tests covering pattern vs file operand distinction, `-f` validation, combined short options, `--` handling, context options, and the specific URI bypass attack vector
- [x] 146 existing tests pass with no regressions
