### PR TITLE
fix(guard): refresh receipt sync auth after rejection

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1343,6 +1343,7 @@ def sync_receipts(
         device_name=device_name,
     )
     latest_uploaded_rowid: int | None = None
+    auth_refresh_retried = False
     for receipt_batch in _iter_receipt_sync_batches(receipts):
         body = json.dumps(
             {
@@ -1369,12 +1370,48 @@ def sync_receipts(
                 retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
             )
         except urllib.error.HTTPError as error:
-            if error.code == 403:
+            if error.code == 401:
+                if auth_context is None and not auth_refresh_retried:
+                    auth_refresh_retried = True
+                    resolved_auth_context = _resolve_guard_sync_auth_context(store, force_refresh=True)
+                    sync_url = _normalized_receipts_sync_url(
+                        _validate_guard_sync_url(_auth_context_sync_url(resolved_auth_context))
+                    )
+                    request = _guard_sync_request(
+                        resolved_auth_context,
+                        request_url=sync_url,
+                        method="POST",
+                        data=body,
+                        extra_headers=None,
+                    )
+                    try:
+                        payload = _urlopen_json_with_timeout_retry(
+                            request=request,
+                            timeout_seconds=_SYNC_HTTP_TIMEOUT_SECONDS,
+                            retry_timeout_seconds=_SYNC_HTTP_RETRY_TIMEOUT_SECONDS,
+                        )
+                    except urllib.error.HTTPError as retry_error:
+                        if retry_error.code == 401:
+                            raise GuardSyncAuthorizationExpiredError(
+                                _guard_oauth_reauthorization_message()
+                            ) from retry_error
+                        if retry_error.code == 403:
+                            _is_plan, _msg = _check_plan_restriction_403(retry_error)
+                            if _is_plan:
+                                raise GuardSyncNotAvailableError(_msg) from retry_error
+                            raise RuntimeError(_msg) from retry_error
+                        raise RuntimeError(_sync_http_error_message(retry_error)) from retry_error
+                    except OSError as retry_error:
+                        raise RuntimeError(_sync_url_error_message(retry_error)) from retry_error
+                else:
+                    raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message()) from error
+            elif error.code == 403:
                 _is_plan, _msg = _check_plan_restriction_403(error)
                 if _is_plan:
                     raise GuardSyncNotAvailableError(_msg) from error
                 raise RuntimeError(_msg) from error
-            raise RuntimeError(_sync_http_error_message(error)) from error
+            else:
+                raise RuntimeError(_sync_http_error_message(error)) from error
         except OSError as error:
             raise RuntimeError(_sync_url_error_message(error)) from error
         cursor_batch_rowids = _receipt_sync_cursor_rowids_from_batch(
@@ -2978,6 +3015,7 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
     oauth_credentials: dict[str, object],
     *,
     persist_recovered_secret: bool = False,
+    force_refresh: bool = False,
 ) -> dict[str, object]:
     issuer = _optional_string(oauth_credentials.get("issuer"))
     client_id = _optional_string(oauth_credentials.get("client_id"))
@@ -2989,7 +3027,9 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
         oauth_client = resolve_guard_oauth_client_config(issuer)
     except ValueError as error:
         raise GuardSyncAuthorizationExpiredError(f"{_guard_oauth_reauthorization_message()} {error}") from error
-    cached_access_token = _cached_oauth_access_token(oauth_credentials, now=datetime.now(timezone.utc))
+    cached_access_token = (
+        None if force_refresh else _cached_oauth_access_token(oauth_credentials, now=datetime.now(timezone.utc))
+    )
     if cached_access_token is not None and not persist_recovered_secret:
         sync_url = _validate_guard_sync_url(
             _oauth_sync_url_from_issuer(oauth_client.issuer),
@@ -3066,6 +3106,7 @@ def _resolve_guard_sync_auth_context(
     store: GuardStore,
     *,
     allow_primary_repair: bool = True,
+    force_refresh: bool = False,
 ) -> dict[str, object]:
     if _test_sync_auth_context_override is not None:
         override = dict(_test_sync_auth_context_override)
@@ -3078,7 +3119,11 @@ def _resolve_guard_sync_auth_context(
         oauth_health = store.get_oauth_local_credential_health()
         oauth_credentials = store.get_oauth_local_credentials(allow_primary=allow_primary_repair)
         if oauth_credentials is not None:
-            return _resolve_guard_sync_auth_context_from_oauth_credentials(store, oauth_credentials)
+            return _resolve_guard_sync_auth_context_from_oauth_credentials(
+                store,
+                oauth_credentials,
+                force_refresh=force_refresh,
+            )
         if bool(oauth_health.get("configured")):
             recoverable_credentials = store.get_recoverable_oauth_local_credentials()
             if recoverable_credentials is not None:
@@ -3086,6 +3131,7 @@ def _resolve_guard_sync_auth_context(
                     store,
                     recoverable_credentials,
                     persist_recovered_secret=allow_primary_repair,
+                    force_refresh=force_refresh,
                 )
             raise GuardSyncAuthorizationExpiredError(_guard_oauth_reauthorization_message())
         raise GuardSyncNotConfiguredError("Guard is not logged in.")

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2957,6 +2957,7 @@ def _persist_rotated_oauth_refresh_token(
     refresh_token: str,
     access_token: str | None = None,
     access_token_expires_at: str | None = None,
+    force_primary_secret_rewrite: bool = False,
 ) -> None:
     issuer = _optional_string(credentials.get("issuer"))
     client_id = _optional_string(credentials.get("client_id"))
@@ -3007,6 +3008,7 @@ def _persist_rotated_oauth_refresh_token(
         access_token=access_token,
         access_token_expires_at=access_token_expires_at,
         now=_now(),
+        force_primary_secret_rewrite=force_primary_secret_rewrite,
     )
 
 
@@ -3064,6 +3066,7 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
             refresh_token=rotated_refresh_token,
             access_token=_optional_string(refreshed.get("access_token")),
             access_token_expires_at=_optional_string(refreshed.get("access_token_expires_at")),
+            force_primary_secret_rewrite=force_refresh,
         )
     sync_url = _validate_guard_sync_url(
         _oauth_sync_url_from_issuer(oauth_client.issuer),

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3051,7 +3051,12 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
     package_firewall_entitlement: dict[str, object] | None = (
         refreshed_entitlement if isinstance(refreshed_entitlement, dict) else None
     )
-    if rotated_refresh_token != refresh_token or package_firewall_entitlement is not None or persist_recovered_secret:
+    if (
+        force_refresh
+        or rotated_refresh_token != refresh_token
+        or package_firewall_entitlement is not None
+        or persist_recovered_secret
+    ):
         _persist_rotated_oauth_refresh_token(
             store=store,
             credentials=oauth_credentials,

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -113,6 +113,7 @@ class StoreOAuthConnectMixin:
                 runtime_label=runtime_label,
                 access_token=access_token,
                 access_token_expires_at=access_token_expires_at,
+                force_primary_secret_rewrite=force_primary_secret_rewrite,
             )
 
     def _set_oauth_local_credentials_unlocked(
@@ -135,6 +136,7 @@ class StoreOAuthConnectMixin:
         runtime_label: str | None = None,
         access_token: str | None = None,
         access_token_expires_at: str | None = None,
+        force_primary_secret_rewrite: bool = False,
     ) -> None:
         normalized_issuer = resolve_guard_oauth_client_config(issuer).issuer
         secret_payload = {

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -92,6 +92,7 @@ class StoreOAuthConnectMixin:
         runtime_label: str | None = None,
         access_token: str | None = None,
         access_token_expires_at: str | None = None,
+        force_primary_secret_rewrite: bool = False,
     ) -> None:
         with self.hold_oauth_credential_lock():
             self._set_oauth_local_credentials_unlocked(
@@ -185,7 +186,8 @@ class StoreOAuthConnectMixin:
         # Metadata-only updates can skip the primary rewrite because the encrypted
         # fallback remains current and continues to backstop headless recovery.
         skip_primary_secret_rewrite = (
-            not secret_material_changed
+            not force_primary_secret_rewrite
+            and not secret_material_changed
             and isinstance(self._oauth_secret_store, FallbackSecretStore)
             and isinstance(self._oauth_secret_store.primary, SystemKeyringSecretStore)
             and isinstance(self._oauth_secret_store.fallback, EncryptedFileSecretStore)

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import urllib.error
 from datetime import datetime, timezone
+
+import pytest
 
 import codex_plugin_scanner.guard.runtime.runner as runner
 from codex_plugin_scanner.guard.config import update_guard_settings
@@ -15,6 +18,61 @@ from codex_plugin_scanner.guard.runtime.runner import (
     _receipt_sync_rows_with_command_detail_backfill,
 )
 from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _store_blocked_command_receipt(store: GuardStore, receipt_id: str = "guard-receipt-sync-auth") -> None:
+    store.add_receipt(
+        GuardReceipt(
+            receipt_id=receipt_id,
+            timestamp=datetime(2026, 4, 15, tzinfo=timezone.utc).isoformat(),
+            harness="codex",
+            artifact_id="codex:tool-action:sync-auth",
+            artifact_hash="hash-sync-auth",
+            policy_decision="block",
+            capabilities_summary="tool action request",
+            changed_capabilities=(),
+            provenance_summary="",
+            user_override=None,
+            artifact_name="bash",
+            source_scope="project",
+            diff_summary=None,
+            approval_source=None,
+            approval_request_id=None,
+            scanner_evidence=(),
+            browser_intent=None,
+        ),
+        action_envelope=GuardActionEnvelope(
+            schema_version=1,
+            action_id="action-sync-auth",
+            harness="codex",
+            event_name="PreToolUse",
+            action_type="shell_command",
+            workspace=None,
+            workspace_hash="workspace",
+            tool_name="bash",
+            command="cd repo && npx vitest run example.test.ts --reporter=verbose",
+            prompt_excerpt=None,
+            prompt_text=None,
+            target_paths=(),
+            network_hosts=(),
+            mcp_server=None,
+            mcp_tool=None,
+            package_manager=None,
+            package_name=None,
+            package_intent_kind=None,
+            package_targets=(),
+        ),
+    )
+
+
+def _sync_unauthorized_error() -> urllib.error.HTTPError:
+    return urllib.error.HTTPError(
+        "https://hol.org/api/guard/receipts/sync",
+        401,
+        "Unauthorized",
+        {},
+        None,
+    )
 
 
 def test_cloud_receipt_redaction_relaxation_resets_receipt_cursor_before_storing_level(tmp_path) -> None:
@@ -100,6 +158,75 @@ def test_command_detail_backfill_rows_do_not_advance_receipt_cursor() -> None:
     )
 
     assert rowids == [101, 102]
+
+
+def test_receipt_sync_401_with_explicit_auth_context_keeps_cursor_and_backfill_marker(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path)
+    _store_blocked_command_receipt(store)
+
+    def reject_sync(**_kwargs: object) -> dict[str, object]:
+        raise _sync_unauthorized_error()
+
+    monkeypatch.setattr(runner, "_urlopen_json_with_timeout_retry", reject_sync)
+
+    with pytest.raises(runner.GuardSyncAuthorizationExpiredError):
+        runner.sync_receipts(
+            store,
+            auth_context={
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+                "access_token": "stale",
+            },
+        )
+
+    assert store.get_sync_payload("receipt_sync_cursor") is None
+    assert store.get_sync_payload(_RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER) is None
+
+
+def test_receipt_sync_401_forces_oauth_refresh_before_retry(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path)
+    _store_blocked_command_receipt(store)
+    refresh_flags: list[bool] = []
+    post_attempts = 0
+
+    def resolve_auth_context(
+        _store: GuardStore,
+        *,
+        allow_primary_repair: bool = True,
+        force_refresh: bool = False,
+    ) -> dict[str, object]:
+        refresh_flags.append(force_refresh)
+        return {
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+            "access_token": "fresh" if force_refresh else "stale",
+        }
+
+    def post_sync(**_kwargs: object) -> dict[str, object]:
+        nonlocal post_attempts
+        post_attempts += 1
+        if post_attempts == 1:
+            raise _sync_unauthorized_error()
+        return {
+            "syncedAt": "2026-04-15T00:01:00Z",
+            "receiptsStored": 1,
+        }
+
+    monkeypatch.setattr(runner, "_resolve_guard_sync_auth_context", resolve_auth_context)
+    monkeypatch.setattr(runner, "_urlopen_json_with_timeout_retry", post_sync)
+
+    runner.sync_receipts(store)
+
+    assert refresh_flags[:2] == [False, True]
+    assert post_attempts >= 2
+    assert store.get_sync_payload("receipt_sync_cursor") == {
+        "last_rowid": 1,
+        "synced_at": "2026-04-15T00:01:00Z",
+    }
 
 
 def test_relaxed_redaction_sync_adds_recent_blocked_command_detail_backfill(tmp_path) -> None:

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -275,6 +275,32 @@ def test_forced_oauth_refresh_persists_same_refresh_token_access_token(
     assert persisted[0]["force_primary_secret_rewrite"] is True
 
 
+def test_oauth_local_credentials_forwards_primary_rewrite_flag(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path)
+    captured: list[dict[str, object]] = []
+
+    monkeypatch.setattr(store, "_set_oauth_local_credentials_unlocked", lambda **kwargs: captured.append(kwargs))
+
+    store.set_oauth_local_credentials(
+        issuer="http://127.0.0.1:3000",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token",
+        dpop_private_key_pem="private-key",
+        dpop_public_jwk={"kty": "EC"},
+        dpop_public_jwk_thumbprint="thumbprint",
+        now="2026-04-15T00:01:00Z",
+        access_token="access-token",
+        access_token_expires_at="2026-04-15T00:30:00Z",
+        force_primary_secret_rewrite=True,
+    )
+
+    assert captured
+    assert captured[0]["force_primary_secret_rewrite"] is True
+
+
 def test_relaxed_redaction_sync_adds_recent_blocked_command_detail_backfill(tmp_path) -> None:
     store = GuardStore(tmp_path)
     store.add_receipt(

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -272,6 +272,7 @@ def test_forced_oauth_refresh_persists_same_refresh_token_access_token(
     assert persisted[0]["refresh_token"] == "same-refresh-token"
     assert persisted[0]["access_token"] == "fresh-access-token"
     assert persisted[0]["access_token_expires_at"] == "2026-04-15T00:30:00+00:00"
+    assert persisted[0]["force_primary_secret_rewrite"] is True
 
 
 def test_relaxed_redaction_sync_adds_recent_blocked_command_detail_backfill(tmp_path) -> None:

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -229,6 +229,51 @@ def test_receipt_sync_401_forces_oauth_refresh_before_retry(
     }
 
 
+def test_forced_oauth_refresh_persists_same_refresh_token_access_token(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = GuardStore(tmp_path)
+    persisted: list[dict[str, object]] = []
+
+    class OAuthClient:
+        issuer = "http://127.0.0.1:3000"
+        token_endpoint = "http://127.0.0.1:3000/oauth/token"
+
+    def fake_refresh(**_kwargs: object) -> dict[str, object]:
+        return {
+            "access_token": "fresh-access-token",
+            "access_token_expires_at": "2026-04-15T00:30:00+00:00",
+            "refresh_token": "same-refresh-token",
+        }
+
+    monkeypatch.setattr(runner, "resolve_guard_oauth_client_config", lambda _issuer: OAuthClient())
+    monkeypatch.setattr(runner, "_oauth_dpop_key_material", lambda _credentials: None)
+    monkeypatch.setattr(runner, "_refresh_guard_oauth_access_token", fake_refresh)
+    monkeypatch.setattr(store, "set_oauth_local_credentials", lambda **kwargs: persisted.append(kwargs))
+
+    auth_context = runner._resolve_guard_sync_auth_context_from_oauth_credentials(
+        store,
+        {
+            "issuer": "http://127.0.0.1:3000",
+            "client_id": "guard-local-daemon",
+            "refresh_token": "same-refresh-token",
+            "access_token": "stale-access-token",
+            "access_token_expires_at": "2099-04-15T00:30:00+00:00",
+            "dpop_private_key_pem": "private-key",
+            "dpop_public_jwk": {"kty": "EC", "crv": "P-256"},
+            "dpop_public_jwk_thumbprint": "thumbprint",
+        },
+        force_refresh=True,
+    )
+
+    assert auth_context["access_token"] == "fresh-access-token"
+    assert persisted
+    assert persisted[0]["refresh_token"] == "same-refresh-token"
+    assert persisted[0]["access_token"] == "fresh-access-token"
+    assert persisted[0]["access_token_expires_at"] == "2026-04-15T00:30:00+00:00"
+
+
 def test_relaxed_redaction_sync_adds_recent_blocked_command_detail_backfill(tmp_path) -> None:
     store = GuardStore(tmp_path)
     store.add_receipt(


### PR DESCRIPTION
- Refresh OAuth sync auth once when receipt upload is rejected with 401.
- Keep receipt cursor and command-detail backfill state unchanged when auth cannot recover.
- `PYTHONPATH=src python3 -m pytest tests/test_guard_receipt_redaction_cursor.py -q`
- `PYTHONPATH=src python3 -m pytest tests/test_guard_receipt_redaction_cursor.py tests/test_guard_events.py -k 'cloud_sync_receipt_payload or receipt_sync_401 or command_detail_backfill or receipt_redaction' -q`
- `python3 -m ruff check src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_receipt_redaction_cursor.py`
