### PR TITLE
fix(guard): disambiguate pi aibom roots

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/pi.py
+++ b/src/codex_plugin_scanner/guard/adapters/pi.py
@@ -106,22 +106,23 @@ class PiHarnessAdapter(HarnessAdapter):
         found_paths: list[str] = []
         seen_keys: set[str] = set()
         roots = [
-            (self._global_root(context), "global"),
-            (self._omp_global_root(context), "global"),
+            (self._global_root(context), "global", "pi-global"),
+            (self._omp_global_root(context), "global", "omp-global"),
         ]
         project_root = self._project_root(context)
         if project_root is not None:
-            roots.append((project_root, "project"))
+            roots.append((project_root, "project", "pi-project"))
         omp_project_root = self._omp_project_root(context)
         if omp_project_root is not None:
-            roots.append((omp_project_root, "project"))
-        for root, scope in roots:
+            roots.append((omp_project_root, "project", "omp-project"))
+        for root, scope, id_scope in roots:
             self._append_settings_artifacts(
                 artifacts,
                 found_paths,
                 seen_keys,
                 settings_path=root / PI_SETTINGS_FILE,
                 scope=scope,
+                id_scope=id_scope,
                 extension_root=root / "extensions",
                 skill_root=root / "skills",
                 prompt_root=root / "prompts",
@@ -133,6 +134,7 @@ class PiHarnessAdapter(HarnessAdapter):
                 seen_keys,
                 extension_root=root / "extensions",
                 scope=scope,
+                id_scope=id_scope,
                 id_root=root / "extensions",
             )
             self._append_skill_artifacts(
@@ -141,6 +143,7 @@ class PiHarnessAdapter(HarnessAdapter):
                 seen_keys,
                 skill_root=root / "skills",
                 scope=scope,
+                id_scope=id_scope,
                 id_root=root / "skills",
             )
             self._append_prompt_artifacts(
@@ -149,6 +152,7 @@ class PiHarnessAdapter(HarnessAdapter):
                 seen_keys,
                 prompt_root=root / "prompts",
                 scope=scope,
+                id_scope=id_scope,
                 id_root=root / "prompts",
             )
             self._append_theme_artifacts(
@@ -157,6 +161,7 @@ class PiHarnessAdapter(HarnessAdapter):
                 seen_keys,
                 theme_root=root / "themes",
                 scope=scope,
+                id_scope=id_scope,
                 id_root=root / "themes",
             )
         command_available = self.resolved_executable(context) is not None
@@ -182,6 +187,7 @@ class PiHarnessAdapter(HarnessAdapter):
         *,
         settings_path: Path,
         scope: str,
+        id_scope: str,
         extension_root: Path,
         skill_root: Path,
         prompt_root: Path,
@@ -191,7 +197,7 @@ class PiHarnessAdapter(HarnessAdapter):
             return
         append_found_path(found_paths, settings_path)
         payload = json_payload(settings_path)
-        self._append_package_setting_artifacts(artifacts, seen_keys, settings_path, payload, scope)
+        self._append_package_setting_artifacts(artifacts, seen_keys, settings_path, payload, scope, id_scope)
         self._append_configured_resource_setting_artifacts(
             artifacts,
             found_paths,
@@ -199,6 +205,7 @@ class PiHarnessAdapter(HarnessAdapter):
             settings_path=settings_path,
             payload=payload,
             scope=scope,
+            id_scope=id_scope,
             key="extensions",
             artifact_type="extension",
             default_root=extension_root,
@@ -210,6 +217,7 @@ class PiHarnessAdapter(HarnessAdapter):
             settings_path=settings_path,
             payload=payload,
             scope=scope,
+            id_scope=id_scope,
             key="skills",
             artifact_type="skill",
             default_root=skill_root,
@@ -221,6 +229,7 @@ class PiHarnessAdapter(HarnessAdapter):
             settings_path=settings_path,
             payload=payload,
             scope=scope,
+            id_scope=id_scope,
             key="prompts",
             artifact_type="prompt",
             default_root=prompt_root,
@@ -232,6 +241,7 @@ class PiHarnessAdapter(HarnessAdapter):
             settings_path=settings_path,
             payload=payload,
             scope=scope,
+            id_scope=id_scope,
             key="themes",
             artifact_type="theme",
             default_root=theme_root,
@@ -244,6 +254,7 @@ class PiHarnessAdapter(HarnessAdapter):
         settings_path: Path,
         payload: dict[str, object],
         scope: str,
+        id_scope: str,
     ) -> None:
         values = payload.get("packages")
         if not isinstance(values, list):
@@ -251,7 +262,7 @@ class PiHarnessAdapter(HarnessAdapter):
         for value in values:
             if not isinstance(value, str) or not value.strip():
                 continue
-            artifact_id = f"pi:{scope}:package:{stable_suffix(value)}"
+            artifact_id = f"pi:{id_scope}:package:{stable_suffix(value)}"
             append_artifact(
                 artifacts,
                 seen_keys,
@@ -275,6 +286,7 @@ class PiHarnessAdapter(HarnessAdapter):
         settings_path: Path,
         payload: dict[str, object],
         scope: str,
+        id_scope: str,
         key: str,
         artifact_type: str,
         default_root: Path,
@@ -287,7 +299,7 @@ class PiHarnessAdapter(HarnessAdapter):
                 continue
             matches = resolve_configured_paths(settings_path, value)
             if not matches:
-                artifact_id = f"pi:{scope}:{artifact_type}:configured:{stable_suffix(value)}"
+                artifact_id = f"pi:{id_scope}:{artifact_type}:configured:{stable_suffix(value)}"
                 append_artifact(
                     artifacts,
                     seen_keys,
@@ -315,10 +327,11 @@ class PiHarnessAdapter(HarnessAdapter):
                             seen_keys,
                             extension_root=match,
                             scope=scope,
+                            id_scope=id_scope,
                             id_root=id_root,
                         )
                     elif match.suffix in EXTENSION_SUFFIXES:
-                        self._append_extension_file(artifacts, found_paths, seen_keys, match, scope, id_root)
+                        self._append_extension_file(artifacts, found_paths, seen_keys, match, scope, id_scope, id_root)
                 elif artifact_type == "skill":
                     if match.is_dir():
                         self._append_skill_artifacts(
@@ -327,10 +340,11 @@ class PiHarnessAdapter(HarnessAdapter):
                             seen_keys,
                             skill_root=match,
                             scope=scope,
+                            id_scope=id_scope,
                             id_root=id_root,
                         )
                     elif match.name == "SKILL.md":
-                        self._append_skill_file(artifacts, found_paths, seen_keys, match, scope, id_root)
+                        self._append_skill_file(artifacts, found_paths, seen_keys, match, scope, id_scope, id_root)
                 elif artifact_type == "prompt":
                     if match.is_dir():
                         self._append_prompt_artifacts(
@@ -339,10 +353,11 @@ class PiHarnessAdapter(HarnessAdapter):
                             seen_keys,
                             prompt_root=match,
                             scope=scope,
+                            id_scope=id_scope,
                             id_root=id_root,
                         )
                     elif match.suffix == ".md":
-                        self._append_prompt_file(artifacts, found_paths, seen_keys, match, scope, id_root)
+                        self._append_prompt_file(artifacts, found_paths, seen_keys, match, scope, id_scope, id_root)
                 elif artifact_type == "theme":
                     if match.is_dir():
                         self._append_theme_artifacts(
@@ -351,10 +366,11 @@ class PiHarnessAdapter(HarnessAdapter):
                             seen_keys,
                             theme_root=match,
                             scope=scope,
+                            id_scope=id_scope,
                             id_root=id_root,
                         )
                     elif match.suffix in THEME_SUFFIXES:
-                        self._append_theme_file(artifacts, found_paths, seen_keys, match, scope, id_root)
+                        self._append_theme_file(artifacts, found_paths, seen_keys, match, scope, id_scope, id_root)
 
     def _append_extension_artifacts(
         self,
@@ -364,13 +380,14 @@ class PiHarnessAdapter(HarnessAdapter):
         *,
         extension_root: Path,
         scope: str,
+        id_scope: str,
         id_root: Path,
     ) -> None:
         if not extension_root.is_dir():
             return
         for path in sorted(extension_root.rglob("*")):
             if path.is_file() and path.suffix in EXTENSION_SUFFIXES:
-                self._append_extension_file(artifacts, found_paths, seen_keys, path, scope, id_root)
+                self._append_extension_file(artifacts, found_paths, seen_keys, path, scope, id_scope, id_root)
 
     def _append_extension_file(
         self,
@@ -379,6 +396,7 @@ class PiHarnessAdapter(HarnessAdapter):
         seen_keys: set[str],
         path: Path,
         scope: str,
+        id_scope: str,
         id_root: Path,
     ) -> None:
         append_found_path(found_paths, path)
@@ -387,13 +405,13 @@ class PiHarnessAdapter(HarnessAdapter):
             artifacts,
             seen_keys,
             artifact(
-                artifact_id=f"pi:{scope}:extension:{relative}",
+                artifact_id=f"pi:{id_scope}:extension:{relative}",
                 name=relative,
                 artifact_type="extension",
                 scope=scope,
                 path=path,
             ),
-            dedupe_key=f"extension:{path.resolve()}",
+            dedupe_key=f"extension:{id_scope}:{path.resolve()}",
         )
 
     def _append_skill_artifacts(
@@ -404,12 +422,13 @@ class PiHarnessAdapter(HarnessAdapter):
         *,
         skill_root: Path,
         scope: str,
+        id_scope: str,
         id_root: Path,
     ) -> None:
         if not skill_root.is_dir():
             return
         for skill_path in sorted(skill_root.rglob("SKILL.md")):
-            self._append_skill_file(artifacts, found_paths, seen_keys, skill_path, scope, id_root)
+            self._append_skill_file(artifacts, found_paths, seen_keys, skill_path, scope, id_scope, id_root)
 
     def _append_skill_file(
         self,
@@ -418,6 +437,7 @@ class PiHarnessAdapter(HarnessAdapter):
         seen_keys: set[str],
         path: Path,
         scope: str,
+        id_scope: str,
         id_root: Path,
     ) -> None:
         append_found_path(found_paths, path)
@@ -427,13 +447,13 @@ class PiHarnessAdapter(HarnessAdapter):
             artifacts,
             seen_keys,
             artifact(
-                artifact_id=f"pi:{scope}:skill:{relative}",
+                artifact_id=f"pi:{id_scope}:skill:{relative}",
                 name=relative,
                 artifact_type="skill",
                 scope=scope,
                 path=path,
             ),
-            dedupe_key=f"skill:{path.resolve()}",
+            dedupe_key=f"skill:{id_scope}:{path.resolve()}",
         )
 
     def _append_prompt_artifacts(
@@ -444,12 +464,13 @@ class PiHarnessAdapter(HarnessAdapter):
         *,
         prompt_root: Path,
         scope: str,
+        id_scope: str,
         id_root: Path,
     ) -> None:
         if not prompt_root.is_dir():
             return
         for prompt_path in sorted(prompt_root.rglob("*.md")):
-            self._append_prompt_file(artifacts, found_paths, seen_keys, prompt_path, scope, id_root)
+            self._append_prompt_file(artifacts, found_paths, seen_keys, prompt_path, scope, id_scope, id_root)
 
     def _append_prompt_file(
         self,
@@ -458,6 +479,7 @@ class PiHarnessAdapter(HarnessAdapter):
         seen_keys: set[str],
         path: Path,
         scope: str,
+        id_scope: str,
         id_root: Path,
     ) -> None:
         append_found_path(found_paths, path)
@@ -466,13 +488,13 @@ class PiHarnessAdapter(HarnessAdapter):
             artifacts,
             seen_keys,
             artifact(
-                artifact_id=f"pi:{scope}:prompt:{relative}",
+                artifact_id=f"pi:{id_scope}:prompt:{relative}",
                 name=relative,
                 artifact_type="prompt",
                 scope=scope,
                 path=path,
             ),
-            dedupe_key=f"prompt:{path.resolve()}",
+            dedupe_key=f"prompt:{id_scope}:{path.resolve()}",
         )
 
     def _append_theme_artifacts(
@@ -483,13 +505,14 @@ class PiHarnessAdapter(HarnessAdapter):
         *,
         theme_root: Path,
         scope: str,
+        id_scope: str,
         id_root: Path,
     ) -> None:
         if not theme_root.is_dir():
             return
         for theme_path in sorted(theme_root.rglob("*")):
             if theme_path.is_file() and theme_path.suffix in THEME_SUFFIXES:
-                self._append_theme_file(artifacts, found_paths, seen_keys, theme_path, scope, id_root)
+                self._append_theme_file(artifacts, found_paths, seen_keys, theme_path, scope, id_scope, id_root)
 
     def _append_theme_file(
         self,
@@ -498,6 +521,7 @@ class PiHarnessAdapter(HarnessAdapter):
         seen_keys: set[str],
         path: Path,
         scope: str,
+        id_scope: str,
         id_root: Path,
     ) -> None:
         append_found_path(found_paths, path)
@@ -506,13 +530,13 @@ class PiHarnessAdapter(HarnessAdapter):
             artifacts,
             seen_keys,
             artifact(
-                artifact_id=f"pi:{scope}:theme:{relative}",
+                artifact_id=f"pi:{id_scope}:theme:{relative}",
                 name=relative,
                 artifact_type="theme",
                 scope=scope,
                 path=path,
             ),
-            dedupe_key=f"theme:{path.resolve()}",
+            dedupe_key=f"theme:{id_scope}:{path.resolve()}",
         )
 
     def install(self, context: HarnessContext) -> dict[str, object]:

--- a/tests/test_pi_adapter.py
+++ b/tests/test_pi_adapter.py
@@ -20,6 +20,7 @@ from codex_plugin_scanner.guard.cli.commands_support_codex_tool_output_messages 
 )
 from codex_plugin_scanner.guard.cli.commands_support_runtime_artifacts import _codex_post_tool_output_artifact
 from codex_plugin_scanner.guard.config import GuardConfig
+from codex_plugin_scanner.guard.inventory_contract import inventory_snapshot_from_detection
 from codex_plugin_scanner.guard.runtime.actions import normalize_harness_payload
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -116,12 +117,12 @@ class TestPiDetect:
         assert result.harness == "pi"
         assert any(path.endswith(".pi/agent/settings.json") for path in result.config_paths)
         artifact_ids = {artifact.artifact_id for artifact in result.artifacts}
-        assert f"pi:global:package:{stable_suffix('npm:@demo/pi-tools@1.2.3')}" in artifact_ids
-        assert "pi:global:extension:demo.ts" in artifact_ids
-        assert "pi:global:skill:skills/ship" in artifact_ids
-        assert "pi:global:prompt:review.md" in artifact_ids
-        assert "pi:global:theme:night.json" in artifact_ids
-        assert "pi:project:extension:local.ts" in artifact_ids
+        assert f"pi:pi-global:package:{stable_suffix('npm:@demo/pi-tools@1.2.3')}" in artifact_ids
+        assert "pi:pi-global:extension:demo.ts" in artifact_ids
+        assert "pi:pi-global:skill:skills/ship" in artifact_ids
+        assert "pi:pi-global:prompt:review.md" in artifact_ids
+        assert "pi:pi-global:theme:night.json" in artifact_ids
+        assert "pi:pi-project:extension:local.ts" in artifact_ids
 
     def test_detect_keeps_empty_settings_file(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path)
@@ -143,7 +144,40 @@ class TestPiDetect:
         result = get_adapter("pi").detect(ctx)
 
         assert str(ctx.home_dir / ".omp" / "agent" / "settings.json") in result.config_paths
-        assert "pi:global:extension:omp-ext.ts" in {artifact.artifact_id for artifact in result.artifacts}
+        assert "pi:omp-global:extension:omp-ext.ts" in {artifact.artifact_id for artifact in result.artifacts}
+
+    def test_pi_and_omp_managed_extensions_have_distinct_aibom_item_ids(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        _write_text(ctx.home_dir / ".pi" / "agent" / "extensions" / "hol-guard.ts", "export default 'pi';\n")
+        _write_text(ctx.home_dir / ".omp" / "agent" / "extensions" / "hol-guard.ts", "export default 'omp';\n")
+
+        detection = get_adapter("pi").detect(ctx)
+        snapshot = inventory_snapshot_from_detection(
+            detection,
+            generated_at="2026-06-29T00:00:00Z",
+            home_dir=ctx.home_dir,
+            workspace_dir=ctx.workspace_dir,
+        )
+
+        item_keys = [(item.item_kind, item.item_id) for item in snapshot.items]
+        assert len(item_keys) == len(set(item_keys))
+        assert {item.item_id for item in snapshot.items} >= {
+            "pi:pi-global:extension:hol-guard.ts",
+            "pi:omp-global:extension:hol-guard.ts",
+        }
+
+    def test_pi_and_omp_shared_configured_extension_keeps_both_scoped_items(self, tmp_path: Path) -> None:
+        ctx = _ctx(tmp_path)
+        shared_extension = tmp_path / "shared" / "hol-guard.ts"
+        _write_text(shared_extension, "export default 'shared';\n")
+        _write_json(ctx.home_dir / ".pi" / "agent" / "settings.json", {"extensions": [str(shared_extension)]})
+        _write_json(ctx.home_dir / ".omp" / "agent" / "settings.json", {"extensions": [str(shared_extension)]})
+
+        result = get_adapter("pi").detect(ctx)
+
+        artifact_ids = {artifact.artifact_id for artifact in result.artifacts}
+        assert "pi:pi-global:extension:hol-guard.ts" in artifact_ids
+        assert "pi:omp-global:extension:hol-guard.ts" in artifact_ids
 
     def test_detect_expands_configured_extension_glob(self, tmp_path: Path) -> None:
         ctx = _ctx(tmp_path, workspace=True)
@@ -159,8 +193,8 @@ class TestPiDetect:
         result = get_adapter("pi").detect(ctx)
 
         artifact_ids = {artifact.artifact_id for artifact in result.artifacts}
-        assert "pi:project:extension:one.ts" in artifact_ids
-        assert "pi:project:extension:two.ts" in artifact_ids
+        assert "pi:pi-project:extension:one.ts" in artifact_ids
+        assert "pi:pi-project:extension:two.ts" in artifact_ids
         assert str(shared_root / "one.ts") in result.config_paths
 
     def test_root_skill_uses_stable_identity(self, tmp_path: Path) -> None:
@@ -170,7 +204,7 @@ class TestPiDetect:
         result = get_adapter("pi").detect(ctx)
 
         skills = [artifact for artifact in result.artifacts if artifact.artifact_type == "skill"]
-        assert skills[0].artifact_id == "pi:global:skill:skills"
+        assert skills[0].artifact_id == "pi:pi-global:skill:skills"
         assert skills[0].name == "skills"
 
 


### PR DESCRIPTION
## Summary
- Give Pi and OMP roots distinct AIBOM artifact identity prefixes while preserving their global/project source scope.
- Add regression coverage proving same-named Pi and OMP managed extensions produce unique inventory item IDs.

## Testing
- `python3 -m pytest tests/test_pi_adapter.py -q`
- `python3 -m py_compile src/codex_plugin_scanner/guard/adapters/pi.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/pi.py tests/test_pi_adapter.py`
- `uv run --extra dev basedpyright src/codex_plugin_scanner/guard/adapters/pi.py`
