### PR TITLE
fix(guard): stabilize AIBOM inventory evidence snapshots

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -73,6 +73,12 @@ def trust_resolution_from_domain(
         "specVersion": domain.spec_version,
         "trustDomain": domain.domain,
         "attestationStatus": "unsigned",
+        "evidenceSchemaVersion": "guard-aibom-local-baseline-evidence.v1",
+        "evidence": _local_baseline_evidence_payload(
+            domain,
+            captured_at=normalized_captured_at,
+            trust_components=trust_components,
+        ),
         "evidenceHash": _trust_evidence_hash(
             {
                 "capturedAt": normalized_captured_at,
@@ -604,6 +610,11 @@ def _trust_layer_from_domain(
 
     trust_components = _trust_components_from_domain(domain)
     normalized_captured_at = _normalize_inventory_datetime(captured_at)
+    evidence = _local_baseline_evidence_payload(
+        domain,
+        captured_at=normalized_captured_at,
+        trust_components=trust_components,
+    )
 
     return {
         "layerId": "local_baseline",
@@ -620,6 +631,8 @@ def _trust_layer_from_domain(
             "specVersion": domain.spec_version,
             "trustDomain": domain.domain,
             "attestationStatus": "unsigned",
+            "evidenceSchemaVersion": "guard-aibom-local-baseline-evidence.v1",
+            "evidence": evidence,
             "evidenceHash": _trust_evidence_hash(
                 {
                     "capturedAt": normalized_captured_at,
@@ -632,6 +645,36 @@ def _trust_layer_from_domain(
                 }
             ),
         },
+    }
+
+
+def _local_baseline_evidence_payload(
+    domain: TrustDomainScore,
+    *,
+    captured_at: object,
+    trust_components: list[dict[str, object]],
+) -> dict[str, object]:
+    return {
+        "source": "hol-guard-local-baseline",
+        "capturedAt": captured_at,
+        "trustDomain": domain.domain,
+        "profileId": domain.profile_id,
+        "profileVersion": domain.profile_version,
+        "specId": domain.spec_id,
+        "specVersion": domain.spec_version,
+        "componentCount": len(trust_components),
+        "components": [
+            {
+                "componentId": str(component.get("componentId", "")),
+                "confidence": component.get("confidence"),
+                "label": str(component.get("label", "")),
+                "score": component.get("score"),
+                "status": str(component.get("status", "")),
+                "summary": str(component.get("summary", "")),
+                "weight": component.get("weight"),
+            }
+            for component in trust_components
+        ],
     }
 
 

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -518,7 +518,7 @@ def _inventory_snapshot_content_hash(
                     "artifact_id": finding.artifact_id,
                     "check_id": finding.check_id,
                     "confidence": finding.confidence,
-                    "evidence": finding.evidence,
+                    "evidence": _stable_snapshot_value(finding.evidence),
                     "finding_id": finding.finding_id,
                     "severity": finding.severity,
                     "source": finding.source,
@@ -548,20 +548,26 @@ def _stable_snapshot_value(value: object) -> object:
             if str(key)
             not in {
                 "attestation",
+                "attestationBindings",
                 "capturedAt",
-                "createdAt",
+                "duration_ms",
+                "durationMs",
+                "elapsedMs",
                 "evidenceHash",
                 "generatedAt",
                 "lastSeenAt",
                 "observedAt",
+                "scanDurationMs",
                 "syncedAt",
-                "timestamp",
-                "updatedAt",
             }
         }
     if isinstance(value, (list, tuple)):
-        return [_stable_snapshot_value(item) for item in value]
+        return sorted((_stable_snapshot_value(item) for item in value), key=_stable_snapshot_sort_key)
     return value
+
+
+def _stable_snapshot_sort_key(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
 
 
 def inventory_item_id(agent_type: str, item_kind: str, display_name: str, semantic_text: str) -> str:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -454,13 +454,12 @@ def inventory_snapshot_from_detection(
     )
     symlink_findings = _symlink_findings_from_items(harness, item_tuple) if include_symlinks else ()
     sources = (*config_sources, *_cisco_inventory_sources(cisco_runs))
-    snapshot_hash = fingerprint_mapping(
-        {
-            "agent_type": harness,
-            "generated_at": generated_at,
-            "item_ids": [item.item_id for item in items],
-            "finding_ids": [finding.finding_id for finding in cisco_findings],
-        }
+    snapshot_hash = _inventory_snapshot_content_hash(
+        agent_type=harness,
+        items=item_tuple,
+        findings=(*cisco_findings, *symlink_findings),
+        sources=sources,
+        runtime_version=runtime_version,
     )
     return GuardAgentInventorySnapshot(
         snapshot_id=f"{harness}:snapshot:{snapshot_hash[:24]}",
@@ -485,6 +484,84 @@ def fingerprint_text(value: str) -> str:
 def fingerprint_mapping(value: object) -> str:
     encoded = json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
     return fingerprint_text(encoded)
+
+
+def _inventory_snapshot_content_hash(
+    *,
+    agent_type: str,
+    items: tuple[GuardAgentInventoryItem, ...],
+    findings: tuple[GuardAgentInventoryFinding, ...],
+    sources: tuple[GuardInventorySource, ...],
+    runtime_version: str | None,
+) -> str:
+    return fingerprint_mapping(
+        {
+            "agent_type": agent_type,
+            "runtime_version": runtime_version,
+            "items": [
+                {
+                    "capability_categories": item.capability_categories,
+                    "content_hash": item.content_hash,
+                    "drift_state": item.drift_state,
+                    "item_id": item.item_id,
+                    "item_kind": item.item_kind,
+                    "metadata": _stable_snapshot_value(item.metadata),
+                    "risk_level": item.risk_level,
+                    "scanner_sources": item.scanner_sources,
+                    "security_score": item.security_score,
+                    "source_fingerprint": item.source_fingerprint,
+                }
+                for item in sorted(items, key=lambda value: (value.item_kind, value.item_id))
+            ],
+            "findings": [
+                {
+                    "artifact_id": finding.artifact_id,
+                    "check_id": finding.check_id,
+                    "confidence": finding.confidence,
+                    "evidence": finding.evidence,
+                    "finding_id": finding.finding_id,
+                    "severity": finding.severity,
+                    "source": finding.source,
+                    "summary": finding.summary,
+                    "title": finding.title,
+                }
+                for finding in sorted(findings, key=lambda value: (value.source, value.finding_id))
+            ],
+            "sources": [
+                {
+                    "detail": source.detail,
+                    "source_id": source.source_id,
+                    "source_type": source.source_type,
+                    "status": source.status,
+                }
+                for source in sorted(sources, key=lambda value: (value.source_type, value.source_id))
+            ],
+        }
+    )
+
+
+def _stable_snapshot_value(value: object) -> object:
+    if isinstance(value, dict):
+        return {
+            key: _stable_snapshot_value(item)
+            for key, item in sorted(value.items(), key=lambda entry: str(entry[0]))
+            if str(key)
+            not in {
+                "attestation",
+                "capturedAt",
+                "createdAt",
+                "evidenceHash",
+                "generatedAt",
+                "lastSeenAt",
+                "observedAt",
+                "syncedAt",
+                "timestamp",
+                "updatedAt",
+            }
+        }
+    if isinstance(value, (list, tuple)):
+        return [_stable_snapshot_value(item) for item in value]
+    return value
 
 
 def inventory_item_id(agent_type: str, item_kind: str, display_name: str, semantic_text: str) -> str:
@@ -614,7 +691,7 @@ def _item_from_artifact(
             "artifact_id": artifact_id,
             "artifact_type": artifact_type,
             "name": name,
-            "metadata": safe_metadata,
+            "metadata": _stable_snapshot_value(safe_metadata),
         }
     )
     content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -185,6 +185,75 @@ def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Pat
     components = trust.get("trustComponents")
     assert isinstance(components, list)
     assert components
+    assert metadata.get("evidenceSchemaVersion") == "guard-aibom-local-baseline-evidence.v1"
+    evidence = metadata.get("evidence")
+    assert isinstance(evidence, dict)
+    assert evidence.get("source") == "hol-guard-local-baseline"
+    assert evidence.get("trustDomain") == "plugin"
+    assert evidence.get("componentCount") == len(components)
+    evidence_components = evidence.get("components")
+    assert isinstance(evidence_components, list)
+    assert evidence_components
+    trust_layers = plugin_item.metadata.get("trustLayers")
+    assert isinstance(trust_layers, list)
+    local_layer = next(
+        layer for layer in trust_layers if isinstance(layer, dict) and layer.get("layerType") == "local_baseline"
+    )
+    layer_metadata = local_layer.get("metadata")
+    assert isinstance(layer_metadata, dict)
+    layer_evidence = layer_metadata.get("evidence")
+    assert isinstance(layer_evidence, dict)
+    assert layer_evidence.get("source") == "hol-guard-local-baseline"
+
+
+def test_inventory_snapshot_id_uses_stable_content_hash(tmp_path: Path) -> None:
+    plugin_dir = tmp_path / "plugin"
+    _write_good_plugin(plugin_dir)
+
+    first_snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:plugin:trust-demo",
+            name="trust-demo",
+            harness="codex",
+            artifact_type="plugin",
+            source_scope="project",
+            config_path=str(plugin_dir),
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+    second_snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:plugin:trust-demo",
+            name="trust-demo",
+            harness="codex",
+            artifact_type="plugin",
+            source_scope="project",
+            config_path=str(plugin_dir),
+        ),
+        generated_at="2026-06-10T12:05:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+
+    assert second_snapshot.snapshot_id == first_snapshot.snapshot_id
+
+    changed_snapshot = _snapshot_for_artifact(
+        artifact=GuardArtifact(
+            artifact_id="codex:project:plugin:trust-demo-renamed",
+            name="trust-demo-renamed",
+            harness="codex",
+            artifact_type="plugin",
+            source_scope="project",
+            config_path=str(plugin_dir),
+        ),
+        generated_at="2026-06-10T12:10:00+00:00",
+        home_dir=tmp_path,
+        workspace_dir=plugin_dir,
+    )
+
+    assert changed_snapshot.snapshot_id != first_snapshot.snapshot_id
 
 
 def test_guard_evidence_hash_is_stable_across_key_order() -> None:

--- a/tests/test_guard_aibom_trust_metadata.py
+++ b/tests/test_guard_aibom_trust_metadata.py
@@ -30,6 +30,7 @@ from codex_plugin_scanner.guard.runtime.trust_attestation import (
     sign_trust_attestation,
     verify_trust_attestation,
 )
+from codex_plugin_scanner.models import Finding, Severity
 from codex_plugin_scanner.trust_models import TrustDomainScore
 
 
@@ -209,6 +210,39 @@ def test_inventory_snapshot_attaches_local_plugin_trust_resolution(tmp_path: Pat
 def test_inventory_snapshot_id_uses_stable_content_hash(tmp_path: Path) -> None:
     plugin_dir = tmp_path / "plugin"
     _write_good_plugin(plugin_dir)
+    cisco_finding = Finding(
+        rule_id="mcp-verified-device-claim",
+        severity=Severity.LOW,
+        category="mcp",
+        title="Verified device claim",
+        description="Cisco MCP scan results.",
+        file_path=str(plugin_dir / "README.md"),
+        source="cisco-mcp-scanner",
+    )
+    first_cisco_run = CiscoInventoryRun(
+        source="cisco-mcp-scanner",
+        status="enabled",
+        message="Cisco MCP scan results.",
+        findings=(cisco_finding,),
+        duration_ms=41,
+        metadata={
+            "attestationBindings": [{"createdAt": "2026-06-10T12:00:00+00:00", "nonce": "one"}],
+            "duration_ms": 41,
+            "scanDurationMs": 41,
+        },
+    )
+    replayed_cisco_run = CiscoInventoryRun(
+        source="cisco-mcp-scanner",
+        status="enabled",
+        message="Cisco MCP scan results.",
+        findings=(cisco_finding,),
+        duration_ms=973,
+        metadata={
+            "attestationBindings": [{"createdAt": "2026-06-10T12:05:00+00:00", "nonce": "two"}],
+            "duration_ms": 973,
+            "scanDurationMs": 973,
+        },
+    )
 
     first_snapshot = _snapshot_for_artifact(
         artifact=GuardArtifact(
@@ -222,6 +256,7 @@ def test_inventory_snapshot_id_uses_stable_content_hash(tmp_path: Path) -> None:
         generated_at="2026-06-10T12:00:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
+        cisco_runs=(first_cisco_run,),
     )
     second_snapshot = _snapshot_for_artifact(
         artifact=GuardArtifact(
@@ -235,6 +270,7 @@ def test_inventory_snapshot_id_uses_stable_content_hash(tmp_path: Path) -> None:
         generated_at="2026-06-10T12:05:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
+        cisco_runs=(replayed_cisco_run,),
     )
 
     assert second_snapshot.snapshot_id == first_snapshot.snapshot_id
@@ -251,6 +287,7 @@ def test_inventory_snapshot_id_uses_stable_content_hash(tmp_path: Path) -> None:
         generated_at="2026-06-10T12:10:00+00:00",
         home_dir=tmp_path,
         workspace_dir=plugin_dir,
+        cisco_runs=(replayed_cisco_run,),
     )
 
     assert changed_snapshot.snapshot_id != first_snapshot.snapshot_id


### PR DESCRIPTION
## Summary
- Stabilize AIBOM inventory snapshot ids so unchanged runtime scans reuse the same content-derived id
- Attach local baseline evidence payloads to trust metadata for runtime-scored layers
- Cover stable snapshot ids and local baseline evidence with regression tests

## Testing
- `python3 -m compileall -q src/codex_plugin_scanner/guard`
- `python3 -m ruff check src/codex_plugin_scanner/guard/aibom_trust_metadata.py src/codex_plugin_scanner/guard/inventory_contract.py tests/test_guard_aibom_trust_metadata.py`
- `pytest tests/test_guard_aibom_trust_metadata.py tests/test_guard_aibom_cli.py -q`
