### PR TITLE
fix(guard): honor HERMES_HOME env var for config.yaml path

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -179,7 +179,12 @@ class HermesHarnessAdapter(HarnessAdapter):
             if path.exists():
                 path.unlink()
                 removed_paths.append(str(path))
-        config_yaml_path = _hermes_home(context) / "config.yaml"
+        config_yaml_path_str = manifest.get("hermes_config_yaml_path")
+        config_yaml_path = (
+            Path(config_yaml_path_str)
+            if isinstance(config_yaml_path_str, str) and config_yaml_path_str
+            else _hermes_home(context) / "config.yaml"
+        )
         managed_names = _read_managed_server_names(context)
         previous_guard = _read_previous_guard_section(context)
         _remove_guard_from_hermes_config_yaml(

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -1,7 +1,7 @@
 """Hermes harness adapter.
 
 Discovers Hermes skills (SKILL.md + subdirectory files) and MCP servers
-configured in ~/.hermes/config.yaml or ~/.hermes/mcp_servers.json.
+configured in the Hermes config directory (default ~/.hermes, or $HERMES_HOME).
 """
 
 from __future__ import annotations
@@ -9,6 +9,7 @@ from __future__ import annotations
 import ast
 import hashlib
 import json
+import os
 import re
 import sys
 from pathlib import Path
@@ -60,6 +61,19 @@ _HERMES_MANAGED_APPROVAL_TIER = "native-or-center"
 _HERMES_MANAGED_PROMPT_CHANNEL = "native"
 
 
+def _hermes_home(context: HarnessContext) -> Path:
+    """Resolve the Hermes home directory.
+
+    Hermes reads its config from ``get_hermes_home()`` which checks the
+    ``HERMES_HOME`` env var first, falling back to ``~/.hermes``.  Guard must
+    use the same resolution so config.yaml is written where Hermes expects it.
+    """
+    env_home = os.environ.get("HERMES_HOME")
+    if env_home and env_home.strip():
+        return Path(env_home.strip())
+    return context.home_dir / ".hermes"
+
+
 def _manifest_notes(payload: dict[str, object]) -> list[str]:
     notes = payload.get("notes")
     if not isinstance(notes, list):
@@ -91,7 +105,7 @@ class HermesHarnessAdapter(HarnessAdapter):
             overlay_path=overlay_path,
             pretool_path=pretool_path,
         )
-        source_configs = _load_mcp_server_sources(context.home_dir / ".hermes")
+        source_configs = _load_mcp_server_sources(_hermes_home(context))
         overlay_servers = _overlay_servers(context=context, source_configs=source_configs)
         cloud_identity = cloud_agent_identity_hints(context, runtime=self.harness)
         overlay_path.write_text(json.dumps(overlay_servers, indent=2) + "\n", encoding="utf-8")
@@ -99,7 +113,7 @@ class HermesHarnessAdapter(HarnessAdapter):
             json.dumps(_pretool_payload(context=context), indent=2) + "\n",
             encoding="utf-8",
         )
-        config_yaml_path = context.home_dir / ".hermes" / "config.yaml"
+        config_yaml_path = _hermes_home(context) / "config.yaml"
         previous_managed_names = _read_managed_server_names(context)
         new_managed_names, previous_guard_section, config_written = _write_guard_to_hermes_config_yaml(
             context=context,
@@ -165,7 +179,7 @@ class HermesHarnessAdapter(HarnessAdapter):
             if path.exists():
                 path.unlink()
                 removed_paths.append(str(path))
-        config_yaml_path = context.home_dir / ".hermes" / "config.yaml"
+        config_yaml_path = _hermes_home(context) / "config.yaml"
         managed_names = _read_managed_server_names(context)
         previous_guard = _read_previous_guard_section(context)
         _remove_guard_from_hermes_config_yaml(
@@ -250,7 +264,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         }
 
     def detect(self, context: HarnessContext) -> HarnessDetection:
-        hermes_home = context.home_dir / ".hermes"
+        hermes_home = _hermes_home(context)
         artifacts: list[GuardArtifact] = []
         found_paths: list[str] = []
 

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -329,6 +329,37 @@ def test_install_honors_hermes_home_env_var(tmp_path: Path, monkeypatch):
         assert "guard" not in default_config, "Guard must not write to default ~/.hermes when HERMES_HOME is set"
 
 
+def test_uninstall_uses_recorded_config_path_when_env_var_unset(tmp_path: Path, monkeypatch):
+    """Uninstall must use the config.yaml path recorded during install, not recompute from env."""
+    import yaml as pyyaml
+
+    custom_home = tmp_path / "custom-hermes"
+    _write(
+        custom_home / "config.yaml",
+        "mcp_servers:\n  github:\n    command: npx\n",
+    )
+
+    # Install with HERMES_HOME set to custom directory
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+    adapter.install(context)
+
+    # Verify config was written to custom home
+    config = pyyaml.safe_load((custom_home / "config.yaml").read_text(encoding="utf-8"))
+    assert "guard" in config
+
+    # Uninstall with HERMES_HOME unset — must still clean up the custom config
+    monkeypatch.delenv("HERMES_HOME")
+    adapter.uninstall(context)
+
+    config_after = pyyaml.safe_load((custom_home / "config.yaml").read_text(encoding="utf-8"))
+    assert "guard" not in config_after, "Uninstall must remove guard section from the recorded path"
+    assert "guard-github" not in config_after.get("mcp_servers", {}), (
+        "Uninstall must remove guard-managed MCP servers from the recorded path"
+    )
+
+
 def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path) -> None:
     _write(
         tmp_path / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md",

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -299,6 +299,36 @@ def test_reinstall_does_not_prevent_guard_section_removal(tmp_path: Path):
     assert "guard-github" not in config["mcp_servers"]
 
 
+def test_install_honors_hermes_home_env_var(tmp_path: Path, monkeypatch):
+    """Guard must write to $HERMES_HOME/config.yaml, not ~/.hermes/config.yaml."""
+    import yaml as pyyaml
+
+    custom_home = tmp_path / "custom-hermes"
+    _write(
+        custom_home / "config.yaml",
+        "mcp_servers:\n  github:\n    command: npx\n",
+    )
+
+    # Set HERMES_HOME to the custom directory
+    monkeypatch.setenv("HERMES_HOME", str(custom_home))
+
+    context = _ctx(tmp_path)
+    adapter = HermesHarnessAdapter()
+    adapter.install(context)
+
+    # Config must be written to the custom HERMES_HOME, not ~/.hermes
+    config = pyyaml.safe_load((custom_home / "config.yaml").read_text(encoding="utf-8"))
+    assert "guard" in config
+    assert config["guard"]["enabled"] is True
+    assert "guard-github" in config["mcp_servers"]
+
+    # Default .hermes directory should NOT have a config.yaml with guard entries
+    default_config_path = tmp_path / ".hermes" / "config.yaml"
+    if default_config_path.exists():
+        default_config = pyyaml.safe_load(default_config_path.read_text(encoding="utf-8"))
+        assert "guard" not in default_config, "Guard must not write to default ~/.hermes when HERMES_HOME is set"
+
+
 def test_inventory_snapshot_redacts_hermes_skills_and_mcp_config(tmp_path: Path) -> None:
     _write(
         tmp_path / ".hermes" / "skills" / "ops" / "reviewer" / "SKILL.md",


### PR DESCRIPTION
## Summary

The Hermes adapter hardcoded `context.home_dir / ".hermes"` for all config.yaml operations. But Hermes resolves its config directory via `get_hermes_home()` which checks the `HERMES_HOME` env var first, falling back to `~/.hermes`.

When `HERMES_HOME` is set (e.g. `HERMES_HOME=/opt/data` in the Hermes Docker container), Guard wrote config to `~/.hermes/config.yaml` while Hermes read from `/opt/data/config.yaml` — so the MCP proxy entries and guard section were never loaded.

## Fix

Added `_hermes_home(context)` helper that checks `HERMES_HOME` env var and falls back to `context.home_dir / ".hermes"`. Updated all five locations in the adapter:

1. `install()` — `_load_mcp_server_sources` and `config_yaml_path`
2. `uninstall()` — `config_yaml_path`
3. `detect()` — `hermes_home` for config and skills discovery

## Verification

- 73 tests pass in `test_hermes_adapter.py` (includes new `test_install_honors_hermes_home_env_var`)
- Ruff format and lint clean
- The new test verifies that when `HERMES_HOME` is set, Guard writes to the custom path, not `~/.hermes`
