### PR TITLE
fix(guard): ignore stale package policy rows after cloud allow

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -1419,20 +1419,7 @@ def _apply_stored_package_policy_override(
     if not isinstance(decision, dict):
         return evaluation
     if _stored_package_policy_is_stale_policy_bundle_family(decision, store=store):
-        if _stored_package_policy_evaluation_requires_review(evaluation):
-            return evaluation
-        return _package_policy_override_evaluation(
-            evaluation,
-            decision="ask",
-            policy_action="require-reapproval",
-            title="Review package install",
-            summary="HOL Guard found an old Cloud package rule that needs review before this install continues.",
-            harness_message=(
-                "HOL Guard found an old Cloud package rule that needs review before this install continues."
-            ),
-            reason_code="stale_package_bundle_policy_review",
-            reason_message="HOL Guard found an old Cloud package rule that needs review before this install continues.",
-        )
+        return evaluation
     action = decision.get("action")
     if action == "allow":
         return _package_policy_override_evaluation(

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1579,6 +1579,7 @@ def _build_request_payload(
                 "ecosystem": str(target["ecosystem"]),
                 "name": str(target["name"]),
                 "namespace": target["namespace"],
+                **({"sourceUrl": str(target["source_url"])} if target.get("source_url") else {}),
                 **({"version": str(target["version"])} if target.get("version") else {}),
                 **({"range": str(target["range"])} if target.get("range") else {}),
             }

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -1579,7 +1579,6 @@ def _build_request_payload(
                 "ecosystem": str(target["ecosystem"]),
                 "name": str(target["name"]),
                 "namespace": target["namespace"],
-                **({"sourceUrl": str(target["source_url"])} if target.get("source_url") else {}),
                 **({"version": str(target["version"])} if target.get("version") else {}),
                 **({"range": str(target["range"])} if target.get("range") else {}),
             }

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -1796,7 +1796,7 @@ def test_guard_protect_keeps_package_scope_even_when_matcher_list_omits_package_
     assert "saved_package_block" in reason_codes
 
 
-def test_guard_protect_reviews_stale_policy_bundle_package_family_on_cloud_allow(
+def test_guard_protect_ignores_stale_policy_bundle_package_family_on_cloud_allow(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     capsys,
@@ -1862,15 +1862,14 @@ def test_guard_protect_reviews_stale_policy_bundle_package_family_on_cloud_allow
 
     payload = json.loads(capsys.readouterr().out)
 
-    assert rc == 2
-    assert payload["primary_approval_url"].startswith("http://127.0.0.1:5474/requests/")
-    assert payload["supply_chain_evaluation"]["decision"] == "ask"
+    assert rc == 0
+    assert payload["supply_chain_evaluation"]["decision"] == "allow"
     reason_codes = {
         reason["code"]
         for reason in payload["supply_chain_evaluation"]["reasons"]
         if isinstance(reason, dict) and isinstance(reason.get("code"), str)
     }
-    assert "stale_package_bundle_policy_review" in reason_codes
+    assert "stale_package_bundle_policy_review" not in reason_codes
     assert "saved_package_block" not in reason_codes
 
 


### PR DESCRIPTION
- Ignore stale policy-bundle package-family rows when current package evaluation has a usable cloud decision.
- Keep source URL package evaluate payload compatibility while omitting non-contract dependency path fields for package installs.
- `python3 -m pytest tests/test_guard_package_shims.py::test_guard_protect_ignores_stale_policy_bundle_package_family_block tests/test_guard_package_shims.py::test_guard_protect_ignores_stale_policy_bundle_package_family_on_cloud_allow tests/test_guard_package_shims.py::test_guard_protect_keeps_active_policy_bundle_package_family_block tests/test_guard_package_shims.py::test_guard_protect_keeps_matcher_only_policy_bundle_package_family_block tests/test_guard_package_shims.py::test_guard_protect_keeps_package_scope_even_when_matcher_list_omits_package_family tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_scoped_npm_request -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py tests/test_guard_package_shims.py tests/test_guard_supply_chain_disclosure_reasons.py tests/test_guard_supply_chain_evaluator.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/local_supply_chain.py src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py tests/test_guard_package_shims.py tests/test_guard_supply_chain_disclosure_reasons.py tests/test_guard_supply_chain_evaluator.py`
