### PR TITLE
fix(guard): preserve Cisco MCP evidence for AIBOM tools

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -281,7 +281,10 @@ def _local_mcp_security_for_artifact(
 ) -> dict[str, object] | None:
     from .inventory_contract import _normalize_inventory_datetime
 
-    if item_kind != "mcp_server" or getattr(artifact, "artifact_type", None) != "mcp_server":
+    if item_kind not in {"mcp_server", "mcp_tool"} or getattr(artifact, "artifact_type", None) not in {
+        "mcp_server",
+        "mcp_tool",
+    }:
         return None
 
     trust_root = _trust_root_for_artifact(artifact, item_kind=item_kind, workspace_dir=workspace_dir)
@@ -342,7 +345,7 @@ def _local_mcp_security_for_artifact(
     metadata_payload["evidenceHash"] = guard_evidence_hash(
         {
             "capturedAt": normalized_captured_at,
-            "entityType": "mcp_server",
+            "entityType": item_kind,
             "findings": findings,
             "provider": "cisco-mcp-scanner",
             "safety": safety,
@@ -352,7 +355,7 @@ def _local_mcp_security_for_artifact(
     )
 
     return {
-        "entityType": "mcp_server",
+        "entityType": item_kind,
         "source": "local_indexed",
         "provider": "cisco-mcp-scanner",
         "status": status,

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -803,39 +803,13 @@ def _mcp_tool_items_from_artifact(
                 "annotations": safe_annotations,
             }
         )
-        metadata = _apply_tool_trust_attestation_metadata(
-            metadata,
-            harness=harness,
-            item_id=tool_item_id,
-            content_hash=semantic_hash,
-            trust_attestation_context=trust_attestation_context,
-        )
         tool_layers = metadata.get("trustLayers")
-        signed_tool_layers = list(tool_layers) if isinstance(tool_layers, list) else []
-        normalized_tool_layers: list[dict[str, object]] = []
-        for layer in signed_tool_layers:
-            if isinstance(layer, dict) and layer.get("layerType") == "cisco_mcp_scanner":
-                raw_layer_metadata = layer.get("metadata")
-                layer_metadata = dict(raw_layer_metadata) if isinstance(raw_layer_metadata, dict) else {}
-                normalized_tool_layers.append(
-                    {
-                        **layer,
-                        "metadata": {
-                            **{
-                                key: value
-                                for key, value in layer_metadata.items()
-                                if key not in {"attestation", "attestationBindings"}
-                            },
-                            "attestationStatus": "unsigned",
-                        },
-                    }
-                )
-            elif isinstance(layer, dict):
-                normalized_tool_layers.append(layer)
-        signed_tool_layers = normalized_tool_layers
-        if signed_tool_layers:
-            metadata["trustLayers"] = signed_tool_layers
-        has_tool_cisco_layer = any(layer.get("layerType") == "cisco_mcp_scanner" for layer in signed_tool_layers)
+        tool_layer_dicts = (
+            [layer for layer in tool_layers if isinstance(layer, dict)] if isinstance(tool_layers, list) else []
+        )
+        if tool_layer_dicts:
+            metadata["trustLayers"] = tool_layer_dicts
+        has_tool_cisco_layer = any(layer.get("layerType") == "cisco_mcp_scanner" for layer in tool_layer_dicts)
         if inherited_layers and not has_tool_cisco_layer:
             inherited_tool_layers: list[dict[str, object]] = []
             for layer in inherited_layers:
@@ -848,14 +822,28 @@ def _mcp_tool_items_from_artifact(
                             **{
                                 key: value
                                 for key, value in layer_metadata.items()
-                                if key not in {"attestation", "attestationBindings"}
+                                if key
+                                not in {
+                                    "attestation",
+                                    "attestationBindings",
+                                    "attestationRef",
+                                    "attestationStatus",
+                                    "attestationVerification",
+                                }
                             },
                             "attestationStatus": "unsigned",
                             "inheritedFromServerItemId": server_item.item_id,
                         },
                     }
                 )
-            metadata["trustLayers"] = [*signed_tool_layers, *inherited_tool_layers]
+            metadata["trustLayers"] = [*tool_layer_dicts, *inherited_tool_layers]
+        metadata = _apply_tool_trust_attestation_metadata(
+            metadata,
+            harness=harness,
+            item_id=tool_item_id,
+            content_hash=semantic_hash,
+            trust_attestation_context=trust_attestation_context,
+        )
         tool_description = _inventory_item_description_module().resolve_inventory_item_description(
             harness=harness,
             item_kind="mcp_tool",

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -809,6 +809,19 @@ def _mcp_tool_items_from_artifact(
         )
         if tool_layer_dicts:
             metadata["trustLayers"] = tool_layer_dicts
+        metadata = _apply_tool_trust_attestation_metadata(
+            metadata,
+            harness=harness,
+            item_id=tool_item_id,
+            content_hash=semantic_hash,
+            trust_attestation_context=trust_attestation_context,
+        )
+        signed_tool_layers = metadata.get("trustLayers")
+        tool_layer_dicts = (
+            [layer for layer in signed_tool_layers if isinstance(layer, dict)]
+            if isinstance(signed_tool_layers, list)
+            else []
+        )
         has_tool_cisco_layer = any(layer.get("layerType") == "cisco_mcp_scanner" for layer in tool_layer_dicts)
         if inherited_layers and not has_tool_cisco_layer:
             inherited_tool_layers: list[dict[str, object]] = []
@@ -837,13 +850,6 @@ def _mcp_tool_items_from_artifact(
                     }
                 )
             metadata["trustLayers"] = [*tool_layer_dicts, *inherited_tool_layers]
-        metadata = _apply_tool_trust_attestation_metadata(
-            metadata,
-            harness=harness,
-            item_id=tool_item_id,
-            content_hash=semantic_hash,
-            trust_attestation_context=trust_attestation_context,
-        )
         tool_description = _inventory_item_description_module().resolve_inventory_item_description(
             harness=harness,
             item_kind="mcp_tool",

--- a/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py
@@ -18,7 +18,7 @@ from types import ModuleType
 from typing import Protocol, TypeGuard, TypeVar
 
 from ..models import Finding, Severity, severity_from_value
-from .cisco_skill_scanner import CiscoIntegrationStatus, cisco_runtime_unavailable_message
+from .cisco_skill_scanner import CiscoIntegrationStatus
 
 _EXCLUDED_DIRS = {
     ".codex-plugin",
@@ -65,6 +65,10 @@ class CiscoMcpScanSummary:
     total_findings: int
     findings_by_severity: dict[str, int]
     scan_mode: str = "static"
+
+
+def cisco_runtime_unavailable_message() -> str | None:
+    return None
 
 
 @dataclass(frozen=True, slots=True)

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -870,6 +870,14 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
     search_tool = next(item for item in snapshot.items if item.item_id.endswith(":tool:search_docs"))
     delete_tool = next(item for item in snapshot.items if item.item_id.endswith(":tool:delete_docs"))
 
+    search_local_security = search_tool.metadata.get("localSecurity")
+    assert isinstance(search_local_security, dict)
+    assert search_local_security.get("entityType") == "mcp_tool"
+    assert search_local_security.get("provider") == "cisco-mcp-scanner"
+    search_safety = search_local_security.get("safety")
+    assert isinstance(search_safety, dict)
+    assert search_safety.get("score") == 90
+
     search_trust, search_metadata = _assert_local_trust(search_tool.metadata, trust_domain="mcp")
     _delete_trust, delete_metadata = _assert_local_trust(delete_tool.metadata, trust_domain="mcp")
     assert search_metadata.get("evidenceHash") != delete_metadata.get("evidenceHash")
@@ -909,8 +917,28 @@ def test_inventory_snapshot_attaches_mcp_tool_trust_resolution(monkeypatch, tmp_
     )
     cisco_layer_metadata = cisco_layer.get("metadata")
     assert isinstance(cisco_layer_metadata, dict)
-    assert cisco_layer_metadata.get("attestationStatus") == "unsigned"
-    assert cisco_layer_metadata.get("attestation") is None
+    assert cisco_layer_metadata.get("attestationStatus") == "signed"
+    cisco_attestation = cisco_layer_metadata.get("attestation")
+    assert isinstance(cisco_attestation, dict)
+    cisco_layer_id = cisco_layer.get("layerId")
+    assert isinstance(cisco_layer_id, str)
+    cisco_layer_type = cisco_layer.get("layerType")
+    assert isinstance(cisco_layer_type, str)
+    verify_trust_attestation(
+        payload=build_trust_attestation_payload(
+            agent_id=snapshot.agent_id,
+            item_id=search_tool.item_id,
+            item_kind=search_tool.item_kind,
+            content_hash=search_tool.content_hash,
+            captured_at=str(cisco_layer.get("capturedAt")),
+            evidence_hash=str(cisco_layer_metadata.get("evidenceHash")),
+            scope="trust_layer",
+            layer_id=cisco_layer_id,
+            layer_type=cisco_layer_type,
+        ),
+        envelope=cisco_attestation,
+        trusted_keys=(verification_key,),
+    )
     assert search_trust.get("trustScore") is not None
 
 

--- a/tests/test_guard_cisco_evidence.py
+++ b/tests/test_guard_cisco_evidence.py
@@ -149,6 +149,8 @@ def test_guard_store_invalidates_scanner_cache_when_hash_or_version_changes(tmp_
 
 
 def test_skill_scanner_reports_timeout_without_marking_scan_failed(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setattr(cisco_skill_scanner.sys, "version_info", (3, 13, 0))
+
     class SlowScanner:
         def __init__(self, policy: object) -> None:
             self.policy = policy

--- a/tests/test_guard_cisco_runtime_cli.py
+++ b/tests/test_guard_cisco_runtime_cli.py
@@ -166,7 +166,7 @@ def test_default_detector_registry_includes_cisco_sources() -> None:
     assert "cisco.mcp" in detector_ids
 
 
-def test_cisco_scanners_warn_and_skip_on_python_314(
+def test_skill_scanner_warns_on_python_314_but_mcp_scanner_checks_dependency(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -180,7 +180,7 @@ def test_cisco_scanners_warn_and_skip_on_python_314(
     assert mcp_summary.status is CiscoIntegrationStatus.UNAVAILABLE
     assert "Python 3.14+" in skill_summary.message
     assert "Python 3.10 through 3.13" in skill_summary.message
-    assert "Python 3.14+" in mcp_summary.message
+    assert "Cisco MCP scanner is required but not installed" in mcp_summary.message
 
 
 def test_guard_scan_skills_deep_uses_cisco_skill_scanner(


### PR DESCRIPTION
## Summary
- Preserve signed Cisco MCP scanner trust layers for MCP tool AIBOM items instead of downgrading them to unsigned metadata.
- Allow MCP scanner static analysis to run independently of the skill-scanner Python 3.14 gate.
- Add regressions for signed MCP tool Cisco evidence and Python 3.14 scanner status behavior.

## Verification
- python3 -m ruff check src/codex_plugin_scanner/integrations/cisco_mcp_scanner.py src/codex_plugin_scanner/guard/aibom_trust_metadata.py src/codex_plugin_scanner/guard/inventory_contract.py tests/test_guard_aibom_trust_metadata.py tests/test_guard_cisco_runtime_cli.py tests/test_guard_cisco_evidence.py
- pytest tests/test_guard_aibom_trust_metadata.py tests/test_guard_cisco_evidence.py tests/test_guard_cisco_runtime_cli.py tests/test_mcp_security.py -q
