### PR TITLE
fix(guard): omit workspace context for global package installs

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_common.py
@@ -77,6 +77,7 @@ def build_package_request_artifact(
     config_path: str,
     source_scope: str,
 ) -> GuardArtifact:
+    manifest_paths, lockfile_paths = _artifact_workspace_paths(intent)
     fingerprint = hashlib.sha256(
         json.dumps(
             {
@@ -85,8 +86,8 @@ def build_package_request_artifact(
                 "intent_kind": intent.intent_kind,
                 "redacted_command": intent.redacted_command,
                 "targets": [target.to_dict() for target in intent.targets],
-                "manifest_paths": list(intent.manifest_paths),
-                "lockfile_paths": list(intent.lockfile_paths),
+                "manifest_paths": list(manifest_paths),
+                "lockfile_paths": list(lockfile_paths),
             },
             sort_keys=True,
         ).encode("utf-8")
@@ -103,8 +104,8 @@ def build_package_request_artifact(
             "package_manager": intent.package_manager,
             "intent_kind": intent.intent_kind,
             "targets": [target.to_dict() for target in intent.targets],
-            "manifest_paths": list(intent.manifest_paths),
-            "lockfile_paths": list(intent.lockfile_paths),
+            "manifest_paths": list(manifest_paths),
+            "lockfile_paths": list(lockfile_paths),
             "flags": list(intent.flags),
             "notes": list(intent.notes),
             "redacted_command": intent.redacted_command,
@@ -114,6 +115,44 @@ def build_package_request_artifact(
             "runtime_request_reason": package_runtime_reason(intent),
         },
     )
+
+
+def _artifact_workspace_paths(intent: PackageIntent) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    if _is_global_package_install(intent):
+        return (), ()
+    return intent.manifest_paths, intent.lockfile_paths
+
+
+def _is_global_package_install(intent: PackageIntent) -> bool:
+    if intent.package_manager not in {"npm", "pnpm", "yarn"}:
+        return False
+    if "multiple-package-segments" in intent.notes:
+        return _all_package_segments_are_global(intent)
+    return any(_is_true_global_flag(flag) for flag in intent.flags)
+
+
+def _all_package_segments_are_global(intent: PackageIntent) -> bool:
+    segments = tuple(segment.strip() for segment in intent.redacted_command.split(" ; ") if segment.strip())
+    if not segments:
+        return False
+    return all(_segment_has_global_flag(segment) for segment in segments)
+
+
+def _segment_has_global_flag(segment: str) -> bool:
+    try:
+        tokens = shlex.split(segment)
+    except ValueError:
+        tokens = segment.split()
+    return any(_is_true_global_flag(token) for token in tokens)
+
+
+def _is_true_global_flag(flag: str) -> bool:
+    normalized = flag.strip().lower()
+    if normalized in {"-g", "--global"}:
+        return True
+    if normalized.startswith("--global="):
+        return normalized.split("=", 1)[1] not in {"", "0", "false", "no", "off"}
+    return normalized == "--location=global"
 
 
 def package_request_summary(intent: PackageIntent) -> str:
@@ -170,9 +209,19 @@ def redacted_command(tokens: tuple[str, ...]) -> str:
 
 def flag_tokens(tokens: tuple[str, ...]) -> tuple[str, ...]:
     flags: list[str] = []
-    for token in tokens:
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
         if token.startswith("-"):
-            flags.append(token.split("=", 1)[0] if token.startswith("--") and "=" in token else token)
+            if token == "--location" and index + 1 < len(tokens) and not tokens[index + 1].startswith("-"):
+                flags.append(f"--location={tokens[index + 1]}")
+                index += 2
+                continue
+            if token.startswith(("--global=", "--location=")):
+                flags.append(token)
+            else:
+                flags.append(token.split("=", 1)[0] if token.startswith("--") and "=" in token else token)
+        index += 1
     return tuple(dict.fromkeys(flags))
 
 

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -253,8 +253,16 @@ def evaluate_package_request_artifact(
                     bundle_version=bundle_meta["bundle_version"],
                     workspace_fingerprint=workspace_fingerprint,
                 )
-                _persist_evidence(store=store, artifact=artifact, evaluation=cached_result, now=now_value)
-                return cached_result
+                if not _cached_cloud_validation_error_requires_uncached_retry(
+                    cached,
+                    store=store,
+                    artifact=artifact,
+                    evaluation=cached_result,
+                    workspace_dir=workspace_dir,
+                    now=now_value,
+                ):
+                    _persist_evidence(store=store, artifact=artifact, evaluation=cached_result, now=now_value)
+                    return cached_result
     bundle_evaluation = (
         _evaluate_with_bundle(
             artifact=artifact,
@@ -366,7 +374,12 @@ def evaluate_package_request_artifact(
             fallback = _with_additional_reason(fallback, cloud_fallback_reason)
             if _cloud_fallback_requires_reconnect_copy(cloud_fallback_reason):
                 fallback = _with_cloud_auth_reconnect_copy(fallback)
-        if bundle_meta is not None and bundle_evaluation.decision != "monitor" and isinstance(bundle_payload, dict):
+        if (
+            bundle_meta is not None
+            and bundle_evaluation.decision != "monitor"
+            and fallback.cache_status != "cloud-error"
+            and isinstance(bundle_payload, dict)
+        ):
             cache_workspace_id = workspace_id
             if cache_workspace_id is None:
                 bundle_section = bundle_payload.get("bundle")
@@ -534,9 +547,11 @@ def _cache_reusable_cloud_validation_error(
     evaluation: PackageRequestEvaluation,
     now: str,
 ) -> None:
-    if workspace_id is None or bundle_meta is None:
-        return
-    if not any(str(reason.get("code") or "") == "cloud_validation_error" for reason in evaluation.reasons):
+    if (
+        workspace_id is None
+        or bundle_meta is None
+        or not _evaluation_has_reason_code(evaluation, "cloud_validation_error")
+    ):
         return
     store.cache_supply_chain_evaluation(
         workspace_id=workspace_id,
@@ -548,6 +563,69 @@ def _cache_reusable_cloud_validation_error(
         decision=evaluation.to_cache_dict(),
         now=now,
     )
+
+
+def _cached_cloud_validation_error_requires_uncached_retry(
+    cached: dict[str, object],
+    *,
+    store: GuardStore,
+    artifact: GuardArtifact,
+    evaluation: PackageRequestEvaluation,
+    workspace_dir: Path | None,
+    now: str,
+) -> bool:
+    if not _cached_eval_has_reason_code(cached, "cloud_validation_error"):
+        return False
+    return not _cached_cloud_validation_error_has_saved_policy(
+        store=store,
+        artifact=artifact,
+        evaluation=evaluation,
+        workspace_dir=workspace_dir,
+        now=now,
+    )
+
+
+def _cached_cloud_validation_error_has_saved_policy(
+    *,
+    store: GuardStore,
+    artifact: GuardArtifact,
+    evaluation: PackageRequestEvaluation,
+    workspace_dir: Path | None,
+    now: str,
+) -> bool:
+    if workspace_dir is None:
+        return False
+    try:
+        from ..local_supply_chain import (  # local import avoids the runtime/local helper cycle
+            _stored_package_policy_is_stale_policy_bundle_family,
+            package_request_policy_hash,
+        )
+
+        artifact_hash = package_request_policy_hash(
+            artifact=artifact,
+            store=store,
+            workspace_dir=workspace_dir,
+            evaluation=evaluation,
+        )
+    except (ImportError, TypeError, ValueError, OSError):
+        return False
+    decision = store.resolve_policy_decision(
+        artifact.harness,
+        artifact.artifact_id,
+        artifact_hash,
+        str(workspace_dir),
+        artifact.publisher,
+        now,
+    )
+    if not isinstance(decision, dict):
+        return False
+    if _stored_package_policy_is_stale_policy_bundle_family(decision, store=store):
+        return False
+    return decision.get("action") in {"allow", "block"}
+
+
+def _evaluation_has_reason_code(evaluation: PackageRequestEvaluation, code: str) -> bool:
+    return any(isinstance(reason, dict) and str(reason.get("code") or "") == code for reason in evaluation.reasons)
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_guard_supply_chain_evaluator.py
+++ b/tests/test_guard_supply_chain_evaluator.py
@@ -25,6 +25,7 @@ from codex_plugin_scanner.guard.cli.oauth_client import generate_dpop_key_pair
 from codex_plugin_scanner.guard.runtime.package_intent_common import (
     PackageIntent,
     build_package_request_artifact,
+    flag_tokens,
     js_target,
     python_target,
 )
@@ -218,13 +219,14 @@ def _artifact_for_targets(
     lockfile_paths: tuple[str, ...] = (),
     flags: tuple[str, ...] = (),
     notes: tuple[str, ...] = (),
+    redacted_command: str | None = None,
 ) -> object:
     command_tokens = tuple([package_manager, intent_kind, *targets])
     intent = PackageIntent(
         package_manager=package_manager,
         intent_kind=intent_kind,
         command_tokens=command_tokens,
-        redacted_command=" ".join(command_tokens),
+        redacted_command=redacted_command or " ".join(command_tokens),
         targets=tuple(js_target(target) for target in targets),
         manifest_paths=manifest_paths,
         lockfile_paths=lockfile_paths,
@@ -471,7 +473,12 @@ def test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_sc
         )
         workspace_dir = tmp_path / "workspace"
         workspace_dir.mkdir()
-        artifact = _artifact_for_targets("@stripe/cli", flags=("-g",))
+        artifact = _artifact_for_targets(
+            "@stripe/cli",
+            flags=("-g",),
+            manifest_paths=("package.json",),
+            lockfile_paths=("package-lock.json",),
+        )
 
         result = evaluate_package_request_artifact(
             artifact=artifact,
@@ -491,7 +498,59 @@ def test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_sc
         "namespace": "@stripe",
         "range": "latest",
     }
+    assert "lockfileContext" not in request_payload
+    assert "workspaceContext" not in request_payload
     assert result.decision == "allow"
+
+
+def test_global_false_package_request_keeps_workspace_context() -> None:
+    artifact = _artifact_for_targets(
+        "left-pad",
+        flags=("--global=false",),
+        manifest_paths=("package.json",),
+        lockfile_paths=("package-lock.json",),
+    )
+
+    assert artifact.metadata["manifest_paths"] == ["package.json"]
+    assert artifact.metadata["lockfile_paths"] == ["package-lock.json"]
+
+
+def test_flag_tokens_preserves_global_boolean_values() -> None:
+    assert flag_tokens(("install", "--global=false", "--location=project", "left-pad")) == (
+        "--global=false",
+        "--location=project",
+    )
+    assert flag_tokens(("install", "--location", "global", "left-pad")) == ("--location=global",)
+    assert flag_tokens(("install", "--location", "project", "left-pad")) == ("--location=project",)
+
+
+def test_merged_global_and_project_install_keeps_workspace_context() -> None:
+    artifact = _artifact_for_targets(
+        "eslint",
+        "left-pad",
+        flags=("-g",),
+        notes=("multiple-package-segments",),
+        manifest_paths=("package.json",),
+        lockfile_paths=("package-lock.json",),
+    )
+
+    assert artifact.metadata["manifest_paths"] == ["package.json"]
+    assert artifact.metadata["lockfile_paths"] == ["package-lock.json"]
+
+
+def test_merged_all_global_installs_omit_workspace_context() -> None:
+    artifact = _artifact_for_targets(
+        "eslint",
+        "typescript",
+        flags=("-g",),
+        notes=("multiple-package-segments",),
+        manifest_paths=("package.json",),
+        lockfile_paths=("package-lock.json",),
+        redacted_command="npm install -g eslint ; npm install -g typescript",
+    )
+
+    assert artifact.metadata["manifest_paths"] == []
+    assert artifact.metadata["lockfile_paths"] == []
 
 
 def test_evaluate_package_request_artifact_does_not_convert_npm_source_specs_to_latest(
@@ -902,10 +961,12 @@ def test_evaluate_package_request_artifact_fails_closed_on_untrusted_cloud_http_
         )
 
     monkeypatch.setattr(evaluator_module, "_urlopen_json_with_timeout_retry", raise_http_error)
+    artifact = _artifact_for_targets("left-pad@1.0.0")
+    workspace_dir = tmp_path / "workspace"
     result = evaluate_package_request_artifact(
-        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        artifact=artifact,
         store=store,
-        workspace_dir=tmp_path / "workspace",
+        workspace_dir=workspace_dir,
         now="2026-05-19T00:00:00Z",
     )
 
@@ -943,11 +1004,13 @@ def test_evaluate_package_request_artifact_strict_mode_blocks_on_cloud_unreachab
     def raise_timeout(*args: object, **kwargs: object) -> object:
         raise TimeoutError("network unreachable")
 
+    artifact = _artifact_for_targets("left-pad@1.0.0")
+    workspace_dir = tmp_path / "workspace"
     monkeypatch.setattr(evaluator_module, "_urlopen_json_with_timeout_retry", raise_timeout)
     result = evaluate_package_request_artifact(
-        artifact=_artifact_for_targets("left-pad@1.0.0"),
+        artifact=artifact,
         store=store,
-        workspace_dir=tmp_path / "workspace",
+        workspace_dir=workspace_dir,
         now="2026-05-19T00:00:00Z",
     )
 
@@ -955,6 +1018,35 @@ def test_evaluate_package_request_artifact_strict_mode_blocks_on_cloud_unreachab
     assert result.policy_action == "block"
     assert result.enforcement == "premium_cloud"
     assert any(reason["code"] == "cloud_validation_error" for reason in result.reasons)
+    cached = store.get_cached_supply_chain_evaluation(
+        workspace_id=WORKSPACE_ID,
+        package_intent_hash=result.package_intent_hash,
+        feed_snapshot_hash="feed-snapshot-1",
+        policy_hash="policy-hash-1",
+        scoring_version="scf-v1",
+        bundle_version="1747612800000-deadbeef",
+    )
+    assert isinstance(cached, dict)
+
+    monkeypatch.setattr(
+        evaluator_module,
+        "_urlopen_json_with_timeout_retry",
+        lambda *args, **kwargs: _cloud_response(
+            decision="monitor",
+            enforcement="premium_cloud",
+            entitlement_state="premium",
+            package_name="left-pad",
+        ),
+    )
+    retried = evaluate_package_request_artifact(
+        artifact=artifact,
+        store=store,
+        workspace_dir=workspace_dir,
+        now="2026-05-19T00:05:00Z",
+    )
+
+    assert retried.decision == "monitor"
+    assert not any(reason["code"] == "cloud_validation_error" for reason in retried.reasons)
 
 
 def test_evaluate_package_request_artifact_rejects_untrusted_cloud_endpoint_before_network(


### PR DESCRIPTION
- Treat global JavaScript package installs as package-only requests so project manifests and lockfiles do not poison cloud validation.
- Preserve project install workspace context, including `--global=false`; only true global npm, pnpm, and yarn flags suppress manifest and lockfile metadata.
- `python3 -m pytest tests/test_guard_supply_chain_evaluator.py::test_evaluate_package_request_artifact_posts_latest_range_for_unversioned_scoped_npm_request tests/test_guard_supply_chain_evaluator.py::test_global_false_package_request_keeps_workspace_context -q`
- `python3 -m pytest tests/test_guard_package_shims.py::test_guard_protect_ignores_stale_policy_bundle_package_family_on_cloud_allow -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/package_intent_common.py tests/test_guard_supply_chain_evaluator.py`
- `python3 -m ruff format --check src/codex_plugin_scanner/guard/runtime/package_intent_common.py tests/test_guard_supply_chain_evaluator.py`
- `PYTHONPATH=src python3 -m codex_plugin_scanner.cli guard protect --dry-run --json npm i -g @stripe/cli`
