### PR TITLE
fix(guard): preserve previous guard section on Hermes reinstall

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -112,7 +112,13 @@ class HermesHarnessAdapter(HarnessAdapter):
         # existing manifest so uninstall can still clean up prior entries.
         if new_managed_names:
             _write_managed_server_names(context, new_managed_names)
-            _write_previous_guard_section(context, previous_guard_section)
+            # On reinstall, don't overwrite the saved previous guard section —
+            # the one from the first install captured the user's original. If
+            # we overwrote it with the Guard-managed section, uninstall would
+            # restore Guard's defaults instead of removing the section.
+            existing_previous_guard = _previous_guard_section_path(context)
+            if not existing_previous_guard.exists():
+                _write_previous_guard_section(context, previous_guard_section)
         manifest = {
             "harness": self.harness,
             "active": True,

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -278,6 +278,27 @@ def test_uninstall_restores_user_guard_section(tmp_path: Path):
     assert config["guard"]["fail_open"] is False
 
 
+def test_reinstall_does_not_prevent_guard_section_removal(tmp_path: Path):
+    """Guard section must be removed after install -> reinstall -> uninstall."""
+    import yaml as pyyaml
+
+    _write(
+        tmp_path / ".hermes" / "config.yaml",
+        "mcp_servers:\n  github:\n    command: npx\n",
+    )
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+
+    adapter.install(context)
+    adapter.install(context)
+    adapter.uninstall(context)
+
+    config = pyyaml.safe_load((tmp_path / ".hermes" / "config.yaml").read_text(encoding="utf-8"))
+    assert "guard" not in config
+    assert "github" in config["mcp_servers"]
+    assert "guard-github" not in config["mcp_servers"]
+
+
 def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path) -> None:
     _write(
         tmp_path / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md",


### PR DESCRIPTION
## Summary

On reinstall, `previous-guard-section.json` was being overwritten with the Guard-managed `guard` section — captured from the existing `config.yaml` that Guard itself wrote on the first install. This caused uninstall to restore Guard's defaults instead of removing the `guard` section entirely.

## Fix

Only write the `previous-guard-section.json` manifest on first install. On reinstall, preserve the existing manifest so uninstall can correctly restore or remove the guard section.

## Verification

- 72 tests pass in `test_hermes_adapter.py` (includes new `test_reinstall_does_not_prevent_guard_section_removal`)
- Ruff format and lint clean
- Docker integration test: full install → reinstall → uninstall cycle verified in `python:3.13-slim` container

```python
def test_reinstall_does_not_prevent_guard_section_removal(tmp_path: Path):
    """Guard section must be removed after install -> reinstall -> uninstall."""
    adapter.install(context)
    adapter.install(context)
    adapter.uninstall(context)
    assert "guard" not in config
    assert "github" in config["mcp_servers"]
```
