### PR TITLE
fix(guard): preserve Cisco scanner evidence status

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -878,6 +878,17 @@ def _cisco_trust_layer(
             if value is not None:
                 safe_metadata[key] = value
     safe_metadata["attestationStatus"] = "unsigned"
+    safe_metadata["evidenceSchemaVersion"] = "guard-aibom-cisco-scanner-evidence.v1"
+    safe_metadata["evidence"] = _cisco_evidence_payload(
+        layer_id=layer_id,
+        label=label,
+        status=status,
+        message=message,
+        captured_at=_normalize_inventory_datetime(captured_at),
+        trust_score=trust_score,
+        trust_components=trust_components,
+        metadata=safe_metadata,
+    )
     safe_metadata["evidenceHash"] = _trust_evidence_hash(
         {
             "capturedAt": _normalize_inventory_datetime(captured_at),
@@ -901,6 +912,45 @@ def _cisco_trust_layer(
         "capturedAt": _normalize_inventory_datetime(captured_at),
         "metadata": safe_metadata,
     }
+
+
+def _cisco_evidence_payload(
+    *,
+    layer_id: TrustLayerType,
+    label: str,
+    status: str,
+    message: str,
+    captured_at: object,
+    trust_score: int | None,
+    trust_components: list[dict[str, object]],
+    metadata: dict[str, object],
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "source": metadata.get("scannerSource", "unknown"),
+        "layerId": layer_id,
+        "label": label,
+        "status": status,
+        "message": message,
+        "capturedAt": captured_at,
+        "trustScore": trust_score,
+        "componentCount": len(trust_components),
+        "totalFindings": metadata.get("totalFindings", 0),
+        "findingsBySeverity": metadata.get("findingsBySeverity", {}),
+    }
+    for key in (
+        "analyzersUsed",
+        "policyName",
+        "scanMode",
+        "mode",
+        "targetsScanned",
+        "skillsScanned",
+        "skillsSkipped",
+        "durationMs",
+    ):
+        value = metadata.get(key)
+        if value is not None:
+            payload[key] = value
+    return payload
 
 
 def _cisco_severity_counts(run: object) -> dict[str, int]:

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -860,10 +860,12 @@ def _cisco_trust_layer(
     safe_metadata: dict[str, object] = {
         "scannerSource": str(getattr(run, "source", "unknown")),
         "message": message,
-        "durationMs": getattr(run, "duration_ms", None) if isinstance(getattr(run, "duration_ms", None), int) else None,
         "totalFindings": sum(severity_counts.values()),
         "findingsBySeverity": severity_counts,
     }
+    duration_ms = getattr(run, "duration_ms", None)
+    if isinstance(duration_ms, int):
+        safe_metadata["durationMs"] = duration_ms
     if isinstance(run_metadata, dict):
         for key in (
             "analyzersUsed",
@@ -898,7 +900,9 @@ def _cisco_trust_layer(
             "trustScore": trust_score,
             "trustComponents": trust_components,
             "metadata": {
-                key: value for key, value in safe_metadata.items() if key not in {"attestationStatus", "evidenceHash"}
+                key: value
+                for key, value in safe_metadata.items()
+                if key not in {"attestationStatus", "evidenceHash"} and value is not None
             },
         }
     )

--- a/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
+++ b/src/codex_plugin_scanner/guard/aibom_trust_metadata.py
@@ -881,7 +881,7 @@ def _cisco_trust_layer(
                 safe_metadata[key] = value
     safe_metadata["attestationStatus"] = "unsigned"
     safe_metadata["evidenceSchemaVersion"] = "guard-aibom-cisco-scanner-evidence.v1"
-    safe_metadata["evidence"] = _cisco_evidence_payload(
+    evidence_payload = _cisco_evidence_payload(
         layer_id=layer_id,
         label=label,
         status=status,
@@ -891,21 +891,8 @@ def _cisco_trust_layer(
         trust_components=trust_components,
         metadata=safe_metadata,
     )
-    safe_metadata["evidenceHash"] = _trust_evidence_hash(
-        {
-            "capturedAt": _normalize_inventory_datetime(captured_at),
-            "layerId": layer_id,
-            "layerType": layer_id,
-            "status": status,
-            "trustScore": trust_score,
-            "trustComponents": trust_components,
-            "metadata": {
-                key: value
-                for key, value in safe_metadata.items()
-                if key not in {"attestationStatus", "evidenceHash"} and value is not None
-            },
-        }
-    )
+    safe_metadata["evidence"] = evidence_payload
+    safe_metadata["evidenceHash"] = _trust_evidence_hash(evidence_payload)
 
     return {
         "layerId": layer_id,

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -516,7 +516,7 @@ def test_inventory_snapshot_attaches_cisco_unavailable_status_evidence(tmp_path:
         status="unavailable",
         message="Cisco MCP scanner runtime unavailable.",
         findings=(),
-        duration_ms=7,
+        duration_ms=cast(Any, None),
         metadata={
             "target": ".mcp.json",
             "_targetPath": str(workspace),
@@ -551,12 +551,14 @@ def test_inventory_snapshot_attaches_cisco_unavailable_status_evidence(tmp_path:
     metadata = cisco_layer.get("metadata")
     assert isinstance(metadata, dict)
     assert metadata.get("evidenceSchemaVersion") == "guard-aibom-cisco-scanner-evidence.v1"
+    assert "durationMs" not in metadata
     evidence = metadata.get("evidence")
     assert isinstance(evidence, dict)
     assert evidence.get("status") == "unavailable"
     assert evidence.get("message") == "Cisco MCP scanner runtime unavailable."
     assert evidence.get("totalFindings") == 0
     assert evidence.get("targetsScanned") == 0
+    assert "durationMs" not in evidence
     assert str(workspace) not in encoded
 
 

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -21,6 +21,7 @@ from codex_plugin_scanner.guard.inventory_contract import (
     serialize_inventory_snapshot,
 )
 from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
+from codex_plugin_scanner.guard.runtime.evidence_hash import guard_evidence_hash
 from codex_plugin_scanner.models import Finding, Severity
 
 
@@ -559,6 +560,7 @@ def test_inventory_snapshot_attaches_cisco_unavailable_status_evidence(tmp_path:
     assert evidence.get("totalFindings") == 0
     assert evidence.get("targetsScanned") == 0
     assert "durationMs" not in evidence
+    assert metadata.get("evidenceHash") == guard_evidence_hash(evidence)
     assert str(workspace) not in encoded
 
 

--- a/tests/test_guard_inventory_contract.py
+++ b/tests/test_guard_inventory_contract.py
@@ -468,6 +468,9 @@ def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tm
         and layer.get("trustScore") == 70
         and isinstance(layer.get("metadata"), dict)
         and layer["metadata"].get("attestationStatus") == "unsigned"
+        and isinstance(layer["metadata"].get("evidence"), dict)
+        and layer["metadata"]["evidence"].get("status") == "enabled"
+        and layer["metadata"]["evidence"].get("trustScore") == 70
         and isinstance(layer["metadata"].get("evidenceHash"), str)
         for layer in server_layers
     )
@@ -483,6 +486,77 @@ def test_inventory_snapshot_attaches_cisco_mcp_trust_layer_to_server_and_tool(tm
         and layer["metadata"].get("inheritedFromServerItemId") is None
         for layer in tool_layers
     )
+    assert str(workspace) not in encoded
+
+
+def test_inventory_snapshot_attaches_cisco_unavailable_status_evidence(tmp_path: Path) -> None:
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    mcp_file = workspace / ".mcp.json"
+    mcp_file.write_text('{"mcpServers": {"local-demo": {"command": "python"}}}\n', encoding="utf-8")
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=True,
+        config_paths=(str(mcp_file),),
+        artifacts=(
+            GuardArtifact(
+                artifact_id="codex:project:mcp:local-demo",
+                name="local-demo",
+                harness="codex",
+                artifact_type="mcp_server",
+                source_scope="project",
+                config_path=str(mcp_file),
+                transport="stdio",
+            ),
+        ),
+    )
+    cisco_run = CiscoInventoryRun(
+        source="cisco-mcp-scanner",
+        status="unavailable",
+        message="Cisco MCP scanner runtime unavailable.",
+        findings=(),
+        duration_ms=7,
+        metadata={
+            "target": ".mcp.json",
+            "_targetPath": str(workspace),
+            "_configPath": str(mcp_file),
+            "targetsScanned": 0,
+            "totalFindings": 0,
+            "findingsBySeverity": {"critical": 0, "high": 0, "medium": 0, "low": 0},
+            "analyzersUsed": [],
+            "scanMode": "static",
+            "mode": "auto",
+        },
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-06-10T00:00:00Z",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+        cisco_runs=(cisco_run,),
+    )
+    server_item = next(item for item in snapshot.items if item.item_kind == "mcp_server")
+    trust_layers = server_item.metadata.get("trustLayers")
+    encoded = json.dumps(serialize_inventory_snapshot(snapshot), sort_keys=True)
+
+    assert isinstance(trust_layers, list)
+    cisco_layer = next(
+        layer for layer in trust_layers if isinstance(layer, dict) and layer.get("layerType") == "cisco_mcp_scanner"
+    )
+    assert cisco_layer.get("status") == "unavailable"
+    assert cisco_layer.get("trustScore") is None
+    assert cisco_layer.get("trustComponents") == []
+    metadata = cisco_layer.get("metadata")
+    assert isinstance(metadata, dict)
+    assert metadata.get("evidenceSchemaVersion") == "guard-aibom-cisco-scanner-evidence.v1"
+    evidence = metadata.get("evidence")
+    assert isinstance(evidence, dict)
+    assert evidence.get("status") == "unavailable"
+    assert evidence.get("message") == "Cisco MCP scanner runtime unavailable."
+    assert evidence.get("totalFindings") == 0
+    assert evidence.get("targetsScanned") == 0
     assert str(workspace) not in encoded
 
 


### PR DESCRIPTION
## Summary
- Preserve structured Cisco scanner evidence metadata for AIBOM trust layers even when the scanner is unavailable, skipped, or timed out
- Add regression coverage for non-scored Cisco trust layers so they remain explainable instead of empty

## Testing
- `python3 -m pytest tests/test_guard_inventory_contract.py tests/test_guard_inventory_cisco.py -q`
- `python3 -m compileall -q src/codex_plugin_scanner/guard/aibom_trust_metadata.py tests/test_guard_inventory_contract.py`
