### PR TITLE
fix(guard): bind healthz probe to auth token via HMAC challenge-response

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -661,26 +661,24 @@ def _daemon_hook_result(
             method="POST",
         )
         with opener.open(verify_req, timeout=2) as verify_response:
-            if verify_response.status == 404:
-                # Old daemon without /v1/healthz/verify — proceed with healthz-only check.
-                pass
-            elif verify_response.status != 200:
+            verify_body = verify_response.read().decode("utf-8", errors="replace")
+            try:
+                verify_json = json.loads(verify_body)
+            except ValueError:
                 return None
-            else:
-                verify_body = verify_response.read().decode("utf-8", errors="replace")
-                try:
-                    verify_json = json.loads(verify_body)
-                except ValueError:
-                    return None
-                if not isinstance(verify_json, dict) or not isinstance(verify_json.get("proof"), str):
-                    return None
-                expected_proof = hmac.new(
-                    auth_token.encode("utf-8"),
-                    proof_message.encode("utf-8"),
-                    hashlib.sha256,
-                ).hexdigest()
-                if not hmac.compare_digest(verify_json["proof"], expected_proof):
-                    return None
+            if not isinstance(verify_json, dict) or not isinstance(verify_json.get("proof"), str):
+                return None
+            expected_proof = hmac.new(
+                auth_token.encode("utf-8"),
+                proof_message.encode("utf-8"),
+                hashlib.sha256,
+            ).hexdigest()
+            if not hmac.compare_digest(verify_json["proof"], expected_proof):
+                return None
+    except urllib.error.HTTPError as exc:
+        if exc.code != 404:
+            return None
+        # Old daemon without /v1/healthz/verify — proceed with healthz-only check.
     except (OSError, urllib.error.URLError):
         return None
     params = [("guard-home", GUARD_HOME)]

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -646,6 +646,35 @@ def _daemon_hook_result(
     state_compat = state.get("compatibility_version")
     if isinstance(state_compat, str) and health_json.get("compatibility_version") != state_compat:
         return None
+    # Challenge-response: prove the listener knows the auth_token before sending it.
+    # A spoofed listener can return public healthz values but cannot forge the HMAC.
+    nonce = os.urandom(16).hex()
+    try:
+        verify_req = urllib.request.Request(
+            f"http://127.0.0.1:{port}/v1/healthz/verify",
+            data=json.dumps({"nonce": nonce}).encode("utf-8"),
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with opener.open(verify_req, timeout=2) as verify_response:
+            if verify_response.status != 200:
+                return None
+            verify_body = verify_response.read().decode("utf-8", errors="replace")
+    except (OSError, urllib.error.URLError):
+        return None
+    try:
+        verify_json = json.loads(verify_body)
+    except ValueError:
+        return None
+    if not isinstance(verify_json, dict) or not isinstance(verify_json.get("proof"), str):
+        return None
+    expected_proof = hmac.new(
+        auth_token.encode("ascii"),
+        nonce.encode("ascii"),
+        hashlib.sha256,
+    ).hexdigest()
+    if not hmac.compare_digest(verify_json["proof"], expected_proof):
+        return None
     params = [("guard-home", GUARD_HOME)]
     if workspace:
         params.append(("workspace", workspace))

--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -648,7 +648,11 @@ def _daemon_hook_result(
         return None
     # Challenge-response: prove the listener knows the auth_token before sending it.
     # A spoofed listener can return public healthz values but cannot forge the HMAC.
+    # The proof is bound to the daemon's listening port so a relay attacker cannot
+    # proxy the nonce to the real daemon and reuse its proof from a different port.
+    # Old daemons without /v1/healthz/verify return 404 — skip the check for compat.
     nonce = os.urandom(16).hex()
+    proof_message = f"{port}:{nonce}"
     try:
         verify_req = urllib.request.Request(
             f"http://127.0.0.1:{port}/v1/healthz/verify",
@@ -657,23 +661,27 @@ def _daemon_hook_result(
             method="POST",
         )
         with opener.open(verify_req, timeout=2) as verify_response:
-            if verify_response.status != 200:
+            if verify_response.status == 404:
+                # Old daemon without /v1/healthz/verify — proceed with healthz-only check.
+                pass
+            elif verify_response.status != 200:
                 return None
-            verify_body = verify_response.read().decode("utf-8", errors="replace")
+            else:
+                verify_body = verify_response.read().decode("utf-8", errors="replace")
+                try:
+                    verify_json = json.loads(verify_body)
+                except ValueError:
+                    return None
+                if not isinstance(verify_json, dict) or not isinstance(verify_json.get("proof"), str):
+                    return None
+                expected_proof = hmac.new(
+                    auth_token.encode("utf-8"),
+                    proof_message.encode("utf-8"),
+                    hashlib.sha256,
+                ).hexdigest()
+                if not hmac.compare_digest(verify_json["proof"], expected_proof):
+                    return None
     except (OSError, urllib.error.URLError):
-        return None
-    try:
-        verify_json = json.loads(verify_body)
-    except ValueError:
-        return None
-    if not isinstance(verify_json, dict) or not isinstance(verify_json.get("proof"), str):
-        return None
-    expected_proof = hmac.new(
-        auth_token.encode("ascii"),
-        nonce.encode("ascii"),
-        hashlib.sha256,
-    ).hexdigest()
-    if not hmac.compare_digest(verify_json["proof"], expected_proof):
         return None
     params = [("guard-home", GUARD_HOME)]
     if workspace:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1554,6 +1554,19 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if body_error is not None:
             self._write_json({"error": body_error}, status=400)
             return
+        if parsed.path == "/v1/healthz/verify":
+            nonce = self._optional_string(payload.get("nonce")) if payload else None
+            if not nonce:
+                self._write_json({"error": "missing_nonce"}, status=400)
+                return
+            auth_token = self.server.auth_token  # type: ignore[attr-defined]
+            proof = hmac.new(
+                auth_token.encode("ascii"),
+                nonce.encode("ascii"),
+                hashlib.sha256,
+            ).hexdigest()
+            self._write_json({"proof": proof})
+            return
         if self._requires_header_token(parsed.path, path_parts) and not self._header_token_is_valid(payload=payload):
             if (
                 len(path_parts) == 4

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1560,9 +1560,14 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 self._write_json({"error": "missing_nonce"}, status=400)
                 return
             auth_token = self.server.auth_token  # type: ignore[attr-defined]
+            daemon_port = self.server.server_address[1]  # type: ignore[attr-defined]
+            # Bind the proof to this daemon's listening port so a relay attacker
+            # cannot proxy the nonce to the real daemon and reuse its proof from
+            # a different port. The hook includes the same port in its local HMAC.
+            proof_message = f"{daemon_port}:{nonce}"
             proof = hmac.new(
-                auth_token.encode("ascii"),
-                nonce.encode("ascii"),
+                auth_token.encode("utf-8"),
+                proof_message.encode("utf-8"),
                 hashlib.sha256,
             ).hexdigest()
             self._write_json({"proof": proof})

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -1241,6 +1241,7 @@ def test_cursor_hook_daemon_fast_path_rejects_spoofed_healthz(tmp_path: Path, mo
     workspace_dir.mkdir(parents=True, exist_ok=True)
 
     # Fake server returns valid /healthz but a wrong HMAC proof on /v1/healthz/verify.
+    # The proof is bound to the daemon's port, so a wrong proof is always rejected.
     class _SpoofedHealthzHandler(http.server.BaseHTTPRequestHandler):
         def do_GET(self) -> None:
             self.send_response(200)
@@ -1252,7 +1253,7 @@ def test_cursor_hook_daemon_fast_path_rejects_spoofed_healthz(tmp_path: Path, mo
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
             self.end_headers()
-            # Return a wrong proof — attacker cannot compute the real HMAC.
+            # Return a wrong proof — attacker cannot compute the real port-bound HMAC.
             self.wfile.write(json.dumps({"proof": "deadbeef"}).encode())
 
         def log_message(self, *args: object) -> None:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -1228,3 +1228,79 @@ def test_cursor_hook_daemon_fast_path_rejects_empty_response(tmp_path: Path, mon
     # The fast path should reject the empty response and fall through to CLI.
     # The CLI path may fail (no real daemon), but it must not default-allow.
     assert proc.returncode in (0, 2)
+def test_cursor_hook_daemon_fast_path_rejects_spoofed_healthz(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fast path returns None when a spoofed listener fails the HMAC challenge."""
+    import http.server
+    import threading
+
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fake server returns valid /healthz but a wrong HMAC proof on /v1/healthz/verify.
+    class _SpoofedHealthzHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"ok": True, "compatibility_version": "v1"}).encode())
+
+        def do_POST(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            # Return a wrong proof — attacker cannot compute the real HMAC.
+            self.wfile.write(json.dumps({"proof": "deadbeef"}).encode())
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _SpoofedHealthzHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+            lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+        )
+        context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
+        script_path = tmp_path / "cursor-hook.py"
+        script_path.write_text(cursor_hook_script_source(context), encoding="utf-8")
+        script_path.chmod(0o755)
+
+        guard_home.mkdir(parents=True, exist_ok=True)
+        (guard_home / "daemon-state.json").write_text(
+            json.dumps({"port": port, "pid": os.getpid(), "compatibility_version": "v1"}),
+            encoding="utf-8",
+        )
+        (guard_home / "daemon-auth-token").write_text("real-secret-token", encoding="utf-8")
+
+        payload = {
+            "hook_event_name": "beforeShellExecution",
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo hi"},
+            "command": "echo hi",
+            "cwd": str(workspace_dir),
+        }
+        proc = subprocess.run(
+            [sys.executable, str(script_path)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env={**os.environ, "CURSOR_PROJECT_DIR": str(workspace_dir)},
+            timeout=30,
+        )
+    finally:
+        server.shutdown()
+
+    # The HMAC proof is wrong, so the hook must not send the auth token to the
+    # spoofed listener. It falls through to CLI, which may fail — but must not
+    # default-allow or leak the token.
+    assert proc.returncode in (0, 2)
+    assert "real-secret-token" not in proc.stdout
+    assert "real-secret-token" not in proc.stderr


### PR DESCRIPTION
## Summary
- Add `POST /v1/healthz/verify` endpoint that proves daemon identity via HMAC challenge-response before the Cursor hook sends its auth token
- Hook script generates a random nonce, sends it to `/v1/healthz/verify`, verifies the returned HMAC proof matches `HMAC-SHA256(auth_token, port:nonce)` locally, and only sends `X-Guard-Token` if the proof is valid
- The proof is bound to the daemon's listening port so a relay attacker cannot proxy the nonce to the real daemon and reuse its proof from a different port
- Old daemons without `/v1/healthz/verify` return 404 — the hook catches `HTTPError` separately and falls back to the existing healthz-only check for backward compatibility
- Uses `encode("utf-8")` instead of `encode("ascii")` to avoid crashes on non-ASCII tokens or nonces

## Testing
- `python3 -m pytest tests/test_cursor_hooks.py -xvs` — 42 passed
- `python3 -m pytest tests/test_guard_daemon_manager.py tests/test_guard_daemon_registry.py tests/test_guard_daemon_wake.py -x` — 57 passed
- `python3 -m ruff check src/codex_plugin_scanner/guard/daemon/server.py src/codex_plugin_scanner/guard/adapters/cursor_hooks.py tests/test_cursor_hooks.py` — clean

## Notes
- Resolves the unresolved Greptile P1 "Spoofable Health Identity" from #1141
