### PR TITLE
fix(cli): add progress indicators to hol-guard connect flow

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -5,6 +5,7 @@
 
 from __future__ import annotations
 
+import sys
 from typing import TYPE_CHECKING, cast
 
 if TYPE_CHECKING:
@@ -15,6 +16,11 @@ if TYPE_CHECKING:
 from ._commands_shared import *
 from .commands_parser_helpers import *
 from ..local_supply_chain import _resolve_guard_sync_auth_context as _local_resolve_guard_sync_auth_context
+
+
+def _print_connect_progress(message: str) -> None:
+    """Print a progress message to stderr during connect flow so the user sees activity."""
+    print(f"hol-guard: {message}", file=sys.stderr, flush=True)
 
 
 def _connect_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
@@ -262,6 +268,7 @@ def _finalize_guard_connect_payload(
         return payload
     payload["sync_attempted"] = True
     try:
+        _print_connect_progress("Syncing local proof to Guard Cloud...")
         sync_payload = sync_local_guard_cloud_proof(
             store,
             auth_context=resolved_sync_auth_context,
@@ -324,6 +331,7 @@ def _finalize_guard_connect_payload(
             }
         )
         return payload
+    _print_connect_progress("Guard Cloud sync complete.")
     latest_state = store.record_latest_guard_connect_sync_success(
         sync_payload=sync_payload,
         now=str(sync_payload.get("synced_at") or now),
@@ -340,6 +348,7 @@ def _finalize_guard_connect_payload(
         }
     )
     try:
+        _print_connect_progress("Syncing supply chain state...")
         payload["supply_chain"] = sync_supply_chain_cloud_state(
             store,
             auth_context=resolved_sync_auth_context,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -6,6 +6,7 @@ import base64
 import http.server
 import json
 import secrets
+import sys
 import threading
 import time
 import urllib.error
@@ -37,6 +38,12 @@ from .oauth_client import (
     guard_api_base_path,
     resolve_guard_oauth_client_config,
 )
+
+_PROGRESS_PREFIX = "hol-guard:"
+
+def _progress(message: str) -> None:
+    """Print a progress message to stderr so the user sees activity during long operations."""
+    print(f"{_PROGRESS_PREFIX} {message}", file=sys.stderr, flush=True)
 
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
@@ -1198,19 +1205,24 @@ def run_guard_browser_connect_command(
     wait_timeout_seconds: float = 180,
     include_sync_auth_context: bool = False,
 ) -> dict[str, object]:
+    _progress("Preparing Guard Cloud authorization...")
     prepare_guard_cloud_connect_authorization(store)
     device = store.get_device_metadata()
     _, allowed_origin = resolve_connect_url(connect_url)
     oauth_client = resolve_guard_oauth_client_config(allowed_origin)
     browser_opener = open_browser if open_browser is not None else __import__("webbrowser").open
+    _progress("Starting browser authorization session...")
     session = start_browser_session(
         connect_url=connect_url,
         machine_id=str(device["installation_id"]),
         machine_label=str(device["device_label"]),
     )
     try:
+        _progress("Opening browser for sign-in...")
         browser_opened = bool(browser_opener(session.authorize_url))
+        _progress("Waiting for authentication (complete sign-in in your browser)...")
         callback = session.wait_for_callback(wait_timeout_seconds)
+        _progress("Exchanging authorization code for tokens...")
         token_result = exchange_authorization_code(
             token_endpoint=oauth_client.token_endpoint,
             client_id=oauth_client.client_id,
@@ -1223,6 +1235,7 @@ def run_guard_browser_connect_command(
         session.close()
     if token_result.refresh_token is None:
         raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
+    _progress("Saving credentials locally...")
     timestamp = now or datetime.now(timezone.utc).isoformat()
     _persist_oauth_local_credentials(
         store=store,


### PR DESCRIPTION
## Problem

`hol-guard connect` has multiple silent gaps where the terminal shows nothing — up to 17+ seconds during receipts sync alone. Users reported the terminal appearing "stuck" after completing MFA, even though the connect was actually succeeding.

## Fix

Added progress messages to stderr at every step of the connect flow:

```
hol-guard: Preparing Guard Cloud authorization...
hol-guard: Starting browser authorization session...
hol-guard: Opening browser for sign-in...
hol-guard: Waiting for authentication (complete sign-in in your browser)...
hol-guard: Exchanging authorization code for tokens...
hol-guard: Saving credentials locally...
hol-guard: Syncing local proof to Guard Cloud...
hol-guard: Guard Cloud sync complete.
hol-guard: Syncing supply chain state...
```

### Design decisions

- **stderr only**: `stdout` is reserved for the JSON/rich payload emitted by `_emit()`. Writing to stdout would corrupt `--json` output mode.
- **`flush=True`**: Messages appear immediately, not buffered.
- **`hol-guard:` prefix**: Identifies the source clearly in mixed output.
- **Static prints, not spinners**: Simpler, more reliable, and works in all terminal types. The `rich` spinner would require a live display context that conflicts with the existing render pipeline.

### Files changed

- `connect_flow.py`: Added `_progress()` helper + 6 progress messages in `run_guard_browser_connect_command`
- `commands_support_connect.py`: Added `_print_connect_progress()` helper + 3 progress messages in `_finalize_guard_connect_payload` (before sync, after sync, before supply chain sync)

### Testing

- Python syntax validated for both files
- `_progress()` function output format verified — messages print correctly with prefix and flush
- Cannot run full `hol-guard connect` E2E in Docker harness (requires OAuth/MFA), but the user's connect already succeeded — this fix purely adds terminal output