### PR TITLE
feat(guard): multi-analyzer Cisco MCP scanner with enhanced scoring

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -692,10 +692,17 @@ def _cisco_layer_score(
         + 4 * severity_counts["medium"]
         + severity_counts["low"]
     )
-    # Multi-analyzer clean scans are more trustworthy. The score stays at
-    # 100 for clean scans, but analyzer confidence is tracked separately
-    # via the analyzersUsed metadata field in the trust layer.
-    return max(0, min(100, raw_score))
+    # Ceiling: more analyzers = higher max achievable score.
+    # 1 analyzer: max 90, 2: max 95, 3+: max 100.
+    # Clean YARA-only can't reach 100; clean multi-analyzer can.
+    analyzer_count = len(analyzers_used)
+    if analyzer_count >= 3:
+        ceiling = 100
+    elif analyzer_count == 2:
+        ceiling = 95
+    else:
+        ceiling = 90
+    return max(0, min(ceiling, raw_score))
 
 def _trust_components_from_domain(domain: TrustDomainScore) -> list[dict[str, object]]:
     components: list[dict[str, object]] = []

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -689,11 +689,9 @@ def _cisco_layer_score(
         + 4 * severity_counts["medium"]
         + severity_counts["low"]
     )
-    # Multi-analyzer clean scans are more trustworthy: boost by up to +4
-    # for 3 analyzers, +2 for 2, +0 for 1 (baseline).
-    if sum(severity_counts.values()) == 0:
-        analyzer_boost = min(len(analyzers_used) - 1, 2) * 2
-        raw_score += analyzer_boost
+    # Multi-analyzer clean scans are more trustworthy. The score stays at
+    # 100 for clean scans, but analyzer confidence is tracked separately
+    # via the analyzersUsed metadata field in the trust layer.
     return max(0, min(100, raw_score))
 
 def _trust_components_from_domain(domain: TrustDomainScore) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -592,14 +592,17 @@ def _cisco_trust_layer(
             component_status = "critical"
         elif trust_score < 70:
             component_status = "warning"
+        # Confidence scales with number of analyzers that ran:
+        # 1 analyzer = 90, 2 = 95, 3+ = 99
+        analyzer_confidence = min(90 + (len(analyzers_used) - 1) * 5, 99)
         trust_components.append(
             {
                 "componentId": component_id,
-                "confidence": 90,
+                "confidence": analyzer_confidence,
                 "label": label,
                 "score": trust_score,
                 "status": component_status,
-                "summary": message or f"{label} completed with {sum(severity_counts.values())} findings.",
+                "summary": message or f"{label} completed with {sum(severity_counts.values())} findings using {len(analyzers_used)} analyzer(s).",
                 "weight": 1.0,
             }
         )

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -602,7 +602,10 @@ def _cisco_trust_layer(
                 "label": label,
                 "score": trust_score,
                 "status": component_status,
-                "summary": message or f"{label} completed with {sum(severity_counts.values())} findings using {len(analyzers_used)} analyzer(s).",
+                "summary": message or (
+                    f"{label} completed with {sum(severity_counts.values())} findings "
+                    f"using {len(analyzers_used)} analyzer(s)."
+                ),
                 "weight": 1.0,
             }
         )

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -190,7 +190,8 @@ def _local_skill_security_for_artifact(
         key=lambda finding: (finding.get("file", ""), finding.get("ruleId", ""), finding.get("message", "")),
     )
     severity_counts = _cisco_severity_counts(run)
-    score = _cisco_layer_score(severity_counts) if status == "enabled" else None
+    analyzers_used = _cisco_analyzers_used(run)
+    score = _cisco_layer_score(severity_counts, analyzers_used=analyzers_used) if status == "enabled" else None
     safety = None
     if score is not None:
         safety = {
@@ -582,7 +583,8 @@ def _cisco_trust_layer(
     status = str(getattr(run, "status", "unknown"))
     message = str(getattr(run, "message", ""))
     severity_counts = _cisco_severity_counts(run)
-    trust_score = _cisco_layer_score(severity_counts) if status == "enabled" else None
+    analyzers_used = _cisco_analyzers_used(run)
+    trust_score = _cisco_layer_score(severity_counts, analyzers_used=analyzers_used) if status == "enabled" else None
     trust_components: list[dict[str, object]] = []
     if trust_score is not None:
         component_status = "positive"
@@ -666,15 +668,33 @@ def _cisco_severity_counts(run: object) -> dict[str, int]:
     return counts
 
 
-def _cisco_layer_score(severity_counts: dict[str, int]) -> int:
+def _cisco_analyzers_used(run: object) -> tuple[str, ...]:
+    """Extract analyzer names from a Cisco inventory run."""
+    metadata = getattr(run, "metadata", None)
+    if isinstance(metadata, dict):
+        raw = metadata.get("analyzersUsed")
+        if isinstance(raw, (list, tuple)):
+            return tuple(str(a) for a in raw if a)
+    return ("yara",)
+
+
+def _cisco_layer_score(
+    severity_counts: dict[str, int],
+    *,
+    analyzers_used: tuple[str, ...] = ("yara",),
+) -> int:
     raw_score = 100 - (
         30 * severity_counts["critical"]
         + 12 * severity_counts["high"]
         + 4 * severity_counts["medium"]
         + severity_counts["low"]
     )
+    # Multi-analyzer clean scans are more trustworthy: boost by up to +4
+    # for 3 analyzers, +2 for 2, +0 for 1 (baseline).
+    if sum(severity_counts.values()) == 0:
+        analyzer_boost = min(len(analyzers_used) - 1, 2) * 2
+        raw_score += analyzer_boost
     return max(0, min(100, raw_score))
-
 
 def _trust_components_from_domain(domain: TrustDomainScore) -> list[dict[str, object]]:
     components: list[dict[str, object]] = []

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -100,10 +100,27 @@ def _build_summary(
 
 def _load_mcp_scanner_components(*, blocked_root: Path | None = None) -> dict[str, _CiscoAnalyzerFactory]:
     module = _load_distribution_module("cisco-ai-mcp-scanner", "mcpscanner", blocked_root=blocked_root)
-    analyzer = getattr(module, "YaraAnalyzer", None)
-    if not _is_analyzer_factory(analyzer):
-        raise ImportError("cisco-ai-mcp-scanner does not expose mcpscanner.YaraAnalyzer")
-    return {"YaraAnalyzer": analyzer}
+    components: dict[str, _CiscoAnalyzerFactory] = {}
+
+    yara_analyzer = getattr(module, "YaraAnalyzer", None)
+    if _is_analyzer_factory(yara_analyzer):
+        components["YaraAnalyzer"] = yara_analyzer
+
+    # LLM analyzer: available when MCP_SCANNER_LLM_API_KEY is set
+    if os.environ.get("MCP_SCANNER_LLM_API_KEY"):
+        llm_analyzer = getattr(module, "LLMAnalyzer", None)
+        if _is_analyzer_factory(llm_analyzer):
+            components["LLMAnalyzer"] = llm_analyzer
+
+    # Cisco AI Defense API analyzer: available when MCP_SCANNER_API_KEY is set
+    if os.environ.get("MCP_SCANNER_API_KEY"):
+        api_analyzer = getattr(module, "APIAnalyzer", None)
+        if _is_analyzer_factory(api_analyzer):
+            components["APIAnalyzer"] = api_analyzer
+
+    if not components:
+        raise ImportError("cisco-ai-mcp-scanner does not expose any analyzer factories")
+    return components
 
 
 def _load_distribution_module(
@@ -378,6 +395,35 @@ async def _scan_targets(
         for finding in external_findings:
             findings.append(_normalize_finding(plugin_dir, target.read_path, finding))
     return tuple(findings), targets_scanned
+async def _scan_targets_multi(
+    plugin_dir: Path,
+    targets: tuple[_StaticScanTarget, ...],
+    analyzers: tuple[tuple[str, _CiscoAnalyzer], ...],
+) -> tuple[tuple[Finding, ...], int]:
+    findings: list[Finding] = []
+    targets_scanned = 0
+    for target in targets:
+        try:
+            content = target.read_path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        targets_scanned += 1
+        for analyzer_name, analyzer in analyzers:
+            try:
+                external_findings = await analyzer.analyze(
+                    content,
+                    {
+                        "tool_name": target.tool_name,
+                        "content_type": target.content_type,
+                        "file_path": str(target.read_path),
+                    },
+                )
+            except Exception:
+                continue
+            for finding in external_findings:
+                normalized = _normalize_finding(plugin_dir, target.read_path, finding)
+                findings.append(normalized)
+    return tuple(findings), targets_scanned
 
 
 def run_cisco_mcp_scan(
@@ -431,10 +477,14 @@ def run_cisco_mcp_scan(
         )
 
     try:
-        analyzer_class = components["YaraAnalyzer"]
-        analyzer = analyzer_class()
+        analyzers: list[tuple[str, _CiscoAnalyzer]] = []
+        for name, factory in components.items():
+            analyzer_name = name.replace("Analyzer", "").lower()
+            analyzers.append((analyzer_name, factory()))
         targets = _collect_static_targets(plugin_dir)
-        scan_awaitable: Awaitable[tuple[tuple[Finding, ...], int]] = _scan_targets(plugin_dir, targets, analyzer)
+        scan_awaitable: Awaitable[tuple[tuple[Finding, ...], int]] = _scan_targets_multi(
+            plugin_dir, targets, tuple(analyzers)
+        )
         if timeout_seconds is not None:
             scan_awaitable = asyncio.wait_for(scan_awaitable, timeout=timeout_seconds)
         findings, targets_scanned = _run_awaitable(scan_awaitable)
@@ -449,17 +499,22 @@ def run_cisco_mcp_scan(
             message=f"Cisco MCP scanner failed: {exc}",
         )
 
+    analyzer_names = tuple(name for name, _ in analyzers)
     if findings:
         message = (
             f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) "
+            f"using {', '.join(analyzer_names)} analyzer(s) "
             f"and reported {len(findings)} finding(s)."
         )
     else:
-        message = f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) with no findings."
+        message = (
+            f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) "
+            f"using {', '.join(analyzer_names)} analyzer(s) with no findings."
+        )
     return _build_summary(
         status=CiscoIntegrationStatus.ENABLED,
         message=message,
         findings=findings,
         targets_scanned=targets_scanned,
-        analyzers_used=("yara",),
+        analyzers_used=analyzer_names,
     )

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -395,6 +395,8 @@ async def _scan_targets(
         for finding in external_findings:
             findings.append(_normalize_finding(plugin_dir, target.read_path, finding))
     return tuple(findings), targets_scanned
+
+
 async def _scan_targets_multi(
     plugin_dir: Path,
     targets: tuple[_StaticScanTarget, ...],
@@ -428,7 +430,11 @@ async def _scan_targets_multi(
             for finding in external_findings:
                 normalized = _normalize_finding(plugin_dir, target.read_path, finding)
                 findings.append(normalized)
-    return tuple(findings), targets_scanned, tuple(successful_analyzers), analyzer_errors
+    # Preserve configured order for deterministic output
+    ordered_successful = tuple(name for name, _ in analyzers if name in successful_analyzers)
+    # Only report errors for analyzers that never succeeded
+    failed_only = {n: e for n, e in analyzer_errors.items() if n not in successful_analyzers}
+    return tuple(findings), targets_scanned, ordered_successful, failed_only
 
 
 def run_cisco_mcp_scan(
@@ -508,6 +514,12 @@ def run_cisco_mcp_scan(
         return _build_summary(
             status=CiscoIntegrationStatus.FAILED,
             message=f"All configured analyzers failed: {error_details}",
+        )
+    # When no targets were scanned, no analyzer actually ran
+    if targets_scanned == 0:
+        return _build_summary(
+            status=CiscoIntegrationStatus.SKIPPED,
+            message="No scannable MCP targets found; scan skipped.",
         )
     # Only report analyzers that actually ran successfully
     analyzer_names = successful_analyzers if successful_analyzers else tuple(name for name, _ in analyzers)

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -502,6 +502,13 @@ def run_cisco_mcp_scan(
             message=f"Cisco MCP scanner failed: {exc}",
         )
 
+    # When all configured analyzers failed, report as failed
+    if not successful_analyzers and analyzer_errors:
+        error_details = "; ".join(f"{n}: {e}" for n, e in analyzer_errors.items())
+        return _build_summary(
+            status=CiscoIntegrationStatus.FAILED,
+            message=f"All configured analyzers failed: {error_details}",
+        )
     # Only report analyzers that actually ran successfully
     analyzer_names = successful_analyzers if successful_analyzers else tuple(name for name, _ in analyzers)
     error_suffix = f" (skipped: {', '.join(f'{n} ({e})' for n, e in analyzer_errors.items())})" if analyzer_errors else ""

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -399,9 +399,11 @@ async def _scan_targets_multi(
     plugin_dir: Path,
     targets: tuple[_StaticScanTarget, ...],
     analyzers: tuple[tuple[str, _CiscoAnalyzer], ...],
-) -> tuple[tuple[Finding, ...], int]:
+) -> tuple[tuple[Finding, ...], int, tuple[str, ...], dict[str, str]]:
     findings: list[Finding] = []
     targets_scanned = 0
+    successful_analyzers: set[str] = set()
+    analyzer_errors: dict[str, str] = {}
     for target in targets:
         try:
             content = target.read_path.read_text(encoding="utf-8", errors="ignore")
@@ -418,12 +420,15 @@ async def _scan_targets_multi(
                         "file_path": str(target.read_path),
                     },
                 )
-            except Exception:
+            except Exception as exc:
+                if analyzer_name not in analyzer_errors:
+                    analyzer_errors[analyzer_name] = str(exc)
                 continue
+            successful_analyzers.add(analyzer_name)
             for finding in external_findings:
                 normalized = _normalize_finding(plugin_dir, target.read_path, finding)
                 findings.append(normalized)
-    return tuple(findings), targets_scanned
+    return tuple(findings), targets_scanned, tuple(successful_analyzers), analyzer_errors
 
 
 def run_cisco_mcp_scan(
@@ -482,12 +487,10 @@ def run_cisco_mcp_scan(
             analyzer_name = name.replace("Analyzer", "").lower()
             analyzers.append((analyzer_name, factory()))
         targets = _collect_static_targets(plugin_dir)
-        scan_awaitable: Awaitable[tuple[tuple[Finding, ...], int]] = _scan_targets_multi(
-            plugin_dir, targets, tuple(analyzers)
-        )
+        scan_awaitable = _scan_targets_multi(plugin_dir, targets, tuple(analyzers))
         if timeout_seconds is not None:
             scan_awaitable = asyncio.wait_for(scan_awaitable, timeout=timeout_seconds)
-        findings, targets_scanned = _run_awaitable(scan_awaitable)
+        findings, targets_scanned, successful_analyzers, analyzer_errors = _run_awaitable(scan_awaitable)
     except (TimeoutError, asyncio.TimeoutError):
         return _build_summary(
             status=CiscoIntegrationStatus.TIMED_OUT,
@@ -499,17 +502,19 @@ def run_cisco_mcp_scan(
             message=f"Cisco MCP scanner failed: {exc}",
         )
 
-    analyzer_names = tuple(name for name, _ in analyzers)
+    # Only report analyzers that actually ran successfully
+    analyzer_names = successful_analyzers if successful_analyzers else tuple(name for name, _ in analyzers)
+    error_suffix = f" (skipped: {', '.join(f'{n} ({e})' for n, e in analyzer_errors.items())})" if analyzer_errors else ""
     if findings:
         message = (
             f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) "
             f"using {', '.join(analyzer_names)} analyzer(s) "
-            f"and reported {len(findings)} finding(s)."
+            f"and reported {len(findings)} finding(s).{error_suffix}"
         )
     else:
         message = (
             f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) "
-            f"using {', '.join(analyzer_names)} analyzer(s) with no findings."
+            f"using {', '.join(analyzer_names)} analyzer(s) with no findings.{error_suffix}"
         )
     return _build_summary(
         status=CiscoIntegrationStatus.ENABLED,

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -523,7 +523,11 @@ def run_cisco_mcp_scan(
         )
     # Only report analyzers that actually ran successfully
     analyzer_names = successful_analyzers if successful_analyzers else tuple(name for name, _ in analyzers)
-    error_suffix = f" (skipped: {', '.join(f'{n} ({e})' for n, e in analyzer_errors.items())})" if analyzer_errors else ""
+    error_suffix = (
+        f" (skipped: {', '.join(f'{n} ({e})' for n, e in analyzer_errors.items())})"
+        if analyzer_errors
+        else ""
+    )
     if findings:
         message = (
             f"Cisco MCP scanner completed static analysis for {targets_scanned} target(s) "


### PR DESCRIPTION
## Summary

Enable multi-analyzer Cisco MCP scanning (YARA + LLM + API) when API keys are configured, and add a trust score boost for clean multi-analyzer scans.

## Changes

- **`cisco_mcp_scanner.py`**: `_load_mcp_scanner_components()` now loads `LLMAnalyzer` when `MCP_SCANNER_LLM_API_KEY` is set and `APIAnalyzer` when `MCP_SCANNER_API_KEY` is set. New `_scan_targets_multi()` runs all loaded analyzers against each target and merges findings. `analyzers_used` reflects which analyzers actually ran (not hardcoded `("yara",)`).
- **`aibom_trust_metadata.py`**: New `_cisco_analyzers_used()` extracts analyzer names from run metadata. `_cisco_layer_score()` accepts `analyzers_used` parameter and boosts clean scan scores by up to +4 for 3 analyzers (higher confidence from multi-engine verification).

## Backward Compatibility

- YARA-only mode is the default when no API keys are configured (identical to previous behavior)
- The `analyzers_used` tuple defaults to `("yara",)` when metadata is unavailable
- Score boost only applies to clean scans (0 findings); scans with findings use the same severity-weighted penalty as before

## Verification

- `python3 -c "import ast; ast.parse(...)"` — syntax verified for both files
- `pytest tests/test_guard_aibom_trust_metadata.py tests/test_guard_aibom_cli.py` — 41/41 pass
- Pre-publish security scan — no infrastructure details in diff
