### PR TITLE
fix(cli): advance progress bar on first step

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -6,7 +6,6 @@ import base64
 import http.server
 import json
 import secrets
-import sys
 import threading
 import time
 import urllib.error

--- a/src/codex_plugin_scanner/guard/cli/progress.py
+++ b/src/codex_plugin_scanner/guard/cli/progress.py
@@ -13,7 +13,6 @@ try:
     from rich.console import Console
     from rich.progress import (
         BarColumn,
-        MofNCompleteColumn,
         Progress,
         SpinnerColumn,
         TaskProgressColumn,

--- a/src/codex_plugin_scanner/guard/cli/progress.py
+++ b/src/codex_plugin_scanner/guard/cli/progress.py
@@ -90,21 +90,21 @@ class GuardProgress:
         """Advance the progress bar and update the description.
 
         Call this *before* starting the next step so the spinner shows
-        the new label while the step runs.
+        the new label while the step runs. The bar advances immediately
+        so step 1 shows 1/total (not 0%) while it runs.
         """
         if self._use_rich and self._progress is not None and self._task is not None:
+            self._progress.advance(self._task)
             self._progress.update(self._task, description=description)
-            if self._completed > 0:
-                self._progress.advance(self._task)
             self._completed += 1
         else:
+            self._completed += 1
             pct = int(self._completed * 100 / self._total) if self._total else 0
             print(
                 f"hol-guard: [{pct:3d}%] {description}",
                 file=sys.stderr,
                 flush=True,
             )
-            self._completed += 1
 
     def done(self, description: str = "Complete") -> None:
         """Mark all steps as complete with a green checkmark."""

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -352,8 +352,11 @@ def validated_policy_bundle_payload(
         and payload_hash != f"sha256:{computed_payload_hash}"
     ):
         import logging
+
         logging.getLogger(__name__).warning(
-            "payload_hash_mismatch: portal=%s computed=%s", payload_hash, computed_payload_hash,
+            "payload_hash_mismatch: portal=%s computed=%s",
+            payload_hash,
+            computed_payload_hash,
         )
     bundle_hash = _non_empty_string(policy_bundle.get("bundleHash"))
     if bundle_hash is None:

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -346,7 +346,11 @@ def validated_policy_bundle_payload(
     # bundleHash check below provides the primary integrity guarantee. Log
     # the mismatch but don't reject — blocking here prevents valid bundles
     # from being stored, which breaks per-rule enforcement.
-    if payload_hash is not None and payload_hash != computed_payload_hash and payload_hash != f"sha256:{computed_payload_hash}":
+    if (
+        payload_hash is not None
+        and payload_hash != computed_payload_hash
+        and payload_hash != f"sha256:{computed_payload_hash}"
+    ):
         import logging
         logging.getLogger(__name__).warning(
             "payload_hash_mismatch: portal=%s computed=%s", payload_hash, computed_payload_hash,

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -346,17 +346,10 @@ def validated_policy_bundle_payload(
     # bundleHash check below provides the primary integrity guarantee. Log
     # the mismatch but don't reject — blocking here prevents valid bundles
     # from being stored, which breaks per-rule enforcement.
-    if (
-        payload_hash is not None
-        and payload_hash != computed_payload_hash
-        and payload_hash != f"sha256:{computed_payload_hash}"
-    ):
+    if payload_hash is not None and payload_hash != computed_payload_hash and payload_hash != f"sha256:{computed_payload_hash}":
         import logging
-
         logging.getLogger(__name__).warning(
-            "payload_hash_mismatch: portal=%s computed=%s",
-            payload_hash,
-            computed_payload_hash,
+            "payload_hash_mismatch: portal=%s computed=%s", payload_hash, computed_payload_hash,
         )
     bundle_hash = _non_empty_string(policy_bundle.get("bundleHash"))
     if bundle_hash is None:


### PR DESCRIPTION
## Bug

The progress bar stays at 0% during the first step — which is the longest step (10-17s for `sync_local_guard_cloud_proof`). Users see `0% Syncing local proof to Guard Cloud...` for 30+ seconds and think the CLI is stuck.

## Root cause

`step()` skipped `advance()` when `_completed == 0`:

```python
if self._completed > 0:        # False on first call
    self._progress.advance(self._task)
```

So step 1 never advanced the bar while it was running — the bar only started moving on step 2.

## Fix

Call `advance()` unconditionally before updating the description:

```python
self._progress.advance(self._task)     # advance first
self._progress.update(self._task, description=description)
```

Now step 1 shows `1/total` immediately while it runs. The fallback (non-rich) path also increments `_completed` before calculating the percentage so the first `[NN%]` print shows progress instead of 0%.

## Lint fixes

Also removes two unused imports that cause pre-existing ruff lint failures on `main`:
- `MofNCompleteColumn` from `progress.py`
- `sys` from `connect_flow.py`

## Notes

CI is already red on `main` with these same ruff lint errors plus pre-existing basedpyright type errors in `progress.py` that are hidden behind the ruff failures. This PR fixes the ruff errors; the basedpyright type errors are pre-existing and out of scope.

## Testing

64 connect flow + device connect tests pass.
