### PR TITLE
fix(guard): backfill receipt command details

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1316,6 +1316,7 @@ def sync_receipts(
     _ensure_relaxed_receipt_redaction_resync(store, level=redaction_level, synced_at=local_guard_online_at)
     prior_receipt_cursor = _receipt_sync_cursor_rowid(store)
     receipts = _receipt_sync_rows_for_upload(store, cursor_rowid=prior_receipt_cursor)
+    cursor_receipt_ids = {item.get("receipt_id") for item in receipts if isinstance(item.get("receipt_id"), str)}
     receipts, command_detail_backfill_marker = _receipt_sync_rows_with_command_detail_backfill(
         store,
         receipts=receipts,
@@ -1376,8 +1377,11 @@ def sync_receipts(
             raise RuntimeError(_sync_http_error_message(error)) from error
         except OSError as error:
             raise RuntimeError(_sync_url_error_message(error)) from error
-        batch_rowids = [item.get("receipt_rowid") for item in receipt_batch]
-        for rowid in batch_rowids:
+        cursor_batch_rowids = _receipt_sync_cursor_rowids_from_batch(
+            receipt_batch,
+            cursor_receipt_ids=cursor_receipt_ids,
+        )
+        for rowid in cursor_batch_rowids:
             if isinstance(rowid, int) and (latest_uploaded_rowid is None or rowid > latest_uploaded_rowid):
                 latest_uploaded_rowid = rowid
         batch_synced_at = _sync_timestamp(payload)
@@ -3930,6 +3934,14 @@ def _receipt_sync_rows_with_command_detail_backfill(
         "limit": _RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT,
         "receipts": added,
     }
+
+
+def _receipt_sync_cursor_rowids_from_batch(
+    receipt_batch: Sequence[Mapping[str, object]],
+    *,
+    cursor_receipt_ids: set[object],
+) -> list[object]:
+    return [item.get("receipt_rowid") for item in receipt_batch if item.get("receipt_id") in cursor_receipt_ids]
 
 
 def _receipt_sync_context(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3929,7 +3929,11 @@ def _receipt_sync_rows_with_command_detail_backfill(
         merged.append(row)
         seen_receipt_ids.add(receipt_id)
         added += 1
-    backfill_rowids = [row.get("receipt_rowid") for row in backfill_rows if isinstance(row.get("receipt_rowid"), int)]
+    backfill_rowids: list[int] = []
+    for row in backfill_rows:
+        receipt_rowid = row.get("receipt_rowid")
+        if isinstance(receipt_rowid, int):
+            backfill_rowids.append(receipt_rowid)
     next_before_rowid = min(backfill_rowids) if backfill_rowids else before_rowid
     complete = len(backfill_rows) < _RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT
     return merged, {

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3911,11 +3911,13 @@ def _receipt_sync_rows_with_command_detail_backfill(
     if _receipt_redaction_level_rank(redaction_level) <= _receipt_redaction_level_rank("full"):
         return receipts, None
     marker = store.get_sync_payload(_RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER)
-    if isinstance(marker, dict) and marker.get("level") == redaction_level:
+    before_rowid = _receipt_command_detail_backfill_before_rowid(marker, redaction_level=redaction_level)
+    if isinstance(marker, dict) and marker.get("level") == redaction_level and marker.get("complete") is True:
         return receipts, None
     backfill_rows = store.list_receipts_for_command_detail_backfill(
         limit=_RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT,
         days=_RECEIPT_COMMAND_DETAIL_BACKFILL_DAYS,
+        before_rowid=before_rowid,
     )
     seen_receipt_ids = {item.get("receipt_id") for item in receipts if isinstance(item.get("receipt_id"), str)}
     merged = list(receipts)
@@ -3927,13 +3929,31 @@ def _receipt_sync_rows_with_command_detail_backfill(
         merged.append(row)
         seen_receipt_ids.add(receipt_id)
         added += 1
+    backfill_rowids = [row.get("receipt_rowid") for row in backfill_rows if isinstance(row.get("receipt_rowid"), int)]
+    next_before_rowid = min(backfill_rowids) if backfill_rowids else before_rowid
+    complete = len(backfill_rows) < _RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT
     return merged, {
         "level": redaction_level,
         "updated_at": synced_at,
         "days": _RECEIPT_COMMAND_DETAIL_BACKFILL_DAYS,
         "limit": _RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT,
         "receipts": added,
+        "queried": len(backfill_rows),
+        "before_rowid": next_before_rowid,
+        "complete": complete,
     }
+
+
+def _receipt_command_detail_backfill_before_rowid(marker: object, *, redaction_level: str) -> int | None:
+    if not isinstance(marker, dict) or marker.get("level") != redaction_level:
+        return None
+    value = marker.get("before_rowid")
+    if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+        return value
+    if isinstance(value, str) and value.strip().isdigit():
+        parsed = int(value.strip())
+        return parsed if parsed > 0 else None
+    return None
 
 
 def _receipt_sync_cursor_rowids_from_batch(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -302,6 +302,8 @@ _RUNTIME_SYNC_RETRY_TIMEOUT_SECONDS = 90
 _RECEIPT_SYNC_BATCH_SIZE = 50
 _RECEIPT_SYNC_CURSOR_PAGE_SIZE = 200
 _RECEIPT_SYNC_CURSOR_BACKFILL_ROWS = 200
+_RECEIPT_COMMAND_DETAIL_BACKFILL_DAYS = 7
+_RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT = 5000
 _PAIN_SIGNAL_TIMEOUT_SECONDS = 10
 _PAIN_SIGNAL_RETRY_TIMEOUT_SECONDS = 90
 _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_MINUTES = 5  # single 404 shouldn't disable sync for a full day
@@ -1314,6 +1316,12 @@ def sync_receipts(
     _ensure_relaxed_receipt_redaction_resync(store, level=redaction_level, synced_at=local_guard_online_at)
     prior_receipt_cursor = _receipt_sync_cursor_rowid(store)
     receipts = _receipt_sync_rows_for_upload(store, cursor_rowid=prior_receipt_cursor)
+    receipts, command_detail_backfill_marker = _receipt_sync_rows_with_command_detail_backfill(
+        store,
+        receipts=receipts,
+        redaction_level=redaction_level,
+        synced_at=local_guard_online_at,
+    )
     inventory = store.list_inventory()
     payload: dict[str, object] = {}
     receipts_stored_total = 0
@@ -1411,6 +1419,12 @@ def sync_receipts(
         aibom_context["workspace_dir"] = str(workspace_dir)
     if aibom_context:
         store.set_sync_payload("aibom_inventory_context", aibom_context, now)
+    if command_detail_backfill_marker is not None:
+        store.set_sync_payload(
+            _RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER,
+            command_detail_backfill_marker,
+            now,
+        )
     persisted_cursor_rowid = latest_uploaded_rowid if latest_uploaded_rowid is not None else prior_receipt_cursor
     _persist_receipt_sync_cursor(
         store=store,
@@ -3883,6 +3897,41 @@ def _receipt_sync_rows_for_upload(store: GuardStore, *, cursor_rowid: int | None
     return store.list_receipts_since_rowid(after_rowid=cursor_rowid, limit=_RECEIPT_SYNC_CURSOR_PAGE_SIZE)
 
 
+def _receipt_sync_rows_with_command_detail_backfill(
+    store: GuardStore,
+    *,
+    receipts: list[dict[str, object]],
+    redaction_level: str,
+    synced_at: str,
+) -> tuple[list[dict[str, object]], dict[str, object] | None]:
+    if _receipt_redaction_level_rank(redaction_level) <= _receipt_redaction_level_rank("full"):
+        return receipts, None
+    marker = store.get_sync_payload(_RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER)
+    if isinstance(marker, dict) and marker.get("level") == redaction_level:
+        return receipts, None
+    backfill_rows = store.list_receipts_for_command_detail_backfill(
+        limit=_RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT,
+        days=_RECEIPT_COMMAND_DETAIL_BACKFILL_DAYS,
+    )
+    seen_receipt_ids = {item.get("receipt_id") for item in receipts if isinstance(item.get("receipt_id"), str)}
+    merged = list(receipts)
+    added = 0
+    for row in backfill_rows:
+        receipt_id = row.get("receipt_id")
+        if not isinstance(receipt_id, str) or receipt_id in seen_receipt_ids:
+            continue
+        merged.append(row)
+        seen_receipt_ids.add(receipt_id)
+        added += 1
+    return merged, {
+        "level": redaction_level,
+        "updated_at": synced_at,
+        "days": _RECEIPT_COMMAND_DETAIL_BACKFILL_DAYS,
+        "limit": _RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT,
+        "receipts": added,
+    }
+
+
 def _receipt_sync_context(
     store: GuardStore,
     *,
@@ -3940,6 +3989,7 @@ _RECEIPT_REDACTION_LEVEL_RANK: dict[str, int] = {
     "none": 2,
 }
 _RELAXED_RECEIPT_REDACTION_RESYNC_MARKER = "cloud_receipt_redaction_relaxed_resync_v1"
+_RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER = "cloud_receipt_command_detail_backfill_v1"
 
 
 def _receipt_redaction_level_rank(level: str | None) -> int:

--- a/src/codex_plugin_scanner/guard/store_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_receipts.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta, timezone
+
 # ruff: noqa: F403,F405
 from .store_base import *
 
@@ -224,6 +226,26 @@ class StoreReceiptsRuntimeMixin:
         with self._connect() as connection:
             rows = connection.execute(query, params).fetchall()
         return [self._receipt_dict_from_row(row) for row in rows]
+
+    def list_receipts_for_command_detail_backfill(
+        self,
+        *,
+        limit: int = 2000,
+        days: int = 7,
+    ) -> list[dict[str, object]]:
+        cutoff = (datetime.now(timezone.utc) - timedelta(days=max(days, 1))).isoformat()
+        query = self._receipt_base_query(
+            """
+            where r.timestamp >= ?
+              and r.policy_decision in ('block', 'review', 'require-reapproval')
+              and (e.envelope_full_json is not null or a.action_envelope_json is not null)
+            order by r.rowid desc
+            limit ?
+            """
+        )
+        with self._connect() as connection:
+            rows = connection.execute(query, (cutoff, max(limit, 1))).fetchall()
+        return [self._receipt_dict_from_row(row) for row in reversed(rows)]
 
     def latest_receipt_rowid(self, *, harness: str | None = None) -> int | None:
         query = "select max(rowid) as max_rowid from runtime_receipts"

--- a/src/codex_plugin_scanner/guard/store_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_receipts.py
@@ -232,19 +232,25 @@ class StoreReceiptsRuntimeMixin:
         *,
         limit: int = 2000,
         days: int = 7,
+        before_rowid: int | None = None,
     ) -> list[dict[str, object]]:
         cutoff = (datetime.now(timezone.utc) - timedelta(days=max(days, 1))).isoformat()
+        rowid_clause = "and r.rowid < ?" if before_rowid is not None else ""
         query = self._receipt_base_query(
-            """
+            f"""
             where r.timestamp >= ?
               and r.policy_decision in ('block', 'review', 'require-reapproval')
               and (e.envelope_full_json is not null or a.action_envelope_json is not null)
+              {rowid_clause}
             order by r.rowid desc
             limit ?
             """
         )
         with self._connect() as connection:
-            rows = connection.execute(query, (cutoff, max(limit, 1))).fetchall()
+            params: tuple[object, ...] = (
+                (cutoff, before_rowid, max(limit, 1)) if before_rowid is not None else (cutoff, max(limit, 1))
+            )
+            rows = connection.execute(query, params).fetchall()
         return [self._receipt_dict_from_row(row) for row in reversed(rows)]
 
     def latest_receipt_rowid(self, *, harness: str | None = None) -> int | None:

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import codex_plugin_scanner.guard.runtime.runner as runner
 from codex_plugin_scanner.guard.config import update_guard_settings
 from codex_plugin_scanner.guard.models import GuardReceipt
 from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
@@ -163,6 +164,9 @@ def test_relaxed_redaction_sync_adds_recent_blocked_command_detail_backfill(tmp_
         "days": 7,
         "limit": 5000,
         "receipts": 1,
+        "queried": 1,
+        "before_rowid": 1,
+        "complete": True,
     }
 
 
@@ -170,7 +174,7 @@ def test_relaxed_redaction_command_detail_backfill_marker_prevents_repeat(tmp_pa
     store = GuardStore(tmp_path)
     store.set_sync_payload(
         _RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER,
-        {"level": "partial", "updated_at": "2026-04-15T00:01:00Z"},
+        {"level": "partial", "updated_at": "2026-04-15T00:01:00Z", "complete": True},
         "2026-04-15T00:01:00Z",
     )
 
@@ -183,6 +187,89 @@ def test_relaxed_redaction_command_detail_backfill_marker_prevents_repeat(tmp_pa
 
     assert rows == []
     assert marker is None
+
+
+def test_capped_command_detail_backfill_pages_remaining_receipts(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(runner, "_RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT", 1)
+    store = GuardStore(tmp_path)
+    for index in range(2):
+        store.add_receipt(
+            GuardReceipt(
+                receipt_id=f"guard-receipt-backfill-{index}",
+                timestamp=datetime(2026, 4, 15, 0, index, tzinfo=timezone.utc),
+                harness="codex",
+                artifact_id=f"codex:tool-action:backfill-{index}",
+                artifact_hash=f"hash-backfill-{index}",
+                policy_decision="block",
+                capabilities_summary="tool action request",
+                changed_capabilities=(),
+                provenance_summary="",
+                user_override=None,
+                artifact_name="bash",
+                source_scope="project",
+                diff_summary=None,
+                approval_source=None,
+                approval_request_id=None,
+                scanner_evidence=(),
+                browser_intent=None,
+            ),
+            action_envelope=GuardActionEnvelope(
+                schema_version=1,
+                action_id=f"action-backfill-{index}",
+                harness="codex",
+                event_name="PreToolUse",
+                action_type="shell_command",
+                workspace=None,
+                workspace_hash="workspace",
+                tool_name="bash",
+                command=f"cd repo && npm test -- --runInBand case-{index}",
+                prompt_excerpt=None,
+                prompt_text=None,
+                target_paths=(),
+                network_hosts=(),
+                mcp_server=None,
+                mcp_tool=None,
+                package_manager=None,
+                package_name=None,
+                package_intent_kind=None,
+                package_targets=(),
+                pre_execution_result="block",
+                script_name=None,
+                raw_payload_redacted={},
+            ),
+        )
+
+    first_rows, first_marker = _receipt_sync_rows_with_command_detail_backfill(
+        store,
+        receipts=[],
+        redaction_level="partial",
+        synced_at="2026-04-15T00:02:00Z",
+    )
+
+    assert [row["receipt_id"] for row in first_rows] == ["guard-receipt-backfill-1"]
+    assert first_marker is not None
+    assert first_marker["complete"] is False
+    assert first_marker["before_rowid"] == 2
+    store.set_sync_payload(
+        _RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER,
+        first_marker,
+        "2026-04-15T00:02:00Z",
+    )
+
+    second_rows, second_marker = _receipt_sync_rows_with_command_detail_backfill(
+        store,
+        receipts=[],
+        redaction_level="partial",
+        synced_at="2026-04-15T00:03:00Z",
+    )
+
+    assert [row["receipt_id"] for row in second_rows] == ["guard-receipt-backfill-0"]
+    assert second_marker is not None
+    assert second_marker["complete"] is False
+    assert second_marker["before_rowid"] == 1
 
 
 def test_existing_relaxed_receipt_redaction_resets_cursor_once(tmp_path) -> None:

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -199,7 +199,7 @@ def test_capped_command_detail_backfill_pages_remaining_receipts(
         store.add_receipt(
             GuardReceipt(
                 receipt_id=f"guard-receipt-backfill-{index}",
-                timestamp=datetime(2026, 4, 15, 0, index, tzinfo=timezone.utc),
+                timestamp=f"2099-04-15T00:0{index}:00+00:00",
                 harness="codex",
                 artifact_id=f"codex:tool-action:backfill-{index}",
                 artifact_hash=f"hash-backfill-{index}",

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 from codex_plugin_scanner.guard.config import update_guard_settings
+from codex_plugin_scanner.guard.models import GuardReceipt
+from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
 from codex_plugin_scanner.guard.runtime.runner import (
+    _RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER,
     _RELAXED_RECEIPT_REDACTION_RESYNC_MARKER,
     _ensure_relaxed_receipt_redaction_resync,
     _persist_cloud_receipt_redaction_level,
+    _receipt_sync_rows_with_command_detail_backfill,
 )
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -79,6 +85,90 @@ def test_cloud_receipt_redaction_tightening_keeps_receipt_cursor(tmp_path) -> No
         "last_rowid": 17,
         "synced_at": "2026-04-15T00:00:00Z",
     }
+
+
+def test_relaxed_redaction_sync_adds_recent_blocked_command_detail_backfill(tmp_path) -> None:
+    store = GuardStore(tmp_path)
+    store.add_receipt(
+        GuardReceipt(
+            receipt_id="guard-receipt-backfill",
+            timestamp=datetime.now(timezone.utc).isoformat(),
+            harness="codex",
+            artifact_id="codex:tool-action:backfill",
+            artifact_hash="hash-backfill",
+            policy_decision="block",
+            capabilities_summary="tool action request",
+            changed_capabilities=(),
+            provenance_summary="",
+            user_override=None,
+            artifact_name="bash",
+            source_scope="project",
+            diff_summary=None,
+            approval_source=None,
+            approval_request_id=None,
+            scanner_evidence=(),
+            browser_intent=None,
+        ),
+        action_envelope=GuardActionEnvelope(
+            schema_version=1,
+            action_id="action-backfill",
+            harness="codex",
+            event_name="PreToolUse",
+            action_type="shell_command",
+            workspace=None,
+            workspace_hash="workspace",
+            tool_name="bash",
+            command="cd repo && npx vitest run example.test.ts --reporter=verbose",
+            prompt_excerpt=None,
+            prompt_text=None,
+            target_paths=(),
+            network_hosts=(),
+            mcp_server=None,
+            mcp_tool=None,
+            package_manager=None,
+            package_name=None,
+            package_intent_kind=None,
+            package_targets=(),
+            pre_execution_result="block",
+            script_name=None,
+            raw_payload_redacted={},
+        ),
+    )
+
+    rows, marker = _receipt_sync_rows_with_command_detail_backfill(
+        store,
+        receipts=[],
+        redaction_level="partial",
+        synced_at="2026-04-15T00:01:00Z",
+    )
+
+    assert [row["receipt_id"] for row in rows] == ["guard-receipt-backfill"]
+    assert marker == {
+        "level": "partial",
+        "updated_at": "2026-04-15T00:01:00Z",
+        "days": 7,
+        "limit": 5000,
+        "receipts": 1,
+    }
+
+
+def test_relaxed_redaction_command_detail_backfill_marker_prevents_repeat(tmp_path) -> None:
+    store = GuardStore(tmp_path)
+    store.set_sync_payload(
+        _RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER,
+        {"level": "partial", "updated_at": "2026-04-15T00:01:00Z"},
+        "2026-04-15T00:01:00Z",
+    )
+
+    rows, marker = _receipt_sync_rows_with_command_detail_backfill(
+        store,
+        receipts=[],
+        redaction_level="partial",
+        synced_at="2026-04-15T00:02:00Z",
+    )
+
+    assert rows == []
+    assert marker is None
 
 
 def test_existing_relaxed_receipt_redaction_resets_cursor_once(tmp_path) -> None:

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -10,6 +10,7 @@ from codex_plugin_scanner.guard.runtime.runner import (
     _RELAXED_RECEIPT_REDACTION_RESYNC_MARKER,
     _ensure_relaxed_receipt_redaction_resync,
     _persist_cloud_receipt_redaction_level,
+    _receipt_sync_cursor_rowids_from_batch,
     _receipt_sync_rows_with_command_detail_backfill,
 )
 from codex_plugin_scanner.guard.store import GuardStore
@@ -85,6 +86,19 @@ def test_cloud_receipt_redaction_tightening_keeps_receipt_cursor(tmp_path) -> No
         "last_rowid": 17,
         "synced_at": "2026-04-15T00:00:00Z",
     }
+
+
+def test_command_detail_backfill_rows_do_not_advance_receipt_cursor() -> None:
+    rowids = _receipt_sync_cursor_rowids_from_batch(
+        [
+            {"receipt_id": "cursor-1", "receipt_rowid": 101},
+            {"receipt_id": "backfill-1", "receipt_rowid": 5000},
+            {"receipt_id": "cursor-2", "receipt_rowid": 102},
+        ],
+        cursor_receipt_ids={"cursor-1", "cursor-2"},
+    )
+
+    assert rowids == [101, 102]
 
 
 def test_relaxed_redaction_sync_adds_recent_blocked_command_detail_backfill(tmp_path) -> None:


### PR DESCRIPTION
- Backfill recent actionable receipt command details when cloud receipt redaction is relaxed.
- Keep the normal receipt cursor moving by deduping the backfill into the regular sync upload.
- Add regression coverage for one-time command-detail backfill behavior.

Verification:
- `python3 -m ruff format src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/store_receipts.py tests/test_guard_receipt_redaction_cursor.py`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/store_receipts.py tests/test_guard_receipt_redaction_cursor.py`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_receipt_redaction_cursor.py tests/test_guard_events.py -k 'cloud_sync_receipt_payload' -q`
