### PR TITLE
fix(guard): ignore stale package bundle family blocks

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -1417,6 +1417,21 @@ def _apply_stored_package_policy_override(
     )
     if not isinstance(decision, dict):
         return evaluation
+    if _stored_package_policy_is_stale_policy_bundle_family(decision, store=store):
+        if _stored_package_policy_evaluation_requires_review(evaluation):
+            return evaluation
+        return _package_policy_override_evaluation(
+            evaluation,
+            decision="ask",
+            policy_action="require-reapproval",
+            title="Review package install",
+            summary="HOL Guard found an old Cloud package rule that needs review before this install continues.",
+            harness_message=(
+                "HOL Guard found an old Cloud package rule that needs review before this install continues."
+            ),
+            reason_code="stale_package_bundle_policy_review",
+            reason_message="HOL Guard found an old Cloud package rule that needs review before this install continues.",
+        )
     action = decision.get("action")
     if action == "allow":
         return _package_policy_override_evaluation(
@@ -1453,6 +1468,66 @@ def _apply_stored_package_policy_override(
             reason_message="HOL Guard kept this package blocked because a saved package policy already exists.",
         )
     return evaluation
+
+
+def _stored_package_policy_is_stale_policy_bundle_family(decision: dict[str, object], *, store: Any) -> bool:
+    """Ignore package family rows only when the current bundle proves they are stale."""
+
+    if not (
+        _string_value(decision.get("source")) == "policy-bundle"
+        and _string_value(decision.get("artifact_id")) == "family:package-request"
+        and decision.get("artifact_hash") is None
+        and _string_value(decision.get("scope")) in {"harness", "global"}
+    ):
+        return False
+    owner = _string_value(decision.get("owner"))
+    if owner is None:
+        return False
+    get_sync_payload = getattr(store, "get_sync_payload", None)
+    if not callable(get_sync_payload):
+        return False
+    bundle = get_sync_payload("policy_bundle")
+    if not isinstance(bundle, dict):
+        return False
+    rules = bundle.get("rules")
+    if not isinstance(rules, list):
+        return False
+    matching_rules = [rule for rule in rules if isinstance(rule, dict) and _string_value(rule.get("ruleId")) == owner]
+    if not matching_rules:
+        return True
+    return not any(_policy_bundle_rule_has_package_scope(rule) for rule in matching_rules)
+
+
+def _stored_package_policy_evaluation_requires_review(evaluation: Any) -> bool:
+    policy_action = _string_value(getattr(evaluation, "policy_action", None))
+    decision = _string_value(getattr(evaluation, "decision", None))
+    return policy_action in {"block", "require-reapproval"} or decision in {"block", "ask"}
+
+
+def _policy_bundle_rule_has_package_scope(rule: dict[str, object]) -> bool:
+    if _string_value(rule.get("artifactType")) == "package_request":
+        return True
+    matcher_families = rule.get("matcherFamilies")
+    scope = rule.get("scope")
+    if _policy_bundle_scope_has_package_scope(scope):
+        return True
+    if isinstance(matcher_families, list) and "package-request" not in matcher_families:
+        return False
+    if not isinstance(scope, dict):
+        return isinstance(matcher_families, list) and "package-request" in matcher_families
+    return False
+
+
+def _policy_bundle_scope_has_package_scope(scope: object) -> bool:
+    if not isinstance(scope, dict):
+        return False
+    for key in ("ecosystems", "packages", "packageNames", "packageManagers", "registries", "sourceUrls"):
+        value = scope.get(key)
+        if isinstance(value, list) and value:
+            return True
+        if _string_value(value) is not None:
+            return True
+    return False
 
 
 def _saved_package_policy_clear_command(

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -1501,6 +1501,379 @@ def test_guard_protect_pnpm_install_alias_renders_wrapped_review_link_for_cloud_
     assert "review.. Open HOL Guard" not in output
 
 
+def test_guard_protect_ignores_stale_policy_bundle_package_family_block(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    server, thread, sync_url = _start_cloud_eval_server(
+        decision="allow",
+        package_name="cli",
+        evaluate_status=400,
+    )
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    try:
+        store = GuardStore(home_dir)
+        store.replace_remote_policies(
+            [
+                PolicyDecision(
+                    harness="*",
+                    scope="harness",
+                    action="block",
+                    artifact_id="family:package-request",
+                    source="policy-bundle",
+                    owner="policy-graph-default-high-block",
+                    reason="Block immediately high risk.",
+                )
+            ],
+            "2026-05-19T00:00:00Z",
+            remote_write_authorized=True,
+        )
+        store.set_sync_payload(
+            "policy_bundle",
+            {
+                "rules": [
+                    {
+                        "ruleId": "policy-graph-default-high-block",
+                        "matcherFamilies": ["package-request"],
+                        "scope": {"ecosystems": []},
+                    }
+                ]
+            },
+            "2026-05-19T00:00:00Z",
+        )
+        _seed_workspace_sync_credentials(home_dir, sync_url)
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "--dry-run",
+                "npm",
+                "i",
+                "-g",
+                "@stripe/cli",
+            ]
+        )
+    finally:
+        _stop_cloud_eval_server(server, thread)
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert payload["primary_approval_url"].startswith("http://127.0.0.1:5474/requests/")
+    reason_codes = {
+        reason["code"]
+        for reason in payload["supply_chain_evaluation"]["reasons"]
+        if isinstance(reason, dict) and isinstance(reason.get("code"), str)
+    }
+    assert "cloud_validation_error" in reason_codes
+    assert "saved_package_block" not in reason_codes
+    assert "saved package policy" not in payload["supply_chain_evaluation"]["user_copy"]["harness_message"]
+
+
+def test_guard_protect_keeps_active_policy_bundle_package_family_block(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    server, thread, sync_url = _start_cloud_eval_server(
+        decision="allow",
+        package_name="cli",
+        evaluate_status=200,
+    )
+    try:
+        store = GuardStore(home_dir)
+        store.replace_remote_policies(
+            [
+                PolicyDecision(
+                    harness="*",
+                    scope="harness",
+                    action="block",
+                    artifact_id="family:package-request",
+                    source="policy-bundle",
+                    owner="npm-block",
+                    reason="Block npm installs.",
+                )
+            ],
+            "2026-05-19T00:00:00Z",
+            remote_write_authorized=True,
+        )
+        store.set_sync_payload(
+            "policy_bundle",
+            {
+                "rules": [
+                    {
+                        "ruleId": "npm-block",
+                        "matcherFamilies": ["package-request"],
+                        "scope": {"ecosystems": ["npm"]},
+                    }
+                ]
+            },
+            "2026-05-19T00:00:00Z",
+        )
+        _seed_workspace_sync_credentials(home_dir, sync_url)
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "--dry-run",
+                "npm",
+                "i",
+                "-g",
+                "@stripe/cli",
+            ]
+        )
+    finally:
+        _stop_cloud_eval_server(server, thread)
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    reason_codes = {
+        reason["code"]
+        for reason in payload["supply_chain_evaluation"]["reasons"]
+        if isinstance(reason, dict) and isinstance(reason.get("code"), str)
+    }
+    assert "saved_package_block" in reason_codes
+    assert payload["supply_chain_evaluation"]["user_copy"]["next_step"].startswith(
+        "hol-guard policies clear --decision-id"
+    )
+
+
+def test_guard_protect_keeps_matcher_only_policy_bundle_package_family_block(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    server, thread, sync_url = _start_cloud_eval_server(
+        decision="allow",
+        package_name="cli",
+        evaluate_status=200,
+    )
+    try:
+        store = GuardStore(home_dir)
+        store.replace_remote_policies(
+            [
+                PolicyDecision(
+                    harness="*",
+                    scope="harness",
+                    action="block",
+                    artifact_id="family:package-request",
+                    source="policy-bundle",
+                    owner="matcher-only-package-block",
+                    reason="Block package installs.",
+                )
+            ],
+            "2026-05-19T00:00:00Z",
+            remote_write_authorized=True,
+        )
+        store.set_sync_payload(
+            "policy_bundle",
+            {"rules": [{"ruleId": "matcher-only-package-block", "matcherFamilies": ["package-request"]}]},
+            "2026-05-19T00:00:00Z",
+        )
+        _seed_workspace_sync_credentials(home_dir, sync_url)
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "--dry-run",
+                "npm",
+                "i",
+                "-g",
+                "@stripe/cli",
+            ]
+        )
+    finally:
+        _stop_cloud_eval_server(server, thread)
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    reason_codes = {
+        reason["code"]
+        for reason in payload["supply_chain_evaluation"]["reasons"]
+        if isinstance(reason, dict) and isinstance(reason.get("code"), str)
+    }
+    assert "saved_package_block" in reason_codes
+
+
+def test_guard_protect_keeps_package_scope_even_when_matcher_list_omits_package_family(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    server, thread, sync_url = _start_cloud_eval_server(
+        decision="allow",
+        package_name="cli",
+        evaluate_status=200,
+    )
+    try:
+        store = GuardStore(home_dir)
+        store.replace_remote_policies(
+            [
+                PolicyDecision(
+                    harness="*",
+                    scope="harness",
+                    action="block",
+                    artifact_id="family:package-request",
+                    source="policy-bundle",
+                    owner="ecosystem-package-block",
+                    reason="Block npm installs.",
+                )
+            ],
+            "2026-05-19T00:00:00Z",
+            remote_write_authorized=True,
+        )
+        store.set_sync_payload(
+            "policy_bundle",
+            {
+                "rules": [
+                    {
+                        "ruleId": "ecosystem-package-block",
+                        "matcherFamilies": ["tool-action"],
+                        "scope": {"ecosystems": ["npm"]},
+                    }
+                ]
+            },
+            "2026-05-19T00:00:00Z",
+        )
+        _seed_workspace_sync_credentials(home_dir, sync_url)
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "--dry-run",
+                "npm",
+                "i",
+                "-g",
+                "@stripe/cli",
+            ]
+        )
+    finally:
+        _stop_cloud_eval_server(server, thread)
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    reason_codes = {
+        reason["code"]
+        for reason in payload["supply_chain_evaluation"]["reasons"]
+        if isinstance(reason, dict) and isinstance(reason.get("code"), str)
+    }
+    assert "saved_package_block" in reason_codes
+
+
+def test_guard_protect_reviews_stale_policy_bundle_package_family_on_cloud_allow(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys,
+) -> None:
+    home_dir = tmp_path / "guard-home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir(parents=True, exist_ok=True)
+    server, thread, sync_url = _start_cloud_eval_server(
+        decision="allow",
+        package_name="cli",
+        evaluate_status=200,
+    )
+    monkeypatch.setattr(guard_commands_module, "ensure_guard_daemon", lambda _home: "http://127.0.0.1:5474")
+    try:
+        store = GuardStore(home_dir)
+        store.replace_remote_policies(
+            [
+                PolicyDecision(
+                    harness="*",
+                    scope="harness",
+                    action="block",
+                    artifact_id="family:package-request",
+                    source="policy-bundle",
+                    owner="policy-graph-default-high-block",
+                    reason="Block immediately high risk.",
+                )
+            ],
+            "2026-05-19T00:00:00Z",
+            remote_write_authorized=True,
+        )
+        store.set_sync_payload(
+            "policy_bundle",
+            {
+                "rules": [
+                    {
+                        "ruleId": "policy-graph-default-high-block",
+                        "matcherFamilies": ["package-request"],
+                        "scope": {"ecosystems": []},
+                    }
+                ]
+            },
+            "2026-05-19T00:00:00Z",
+        )
+        _seed_workspace_sync_credentials(home_dir, sync_url)
+        rc = main(
+            [
+                "guard",
+                "protect",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--json",
+                "--dry-run",
+                "npm",
+                "i",
+                "-g",
+                "@stripe/cli",
+            ]
+        )
+    finally:
+        _stop_cloud_eval_server(server, thread)
+
+    payload = json.loads(capsys.readouterr().out)
+
+    assert rc == 2
+    assert payload["primary_approval_url"].startswith("http://127.0.0.1:5474/requests/")
+    assert payload["supply_chain_evaluation"]["decision"] == "ask"
+    reason_codes = {
+        reason["code"]
+        for reason in payload["supply_chain_evaluation"]["reasons"]
+        if isinstance(reason, dict) and isinstance(reason.get("code"), str)
+    }
+    assert "stale_package_bundle_policy_review" in reason_codes
+    assert "saved_package_block" not in reason_codes
+
+
 def test_guard_protect_retry_runs_after_local_package_approval(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary
- Ignore stale policy-bundle package family rows when evaluating package installs
- Preserve package-specific supply-chain evaluation and local approval links for unvalidated installs

## Testing
- `python3 -m pytest tests/test_guard_package_shims.py::test_guard_protect_ignores_stale_policy_bundle_package_family_block -q`
- `python3 -m pytest tests/test_guard_package_shims.py::test_guard_protect_pnpm_install_alias_renders_wrapped_review_link_for_cloud_validation_error tests/test_guard_package_shims.py::test_guard_protect_retry_after_local_package_approval_reuses_recent_cloud_validation_error_cache tests/test_guard_package_shims.py::test_guard_protect_ignores_stale_policy_bundle_package_family_block tests/test_guard_policy_bundle_browser_scopes.py tests/test_guard_supply_chain_evaluator.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_package_shims.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_package_shims.py`
