### PR TITLE
fix(dashboard): consolidate secondary risk alert into evidence carousel

### DIFF
--- a/dashboard/node_modules
+++ b/dashboard/node_modules
@@ -1,0 +1,1 @@
+../../../dashboard/node_modules

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -1172,6 +1172,14 @@ function ReviewDecisionCard(props: {
   const pauseReason = whyPaused(item);
 
   const evidenceItems: EvidenceItem[] = [];
+  if (secondaryRiskSummary) {
+    evidenceItems.push({
+      id: "secondary-risk",
+      title: "Additional risk",
+      tone: "amber",
+      content: <p className="text-sm text-brand-dark">{secondaryRiskSummary}</p>,
+    });
+  }
   const allSignals = item.decision_v2_json?.signals ?? [];
   if (allSignals.some((s) => s.category === "skill" || s.category === "mcp")) {
     evidenceItems.push({
@@ -1267,15 +1275,6 @@ function ReviewDecisionCard(props: {
         <div className="mt-4 rounded-xl border border-brand-blue/10 bg-brand-blue/[0.04] p-4">
           <p className="text-sm text-brand-dark">{pauseReason}</p>
         </div>
-
-        {secondaryRiskSummary && (
-          <div className="mt-4 rounded-xl border border-brand-attention/15 bg-brand-attention/[0.04] p-4">
-            <div className="flex items-start gap-2.5">
-              <HiMiniExclamationTriangle className="mt-0.5 h-4 w-4 shrink-0 text-brand-attention" aria-hidden="true" />
-              <p className="text-sm text-brand-dark">{secondaryRiskSummary}</p>
-            </div>
-          </div>
-        )}
 
         {whatWouldHappen && (
           <div className="mt-5">
@@ -1430,7 +1429,7 @@ function ReviewDecisionCard(props: {
           </button>
           {showEvidence && (
             <div className="mt-4">
-              <ConsolidatedEvidenceAlert items={evidenceItems} />
+              <ConsolidatedEvidenceAlert key={item.request_id} items={evidenceItems} />
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary

Consolidates the secondary risk summary alert into the `ConsolidatedEvidenceAlert` carousel to reduce cognitive load when multiple alerts are stacked vertically in the review dashboard.

## Problem

The review decision card rendered the secondary risk summary as a separate amber alert box between the pause reason and the evidence section. When multiple alerts were present (secondary risk + scanner evidence + data flow + skill risk + supply chain risk), they stacked vertically, each with their own border, padding, and icon — creating cognitive overload.

## Fix

Move `secondaryRiskSummary` from a standalone alert box into `evidenceItems` as the first item in the `ConsolidatedEvidenceAlert` carousel (amber tone, titled "Additional risk"). Users now cycle through all insights with the Next button instead of scanning a vertical stack of separate alert boxes.

The pause reason box remains separate — it's the primary "why Guard paused this" callout inside the action card, not an evidence item.

## Test plan

- [x] `consolidated-evidence-alert.test.ts` — 4 tests pass (empty, single, multiple, initial render)
- [x] `phase09-review.test.ts` — all tests pass
- [x] `review-workspace.tsx` has zero typecheck errors (14 pre-existing errors in other files unchanged)
