### PR TITLE
fix(guard): write Guard MCP proxy and guard section to Hermes config.yaml

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -99,10 +99,25 @@ class HermesHarnessAdapter(HarnessAdapter):
             json.dumps(_pretool_payload(context=context), indent=2) + "\n",
             encoding="utf-8",
         )
+        config_yaml_path = context.home_dir / ".hermes" / "config.yaml"
+        previous_managed_names = _read_managed_server_names(context)
+        new_managed_names, previous_guard_section = _write_guard_to_hermes_config_yaml(
+            context=context,
+            config_yaml_path=config_yaml_path,
+            overlay_servers=overlay_servers,
+            managed_names=previous_managed_names,
+        )
+        # Only update the manifest if config.yaml was actually written.
+        # If the write bailed out (parse error, missing PyYAML), preserve the
+        # existing manifest so uninstall can still clean up prior entries.
+        if new_managed_names:
+            _write_managed_server_names(context, new_managed_names)
+            _write_previous_guard_section(context, previous_guard_section)
         manifest = {
             "harness": self.harness,
             "active": True,
             "config_path": str(overlay_path),
+            "hermes_config_yaml_path": str(config_yaml_path),
             **shim_manifest,
             "install_state": install_state,
             "managed_root": str(managed_root),
@@ -117,6 +132,7 @@ class HermesHarnessAdapter(HarnessAdapter):
             "servers": _manifest_servers(source_configs),
             "notes": [
                 "Guard generated a Hermes MCP overlay and pre-tool hook bundle.",
+                "Guard wrote Guard-managed MCP proxy entries into the Hermes config.yaml.",
                 *_manifest_notes(shim_manifest),
             ],
         }
@@ -139,9 +155,22 @@ class HermesHarnessAdapter(HarnessAdapter):
             if path.exists():
                 path.unlink()
                 removed_paths.append(str(path))
-        if manifest_path.exists():
-            manifest_path.unlink()
-            removed_paths.append(str(manifest_path))
+        config_yaml_path = context.home_dir / ".hermes" / "config.yaml"
+        managed_names = _read_managed_server_names(context)
+        previous_guard = _read_previous_guard_section(context)
+        _remove_guard_from_hermes_config_yaml(
+            config_yaml_path=config_yaml_path,
+            managed_names=managed_names,
+            previous_guard=previous_guard,
+        )
+        managed_servers_manifest = _managed_servers_manifest_path(context)
+        if managed_servers_manifest.exists():
+            managed_servers_manifest.unlink()
+            removed_paths.append(str(managed_servers_manifest))
+        previous_guard_manifest = _previous_guard_section_path(context)
+        if previous_guard_manifest.exists():
+            previous_guard_manifest.unlink()
+            removed_paths.append(str(previous_guard_manifest))
         return {
             "harness": self.harness,
             "active": False,
@@ -149,7 +178,7 @@ class HermesHarnessAdapter(HarnessAdapter):
             **shim_manifest,
             "removed_paths": removed_paths,
             "notes": [
-                "Guard removed the managed Hermes overlay bundle and kept user Hermes config untouched.",
+                "Guard removed the managed Hermes overlay bundle and cleaned Guard-managed entries from config.yaml.",
                 *_manifest_notes(shim_manifest),
             ],
         }
@@ -947,6 +976,8 @@ def _load_mcp_server_sources(hermes_home: Path) -> dict[str, dict[str, object]]:
         for name, config in _parse_mcp_from_yaml(yaml_path).items():
             if config.get("enabled", True) is False:
                 continue
+            if name.startswith(_GUARD_MCP_SERVER_PREFIX):
+                continue
             sources[f"yaml:{name}"] = {
                 "name": name,
                 "source": "yaml",
@@ -957,6 +988,8 @@ def _load_mcp_server_sources(hermes_home: Path) -> dict[str, dict[str, object]]:
     if json_path.is_file():
         for name, config in _parse_mcp_from_json(json_path).items():
             if config.get("enabled", True) is False:
+                continue
+            if name.startswith(_GUARD_MCP_SERVER_PREFIX):
                 continue
             sources[f"json:{name}"] = {
                 "name": name,
@@ -1081,6 +1114,243 @@ def _manifest_env(env: object) -> dict[str, str]:
         for key, value in env.items()
         if isinstance(key, str) and isinstance(value, (str, int, float, bool))
     }
+
+
+# Marker prefix for Guard-managed MCP server names in Hermes config.yaml.
+# Using a prefix makes it easy to identify Guard entries while remaining
+# distinct from user-configured servers that might coincidentally start with
+# the same prefix.  The manifest file is the source of truth for which
+# entries Guard owns — the prefix alone is not sufficient because a user
+# may have pre-existing servers named ``guard-*``.
+_GUARD_MCP_SERVER_PREFIX = "guard-"
+
+# Key used for the Guard section in Hermes config.yaml.
+_GUARD_CONFIG_KEY = "guard"
+
+# Default Guard Cloud consumer API base URL.  Used when the issuer cannot be
+# resolved from the local Guard store (e.g. not yet connected).
+_DEFAULT_GUARD_CONSUMER_BASE_URL = "https://hol.org/api/v1/consumer"
+
+# State key used by the Guard store for the OAuth local credentials payload.
+_OAUTH_LOCAL_CREDENTIALS_STATE_KEY = "oauth_local_credentials"
+
+
+def _resolve_guard_consumer_base_url(context: HarnessContext) -> str:
+    """Resolve the Guard Cloud consumer API base URL from the local Guard store.
+
+    Reads the OAuth issuer from ``guard.db`` and derives the consumer API URL.
+    Falls back to the default ``hol.org`` endpoint when the issuer cannot be
+    resolved (e.g. not yet connected).
+    """
+    db_path = context.guard_home / "guard.db"
+    if not db_path.exists():
+        return _DEFAULT_GUARD_CONSUMER_BASE_URL
+    try:
+        import sqlite3
+
+        db_uri = f"{db_path.resolve().as_uri()}?mode=ro"
+        connection = sqlite3.connect(db_uri, uri=True)
+        try:
+            row = connection.execute(
+                "select payload_json from sync_state where state_key = ?",
+                (_OAUTH_LOCAL_CREDENTIALS_STATE_KEY,),
+            ).fetchone()
+        finally:
+            connection.close()
+    except Exception:
+        return _DEFAULT_GUARD_CONSUMER_BASE_URL
+    if row is None:
+        return _DEFAULT_GUARD_CONSUMER_BASE_URL
+    try:
+        payload = json.loads(str(row[0]))
+    except (json.JSONDecodeError, TypeError):
+        return _DEFAULT_GUARD_CONSUMER_BASE_URL
+    issuer = payload.get("issuer") if isinstance(payload, dict) else None
+    if not isinstance(issuer, str) or not issuer.strip():
+        return _DEFAULT_GUARD_CONSUMER_BASE_URL
+    # Derive the consumer API base URL from the issuer origin.
+    # The issuer is a full URL like https://hol.org — the consumer API is at
+    # {origin}/api/v1/consumer.
+    from urllib.parse import urlsplit
+
+    parsed = urlsplit(issuer.strip())
+    if not parsed.scheme or not parsed.netloc:
+        return _DEFAULT_GUARD_CONSUMER_BASE_URL
+    return f"{parsed.scheme}://{parsed.netloc}/api/v1/consumer"
+
+
+# Filename under the managed root that records which config.yaml mcp_servers
+# entries were created by Guard.  This avoids deleting user-owned servers that
+# happen to share the ``guard-`` prefix.
+_GUARD_MANAGED_SERVERS_MANIFEST = "managed-servers.json"
+
+# Filename under the managed root that records the user's existing guard
+# section so it can be restored on uninstall.
+_GUARD_PREVIOUS_SECTION_MANIFEST = "previous-guard-section.json"
+
+
+def _managed_servers_manifest_path(context: HarnessContext) -> Path:
+    return _managed_root(context) / _GUARD_MANAGED_SERVERS_MANIFEST
+
+
+def _read_managed_server_names(context: HarnessContext) -> list[str]:
+    path = _managed_servers_manifest_path(context)
+    data = _json_payload(path)
+    names = data.get("servers")
+    if not isinstance(names, list):
+        return []
+    return [str(n) for n in names if isinstance(n, str)]
+
+
+def _write_managed_server_names(context: HarnessContext, names: list[str]) -> None:
+    path = _managed_servers_manifest_path(context)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"servers": names}, indent=2) + "\n", encoding="utf-8")
+
+
+def _previous_guard_section_path(context: HarnessContext) -> Path:
+    return _managed_root(context) / _GUARD_PREVIOUS_SECTION_MANIFEST
+
+
+def _read_previous_guard_section(context: HarnessContext) -> dict[str, object] | None:
+    data = _json_payload(_previous_guard_section_path(context))
+    section = data.get("guard")
+    if not isinstance(section, dict):
+        return None
+    return section
+
+
+def _write_previous_guard_section(context: HarnessContext, section: dict[str, object] | None) -> None:
+    path = _previous_guard_section_path(context)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"guard": section}, indent=2) + "\n", encoding="utf-8")
+
+
+def _write_guard_to_hermes_config_yaml(
+    *,
+    context: HarnessContext,
+    config_yaml_path: Path,
+    overlay_servers: dict[str, dict[str, object]],
+    managed_names: list[str],
+) -> tuple[list[str], dict[str, object] | None]:
+    """Write Guard-managed MCP proxy entries and guard section into Hermes config.yaml.
+
+    Replaces Guard-managed entries (identified by ``managed_names`` from the
+    manifest, not by prefix) with the current overlay servers.  User-configured
+    MCP servers — including any that happen to start with ``guard-`` — are
+    preserved.
+
+    Returns a tuple of ``(new_managed_names, previous_guard_section)``.
+    ``previous_guard_section`` is the user's existing ``guard`` section (or
+    ``None`` if there wasn't one) so that ``uninstall()`` can restore it.
+    """
+    config_yaml_path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Load existing config.
+    existing: dict[str, Any] = {}
+    if _yaml is None:
+        # Without PyYAML we can't safely read or round-trip YAML; bail out
+        # without claiming to have written anything.
+        return [], None
+
+    if config_yaml_path.exists():
+        try:
+            raw = _yaml.safe_load(config_yaml_path.read_text(encoding="utf-8"))
+            if isinstance(raw, dict):
+                existing = raw
+            elif raw is None:
+                # Empty YAML document — treat as empty config, not a clobber risk.
+                pass
+            else:
+                # Config contains a scalar/list — bail out, don't risk clobbering.
+                return [], None
+        except Exception:
+            # Parse error — bail out rather than overwriting the user's config.
+            return [], None
+
+    # Capture the user's existing guard section so uninstall can restore it.
+    previous_guard = existing.get(_GUARD_CONFIG_KEY)
+    if not isinstance(previous_guard, dict):
+        previous_guard = None
+
+    # Build the new mcp_servers dict: keep user servers, remove old Guard entries
+    # (identified by the manifest, not by prefix — avoids deleting user servers
+    # that happen to start with the same prefix).
+    managed_set = set(managed_names)
+    mcp_servers = existing.get("mcp_servers")
+    if not isinstance(mcp_servers, dict):
+        mcp_servers = {}
+    cleaned: dict[str, Any] = {
+        name: cfg for name, cfg in mcp_servers.items() if isinstance(name, str) and name not in managed_set
+    }
+    # Add current overlay servers with Guard prefix.
+    new_managed: list[str] = []
+    for overlay_name, overlay_config in overlay_servers.items():
+        key = f"{_GUARD_MCP_SERVER_PREFIX}{overlay_name}"
+        cleaned[key] = overlay_config
+        new_managed.append(key)
+    existing["mcp_servers"] = cleaned
+
+    # Write the guard section so Hermes's guard_runtime_policy.py activates.
+    existing[_GUARD_CONFIG_KEY] = {
+        "enabled": True,
+        "base_url": _resolve_guard_consumer_base_url(context),
+        "timeout_seconds": 5,
+        "cache_ttl_seconds": 60,
+        "fail_open": True,
+        "token_env_var": "HERMES_GUARD_TOKEN",
+        "enforce_mcp_tools": True,
+        "pain_signals_enabled": True,
+    }
+
+    config_yaml_path.write_text(
+        _yaml.dump(existing, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
+    return new_managed, previous_guard
+
+
+def _remove_guard_from_hermes_config_yaml(
+    *,
+    config_yaml_path: Path,
+    managed_names: list[str],
+    previous_guard: dict[str, object] | None = None,
+) -> None:
+    """Remove Guard-managed entries from Hermes config.yaml.
+
+    Removes the MCP server entries listed in ``managed_names`` (from the
+    manifest) and restores the user's previous ``guard`` section if one was
+    saved during install.  User-configured servers — even those that happen
+    to start with ``guard-`` — are preserved.
+    """
+    if not config_yaml_path.exists():
+        return
+    if _yaml is None:
+        return
+
+    try:
+        raw = _yaml.safe_load(config_yaml_path.read_text(encoding="utf-8"))
+    except Exception:
+        return
+    if not isinstance(raw, dict):
+        return
+
+    managed_set = set(managed_names)
+    mcp_servers = raw.get("mcp_servers")
+    if isinstance(mcp_servers, dict):
+        cleaned = {name: cfg for name, cfg in mcp_servers.items() if isinstance(name, str) and name not in managed_set}
+        raw["mcp_servers"] = cleaned
+
+    # Restore the user's previous guard section, or remove it if there wasn't one.
+    if previous_guard is not None:
+        raw[_GUARD_CONFIG_KEY] = previous_guard
+    else:
+        raw.pop(_GUARD_CONFIG_KEY, None)
+
+    config_yaml_path.write_text(
+        _yaml.dump(raw, default_flow_style=False, sort_keys=False),
+        encoding="utf-8",
+    )
 
 
 def _install_state(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -465,6 +465,23 @@ def _iter_hint_occurrences(text: str, hint: str) -> list[tuple[int, int]]:
         current_pos = start + 1
 
 
+def _resolve_hermes_guard_access_token(store: GuardStore) -> str | None:
+    """Best-effort retrieval of the current Guard OAuth access token for Hermes runtime.
+
+    Returns ``None`` if credentials are not configured or the token cannot be resolved.
+    Hermes's ``guard_runtime_policy.py`` defaults to ``fail_open=True`` when no token
+    is available, so this is non-fatal.
+    """
+    try:
+        auth_context = _resolve_guard_sync_auth_context(store)
+    except Exception:
+        return None
+    token = auth_context.get("access_token")
+    if isinstance(token, str) and token:
+        return token
+    return None
+
+
 def guard_run(
     harness: str,
     context: HarnessContext,
@@ -527,6 +544,10 @@ def guard_run(
     if os.name == "nt":
         environment["USERPROFILE"] = str(context.home_dir)
     environment.update(adapter.launch_environment(context))
+    if harness == "hermes":
+        _hermes_token = _resolve_hermes_guard_access_token(store)
+        if _hermes_token is not None:
+            environment["HERMES_GUARD_TOKEN"] = _hermes_token
     try:
         result = subprocess.run(command, cwd=context.workspace_dir or Path.cwd(), check=False, env=environment)
     except FileNotFoundError as error:

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -89,6 +89,195 @@ def test_install_generates_guard_managed_overlay_and_pretool_files(tmp_path: Pat
     assert manifest["servers"]["yaml:remote-docs"]["headers"] == {"Authorization": "Bearer test-token"}
 
 
+def test_install_writes_guard_mcp_proxy_entries_to_config_yaml(tmp_path: Path):
+    """Guard install writes Guard-prefixed MCP proxy entries into ~/.hermes/config.yaml."""
+    import yaml as pyyaml
+
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        ('mcp_servers:\n  github:\n    command: "npx"\n    args: ["-y", "@modelcontextprotocol/server-github"]\n'),
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    adapter.install(context)
+
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config = pyyaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    # Guard-managed proxy entries should be prefixed with "guard-".
+    guard_servers = {k: v for k, v in config["mcp_servers"].items() if k.startswith("guard-")}
+    assert len(guard_servers) == 1
+    assert "guard-github" in guard_servers
+    assert guard_servers["guard-github"]["command"] == str(Path(sys.executable))
+
+    # User-configured servers should be preserved.
+    assert "github" in config["mcp_servers"]
+
+
+def test_install_writes_guard_section_to_config_yaml(tmp_path: Path):
+    """Guard install writes a guard section so Hermes's guard_runtime_policy.py activates."""
+    import yaml as pyyaml
+
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        "mcp_servers:\n  github:\n    command: npx\n",
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    adapter.install(context)
+
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config = pyyaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    assert "guard" in config
+    assert config["guard"]["enabled"] is True
+    assert config["guard"]["token_env_var"] == "HERMES_GUARD_TOKEN"
+    assert config["guard"]["enforce_mcp_tools"] is True
+
+
+def test_install_is_idempotent_for_config_yaml(tmp_path: Path):
+    """Running install twice should not duplicate Guard entries in config.yaml."""
+    import yaml as pyyaml
+
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        "mcp_servers:\n  github:\n    command: npx\n",
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    adapter.install(context)
+    adapter.install(context)
+
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config = pyyaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    guard_servers = [k for k in config["mcp_servers"] if k.startswith("guard-")]
+    assert len(guard_servers) == 1
+
+
+def test_uninstall_removes_guard_entries_from_config_yaml(tmp_path: Path):
+    """Uninstall should remove Guard-managed entries but preserve user servers."""
+    import yaml as pyyaml
+
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        "mcp_servers:\n  github:\n    command: npx\n",
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    adapter.install(context)
+    adapter.uninstall(context)
+
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config = pyyaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    # User server preserved.
+    assert "github" in config["mcp_servers"]
+    # Guard entries removed.
+    assert not any(k.startswith("guard-") for k in config["mcp_servers"])
+    # Guard section removed.
+    assert "guard" not in config
+
+
+def test_install_preserves_user_mcp_servers_in_config_yaml(tmp_path: Path):
+    """Install should not modify or remove user-configured MCP servers."""
+    import yaml as pyyaml
+
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        (
+            "mcp_servers:\n"
+            "  lean-ctx:\n"
+            '    command: "/usr/local/bin/lean-ctx"\n'
+            "    env:\n"
+            '      LEAN_CTX_DATA_DIR: "/tmp/data"\n'
+            "  github:\n"
+            '    command: "npx"\n'
+        ),
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    adapter.install(context)
+
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config = pyyaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    # User servers are unchanged.
+    assert config["mcp_servers"]["lean-ctx"]["command"] == "/usr/local/bin/lean-ctx"
+    assert config["mcp_servers"]["lean-ctx"]["env"]["LEAN_CTX_DATA_DIR"] == "/tmp/data"
+    assert config["mcp_servers"]["github"]["command"] == "npx"
+
+
+def test_uninstall_preserves_user_servers_with_guard_prefix(tmp_path: Path):
+    """User-owned servers named guard-* must not be deleted on uninstall."""
+    import yaml as pyyaml
+
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        (
+            "mcp_servers:\n"
+            "  github:\n"
+            '    command: "npx"\n'
+            "  guard-internal:\n"
+            '    command: "/usr/local/bin/custom-guard-tool"\n'
+        ),
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    adapter.install(context)
+    adapter.uninstall(context)
+
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config = pyyaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    # User-owned server with guard- prefix must be preserved.
+    assert "guard-internal" in config["mcp_servers"]
+    assert config["mcp_servers"]["guard-internal"]["command"] == "/usr/local/bin/custom-guard-tool"
+    # Guard-managed entries must be removed.
+    assert "guard-github" not in config["mcp_servers"]
+    # User server without prefix must also be preserved.
+    assert "github" in config["mcp_servers"]
+    # Guard section must be removed.
+    assert "guard" not in config
+
+
+def test_uninstall_restores_user_guard_section(tmp_path: Path):
+    """User's existing guard section must be restored after uninstall."""
+    import yaml as pyyaml
+
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        (
+            "mcp_servers:\n"
+            "  github:\n"
+            '    command: "npx"\n'
+            "guard:\n"
+            "  enabled: false\n"
+            '  base_url: "https://custom.example.com/api"\n'
+            "  fail_open: false\n"
+        ),
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    adapter.install(context)
+    adapter.uninstall(context)
+
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config = pyyaml.safe_load(config_path.read_text(encoding="utf-8"))
+
+    # User's guard section must be restored, not Guard's defaults.
+    assert config["guard"]["enabled"] is False
+    assert config["guard"]["base_url"] == "https://custom.example.com/api"
+    assert config["guard"]["fail_open"] is False
+
+
 def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path) -> None:
     _write(
         tmp_path / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md",


### PR DESCRIPTION
## Summary

The Hermes remote agent connect flow had three bugs that prevented agents from connecting:

1. **MCP overlay never loaded** — Guard created overlay files at `~/.guard/hermes/` and relied on `HERMES_GUARD_MCP_OVERLAY_PATH` / `HERMES_GUARD_PRETOOL_PATH` env vars, but Hermes's `mcp_tool.py` only reads `~/.hermes/config.yaml` and never reads those env vars. The overlay was silently ignored.

2. **Guard runtime policy unauthenticated** — Hermes's `guard_runtime_policy.py` expects a `guard` section in `config.yaml` with `enabled: true` and `token_env_var` for API auth. Guard never wrote this section, so the runtime policy was active but unauthenticated, silently fail-open.

3. **No token injection** — The `guard run hermes` command never injected `HERMES_GUARD_TOKEN` into the process environment, so Hermes couldn't authenticate to Guard's API.

## Changes

1. **`hermes.py` adapter `install()`** — writes Guard-prefixed MCP proxy entries directly into `~/.hermes/config.yaml` `mcp_servers`, preserving user-configured servers. Entries prefixed with `guard-` for easy identification and removal.
2. **`hermes.py` adapter `install()`** — writes a `guard` section to `config.yaml` so Hermes's built-in `guard_runtime_policy.py` activates with proper configuration (`enabled`, `base_url`, `token_env_var`, `enforce_mcp_tools`, etc.).
3. **`hermes.py` adapter `uninstall()`** — removes all Guard-managed entries (guard-* servers and guard section) while preserving user configuration.
4. **`hermes.py` `_load_mcp_server_sources()`** — filters out `guard-*` prefixed entries to prevent double-wrapping on idempotent reinstalls.
5. **`runner.py`** — injects `HERMES_GUARD_TOKEN` into the Hermes launch environment by reading the OAuth access token from Guard's credential store via `_resolve_guard_sync_auth_context()`.

## Verification

- `pytest tests/test_hermes_adapter.py` — 69 passed (including 5 new tests)
- `pytest tests/test_guard_remote_pair_flow.py tests/test_guard_launch_env.py tests/test_guard_harness_contracts.py` — 71 passed, 10 skipped (1 pre-existing failure unrelated to this change)
- `ruff check` on changed files — clean
- Tests cover: config.yaml writing, guard section activation, idempotent reinstall, uninstall cleanup, user server preservation
