### PR TITLE
Scope MCP scanner evidence and instruction graph trust

### DIFF
--- a/src/codex_plugin_scanner/guard/access_graph_events.py
+++ b/src/codex_plugin_scanner/guard/access_graph_events.py
@@ -215,7 +215,16 @@ def _add_artifact_entities(
 
 
 def _access_graph_entity_type(artifact_type: str) -> str:
-    if artifact_type in {"skill", "mcp_server", "tool", "repository", "agent", "policy", "integration"}:
+    if artifact_type in {
+        "skill",
+        "mcp_server",
+        "tool",
+        "repository",
+        "agent",
+        "policy",
+        "integration",
+        "instruction",
+    }:
         return artifact_type
     return "tool"
 
@@ -225,6 +234,8 @@ def _access_graph_artifact_edge_type(entity_type: str) -> str | None:
         return "agent_uses_skill"
     if entity_type == "mcp_server":
         return "agent_uses_mcp_server"
+    if entity_type == "instruction":
+        return "agent_uses_instruction"
     return None
 
 

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -131,7 +131,7 @@ def apply_local_trust_metadata(
         )
     )
 
-    local_security = _local_skill_security_for_artifact(
+    local_security = _local_security_for_artifact(
         artifact,
         item_kind=item_kind,
         metadata=metadata,
@@ -145,6 +145,34 @@ def apply_local_trust_metadata(
     if trust_layers:
         enriched["trustLayers"] = _merge_trust_layers(metadata.get("trustLayers"), trust_layers)
     return enriched
+
+
+def _local_security_for_artifact(
+    artifact: object,
+    *,
+    item_kind: InventoryItemKind,
+    metadata: dict[str, object],
+    captured_at: str,
+    cisco_runs: tuple[object, ...],
+    workspace_dir: Path | None,
+) -> dict[str, object] | None:
+    skill_security = _local_skill_security_for_artifact(
+        artifact,
+        item_kind=item_kind,
+        metadata=metadata,
+        captured_at=captured_at,
+        cisco_runs=cisco_runs,
+        workspace_dir=workspace_dir,
+    )
+    if skill_security is not None:
+        return skill_security
+    return _local_mcp_security_for_artifact(
+        artifact,
+        item_kind=item_kind,
+        captured_at=captured_at,
+        cisco_runs=cisco_runs,
+        workspace_dir=workspace_dir,
+    )
 
 
 def _local_skill_security_for_artifact(
@@ -241,6 +269,152 @@ def _local_skill_security_for_artifact(
         "findings": findings,
         "metadata": metadata_payload,
     }
+
+
+def _local_mcp_security_for_artifact(
+    artifact: object,
+    *,
+    item_kind: InventoryItemKind,
+    captured_at: str,
+    cisco_runs: tuple[object, ...],
+    workspace_dir: Path | None,
+) -> dict[str, object] | None:
+    from .inventory_contract import _normalize_inventory_datetime
+
+    if item_kind != "mcp_server" or getattr(artifact, "artifact_type", None) != "mcp_server":
+        return None
+
+    trust_root = _trust_root_for_artifact(artifact, item_kind=item_kind, workspace_dir=workspace_dir)
+    if trust_root is None:
+        return None
+
+    run = next(
+        (
+            candidate
+            for candidate in cisco_runs
+            if getattr(candidate, "source", None) == "cisco-mcp-scanner"
+            and _matches_mcp_cisco_run(artifact, run=candidate)
+        ),
+        None,
+    )
+    if run is None:
+        return None
+
+    status = str(getattr(run, "status", "unknown"))
+    normalized_captured_at = _normalize_inventory_datetime(captured_at)
+    scan_root = _cisco_run_target_path(run) or trust_root
+    findings = _local_mcp_security_findings(run, scan_root=scan_root)
+    findings = sorted(
+        findings,
+        key=lambda finding: (finding.get("file", ""), finding.get("ruleId", ""), finding.get("message", "")),
+    )
+    severity_counts = _cisco_severity_counts(run)
+    analyzers_used = _cisco_analyzers_used(run)
+    score = _cisco_layer_score(severity_counts, analyzers_used=analyzers_used) if status == "enabled" else None
+    safety = None
+    if score is not None:
+        safety = {
+            "score": score,
+            "label": _local_skill_security_label(score),
+            "findingsTotal": len(findings),
+            "highFindings": sum(1 for finding in findings if finding["severity"] == "high"),
+            "scriptsTotal": _local_mcp_targets_total(run),
+            "targetsScanned": _local_mcp_targets_total(run),
+            "permissionsMissing": [],
+        }
+
+    run_metadata = getattr(run, "metadata", None)
+    metadata_payload: dict[str, object] = {
+        "scannerSource": str(getattr(run, "source", "unknown")),
+        "message": str(getattr(run, "message", "")),
+        "findingsBySeverity": severity_counts,
+        "totalFindings": len(findings),
+    }
+    duration_ms = getattr(run, "duration_ms", None)
+    if isinstance(duration_ms, int):
+        metadata_payload["durationMs"] = duration_ms
+    if isinstance(run_metadata, dict):
+        for key in ("analyzersUsed", "scanMode", "mode", "targetsScanned"):
+            value = run_metadata.get(key)
+            if value is not None:
+                metadata_payload[key] = value
+
+    metadata_payload["evidenceHash"] = guard_evidence_hash(
+        {
+            "capturedAt": normalized_captured_at,
+            "entityType": "mcp_server",
+            "findings": findings,
+            "provider": "cisco-mcp-scanner",
+            "safety": safety,
+            "source": "local_indexed",
+            "status": status,
+        }
+    )
+
+    return {
+        "entityType": "mcp_server",
+        "source": "local_indexed",
+        "provider": "cisco-mcp-scanner",
+        "status": status,
+        "capturedAt": normalized_captured_at,
+        "safety": safety,
+        "findings": findings,
+        "metadata": metadata_payload,
+    }
+
+
+def _local_mcp_security_findings(
+    run: object,
+    *,
+    scan_root: Path,
+) -> list[dict[str, object]]:
+    results: list[dict[str, object]] = []
+    try:
+        resolved_scan_root = scan_root.resolve()
+    except OSError:
+        resolved_scan_root = scan_root
+    for finding in tuple(getattr(run, "findings", ()) or ()):
+        file_path = getattr(finding, "file_path", None)
+        if isinstance(file_path, str) and file_path.strip():
+            raw_path = Path(file_path)
+            path = raw_path if raw_path.is_absolute() else scan_root / raw_path
+            if not _paths_related(scan_root, path):
+                continue
+            try:
+                relative_file = str(path.resolve().relative_to(resolved_scan_root))
+            except ValueError:
+                relative_file = path.name
+        else:
+            relative_file = ".mcp.json"
+
+        results.append(
+            {
+                "ruleId": str(getattr(finding, "rule_id", "unknown")),
+                "severity": _local_skill_security_severity(getattr(finding, "severity", None)),
+                "file": relative_file,
+                "message": _local_mcp_security_message(finding),
+            }
+        )
+    return results
+
+
+def _local_mcp_security_message(finding: object) -> str:
+    description = getattr(finding, "description", None)
+    if isinstance(description, str) and description.strip():
+        return description.strip()
+    title = getattr(finding, "title", None)
+    if isinstance(title, str) and title.strip():
+        return title.strip()
+    return "MCP security finding"
+
+
+def _local_mcp_targets_total(run: object) -> int:
+    metadata = getattr(run, "metadata", None)
+    if isinstance(metadata, dict):
+        value = metadata.get("targetsScanned")
+        if isinstance(value, int):
+            return max(0, value)
+    return 0
 
 
 def _local_skill_security_findings(
@@ -507,7 +681,14 @@ def _cisco_trust_layers_for_artifact(
                     label="Cisco Skill Scanner",
                 )
             )
-        if source == "cisco-mcp-scanner" and item_kind == "mcp_server" and _matches_mcp_cisco_run(artifact, run=run):
+        if (
+            source == "cisco-mcp-scanner"
+            and item_kind in {"mcp_server", "mcp_tool"}
+            and _matches_mcp_cisco_run(
+                artifact,
+                run=run,
+            )
+        ):
             layers.append(
                 _cisco_trust_layer(
                     run,
@@ -537,11 +718,16 @@ def _matches_skill_cisco_run(
 
 
 def _matches_mcp_cisco_run(artifact: object, *, run: object) -> bool:
-    run_target = _cisco_run_target_path(run)
+    run_config_path = _cisco_run_config_path(run)
     config_path = getattr(artifact, "config_path", None)
-    if run_target is None or not isinstance(config_path, str) or not config_path.strip():
+    if not isinstance(config_path, str) or not config_path.strip():
         return False
     path = Path(config_path)
+    if run_config_path is not None:
+        return _paths_related(path, run_config_path)
+    run_target = _cisco_run_target_path(run)
+    if run_target is None:
+        return False
     if path.is_file() and (_paths_related(path, run_target) or _paths_related(path.parent, run_target)):
         return True
     return _paths_related(path, run_target)
@@ -560,10 +746,23 @@ def _paths_related(left: Path, right: Path) -> bool:
     )
 
 
+def _cisco_run_config_path(run: object) -> Path | None:
+    metadata = getattr(run, "metadata", None)
+    if not isinstance(metadata, dict):
+        return None
+    config_path = metadata.get("_configPath")
+    if not isinstance(config_path, str) or not config_path.strip():
+        return None
+    return Path(config_path)
+
+
 def _cisco_run_target_path(run: object) -> Path | None:
     metadata = getattr(run, "metadata", None)
     if not isinstance(metadata, dict):
         return None
+    target = metadata.get("_targetPath")
+    if isinstance(target, str) and target.strip() and target != "missing":
+        return Path(target)
     target = metadata.get("target")
     if not isinstance(target, str) or not target.strip() or target == "missing":
         return None

--- a/src/codex_plugin_scanner/guard/inventory_cisco.py
+++ b/src/codex_plugin_scanner/guard/inventory_cisco.py
@@ -38,9 +38,10 @@ def run_cisco_inventory_scans(
     remaining_timeout_seconds = timeout_seconds
     if mcp_mode != "off":
         mcp_started = time.perf_counter()
-        runs.append(
-            _run_mcp_inventory_scan(
+        runs.extend(
+            _run_mcp_inventory_scans(
                 context=context,
+                detection=detection,
                 mode=mcp_mode,
                 timeout_seconds=remaining_timeout_seconds,
             )
@@ -62,33 +63,65 @@ def run_cisco_inventory_scans(
     return tuple(runs)
 
 
-def _run_mcp_inventory_scan(
+def _run_mcp_inventory_scans(
     *,
     context: HarnessContext,
+    detection: object,
     mode: str,
     timeout_seconds: float | None,
+) -> tuple[CiscoInventoryRun, ...]:
+    targets = _mcp_scan_targets(context=context, detection=detection)
+    if not targets:
+        return (
+            CiscoInventoryRun(
+                source="cisco-mcp-scanner",
+                status="skipped",
+                message="No MCP configuration found; Cisco MCP inventory scan skipped.",
+                findings=(),
+                duration_ms=0,
+                metadata={"target": "missing", "targetsScanned": 0, "mode": mode},
+            ),
+        )
+    remaining_timeout_seconds = timeout_seconds
+    runs: list[CiscoInventoryRun] = []
+    for root, config_path in targets:
+        if remaining_timeout_seconds is not None and remaining_timeout_seconds <= 0:
+            runs.append(
+                _build_mcp_inventory_budget_exhausted_run(
+                    root=root,
+                    config_path=config_path,
+                    mode=mode,
+                    workspace_dir=context.workspace_dir,
+                )
+            )
+            continue
+        started = time.perf_counter()
+        runs.append(
+            _run_single_mcp_inventory_scan(
+                root=root,
+                config_path=config_path,
+                mode=mode,
+                timeout_seconds=remaining_timeout_seconds,
+                workspace_dir=context.workspace_dir,
+            )
+        )
+        remaining_timeout_seconds = _consume_timeout_budget(
+            remaining_timeout_seconds,
+            started_at=started,
+        )
+    return tuple(runs)
+
+
+def _run_single_mcp_inventory_scan(
+    *,
+    root: Path,
+    config_path: Path,
+    mode: str,
+    timeout_seconds: float | None,
+    workspace_dir: Path | None,
 ) -> CiscoInventoryRun:
-    root = _mcp_scan_root(context)
-    if root is None:
-        return CiscoInventoryRun(
-            source="cisco-mcp-scanner",
-            status="skipped",
-            message="No .mcp.json found; Cisco MCP inventory scan skipped.",
-            findings=(),
-            duration_ms=0,
-            metadata={"target": "missing", "targetsScanned": 0, "mode": mode},
-        )
-    if timeout_seconds is not None and timeout_seconds <= 0:
-        return CiscoInventoryRun(
-            source="cisco-mcp-scanner",
-            status="timed_out",
-            message="Cisco MCP inventory scan timed out before Guard could start it.",
-            findings=(),
-            duration_ms=0,
-            metadata={"target": root.name, "targetsScanned": 0, "mode": mode},
-        )
     started = time.perf_counter()
-    summary = run_cisco_mcp_scan(root, mode=mode, timeout_seconds=timeout_seconds)
+    summary = run_cisco_mcp_scan(root, mode=mode, timeout_seconds=timeout_seconds, config_path=config_path)
     duration_ms = int((time.perf_counter() - started) * 1000)
     return CiscoInventoryRun(
         source="cisco-mcp-scanner",
@@ -97,12 +130,33 @@ def _run_mcp_inventory_scan(
         findings=summary.findings,
         duration_ms=duration_ms,
         metadata={
-            "target": root.name,
+            "target": _safe_mcp_target_label(root=root, config_path=config_path, workspace_dir=workspace_dir),
+            "_targetPath": str(root),
+            "_configPath": str(config_path),
             "targetsScanned": summary.targets_scanned,
             "totalFindings": summary.total_findings,
             "findingsBySeverity": summary.findings_by_severity,
             "analyzersUsed": summary.analyzers_used,
             "scanMode": summary.scan_mode,
+            "mode": mode,
+        },
+    )
+
+
+def _build_mcp_inventory_budget_exhausted_run(
+    *, root: Path, config_path: Path, mode: str, workspace_dir: Path | None
+) -> CiscoInventoryRun:
+    return CiscoInventoryRun(
+        source="cisco-mcp-scanner",
+        status="timed_out",
+        message="Cisco MCP inventory scan timed out before Guard could start this configuration.",
+        findings=(),
+        duration_ms=0,
+        metadata={
+            "target": _safe_mcp_target_label(root=root, config_path=config_path, workspace_dir=workspace_dir),
+            "_targetPath": str(root),
+            "_configPath": str(config_path),
+            "targetsScanned": 0,
             "mode": mode,
         },
     )
@@ -197,15 +251,70 @@ def _build_skill_inventory_budget_exhausted_run(*, root: Path, mode: str) -> Cis
     )
 
 
-def _mcp_scan_root(context: HarnessContext) -> Path | None:
-    candidates = []
-    if context.workspace_dir is not None:
-        candidates.append(context.workspace_dir)
-    candidates.append(context.home_dir)
-    for candidate in candidates:
-        if (candidate / ".mcp.json").is_file():
-            return candidate
-    return None
+def _mcp_scan_targets(*, context: HarnessContext, detection: object) -> tuple[tuple[Path, Path], ...]:
+    targets: list[tuple[Path, Path]] = []
+    seen: set[str] = set()
+
+    for base_dir in (context.workspace_dir, context.home_dir):
+        if base_dir is None:
+            continue
+        config_path = base_dir / ".mcp.json"
+        if config_path.is_file():
+            _extend_unique_mcp_targets(targets, seen, root=base_dir, config_path=config_path)
+
+    for artifact in tuple(getattr(detection, "artifacts", ())):
+        if str(getattr(artifact, "artifact_type", "")) != "mcp_server":
+            continue
+        config_value = getattr(artifact, "config_path", None)
+        if not isinstance(config_value, str) or not config_value.strip():
+            continue
+        config_path = Path(config_value)
+        if not config_path.is_file():
+            continue
+        root = _mcp_scan_root_for_config(config_path, context=context)
+        _extend_unique_mcp_targets(targets, seen, root=root, config_path=config_path)
+
+    return tuple(targets)
+
+
+def _extend_unique_mcp_targets(
+    targets: list[tuple[Path, Path]],
+    seen: set[str],
+    *,
+    root: Path,
+    config_path: Path,
+) -> None:
+    try:
+        key = f"{root.resolve()}::{config_path.resolve()}"
+    except OSError:
+        return
+    if key in seen:
+        return
+    seen.add(key)
+    targets.append((root, config_path))
+
+
+def _mcp_scan_root_for_config(config_path: Path, *, context: HarnessContext) -> Path:
+    workspace_dir = context.workspace_dir
+    if workspace_dir is None:
+        return config_path.parent
+    try:
+        config_path.resolve().relative_to(workspace_dir.resolve())
+    except (OSError, ValueError):
+        return config_path.parent
+    return workspace_dir
+
+
+def _safe_mcp_target_label(*, root: Path, config_path: Path, workspace_dir: Path | None = None) -> str:
+    if workspace_dir is not None:
+        try:
+            return config_path.resolve().relative_to(workspace_dir.resolve()).as_posix()
+        except (OSError, ValueError):
+            pass
+    try:
+        return config_path.resolve().relative_to(root.resolve()).as_posix()
+    except (OSError, ValueError):
+        return config_path.name
 
 
 def _skill_scan_roots(*, harness: str, context: HarnessContext, detection: object) -> tuple[Path, ...]:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -430,6 +430,7 @@ def inventory_snapshot_from_detection(
                 generated_at=generated_at,
                 home_dir=home_dir,
                 workspace_dir=workspace_dir,
+                cisco_runs=cisco_runs,
                 trust_attestation_context=trust_attestation_context,
             )
         )
@@ -724,6 +725,7 @@ def _mcp_tool_items_from_artifact(
     generated_at: str,
     home_dir: Path,
     workspace_dir: Path | None,
+    cisco_runs: tuple[object, ...] = (),
     trust_attestation_context: Mapping[str, object] | None = None,
 ) -> tuple[GuardAgentInventoryItem, ...]:
     artifact_type = str(getattr(artifact, "artifact_type", "unknown"))
@@ -787,6 +789,7 @@ def _mcp_tool_items_from_artifact(
             item_kind="mcp_tool",
             metadata=metadata,
             workspace_dir=workspace_dir,
+            cisco_runs=cisco_runs,
         )
         capabilities = _capabilities_for_mcp_tool(name, description, input_schema, safe_annotations)
         tool_item_id = f"{server_item.item_id}:tool:{name}"
@@ -807,9 +810,33 @@ def _mcp_tool_items_from_artifact(
             content_hash=semantic_hash,
             trust_attestation_context=trust_attestation_context,
         )
-        if inherited_layers:
-            tool_layers = metadata.get("trustLayers")
-            signed_tool_layers = list(tool_layers) if isinstance(tool_layers, list) else []
+        tool_layers = metadata.get("trustLayers")
+        signed_tool_layers = list(tool_layers) if isinstance(tool_layers, list) else []
+        normalized_tool_layers: list[dict[str, object]] = []
+        for layer in signed_tool_layers:
+            if isinstance(layer, dict) and layer.get("layerType") == "cisco_mcp_scanner":
+                raw_layer_metadata = layer.get("metadata")
+                layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
+                normalized_tool_layers.append(
+                    {
+                        **layer,
+                        "metadata": {
+                            **{
+                                key: value
+                                for key, value in layer_metadata.items()
+                                if key not in {"attestation", "attestationBindings"}
+                            },
+                            "attestationStatus": "unsigned",
+                        },
+                    }
+                )
+            elif isinstance(layer, dict):
+                normalized_tool_layers.append(layer)
+        signed_tool_layers = normalized_tool_layers
+        if signed_tool_layers:
+            metadata["trustLayers"] = signed_tool_layers
+        has_tool_cisco_layer = any(layer.get("layerType") == "cisco_mcp_scanner" for layer in signed_tool_layers)
+        if inherited_layers and not has_tool_cisco_layer:
             inherited_tool_layers: list[dict[str, object]] = []
             for layer in inherited_layers:
                 raw_layer_metadata = layer.get("metadata")
@@ -818,7 +845,11 @@ def _mcp_tool_items_from_artifact(
                     {
                         **layer,
                         "metadata": {
-                            **{key: value for key, value in layer_metadata.items() if key != "attestation"},
+                            **{
+                                key: value
+                                for key, value in layer_metadata.items()
+                                if key not in {"attestation", "attestationBindings"}
+                            },
                             "attestationStatus": "unsigned",
                             "inheritedFromServerItemId": server_item.item_id,
                         },

--- a/src/codex_plugin_scanner/guard/policy_bundle_parser.py
+++ b/src/codex_plugin_scanner/guard/policy_bundle_parser.py
@@ -353,10 +353,7 @@ def validated_policy_bundle_payload(
     ):
         import logging
 
-        logging.getLogger(__name__).warning(
-            "payload_hash_mismatch: portal_present=true computed_payload_hash=%s",
-            computed_payload_hash,
-        )
+        logging.getLogger(__name__).warning("payload_hash_mismatch")
     bundle_hash = _non_empty_string(policy_bundle.get("bundleHash"))
     if bundle_hash is None:
         return None, "invalid_bundle_hash"

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import importlib.util
+import json
 import os
 import sys
-from collections.abc import Awaitable
+from collections.abc import Awaitable, Iterable
 from dataclasses import dataclass
 from importlib import metadata as importlib_metadata
 from importlib.machinery import ModuleSpec
@@ -32,6 +33,7 @@ _EXCLUDED_DIRS = {
 }
 _SOURCE_SUFFIXES = {".cjs", ".js", ".json", ".jsx", ".mjs", ".py", ".ts", ".tsx"}
 _MAX_TARGET_SIZE_BYTES = 1_000_000
+_MAX_STATIC_TARGETS = 512
 T = TypeVar("T")
 
 
@@ -287,9 +289,9 @@ def _normalize_finding(plugin_dir: Path, file_path: Path, finding: object) -> Fi
     )
 
 
-def _collect_static_targets(plugin_dir: Path) -> tuple[_StaticScanTarget, ...]:
-    config_path = plugin_dir / ".mcp.json"
-    resolved_config_path = _safe_resolved_static_target(plugin_dir, config_path)
+def _collect_static_targets(plugin_dir: Path, config_path: Path | None = None) -> tuple[_StaticScanTarget, ...]:
+    effective_config_path = config_path or plugin_dir / ".mcp.json"
+    resolved_config_path = _safe_resolved_static_target(plugin_dir, effective_config_path)
     if resolved_config_path is None:
         return ()
 
@@ -300,37 +302,149 @@ def _collect_static_targets(plugin_dir: Path) -> tuple[_StaticScanTarget, ...]:
             targets.append(
                 _StaticScanTarget(
                     read_path=resolved_config_path,
-                    tool_name=config_path.name,
+                    tool_name=effective_config_path.name,
                     content_type="mcp-config",
                 )
             )
             seen_targets.add(resolved_config_path)
     except OSError:
         pass
-    for root, dirs, files in os.walk(plugin_dir, topdown=True):
+
+    default_config_path = plugin_dir / ".mcp.json"
+    is_default_config = _same_resolved_path(effective_config_path, default_config_path)
+    scan_roots = (plugin_dir,) if is_default_config else (resolved_config_path.parent,)
+    for scan_root in scan_roots:
+        _append_static_source_targets_from_tree(
+            plugin_dir=plugin_dir,
+            scan_root=scan_root,
+            config_path=resolved_config_path,
+            targets=targets,
+            seen_targets=seen_targets,
+        )
+
+    if not is_default_config:
+        _append_static_source_targets(
+            plugin_dir=plugin_dir,
+            candidates=_mcp_config_referenced_source_paths(
+                plugin_dir=plugin_dir,
+                config_path=resolved_config_path,
+            ),
+            targets=targets,
+            seen_targets=seen_targets,
+        )
+    return tuple(targets)
+
+
+def _append_static_source_targets_from_tree(
+    *,
+    plugin_dir: Path,
+    scan_root: Path,
+    config_path: Path,
+    targets: list[_StaticScanTarget],
+    seen_targets: set[Path],
+) -> None:
+    try:
+        scan_root.resolve(strict=True).relative_to(plugin_dir.resolve(strict=True))
+    except (OSError, RuntimeError, ValueError):
+        return
+    for root, dirs, files in os.walk(scan_root, topdown=True):
         dirs[:] = sorted(dir_name for dir_name in dirs if dir_name not in _EXCLUDED_DIRS)
         current_dir = Path(root)
-        for file_name in sorted(files):
-            file_path = current_dir / file_name
-            if file_path == config_path or file_path.suffix.lower() not in _SOURCE_SUFFIXES:
+        candidates = (
+            current_dir / file_name
+            for file_name in sorted(files)
+            if (current_dir / file_name).suffix.lower() in _SOURCE_SUFFIXES and current_dir / file_name != config_path
+        )
+        _append_static_source_targets(
+            plugin_dir=plugin_dir,
+            candidates=candidates,
+            targets=targets,
+            seen_targets=seen_targets,
+        )
+
+
+def _append_static_source_targets(
+    *,
+    plugin_dir: Path,
+    candidates: Iterable[Path],
+    targets: list[_StaticScanTarget],
+    seen_targets: set[Path],
+) -> None:
+    for candidate in candidates:
+        if len(targets) >= _MAX_STATIC_TARGETS:
+            return
+        if not isinstance(candidate, Path):
+            continue
+        if candidate.suffix.lower() not in _SOURCE_SUFFIXES:
+            continue
+        resolved_file_path = _safe_resolved_static_target(plugin_dir, candidate)
+        if resolved_file_path is None or resolved_file_path in seen_targets:
+            continue
+        try:
+            if resolved_file_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
                 continue
-            resolved_file_path = _safe_resolved_static_target(plugin_dir, file_path)
-            if resolved_file_path is None or resolved_file_path in seen_targets:
-                continue
-            try:
-                if resolved_file_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
-                    continue
-            except OSError:
-                continue
-            targets.append(
-                _StaticScanTarget(
-                    read_path=resolved_file_path,
-                    tool_name=resolved_file_path.name,
-                    content_type="mcp-source",
-                )
+        except OSError:
+            continue
+        targets.append(
+            _StaticScanTarget(
+                read_path=resolved_file_path,
+                tool_name=resolved_file_path.name,
+                content_type="mcp-source",
             )
-            seen_targets.add(resolved_file_path)
-    return tuple(targets)
+        )
+        seen_targets.add(resolved_file_path)
+
+
+def _mcp_config_referenced_source_paths(*, plugin_dir: Path, config_path: Path) -> tuple[Path, ...]:
+    try:
+        if config_path.stat().st_size > _MAX_TARGET_SIZE_BYTES:
+            return ()
+        config = json.loads(config_path.read_text(encoding="utf-8", errors="ignore"))
+    except (OSError, json.JSONDecodeError):
+        return ()
+
+    candidates: list[Path] = []
+    for value in _mcp_config_command_values(config):
+        raw_path = Path(value)
+        if raw_path.suffix.lower() not in _SOURCE_SUFFIXES:
+            continue
+        if raw_path.is_absolute():
+            candidates.append(raw_path)
+            continue
+        candidates.append(config_path.parent / raw_path)
+        candidates.append(plugin_dir / raw_path)
+    return tuple(candidates)
+
+
+def _mcp_config_command_values(config: object) -> tuple[str, ...]:
+    servers: list[object] = []
+    if isinstance(config, dict):
+        servers.append(config)
+        for key in ("mcpServers", "servers"):
+            collection = config.get(key)
+            if isinstance(collection, dict):
+                servers.extend(collection.values())
+            elif isinstance(collection, list):
+                servers.extend(collection)
+
+    values: list[str] = []
+    for server in servers:
+        if not isinstance(server, dict):
+            continue
+        command = server.get("command")
+        if isinstance(command, str) and command.strip():
+            values.append(command.strip())
+        args = server.get("args")
+        if isinstance(args, list):
+            values.extend(arg.strip() for arg in args if isinstance(arg, str) and arg.strip())
+    return tuple(values)
+
+
+def _same_resolved_path(left: Path, right: Path) -> bool:
+    try:
+        return left.resolve(strict=False) == right.resolve(strict=False)
+    except OSError:
+        return left == right
 
 
 def _safe_resolved_static_target(plugin_dir: Path, target: Path) -> Path | None:
@@ -441,10 +555,11 @@ def run_cisco_mcp_scan(
     plugin_dir: Path,
     mode: str = "auto",
     timeout_seconds: float | None = None,
+    config_path: Path | None = None,
 ) -> CiscoMcpScanSummary:
     """Run Cisco MCP scanner static analysis when available."""
 
-    config_path = plugin_dir / ".mcp.json"
+    effective_config_path = config_path or plugin_dir / ".mcp.json"
 
     if mode == "off":
         return _build_summary(
@@ -452,10 +567,10 @@ def run_cisco_mcp_scan(
             message="Cisco MCP scanning disabled by configuration.",
         )
 
-    if _safe_resolved_static_target(plugin_dir, config_path) is None:
+    if _safe_resolved_static_target(plugin_dir, effective_config_path) is None:
         return _build_summary(
             status=CiscoIntegrationStatus.SKIPPED,
-            message="No .mcp.json found; Cisco MCP scan skipped.",
+            message="No MCP configuration found; Cisco MCP scan skipped.",
         )
     runtime_message = cisco_runtime_unavailable_message()
     if runtime_message is not None:
@@ -492,7 +607,7 @@ def run_cisco_mcp_scan(
         for name, factory in components.items():
             analyzer_name = name.replace("Analyzer", "").lower()
             analyzers.append((analyzer_name, factory()))
-        targets = _collect_static_targets(plugin_dir)
+        targets = _collect_static_targets(plugin_dir, effective_config_path)
         scan_awaitable = _scan_targets_multi(plugin_dir, targets, tuple(analyzers))
         if timeout_seconds is not None:
             scan_awaitable = asyncio.wait_for(scan_awaitable, timeout=timeout_seconds)

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -855,6 +855,18 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
             ),
         ),
     )
+    server_item = next(item for item in snapshot.items if item.item_kind == "mcp_server")
+    local_security = server_item.metadata.get("localSecurity")
+    assert isinstance(local_security, dict)
+    assert local_security.get("entityType") == "mcp_server"
+    assert local_security.get("provider") == "cisco-mcp-scanner"
+    safety = local_security.get("safety")
+    assert isinstance(safety, dict)
+    assert safety.get("score") == 90
+    assert safety.get("targetsScanned") == 1
+    local_security_metadata = local_security.get("metadata")
+    assert isinstance(local_security_metadata, dict)
+    assert isinstance(local_security_metadata.get("evidenceHash"), str)
     search_tool = next(item for item in snapshot.items if item.item_id.endswith(":tool:search_docs"))
     delete_tool = next(item for item in snapshot.items if item.item_id.endswith(":tool:delete_docs"))
 

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -113,6 +113,32 @@ def test_evaluate_detection_queues_access_graph_snapshot_without_syncing(tmp_pat
     assert any(entity["entityType"] == "mcp_server" for entity in payload["payload"]["entities"])
 
 
+def test_evaluate_detection_queues_instruction_access_graph_edges(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    instruction_path = tmp_path / "workspace" / "AGENTS.md"
+    instruction_path.parent.mkdir(parents=True)
+    instruction_path.write_text("# Agent rules\n\nReview changes before using tools.\n", encoding="utf-8")
+    artifact = GuardArtifact(
+        artifact_id="codex:project:instruction:agents-md",
+        name="AGENTS.md",
+        harness="codex",
+        artifact_type="instruction",
+        source_scope="project",
+        config_path=str(instruction_path),
+    )
+    config = GuardConfig(guard_home=tmp_path / "guard-home", workspace=None)
+
+    evaluation = evaluate_detection(_detection(artifact), store, config, default_action="allow", persist=True)
+    pending = store.list_guard_events_v1(uploaded=False, limit=10)
+    snapshot_events = [item for item in pending if item["event_type"] == "access_graph.snapshot"]
+    payload = snapshot_events[0]["payload"]
+    graph_payload = payload["payload"]
+
+    assert evaluation["blocked"] is False
+    assert any(entity["entityType"] == "instruction" for entity in graph_payload["entities"])
+    assert any(edge["edgeType"] == "agent_uses_instruction" for edge in graph_payload["edges"])
+
 def test_evaluate_detection_queues_access_graph_snapshot_without_cloud_workspace(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store)

--- a/tests/test_guard_inventory_cisco.py
+++ b/tests/test_guard_inventory_cisco.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from pathlib import Path
-from types import SimpleNamespace
 
 import codex_plugin_scanner.guard.inventory_cisco as inventory_cisco
 from codex_plugin_scanner.guard.adapters.base import HarnessContext
@@ -98,7 +97,12 @@ def test_cisco_inventory_scans_run_mcp_and_skill_scanners_with_required_mode(tmp
     )
     calls: list[tuple[str, Path, str, float | None]] = []
 
-    def fake_mcp_scan(plugin_dir: Path, mode: str, timeout_seconds: float | None = None) -> _McpSummary:
+    def fake_mcp_scan(
+        plugin_dir: Path,
+        mode: str,
+        timeout_seconds: float | None = None,
+        config_path: Path | None = None,
+    ) -> _McpSummary:
         calls.append(("mcp", plugin_dir, mode, timeout_seconds))
         return _McpSummary(
             status=CiscoIntegrationStatus.ENABLED,
@@ -144,6 +148,70 @@ def test_cisco_inventory_scans_run_mcp_and_skill_scanners_with_required_mode(tmp
     assert calls[1][3] is not None
     assert 0 < calls[1][3] <= 3.5
     assert all(run.status == "enabled" for run in runs)
+    mcp_run = next(run for run in runs if run.source == "cisco-mcp-scanner")
+    assert mcp_run.metadata["target"] == ".mcp.json"
+    assert mcp_run.metadata["_targetPath"] == str(workspace_dir)
+    assert mcp_run.metadata["_configPath"] == str(workspace_dir / ".mcp.json")
+
+
+def test_cisco_inventory_scans_use_detected_mcp_config_paths(tmp_path: Path, monkeypatch) -> None:
+    context = _ctx(tmp_path)
+    workspace_dir = context.workspace_dir
+    assert workspace_dir is not None
+    cursor_config = workspace_dir / ".cursor" / "mcp.json"
+    cursor_config.parent.mkdir(parents=True)
+    cursor_config.write_text('{"mcpServers": {"cursor-demo": {"command": "node"}}}\n', encoding="utf-8")
+    detection = HarnessDetection(
+        harness="cursor",
+        installed=True,
+        command_available=False,
+        config_paths=(str(cursor_config),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="cursor:project:mcp:cursor-demo",
+                name="cursor-demo",
+                harness="cursor",
+                artifact_type="mcp_server",
+                source_scope="project",
+                config_path=str(cursor_config),
+            ),
+        ),
+    )
+    calls: list[tuple[Path, Path | None]] = []
+
+    def fake_mcp_scan(
+        plugin_dir: Path,
+        mode: str,
+        timeout_seconds: float | None = None,
+        config_path: Path | None = None,
+    ) -> _McpSummary:
+        del mode, timeout_seconds
+        calls.append((plugin_dir, config_path))
+        return _McpSummary(
+            status=CiscoIntegrationStatus.ENABLED,
+            message="MCP scanner completed.",
+            findings=(),
+            targets_scanned=1,
+            analyzers_used=("yara",),
+            total_findings=0,
+            findings_by_severity={severity.value: 0 for severity in Severity},
+        )
+
+    monkeypatch.setattr("codex_plugin_scanner.guard.inventory_cisco.run_cisco_mcp_scan", fake_mcp_scan)
+
+    runs = run_cisco_inventory_scans(
+        harness="cursor",
+        context=context,
+        detection=detection,
+        mcp_mode="on",
+        skill_mode="off",
+    )
+
+    assert calls == [(workspace_dir, cursor_config)]
+    assert len(runs) == 1
+    assert runs[0].metadata["target"] == ".cursor/mcp.json"
+    assert runs[0].metadata["_targetPath"] == str(workspace_dir)
+    assert runs[0].metadata["_configPath"] == str(cursor_config)
 
 
 def test_cisco_inventory_scans_preserve_timeout_status(tmp_path: Path, monkeypatch) -> None:
@@ -159,9 +227,14 @@ def test_cisco_inventory_scans_preserve_timeout_status(tmp_path: Path, monkeypat
         artifacts=(),
     )
 
-    def fake_mcp_scan(plugin_dir: Path, mode: str, timeout_seconds: float | None = None) -> object:
-        del plugin_dir, mode, timeout_seconds
-        return SimpleNamespace(
+    def fake_mcp_scan(
+        plugin_dir: Path,
+        mode: str,
+        timeout_seconds: float | None = None,
+        config_path: Path | None = None,
+    ) -> object:
+        del plugin_dir, mode, timeout_seconds, config_path
+        return _McpSummary(
             status=CiscoIntegrationStatus.TIMED_OUT,
             message="Cisco MCP scanner timed out.",
             findings=(),
@@ -363,9 +436,7 @@ def test_cisco_inventory_scans_collapse_detected_skill_roots_into_collection_dir
     assert [run.metadata["target"] for run in runs] == [str(skill_a.parent.parent)]
 
 
-def test_cisco_inventory_scans_share_timeout_budget_across_skill_collection_roots(
-    tmp_path: Path, monkeypatch
-) -> None:
+def test_cisco_inventory_scans_share_timeout_budget_across_skill_collection_roots(tmp_path: Path, monkeypatch) -> None:
     context = _ctx(tmp_path)
     home_dir = context.home_dir
     assert home_dir is not None

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -423,7 +423,7 @@ def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tm
                 category="transport",
                 title="Critical transport finding",
                 description="Remote unauthenticated endpoint.",
-                file_path=str(mcp_file),
+                file_path=".mcp.json",
             ),
         ),
         duration_ms=21,
@@ -435,6 +435,7 @@ def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tm
             "analyzersUsed": ["owasp"],
             "scanMode": "static",
             "mode": "auto",
+            "attestationBindings": {"deviceId": "local-device", "sequence": 1},
         },
     )
 
@@ -452,6 +453,15 @@ def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tm
     server_layers = server_item.metadata.get("trustLayers")
     tool_layers = tool_item.metadata.get("trustLayers")
     assert isinstance(server_layers, list)
+    local_security = server_item.metadata.get("localSecurity")
+    assert isinstance(local_security, dict)
+    assert local_security.get("entityType") == "mcp_server"
+    safety = local_security.get("safety")
+    assert isinstance(safety, dict)
+    assert safety.get("score") == 70
+    findings = local_security.get("findings")
+    assert isinstance(findings, list)
+    assert findings[0].get("file") == ".mcp.json"
     assert any(
         isinstance(layer, dict)
         and layer.get("layerType") == "cisco_mcp_scanner"
@@ -465,10 +475,12 @@ def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tm
     assert any(
         isinstance(layer, dict)
         and layer.get("layerType") == "cisco_mcp_scanner"
+        and layer.get("trustScore") == 70
         and isinstance(layer.get("metadata"), dict)
         and layer["metadata"].get("attestationStatus") == "unsigned"
         and layer["metadata"].get("attestation") is None
-        and layer["metadata"].get("inheritedFromServerItemId") == server_item.item_id
+        and layer["metadata"].get("attestationBindings") is None
+        and layer["metadata"].get("inheritedFromServerItemId") is None
         for layer in tool_layers
     )
     assert str(workspace) not in encoded

--- a/tests/test_mcp_security.py
+++ b/tests/test_mcp_security.py
@@ -76,6 +76,84 @@ def test_scan_ignores_excluded_descendants(monkeypatch, tmp_path: Path) -> None:
     assert all("node_modules" not in path for path in analyzed_paths)
 
 
+def test_scan_accepts_explicit_mcp_config_path(monkeypatch, tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config_path = workspace / ".cursor" / "mcp.json"
+    config_path.parent.mkdir()
+    config_path.write_text(
+        json.dumps({"mcpServers": {"demo": {"command": "python", "args": ["server.py"]}}}),
+        encoding="utf-8",
+    )
+    (workspace / "server.py").write_text("print('hello')\n", encoding="utf-8")
+    (workspace / "unrelated.py").write_text("print('skip')\n", encoding="utf-8")
+    analyzed_paths: list[str] = []
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            analyzed_paths.append(str((context or {}).get("file_path", "")))
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner.cisco_runtime_unavailable_message",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(workspace, mode="on", config_path=config_path)
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 2
+    assert str(config_path) in analyzed_paths
+    assert str(workspace / "server.py") in analyzed_paths
+    assert str(workspace / "unrelated.py") not in analyzed_paths
+
+
+def test_scan_resolves_nested_config_parent_relative_source_arg(monkeypatch, tmp_path: Path) -> None:
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    config_path = workspace / ".cursor" / "mcp.json"
+    config_path.parent.mkdir()
+    config_path.write_text(
+        json.dumps({"mcpServers": {"demo": {"command": "python", "args": ["../server.py"]}}}),
+        encoding="utf-8",
+    )
+    (workspace / "server.py").write_text("print('hello')\n", encoding="utf-8")
+    (workspace / "unrelated.py").write_text("print('skip')\n", encoding="utf-8")
+    analyzed_paths: list[str] = []
+
+    class RecordingYaraAnalyzer:
+        def __init__(self, *args: object, **kwargs: object) -> None:
+            return None
+
+        async def analyze(self, content: str, context: dict[str, Any] | None = None) -> list[FakeCiscoFinding]:
+            analyzed_paths.append(str((context or {}).get("file_path", "")))
+            return []
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner.cisco_runtime_unavailable_message",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "codex_plugin_scanner.integrations.cisco_mcp_scanner._load_mcp_scanner_components",
+        lambda: {"YaraAnalyzer": RecordingYaraAnalyzer},
+    )
+
+    summary = run_cisco_mcp_scan(workspace, mode="on", config_path=config_path)
+
+    assert summary.status == CiscoIntegrationStatus.ENABLED
+    assert summary.targets_scanned == 2
+    assert str(config_path) in analyzed_paths
+    assert str(workspace / "server.py") in analyzed_paths
+    assert str(workspace / "unrelated.py") not in analyzed_paths
+
+
 def test_scan_includes_dist_descendants(monkeypatch, tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugin"
     _write_plugin(plugin_dir)


### PR DESCRIPTION
## Summary
- Scope Cisco MCP scanner runs to explicit MCP configuration targets and sanitized target labels.
- Attach Cisco MCP trust and local security metadata only to matching MCP server/tool inventory items.
- Preserve instruction artifacts as instruction access-graph entities and emit instruction-use edges.

## Testing
- `uv run pytest tests/test_guard_inventory_cisco.py tests/test_mcp_security.py::test_scan_accepts_explicit_mcp_config_path tests/test_guard_inventory_contract.py::test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool tests/test_guard_aibom_trust_metadata.py::test_inventory_snapshot_attaches_mcp_tool_trust_resolution tests/test_guard_cloud_local_sync.py::test_evaluate_detection_queues_instruction_access_graph_edges`
- `uv run ruff check src/codex_plugin_scanner/guard/inventory_cisco.py src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py src/codex_plugin_scanner/guard/aibom_trust_metadata.py src/codex_plugin_scanner/guard/inventory_contract.py src/codex_plugin_scanner/guard/access_graph_events.py tests/test_guard_inventory_cisco.py tests/test_guard_aibom_trust_metadata.py tests/test_guard_inventory_contract.py tests/test_guard_cloud_local_sync.py tests/test_mcp_security.py`
- `uv run --extra dev basedpyright src/codex_plugin_scanner/guard/inventory_cisco.py src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py src/codex_plugin_scanner/guard/aibom_trust_metadata.py src/codex_plugin_scanner/guard/inventory_contract.py src/codex_plugin_scanner/guard/access_graph_events.py`
