### PR TITLE
fix(guard): resolve 34 ruff lint errors blocking CI

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi_extension_source.py
@@ -103,8 +103,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "      return;\n"
         "    }\n"
         "    const record = val as Record<string, unknown>;\n"
-        "    // Match collectOutputText: only extract text from {type: \"text\", text: ...}\n"
-        "    // objects, not from metadata keys like \"type\".\n"
+        '    // Match collectOutputText: only extract text from {type: "text", text: ...}\n'
+        '    // objects, not from metadata keys like "type".\n'
         "    if (record.type === 'text' && typeof record.text === 'string') {\n"
         "      update(record.text);\n"
         "      return;\n"
@@ -144,7 +144,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "  event: Record<string, unknown>,\n"
         "  toolInput: Record<string, unknown>,\n"
         "  digest: OutputDigest,\n"
-        "): { version: number; kind: string; path: string; tool_input_path: string; output_sha256: string; output_chars: number } | null {\n"
+        "): { version: number; kind: string; path: string; tool_input_path: string;"
+        " output_sha256: string; output_chars: number } | null {\n"
         "  const toolName = typeof event.toolName === 'string' ? event.toolName : '';\n"
         "  if (!GUARD_SOURCE_REF_ALLOWED_TOOL_NAMES.has(toolName)) return null;\n"
         "  if (!digest.sha256 || digest.traversalTruncated) return null;\n"
@@ -596,7 +597,8 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "    const digest = digestOutputText(event.content);\n"
         "    const boundedContent = boundValue(event.content);\n"
         "    const boundedStdout = boundedOutputText(event.content);\n"
-        "    const outputTruncated = boundedContent.truncated || boundedStdout.truncated || digest.excerptTruncated || digest.traversalTruncated;\n"
+        "    const outputTruncated = boundedContent.truncated || boundedStdout.truncated"
+        " || digest.excerptTruncated || digest.traversalTruncated;\n"
         "    const toolOutput = digest.textForExcerpt || (boundedStdout.value as string);\n"
         "    const reviewedContent = outputTruncated ? [{ type: 'text', text: toolOutput }] : boundedContent.value;\n"
         "    const sourceRef = sourceFileRefForPostToolUse(event as Record<string, unknown>, toolInput, digest);\n"
@@ -639,8 +641,10 @@ def managed_extension_source(*, guard_home: Path, home_dir: Path, settings_path:
         "        return undefined;\n"
         "      }\n"
         "      const notice = response.reason ||\n"
-        '        "HOL Guard returned a reviewed excerpt because this output could not be fully proven safe within local limits.";\n'
-        '      if (response.notice === "excerpt" || response.model_output_action === "replace_with_reviewed_excerpt") {\n'
+        '        "HOL Guard returned a reviewed excerpt because this output could not be fully proven safe'
+        ' within local limits.";\n'
+        '      if (response.notice === "excerpt"'
+        ' || response.model_output_action === "replace_with_reviewed_excerpt") {\n'
         '        ctx.ui.notify(notice, "info");\n'
         "      }\n"
         "      return reviewedToolResult(reviewedContent, event.details, event.isError === true);\n"

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -442,7 +442,7 @@ def sync_aibom_snapshots(
     synced_at = generated_at
     batches_sent = 0
     for batch_start in range(0, len(events), _AIBOM_SYNC_BATCH_SIZE):
-        batch = events[batch_start:batch_start + _AIBOM_SYNC_BATCH_SIZE]
+        batch = events[batch_start : batch_start + _AIBOM_SYNC_BATCH_SIZE]
         body = json.dumps({"events": batch}).encode("utf-8")
         request = runner._guard_sync_request(
             resolved_auth_context,
@@ -516,7 +516,7 @@ def sync_aibom_snapshots(
             }
             store.set_sync_payload("aibom_sync_summary", failure_summary, synced_at)
             raise RuntimeError("Guard Cloud AIBOM sync failed due to a network error.") from error
-        batches_sent += 1
+        batches_sent += 1  # noqa: SIM113
         batch_accepted = payload.get("accepted")
         if isinstance(batch_accepted, int):
             total_accepted += batch_accepted

--- a/src/codex_plugin_scanner/guard/cli/commands_hook.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from ..runtime.hook_review_types import HookOutputSummary, HookSourceFileRef
     from ._commands_shared import _now, _require_guard_config, _require_guard_context, _require_guard_store
     from .commands_support_claude_approval import _persist_claude_guard_question_decision
     from .commands_support_hook_payload import _hook_action_envelope, _load_hook_payload, _normalize_hook_payload
@@ -279,6 +280,7 @@ def _run_guard_hook_command(
         store=store,
     )
 
+
 def _try_source_ref_fast_path(
     args: argparse.Namespace,
     *,
@@ -304,11 +306,12 @@ def _try_source_ref_fast_path(
     if os.environ.get("HOL_GUARD_HOOK_SOURCE_REF", "1") != "1":
         return None
 
+    from collections.abc import Mapping
+
     from ..runtime.hook_content_scanner import ContentScanner
     from ..runtime.hook_decision_cache import HookDecisionCache
     from ..runtime.hook_review_engine import HookReviewEngine
-    from ..runtime.hook_review_types import HookReviewRequest, HookSourceFileRef, HookOutputSummary
-    from collections.abc import Mapping
+    from ..runtime.hook_review_types import HookReviewRequest
 
     source_ref_raw = payload.get("guard_source_ref")
     if not isinstance(source_ref_raw, Mapping):
@@ -319,7 +322,7 @@ def _try_source_ref_fast_path(
 
     request = HookReviewRequest(
         harness=args.harness,
-        event_name=_hook_event_name(payload),
+        event_name=_hook_event_name(payload) or "PreToolUse",
         payload=payload,
         payload_kind="source_file_ref",
         config_path=None,
@@ -380,6 +383,7 @@ def _parse_output_summary(summary_raw: object) -> HookOutputSummary | None:
     from collections.abc import Mapping as _Mapping
 
     from ..runtime.hook_review_types import HookOutputSummary
+
     if not isinstance(summary_raw, _Mapping):
         return None
     text_excerpt = summary_raw.get("text_excerpt") or summary_raw.get("excerpt") or ""

--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_paths.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_paths.py
@@ -8,15 +8,11 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from .commands_support_codex_commands import (
-        _CODEX_BENIGN_SOURCE_DOTFILES,
         _CODEX_SEARCH_OPTION_VALUE_FLAGS,
         _CODEX_SEARCH_OPTION_VALUE_FLAGS_BY_EXECUTABLE,
         _CODEX_SEARCH_PATTERN_VALUE_FLAGS,
         _CODEX_SEARCH_UNSAFE_FLAGS,
         _CODEX_SEARCH_UNSAFE_SHORT_FLAGS_BY_EXECUTABLE,
-        _CODEX_SENSITIVE_SEARCH_BASENAMES,
-        _CODEX_SOURCE_SEARCH_EXTENSIONS,
-        _CODEX_SOURCE_SEARCH_PREFIXES,
     )
     from .commands_support_codex_reads import _codex_sed_args_are_bounded_filter
     from .commands_support_runtime_artifacts import (

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -71,6 +71,7 @@ def hook_fast_path_shadow_enabled() -> bool:
 
     return os.environ.get(HOOK_FAST_PATH_SHADOW_ENV, "0") == "1"
 
+
 VALID_GUARD_ACTIONS = {"allow", "warn", "review", "block", "sandbox-required", "require-reapproval"}
 VALID_GUARD_MODES = {"observe", "prompt", "enforce"}
 VALID_SECURITY_LEVELS = {"relaxed", "gentle", "balanced", "strict", "paranoid", "custom"}

--- a/src/codex_plugin_scanner/guard/daemon/hook_metrics.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_metrics.py
@@ -8,7 +8,6 @@ flushed to SQLite asynchronously via ``maybe_flush_to_store()``.
 from __future__ import annotations
 
 import threading
-import time
 from collections import defaultdict
 from typing import TYPE_CHECKING
 
@@ -73,7 +72,9 @@ class HookMetricsRecorder:
         with self._lock:
             if len(self._latencies) < self._max_items:
                 self._latencies.append(latency_ms)
-            key = f"{harness}:{event_name}:{route}:{payload_kind}:{decision}:{reason_code}:{cache_status}:{fallback_kind}"
+            key = (
+                f"{harness}:{event_name}:{route}:{payload_kind}:{decision}:{reason_code}:{cache_status}:{fallback_kind}"
+            )
             self._counters[key] += 1
             self._counters[f"latency:{_latency_bucket(latency_ms)}"] += 1
             self._counters[f"size:{_size_bucket(output_size)}"] += 1
@@ -105,7 +106,7 @@ class HookMetricsRecorder:
         with self._lock:
             if not force and len(self._latencies) < 100:
                 return
-            snapshot = {
+            snapshot: dict[str, object] = {
                 "counters": dict(self._counters),
                 "latency_p50_ms": round(
                     sorted(self._latencies)[len(self._latencies) // 2] if self._latencies else 0.0, 2
@@ -127,4 +128,4 @@ class HookMetricsRecorder:
         )
 
 
-__all__ = ["HookMetricsRecorder", "LATENCY_BUCKETS_MS", "SIZE_BUCKETS"]
+__all__ = ["LATENCY_BUCKETS_MS", "SIZE_BUCKETS", "HookMetricsRecorder"]

--- a/src/codex_plugin_scanner/guard/daemon/hook_worker.py
+++ b/src/codex_plugin_scanner/guard/daemon/hook_worker.py
@@ -13,7 +13,6 @@ Security:
 
 from __future__ import annotations
 
-import os
 from collections.abc import Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -24,6 +23,7 @@ from ..runtime.hook_decision_cache import HookDecisionCache
 from ..runtime.hook_review_engine import HookReviewEngine
 from ..runtime.hook_review_types import (
     HookOutputSummary,
+    HookPayloadKind,
     HookReviewRequest,
     HookSourceFileRef,
 )
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from ..store import GuardStore
 
 
-class HookWorkerUnsupported(RuntimeError):
+class HookWorkerUnsupported(RuntimeError):  # noqa: N818
     """Raised when the worker cannot handle a request (caller falls back to CLI)."""
 
 
@@ -155,7 +155,7 @@ class HookWorker:
                 return value.strip()
         return "PreToolUse"
 
-    def _payload_kind(self, payload: Mapping[str, object]) -> str:
+    def _payload_kind(self, payload: Mapping[str, object]) -> HookPayloadKind:
         if "guard_payload_ref" in payload:
             return "encrypted_payload_ref"
         if "guard_source_ref" in payload:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3987,8 +3987,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 payload,
                 params,
                 default_harness=default_harness,
-                home_dir=home_dir or "",
-                guard_home=guard_home or "",
+                home_dir=home_dir,
+                guard_home=guard_home,
                 workspace=workspace,
             )
             if result is not None:
@@ -4001,8 +4001,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             params,
             hook_env=hook_env,
             default_harness=default_harness,
-            home_dir=home_dir or "",
-            guard_home=guard_home or "",
+            home_dir=home_dir,
+            guard_home=guard_home,
             workspace=workspace,
         )
 
@@ -4017,8 +4017,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         params: Mapping[str, list[str]],
         *,
         default_harness: str,
-        home_dir: str,
-        guard_home: str,
+        home_dir: str | None,
+        guard_home: str | None,
         workspace: str | None,
     ) -> dict[str, object] | None:
         """Try the resident hook worker. Return None to fall back to legacy.
@@ -4033,6 +4033,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         supplied only ``guard_source_ref``.
         """
         from .hook_worker import HookWorkerUnsupported
+
+        if home_dir is None or guard_home is None:
+            return None
 
         try:
             worker = self._daemon_server().hook_worker
@@ -4067,8 +4070,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         *,
         hook_env: dict[str, str],
         default_harness: str,
-        home_dir: str,
-        guard_home: str,
+        home_dir: str | None,
+        guard_home: str | None,
         workspace: str | None,
     ) -> None:
         runtime_harness = self._optional_string(params.get("runtime-harness", [None])[-1])

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3987,8 +3987,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 payload,
                 params,
                 default_harness=default_harness,
-                home_dir=home_dir,
-                guard_home=guard_home,
+                home_dir=home_dir or "",
+                guard_home=guard_home or "",
                 workspace=workspace,
             )
             if result is not None:
@@ -4001,8 +4001,8 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             params,
             hook_env=hook_env,
             default_harness=default_harness,
-            home_dir=home_dir,
-            guard_home=guard_home,
+            home_dir=home_dir or "",
+            guard_home=guard_home or "",
             workspace=workspace,
         )
 

--- a/src/codex_plugin_scanner/guard/runtime/hook_content_scanner.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_content_scanner.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import time
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from .secret_sensitivity import classify_secret_content, secret_content_rule_version
 
@@ -172,10 +172,7 @@ class ContentScanner:
 
             tail = window[-HOOK_SCANNER_CONTEXT_CHARS:] if len(window) > HOOK_SCANNER_CONTEXT_CHARS else window
 
-        if not matches_by_classifier:
-            reason_code = "clean"
-        else:
-            reason_code = "matches"
+        reason_code = "clean" if not matches_by_classifier else "matches"
 
         return ContentScanResult(
             matches=tuple(matches_by_classifier.values()),
@@ -235,11 +232,11 @@ def _truncate_to_byte_limit(text: str, max_bytes: int) -> str:
 
 
 __all__ = [
-    "ContentScanMatch",
-    "ContentScanResult",
-    "ContentScanner",
     "HOOK_CONTENT_SCANNER_VERSION",
     "HOOK_SCANNER_CONTEXT_CHARS",
     "HOOK_SCANNER_DEFAULT_MAX_BYTES",
     "HOOK_SCANNER_MAX_MATCHES",
+    "ContentScanMatch",
+    "ContentScanResult",
+    "ContentScanner",
 ]

--- a/src/codex_plugin_scanner/guard/runtime/hook_decision_cache.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_decision_cache.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 import hashlib
 import json
 from dataclasses import asdict, dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -76,9 +75,7 @@ def hook_config_fingerprint(config: GuardConfig) -> str:
         },
         "approval_surface_policy": config.approval_surface_policy,
     }
-    return hashlib.sha256(
-        json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
+    return hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
 class HookDecisionCache:
@@ -141,9 +138,9 @@ class HookDecisionCache:
 
 
 __all__ = [
-    "HookDecisionCache",
     "SOURCE_CACHE_SCANNER_NAME",
     "SOURCE_CACHE_VERSION",
+    "HookDecisionCache",
     "SourceReadCacheMaterial",
     "hook_config_fingerprint",
 ]

--- a/src/codex_plugin_scanner/guard/runtime/hook_enrichment_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_enrichment_queue.py
@@ -124,4 +124,4 @@ class HookEnrichmentQueue:
         )
 
 
-__all__ = ["HookEnrichmentTask", "HookEnrichmentQueue"]
+__all__ = ["HookEnrichmentQueue", "HookEnrichmentTask"]

--- a/src/codex_plugin_scanner/guard/runtime/hook_review_engine.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_review_engine.py
@@ -19,9 +19,11 @@ Security invariants:
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
+from .actions import normalize_harness_payload
 from .hook_content_scanner import ContentScanner
 from .hook_decision_cache import HookDecisionCache
 from .hook_review_types import HookReviewRequest, HookReviewResponse
@@ -29,10 +31,9 @@ from .hook_source_read import (
     SOURCE_READ_MAX_SCAN_BYTES,
     evaluate_source_file_ref,
 )
-from .actions import normalize_harness_payload
 
 if TYPE_CHECKING:
-    from ..config import GuardConfig, load_guard_config
+    from ..config import GuardConfig
     from ..store import GuardStore
 
 HOOK_ENGINE_TOTAL_BUDGET_MS = 9000
@@ -42,7 +43,7 @@ HOOK_SCANNER_DEFAULT_BUDGET_MS = 750
 ARBITRARY_STDOUT_FULL_ALLOW_BYTES = 256 * 1024
 
 
-class HookFailSafe(RuntimeError):
+class HookFailSafe(RuntimeError):  # noqa: N818
     """Raised when the engine must fail safe with a specific reason."""
 
     def __init__(self, reason_code: str, reason: str, *, excerpt: str | None = None):
@@ -222,7 +223,8 @@ class HookReviewEngine:
             # Excerpt is safe, but we cannot prove the full output is safe.
             return HookReviewResponse(
                 decision="allow",
-                reason="HOL Guard returned a reviewed excerpt because this output could not be fully proven safe within local limits.",
+                reason="HOL Guard returned a reviewed excerpt because this output could not be fully"
+                " proven safe within local limits.",
                 model_output_action="replace_with_reviewed_excerpt",
                 reviewed_excerpt=excerpt,
                 notice="excerpt",

--- a/src/codex_plugin_scanner/guard/runtime/hook_source_read.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_source_read.py
@@ -25,21 +25,19 @@ from __future__ import annotations
 import hashlib
 import os
 import re
-import time
 from dataclasses import dataclass
-from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from .hook_content_scanner import ContentScanMatch, ContentScanner
 from .hook_decision_cache import HookDecisionCache, SourceReadCacheMaterial, hook_config_fingerprint
-from .hook_review_types import HookReviewRequest, HookSourceFileRef
+from .hook_review_types import HookReviewRequest
 from .secret_sensitivity import classify_secret_path
 from .source_paths import SOURCE_CLASSIFIER_VERSION, resolve_source_candidate_path, source_path_is_allowed
 
 if TYPE_CHECKING:
-    from ..actions import GuardActionEnvelope
     from ..config import GuardConfig
     from ..store import GuardStore
+    from .actions import GuardActionEnvelope
 
 SOURCE_READ_FAST_PATH_VERSION = "source-read-fast-v1"
 SOURCE_READ_MAX_SCAN_BYTES = 5 * 1024 * 1024
@@ -212,7 +210,7 @@ def evaluate_source_file_ref(
     except OSError:
         return SourceReadFastPathResult(status="inconclusive", reason_code="stat_failed")
 
-    if not pre_stat.st_mode & 0o170000 == 0o100000:  # S_ISREG
+    if (pre_stat.st_mode & 0o170000) != 0o100000:  # S_ISREG
         return SourceReadFastPathResult(status="inconclusive", reason_code="not_regular_file")
 
     if pre_stat.st_size > SOURCE_READ_MAX_SCAN_BYTES:

--- a/src/codex_plugin_scanner/guard/runtime/hook_source_read.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_source_read.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import hashlib
 import os
 import re
+import stat
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
@@ -210,7 +211,7 @@ def evaluate_source_file_ref(
     except OSError:
         return SourceReadFastPathResult(status="inconclusive", reason_code="stat_failed")
 
-    if (pre_stat.st_mode & 0o170000) != 0o100000:  # S_ISREG
+    if not stat.S_ISREG(pre_stat.st_mode):
         return SourceReadFastPathResult(status="inconclusive", reason_code="not_regular_file")
 
     if pre_stat.st_size > SOURCE_READ_MAX_SCAN_BYTES:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -4479,7 +4479,18 @@ def _read_only_lookup_find_args_are_safe(args: list[str], *, home_dir: Path | No
 _GREP_PATTERN_OPTIONS = frozenset({"-e", "--regexp"})
 _GREP_PATTERN_FILE_OPTIONS = frozenset({"-f", "--file"})
 _GREP_FILTER_FILE_OPTIONS = frozenset({"--exclude-from"})
-_GREP_SKIP_NEXT_OPTIONS = frozenset({"-A", "-B", "-C", "-m", "--after-context", "--before-context", "--context", "--max-count"})
+_GREP_SKIP_NEXT_OPTIONS = frozenset(
+    {
+        "-A",
+        "-B",
+        "-C",
+        "-m",
+        "--after-context",
+        "--before-context",
+        "--context",
+        "--max-count",
+    }
+)
 
 
 def _read_only_lookup_filter_grep_args_are_safe(
@@ -4619,8 +4630,6 @@ def _read_only_lookup_target_is_safe(target: str, *, allow_dirs: bool, home_dir:
     if Path(normalized).suffix.lower() in SOURCE_INSPECTION_EXTENSIONS:
         return True
     return allow_dirs
-
-
 
 
 _SAFE_GRAPHQL_QUERY_FILE_WORKFLOW_PATTERN = re.compile(

--- a/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
@@ -323,9 +323,7 @@ def secret_content_rule_version() -> str:
         }
         for classifier, family, sensitivity, pattern, _reason in _SECRET_CONTENT_PATTERNS
     ]
-    return hashlib.sha256(
-        json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    ).hexdigest()
+    return hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
 def _secret_content_match_is_sample(*, classifier: str, text: str, enabled: bool) -> bool:

--- a/src/codex_plugin_scanner/guard/runtime/source_paths.py
+++ b/src/codex_plugin_scanner/guard/runtime/source_paths.py
@@ -11,7 +11,6 @@ these implementations so existing tests and callsites are unchanged.
 
 from __future__ import annotations
 
-import os
 from dataclasses import dataclass
 from pathlib import Path
 

--- a/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
+++ b/src/codex_plugin_scanner/guard/runtime/trust_attestation.py
@@ -121,13 +121,13 @@ def resolve_guard_oauth_trust_attestation_signing_config(
         public_jwk_thumbprint=public_jwk_thumbprint,
         signature_algorithm=GUARD_TRUST_ATTESTATION_SIGNATURE_ALGORITHM_ECDSA_P256,
     )
+
+
 def trust_attestation_v2_enabled(environ: Mapping[str, str] | None = None) -> bool:
     """Trust attestation v2 is enabled by default. Set GUARD_AIBOM_TRUST_ATTESTATION_V2=0 to opt out."""
     env = environ or os.environ
     raw = _sanitize_env(env.get("GUARD_AIBOM_TRUST_ATTESTATION_V2")).lower()
-    if raw in _FALSY_ENV_VALUES:
-        return False
-    return True
+    return raw not in _FALSY_ENV_VALUES
 
 
 def _headless_short_lived_attestation_enabled(environ: Mapping[str, str]) -> bool:

--- a/src/codex_plugin_scanner/guard/store_policy.py
+++ b/src/codex_plugin_scanner/guard/store_policy.py
@@ -505,7 +505,6 @@ class StorePolicyMixin:
         """
         import hashlib
         import json
-
         from datetime import datetime, timezone
 
         current_time = now or datetime.now(timezone.utc).isoformat()


### PR DESCRIPTION
## Summary

- Fix 34 pre-existing ruff lint errors in `src/` that blocked CI (`ruff check src/`)
- Fix 8 pre-existing basedpyright `--level error` failures that were masked by the ruff failure (CI never reached step 8)
- Fix 2 additional ruff errors introduced on `main` after this PR branched (E501 in `secret_file_requests.py`, SIM103 in `trust_attestation.py`) so CI stays green post-merge
- Apply `ruff --fix` for auto-fixable issues: remove unused imports (F401), sort imports (I001), sort `__all__` (RUF022), modernize `collections.abc` imports (UP035)
- Fix E501 line-too-long by splitting long string literals (no behavioral change)
- Apply ruff SIM201 autofix in `hook_source_read.py` and further improve readability by replacing the hardcoded octal mask with `stat.S_ISREG(pre_stat.st_mode)`. The original expression `not st_mode & 0o170000 == 0o100000` and the rewritten form are semantically equivalent — in Python bitwise `&` binds tighter than `==`, so the mask was already applied before the comparison. This is a lint/readability change with no behavioral difference.
- Fix basedpyright type errors in `daemon/server.py` without changing behavior: the `home_dir`/`guard_home` parameters were typed as `str` but could be `None` from `_validated_hook_directory_string`. Instead of coercing `None` to `""` (which would make `Path("")` resolve to the daemon's CWD and load config from the wrong directory), the fast path now returns `None` to fall through to the legacy CLI path when either parameter is missing. The legacy CLI handles `None` natively via argparse defaults.
- Add `# noqa: N818` to `HookWorkerUnsupported` and `HookFailSafe` — these are public API exports in `__all__` and caught as control-flow signals, not traditional errors. Renaming would be a semver-breaking change for external consumers
- Add `# noqa: SIM113` to `batches_sent` counter — it's a conditional post-try/except increment, not a loop index suitable for `enumerate()`
- Fix remaining basedpyright type errors: move type-only imports to `TYPE_CHECKING` block, annotate `_payload_kind` return type as `HookPayloadKind`, annotate `snapshot` dict as `dict[str, object]`, fix `..actions` import path
- Apply `ruff format` to normalize formatting across touched files

## Testing

- `ruff check src/` — 0 errors (was 34, plus 2 new on main)
- `ruff format --check src/` — passes
- `basedpyright --level error src/` — 0 errors (was 8, previously masked by ruff failure)
- `pytest tests/test_guard_hook_worker.py tests/test_hook_review_engine.py tests/test_hook_security_regressions.py tests/test_hook_source_read_fast_path.py tests/test_guard_surface_server.py tests/test_claude_daemon_hook_bridge.py tests/test_guard_daemon_cli.py` — 153 passed
