### PR TITLE
fix(guard): omit empty supply chain lockfile context

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1564,7 +1564,7 @@ def _build_request_payload(
     policy_version: str,
 ) -> dict[str, object]:
     lockfile_context = _lockfile_context(workspace_dir, artifact)
-    return {
+    payload: dict[str, object] = {
         "commandShape": {
             "argCount": len(str(artifact.metadata.get("redacted_command") or "").split()),
             "flags": list(_string_tuple(artifact.metadata.get("flags"))),
@@ -1573,7 +1573,6 @@ def _build_request_payload(
             "verb": str(artifact.metadata.get("intent_kind") or "install"),
         },
         "harness": artifact.harness,
-        "lockfileContext": lockfile_context,
         "packages": [
             {
                 "direct": True,
@@ -1590,6 +1589,9 @@ def _build_request_payload(
         "policyVersion": policy_version,
         "workspaceFingerprint": workspace_fingerprint,
     }
+    if lockfile_context is not None:
+        payload["lockfileContext"] = lockfile_context
+    return payload
 
 
 def _lockfile_context(workspace_dir: Path | None, artifact: GuardArtifact) -> dict[str, object] | None:

--- a/tests/test_guard_supply_chain_disclosure_reasons.py
+++ b/tests/test_guard_supply_chain_disclosure_reasons.py
@@ -178,11 +178,7 @@ def test_unknown_package_disclosure_reason(tmp_path: Path, monkeypatch: pytest.M
     )
 
     assert any(reason["code"] == "no_cached_match" for package in result.packages for reason in package["reasons"])
-    assert any(
-        reason["code"] == "unidentified_package"
-        for package in result.packages
-        for reason in package["reasons"]
-    )
+    assert any(reason["code"] == "unidentified_package" for package in result.packages for reason in package["reasons"])
 
 
 def test_unidentified_package_reason_fires_for_supported_ecosystem(tmp_path: Path) -> None:
@@ -216,11 +212,7 @@ def test_unidentified_package_reason_absent_for_unsupported_ecosystem(tmp_path: 
         workspace_dir=workspace_dir,
         now="2026-05-19T00:00:00Z",
     )
-    assert all(
-        reason["code"] != "unidentified_package"
-        for package in result.packages
-        for reason in package["reasons"]
-    )
+    assert all(reason["code"] != "unidentified_package" for package in result.packages for reason in package["reasons"])
 
 
 def test_unknown_package_result_directly_skips_unidentified_for_unsupported() -> None:
@@ -269,11 +261,8 @@ def test_known_package_does_not_emit_unidentified_package(
         workspace_dir=tmp_path / "workspace",
         now="2026-05-19T00:00:00Z",
     )
-    assert all(
-        reason["code"] != "unidentified_package"
-        for package in result.packages
-        for reason in package["reasons"]
-    )
+    assert all(reason["code"] != "unidentified_package" for package in result.packages for reason in package["reasons"])
+
 
 def test_policy_version_hash_consistency_between_cloud_request_and_local_evaluation(
     tmp_path: Path,
@@ -309,3 +298,4 @@ def test_policy_version_hash_consistency_between_cloud_request_and_local_evaluat
     )
 
     assert request_payload["policyVersion"] == POLICY_HASH
+    assert "lockfileContext" not in request_payload


### PR DESCRIPTION
## Summary
- omit null lockfileContext from supply-chain cloud evaluation payloads
- keep lockfileContext when real lockfile metadata exists
- add regression coverage for workspaces without lockfiles

## Verification
- python3 -m pytest tests/test_guard_supply_chain_disclosure_reasons.py tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_response tests/test_guard_supply_chain_evaluator.py::test_canonical_decision_order_prefers_cloud_over_signed_bundle tests/test_guard_package_shims.py::test_guard_protect_ignores_stale_policy_bundle_package_family_block -q
- python3 -m ruff check src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py tests/test_guard_supply_chain_disclosure_reasons.py
- python3 -m ruff format --check src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py tests/test_guard_supply_chain_disclosure_reasons.py