### PR TITLE
fix(guard): omit workspace context for global package installs

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -77,6 +77,7 @@ def build_package_request_artifact(
     config_path: str,
     source_scope: str,
 ) -> GuardArtifact:
+    manifest_paths, lockfile_paths = _artifact_workspace_paths(intent)
     fingerprint = hashlib.sha256(
         json.dumps(
             {
@@ -85,8 +86,8 @@ def build_package_request_artifact(
                 "intent_kind": intent.intent_kind,
                 "redacted_command": intent.redacted_command,
                 "targets": [target.to_dict() for target in intent.targets],
-                "manifest_paths": list(intent.manifest_paths),
-                "lockfile_paths": list(intent.lockfile_paths),
+                "manifest_paths": list(manifest_paths),
+                "lockfile_paths": list(lockfile_paths),
             },
             sort_keys=True,
         ).encode("utf-8")
@@ -103,8 +104,8 @@ def build_package_request_artifact(
             "package_manager": intent.package_manager,
             "intent_kind": intent.intent_kind,
             "targets": [target.to_dict() for target in intent.targets],
-            "manifest_paths": list(intent.manifest_paths),
-            "lockfile_paths": list(intent.lockfile_paths),
+            "manifest_paths": list(manifest_paths),
+            "lockfile_paths": list(lockfile_paths),
             "flags": list(intent.flags),
             "notes": list(intent.notes),
             "redacted_command": intent.redacted_command,
@@ -114,6 +115,26 @@ def build_package_request_artifact(
             "runtime_request_reason": package_runtime_reason(intent),
         },
     )
+
+
+def _artifact_workspace_paths(intent: PackageIntent) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    if _is_global_package_install(intent):
+        return (), ()
+    return intent.manifest_paths, intent.lockfile_paths
+
+
+def _is_global_package_install(intent: PackageIntent) -> bool:
+    if intent.package_manager not in {"npm", "pnpm", "yarn"}:
+        return False
+    for flag in intent.flags:
+        normalized = flag.strip().lower()
+        if normalized in {"-g", "--global"}:
+            return True
+        if normalized.startswith("--global="):
+            return True
+        if normalized == "--location=global":
+            return True
+    return False
 
 
 def package_request_summary(intent: PackageIntent) -> str:

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -471,7 +471,12 @@ def test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_sc
         )
         workspace_dir = tmp_path / "workspace"
         workspace_dir.mkdir()
-        artifact = _artifact_for_targets("@stripe/cli", flags=("-g",))
+        artifact = _artifact_for_targets(
+            "@stripe/cli",
+            flags=("-g",),
+            manifest_paths=("package.json",),
+            lockfile_paths=("package-lock.json",),
+        )
 
         result = evaluate_package_request_artifact(
             artifact=artifact,
@@ -491,6 +496,8 @@ def test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_sc
         "namespace": "@stripe",
         "range": "latest",
     }
+    assert "lockfileContext" not in request_payload
+    assert "workspaceContext" not in request_payload
     assert result.decision == "allow"
 
 


### PR DESCRIPTION
- Treat global JavaScript package installs as package-only requests so project manifests and lockfiles do not poison cloud validation.
- Preserve project install workspace context; only global npm, pnpm, and yarn flags suppress manifest and lockfile metadata.
- `python3 -m pytest tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_scoped_npm_request -q`
- `python3 -m pytest tests/test_guard_package_shims.py::test_guard_protect_ignores_stale_policy_bundle_package_family_on_cloud_allow -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/package_intent_common.py tests/test_guard_supply_chain_evaluator.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/runtime/package_intent_common.py tests/test_guard_supply_chain_evaluator.py`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard protect --dry-run --json npm i -g @stripe/cli`
