### PR TITLE
feat(guard): defer AIBOM sync to background

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -68,6 +68,8 @@ def _run_guard_login_command(
         open_device_browser=False,
         wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
         announce_copy=None if getattr(args, "json", False) else _announce_guard_device_connect_copy,
+        home_dir=context.home_dir if context is not None else None,
+        workspace_dir=context.workspace_dir if context is not None else workspace,
     )
     if payload is None:
         return exit_code
@@ -145,6 +147,8 @@ def _run_guard_connect_command(
             open_device_browser=False,
             wait_timeout_seconds=int(getattr(args, "wait_timeout_seconds", 180) or 180),
             announce_copy=None if getattr(args, "json", False) else _announce_guard_device_connect_copy,
+            home_dir=context.home_dir if context is not None else None,
+            workspace_dir=context.workspace_dir if context is not None else workspace,
         )
         if payload is None:
             return exit_code
@@ -160,6 +164,8 @@ def _run_guard_connect_command(
             announce_copy=None if getattr(args, "json", False) else _announce_guard_device_connect_copy,
             ci_safe=ci_safe,
             machine_label=machine_label,
+            home_dir=context.home_dir if context is not None else None,
+            workspace_dir=context.workspace_dir if context is not None else workspace,
         )
         if payload is None:
             return exit_code
@@ -250,16 +256,29 @@ def _run_guard_sync_command(
     context = _require_guard_context(context)
     try:
         auth_context = _cloud_guard_sync_auth_context(store)
+        # Default CLI sync stays fast; --deep opts into foreground AIBOM refresh.
+        include_aibom = bool(getattr(args, "deep", False))
         from .progress import GuardProgress
 
         with GuardProgress(total=2, title="Guard Sync") as bar:
-            bar.step("Syncing receipts to Guard Cloud...")
-            payload = sync_receipts(
-                store,
-                auth_context=auth_context,
-                home_dir=context.home_dir,
-                workspace_dir=context.workspace_dir,
-            )
+            bar.step("Syncing receipts and Guard events to Guard Cloud...")
+            if include_aibom:
+                with store.hold_cloud_sync_lock():
+                    payload = sync_receipts(
+                        store,
+                        auth_context=auth_context,
+                        home_dir=context.home_dir,
+                        workspace_dir=context.workspace_dir,
+                        include_aibom=True,
+                    )
+            else:
+                payload = sync_receipts(
+                    store,
+                    auth_context=auth_context,
+                    home_dir=context.home_dir,
+                    workspace_dir=context.workspace_dir,
+                    include_aibom=False,
+                )
             bar.step("Syncing supply chain state...")
             with suppress(GuardSyncNotConfiguredError, RuntimeError):
                 payload["supply_chain"] = _validated_supply_chain_sync_payload(
@@ -519,7 +538,16 @@ def _run_guard_daemon_command(
         return _handle_daemon_repair(guard_home, getattr(args, "json", False))
     if daemon_command == "stop":
         return _handle_daemon_stop(guard_home, getattr(args, "json", False))
-    daemon = GuardDaemonServer(store, port=args.port or 0)
+    daemon_home_dir = context.home_dir if context is not None else None
+    daemon_workspace_dir = (
+        context.workspace_dir if context is not None and context.workspace_dir is not None else workspace
+    )
+    daemon = GuardDaemonServer(
+        store,
+        port=args.port or 0,
+        home_dir=daemon_home_dir,
+        workspace_dir=daemon_workspace_dir,
+    )
     if args.serve:
         daemon.serve()
         return 0

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py
@@ -129,6 +129,11 @@ def _configure_guard_cloud_parsers(
         help="Named connection profile to sync from. Defaults to 'default'.",
     )
     sync_parser.add_argument("--json", action="store_true")
+    sync_parser.add_argument(
+        "--deep",
+        action="store_true",
+        help="Also refresh AIBOM inventory during this foreground sync.",
+    )
 
     commands_parser = guard_subparsers.add_parser(
         "commands",

--- a/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_connect.py
@@ -210,6 +210,8 @@ def _finalize_guard_connect_payload(
     connect_url: str,
     payload: dict[str, object],
     now: str,
+    home_dir: Path | None = None,
+    workspace_dir: Path | None = None,
 ) -> dict[str, object]:
     sync_auth_context = payload.pop(CONNECT_SYNC_AUTH_CONTEXT_KEY, None)
     resolved_sync_auth_context = sync_auth_context if isinstance(sync_auth_context, dict) else None
@@ -271,6 +273,8 @@ def _finalize_guard_connect_payload(
                 store,
                 auth_context=resolved_sync_auth_context,
                 now=now,
+                home_dir=home_dir,
+                workspace_dir=workspace_dir,
             )
             sync_bar.step("Syncing supply chain state...")
             try:
@@ -419,6 +423,8 @@ def _build_guard_device_connect_payload(
     announce_copy=None,
     ci_safe: bool = False,
     machine_label: str | None = None,
+    home_dir: Path | None = None,
+    workspace_dir: Path | None = None,
 ) -> tuple[dict[str, object] | None, int]:
     try:
         if use_browser_oauth:
@@ -460,6 +466,8 @@ def _build_guard_device_connect_payload(
         connect_url=connect_url,
         payload=payload,
         now=_now(),
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
     )
     return payload, 0
 

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -29,6 +29,7 @@ from urllib.parse import parse_qs, parse_qsl, unquote, urlencode, urlparse, urlu
 from ...version import __version__
 from ..adapters import get_adapter
 from ..adapters.base import HarnessContext
+from ..aibom_cli import _AIBOM_AUTO_SYNC_INTERVAL_SECONDS, sync_aibom_snapshots_if_due
 from ..approval_gate import (
     ApprovalGateError,
     begin_totp_enrollment,
@@ -5188,7 +5189,11 @@ class GuardDaemonServer:
         *,
         bundle_refresh_backoff_seconds: float = _DEFAULT_SUPPLY_CHAIN_REFRESH_BACKOFF_SECONDS,
         bundle_refresh_interval_seconds: float | None = _DEFAULT_SUPPLY_CHAIN_REFRESH_INTERVAL_SECONDS,
+        aibom_refresh_backoff_seconds: float = _DEFAULT_SUPPLY_CHAIN_REFRESH_BACKOFF_SECONDS,
+        aibom_refresh_interval_seconds: float | None = float(_AIBOM_AUTO_SYNC_INTERVAL_SECONDS),
         idle_timeout_seconds: float | None = None,
+        home_dir: Path | None = None,
+        workspace_dir: Path | None = None,
     ) -> None:
         _validate_dashboard_bundle()
         self._server = _GuardDaemonHttpServer(
@@ -5207,6 +5212,11 @@ class GuardDaemonServer:
         self.port = self._server.daemon_port()
         self._bundle_refresh_backoff_seconds = bundle_refresh_backoff_seconds
         self._bundle_refresh_interval_seconds = bundle_refresh_interval_seconds
+        self._aibom_refresh_backoff_seconds = aibom_refresh_backoff_seconds
+        self._aibom_refresh_interval_seconds = aibom_refresh_interval_seconds
+        self._aibom_home_dir = home_dir.expanduser() if home_dir is not None else None
+        self._aibom_workspace_dir = workspace_dir.expanduser() if workspace_dir is not None else None
+        self._aibom_refresh_thread: threading.Thread | None = None
         self._bundle_refresh_thread: threading.Thread | None = None
         self._command_queue_worker: CommandQueueWorker | None = None
         self._thread: threading.Thread | None = None
@@ -5238,6 +5248,9 @@ class GuardDaemonServer:
         if self._bundle_refresh_thread is not None:
             self._bundle_refresh_thread.join(timeout=5)
             self._bundle_refresh_thread = None
+        if self._aibom_refresh_thread is not None:
+            self._aibom_refresh_thread.join(timeout=5)
+            self._aibom_refresh_thread = None
         self._command_queue_worker = stop_command_queue_worker(self._command_queue_worker)
 
     def _begin_service(self) -> None:
@@ -5253,6 +5266,7 @@ class GuardDaemonServer:
         )
         self._start_watchdog()
         self._start_supply_chain_bundle_refresh()
+        self._start_aibom_inventory_refresh()
         self._command_queue_worker = start_command_queue_worker(self._server.store, self._command_queue_worker)
 
     def _serve_forever(self) -> None:
@@ -5345,6 +5359,113 @@ class GuardDaemonServer:
             except Exception as error:
                 self._server.store.set_sync_payload(
                     "supply_chain_bundle_daemon",
+                    {
+                        "error": str(error),
+                        "refreshed_at": refreshed_at,
+                        "status": "error",
+                    },
+                    refreshed_at,
+                )
+                wait_seconds = backoff_seconds
+            if self._shutdown_started.wait(wait_seconds):
+                return
+
+    def _start_aibom_inventory_refresh(self) -> None:
+        if self._aibom_refresh_interval_seconds is None or self._aibom_refresh_interval_seconds <= 0:
+            return
+        if self._aibom_refresh_thread is not None and self._aibom_refresh_thread.is_alive():
+            return
+        self._aibom_refresh_thread = threading.Thread(
+            target=self._refresh_aibom_inventory_loop,
+            daemon=True,
+        )
+        self._aibom_refresh_thread.start()
+
+    def _aibom_inventory_context_dirs(self) -> tuple[Path | None, Path | None]:
+        payload = self._server.store.get_sync_payload("aibom_inventory_context")
+        if isinstance(payload, dict):
+            home_value = payload.get("home_dir")
+            workspace_value = payload.get("workspace_dir")
+        else:
+            home_value = None
+            workspace_value = None
+        home_dir = (
+            Path(home_value).expanduser()
+            if isinstance(home_value, str) and home_value.strip()
+            else self._aibom_home_dir
+        )
+        workspace_dir = (
+            Path(workspace_value).expanduser()
+            if isinstance(workspace_value, str) and workspace_value.strip()
+            else self._aibom_workspace_dir
+        )
+        return home_dir, workspace_dir
+
+    def _refresh_aibom_inventory_loop(self) -> None:
+        interval_seconds = self._aibom_refresh_interval_seconds
+        if interval_seconds is None or interval_seconds <= 0:
+            return
+        backoff_seconds = (
+            self._aibom_refresh_backoff_seconds if self._aibom_refresh_backoff_seconds > 0 else interval_seconds
+        )
+        if self._shutdown_started.wait(interval_seconds):
+            return
+        while not self._shutdown_started.is_set():
+            refreshed_at = _now()
+            try:
+                home_dir, workspace_dir = self._aibom_inventory_context_dirs()
+                if workspace_dir is None:
+                    self._server.store.set_sync_payload(
+                        "aibom_inventory_daemon",
+                        {
+                            "status": "missing_workspace_context",
+                            "reason": "missing_workspace_context",
+                            "skipped": True,
+                            "refreshed_at": refreshed_at,
+                        },
+                        refreshed_at,
+                    )
+                    if self._shutdown_started.wait(backoff_seconds):
+                        return
+                    continue
+                auth_context = _resolve_guard_sync_auth_context(self._server.store)
+                with self._server.store.hold_cloud_sync_lock():
+                    summary = sync_aibom_snapshots_if_due(
+                        self._server.store,
+                        generated_at=refreshed_at,
+                        min_interval_seconds=max(int(interval_seconds), 1),
+                        auth_context=auth_context,
+                        home_dir=home_dir,
+                        workspace_dir=workspace_dir,
+                    )
+                status = "synced" if summary.get("synced") is True else str(summary.get("reason") or "skipped")
+                self._server.store.set_sync_payload(
+                    "aibom_inventory_daemon",
+                    {**summary, "status": status, "refreshed_at": refreshed_at},
+                    refreshed_at,
+                )
+                wait_seconds = interval_seconds
+            except GuardSyncAuthorizationExpiredError as error:
+                self._server.store.set_sync_payload(
+                    "aibom_inventory_daemon",
+                    {
+                        "status": "auth_expired",
+                        "refreshed_at": refreshed_at,
+                        "message": str(error),
+                    },
+                    refreshed_at,
+                )
+                wait_seconds = backoff_seconds
+            except GuardSyncNotConfiguredError:
+                self._server.store.set_sync_payload(
+                    "aibom_inventory_daemon",
+                    {"status": "not_configured", "refreshed_at": refreshed_at},
+                    refreshed_at,
+                )
+                wait_seconds = backoff_seconds
+            except Exception as error:
+                self._server.store.set_sync_payload(
+                    "aibom_inventory_daemon",
                     {
                         "error": str(error),
                         "refreshed_at": refreshed_at,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1261,6 +1261,7 @@ def sync_receipts(
     auth_context: dict[str, object] | None = None,
     home_dir: Path | None = None,
     workspace_dir: Path | None = None,
+    include_aibom: bool = False,
 ) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
@@ -1360,6 +1361,13 @@ def sync_receipts(
             exceptions_payload.extend(item for item in exceptions if isinstance(item, dict))
         remote_decisions.update(_build_remote_policy_decisions(payload))
     now = _sync_timestamp(payload)
+    aibom_context: dict[str, object] = {}
+    if home_dir is not None:
+        aibom_context["home_dir"] = str(home_dir)
+    if workspace_dir is not None:
+        aibom_context["workspace_dir"] = str(workspace_dir)
+    if aibom_context:
+        store.set_sync_payload("aibom_inventory_context", aibom_context, now)
     persisted_cursor_rowid = latest_uploaded_rowid if latest_uploaded_rowid is not None else prior_receipt_cursor
     _persist_receipt_sync_cursor(
         store=store,
@@ -1562,15 +1570,26 @@ def sync_receipts(
     if remote_policy_sync_blocked:
         summary["remote_policy_sync_blocked"] = True
     summary["guard_events_v1"] = sync_guard_events(store, auth_context=resolved_auth_context)
-    from ..aibom_cli import sync_aibom_snapshots_if_due
+    if include_aibom:
+        from ..aibom_cli import sync_aibom_snapshots_if_due
 
-    summary["aibom_inventory"] = sync_aibom_snapshots_if_due(
-        store,
-        generated_at=now,
-        auth_context=resolved_auth_context,
-        home_dir=home_dir,
-        workspace_dir=workspace_dir,
-    )
+        summary["aibom_inventory"] = sync_aibom_snapshots_if_due(
+            store,
+            generated_at=now,
+            auth_context=resolved_auth_context,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+    else:
+        summary["aibom_inventory"] = {
+            "synced": False,
+            "skipped": True,
+            "reason": "background_deferred",
+            "message": (
+                "AIBOM inventory refresh is deferred to the Guard daemon background lane; "
+                "run hol-guard guard sync --deep to refresh now."
+            ),
+        }
     if persist_sync_summary:
         store.set_sync_payload("sync_summary", summary, now)
     if persist_connect_state:
@@ -2174,6 +2193,9 @@ def sync_local_guard_cloud_proof(
     *,
     auth_context: dict[str, object] | None = None,
     now: str | None = None,
+    home_dir: Path | None = None,
+    workspace_dir: Path | None = None,
+    include_aibom: bool = False,
 ) -> dict[str, object]:
     """Publish the local Guard runtime session before syncing receipts."""
     resolved_now = now or _now()
@@ -2190,6 +2212,9 @@ def sync_local_guard_cloud_proof(
             persist_sync_summary=False,
             persist_connect_state=False,
             auth_context=resolved_auth_context,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+            include_aibom=include_aibom,
         )
         summary = dict(receipts_summary)
         summary.update(

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -64,6 +64,7 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_transient_sy
         *,
         auth_context: dict[str, object] | None = None,
         now: str | None = None,
+        **_kwargs: object,
     ) -> dict[str, object]:
         assert auth_context is None
         raise RuntimeError("temporary receipt sync failure")
@@ -113,6 +114,7 @@ def test_finalize_guard_connect_payload_keeps_first_sync_pending_on_sync_lock_ti
         *,
         auth_context: dict[str, object] | None = None,
         now: str | None = None,
+        **_kwargs: object,
     ) -> dict[str, object]:
         assert auth_context is None
         raise TimeoutError("Timed out waiting for Guard Cloud sync lock.")
@@ -155,6 +157,7 @@ def test_finalize_guard_connect_payload_uses_fresh_oauth_access_token_once(tmp_p
         *,
         auth_context: dict[str, object] | None = None,
         now: str | None = None,
+        **_kwargs: object,
     ) -> dict[str, object]:
         sync_calls.append(auth_context)
         return {
@@ -254,6 +257,7 @@ def test_daemon_finalize_guard_connect_payload_uses_fresh_oauth_access_token_onc
         *,
         auth_context: dict[str, object] | None = None,
         now: str | None = None,
+        **_kwargs: object,
     ) -> dict[str, object]:
         sync_calls.append(auth_context)
         return {
@@ -363,6 +367,7 @@ def test_daemon_finalize_guard_connect_payload_keeps_first_sync_pending_on_sync_
         *,
         auth_context: dict[str, object] | None = None,
         now: str | None = None,
+        **_kwargs: object,
     ) -> dict[str, object]:
         assert auth_context is None
         raise TimeoutError("Timed out waiting for Guard Cloud sync lock.")
@@ -497,6 +502,7 @@ def test_finalize_guard_connect_payload_keeps_reauth_failures_in_retry_required_
         *,
         auth_context: dict[str, object] | None = None,
         now: str | None = None,
+        **_kwargs: object,
     ) -> dict[str, object]:
         assert auth_context is None
         raise guard_commands_module.GuardSyncAuthorizationExpiredError("reauth required")
@@ -543,6 +549,7 @@ def test_headless_first_sync_auth_expiry_marks_connect_state_for_repair(tmp_path
         *,
         auth_context: dict[str, object] | None = None,
         now: str | None = None,
+        **_kwargs: object,
     ) -> dict[str, object]:
         raise guard_commands_module.GuardSyncAuthorizationExpiredError("reauth required")
 

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -6906,9 +6906,12 @@ url = http://127.0.0.1:8787/guard-canary
             *,
             auth_context: dict[str, object] | None = None,
             now: str | None = None,
+            home_dir: Path | None = None,
+            workspace_dir: Path | None = None,
         ) -> dict[str, object]:
             del store
             assert auth_context is None
+            del home_dir, workspace_dir
             sync_calls.append("first-proof")
             return {
                 "synced_at": "2026-06-04T18:31:00+00:00",
@@ -6967,7 +6970,9 @@ url = http://127.0.0.1:8787/guard-canary
                 "--json",
             ]
         )
-        output = json.loads(capsys.readouterr().out)
+        captured = capsys.readouterr()
+        assert rc == 0, captured.err
+        output = json.loads(captured.out)
         latest_state = store.get_latest_guard_connect_state(now="2026-06-04T18:31:00+00:00")
 
         assert rc == 0

--- a/tests/test_guard_event_schema_v1.py
+++ b/tests/test_guard_event_schema_v1.py
@@ -300,6 +300,57 @@ def test_sync_receipts_uploads_pending_guard_events(tmp_path) -> None:
         "/api/v1/guard/events",
     ]
     assert store.list_guard_events_v1(uploaded=False, limit=10) == []
+    assert result["aibom_inventory"]["synced"] is False
+    assert result["aibom_inventory"]["reason"] == "background_deferred"
+
+
+def test_sync_receipts_runs_aibom_when_deep_sync_is_requested(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path)
+    store.add_receipt(_receipt())
+    _EventIngestHandler.requests = []
+    server = HTTPServer(("127.0.0.1", 0), _EventIngestHandler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    calls: list[tuple[object, object]] = []
+
+    def fake_sync_aibom_snapshots_if_due(
+        current_store: GuardStore,
+        *,
+        generated_at: str,
+        auth_context: dict[str, object] | None = None,
+        home_dir=None,
+        workspace_dir=None,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        del current_store, generated_at, auth_context
+        calls.append((home_dir, workspace_dir))
+        return {"synced": True, "accepted": 1}
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.aibom_cli.sync_aibom_snapshots_if_due",
+        fake_sync_aibom_snapshots_if_due,
+    )
+    try:
+        _seed_guard_cloud(
+            store,
+            sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
+            token="token-1",
+        )
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+
+        result = sync_receipts(
+            store,
+            include_aibom=True,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+
+    assert calls == [(home_dir, workspace_dir)]
+    assert result["aibom_inventory"] == {"synced": True, "accepted": 1}
 
 
 def test_sync_receipts_keeps_receipt_success_when_v1_events_endpoint_is_missing(tmp_path) -> None:

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -3563,6 +3563,7 @@ clearer UX and an implementation plan with technical references.
             persist_sync_summary: bool = True,
             persist_connect_state: bool = True,
             auth_context: dict[str, object] | None = None,
+            **_kwargs: object,
         ) -> dict[str, object]:
             assert current_store is store
             assert persist_sync_summary is False
@@ -3659,6 +3660,7 @@ clearer UX and an implementation plan with technical references.
             persist_sync_summary: bool = True,
             persist_connect_state: bool = True,
             auth_context: dict[str, object] | None = None,
+            **_kwargs: object,
         ) -> dict[str, object]:
             assert current_store is store
             assert persist_sync_summary is False

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -172,3 +172,188 @@ def test_daemon_bundle_refresh_reports_retryable_error(
     assert isinstance(summary, dict)
     assert summary["status"] == "error"
     assert "oauth upstream down" in str(summary["error"])
+
+
+def _wait_for_aibom_status(store, *, expected: str, timeout: float = 1.0) -> dict[str, object]:
+    """Poll until the AIBOM daemon payload carries the expected status string."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        payload = store.get_sync_payload("aibom_inventory_daemon")
+        if isinstance(payload, dict) and payload.get("status") == expected:
+            return payload
+        time.sleep(0.02)
+    payload = store.get_sync_payload("aibom_inventory_daemon")
+    assert isinstance(payload, dict), f"aibom_inventory_daemon payload missing: {payload!r}"
+    assert payload.get("status") == expected, f"expected status={expected!r}, got {payload!r}"
+    return payload
+
+
+def test_daemon_aibom_refresh_records_synced_on_success(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """AIBOM refresh loop stores aibom_inventory_daemon with status=synced on success."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    calls: list[dict[str, object]] = []
+
+    def _fake_sync(_store: GuardStore, **kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {"synced": True, "synced_at": "2026-06-29T00:00:00Z", "snapshots": 2, "accepted": 2}
+
+    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fake_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=0.05,
+        aibom_refresh_backoff_seconds=0.05,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    )
+    daemon.start()
+    try:
+        _wait_for_aibom_status(store, expected="synced")
+    finally:
+        daemon.stop()
+
+    assert calls
+    assert calls[0]["home_dir"] == home_dir
+    assert calls[0]["workspace_dir"] == workspace_dir
+    summary = store.get_sync_payload("aibom_inventory_daemon")
+    assert isinstance(summary, dict)
+    assert summary["status"] == "synced"
+    assert summary["synced"] is True
+    assert summary["snapshots"] == 2
+
+
+def test_daemon_aibom_refresh_records_skipped_when_not_due(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """AIBOM refresh loop stores status derived from reason when sync returns synced=False."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+
+    def _fake_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        return {"synced": False, "reason": "not_due", "skipped": True}
+
+    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fake_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=0.05,
+        aibom_refresh_backoff_seconds=0.05,
+        workspace_dir=tmp_path / "workspace",
+    )
+    daemon.start()
+    try:
+        _wait_for_aibom_status(store, expected="not_due")
+    finally:
+        daemon.stop()
+
+    summary = store.get_sync_payload("aibom_inventory_daemon")
+    assert isinstance(summary, dict)
+    assert summary["status"] == "not_due"
+    assert summary["synced"] is False
+    assert summary["skipped"] is True
+
+
+def test_daemon_aibom_refresh_waits_for_workspace_context(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """AIBOM daemon records a skipped status instead of syncing without a workspace."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+
+    def _unexpected_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        raise AssertionError("AIBOM sync should wait for a real workspace context")
+
+    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _unexpected_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=0.05,
+        aibom_refresh_backoff_seconds=0.05,
+    )
+    daemon.start()
+    try:
+        summary = _wait_for_aibom_status(store, expected="missing_workspace_context")
+    finally:
+        daemon.stop()
+
+    assert summary["skipped"] is True
+    assert summary["reason"] == "missing_workspace_context"
+
+
+def test_daemon_aibom_refresh_records_error_on_exception(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """AIBOM refresh loop stores status=error when sync_aibom_snapshots_if_due raises."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+
+    def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        raise RuntimeError("AIBOM snapshot upload failed: mirror node timeout")
+
+    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fail_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=0.05,
+        aibom_refresh_backoff_seconds=0.05,
+        workspace_dir=tmp_path / "workspace",
+    )
+    daemon.start()
+    try:
+        _wait_for_aibom_status(store, expected="error")
+    finally:
+        daemon.stop()
+
+    summary = store.get_sync_payload("aibom_inventory_daemon")
+    assert isinstance(summary, dict)
+    assert summary["status"] == "error"
+    assert "mirror node timeout" in str(summary["error"])
+
+
+def test_daemon_aibom_refresh_stops_cleanly(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Daemon.stop() joins the AIBOM refresh thread within timeout."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+
+    monkeypatch.setattr(
+        guard_daemon_module,
+        "sync_aibom_snapshots_if_due",
+        lambda _store, **_kwargs: {"synced": True, "synced_at": "2026-06-29T00:00:00Z"},
+    )
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=0.05,
+        aibom_refresh_backoff_seconds=0.05,
+        workspace_dir=tmp_path / "workspace",
+    )
+    daemon.start()
+    # Let at least one refresh cycle run
+    _wait_for_aibom_status(store, expected="synced")
+
+    daemon.stop()
+
+    # Thread reference is cleared and no longer alive after stop
+    assert daemon._aibom_refresh_thread is None


### PR DESCRIPTION
## Summary
- Defer AIBOM inventory refresh out of the default foreground Guard sync path.
- Add an explicit deep sync path for immediate AIBOM refresh.
- Add a daemon background AIBOM refresh loop and focused regression coverage.

## Testing
- `uv run pytest tests/test_guard_event_schema_v1.py tests/test_guard_supply_chain_daemon.py tests/test_guard_cli.py -q -k 'sync or aibom or supply_chain'`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py src/codex_plugin_scanner/guard/cli/commands_parser_cloud.py src/codex_plugin_scanner/guard/cli/commands_support_connect.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_cli.py tests/test_guard_event_schema_v1.py tests/test_guard_supply_chain_daemon.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/daemon/server.py`
- `uv run hol-guard guard sync --help`
