### PR TITLE
fix(cli): progress bar stuck at 0% on first step

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/progress.py
+++ b/src/codex_plugin_scanner/guard/cli/progress.py
@@ -90,21 +90,21 @@ class GuardProgress:
         """Advance the progress bar and update the description.
 
         Call this *before* starting the next step so the spinner shows
-        the new label while the step runs.
+        the new label while the step runs. The bar advances immediately
+        so step 1 shows 1/total (not 0%) while it runs.
         """
         if self._use_rich and self._progress is not None and self._task is not None:
+            self._progress.advance(self._task)
             self._progress.update(self._task, description=description)
-            if self._completed > 0:
-                self._progress.advance(self._task)
             self._completed += 1
         else:
+            self._completed += 1
             pct = int(self._completed * 100 / self._total) if self._total else 0
             print(
                 f"hol-guard: [{pct:3d}%] {description}",
                 file=sys.stderr,
                 flush=True,
             )
-            self._completed += 1
 
     def done(self, description: str = "Complete") -> None:
         """Mark all steps as complete with a green checkmark."""


### PR DESCRIPTION
## Bug

The progress bar stays at 0% during the first step — which is the longest step (10-17s for `sync_local_guard_cloud_proof`). The user sees `0% Syncing local proof to Guard Cloud...` for 30+ seconds and thinks it's stuck.

## Root cause

`step()` skipped `advance()` when `_completed == 0`:

```python
if self._completed > 0:        # ← False on first call
    self._progress.advance(self._task)
```

So step 1 never advanced the bar while it was running.

## Fix

Call `advance()` unconditionally before updating the description:

```python
self._progress.advance(self._task)     # advance first
self._progress.update(self._task, description=description)
```

Now step 1 shows `1/total` immediately while it runs. The fallback path also increments `_completed` before calculating the percentage.

## Testing

64 connect flow + device connect tests pass.