### PR TITLE
fix(guard): route supply-chain batch audits

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -2744,12 +2744,11 @@ def _inventory_summary(inventory: tuple[dict[str, object], ...]) -> dict[str, in
 
 def _normalized_supply_chain_batch_url(sync_url: str, workspace_id: str) -> str:
     parsed = urllib.parse.urlsplit(sync_url)
-    if parsed.path.rstrip("/") == "/api/guard/receipts/sync":
-        next_path = "/api/guard/supply-chain/evaluate/batch"
-    elif parsed.path.rstrip("/") == "/guard/receipts/sync":
-        next_path = "/guard/supply-chain/evaluate/batch"
+    sync_path = parsed.path.rstrip("/")
+    if sync_path.endswith("/receipts/sync"):
+        next_path = sync_path[: -len("/receipts/sync")] + "/supply-chain/evaluate/batch"
     else:
-        next_path = parsed.path.rstrip("/") + "/supply-chain/evaluate/batch"
+        next_path = sync_path + "/supply-chain/evaluate/batch"
     query_pairs = [
         (key, value)
         for key, value in urllib.parse.parse_qsl(parsed.query, keep_blank_values=True)

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -48,6 +48,15 @@ def _seed_guard_cloud(store, *, workspace_id=None, sync_url=None, token="demo-to
 WORKSPACE_ID = "2de4fcb4-a5b2-447a-a67f-21c6eb4c5f3c"
 
 
+def test_normalized_supply_chain_batch_url_preserves_sync_prefix() -> None:
+    assert local_supply_chain_module._normalized_supply_chain_batch_url(
+        "https://guard.example/api/guard/receipts/sync", WORKSPACE_ID
+    ) == f"https://guard.example/api/guard/supply-chain/evaluate/batch?workspaceId={WORKSPACE_ID}"
+    assert local_supply_chain_module._normalized_supply_chain_batch_url(
+        "https://guard.example/registry/api/v1/guard/receipts/sync?workspaceId=old", WORKSPACE_ID
+    ) == f"https://guard.example/registry/api/v1/guard/supply-chain/evaluate/batch?workspaceId={WORKSPACE_ID}"
+
+
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Summary
- Preserve the configured sync URL prefix when deriving the supply-chain batch audit endpoint.
- Add coverage for prefixed receipts sync paths so runtime audits call the sibling batch endpoint instead of appending under the receipts route.

## Testing
- `uv run pytest tests/test_guard_local_supply_chain_audit_phase16.py::test_guard_supply_chain_scan_uses_cloud_batch_for_premium_workspaces tests/test_guard_local_supply_chain_audit_phase16.py::test_sync_managed_workspace_audits_enqueues_persisted_job_mode_for_managed_workspaces tests/test_guard_local_supply_chain_audit_phase16.py::test_normalized_supply_chain_batch_url_preserves_sync_prefix`
- `uv run ruff check src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_local_supply_chain_audit_phase16.py`
