### PR TITLE
fix(guard): renew batch audit DPoP proofs

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -2298,15 +2298,24 @@ def _run_cloud_workspace_audit(
         }
     else:
         request_url = _normalized_supply_chain_batch_url(str(resolved_auth_context["sync_url"]), workspace_id)
-        request_headers = runner._guard_sync_headers(resolved_auth_context, request_url=request_url, method="POST")
     aggregated_packages: list[dict[str, object]] = []
+    aggregated_processed_count = 0
     aggregated_reasons: list[dict[str, object]] = []
+    aggregated_total_packages = 0
     cursor: str | None = None
     last_response: dict[str, object] | None = None
     for _ in range(_CLOUD_AUDIT_MAX_PAGES):
         page_payload = dict(request_payload)
         if cursor is not None:
             page_payload["cursor"] = cursor
+        request_headers = (
+            {
+                "Authorization": f"Bearer {token}",
+                "Content-Type": "application/json",
+            }
+            if resolved_auth_context is None
+            else runner._guard_sync_headers(resolved_auth_context, request_url=request_url, method="POST")
+        )
         request = urllib.request.Request(
             request_url,
             data=json.dumps(page_payload).encode("utf-8"),
@@ -2342,6 +2351,14 @@ def _run_cloud_workspace_audit(
             )
         last_response = response_payload
         response_packages = response_payload.get("packages")
+        page_processed_count = _int_value(response_payload.get("processedCount"))
+        page_total_packages = _int_value(response_payload.get("totalPackages"))
+        if page_total_packages is not None:
+            aggregated_total_packages = max(aggregated_total_packages, page_total_packages)
+        if page_processed_count is not None:
+            aggregated_processed_count += page_processed_count
+        elif isinstance(response_packages, list):
+            aggregated_processed_count += len(response_packages)
         if isinstance(response_packages, list):
             aggregated_packages.extend(item for item in response_packages if isinstance(item, dict))
         response_reasons = response_payload.get("reasons")
@@ -2363,6 +2380,8 @@ def _run_cloud_workspace_audit(
         return (None, None)
     merged_response = dict(last_response)
     merged_response["packages"] = aggregated_packages
+    merged_response["processedCount"] = aggregated_processed_count
+    merged_response["totalPackages"] = max(aggregated_total_packages, len(aggregated_packages))
     merged_response["reasons"] = aggregated_reasons
     return (merged_response, None)
 

--- a/tests/test_guard_local_supply_chain_audit_phase16.py
+++ b/tests/test_guard_local_supply_chain_audit_phase16.py
@@ -57,6 +57,96 @@ def test_normalized_supply_chain_batch_url_preserves_sync_prefix() -> None:
     ) == f"https://guard.example/registry/api/v1/guard/supply-chain/evaluate/batch?workspaceId={WORKSPACE_ID}"
 
 
+def test_cloud_workspace_audit_renews_dpop_proof_for_each_page(monkeypatch: pytest.MonkeyPatch) -> None:
+    runner = local_supply_chain_module._runtime_runner_module()
+    signed_proofs: list[str] = []
+    request_bodies: list[dict[str, object]] = []
+
+    def _fake_guard_sync_headers(
+        auth_context: dict[str, object],
+        *,
+        request_url: str,
+        method: str,
+    ) -> dict[str, str]:
+        del auth_context, request_url, method
+        proof = f"proof-{len(signed_proofs) + 1}"
+        signed_proofs.append(proof)
+        return {
+            "Authorization": "Bearer token",
+            "Content-Type": "application/json",
+            "DPoP": proof,
+        }
+
+    class _JsonResponse(io.StringIO):
+        def __enter__(self) -> _JsonResponse:
+            return self
+
+        def __exit__(self, *args: object) -> None:
+            self.close()
+
+    def _fake_urlopen(request: object, timeout: int) -> _JsonResponse:
+        del timeout
+        assert isinstance(request, local_supply_chain_module.urllib.request.Request)
+        dpop_header = dict(request.header_items()).get("Dpop")
+        assert dpop_header == f"proof-{len(request_bodies) + 1}"
+        body = request.data
+        assert isinstance(body, bytes)
+        request_bodies.append(json.loads(body.decode("utf-8")))
+        if len(request_bodies) == 1:
+            return _JsonResponse(
+                json.dumps(
+                    {
+                        "decision": "monitor",
+                        "packages": [{"ecosystem": "npm", "name": "react"}],
+                        "reasons": [],
+                        "nextCursor": "cursor-1",
+                        "processedCount": 2,
+                        "totalPackages": 3,
+                    }
+                )
+            )
+        return _JsonResponse(
+            json.dumps(
+                {
+                    "decision": "monitor",
+                    "packages": [{"ecosystem": "npm", "name": "scheduler"}],
+                    "processedCount": 1,
+                    "reasons": [],
+                    "totalPackages": 2,
+                }
+            )
+        )
+
+    monkeypatch.setattr(runner, "_guard_sync_headers", _fake_guard_sync_headers)
+    monkeypatch.setattr(local_supply_chain_module.urllib.request, "urlopen", _fake_urlopen)
+
+    response, fallback = local_supply_chain_module._run_cloud_workspace_audit(
+        auth_context={
+            "access_token": "token",
+            "sync_url": "https://guard.example/api/guard/receipts/sync",
+        },
+        request_payload={
+            "mode": "paged",
+            "packages": [
+                {"ecosystem": "npm", "name": "react"},
+                {"ecosystem": "npm", "name": "scheduler"},
+            ],
+            "pageSize": 1,
+            "workspaceFingerprint": "fingerprint-1",
+        },
+        workspace_id=WORKSPACE_ID,
+    )
+
+    assert fallback is None
+    assert response is not None
+    assert [item["name"] for item in response["packages"]] == ["react", "scheduler"]
+    assert response["processedCount"] == 3
+    assert response["totalPackages"] == 3
+    assert signed_proofs == ["proof-1", "proof-2"]
+    assert request_bodies[0].get("cursor") is None
+    assert request_bodies[1]["cursor"] == "cursor-1"
+
+
 def _write_text(path: Path, text: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(text, encoding="utf-8")


### PR DESCRIPTION
## Summary
- Renew signed batch audit headers for each cloud response page so multi-page audits do not reuse a DPoP proof.
- Preserve the merged processed count after aggregating cloud package pages.

## Testing
- `uv run pytest tests/test_guard_local_supply_chain_audit_phase16.py::test_normalized_supply_chain_batch_url_preserves_sync_prefix tests/test_guard_local_supply_chain_audit_phase16.py::test_cloud_workspace_audit_renews_dpop_proof_for_each_page tests/test_guard_local_supply_chain_audit_phase16.py::test_guard_supply_chain_scan_uses_cloud_batch_for_premium_workspaces tests/test_guard_local_supply_chain_audit_phase16.py::test_sync_managed_workspace_audits_enqueues_persisted_job_mode_for_managed_workspaces`
- `uv run ruff check src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_local_supply_chain_audit_phase16.py`
- `uv run hol-guard guard supply-chain audit --workspace <workspace> --json`
