### PR TITLE
fix(guard): remove 404 bypass from HMAC challenge-response

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
+++ b/src/codex_plugin_scanner/guard/adapters/cursor_hooks.py
@@ -650,7 +650,8 @@ def _daemon_hook_result(
     # A spoofed listener can return public healthz values but cannot forge the HMAC.
     # The proof is bound to the daemon's listening port so a relay attacker cannot
     # proxy the nonce to the real daemon and reuse its proof from a different port.
-    # Old daemons without /v1/healthz/verify return 404 — skip the check for compat.
+    # Old daemons without /v1/healthz/verify fail with HTTPError — return None to
+    # fall through to the CLI path. Never bypass the HMAC challenge.
     nonce = os.urandom(16).hex()
     proof_message = f"{port}:{nonce}"
     try:
@@ -675,11 +676,7 @@ def _daemon_hook_result(
             ).hexdigest()
             if not hmac.compare_digest(verify_json["proof"], expected_proof):
                 return None
-    except urllib.error.HTTPError as exc:
-        if exc.code != 404:
-            return None
-        # Old daemon without /v1/healthz/verify — proceed with healthz-only check.
-    except (OSError, urllib.error.URLError):
+    except (urllib.error.HTTPError, OSError, urllib.error.URLError):
         return None
     params = [("guard-home", GUARD_HOME)]
     if workspace:

--- a/tests/test_cursor_hooks.py
+++ b/tests/test_cursor_hooks.py
@@ -1305,3 +1305,76 @@ def test_cursor_hook_daemon_fast_path_rejects_spoofed_healthz(tmp_path: Path, mo
     assert proc.returncode in (0, 2)
     assert "real-secret-token" not in proc.stdout
     assert "real-secret-token" not in proc.stderr
+def test_cursor_hook_daemon_fast_path_404_falls_through_to_cli(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fast path returns None when /v1/healthz/verify returns 404, falling through to CLI."""
+    import http.server
+    import threading
+
+    from codex_plugin_scanner.guard.adapters.cursor_hooks import cursor_hook_script_source
+
+    home_dir = tmp_path / "home"
+    guard_home = tmp_path / "guard"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+
+    # Fake server returns valid /healthz but 404 on /v1/healthz/verify (old daemon).
+    class _NoVerifyEndpointHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self) -> None:
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(json.dumps({"ok": True, "compatibility_version": "v1"}).encode())
+
+        def do_POST(self) -> None:
+            # Old daemon lacks /v1/healthz/verify — return 404.
+            self.send_response(404)
+            self.end_headers()
+
+        def log_message(self, *args: object) -> None:
+            pass
+
+    server = http.server.HTTPServer(("127.0.0.1", 0), _NoVerifyEndpointHandler)
+    port = server.server_address[1]
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+
+    try:
+        monkeypatch.setattr(
+            "codex_plugin_scanner.guard.adapters.cursor_hooks._resolve_guard_cli_command",
+            lambda: [sys.executable, "-m", "codex_plugin_scanner.cli"],
+        )
+        context = HarnessContext(home_dir=home_dir, guard_home=guard_home, workspace_dir=workspace_dir)
+        script_path = tmp_path / "cursor-hook.py"
+        script_path.write_text(cursor_hook_script_source(context), encoding="utf-8")
+        script_path.chmod(0o755)
+
+        guard_home.mkdir(parents=True, exist_ok=True)
+        (guard_home / "daemon-state.json").write_text(
+            json.dumps({"port": port, "pid": os.getpid(), "compatibility_version": "v1"}),
+            encoding="utf-8",
+        )
+        (guard_home / "daemon-auth-token").write_text("secret-token-404", encoding="utf-8")
+
+        payload = {
+            "hook_event_name": "beforeShellExecution",
+            "tool_name": "Bash",
+            "tool_input": {"command": "echo hi"},
+            "command": "echo hi",
+            "cwd": str(workspace_dir),
+        }
+        proc = subprocess.run(
+            [sys.executable, str(script_path)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            env={**os.environ, "CURSOR_PROJECT_DIR": str(workspace_dir)},
+            timeout=30,
+        )
+    finally:
+        server.shutdown()
+
+    # 404 means old daemon without verify endpoint — must fall through to CLI.
+    # Must not send the auth token to the listener or default-allow.
+    assert proc.returncode in (0, 2)
+    assert "secret-token-404" not in proc.stdout
+    assert "secret-token-404" not in proc.stderr


### PR DESCRIPTION
## Summary
- Remove the 404 backward-compat bypass from the HMAC challenge-response introduced in #1213
- A spoofed listener could return valid `/healthz` + 404 on `/v1/healthz/verify` to skip the HMAC challenge and receive `X-Guard-Token`
- Any HTTP error (including 404 from old daemons) now returns `None` and falls through to the CLI path — slower but safe
- Old daemons are not broken; they use the CLI fallback which was always the pre-fast-path behavior

## Testing
- `python3 -m pytest tests/test_cursor_hooks.py -xvs` — 43 passed
- `python3 -m ruff check src/codex_plugin_scanner/guard/adapters/cursor_hooks.py tests/test_cursor_hooks.py` — clean

## Notes
- Fixes the Greptile P1 "Verify 404 Downgrades Identity" raised on #1213
