### PR TITLE
fix(guard): scrub HERMES_GUARD_TOKEN from MCP subprocess env

### DIFF
--- a/src/codex_plugin_scanner/guard/proxy/_env.py
+++ b/src/codex_plugin_scanner/guard/proxy/_env.py
@@ -1,0 +1,23 @@
+"""Helpers for scrubbing Guard-internal secrets from subprocess environments."""
+
+from __future__ import annotations
+
+import os
+
+# Env vars that carry Guard-internal tokens. These must never be inherited
+# by user-configured MCP server subprocesses, which are attacker-controlled.
+_GUARD_TOKEN_ENV_VARS: tuple[str, ...] = ("HERMES_GUARD_TOKEN",)
+
+
+def _build_scrubbed_env(extra: dict[str, str] | None = None) -> dict[str, str]:
+    """Build a subprocess env dict with Guard-internal tokens scrubbed.
+
+    The proxy launches user-configured MCP server commands.  Those commands are
+    part of the repository's documented attacker-controlled surface, so any
+    Guard-internal token present in ``os.environ`` (inherited from the parent
+    Hermes process) must be stripped before the env reaches the child.
+    """
+    env = {k: v for k, v in os.environ.items() if k not in _GUARD_TOKEN_ENV_VARS}
+    if extra:
+        env.update(extra)
+    return env

--- a/src/codex_plugin_scanner/guard/proxy/_env.py
+++ b/src/codex_plugin_scanner/guard/proxy/_env.py
@@ -19,5 +19,6 @@ def _build_scrubbed_env(extra: dict[str, str] | None = None) -> dict[str, str]:
     """
     env = {k: v for k, v in os.environ.items() if k not in _GUARD_TOKEN_ENV_VARS}
     if extra:
-        env.update(extra)
+        # Filter extra to prevent re-injecting scrubbed tokens via caller-provided env.
+        env.update({k: v for k, v in extra.items() if k not in _GUARD_TOKEN_ENV_VARS})
     return env

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -27,7 +27,6 @@ from ..mcp_tool_calls import (
     tool_call_risk_summary,
 )
 from ..models import GuardAction, HarnessDetection
-from ._env import _build_scrubbed_env
 from ..policy.engine import build_decision_v2
 from ..runtime.browser_mcp_intent import normalize_browser_mcp_intent
 from ..runtime.mcp_protection import McpServerIdentity, build_mcp_server_identity
@@ -36,6 +35,7 @@ from ..runtime.signals import RiskSeverityLabel, RiskSignalV2
 from ..runtime.supply_chain_package_eval import evaluate_package_request_artifact
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
+from ._env import _build_scrubbed_env
 from .stdio import (
     ProxyIoTimeoutError,
     _blocked_tool_response,

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -27,6 +27,7 @@ from ..mcp_tool_calls import (
     tool_call_risk_summary,
 )
 from ..models import GuardAction, HarnessDetection
+from ._env import _build_scrubbed_env
 from ..policy.engine import build_decision_v2
 from ..runtime.browser_mcp_intent import normalize_browser_mcp_intent
 from ..runtime.mcp_protection import McpServerIdentity, build_mcp_server_identity
@@ -269,6 +270,7 @@ class RuntimeMcpGuardProxy:
             stderr=None,
             text=True,
             cwd=self.context.workspace_dir,
+            env=_build_scrubbed_env(),
         )
 
     def _handle_message(

--- a/src/codex_plugin_scanner/guard/proxy/stdio.py
+++ b/src/codex_plugin_scanner/guard/proxy/stdio.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import io
 import json
-import os
 import queue
 import select
 import subprocess
@@ -30,6 +29,7 @@ from ..receipts import build_receipt
 from ..runtime.secret_file_requests import build_file_read_request_artifact, extract_sensitive_file_read_request
 from ..runtime.surface_server import GuardSurfaceRuntime
 from ..store import GuardStore
+from ._env import _build_scrubbed_env
 
 _DEFAULT_PROXY_RESPONSE_TIMEOUT_SECONDS = 30.0
 _PROXY_TERMINATION_TIMEOUT_SECONDS = 1.0
@@ -339,7 +339,7 @@ class StdioGuardProxy:
             stderr=None,
             text=True,
             cwd=self.cwd,
-            env={**os.environ, **self.env},
+            env=_build_scrubbed_env(self.env),
         )
 
     def _forward_message(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -547,6 +547,10 @@ def guard_run(
     if harness == "hermes":
         _hermes_token = _resolve_hermes_guard_access_token(store)
         if _hermes_token is not None:
+            # The token is needed by Hermes's guard_runtime_policy.py to call
+            # the Guard policy API.  It must NOT leak to user-configured MCP
+            # server subprocesses; the proxy layer scrubs it before launching
+            # those processes (see proxy._build_scrubbed_env).
             environment["HERMES_GUARD_TOKEN"] = _hermes_token
     try:
         result = subprocess.run(command, cwd=context.workspace_dir or Path.cwd(), check=False, env=environment)

--- a/tests/test_guard_proxy_env_scrubbing.py
+++ b/tests/test_guard_proxy_env_scrubbing.py
@@ -1,0 +1,107 @@
+"""Tests that Guard-internal tokens are scrubbed from subprocess environments.
+
+The proxy launches user-configured MCP server commands, which are an
+attacker-controlled surface.  Guard-internal tokens (e.g. HERMES_GUARD_TOKEN)
+must never leak into those subprocesses.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from codex_plugin_scanner.guard.proxy._env import _GUARD_TOKEN_ENV_VARS, _build_scrubbed_env
+
+
+class TestBuildScrubbedEnv:
+    """Unit tests for _build_scrubbed_env."""
+
+    def test_hermes_guard_token_is_removed(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_GUARD_TOKEN", "secret-oauth-token-12345")
+        env = _build_scrubbed_env()
+        assert "HERMES_GUARD_TOKEN" not in env
+
+    def test_non_token_vars_are_preserved(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_GUARD_TOKEN", "secret")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        monkeypatch.setenv("HOME", "/tmp/test")
+        env = _build_scrubbed_env()
+        assert env["PATH"] == "/usr/bin:/bin"
+        assert env["HOME"] == "/tmp/test"
+
+    def test_extra_env_is_merged(self) -> None:
+        env = _build_scrubbed_env({"MCP_SERVER_PORT": "8080"})
+        assert env["MCP_SERVER_PORT"] == "8080"
+
+    def test_no_extra_returns_clean_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("HERMES_GUARD_TOKEN", "secret")
+        env = _build_scrubbed_env()
+        assert isinstance(env, dict)
+        assert "HERMES_GUARD_TOKEN" not in env
+
+    def test_guard_token_env_vars_constant_contents(self) -> None:
+        assert _GUARD_TOKEN_ENV_VARS == ("HERMES_GUARD_TOKEN",)
+
+
+class TestStdioProxyScrubbing:
+    """Integration test: StdioGuardProxy._start_process uses scrubbed env."""
+
+    def test_stdio_proxy_scrubs_hermes_guard_token(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Verify that _start_process strips HERMES_GUARD_TOKEN from the child env."""
+        from codex_plugin_scanner.guard.proxy.stdio import StdioGuardProxy
+
+        monkeypatch.setenv("HERMES_GUARD_TOKEN", "leak-me-please")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        captured_env: dict[str, str] = {}
+
+        class FakePopen:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                captured_env.update(kwargs.get("env", {}))
+                self.stdin = None
+                self.stdout = None
+                self.returncode = 0
+
+            def poll(self) -> int:
+                return 0
+
+            def wait(self, timeout: float | None = None) -> int:
+                return 0
+
+            def terminate(self) -> None:
+                pass
+
+        with mock.patch("codex_plugin_scanner.guard.proxy.stdio.subprocess.Popen", FakePopen):
+            proxy = StdioGuardProxy(
+                command=["echo", "hello"],
+                cwd=tmp_path,
+            )
+            proxy._start_process()
+
+        assert "HERMES_GUARD_TOKEN" not in captured_env, (
+            "HERMES_GUARD_TOKEN leaked into stdio proxy subprocess env"
+        )
+        assert captured_env.get("PATH") == "/usr/bin:/bin"
+
+
+class TestRuntimeMcpProxyScrubbing:
+    """Integration test: RuntimeMcpGuardProxy._start_process uses scrubbed env."""
+
+    def test_runtime_mcp_proxy_passes_explicit_scrubbed_env(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """Verify _start_process passes env=_build_scrubbed_env() to subprocess.Popen."""
+        import inspect
+
+        from codex_plugin_scanner.guard.proxy.runtime_mcp import RuntimeMcpGuardProxy
+
+        source = inspect.getsource(RuntimeMcpGuardProxy._start_process)
+        assert "env=_build_scrubbed_env()" in source, (
+            "RuntimeMcpGuardProxy._start_process must pass env=_build_scrubbed_env() "
+            "to subprocess.Popen — without it, os.environ (including inherited "
+            "HERMES_GUARD_TOKEN) leaks to user MCP servers"
+        )

--- a/tests/test_guard_proxy_env_scrubbing.py
+++ b/tests/test_guard_proxy_env_scrubbing.py
@@ -35,6 +35,12 @@ class TestBuildScrubbedEnv:
         env = _build_scrubbed_env({"MCP_SERVER_PORT": "8080"})
         assert env["MCP_SERVER_PORT"] == "8080"
 
+    def test_extra_env_cannot_reinject_token(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Tokens in extra are also scrubbed — defense-in-depth against re-injection."""
+        monkeypatch.setenv("HERMES_GUARD_TOKEN", "secret")
+        env = _build_scrubbed_env({"HERMES_GUARD_TOKEN": "still-secret"})
+        assert "HERMES_GUARD_TOKEN" not in env, "Caller-provided extra env must not re-inject scrubbed tokens"
+
     def test_no_extra_returns_clean_dict(self, monkeypatch: pytest.MonkeyPatch) -> None:
         monkeypatch.setenv("HERMES_GUARD_TOKEN", "secret")
         env = _build_scrubbed_env()
@@ -48,9 +54,7 @@ class TestBuildScrubbedEnv:
 class TestStdioProxyScrubbing:
     """Integration test: StdioGuardProxy._start_process uses scrubbed env."""
 
-    def test_stdio_proxy_scrubs_hermes_guard_token(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
+    def test_stdio_proxy_scrubs_hermes_guard_token(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """Verify that _start_process strips HERMES_GUARD_TOKEN from the child env."""
         from codex_plugin_scanner.guard.proxy.stdio import StdioGuardProxy
 
@@ -82,26 +86,63 @@ class TestStdioProxyScrubbing:
             )
             proxy._start_process()
 
-        assert "HERMES_GUARD_TOKEN" not in captured_env, (
-            "HERMES_GUARD_TOKEN leaked into stdio proxy subprocess env"
-        )
+        assert "HERMES_GUARD_TOKEN" not in captured_env, "HERMES_GUARD_TOKEN leaked into stdio proxy subprocess env"
         assert captured_env.get("PATH") == "/usr/bin:/bin"
 
 
 class TestRuntimeMcpProxyScrubbing:
     """Integration test: RuntimeMcpGuardProxy._start_process uses scrubbed env."""
 
-    def test_runtime_mcp_proxy_passes_explicit_scrubbed_env(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-    ) -> None:
-        """Verify _start_process passes env=_build_scrubbed_env() to subprocess.Popen."""
-        import inspect
-
+    def test_runtime_mcp_proxy_scrubs_hermes_guard_token(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Verify that _start_process strips HERMES_GUARD_TOKEN from the child env."""
+        from codex_plugin_scanner.guard.adapters.base import HarnessContext
         from codex_plugin_scanner.guard.proxy.runtime_mcp import RuntimeMcpGuardProxy
 
-        source = inspect.getsource(RuntimeMcpGuardProxy._start_process)
-        assert "env=_build_scrubbed_env()" in source, (
-            "RuntimeMcpGuardProxy._start_process must pass env=_build_scrubbed_env() "
-            "to subprocess.Popen — without it, os.environ (including inherited "
-            "HERMES_GUARD_TOKEN) leaks to user MCP servers"
+        monkeypatch.setenv("HERMES_GUARD_TOKEN", "leak-me-please")
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+
+        captured_env: dict[str, str] = {}
+
+        class FakePopen:
+            def __init__(self, *args: object, **kwargs: object) -> None:
+                captured_env.update(kwargs.get("env", {}))
+                self.stdin = None
+                self.stdout = None
+                self.returncode = 0
+
+            def poll(self) -> int:
+                return 0
+
+            def wait(self, timeout: float | None = None) -> int:
+                return 0
+
+            def terminate(self) -> None:
+                pass
+
+        context = HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=tmp_path,
+            guard_home=tmp_path,
         )
+
+        # Build minimal mocks for required constructor args
+        store = type("MockStore", (), {"get_managed_install": lambda self, h: None})()
+        config = type("MockConfig", (), {})()
+
+        with mock.patch("codex_plugin_scanner.guard.proxy.runtime_mcp.subprocess.Popen", FakePopen):
+            proxy = RuntimeMcpGuardProxy(
+                harness="codex",
+                server_name="test",
+                command=["echo", "hello"],
+                context=context,
+                store=store,
+                config=config,
+                source_scope="project",
+                config_path=str(tmp_path / ".mcp.json"),
+            )
+            proxy._start_process()
+
+        assert "HERMES_GUARD_TOKEN" not in captured_env, (
+            "HERMES_GUARD_TOKEN leaked into runtime_mcp proxy subprocess env"
+        )
+        assert captured_env.get("PATH") == "/usr/bin:/bin"


### PR DESCRIPTION
## Summary

Fixes a High severity Codex Security finding: **Hermes Guard token leaks to MCP subprocesses**.

The Hermes runtime support resolves the Guard OAuth access token and sets it as `HERMES_GUARD_TOKEN` in the environment used to launch Hermes. That environment is process-wide, so Hermes children inherit it. In the Guard-managed Hermes MCP path, Hermes launches the Guard MCP proxy, and the proxy then starts the user-configured MCP server with `env={**os.environ, **self.env}`. Because `os.environ` in the proxy process can contain `HERMES_GUARD_TOKEN`, an attacker-controlled MCP server command can read and exfiltrate the Guard OAuth access token.

MCP server definitions are part of the repository's documented attacker-controlled surface, so this creates a token disclosure path when a user runs Hermes through Guard with a malicious or compromised MCP server configured.

## Fix

Scrub `HERMES_GUARD_TOKEN` from the env dict at the proxy boundary before launching user-configured MCP server subprocesses. The proxy is the trust boundary between Guard-internal processes and user-controlled commands.

- **`proxy/_env.py`** (new): `_build_scrubbed_env()` helper + `_GUARD_TOKEN_ENV_VARS` constant. Strips `HERMES_GUARD_TOKEN` from `os.environ` before merging caller-provided extras.
- **`proxy/stdio.py`**: `_start_process` now uses `_build_scrubbed_env(self.env)` instead of `{**os.environ, **self.env}`.
- **`proxy/runtime_mcp.py`**: `_start_process` now passes `env=_build_scrubbed_env()` explicitly (previously inherited `os.environ` by default, which also leaked the token).
- **`runtime/runner.py`**: Documents the trust boundary — the token is needed by Hermes for policy API calls, and the proxy scrubs it before reaching user MCP servers.

## Test plan

- [x] `tests/test_guard_proxy_env_scrubbing.py` — 7 tests covering scrubbing logic, stdio proxy integration, and runtime_mcp proxy integration
- [x] `ruff check src/codex_plugin_scanner/guard/proxy/ --select=F401,F811,F841` — clean
- [x] `ruff format --check src/codex_plugin_scanner/guard/proxy/` — clean
- [x] Existing proxy tests pass (39/39 in `test_guard_codex_proxy.py`)
- [x] Pre-existing test failures in `test_guard_runtime.py` confirmed on `main` (unrelated)