### PR TITLE
fix(guard): send contract-only supply chain packages

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1579,6 +1579,7 @@ def _build_request_payload(
                 "ecosystem": str(target["ecosystem"]),
                 "name": str(target["name"]),
                 "namespace": target["namespace"],
+                **({"sourceUrl": str(target["source_url"])} if target.get("source_url") else {}),
                 **({"version": str(target["version"])} if target.get("version") else {}),
                 **({"range": str(target["range"])} if target.get("range") else {}),
             }

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1576,11 +1576,9 @@ def _build_request_payload(
         "packages": [
             {
                 "direct": True,
-                "dependencyPath": None,
                 "ecosystem": str(target["ecosystem"]),
                 "name": str(target["name"]),
                 "namespace": target["namespace"],
-                **({"sourceUrl": str(target["source_url"])} if target.get("source_url") else {}),
                 **({"version": str(target["version"])} if target.get("version") else {}),
                 **({"range": str(target["range"])} if target.get("range") else {}),
             }

--- a/tests/test_guard_supply_chain_disclosure_reasons.py
+++ b/tests/test_guard_supply_chain_disclosure_reasons.py
@@ -299,3 +299,10 @@ def test_policy_version_hash_consistency_between_cloud_request_and_local_evaluat
 
     assert request_payload["policyVersion"] == POLICY_HASH
     assert "lockfileContext" not in request_payload
+    assert request_payload["packages"][0].keys() == {
+        "direct",
+        "ecosystem",
+        "name",
+        "namespace",
+        "version",
+    }

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -426,7 +426,13 @@ def test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_re
     assert request_payload["lockfileContext"]["fileName"] == "package-lock.json"
     assert request_payload["packages"][0]["name"] == "minimist"
     assert request_payload["packages"][0]["direct"] is True
-    assert request_payload["packages"][0]["dependencyPath"] is None
+    assert set(request_payload["packages"][0]) == {
+        "direct",
+        "ecosystem",
+        "name",
+        "namespace",
+        "version",
+    }
     assert request_payload["policyVersion"]
     assert request_payload["workspaceFingerprint"]
     assert result.decision == "block"

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -485,7 +485,6 @@ def test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_sc
 
     request_payload = _EvaluateHandler.captured_requests[0]
     assert request_payload["packages"][0] == {
-        "dependencyPath": None,
         "direct": True,
         "ecosystem": "npm",
         "name": "cli",
@@ -592,7 +591,6 @@ def test_evaluate_package_request_artifact_posts_open_range_for_unversioned_pypi
 
     package_payload = _EvaluateHandler.captured_requests[0]["packages"][0]
     assert package_payload == {
-        "dependencyPath": None,
         "direct": True,
         "ecosystem": "pypi",
         "name": "hol-guard",


### PR DESCRIPTION
## Summary
- remove non-contract `dependencyPath` and `sourceUrl` fields from cloud evaluate package intents
- keep lockfileContext behavior from the previous fix
- assert evaluate payload package objects match the v1 contract shape

## Verification
- python3 -m pytest tests/test_guard_supply_chain_disclosure_reasons.py tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_posts_cloud_request_and_maps_block_response tests/test_guard_supply_chain_evaluator.py::test_canonical_decision_order_prefers_cloud_over_signed_bundle tests/test_guard_package_shims.py::test_guard_protect_ignores_stale_policy_bundle_package_family_block -q
- python3 -m ruff check src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py tests/test_guard_supply_chain_disclosure_reasons.py tests/test_guard_supply_chain_evaluator.py
- python3 -m ruff format --check src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py tests/test_guard_supply_chain_disclosure_reasons.py tests/test_guard_supply_chain_evaluator.py