### PR TITLE
Sync workspace context with supply-chain package audits

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -7,6 +7,7 @@ import inspect
 import json
 import os
 import shlex
+import socket
 import subprocess
 import threading
 import time
@@ -27,7 +28,7 @@ from .adapters.base import HarnessContext
 from .advisory_model import ProtectTargetIdentity, advisory_matches_target, build_package_url
 from .config import GuardConfig, resolve_risk_action
 from .models import GuardAction, GuardArtifact, GuardReceipt
-from .redaction import redact_text
+from .redaction import redact_local_path, redact_text
 from .runtime.package_intent_common import (
     PackageIntent,
     PackageIntentTarget,
@@ -2379,6 +2380,79 @@ def _run_cloud_workspace_audit(
     return (merged_response, None)
 
 
+def _codebase_label_from_remote(remote: str) -> str | None:
+    normalized_remote = remote.strip().rstrip("/")
+    if not normalized_remote:
+        return None
+    if "://" in normalized_remote:
+        parsed = urllib.parse.urlparse(normalized_remote)
+        path = parsed.path.lstrip("/")
+    elif ":" in normalized_remote:
+        path = normalized_remote.split(":", 1)[1]
+    else:
+        path = normalized_remote
+    label = path.strip("/")
+    if not label:
+        return None
+    return label[:-4] if label.endswith(".git") else label
+
+
+def _read_git_origin_codebase(workspace_dir: Path) -> str | None:
+    config_path = workspace_dir / ".git" / "config"
+    try:
+        config_text = config_path.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    in_origin = False
+    for raw_line in config_text.splitlines():
+        line = raw_line.strip()
+        if line.startswith("[") and line.endswith("]"):
+            in_origin = line == '[remote "origin"]'
+            continue
+        if not in_origin or not line.startswith("url") or "=" not in line:
+            continue
+        _key, _sep, value = line.partition("=")
+        return _codebase_label_from_remote(value)
+    return None
+
+
+def _safe_machine_name() -> str | None:
+    try:
+        machine = socket.gethostname().strip()
+    except OSError:
+        return None
+    return machine or None
+
+
+def _redacted_workspace_folder_path(workspace_dir: Path) -> str:
+    raw_path = str(workspace_dir)
+    redacted = redact_local_path(raw_path)
+    if redacted != raw_path or not workspace_dir.is_absolute():
+        return redacted
+    parts = [part for part in workspace_dir.parts if part not in {"", "/"}]
+    if len(parts) >= 2:
+        return f"…/{parts[-2]}/{parts[-1]}"
+    return f"…/{workspace_dir.name}"
+
+
+def _build_workspace_context_payload(
+    workspace_dir: Path,
+    manifest_paths: tuple[str, ...],
+    lockfile_paths: tuple[str, ...],
+) -> dict[str, object]:
+    codebase = _read_git_origin_codebase(workspace_dir) or workspace_dir.name
+    return {
+        "agent": _LOCAL_SUPPLY_CHAIN_HARNESS,
+        "codebase": codebase,
+        "folderPath": _redacted_workspace_folder_path(workspace_dir),
+        "lockfilePaths": list(lockfile_paths),
+        "machine": _safe_machine_name(),
+        "manifestPaths": list(manifest_paths),
+        "packageManager": _package_manager_for_scan(manifest_paths),
+        "workspaceName": workspace_dir.name,
+    }
+
+
 def _build_cloud_audit_payload(
     *,
     workspace_dir: Path,
@@ -2427,6 +2501,11 @@ def _build_cloud_audit_payload(
             for item in inventory
         ],
         "policyVersion": policy_version,
+        "workspaceContext": _build_workspace_context_payload(
+            workspace_dir,
+            manifest_paths,
+            lockfile_paths,
+        ),
         "workspaceFingerprint": workspace_fingerprint,
     }
     if payload["lockfileContext"] is None:

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -705,6 +705,75 @@ def test_read_sbom_text_rejects_oversized_files(tmp_path: Path) -> None:
     assert local_supply_chain_module._read_sbom_text(sbom_path) is None
 
 
+def test_build_cloud_audit_payload_includes_workspace_context(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    workspace_dir = tmp_path / "workspace"
+    (workspace_dir / ".git").mkdir(parents=True)
+    _write_text(
+        workspace_dir / ".git" / "config",
+        '[remote "origin"]\n\turl = git@github.com:hashgraph-online/hol-points-portal.git\n',
+    )
+    _write_text(workspace_dir / "package.json", '{"name":"demo"}\n')
+    _write_text(workspace_dir / "pnpm-lock.yaml", "lockfileVersion: '9.0'\n")
+    monkeypatch.setattr(local_supply_chain_module.socket, "gethostname", lambda: "macbook-pro")
+
+    class _Store:
+        def get_sync_payload(self, _key: str) -> dict[str, str]:
+            return {"policy_hash": "policy-hash-1"}
+
+    payload = local_supply_chain_module._build_cloud_audit_payload(
+        workspace_dir=workspace_dir,
+        workspace_id=WORKSPACE_ID,
+        store=_Store(),
+        manifest_paths=("package.json",),
+        lockfile_paths=("pnpm-lock.yaml",),
+        inventory=(
+            {
+                "direct": True,
+                "ecosystem": "npm",
+                "name": "minimist",
+                "version": "1.2.5",
+            },
+        ),
+    )
+
+    assert payload["workspaceContext"] == {
+        "agent": "guard-cli",
+        "codebase": "hashgraph-online/hol-points-portal",
+        "folderPath": local_supply_chain_module._redacted_workspace_folder_path(workspace_dir),
+        "lockfilePaths": ["pnpm-lock.yaml"],
+        "machine": "macbook-pro",
+        "manifestPaths": ["package.json"],
+        "packageManager": "npm",
+        "workspaceName": "workspace",
+    }
+
+
+def test_workspace_context_redacts_path_and_handles_hostname_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _raise_os_error() -> str:
+        raise OSError("hostname unavailable")
+
+    monkeypatch.setattr(local_supply_chain_module.socket, "gethostname", _raise_os_error)
+
+    payload = local_supply_chain_module._build_workspace_context_payload(
+        Path("/Users/alice/projects/app"),
+        ("package.json",),
+        ("package-lock.json",),
+    )
+
+    assert payload["codebase"] == "app"
+    assert payload["folderPath"] == "~/projects/app"
+    assert payload["machine"] is None
+    assert local_supply_chain_module._redacted_workspace_folder_path(Path("/workspace/app")) == "…/workspace/app"
+    assert local_supply_chain_module._codebase_label_from_remote(
+        "git@gitlab.com:team/backend/service.git",
+    ) == "team/backend/service"
+
+
 def test_run_cloud_workspace_audit_falls_back_after_page_limit(monkeypatch: pytest.MonkeyPatch) -> None:
     class _FakeResponse(io.StringIO):
         def __enter__(self) -> _FakeResponse:


### PR DESCRIPTION
## Summary
- Include workspace context in Guard cloud supply-chain audit payloads.
- Send codebase, agent, machine, folder path, manifest paths, lockfile paths, package manager, and workspace name with each workspace audit.
- Cover the new payload metadata with a focused local supply-chain audit test.

## Verification
- `uv run pytest tests/test_guard_local_supply_chain_audit_phase16.py::test_build_cloud_audit_payload_includes_workspace_context`
- `uv run ruff check src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_local_supply_chain_audit_phase16.py`