### PR TITLE
feat(guard): enable trust attestation v2 by default with persistent key

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -111,7 +111,7 @@ def _resolve_trust_attestation_context(
     oauth_credentials = store.get_oauth_local_credentials(allow_primary=True)
     signing_config = resolve_guard_oauth_trust_attestation_signing_config(oauth_credentials)
     if signing_config is None:
-        signing_config = resolve_trust_attestation_signing_config()
+        signing_config = resolve_trust_attestation_signing_config(guard_home=store.guard_home)
     enable_v2 = trust_attestation_v2_enabled()
     installation_id = store.get_or_create_installation_id() if enable_v2 else None
     context: dict[str, object] = {

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -111,7 +111,9 @@ def _resolve_trust_attestation_context(
     oauth_credentials = store.get_oauth_local_credentials(allow_primary=True)
     signing_config = resolve_guard_oauth_trust_attestation_signing_config(oauth_credentials)
     if signing_config is None:
-        signing_config = resolve_trust_attestation_signing_config(guard_home=store.guard_home)
+        # Only auto-generate persistent key during sync (not read-only status/export/inventory)
+        guard_home = store.guard_home if include_upload_session_bindings else None
+        signing_config = resolve_trust_attestation_signing_config(guard_home=guard_home)
     enable_v2 = trust_attestation_v2_enabled()
     installation_id = store.get_or_create_installation_id() if enable_v2 else None
     context: dict[str, object] = {

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -170,9 +170,22 @@ def _resolve_persistent_trust_attestation_signing_config(
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(private_key_pem)
         except FileExistsError:
-            # Another process created the file; read its key
-            private_key_pem = key_path.read_text(encoding="utf-8").strip()
-            private_key = _load_private_key(private_key_pem)
+            # Another process created the file, or the file was corrupt and
+            # already existed. Read its key; if it fails, remove and retry.
+            try:
+                private_key_pem = key_path.read_text(encoding="utf-8").strip()
+                private_key = _load_private_key(private_key_pem)
+            except Exception:
+                key_path.unlink(missing_ok=True)
+                private_key = ec.generate_private_key(ec.SECP256R1())
+                private_key_pem = private_key.private_bytes(
+                    encoding=serialization.Encoding.PEM,
+                    format=serialization.PrivateFormat.PKCS8,
+                    encryption_algorithm=serialization.NoEncryption(),
+                ).decode("utf-8")
+                fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+                with os.fdopen(fd, "w", encoding="utf-8") as f:
+                    f.write(private_key_pem)
         except Exception:
             return None
     public_key_pem = (

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -151,9 +151,13 @@ def _resolve_persistent_trust_attestation_signing_config(
     try:
         private_key_pem = key_path.read_text(encoding="utf-8").strip()
         if not private_key_pem:
-            raise ValueError("Empty key file")
+            raise ValueError("Empty trust attestation key file")
         private_key = _load_private_key(private_key_pem)
     except Exception:
+        # Key file is missing, empty, or corrupted. Generate a new key
+        # using atomic exclusive creation to avoid race conditions between
+        # concurrent Guard processes. If another process already created
+        # the file, read its key instead.
         try:
             private_key = ec.generate_private_key(ec.SECP256R1())
             private_key_pem = private_key.private_bytes(
@@ -162,9 +166,13 @@ def _resolve_persistent_trust_attestation_signing_config(
                 encryption_algorithm=serialization.NoEncryption(),
             ).decode("utf-8")
             key_path.parent.mkdir(parents=True, exist_ok=True)
-            fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
             with os.fdopen(fd, "w", encoding="utf-8") as f:
                 f.write(private_key_pem)
+        except FileExistsError:
+            # Another process created the file; read its key
+            private_key_pem = key_path.read_text(encoding="utf-8").strip()
+            private_key = _load_private_key(private_key_pem)
         except Exception:
             return None
     public_key_pem = (

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Mapping
 from dataclasses import dataclass
 from functools import lru_cache
+from pathlib import Path
 
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives import hashes, serialization
@@ -20,6 +21,9 @@ GUARD_TRUST_ATTESTATION_PAYLOAD_VERSION_V2 = "guard-aibom-trust-attestation.v2"
 GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
 GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256 = "ecdsa-p256-sha256"
 _TRUTHY_ENV_VALUES = frozenset({"1", "true", "yes", "on"})
+_FALSY_ENV_VALUES = frozenset({"0", "false", "no", "off"})
+_DEFAULT_TRUST_ATTESTATION_KEY_FILE = "trust_attestation_key.pem"
+_DEFAULT_TRUST_ATTESTATION_KEY_ID = "guard-aibom-trust-key-local"
 
 
 @dataclass(frozen=True, slots=True)
@@ -48,13 +52,28 @@ def payload_hash_for_trust_attestation(payload: Mapping[str, object]) -> str:
 
 def resolve_trust_attestation_signing_config(
     environ: Mapping[str, str] | None = None,
+    *,
+    guard_home: Path | None = None,
 ) -> GuardTrustAttestationSigningConfig | None:
+    """Resolve the trust attestation signing configuration.
+
+    Priority (highest wins):
+    1. ``GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY`` env var (explicit override)
+    2. ``GUARD_AIBOM_TRUST_ATTESTATION_HEADLESS_SHORT_LIVED=1`` env var (ephemeral key per process)
+    3. Persistent auto-generated key in ``guard_home`` (default for new users)
+    4. ``None`` (attestation disabled)
+    """
     env = environ or os.environ
-    active_key_id = _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID")) or "guard-aibom-trust-key-default"
+    active_key_id = _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID")) or _DEFAULT_TRUST_ATTESTATION_KEY_ID
     private_key_pem = _normalize_pem(_sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY")))
     if not private_key_pem:
         if _headless_short_lived_attestation_enabled(env):
             return _resolve_headless_short_lived_trust_attestation_signing_config(active_key_id=active_key_id)
+        if guard_home is not None:
+            return _resolve_persistent_trust_attestation_signing_config(
+                active_key_id=active_key_id,
+                guard_home=guard_home,
+            )
         return None
     return GuardTrustAttestationSigningConfig(
         active_key_id=active_key_id,
@@ -102,16 +121,69 @@ def resolve_guard_oauth_trust_attestation_signing_config(
         public_jwk_thumbprint=public_jwk_thumbprint,
         signature_algorithm=GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
     )
-
-
 def trust_attestation_v2_enabled(environ: Mapping[str, str] | None = None) -> bool:
+    """Trust attestation v2 is enabled by default. Set GUARD_AIBOM_TRUST_ATTESTATION_V2=0 to opt out."""
     env = environ or os.environ
-    return _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_V2")).lower() in _TRUTHY_ENV_VALUES
+    raw = _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_V2")).lower()
+    if raw in _FALSY_ENV_VALUES:
+        return False
+    return True
 
 
 def _headless_short_lived_attestation_enabled(environ: Mapping[str, str]) -> bool:
     raw = environ.get("GUARD_AIBOM_TRUST_ATTESTATION_HEADLESS_SHORT_LIVED")
     return _sanitize_env(raw).lower() in _TRUTHY_ENV_VALUES
+
+
+def _resolve_persistent_trust_attestation_signing_config(
+    *,
+    active_key_id: str,
+    guard_home: Path,
+) -> GuardTrustAttestationSigningConfig | None:
+    """Load or auto-generate a persistent EC P-256 key stored in guard_home.
+
+    The key is written to ``guard_home / trust_attestation_key.pem`` with 0600
+    permissions. On subsequent runs the same key is loaded, ensuring the server
+    registers the same device key across restarts. Returns ``None`` if the key
+    file cannot be created or read.
+    """
+    key_path = guard_home / _DEFAULT_TRUST_ATTESTATION_KEY_FILE
+    try:
+        private_key_pem = key_path.read_text(encoding="utf-8").strip()
+        if not private_key_pem:
+            return None
+        private_key = _load_private_key(private_key_pem)
+    except (OSError, ValueError):
+        try:
+            private_key = ec.generate_private_key(ec.SECP256R1())
+            private_key_pem = private_key.private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            ).decode("utf-8")
+            key_path.parent.mkdir(parents=True, exist_ok=True)
+            key_path.write_text(private_key_pem, encoding="utf-8")
+            try:
+                key_path.chmod(0o600)
+            except OSError:
+                pass
+        except (OSError, ValueError):
+            return None
+    public_key_pem = (
+        private_key.public_key()
+        .public_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        )
+        .decode("utf-8")
+        .strip()
+    )
+    return GuardTrustAttestationSigningConfig(
+        active_key_id=active_key_id,
+        private_key_pem=_normalize_pem(private_key_pem),
+        public_jwk_thumbprint=_public_key_fingerprint(public_key_pem),
+        signature_algorithm=GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
+    )
 
 
 @lru_cache(maxsize=4)

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -151,9 +151,9 @@ def _resolve_persistent_trust_attestation_signing_config(
     try:
         private_key_pem = key_path.read_text(encoding="utf-8").strip()
         if not private_key_pem:
-            return None
+            raise ValueError("Empty key file")
         private_key = _load_private_key(private_key_pem)
-    except (OSError, ValueError):
+    except Exception:
         try:
             private_key = ec.generate_private_key(ec.SECP256R1())
             private_key_pem = private_key.private_bytes(
@@ -162,12 +162,10 @@ def _resolve_persistent_trust_attestation_signing_config(
                 encryption_algorithm=serialization.NoEncryption(),
             ).decode("utf-8")
             key_path.parent.mkdir(parents=True, exist_ok=True)
-            key_path.write_text(private_key_pem, encoding="utf-8")
-            try:
-                key_path.chmod(0o600)
-            except OSError:
-                pass
-        except (OSError, ValueError):
+            fd = os.open(key_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+            with os.fdopen(fd, "w", encoding="utf-8") as f:
+                f.write(private_key_pem)
+        except Exception:
             return None
     public_key_pem = (
         private_key.public_key()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,17 @@ def _reset_guard_sync_resolver_override(monkeypatch: pytest.MonkeyPatch) -> None
     guard_runner_module._test_sync_auth_context_override = None
 
 
+@pytest.fixture(autouse=True)
+def _isolate_trust_attestation_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Clear trust attestation env vars so tests don't inherit the developer's shell config."""
+    for key in (
+        "GUARD_AIBOM_TRUST_ATTESTATION_V2",
+        "GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY",
+        "GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID",
+        "GUARD_AIBOM_TRUST_ATTESTATION_HEADLESS_SHORT_LIVED",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
 class _FakeSystemKeyringModule:
     def __init__(self) -> None:
         self._secrets: dict[tuple[str, str], str] = {}

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -56,7 +56,10 @@ def _seed_inventory(store: GuardStore, artifact: GuardArtifact, *, now: str) -> 
     )
 
 
-def test_aibom_status_json_includes_layer_and_trust_summary(tmp_path: Path, capsys) -> None:
+def test_aibom_status_json_includes_layer_and_trust_summary(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID", raising=False)
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_codex_fixture(home_dir, workspace_dir)
@@ -100,7 +103,10 @@ def test_aibom_status_json_includes_layer_and_trust_summary(tmp_path: Path, caps
     assert output["status"] in {"not_connected", "workspace_required", "sync_required", "synced"}
 
 
-def test_inventory_json_includes_aibom_metadata_extensions(tmp_path: Path, capsys) -> None:
+def test_inventory_json_includes_aibom_metadata_extensions(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID", raising=False)
     workspace = tmp_path / "repo"
     shared = workspace / "shared-root"
     shared.mkdir(parents=True)
@@ -317,6 +323,7 @@ def test_resolve_trust_attestation_context_defaults_to_v1(monkeypatch: pytest.Mo
     monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
     monkeypatch.setattr(store, "get_or_create_installation_id", lambda: "device-1")
     monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", raising=False)
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
 
     context = aibom_cli._resolve_trust_attestation_context(
         store,
@@ -410,6 +417,76 @@ def test_resolve_trust_attestation_context_tolerates_invalid_generated_at_for_sy
 
     assert context["expiresAt"] is None
     assert context["sequence"] == 1
+
+
+def test_trust_attestation_v2_enabled_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    from codex_plugin_scanner.guard.runtime.trust_attestation import trust_attestation_v2_enabled
+
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", raising=False)
+    assert trust_attestation_v2_enabled() is True
+
+
+def test_trust_attestation_v2_can_be_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    from codex_plugin_scanner.guard.runtime.trust_attestation import trust_attestation_v2_enabled
+
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
+    assert trust_attestation_v2_enabled() is False
+
+
+def test_resolve_trust_attestation_context_auto_generates_persistent_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from codex_plugin_scanner.guard.runtime.trust_attestation import (
+        resolve_trust_attestation_signing_config,
+    )
+
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir(parents=True, exist_ok=True)
+    key_path = guard_home / "trust_attestation_key.pem"
+    assert not key_path.exists()
+
+    config = resolve_trust_attestation_signing_config(guard_home=guard_home)
+    assert config is not None
+    assert key_path.exists()
+    assert config.signature_algorithm == "ecdsa-p256-sha256"
+
+    # Second call loads the same key
+    config2 = resolve_trust_attestation_signing_config(guard_home=guard_home)
+    assert config2 is not None
+    assert config2.private_key_pem == config.private_key_pem
+
+
+def test_env_private_key_overrides_persistent_key(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+
+    from codex_plugin_scanner.guard.runtime.trust_attestation import (
+        resolve_trust_attestation_signing_config,
+    )
+
+    guard_home = tmp_path / "guard"
+    guard_home.mkdir(parents=True, exist_ok=True)
+
+    # Generate a separate key for env var
+    env_key = ec.generate_private_key(ec.SECP256R1())
+    env_key_pem = env_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", env_key_pem)
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID", "env-key-1")
+
+    config = resolve_trust_attestation_signing_config(guard_home=guard_home)
+    assert config is not None
+    assert config.active_key_id == "env-key-1"
+    assert config.private_key_pem == env_key_pem.strip()
+    # Persistent key file should NOT be created when env var is set
+    assert not (guard_home / "trust_attestation_key.pem").exists()
 
 
 def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(
@@ -572,6 +649,7 @@ def test_sync_aibom_snapshots_uses_cloud_sync_cisco_defaults(tmp_path: Path, mon
         return ()
 
     monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", fake_collect_aibom_snapshots)
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
 
     summary = sync_aibom_snapshots(
         store,
@@ -687,7 +765,10 @@ def test_guard_aibom_sync_command_uses_cloud_sync_cisco_defaults(
     assert options.follow_unsafe_symlinks is False
 
 
-def test_aibom_export_json_includes_redaction_report(tmp_path: Path, capsys) -> None:
+def test_aibom_export_json_includes_redaction_report(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", raising=False)
+    monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID", raising=False)
     home_dir = tmp_path / "home"
     workspace_dir = tmp_path / "workspace"
     _build_codex_fixture(home_dir, workspace_dir)


### PR DESCRIPTION
## Summary
- Trust attestation v2 is now enabled by default for all users
- New users get zero-config attestation: a persistent EC P-256 key is auto-generated in `guard_home` on first sync and reused across restarts
- `GUARD_AIBOM_TRUST_ATTESTATION_V2=0` explicitly opts out

## Migration path
- **Users with `GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY` env var**: no change, env var takes priority
- **Users with `HEADLESS_SHORT_LIVED=1`**: no change, ephemeral key takes priority
- **Users without any attestation config**: persistent key auto-generated on next sync
- **Users who want to opt out**: set `GUARD_AIBOM_TRUST_ATTESTATION_V2=0`

## Key resolution priority
1. `GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY` env var (explicit override)
2. `GUARD_AIBOM_TRUST_ATTESTATION_HEADLESS_SHORT_LIVED=1` env var (ephemeral key per process)
3. Persistent auto-generated key in `guard_home/trust_attestation_key.pem` (new default)

## Testing
- `python3 -m pytest tests/test_guard_aibom_cli.py tests/test_guard_aibom_trust_metadata.py -q` (41 passed)
- `python3 -c "import ast; ast.parse(open('src/codex_plugin_scanner/guard/runtime/trust_attestation.py').read())"` (syntax OK)