### PR TITLE
fix(guard): sync package inventory audits

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -408,7 +408,14 @@ def _run_guard_supply_chain_command(
         return exit_code
     if supply_chain_command == "sync":
         try:
-            payload = _validated_supply_chain_sync_payload(sync_supply_chain_bundle(store))
+            auth_context = _cloud_guard_sync_auth_context(store)
+            payload = _validated_supply_chain_sync_payload(
+                sync_supply_chain_cloud_state(
+                    store,
+                    auth_context=auth_context,
+                    workspace_dir=workspace_dir,
+                )
+            )
         except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError) as error:
             message = _guard_sync_failure_message(error)
             if getattr(args, "json", False):

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -423,6 +423,12 @@ def _run_guard_supply_chain_command(
             else:
                 print(message, file=sys.stderr)
             return 1
+        except GuardSyncNotAvailableError as error:
+            if getattr(args, "json", False):
+                _emit("supply-chain-sync", {"synced": False, "error": str(error)}, True)
+            else:
+                print(str(error), file=sys.stderr)
+            return 1
         except RuntimeError as error:
             if getattr(args, "json", False):
                 _emit("supply-chain-sync", {"synced": False, "error": str(error)}, True)

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -2597,6 +2597,7 @@ def sync_managed_workspace_audits(
     workspaces_payload: list[dict[str, object]] = []
     completed_jobs = 0
     failed_jobs = 0
+    incomplete_jobs = 0
     queued_jobs = 0
     skipped_workspaces = 0
     for candidate in _managed_workspace_audit_candidates(store, workspace_dir=workspace_dir):
@@ -2641,22 +2642,42 @@ def sync_managed_workspace_audits(
             final_status = (
                 str(final_response.get("status") or enqueue_response.get("status") or "queued").strip().lower()
             )
-            if final_status == "completed":
-                completed_jobs += 1
-            elif final_status == "failed":
-                failed_jobs += 1
+            cloud_visible_count = _int_value(final_response.get("totalPackages"))
+            cloud_processed_count = _int_value(final_response.get("processedCount"))
+            incomplete_cloud_projection = (
+                final_status == "completed"
+                and cloud_visible_count is not None
+                and cloud_visible_count < len(inventory)
+            )
+            if incomplete_cloud_projection:
+                incomplete_jobs += 1
+                workspace_status = "partial"
             else:
-                queued_jobs += 1
+                workspace_status = final_status
+                if final_status == "completed":
+                    completed_jobs += 1
+                elif final_status == "failed":
+                    failed_jobs += 1
+                else:
+                    queued_jobs += 1
+            message = final_response.get("error")
+            if incomplete_cloud_projection:
+                message = (
+                    "Guard Cloud accepted fewer package rows than hol-guard discovered "
+                    f"({cloud_visible_count} of {len(inventory)} visible)."
+                )
             workspaces_payload.append(
                 {
                     "workspace": workspace_label,
                     "workspace_fingerprint": request_payload.get("workspaceFingerprint"),
                     "job_id": job_id,
-                    "status": final_status,
+                    "status": workspace_status,
                     "package_count": len(inventory),
+                    "cloud_processed_count": cloud_processed_count,
+                    "cloud_visible_count": cloud_visible_count,
                     "manifest_paths": list(manifest_paths),
                     "lockfile_paths": list(lockfile_paths),
-                    "message": final_response.get("error"),
+                    "message": message,
                 }
             )
         except (
@@ -2675,9 +2696,9 @@ def sync_managed_workspace_audits(
                     "package_count": 0,
                 }
             )
-    if failed_jobs > 0 and completed_jobs == 0 and queued_jobs == 0:
+    if failed_jobs > 0 and completed_jobs == 0 and queued_jobs == 0 and incomplete_jobs == 0:
         status = "failed"
-    elif failed_jobs > 0:
+    elif failed_jobs > 0 or incomplete_jobs > 0:
         status = "partial"
     elif completed_jobs > 0 or queued_jobs > 0:
         status = "synced"
@@ -2690,6 +2711,7 @@ def sync_managed_workspace_audits(
         "completed_jobs": completed_jobs,
         "queued_jobs": queued_jobs,
         "failed_jobs": failed_jobs,
+        "incomplete_jobs": incomplete_jobs,
         "skipped_workspaces": skipped_workspaces,
         "workspaces": workspaces_payload,
     }

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -2645,9 +2645,7 @@ def sync_managed_workspace_audits(
             cloud_visible_count = _int_value(final_response.get("totalPackages"))
             cloud_processed_count = _int_value(final_response.get("processedCount"))
             incomplete_cloud_projection = (
-                final_status == "completed"
-                and cloud_visible_count is not None
-                and cloud_visible_count < len(inventory)
+                final_status == "completed" and cloud_visible_count is not None and cloud_visible_count < len(inventory)
             )
             if incomplete_cloud_projection:
                 incomplete_jobs += 1

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -9163,6 +9163,57 @@ url = http://127.0.0.1:8787/guard-canary
         assert len(captured_auth_context) == 2
         assert captured_auth_context[0] == captured_auth_context[1]
 
+    def test_guard_supply_chain_sync_includes_workspace_audits(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        captured: dict[str, object] = {}
+
+        monkeypatch.setattr(
+            guard_commands_module,
+            "_resolve_guard_sync_auth_context",
+            lambda _store: {
+                "access_token": "token",
+                "sync_url": "https://guard.example/api/guard/receipts/sync",
+            },
+        )
+
+        def _fake_sync_supply_chain_cloud_state(_store: GuardStore, **kwargs: object) -> dict[str, object]:
+            captured.update(kwargs)
+            return {
+                "synced_at": "2026-06-18T22:00:01Z",
+                "status": "synced",
+                "workspace_audits": {
+                    "status": "synced",
+                    "completed_jobs": 1,
+                    "workspaces": [{"package_count": 280, "cloud_visible_count": 280}],
+                },
+            }
+
+        monkeypatch.setattr(
+            guard_commands_module,
+            "sync_supply_chain_cloud_state",
+            _fake_sync_supply_chain_cloud_state,
+        )
+
+        rc = main([
+            "guard",
+            "supply-chain",
+            "sync",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert captured["workspace_dir"] == workspace_dir
+        assert output["workspace_audits"]["completed_jobs"] == 1
+        assert output["workspace_audits"]["workspaces"][0]["package_count"] == 280
+        assert output["workspace_audits"]["workspaces"][0]["cloud_visible_count"] == 280
+
     def test_refresh_cloud_policy_bundle_records_auth_expired_reason(self, tmp_path, monkeypatch):
         home_dir = tmp_path / "home"
         _disable_oauth_persistence_assert(monkeypatch)

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -9196,16 +9196,18 @@ url = http://127.0.0.1:8787/guard-canary
             _fake_sync_supply_chain_cloud_state,
         )
 
-        rc = main([
-            "guard",
-            "supply-chain",
-            "sync",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--json",
-        ])
+        rc = main(
+            [
+                "guard",
+                "supply-chain",
+                "sync",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 0
@@ -9237,16 +9239,18 @@ url = http://127.0.0.1:8787/guard-canary
             _fail_sync,
         )
 
-        rc = main([
-            "guard",
-            "supply-chain",
-            "sync",
-            "--home",
-            str(home_dir),
-            "--workspace",
-            str(workspace_dir),
-            "--json",
-        ])
+        rc = main(
+            [
+                "guard",
+                "supply-chain",
+                "sync",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+            ]
+        )
         output = json.loads(capsys.readouterr().out)
 
         assert rc == 1

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -9214,6 +9214,47 @@ url = http://127.0.0.1:8787/guard-canary
         assert output["workspace_audits"]["workspaces"][0]["package_count"] == 280
         assert output["workspace_audits"]["workspaces"][0]["cloud_visible_count"] == 280
 
+    def test_guard_supply_chain_sync_reports_unavailable_error(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+
+        monkeypatch.setattr(
+            guard_commands_module,
+            "_resolve_guard_sync_auth_context",
+            lambda _store: {
+                "access_token": "token",
+                "sync_url": "https://guard.example/api/guard/receipts/sync",
+            },
+        )
+
+        def _fail_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+            raise guard_commands_module.GuardSyncNotAvailableError("Guard supply-chain audit is not available.")
+
+        monkeypatch.setattr(
+            guard_commands_module,
+            "sync_supply_chain_cloud_state",
+            _fail_sync,
+        )
+
+        rc = main([
+            "guard",
+            "supply-chain",
+            "sync",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--json",
+        ])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output == {
+            "synced": False,
+            "error": "Guard supply-chain audit is not available.",
+        }
+
     def test_refresh_cloud_policy_bundle_records_auth_expired_reason(self, tmp_path, monkeypatch):
         home_dir = tmp_path / "home"
         _disable_oauth_persistence_assert(monkeypatch)

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -237,6 +237,71 @@ def test_sync_managed_workspace_audits_enqueues_persisted_job_mode_for_managed_w
     assert summary["workspaces"][0]["package_count"] == 1
 
 
+def test_sync_managed_workspace_audits_reports_partial_when_cloud_visible_count_is_lower(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    _write_text(
+        workspace_dir / "package.json",
+        json.dumps({"name": "demo", "dependencies": {"react": "18.2.0"}}, sort_keys=True) + "\n",
+    )
+    _write_text(
+        workspace_dir / "package-lock.json",
+        json.dumps(
+            {
+                "name": "demo",
+                "lockfileVersion": 3,
+                "packages": {
+                    "": {"dependencies": {"react": "18.2.0"}},
+                    "node_modules/react": {"version": "18.2.0"},
+                    "node_modules/scheduler": {"version": "0.23.2"},
+                    "node_modules/loose-envify": {"version": "1.4.0"},
+                },
+            },
+            sort_keys=True,
+        )
+        + "\n",
+    )
+    store = GuardStore(home_dir)
+    _seed_premium_pairing(store, now="2026-05-25T10:00:00+00:00")
+    store.set_managed_install("codex", True, str(workspace_dir), {}, "2026-05-25T10:00:00+00:00")
+
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "_enqueue_cloud_workspace_audit_job",
+        lambda **_kwargs: {"jobId": "job-1", "status": "queued"},
+    )
+    monkeypatch.setattr(
+        local_supply_chain_module,
+        "_poll_cloud_workspace_audit_job",
+        lambda **_kwargs: {
+            "jobId": "job-1",
+            "status": "completed",
+            "processedCount": 2,
+            "totalPackages": 2,
+        },
+    )
+
+    summary = local_supply_chain_module.sync_managed_workspace_audits(
+        store,
+        auth_context={
+            "access_token": "token",
+            "sync_url": "https://guard.example/api/guard/receipts/sync",
+        },
+    )
+
+    workspace = summary["workspaces"][0]
+    assert summary["status"] == "partial"
+    assert summary["incomplete_jobs"] == 1
+    assert workspace["status"] == "partial"
+    assert workspace["package_count"] == 3
+    assert workspace["cloud_visible_count"] == 2
+    assert "2 of 3 visible" in str(workspace["message"])
+
+
 def test_guard_supply_chain_audit_alias_accepts_sbom_input(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_guard_local_supply_chain_phase15.py
+++ b/tests/test_guard_local_supply_chain_phase15.py
@@ -558,28 +558,39 @@ def test_guard_supply_chain_scan_without_supported_manifests_returns_nonzero(tmp
     assert output["message"] == "No supported manifests or lockfiles found in this workspace."
 
 
-def test_guard_supply_chain_sync_alias_uses_bundle_sync(
+def test_guard_supply_chain_sync_alias_uses_cloud_state_sync(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path, capsys
 ) -> None:
     home_dir = tmp_path / "guard-home"
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
+    captured: dict[str, object] = {}
 
     monkeypatch.setattr(
         commands_module,
-        "sync_supply_chain_bundle",
+        "_resolve_guard_sync_auth_context",
         lambda _store: {
-            "status": "synced",
-            "bundle_version": "1747612800000-deadbeef",
-            "workspace_id": WORKSPACE_ID,
-            "synced_at": "2026-05-19T12:00:00+00:00",
-            "tier": "premium",
-            "advisory_count": 1,
-            "package_count": 1,
-            "policy_hash": "policy-hash-1",
-            "feed_snapshot_hash": "feed-snapshot-1",
-            "ecosystem_support": [{"ecosystem": "npm", "support_level": "protected", "label": "Protected"}],
+            "access_token": "token",
+            "sync_url": "https://guard.example/api/guard/receipts/sync",
         },
+    )
+
+    def fake_sync_supply_chain_cloud_state(_store: GuardStore, **kwargs: object) -> dict[str, object]:
+        captured.update(kwargs)
+        return {
+            "status": "synced",
+            "synced_at": "2026-05-19T12:00:00+00:00",
+            "workspace_audits": {
+                "status": "synced",
+                "completed_jobs": 1,
+                "workspaces": [{"package_count": 3, "cloud_visible_count": 3}],
+            },
+        }
+
+    monkeypatch.setattr(
+        commands_module,
+        "sync_supply_chain_cloud_state",
+        fake_sync_supply_chain_cloud_state,
     )
 
     rc = main(
@@ -597,8 +608,15 @@ def test_guard_supply_chain_sync_alias_uses_bundle_sync(
     output = json.loads(capsys.readouterr().out)
 
     assert rc == 0
+    assert captured["workspace_dir"] == workspace_dir
+    assert captured["auth_context"] == {
+        "access_token": "token",
+        "sync_url": "https://guard.example/api/guard/receipts/sync",
+    }
     assert output["status"] == "synced"
-    assert output["bundle_version"] == "1747612800000-deadbeef"
+    assert output["workspace_audits"]["completed_jobs"] == 1
+    assert output["workspace_audits"]["workspaces"][0]["cloud_visible_count"] == 3
+    assert "supply_chain" in output
 
 
 def test_guard_supply_chain_sync_alias_rejects_invalid_payload(
@@ -608,7 +626,15 @@ def test_guard_supply_chain_sync_alias_rejects_invalid_payload(
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()
 
-    monkeypatch.setattr(commands_module, "sync_supply_chain_bundle", lambda _store: None)
+    monkeypatch.setattr(
+        commands_module,
+        "_resolve_guard_sync_auth_context",
+        lambda _store: {
+            "access_token": "token",
+            "sync_url": "https://guard.example/api/guard/receipts/sync",
+        },
+    )
+    monkeypatch.setattr(commands_module, "sync_supply_chain_cloud_state", lambda _store, **_kwargs: None)
 
     rc = main(
         [


### PR DESCRIPTION
## Summary
- Include workspace package audit jobs when running the supply-chain sync command
- Report partial sync state when Guard Cloud exposes fewer package rows than hol-guard discovered
- Cover package inventory sync counts with focused CLI and audit regression tests

## Testing
- `python3 -m pytest tests/test_guard_cli.py::TestGuardCli::test_guard_sync_includes_supply_chain_workspace_audits tests/test_guard_cli.py::TestGuardCli::test_guard_supply_chain_sync_includes_workspace_audits tests/test_guard_cli.py::TestGuardCli::test_guard_sync_surfaces_auth_expired_reauth_message tests/test_guard_local_supply_chain_audit_phase16.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_cli.py tests/test_guard_local_supply_chain_audit_phase16.py`