### PR TITLE
fix(dashboard): consolidate pause reason into evidence carousel

### DIFF
--- a/dashboard/node_modules
+++ b/dashboard/node_modules
@@ -1,1 +1,0 @@
-../../../dashboard/node_modules

--- a/dashboard/src/approval-center-utils.ts
+++ b/dashboard/src/approval-center-utils.ts
@@ -8,6 +8,7 @@ import type {
 } from "./guard-types";
 import { guardAwareHref } from "./guard-api";
 import { resolveQueueCategory } from "./queue-state";
+import { whyPaused } from "./evidence/plain-english";
 
 export const EMPTY_QUEUE_TITLE = "No blocked actions";
 export const STALE_REQUEST_COPY = "This request was already decided.";
@@ -414,7 +415,8 @@ export function hasReviewEvidence(item: GuardApprovalRequest): boolean {
     (item.risk_signals?.length ?? 0) > 0 ||
     hasRenderableDecisionEvidence(item) ||
     resolveSecondaryRiskSummary(item) !== null ||
-    !!item.why_now
+    !!item.why_now ||
+    whyPaused(item) !== null
   );
 }
 

--- a/dashboard/src/phase09-review.test.ts
+++ b/dashboard/src/phase09-review.test.ts
@@ -731,8 +731,8 @@ const DUPLICATE_SUMMARY_WITH_UNRENDERED_SIGNAL_REQUEST: GuardApprovalRequest = {
   },
 };
 assert(
-  !hasReviewEvidence(DUPLICATE_SUMMARY_WITH_UNRENDERED_SIGNAL_REQUEST),
-  "GR211-11: duplicate summary does not show empty evidence section for unrendered decision_v2 signals"
+  hasReviewEvidence(DUPLICATE_SUMMARY_WITH_UNRENDERED_SIGNAL_REQUEST),
+  "GR211-11: whyPaused always provides at least one evidence item even for unrendered decision_v2 signals"
 );
 
 const DUPLICATE_SUMMARY_SUPPLY_CHAIN_REQUEST: GuardApprovalRequest = {

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -37,7 +37,6 @@ import {
   buildRetryAfterApprovalCopy,
   buildPrimaryReviewAction,
   resolveSecondaryRiskSummary,
-  hasReviewEvidence,
   harnessDisplayName,
   displayArtifactName,
   formatRelativeTime,
@@ -1168,10 +1167,17 @@ function ReviewDecisionCard(props: {
   const harnessName = harnessDisplayName(item.harness);
   const whatWouldHappen = buildWhatWouldHappen(item);
   const secondaryRiskSummary = resolveSecondaryRiskSummary(item);
-  const hasEvidence = hasReviewEvidence(item);
   const pauseReason = whyPaused(item);
 
   const evidenceItems: EvidenceItem[] = [];
+  if (pauseReason) {
+    evidenceItems.push({
+      id: "why-paused",
+      title: "Why paused",
+      tone: "blue",
+      content: <p className="text-sm text-brand-dark">{pauseReason}</p>,
+    });
+  }
   if (secondaryRiskSummary) {
     evidenceItems.push({
       id: "secondary-risk",
@@ -1271,10 +1277,6 @@ function ReviewDecisionCard(props: {
         </div>
 
         <PrimaryActionCard item={item} />
-
-        <div className="mt-4 rounded-xl border border-brand-blue/10 bg-brand-blue/[0.04] p-4">
-          <p className="text-sm text-brand-dark">{pauseReason}</p>
-        </div>
 
         {whatWouldHappen && (
           <div className="mt-5">
@@ -1412,7 +1414,7 @@ function ReviewDecisionCard(props: {
 
       </div>
 
-      {hasEvidence && (
+      {evidenceItems.length > 0 && (
         <div className="rounded-xl border border-slate-100 p-4 sm:p-5">
           <button
             type="button"
@@ -1420,7 +1422,7 @@ function ReviewDecisionCard(props: {
             className="flex w-full items-center justify-between text-left focus:outline-none focus:ring-2 focus:ring-brand-blue/20 rounded-lg px-2 py-1 -ml-2"
             aria-expanded={showEvidence}
           >
-            <SectionLabel>Why Guard paused this</SectionLabel>
+            <SectionLabel>Review details</SectionLabel>
             {showEvidence ? (
               <HiMiniChevronUp className="h-4 w-4 text-slate-400" aria-hidden="true" />
             ) : (


### PR DESCRIPTION
## Summary

Eliminates duplicate alerts in the review dashboard by consolidating the pause reason into the `ConsolidatedEvidenceAlert` carousel.

## Problem

The review card rendered two separate alert boxes stacked vertically:

1. **Pause reason** (blue box): "This file may contain passwords or keys. Guard stops this by default."
2. **Evidence section** titled "Why Guard paused this": contained the `ConsolidatedEvidenceAlert` carousel with secondary risk, scanner evidence, data flow, etc.

Both explained why Guard stopped the action, creating cognitive overload — the exact issue the `ConsolidatedEvidenceAlert` component was built to solve.

## Fix

- **Move `pauseReason` into `evidenceItems`** as the first item (blue tone, titled "Why paused")
- **Remove the standalone pause reason alert box**
- **Change evidence section header** from "Why Guard paused this" to "Review details" to avoid conceptual duplication
- **Gate evidence section on `evidenceItems.length > 0`** instead of `hasReviewEvidence`, since `pauseReason` is always present
- **Add `whyPaused` to `hasReviewEvidence`** in `approval-center-utils.ts` for other callers

## Test plan

- [x] `consolidated-evidence-alert.test.ts` — 4 tests pass
- [x] `phase09-review.test.ts` — all tests pass (updated GR211-11 expectation: `hasReviewEvidence` now returns `true` for requests with only unrendered signals because `whyPaused` always provides evidence)
- [x] Zero typecheck errors in changed files
