### PR TITLE
feat(cli): rich progress bar for hol-guard connect and sync

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -250,20 +250,26 @@ def _run_guard_sync_command(
     context = _require_guard_context(context)
     try:
         auth_context = _cloud_guard_sync_auth_context(store)
-        payload = sync_receipts(
-            store,
-            auth_context=auth_context,
-            home_dir=context.home_dir,
-            workspace_dir=context.workspace_dir,
-        )
-        with suppress(GuardSyncNotConfiguredError, RuntimeError):
-            payload["supply_chain"] = _validated_supply_chain_sync_payload(
-                sync_supply_chain_cloud_state(
-                    store,
-                    auth_context=auth_context,
-                    workspace_dir=context.workspace_dir,
-                )
+        from .progress import GuardProgress
+
+        with GuardProgress(total=2, title="Guard Sync") as bar:
+            bar.step("Syncing receipts to Guard Cloud...")
+            payload = sync_receipts(
+                store,
+                auth_context=auth_context,
+                home_dir=context.home_dir,
+                workspace_dir=context.workspace_dir,
             )
+            bar.step("Syncing supply chain state...")
+            with suppress(GuardSyncNotConfiguredError, RuntimeError):
+                payload["supply_chain"] = _validated_supply_chain_sync_payload(
+                    sync_supply_chain_cloud_state(
+                        store,
+                        auth_context=auth_context,
+                        workspace_dir=context.workspace_dir,
+                    )
+                )
+            bar.done("Sync complete")
     except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
         message = _guard_sync_failure_message(error)
         if getattr(args, "json", False):

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -18,11 +18,6 @@ from .commands_parser_helpers import *
 from ..local_supply_chain import _resolve_guard_sync_auth_context as _local_resolve_guard_sync_auth_context
 
 
-def _print_connect_progress(message: str) -> None:
-    """Print a progress message to stderr during connect flow so the user sees activity."""
-    print(f"hol-guard: {message}", file=sys.stderr, flush=True)
-
-
 def _connect_guard_sync_auth_context(store: GuardStore) -> dict[str, object]:
     resolver = globals().get("_resolve_guard_sync_auth_context")
     if callable(resolver):
@@ -268,12 +263,25 @@ def _finalize_guard_connect_payload(
         return payload
     payload["sync_attempted"] = True
     try:
-        _print_connect_progress("Syncing local proof to Guard Cloud...")
-        sync_payload = sync_local_guard_cloud_proof(
-            store,
-            auth_context=resolved_sync_auth_context,
-            now=now,
-        )
+        from .progress import GuardProgress
+
+        with GuardProgress(total=2, title="Guard Sync") as sync_bar:
+            sync_bar.step("Syncing local proof to Guard Cloud...")
+            sync_payload = sync_local_guard_cloud_proof(
+                store,
+                auth_context=resolved_sync_auth_context,
+                now=now,
+            )
+            sync_bar.step("Syncing supply chain state...")
+            try:
+                payload["supply_chain"] = sync_supply_chain_cloud_state(
+                    store,
+                    auth_context=resolved_sync_auth_context,
+                )
+                sync_bar.done("Guard Cloud sync complete")
+            except (GuardSyncNotConfiguredError, GuardSyncNotAvailableError, RuntimeError) as error:
+                payload["supply_chain_error"] = str(error)
+                sync_bar.done("Guard Cloud sync complete (supply chain skipped)")
     except GuardSyncNotAvailableError as error:
         store.record_latest_guard_connect_sync_result(
             status="connected",
@@ -331,7 +339,6 @@ def _finalize_guard_connect_payload(
             }
         )
         return payload
-    _print_connect_progress("Guard Cloud sync complete.")
     latest_state = store.record_latest_guard_connect_sync_success(
         sync_payload=sync_payload,
         now=str(sync_payload.get("synced_at") or now),
@@ -347,14 +354,6 @@ def _finalize_guard_connect_payload(
             "latest_connect_state": latest_state or store.get_latest_guard_connect_state(now=now),
         }
     )
-    try:
-        _print_connect_progress("Syncing supply chain state...")
-        payload["supply_chain"] = sync_supply_chain_cloud_state(
-            store,
-            auth_context=resolved_sync_auth_context,
-        )
-    except (GuardSyncNotConfiguredError, GuardSyncNotAvailableError, RuntimeError) as error:
-        payload["supply_chain_error"] = str(error)
     return payload
 
 def _filter_policy_items(items: list[dict[str, object]], *, active_only: bool) -> list[dict[str, object]]:

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -39,12 +39,6 @@ from .oauth_client import (
     resolve_guard_oauth_client_config,
 )
 
-_PROGRESS_PREFIX = "hol-guard:"
-
-def _progress(message: str) -> None:
-    """Print a progress message to stderr so the user sees activity during long operations."""
-    print(f"{_PROGRESS_PREFIX} {message}", file=sys.stderr, flush=True)
-
 DEFAULT_GUARD_SYNC_URL = "https://hol.org/api/guard/receipts/sync"
 DEFAULT_GUARD_CONNECT_URL = "https://hol.org/guard/connect"
 DEFAULT_GUARD_DEVICE_SCOPES = (
@@ -1205,54 +1199,60 @@ def run_guard_browser_connect_command(
     wait_timeout_seconds: float = 180,
     include_sync_auth_context: bool = False,
 ) -> dict[str, object]:
-    _progress("Preparing Guard Cloud authorization...")
-    prepare_guard_cloud_connect_authorization(store)
-    device = store.get_device_metadata()
-    _, allowed_origin = resolve_connect_url(connect_url)
-    oauth_client = resolve_guard_oauth_client_config(allowed_origin)
-    browser_opener = open_browser if open_browser is not None else __import__("webbrowser").open
-    _progress("Starting browser authorization session...")
-    session = start_browser_session(
-        connect_url=connect_url,
-        machine_id=str(device["installation_id"]),
-        machine_label=str(device["device_label"]),
-    )
-    try:
-        _progress("Opening browser for sign-in...")
-        browser_opened = bool(browser_opener(session.authorize_url))
-        _progress("Waiting for authentication (complete sign-in in your browser)...")
-        callback = session.wait_for_callback(wait_timeout_seconds)
-        _progress("Exchanging authorization code for tokens...")
-        token_result = exchange_authorization_code(
-            token_endpoint=oauth_client.token_endpoint,
-            client_id=oauth_client.client_id,
-            code=callback.code,
-            redirect_uri=session.redirect_uri,
-            code_verifier=session.pkce_verifier,
-            dpop_key_material=session.dpop_key_material,
+    from .progress import GuardProgress
+
+    with GuardProgress(total=6, title="Guard Connect") as bar:
+        bar.step("Preparing authorization...")
+        prepare_guard_cloud_connect_authorization(store)
+        device = store.get_device_metadata()
+        _, allowed_origin = resolve_connect_url(connect_url)
+        oauth_client = resolve_guard_oauth_client_config(allowed_origin)
+        browser_opener = open_browser if open_browser is not None else __import__("webbrowser").open
+
+        bar.step("Starting browser session...")
+        session = start_browser_session(
+            connect_url=connect_url,
+            machine_id=str(device["installation_id"]),
+            machine_label=str(device["device_label"]),
         )
-    finally:
-        session.close()
-    if token_result.refresh_token is None:
-        raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
-    _progress("Saving credentials locally...")
-    timestamp = now or datetime.now(timezone.utc).isoformat()
-    _persist_oauth_local_credentials(
-        store=store,
-        issuer=oauth_client.issuer,
-        client_id=oauth_client.client_id,
-        refresh_token=token_result.refresh_token,
-        dpop_key_material=session.dpop_key_material,
-        grant_id=token_result.grant_id,
-        machine_id=token_result.machine_id,
-        supply_chain_entitlement=token_result.supply_chain_entitlement,
-        workspace_id=token_result.workspace_id,
-        runtime_id=HEADLESS_RUNTIME_ID,
-        runtime_label=HEADLESS_RUNTIME_LABEL,
-        access_token=token_result.access_token,
-        access_token_expires_at=token_result.access_token_expires_at,
-        now=timestamp,
-    )
+        try:
+            bar.step("Opening browser for sign-in...")
+            browser_opened = bool(browser_opener(session.authorize_url))
+            bar.step("Waiting for authentication (complete sign-in in your browser)...")
+            callback = session.wait_for_callback(wait_timeout_seconds)
+            bar.step("Exchanging authorization code for tokens...")
+            token_result = exchange_authorization_code(
+                token_endpoint=oauth_client.token_endpoint,
+                client_id=oauth_client.client_id,
+                code=callback.code,
+                redirect_uri=session.redirect_uri,
+                code_verifier=session.pkce_verifier,
+                dpop_key_material=session.dpop_key_material,
+            )
+        finally:
+            session.close()
+        if token_result.refresh_token is None:
+            raise RuntimeError("Guard OAuth token exchange failed: missing refresh token.")
+        bar.step("Saving credentials locally...")
+        timestamp = now or datetime.now(timezone.utc).isoformat()
+        _persist_oauth_local_credentials(
+            store=store,
+            issuer=oauth_client.issuer,
+            client_id=oauth_client.client_id,
+            refresh_token=token_result.refresh_token,
+            dpop_key_material=session.dpop_key_material,
+            grant_id=token_result.grant_id,
+            machine_id=token_result.machine_id,
+            supply_chain_entitlement=token_result.supply_chain_entitlement,
+            workspace_id=token_result.workspace_id,
+            runtime_id=HEADLESS_RUNTIME_ID,
+            runtime_label=HEADLESS_RUNTIME_LABEL,
+            access_token=token_result.access_token,
+            access_token_expires_at=token_result.access_token_expires_at,
+            now=timestamp,
+        )
+        bar.done("Authorization complete")
+
     sync_url = _oauth_sync_url_from_issuer(oauth_client.issuer)
     payload: dict[str, object] = {
         "status": "connected",

--- a/src/codex_plugin_scanner/guard/cli/progress.py
+++ b/src/codex_plugin_scanner/guard/cli/progress.py
@@ -1,0 +1,118 @@
+"""Rich progress bar for hol-guard CLI flows (connect, sync).
+
+Falls back to plain stderr prints when rich is unavailable.
+All output goes to stderr so stdout stays clean for --json mode.
+"""
+
+from __future__ import annotations
+
+import sys
+from types import TracebackType
+
+try:
+    from rich.console import Console
+    from rich.progress import (
+        BarColumn,
+        MofNCompleteColumn,
+        Progress,
+        SpinnerColumn,
+        TaskProgressColumn,
+        TextColumn,
+        TimeElapsedColumn,
+    )
+
+    _RICH_AVAILABLE = True
+except ImportError:
+    _RICH_AVAILABLE = False
+
+
+class GuardProgress:
+    """Context manager that renders a multi-step progress bar.
+
+    Usage::
+
+        with GuardProgress(total=8, title="Guard Connect") as bar:
+            bar.step("Preparing authorization...")
+            do_prep()
+            bar.step("Opening browser...")
+            do_browser()
+            bar.done("Connected to Guard Cloud")
+    """
+
+    def __init__(self, *, total: int, title: str = "", use_rich: bool = True) -> None:
+        self._total = total
+        self._completed = 0
+        self._title = title
+        self._use_rich = use_rich and _RICH_AVAILABLE
+
+        if self._use_rich:
+            self._progress = Progress(
+                SpinnerColumn(spinner_name="dots"),
+                BarColumn(bar_width=None, complete_style="green", finished_style="green"),
+                TaskProgressColumn(),
+                TextColumn("[progress.description]{task.description}"),
+                TimeElapsedColumn(),
+                console=Console(file=sys.stderr, soft_wrap=True),
+                transient=False,
+                expand=True,
+            )
+            self._task: object | None = None
+        else:
+            self._progress = None  # type: ignore[assignment]
+
+    # -- context manager protocol -------------------------------------------
+
+    def __enter__(self) -> GuardProgress:
+        if self._use_rich and self._progress is not None:
+            self._progress.__enter__()
+            label = f"{self._title} — " if self._title else ""
+            self._task = self._progress.add_task(
+                f"{label}Starting...",
+                total=self._total,
+            )
+        else:
+            if self._title:
+                print(f"hol-guard: {self._title}", file=sys.stderr, flush=True)
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
+        if self._use_rich and self._progress is not None:
+            self._progress.__exit__(exc_type, exc_val, exc_tb)
+
+    # -- public API ----------------------------------------------------------
+
+    def step(self, description: str) -> None:
+        """Advance the progress bar and update the description.
+
+        Call this *before* starting the next step so the spinner shows
+        the new label while the step runs.
+        """
+        if self._use_rich and self._progress is not None and self._task is not None:
+            self._progress.update(self._task, description=description)
+            if self._completed > 0:
+                self._progress.advance(self._task)
+            self._completed += 1
+        else:
+            pct = int(self._completed * 100 / self._total) if self._total else 0
+            print(
+                f"hol-guard: [{pct:3d}%] {description}",
+                file=sys.stderr,
+                flush=True,
+            )
+            self._completed += 1
+
+    def done(self, description: str = "Complete") -> None:
+        """Mark all steps as complete with a green checkmark."""
+        if self._use_rich and self._progress is not None and self._task is not None:
+            self._progress.update(
+                self._task,
+                description=f"✓ {description}",
+                completed=self._total,
+            )
+        else:
+            print(f"hol-guard: ✓ {description}", file=sys.stderr, flush=True)


### PR DESCRIPTION
## Problem

PR #1186 added static stderr prints for progress, but the user wants a proper progress bar with percentage, elapsed time, and spinner — great DX. The `hol-guard sync` command also had no progress feedback.

## Fix

New `cli/progress.py` module with `GuardProgress` — a context manager that renders a live `rich.progress.Progress` bar with spinner, percentage, bar, description, and elapsed time. Falls back to `[NN%]` prefixed stderr prints when `rich` is unavailable.

### What the user sees

**`hol-guard connect`:**
```
⠋ Guard Connect — ████████████████████████████    83% Exchanging authorization code for tokens... 0:00:12
```

6-step bar: preparing auth → browser session → opening browser → waiting for auth → exchanging tokens → saving credentials → ✓ done

**`hol-guard sync`:**
```
⠋ Guard Sync — ████████████████                  50% Syncing supply chain state... 0:00:03
```

2-step bar: syncing receipts → syncing supply chain → ✓ done

### Design

- **`rich.progress.Progress`** with `SpinnerColumn` (dots), `BarColumn` (green), `TaskProgressColumn`, `TextColumn`, `TimeElapsedColumn`
- **Fallback**: `[NN%] message` stderr prints when rich unavailable (matches `render.py` pattern)
- **stderr only**: stdout stays clean for `--json` mode
- **`step()` called before work starts**: spinner shows the new label while the step runs
- **`done()` marks completion**: green checkmark + full bar
- **`transient=False`**: bar remains visible after completion (not erased)

### Files changed

| File | Change |
|---|---|
| `cli/progress.py` | **NEW** — `GuardProgress` context manager |
| `cli/connect_flow.py` | Replace `_progress()` with `GuardProgress` (6-step bar) |
| `cli/commands_support_connect.py` | Replace `_print_connect_progress()` with `GuardProgress` (2-step sync bar) |
| `cli/commands_dispatch_cloud.py` | Add `GuardProgress` to `_run_guard_sync_command` (2-step sync bar) |

### Testing

- Python syntax validated for all 4 files
- 64 connect flow + device connect tests pass
- 251 sync tests pass (excluding 1 pre-existing git identity enforcement failure)
- Removes unused `_progress` and `_print_connect_progress` helpers from PR #1186

### Supersedes PR #1186

PR #1186 added static prints; this PR replaces them with the rich progress bar. The static prints were a stopgap — this is the real DX fix.