### PR TITLE
Fix Review action labels

### DIFF
--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -36,6 +36,7 @@ from .models import (
     DecisionScope,
     GuardAction,
     GuardApprovalRequest,
+    GuardArtifact,
     HarnessDetection,
     PolicyDecision,
 )
@@ -247,13 +248,133 @@ _GENERIC_TOOL_LABELS = frozenset(
         "Grep",
         "WebFetch",
         "TodoWrite",
+        "mcp_tool",
+        "package_request",
+        "file_read_request",
+        "file_write_request",
+        "tool_action_request",
     }
 )
+_GENERIC_TOOL_LABELS_LOWER = frozenset(label.lower() for label in _GENERIC_TOOL_LABELS)
 
 
 def _is_generic_tool_label(value: str) -> bool:
     """Return True if the value is a generic tool name, not an actual command."""
-    return value in _GENERIC_TOOL_LABELS
+    stripped = value.strip()
+    return stripped in _GENERIC_TOOL_LABELS or stripped.lower() in _GENERIC_TOOL_LABELS_LOWER
+
+
+def _string_from_mapping(mapping: Mapping[str, object], key: str) -> str | None:
+    value = mapping.get(key)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    return None
+
+
+def _first_string_from_mapping(mapping: Mapping[str, object], keys: Sequence[str]) -> str | None:
+    for key in keys:
+        value = _string_from_mapping(mapping, key)
+        if value is not None:
+            return value
+    return None
+
+
+def _string_list_from_mapping(mapping: Mapping[str, object], key: str) -> list[str]:
+    value = mapping.get(key)
+    if isinstance(value, str) and value.strip():
+        return [value.strip()]
+    if not isinstance(value, Sequence) or isinstance(value, str):
+        return []
+    return [str(item).strip() for item in value if isinstance(item, str) and item.strip()]
+
+
+def _review_action_text_from_envelope(envelope: Mapping[str, object]) -> str | None:
+    for key in ("raw_command_text", "rawCommandText", "command", "cmd"):
+        direct = _string_from_mapping(envelope, key)
+        if direct is not None and not _is_generic_tool_label(direct):
+            return direct
+
+    action_type = _string_from_mapping(envelope, "action_type")
+    action_identity = _first_string_from_mapping(envelope, ("action_identity", "actionIdentity"))
+    if action_identity is not None and not _is_generic_tool_label(action_identity):
+        return action_identity
+
+    if action_type in {"file_read", "file_write", "file_read_request", "file_write_request"}:
+        paths = _string_list_from_mapping(envelope, "target_paths") or _string_list_from_mapping(
+            envelope,
+            "targetPaths",
+        )
+        if not paths:
+            single_path = _first_string_from_mapping(
+                envelope,
+                ("target_path", "targetPath", "path", "file_path", "filePath"),
+            )
+            paths = [single_path] if single_path is not None else []
+        if paths:
+            verb = "Read" if action_type in {"file_read", "file_read_request"} else "Write"
+            return f"{verb} {', '.join(paths)}"
+
+    if action_type == "mcp_tool":
+        server = _first_string_from_mapping(envelope, ("mcp_server", "mcpServer", "server"))
+        tool = _first_string_from_mapping(envelope, ("mcp_tool", "mcpTool", "tool_name", "toolName"))
+        if server and tool:
+            return f"{server}.{tool}"
+        return server or tool
+
+    package_manager = _first_string_from_mapping(envelope, ("package_manager", "packageManager"))
+    package_name = _first_string_from_mapping(envelope, ("package_name", "packageName"))
+    if package_manager and package_name:
+        targets = _string_list_from_mapping(envelope, "package_targets") or _string_list_from_mapping(
+            envelope,
+            "packageTargets",
+        )
+        package_target = targets[0] if targets else package_name
+        if package_target.startswith(package_name):
+            return f"{package_manager} install {package_target}"
+        return f"{package_manager} install {package_name}@{package_target}"
+
+    return None
+
+
+def _review_action_text_from_item(item: Mapping[str, object], artifact: GuardArtifact | None) -> str | None:
+    candidates: list[object] = []
+    if artifact is not None:
+        candidates.extend(
+            [
+                artifact.metadata.get("raw_command_text"),
+                artifact.metadata.get("command_text"),
+                artifact.command,
+            ]
+        )
+    candidates.extend(
+        [
+            item.get("raw_command_text"),
+            item.get("rawCommandText"),
+            item.get("review_command"),
+            item.get("reviewCommand"),
+            item.get("action_identity"),
+            item.get("actionIdentity"),
+        ]
+    )
+    envelope_raw = item.get("action_envelope_json")
+    envelope = _item_action_envelope_json(item)
+    if envelope is None and isinstance(envelope_raw, str):
+        try:
+            import json as _json
+
+            parsed = _json.loads(envelope_raw)
+        except (ValueError, TypeError):
+            parsed = None
+        if isinstance(parsed, Mapping):
+            envelope = {str(key): value for key, value in parsed.items() if isinstance(key, str)}
+    if envelope is not None:
+        candidates.append(_review_action_text_from_envelope(envelope))
+    for candidate in candidates:
+        if isinstance(candidate, str) and candidate.strip():
+            stripped = candidate.strip()
+            if not _is_generic_tool_label(stripped):
+                return stripped
+    return None
 
 
 def queue_blocked_approvals(
@@ -290,33 +411,10 @@ def queue_blocked_approvals(
         launch_target = _launch_target(artifact, item)
         raw_command_text: str | None = None
         if redaction_level != "full":
-            candidate: object | None = None
-            if artifact is not None:
-                candidate = artifact.metadata.get("raw_command_text")
-                if not isinstance(candidate, str) or not candidate.strip():
-                    candidate = artifact.metadata.get("command_text")
-                if not isinstance(candidate, str) or not candidate.strip():
-                    candidate = artifact.command if artifact.command is not None else None
-            # Fallback: extract command from action_envelope_json (handles both str and dict types)
-            if not isinstance(candidate, str) or not candidate.strip():
-                envelope_raw = item.get("action_envelope_json")
-                envelope: dict[str, object] | None = None
-                if isinstance(envelope_raw, str):
-                    try:
-                        import json as _json
-
-                        envelope = _json.loads(envelope_raw)
-                    except (ValueError, TypeError):
-                        pass
-                elif isinstance(envelope_raw, dict):
-                    envelope = envelope_raw
-                if isinstance(envelope, dict):
-                    candidate = envelope.get("command")
-            if isinstance(candidate, str) and candidate.strip():
-                stripped = candidate.strip()
-                if not _is_generic_tool_label(stripped):
-                    scrubbed = redact_text(stripped)
-                    raw_command_text = scrubbed.text
+            candidate = _review_action_text_from_item(item, artifact)
+            if candidate is not None:
+                scrubbed = redact_text(candidate)
+                raw_command_text = scrubbed.text
         incident = build_incident_context(
             harness=detection.harness,
             artifact=artifact,
@@ -1114,7 +1212,7 @@ def _item_risk_signals(item: dict[str, object], artifact) -> tuple[str, ...]:
     return artifact_risk_signals(artifact) if artifact is not None else ()
 
 
-def _item_action_envelope_json(item: dict[str, object]) -> dict[str, object] | None:
+def _item_action_envelope_json(item: Mapping[str, object]) -> dict[str, object] | None:
     value = item.get("action_envelope_json")
     if not isinstance(value, Mapping):
         return None

--- a/tests/test_guard_approvals.py
+++ b/tests/test_guard_approvals.py
@@ -34,6 +34,24 @@ from codex_plugin_scanner.guard.models import (
 )
 from codex_plugin_scanner.guard.store import GuardStore
 
+_AGENT_CONTEXT_ENV_MARKERS = (
+    "HOL_GUARD_HOOK_ARGV",
+    "HOL_GUARD_MANAGED_CURSOR_HOOK",
+    "HOL_GUARD_CURSOR_APPROVAL_BINDING",
+    "HOL_GUARD_CURSOR_AFTER_SHELL_PROOF",
+    "CURSOR_SESSION_ID",
+    "CURSOR_TRACE_ID",
+    "CURSOR_TRANSCRIPT_PATH",
+    "CLAUDECODE",
+    "OPENCODE_CONFIG_CONTENT",
+    "CODEX_SANDBOX",
+)
+
+
+def _clear_agent_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in _AGENT_CONTEXT_ENV_MARKERS:
+        monkeypatch.delenv(key, raising=False)
+
 
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -467,6 +485,114 @@ class TestGuardApprovals:
         assert queued[0]["risk_summary"] == "Call arguments mention sensitive local files or secrets."
         assert queued[0]["risk_signals"] == ["call arguments mention sensitive local files or secrets"]
         assert queued[0]["launch_summary"] == "Launches with `dangerous_delete .env`."
+
+    @pytest.mark.parametrize(
+        ("artifact_name", "action_envelope_json", "expected"),
+        [
+            (
+                "Bash",
+                {
+                    "action_type": "shell_command",
+                    "tool_name": "Bash",
+                    "raw_command_text": "bash",
+                    "command": "pnpm install @hashgraphonline/standards-sdk",
+                },
+                "pnpm install @hashgraphonline/standards-sdk",
+            ),
+            (
+                "Read",
+                {
+                    "action_type": "file_read",
+                    "tool_name": "Read",
+                    "target_paths": ["~/workspace/.env.local"],
+                },
+                "Read ~/workspace/.env.local",
+            ),
+            (
+                "file_read_request",
+                {
+                    "action_type": "file_read_request",
+                    "tool_name": "file_read_request",
+                    "target_path": "~/workspace/.npmrc",
+                },
+                "Read ~/workspace/.npmrc",
+            ),
+            (
+                "mcp_tool",
+                {
+                    "action_type": "mcp_tool",
+                    "tool_name": "mcp_tool",
+                    "mcp_server": "linear",
+                    "mcp_tool": "create_issue",
+                },
+                "linear.create_issue",
+            ),
+            (
+                "package_request",
+                {
+                    "action_type": "package_script",
+                    "package_manager": "pnpm",
+                    "package_name": "tsx",
+                    "package_targets": ["tsx@4.20.3"],
+                },
+                "pnpm install tsx@4.20.3",
+            ),
+        ],
+    )
+    def test_guard_queue_preserves_exact_action_label_after_redaction(
+        self,
+        tmp_path,
+        artifact_name,
+        action_envelope_json,
+        expected,
+    ):
+        store = GuardStore(tmp_path / "guard-home")
+        artifact = GuardArtifact(
+            artifact_id=f"codex:runtime:project:{artifact_name}:review",
+            name=artifact_name,
+            harness="codex",
+            artifact_type="tool_action_request",
+            source_scope="project",
+            config_path=str(tmp_path / "workspace" / ".codex" / "config.toml"),
+            metadata={"raw_command_text": artifact_name},
+        )
+        detection = HarnessDetection(
+            harness="codex",
+            installed=True,
+            command_available=True,
+            config_paths=(artifact.config_path,),
+            artifacts=(artifact,),
+        )
+
+        queued = queue_blocked_approvals(
+            detection=detection,
+            evaluation={
+                "artifacts": [
+                    {
+                        "artifact_id": artifact.artifact_id,
+                        "artifact_name": artifact.name,
+                        "artifact_hash": f"hash-{artifact_name}",
+                        "artifact_type": artifact.artifact_type,
+                        "source_scope": artifact.source_scope,
+                        "config_path": artifact.config_path,
+                        "changed_fields": ["runtime_tool_call"],
+                        "policy_action": "require-reapproval",
+                        "action_envelope_json": action_envelope_json,
+                    }
+                ]
+            },
+            store=store,
+            approval_center_url="http://127.0.0.1:4455",
+            now="2026-04-17T00:00:00+00:00",
+            redaction_level="partial",
+        )
+
+        stored = store.get_approval_request(queued[0]["request_id"])
+
+        assert queued[0]["raw_command_text"] == expected
+        assert stored is not None
+        assert stored["raw_command_text"] == expected
+        assert stored["raw_command_text"] not in {"Bash", "Read", "mcp_tool", "package_request"}
 
     def test_guard_queue_sends_only_request_notification_without_setup_preview(self, tmp_path, monkeypatch):
         notice_calls: list[str] = []
@@ -2786,7 +2912,8 @@ class TestGuardApprovals:
             == "HOL Guard needs a fresh approval because this action changed."
         )
 
-    def test_guard_approvals_cli_lists_and_resolves_requests(self, tmp_path, capsys):
+    def test_guard_approvals_cli_lists_and_resolves_requests(self, tmp_path, capsys, monkeypatch):
+        _clear_agent_context(monkeypatch)
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         store.add_approval_request(
@@ -3208,7 +3335,13 @@ class TestGuardApprovals:
             )
         ]
 
-    def test_guard_approvals_cli_derives_workspace_scope_without_workspace_override(self, tmp_path, capsys):
+    def test_guard_approvals_cli_derives_workspace_scope_without_workspace_override(
+        self,
+        tmp_path,
+        capsys,
+        monkeypatch,
+    ):
+        _clear_agent_context(monkeypatch)
         home_dir = tmp_path / "home"
         store = GuardStore(home_dir)
         store.add_approval_request(


### PR DESCRIPTION
## Summary
- Derive Review approval labels from exact shell, file, MCP, and package action details.
- Reject generic runtime tool names as stored Review command labels.
- Add regression coverage for redacted approval queue payloads.

## Tests
- python3 -m pytest tests/test_guard_approvals.py
- python3 -m ruff check src/codex_plugin_scanner/guard/approvals.py tests/test_guard_approvals.py
- python3 -m ruff format --check src/codex_plugin_scanner/guard/approvals.py tests/test_guard_approvals.py