### PR TITLE
fix(guard): allow fixture docs in hook scans

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/progress.py
+++ b/src/codex_plugin_scanner/guard/cli/progress.py
@@ -7,22 +7,11 @@ All output goes to stderr so stdout stays clean for --json mode.
 from __future__ import annotations
 
 import sys
+from importlib.util import find_spec
 from types import TracebackType
+from typing import Any
 
-try:
-    from rich.console import Console
-    from rich.progress import (
-        BarColumn,
-        Progress,
-        SpinnerColumn,
-        TaskProgressColumn,
-        TextColumn,
-        TimeElapsedColumn,
-    )
-
-    _RICH_AVAILABLE = True
-except ImportError:
-    _RICH_AVAILABLE = False
+_rich_available = find_spec("rich") is not None
 
 
 class GuardProgress:
@@ -42,9 +31,21 @@ class GuardProgress:
         self._total = total
         self._completed = 0
         self._title = title
-        self._use_rich = use_rich and _RICH_AVAILABLE
+        self._use_rich = use_rich and _rich_available
+        self._progress: Any | None = None
+        self._task: Any | None = None
 
         if self._use_rich:
+            from rich.console import Console
+            from rich.progress import (
+                BarColumn,
+                Progress,
+                SpinnerColumn,
+                TaskProgressColumn,
+                TextColumn,
+                TimeElapsedColumn,
+            )
+
             self._progress = Progress(
                 SpinnerColumn(spinner_name="dots"),
                 BarColumn(bar_width=None, complete_style="green", finished_style="green"),
@@ -55,9 +56,6 @@ class GuardProgress:
                 transient=False,
                 expand=True,
             )
-            self._task: object | None = None
-        else:
-            self._progress = None  # type: ignore[assignment]
 
     # -- context manager protocol -------------------------------------------
 

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -346,10 +346,16 @@ def validated_policy_bundle_payload(
     # bundleHash check below provides the primary integrity guarantee. Log
     # the mismatch but don't reject — blocking here prevents valid bundles
     # from being stored, which breaks per-rule enforcement.
-    if payload_hash is not None and payload_hash != computed_payload_hash and payload_hash != f"sha256:{computed_payload_hash}":
+    if (
+        payload_hash is not None
+        and payload_hash != computed_payload_hash
+        and payload_hash != f"sha256:{computed_payload_hash}"
+    ):
         import logging
+
         logging.getLogger(__name__).warning(
-            "payload_hash_mismatch: portal=%s computed=%s", payload_hash, computed_payload_hash,
+            "payload_hash_mismatch: portal_present=true computed_payload_hash=%s",
+            computed_payload_hash,
         )
     bundle_hash = _non_empty_string(policy_bundle.get("bundleHash"))
     if bundle_hash is None:

--- a/src/codex_plugin_scanner/guard/runtime/hook_content_scanner.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_content_scanner.py
@@ -14,6 +14,7 @@ calls the network. It is safe to call from the daemon hot path.
 
 from __future__ import annotations
 
+import os
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -191,7 +192,11 @@ def _scan_window(
     matches_by_classifier: dict[str, ContentScanMatch],
 ) -> None:
     """Classify one rolling window and merge new matches."""
-    suppressed_matches = classify_secret_content(window, suppress_samples=True)
+    suppressed_matches = classify_secret_content(
+        window,
+        suppress_samples=True,
+        documentation_sample_context=not local_content,
+    )
     for match in suppressed_matches:
         if match.classifier not in matches_by_classifier:
             matches_by_classifier[match.classifier] = ContentScanMatch(
@@ -214,6 +219,81 @@ def _scan_window(
                     sensitivity=match.sensitivity,
                     reason=match.reason,
                 )
+
+
+_DOCUMENTATION_OR_FIXTURE_SEGMENTS = frozenset(
+    {
+        "__fixtures__",
+        "__tests__",
+        "docs",
+        "documentation",
+        "examples",
+        "fixtures",
+        "samples",
+        "spec",
+        "test",
+        "tests",
+    }
+)
+_DOCUMENTATION_SUFFIXES = (".adoc", ".md", ".mdx", ".rst", ".txt")
+
+
+def should_unsuppress_local_sample_secrets(
+    path: str | None,
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+) -> bool:
+    """Return whether local-content scanning should treat sample assignments as secrets.
+
+    Documentation, examples, tests, and fixture files often contain inert
+    placeholder assignments that agents need to read while editing reviews or
+    security guidance. Real credential formats remain blocked by the higher
+    confidence token classifiers; this helper only controls the medium generic
+    assignment retry for sample-looking values.
+    """
+    if path is None:
+        return True
+    normalized = _normalize_scan_context_path(path, cwd=cwd)
+    segments = tuple(segment for segment in normalized.split("/") if segment)
+    if not segments:
+        return True
+    if ".." in segments:
+        return True
+    if any(segment in _DOCUMENTATION_OR_FIXTURE_SEGMENTS for segment in segments):
+        return False
+    return not segments[-1].endswith(_DOCUMENTATION_SUFFIXES)
+
+
+def _normalize_scan_context_path(path: str, *, cwd: str | os.PathLike[str] | None) -> str:
+    raw_path = path.strip()
+    if not raw_path:
+        return ""
+    has_windows_drive = len(raw_path) >= 3 and raw_path[1] == ":" and raw_path[2] in {"\\", "/"}
+    is_absolute = raw_path.startswith(("/", "\\")) or has_windows_drive
+    if is_absolute:
+        if cwd is not None:
+            try:
+                rel_path = os.path.relpath(raw_path, os.fspath(cwd))
+            except ValueError:
+                rel_path = os.path.basename(raw_path)
+            else:
+                if rel_path == ".." or rel_path.startswith(f"..{os.sep}") or rel_path.startswith("../"):
+                    rel_path = os.path.basename(raw_path)
+            raw_path = rel_path
+        else:
+            raw_path = os.path.basename(raw_path)
+    return os.path.normpath(raw_path).replace("\\", "/").lower()
+
+
+def should_unsuppress_local_sample_secrets_for_paths(
+    paths: tuple[str, ...],
+    *,
+    cwd: str | os.PathLike[str] | None = None,
+) -> bool:
+    """Return False only when every known path is docs/test/fixture context."""
+    if not paths:
+        return True
+    return any(should_unsuppress_local_sample_secrets(path, cwd=cwd) for path in paths)
 
 
 def _truncate_to_byte_limit(text: str, max_bytes: int) -> str:
@@ -239,4 +319,6 @@ __all__ = [
     "ContentScanMatch",
     "ContentScanResult",
     "ContentScanner",
+    "should_unsuppress_local_sample_secrets",
+    "should_unsuppress_local_sample_secrets_for_paths",
 ]

--- a/src/codex_plugin_scanner/guard/runtime/hook_review_engine.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_review_engine.py
@@ -24,7 +24,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from .actions import normalize_harness_payload
-from .hook_content_scanner import ContentScanner
+from .hook_content_scanner import ContentScanner, should_unsuppress_local_sample_secrets_for_paths
 from .hook_decision_cache import HookDecisionCache
 from .hook_review_types import HookReviewRequest, HookReviewResponse
 from .hook_source_read import (
@@ -42,6 +42,13 @@ HOOK_ENGINE_NORMAL_BUDGET_MS = 1000
 HOOK_SOURCE_FAST_PATH_BUDGET_MS = 250
 HOOK_SCANNER_DEFAULT_BUDGET_MS = 750
 ARBITRARY_STDOUT_FULL_ALLOW_BYTES = 256 * 1024
+
+
+def _target_paths(envelope: object) -> tuple[str, ...]:
+    target_paths = getattr(envelope, "target_paths", ())
+    if isinstance(target_paths, (list, tuple)):
+        return tuple(path for path in target_paths if isinstance(path, str) and path.strip())
+    return ()
 
 
 class HookFailSafe(RuntimeError):  # noqa: N818
@@ -177,7 +184,7 @@ class HookReviewEngine:
         config: GuardConfig,
         start: float,
     ) -> HookReviewResponse:
-        """Scan full tool output for PostToolUse file reads without guard_source_ref.
+        """Scan full tool output for PostToolUse file operations without guard_source_ref.
 
         This is the server-side fast path for all harnesses that do not
         generate ``guard_source_ref`` client-side (claude-code, codex,
@@ -185,14 +192,14 @@ class HookReviewEngine:
         payload, scans it for secrets, and returns ``allow_original``
         if clean.
 
-        Only ``file_read`` actions are eligible — shell commands, MCP
+        Only file read/write actions are eligible — shell commands, MCP
         tools, and other action types still need the full CLI policy/
         permission/approval engine and fall through to ``_review_standard``.
         """
         from .hook_output_text import extract_payload_output
 
         action_type = getattr(envelope, "action_type", None)
-        if action_type != "file_read":
+        if action_type not in {"file_read", "file_write"}:
             return self._review_standard(request, envelope, config, start)
 
         extracted = extract_payload_output(request.payload)
@@ -201,13 +208,16 @@ class HookReviewEngine:
             # No output text found in payload — fall back to excerpt path.
             return self._review_standard(request, envelope, config, start)
 
+        target_paths = _target_paths(envelope)
+        scan_local_samples = should_unsuppress_local_sample_secrets_for_paths(target_paths, cwd=request.cwd)
+
         if extracted.truncated:
             # Output too large to scan in full — scan the excerpt before returning.
             excerpt = extracted.text[:SOURCE_READ_FULL_MODEL_BYTES_P95_TARGET]
             deadline = start + (HOOK_SCANNER_DEFAULT_BUDGET_MS / 1000.0)
             scan_result = self.scanner.scan_text(
                 excerpt,
-                local_content=True,
+                local_content=scan_local_samples,
                 source_context=True,
                 max_bytes=SOURCE_READ_MAX_SCAN_BYTES,
                 deadline_monotonic=deadline,
@@ -234,7 +244,7 @@ class HookReviewEngine:
         deadline = start + (HOOK_SCANNER_DEFAULT_BUDGET_MS / 1000.0)
         scan_result = self.scanner.scan_text(
             extracted.text,
-            local_content=True,
+            local_content=scan_local_samples,
             source_context=True,
             max_bytes=SOURCE_READ_MAX_SCAN_BYTES,
             deadline_monotonic=deadline,
@@ -299,6 +309,9 @@ class HookReviewEngine:
         #
         # If the output summary is available and small enough, we can
         # scan the excerpt. But we never allow original without proof.
+        target_paths = _target_paths(envelope)
+        scan_local_samples = should_unsuppress_local_sample_secrets_for_paths(target_paths, cwd=request.cwd)
+
         output_summary = request.output_summary
         if output_summary is not None and output_summary.text_excerpt:
             excerpt = output_summary.text_excerpt
@@ -306,7 +319,7 @@ class HookReviewEngine:
             deadline = start + (HOOK_SCANNER_DEFAULT_BUDGET_MS / 1000.0)
             scan_result = self.scanner.scan_text(
                 excerpt,
-                local_content=True,
+                local_content=scan_local_samples,
                 source_context=False,
                 max_bytes=SOURCE_READ_MAX_SCAN_BYTES,
                 deadline_monotonic=deadline,

--- a/src/codex_plugin_scanner/guard/runtime/hook_source_read.py
+++ b/src/codex_plugin_scanner/guard/runtime/hook_source_read.py
@@ -29,7 +29,7 @@ import stat
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Literal
 
-from .hook_content_scanner import ContentScanMatch, ContentScanner
+from .hook_content_scanner import ContentScanMatch, ContentScanner, should_unsuppress_local_sample_secrets
 from .hook_decision_cache import HookDecisionCache, SourceReadCacheMaterial, hook_config_fingerprint
 from .hook_review_types import HookReviewRequest
 from .secret_sensitivity import classify_secret_path
@@ -299,7 +299,7 @@ def evaluate_source_file_ref(
     # 9. Streaming scan.
     scan_result = scanner.scan_text(
         text,
-        local_content=True,
+        local_content=should_unsuppress_local_sample_secrets(source_ref.path, cwd=request.cwd),
         source_context=True,
         max_bytes=SOURCE_READ_MAX_SCAN_BYTES,
         deadline_monotonic=deadline_monotonic,

--- a/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_sensitivity.py
@@ -93,6 +93,9 @@ _SENSITIVE_PATH_REASONS = {
 _SECRET_ASSIGNMENT_VALUE_PATTERN = r"(?:\"[^\"\r\n]+\"|'[^'\r\n]+'|[^ \t\r\n\"',}]+)"
 _HEDERA_PRIVATE_KEY_VALUE_PATTERN = r"(?:\"(?:0x)?[0-9a-f]{64,96}\"|'(?:0x)?[0-9a-f]{64,96}'|(?:0x)?[0-9a-f]{64,96}\b)"
 _SAMPLE_SECRET_VALUE_PATTERN = re.compile(r"(?i)\b(?:example|fake|dummy|invalid|test|canary)\b")
+_DOCUMENTATION_SAMPLE_SECRET_VALUE_PATTERN = re.compile(
+    r"(?i)^(?:fixture|placeholder)(?:[-_.]?(?:only|value|secret|credential|token|key|example|dummy|fake|test|sample|\d{1,4}))*$"
+)
 _SAMPLE_SUPPRESSIBLE_CONTENT_CLASSIFIERS = frozenset({"credential-assignment", "generic-bearer-token"})
 _SECRET_CONTENT_PATTERNS: tuple[tuple[str, str, SecretContentSensitivity, re.Pattern[str], str], ...] = (
     (
@@ -281,7 +284,12 @@ def classify_legacy_secret_path_families(text: str) -> set[str]:
     return {family for marker, family in LEGACY_SECRET_PATH_TEXT_MARKERS if marker in lowered}
 
 
-def classify_secret_content(text: str | None, *, suppress_samples: bool = True) -> tuple[SecretContentMatch, ...]:
+def classify_secret_content(
+    text: str | None,
+    *,
+    suppress_samples: bool = True,
+    documentation_sample_context: bool = False,
+) -> tuple[SecretContentMatch, ...]:
     if not isinstance(text, str) or not text.strip():
         return ()
     matches: list[SecretContentMatch] = []
@@ -290,7 +298,12 @@ def classify_secret_content(text: str | None, *, suppress_samples: bool = True) 
         if classifier in seen:
             continue
         if not any(
-            not _secret_content_match_is_sample(classifier=classifier, text=match.group(0), enabled=suppress_samples)
+            not _secret_content_match_is_sample(
+                classifier=classifier,
+                text=match.group(0),
+                enabled=suppress_samples,
+                documentation_sample_context=documentation_sample_context,
+            )
             for match in pattern.finditer(text)
         ):
             continue
@@ -311,9 +324,9 @@ def secret_content_rule_version() -> str:
 
     This lets caches invalidate when secret detection patterns change.
     The hash is deterministic across calls within one process and stable
-    as long as ``_SECRET_CONTENT_PATTERNS`` is unchanged.
+    as long as the content patterns or sample suppressors are unchanged.
     """
-    material = [
+    material: list[dict[str, object]] = [
         {
             "classifier": classifier,
             "family": family,
@@ -323,16 +336,56 @@ def secret_content_rule_version() -> str:
         }
         for classifier, family, sensitivity, pattern, _reason in _SECRET_CONTENT_PATTERNS
     ]
+    material.extend(
+        [
+            {
+                "classifier": "sample-secret-values",
+                "pattern": _SAMPLE_SECRET_VALUE_PATTERN.pattern,
+                "flags": _SAMPLE_SECRET_VALUE_PATTERN.flags,
+            },
+            {
+                "classifier": "documentation-sample-secret-values",
+                "pattern": _DOCUMENTATION_SAMPLE_SECRET_VALUE_PATTERN.pattern,
+                "flags": _DOCUMENTATION_SAMPLE_SECRET_VALUE_PATTERN.flags,
+            },
+        ]
+    )
     return hashlib.sha256(json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")).hexdigest()
 
 
-def _secret_content_match_is_sample(*, classifier: str, text: str, enabled: bool) -> bool:
+def _secret_content_match_is_sample(
+    *,
+    classifier: str,
+    text: str,
+    enabled: bool,
+    documentation_sample_context: bool,
+) -> bool:
     if not enabled or classifier not in _SAMPLE_SUPPRESSIBLE_CONTENT_CLASSIFIERS:
         return False
     if classifier == "generic-bearer-token":
         token = text.rsplit(None, 1)[-1]
-        return _SAMPLE_SECRET_VALUE_PATTERN.search(token) is not None and re.search(r"[A-Za-z0-9]{20,}", token) is None
-    return _SAMPLE_SECRET_VALUE_PATTERN.search(text) is not None
+        if _SAMPLE_SECRET_VALUE_PATTERN.search(token) is not None and re.search(r"[A-Za-z0-9]{20,}", token) is None:
+            return True
+        return documentation_sample_context and _DOCUMENTATION_SAMPLE_SECRET_VALUE_PATTERN.fullmatch(token) is not None
+    if _SAMPLE_SECRET_VALUE_PATTERN.search(text) is not None:
+        return True
+    if not documentation_sample_context:
+        return False
+    value = _extract_secret_assignment_value(text)
+    return value is not None and _DOCUMENTATION_SAMPLE_SECRET_VALUE_PATTERN.fullmatch(value) is not None
+
+
+def _extract_secret_assignment_value(text: str) -> str | None:
+    colon_index = text.find(":")
+    equals_index = text.find("=")
+    separator_indexes = [index for index in (colon_index, equals_index) if index >= 0]
+    if not separator_indexes:
+        return None
+    value = text[min(separator_indexes) + 1 :]
+    stripped = value.strip().rstrip(",}").strip()
+    if len(stripped) >= 2 and stripped[0] == stripped[-1] and stripped[0] in {"'", '"'}:
+        stripped = stripped[1:-1]
+    return stripped or None
 
 
 def redacted_secret_path_context(path: str) -> str | None:

--- a/tests/docker/test_all_harness_hooks.py
+++ b/tests/docker/test_all_harness_hooks.py
@@ -4,12 +4,12 @@
 This test starts a real Guard daemon inside a Docker container, then sends
 HTTP hook payloads for each harness to /v1/hooks/{harness}, verifying:
 
-1. Pi PostToolUse with guard_source_ref returns allow_original (fast path)
-2. Pi PreToolUse falls through to legacy CLI
-3. All other harnesses (claude-code, codex, grok, zcode) fall through to
-   legacy CLI for PostToolUse (they don't generate guard_source_ref)
-4. All harnesses' PreToolUse falls through to legacy CLI
-5. Secret content is denied for all harnesses
+1. PreToolUse falls through to legacy CLI
+2. PostToolUse file reads without source_ref use output scanning
+3. PostToolUse with source_ref returns allow_original
+4. Docs/test fixture placeholder content is allowed for read and edit hooks
+5. Real credential-looking output is denied for every harness
+6. Fixture-prefixed realistic output stays denied in docs
 
 Usage:
     python tests/docker/test_all_harness_hooks.py
@@ -227,6 +227,115 @@ def run_tests(port: int, auth_token: str, harnesses: list[str]) -> tuple[int, in
             else:
                 print(f"  [FAIL] {harness} returned not_applicable for source_ref")
                 failed += 1
+
+        # Test 4: docs/test fixture samples do not block large review/security docs
+        result = send_hook(
+            port,
+            harness,
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": "docs/security-review.md"},
+                "tool_response": [
+                    {
+                        "type": "text",
+                        "text": "Review fixture notes: credential = 'fixture-only'\\n"
+                        "Security command examples stay inert in docs.\\n",
+                    }
+                ],
+            },
+            auth_token=auth_token,
+        )
+        if "error" in result:
+            print(f"  [FAIL] Docs fixture output error: {result}")
+            failed += 1
+        elif result.get("model_output_action") == "allow_original" or result.get("policy_action") == "allow":
+            print(f"  [PASS] {harness} docs fixture sample output allowed")
+            passed += 1
+        else:
+            print(f"  [FAIL] {harness} expected docs fixture allow, got {result}")
+            failed += 1
+
+        # Test 5: docs/test fixture samples do not block edit/write patch outputs
+        result = send_hook(
+            port,
+            harness,
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Edit",
+                "tool_input": {
+                    "file_path": "docs/security-review.md",
+                    "old_string": "old",
+                    "new_string": "Review fixture notes: credential = 'fixture-only'\\n",
+                },
+                "tool_response": [
+                    {
+                        "type": "text",
+                        "text": "Applied patch to docs/security-review.md\\n"
+                        "Review fixture notes: credential = 'fixture-only'\\n",
+                    }
+                ],
+                "tool_response_summary": {
+                    "text_excerpt": "Applied patch to docs/security-review.md\\n"
+                    "Review fixture notes: credential = 'fixture-only'\\n",
+                    "excerpt_truncated": False,
+                },
+            },
+            auth_token=auth_token,
+        )
+        if "error" in result:
+            print(f"  [FAIL] Docs fixture edit output error: {result}")
+            failed += 1
+        elif result.get("policy_action") == "allow":
+            print(f"  [PASS] {harness} docs fixture edit output allowed")
+            passed += 1
+        else:
+            print(f"  [FAIL] {harness} expected docs fixture edit allow, got {result}")
+            failed += 1
+
+        # Test 6: real credential-looking output still blocks
+        result = send_hook(
+            port,
+            harness,
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": "src/config.ts"},
+                "tool_response": [{"type": "text", "text": "credential = 'prod-live-value'\\n"}],
+            },
+            auth_token=auth_token,
+        )
+        if "error" in result:
+            print(f"  [FAIL] Real credential output error: {result}")
+            failed += 1
+        elif result.get("model_output_action") == "block" or result.get("policy_action") == "block":
+            print(f"  [PASS] {harness} real credential output blocked")
+            passed += 1
+        else:
+            print(f"  [FAIL] {harness} expected credential block, got {result}")
+            failed += 1
+
+        # Test 7: fixture-prefixed realistic output still blocks in docs
+        result = send_hook(
+            port,
+            harness,
+            {
+                "hook_event_name": "PostToolUse",
+                "tool_name": "Read",
+                "tool_input": {"file_path": "docs/security-review.md"},
+                "tool_response": [{"type": "text", "text": "credential = 'fixture-prod-value'\\n"}],
+            },
+            auth_token=auth_token,
+        )
+        if "error" in result:
+            print(f"  [FAIL] Fixture-prefixed credential output error: {result}")
+            failed += 1
+        elif result.get("model_output_action") == "block" or result.get("policy_action") == "block":
+            print(f"  [PASS] {harness} fixture-prefixed credential output blocked")
+            passed += 1
+        else:
+            print(f"  [FAIL] {harness} expected fixture-prefixed credential block, got {result}")
+            failed += 1
 
     print(f"\n{'=' * 50}\n  RESULTS: {passed} passed, {failed} failed\n{'=' * 50}")
     return passed, failed

--- a/tests/test_guard_hook_worker.py
+++ b/tests/test_guard_hook_worker.py
@@ -385,6 +385,118 @@ class TestHookWorkerAllHarnessFallback:
 class TestHookWorkerOutputScanning:
     """Tests for the server-side output scanning fast path."""
 
+    @pytest.mark.parametrize("harness", ["pi", "claude-code", "codex", "grok", "zcode"])
+    def test_documentation_fixture_sample_output_allows_original(
+        self, worker: HookWorker, workspace: Path, home_dir: Path, guard_home: Path, harness: str
+    ) -> None:
+        """Docs and fixture examples should not block read outputs."""
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "docs/security-review.md"},
+            "tool_response": [
+                {
+                    "type": "text",
+                    "text": "Review fixture notes: credential = 'fixture-only'\\n"
+                    "Security command examples stay inert in docs.\\n",
+                }
+            ],
+        }
+
+        result = worker.review_http_payload(
+            payload=payload,
+            params={},
+            default_harness=harness,
+            home_dir=home_dir,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+
+        assert result["policy_action"] == "allow"
+        if harness == "pi":
+            assert result["decision"] == "allow"
+            assert result["model_output_action"] == "allow_original"
+            assert result["reason_code"] == "output_scan_allow"
+        else:
+            assert result["hookSpecificOutput"] == {"hookEventName": "PostToolUse"}
+
+    @pytest.mark.parametrize("harness", ["pi", "claude-code", "codex", "grok", "zcode"])
+    def test_documentation_fixture_patch_output_allows_original(
+        self, worker: HookWorker, workspace: Path, home_dir: Path, guard_home: Path, harness: str
+    ) -> None:
+        """Docs fixture examples should not block edit/write post-tool outputs."""
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Edit",
+            "tool_input": {
+                "file_path": "docs/security-review.md",
+                "old_string": "old",
+                "new_string": "Review fixture notes: credential = 'fixture-only'\\n",
+            },
+            "tool_response": [
+                {
+                    "type": "text",
+                    "text": "Applied patch to docs/security-review.md\\n"
+                    "Review fixture notes: credential = 'fixture-only'\\n",
+                }
+            ],
+            "tool_response_summary": {
+                "text_excerpt": "Applied patch to docs/security-review.md\\n"
+                "Review fixture notes: credential = 'fixture-only'\\n",
+                "excerpt_truncated": False,
+            },
+        }
+
+        result = worker.review_http_payload(
+            payload=payload,
+            params={},
+            default_harness=harness,
+            home_dir=home_dir,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+
+        assert result["policy_action"] == "allow"
+        if harness == "pi":
+            assert result["decision"] == "allow"
+            assert result["model_output_action"] == "allow_original"
+            assert result["reason_code"] == "output_scan_allow"
+        else:
+            assert result["hookSpecificOutput"] == {"hookEventName": "PostToolUse"}
+
+    def test_source_ref_documentation_fixture_sample_allows_original(
+        self, worker: HookWorker, workspace: Path, home_dir: Path, guard_home: Path
+    ) -> None:
+        """Pi/OMP source refs suppress inert docs fixture assignments."""
+        content = "Review fixture notes: credential = 'fixture-only'\\nSecurity command examples stay inert in docs.\\n"
+        file_path = workspace / "docs" / "security-review.md"
+        file_path.write_text(content)
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "docs/security-review.md"},
+            "guard_source_ref": {
+                "version": 1,
+                "path": "docs/security-review.md",
+                "output_sha256": sha256_text(content),
+                "output_chars": len(content),
+                "tool_input_path": "docs/security-review.md",
+            },
+        }
+
+        result = worker.review_http_payload(
+            payload=payload,
+            params={},
+            default_harness="pi",
+            home_dir=home_dir,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+
+        assert result["decision"] == "allow"
+        assert result["model_output_action"] == "allow_original"
+        assert result["reason_code"] == "source_full_scan_allow"
+
     def test_secret_in_output_blocks(
         self, worker: HookWorker, workspace: Path, home_dir: Path, guard_home: Path
     ) -> None:
@@ -393,7 +505,7 @@ class TestHookWorkerOutputScanning:
             "hook_event_name": "PostToolUse",
             "tool_name": "Read",
             "tool_input": {"file_path": "src/config.ts"},
-            "tool_response": [{"type": "text", "text": "credential = 'fixture-only'\n"}],
+            "tool_response": [{"type": "text", "text": "credential = 'prod-live-value'\n"}],
         }
 
         result = worker.review_http_payload(
@@ -408,6 +520,78 @@ class TestHookWorkerOutputScanning:
         assert result["decision"] == "block"
         assert result["continue"] is False
         assert result["stopReason"] == result["reason"]
+        assert result["policy_action"] == "block"
+        assert result["model_output_action"] == "block"
+        assert result["reason_code"] == "output_secret_match"
+
+    def test_documentation_demo_secret_output_blocks(
+        self, worker: HookWorker, workspace: Path, home_dir: Path, guard_home: Path
+    ) -> None:
+        """Docs relaxation does not suppress realistic non-placeholder secrets."""
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "docs/security-review.md"},
+            "tool_response": [{"type": "text", "text": "credential = 'demo-live-secret'\n"}],
+        }
+
+        result = worker.review_http_payload(
+            payload=payload,
+            params={},
+            default_harness="claude-code",
+            home_dir=home_dir,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+
+        assert result["policy_action"] == "block"
+        assert result["model_output_action"] == "block"
+        assert result["reason_code"] == "output_secret_match"
+
+    def test_documentation_fixture_prefixed_secret_output_blocks(
+        self, worker: HookWorker, workspace: Path, home_dir: Path, guard_home: Path
+    ) -> None:
+        """Docs relaxation only suppresses exact inert fixture placeholders."""
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_path": "docs/security-review.md"},
+            "tool_response": [{"type": "text", "text": "credential = 'fixture-prod-value'\n"}],
+        }
+
+        result = worker.review_http_payload(
+            payload=payload,
+            params={},
+            default_harness="claude-code",
+            home_dir=home_dir,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+
+        assert result["policy_action"] == "block"
+        assert result["model_output_action"] == "block"
+        assert result["reason_code"] == "output_secret_match"
+
+    def test_mixed_docs_and_source_paths_keep_secret_retry(
+        self, worker: HookWorker, workspace: Path, home_dir: Path, guard_home: Path
+    ) -> None:
+        """Mixed target outputs do not inherit docs relaxation."""
+        payload = {
+            "hook_event_name": "PostToolUse",
+            "tool_name": "Read",
+            "tool_input": {"file_paths": ["docs/security-review.md", "src/config.py"]},
+            "tool_response": [{"type": "text", "text": "credential = 'fixture-only'\n"}],
+        }
+
+        result = worker.review_http_payload(
+            payload=payload,
+            params={},
+            default_harness="claude-code",
+            home_dir=home_dir,
+            guard_home=guard_home,
+            workspace=workspace,
+        )
+
         assert result["policy_action"] == "block"
         assert result["model_output_action"] == "block"
         assert result["reason_code"] == "output_secret_match"

--- a/tests/test_hook_content_scanner.py
+++ b/tests/test_hook_content_scanner.py
@@ -7,9 +7,10 @@ import time
 import pytest
 
 from codex_plugin_scanner.guard.runtime.hook_content_scanner import (
-    ContentScanner,
     HOOK_CONTENT_SCANNER_VERSION,
-    HOOK_SCANNER_MAX_MATCHES,
+    ContentScanner,
+    should_unsuppress_local_sample_secrets,
+    should_unsuppress_local_sample_secrets_for_paths,
 )
 from codex_plugin_scanner.guard.runtime.secret_sensitivity import secret_content_rule_version
 
@@ -81,6 +82,40 @@ class TestDetectSecrets:
         result = scanner.scan_text(text, local_content=False, source_context=False)
         # Should not detect because it looks like a sample.
         assert all(m.classifier != "credential-assignment" for m in result.matches)
+
+
+class TestScanContext:
+    @pytest.mark.parametrize(
+        "path",
+        [
+            "docs/security-review.md",
+            "tests/test_guard_hook_worker.py",
+            "fixtures/security/addendum.txt",
+            "examples/policy.mdx",
+        ],
+    )
+    def test_docs_and_fixtures_suppress_sample_assignment_retry(self, path: str) -> None:
+        assert should_unsuppress_local_sample_secrets(path) is False
+
+    @pytest.mark.parametrize("path", ["src/config.ts", "app/settings.py", None])
+    def test_source_paths_keep_local_sample_assignment_retry(self, path: str | None) -> None:
+        assert should_unsuppress_local_sample_secrets(path) is True
+
+    def test_absolute_paths_are_relativized_to_workspace(self) -> None:
+        cwd = "/Users/john/docs/project"
+        assert should_unsuppress_local_sample_secrets("/Users/john/docs/project/src/config.py", cwd=cwd) is True
+        assert should_unsuppress_local_sample_secrets("/Users/john/docs/project/docs/review.md", cwd=cwd) is False
+
+    def test_absolute_paths_outside_workspace_ignore_parent_segments(self) -> None:
+        assert should_unsuppress_local_sample_secrets("/Users/john/docs/project/src/config.py") is True
+
+    def test_mixed_targets_keep_sample_assignment_retry(self) -> None:
+        paths = ("docs/security-review.md", "src/config.py")
+        assert should_unsuppress_local_sample_secrets_for_paths(paths, cwd="/repo") is True
+
+    def test_all_docs_targets_suppress_sample_assignment_retry(self) -> None:
+        paths = ("docs/security-review.md", "tests/test_guard_hook_worker.py")
+        assert should_unsuppress_local_sample_secrets_for_paths(paths, cwd="/repo") is False
 
 
 class TestBudgetExhaustion:


### PR DESCRIPTION
## Summary
- Allow documentation, test, and fixture file-operation outputs with exact placeholder credential examples to pass hook scanning.
- Keep realistic credential-looking outputs blocked, including fixture-prefixed non-placeholder values, and apply the same scan-context rule to source-ref, output-scan, and reviewed-excerpt paths.
- Extend Docker harness coverage across Pi, Claude Code, Codex, Grok, and Zed-compatible hooks.
- Fix CI blockers surfaced on the PR: format the policy payload-hash mismatch branch without logging portal-supplied hash values, and make the optional Rich progress helper pass basedpyright without changing fallback behavior.

## Testing
- `uv run pytest tests/test_guard_risk.py::test_secret_content_classifier_detects_planned_secret_content tests/test_guard_risk.py::test_secret_content_classifier_suppresses_sample_token_values tests/test_hook_content_scanner.py tests/test_guard_hook_worker.py -q --no-header`
- `uv run ruff check src tests/test_hook_content_scanner.py tests/test_guard_hook_worker.py tests/docker/test_all_harness_hooks.py`
- `uv run ruff format --check src tests/test_hook_content_scanner.py tests/test_guard_hook_worker.py tests/docker/test_all_harness_hooks.py`
- `uv run --with basedpyright basedpyright --level error`
- `uv run python tests/docker/test_all_harness_hooks.py`
- `uv run python scripts/bench_guard_hooks.py --cases output-scan-small,output-scan-250kb,output-scan-secret,small-post,read-ts-250kb --iterations 50`
