### PR TITLE
fix(guard): cap cloud request snapshot payloads

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -73,6 +73,8 @@ COMMAND_OPERATION_SCHEMA_VERSIONS: dict[str, int] = {operation: 1 for operation 
 LOCAL_REQUEST_PENDING_SNAPSHOT_LIMIT = 200
 LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT = 50
 LOCAL_REQUEST_SNAPSHOT_MAX_BYTES = 600_000
+LOCAL_REQUEST_SNAPSHOT_MAX_STRING_CHARS = 2_000
+LOCAL_REQUEST_SNAPSHOT_MAX_LIST_ITEMS = 20
 
 
 def execute_guard_command_job(
@@ -472,11 +474,67 @@ def _local_request_snapshot_byte_capped_items(
     for item in items:
         item_bytes = len(json.dumps(item, separators=(",", ":"), sort_keys=True).encode("utf-8"))
         separator_bytes = 1 if selected else 0
-        if selected and used_bytes + separator_bytes + item_bytes > max_bytes:
+        if used_bytes + separator_bytes + item_bytes > max_bytes:
+            if not selected:
+                compact_item = _compact_local_request_snapshot_item(item)
+                compact_bytes = len(
+                    json.dumps(compact_item, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+                )
+                if used_bytes + compact_bytes <= max_bytes:
+                    selected.append(compact_item)
             return selected, False
         selected.append(item)
         used_bytes += separator_bytes + item_bytes
     return selected, True
+
+
+def _compact_local_request_snapshot_item(item: dict[str, object]) -> dict[str, object]:
+    compact = {
+        key: _compact_local_request_snapshot_value(value)
+        for key, value in item.items()
+    }
+    compact_bytes = len(json.dumps(compact, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+    if compact_bytes <= LOCAL_REQUEST_SNAPSHOT_MAX_BYTES:
+        return compact
+    safe_keys = (
+        "localRequestId",
+        "status",
+        "harness",
+        "artifactId",
+        "artifactName",
+        "artifactType",
+        "policyAction",
+        "recommendedScope",
+        "createdAt",
+        "lastSeenAt",
+        "riskHeadline",
+        "riskSummary",
+        "rawCommandText",
+        "reviewCommand",
+    )
+    return {
+        key: compact[key]
+        for key in safe_keys
+        if key in compact
+    }
+
+
+def _compact_local_request_snapshot_value(value: object) -> object:
+    if isinstance(value, str):
+        if len(value) <= LOCAL_REQUEST_SNAPSHOT_MAX_STRING_CHARS:
+            return value
+        return f"{value[:LOCAL_REQUEST_SNAPSHOT_MAX_STRING_CHARS]}...[truncated]"
+    if isinstance(value, list):
+        return [
+            _compact_local_request_snapshot_value(item)
+            for item in value[:LOCAL_REQUEST_SNAPSHOT_MAX_LIST_ITEMS]
+        ]
+    if isinstance(value, dict):
+        return {
+            str(key): _compact_local_request_snapshot_value(item)
+            for key, item in value.items()
+        }
+    return value
 
 
 def _local_request_snapshot_items_for_status(

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import tempfile
 from collections.abc import Callable
 from datetime import datetime, timezone
@@ -69,8 +70,9 @@ APPROVAL_OPERATIONS: tuple[str, ...] = (
 )
 SUPPORTED_COMMAND_OPERATIONS: tuple[str, ...] = (*PACKAGE_SHIM_OPERATIONS, *APP_OPERATIONS, *APPROVAL_OPERATIONS)
 COMMAND_OPERATION_SCHEMA_VERSIONS: dict[str, int] = {operation: 1 for operation in SUPPORTED_COMMAND_OPERATIONS}
-LOCAL_REQUEST_PENDING_SNAPSHOT_LIMIT = 10_000
-LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT = 500
+LOCAL_REQUEST_PENDING_SNAPSHOT_LIMIT = 200
+LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT = 50
+LOCAL_REQUEST_SNAPSHOT_MAX_BYTES = 600_000
 
 
 def execute_guard_command_job(
@@ -444,15 +446,37 @@ def _local_request_snapshot_payload(store: GuardStore) -> dict[str, object]:
         status="resolved",
         limit=LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT,
     )
+    requests, byte_complete = _local_request_snapshot_byte_capped_items(
+        [*pending_items, *resolved_items],
+        max_bytes=LOCAL_REQUEST_SNAPSHOT_MAX_BYTES,
+    )
     return {
-        "requests": [*pending_items, *resolved_items],
-        "pendingComplete": pending_complete,
-        "resolvedComplete": resolved_complete,
+        "requests": requests,
+        "pendingComplete": pending_complete and byte_complete,
+        "resolvedComplete": resolved_complete and byte_complete,
         "pendingLimit": LOCAL_REQUEST_PENDING_SNAPSHOT_LIMIT,
         "resolvedLimit": LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT,
         "pendingCount": len(pending_items),
         "resolvedCount": len(resolved_items),
     }
+
+
+def _local_request_snapshot_byte_capped_items(
+    items: list[dict[str, object]],
+    *,
+    max_bytes: int,
+) -> tuple[list[dict[str, object]], bool]:
+    selected: list[dict[str, object]] = []
+    base_bytes = len(b'{"requests":[]}')
+    used_bytes = base_bytes
+    for item in items:
+        item_bytes = len(json.dumps(item, separators=(",", ":"), sort_keys=True).encode("utf-8"))
+        separator_bytes = 1 if selected else 0
+        if selected and used_bytes + separator_bytes + item_bytes > max_bytes:
+            return selected, False
+        selected.append(item)
+        used_bytes += separator_bytes + item_bytes
+    return selected, True
 
 
 def _local_request_snapshot_items_for_status(

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -489,10 +489,7 @@ def _local_request_snapshot_byte_capped_items(
 
 
 def _compact_local_request_snapshot_item(item: dict[str, object]) -> dict[str, object]:
-    compact = {
-        key: _compact_local_request_snapshot_value(value)
-        for key, value in item.items()
-    }
+    compact = {key: _compact_local_request_snapshot_value(value) for key, value in item.items()}
     compact_bytes = len(json.dumps(compact, separators=(",", ":"), sort_keys=True).encode("utf-8"))
     if compact_bytes <= LOCAL_REQUEST_SNAPSHOT_MAX_BYTES:
         return compact
@@ -512,11 +509,7 @@ def _compact_local_request_snapshot_item(item: dict[str, object]) -> dict[str, o
         "rawCommandText",
         "reviewCommand",
     )
-    return {
-        key: compact[key]
-        for key in safe_keys
-        if key in compact
-    }
+    return {key: compact[key] for key in safe_keys if key in compact}
 
 
 def _compact_local_request_snapshot_value(value: object) -> object:
@@ -525,15 +518,9 @@ def _compact_local_request_snapshot_value(value: object) -> object:
             return value
         return f"{value[:LOCAL_REQUEST_SNAPSHOT_MAX_STRING_CHARS]}...[truncated]"
     if isinstance(value, list):
-        return [
-            _compact_local_request_snapshot_value(item)
-            for item in value[:LOCAL_REQUEST_SNAPSHOT_MAX_LIST_ITEMS]
-        ]
+        return [_compact_local_request_snapshot_value(item) for item in value[:LOCAL_REQUEST_SNAPSHOT_MAX_LIST_ITEMS]]
     if isinstance(value, dict):
-        return {
-            str(key): _compact_local_request_snapshot_value(item)
-            for key, item in value.items()
-        }
+        return {str(key): _compact_local_request_snapshot_value(item) for key, item in value.items()}
     return value
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -448,14 +448,15 @@ def _local_request_snapshot_payload(store: GuardStore) -> dict[str, object]:
         status="resolved",
         limit=LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT,
     )
-    requests, byte_complete = _local_request_snapshot_byte_capped_items(
-        [*pending_items, *resolved_items],
+    requests, pending_byte_complete, resolved_byte_complete = _local_request_snapshot_byte_capped_statuses(
+        pending_items,
+        resolved_items,
         max_bytes=LOCAL_REQUEST_SNAPSHOT_MAX_BYTES,
     )
     return {
         "requests": requests,
-        "pendingComplete": pending_complete and byte_complete,
-        "resolvedComplete": resolved_complete and byte_complete,
+        "pendingComplete": pending_complete and pending_byte_complete,
+        "resolvedComplete": resolved_complete and resolved_byte_complete,
         "pendingLimit": LOCAL_REQUEST_PENDING_SNAPSHOT_LIMIT,
         "resolvedLimit": LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT,
         "pendingCount": len(pending_items),
@@ -463,28 +464,57 @@ def _local_request_snapshot_payload(store: GuardStore) -> dict[str, object]:
     }
 
 
+def _local_request_snapshot_byte_capped_statuses(
+    pending_items: list[dict[str, object]],
+    resolved_items: list[dict[str, object]],
+    *,
+    max_bytes: int,
+) -> tuple[list[dict[str, object]], bool, bool]:
+    selected, pending_complete = _local_request_snapshot_byte_capped_items(
+        pending_items,
+        max_bytes=max_bytes,
+    )
+    if not pending_complete:
+        return selected, False, False
+
+    selected, resolved_complete = _local_request_snapshot_byte_capped_items(
+        resolved_items,
+        existing_items=selected,
+        max_bytes=max_bytes,
+    )
+    return selected, True, resolved_complete
+
+
 def _local_request_snapshot_byte_capped_items(
     items: list[dict[str, object]],
     *,
     max_bytes: int,
+    existing_items: list[dict[str, object]] | None = None,
 ) -> tuple[list[dict[str, object]], bool]:
-    selected: list[dict[str, object]] = []
-    base_bytes = len(b'{"requests":[]}')
-    used_bytes = base_bytes
+    selected: list[dict[str, object]] = list(existing_items or [])
+    initial_len = len(selected)
     for item in items:
-        item_bytes = len(json.dumps(item, separators=(",", ":"), sort_keys=True).encode("utf-8"))
-        separator_bytes = 1 if selected else 0
-        if used_bytes + separator_bytes + item_bytes > max_bytes:
-            if not selected:
+        candidate = [*selected, item]
+        candidate_bytes = len(
+            json.dumps({"requests": candidate}, separators=(",", ":"), sort_keys=True).encode(
+                "utf-8",
+            ),
+        )
+        if candidate_bytes > max_bytes:
+            if len(selected) == initial_len:
                 compact_item = _compact_local_request_snapshot_item(item)
+                compact_candidate = [*selected, compact_item]
                 compact_bytes = len(
-                    json.dumps(compact_item, separators=(",", ":"), sort_keys=True).encode("utf-8"),
+                    json.dumps(
+                        {"requests": compact_candidate},
+                        separators=(",", ":"),
+                        sort_keys=True,
+                    ).encode("utf-8"),
                 )
-                if used_bytes + compact_bytes <= max_bytes:
+                if compact_bytes <= max_bytes:
                     selected.append(compact_item)
             return selected, False
         selected.append(item)
-        used_bytes += separator_bytes + item_bytes
     return selected, True
 
 

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -404,6 +404,63 @@ def test_local_request_snapshot_payload_marks_pending_incomplete_when_truncated(
     ]
 
 
+def test_local_request_snapshot_payload_keeps_pending_complete_when_resolved_truncated(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class StatusSplitStore(FakeStore):
+        def list_approval_requests(
+            self,
+            status: str | None = "pending",
+            harness: str | None = None,
+            limit: int | None = 50,
+            cursor: str | None = None,
+        ) -> list[dict[str, object]]:
+            del harness, cursor
+            if status == "pending":
+                rows = [_approval_request_row("req-pending-0")]
+            elif status == "resolved":
+                rows = [
+                    {
+                        **_approval_request_row("req-resolved-0"),
+                        "status": "resolved",
+                        "resolved_at": "2026-07-02T12:00:00+00:00",
+                        "action_envelope_json": {
+                            "action_type": "shell_command",
+                            "command": "x" * 20_000,
+                            "tool_name": "Bash",
+                        },
+                    }
+                ]
+            else:
+                rows = []
+            return rows if limit is None else rows[:limit]
+
+    store = StatusSplitStore(tmp_path / "guard-home")
+    pending_items, pending_complete = command_executors._local_request_snapshot_items_for_status(
+        store,
+        status="pending",
+        limit=command_executors.LOCAL_REQUEST_PENDING_SNAPSHOT_LIMIT,
+    )
+    pending_only_bytes = len(
+        json.dumps({"requests": pending_items}, separators=(",", ":"), sort_keys=True).encode(
+            "utf-8",
+        ),
+    )
+    monkeypatch.setattr(
+        command_executors,
+        "LOCAL_REQUEST_SNAPSHOT_MAX_BYTES",
+        pending_only_bytes + 512,
+    )
+
+    payload = command_executors._local_request_snapshot_payload(store)
+
+    assert pending_complete is True
+    assert payload["pendingComplete"] is True
+    assert payload["resolvedComplete"] is False
+    assert [item["localRequestId"] for item in payload["requests"]] == ["req-pending-0"]
+
+
 def test_local_request_snapshot_byte_cap_truncates_large_payloads() -> None:
     items = [{"localRequestId": f"req-large-{index}", "rawCommandText": "x" * 12_000} for index in range(400)]
 

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -421,6 +421,32 @@ def test_local_request_snapshot_byte_cap_truncates_large_payloads() -> None:
     assert 0 < len(selected) < len(items)
 
 
+def test_local_request_snapshot_byte_cap_compacts_oversized_first_item() -> None:
+    items = [
+        {
+            "localRequestId": "req-oversized",
+            "status": "pending",
+            "harness": "cursor",
+            "rawCommandText": "x" * (command_executors.LOCAL_REQUEST_SNAPSHOT_MAX_BYTES + 100_000),
+            "actionEnvelope": {
+                "command": "y" * (command_executors.LOCAL_REQUEST_SNAPSHOT_MAX_BYTES + 100_000),
+            },
+        },
+        {"localRequestId": "req-next"},
+    ]
+
+    selected, complete = command_executors._local_request_snapshot_byte_capped_items(
+        items,
+        max_bytes=command_executors.LOCAL_REQUEST_SNAPSHOT_MAX_BYTES,
+    )
+    encoded = json.dumps({"requests": selected}, separators=(",", ":")).encode("utf-8")
+
+    assert len(encoded) <= command_executors.LOCAL_REQUEST_SNAPSHOT_MAX_BYTES
+    assert complete is False
+    assert [item["localRequestId"] for item in selected] == ["req-oversized"]
+    assert str(selected[0]["rawCommandText"]).endswith("...[truncated]")
+
+
 def test_local_request_snapshot_operation_uses_complete_payload(tmp_path: Path) -> None:
     class ManyPendingStore(FakeStore):
         def list_approval_requests(

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -345,7 +345,7 @@ def test_local_request_snapshot_payload_includes_complete_pending_backlog(tmp_pa
         ) -> list[dict[str, object]]:
             del harness, cursor
             if status == "pending":
-                rows = [_approval_request_row(f"req-pending-{index}") for index in range(225)]
+                rows = [_approval_request_row(f"req-pending-{index}") for index in range(125)]
             elif status == "resolved":
                 rows = [
                     {
@@ -363,12 +363,12 @@ def test_local_request_snapshot_payload_includes_complete_pending_backlog(tmp_pa
 
     assert payload["pendingComplete"] is True
     assert payload["resolvedComplete"] is True
-    assert payload["pendingCount"] == 225
+    assert payload["pendingCount"] == 125
     assert payload["resolvedCount"] == 3
-    assert len(payload["requests"]) == 228
+    assert len(payload["requests"]) == 128
     assert {item["localRequestId"] for item in payload["requests"]} >= {
         "req-pending-0",
-        "req-pending-224",
+        "req-pending-124",
         "req-resolved-2",
     }
 
@@ -404,6 +404,23 @@ def test_local_request_snapshot_payload_marks_pending_incomplete_when_truncated(
     ]
 
 
+def test_local_request_snapshot_byte_cap_truncates_large_payloads() -> None:
+    items = [
+        {"localRequestId": f"req-large-{index}", "rawCommandText": "x" * 12_000}
+        for index in range(400)
+    ]
+
+    selected, complete = command_executors._local_request_snapshot_byte_capped_items(
+        items,
+        max_bytes=command_executors.LOCAL_REQUEST_SNAPSHOT_MAX_BYTES,
+    )
+    encoded = json.dumps({"requests": selected}, separators=(",", ":")).encode("utf-8")
+
+    assert len(encoded) <= command_executors.LOCAL_REQUEST_SNAPSHOT_MAX_BYTES
+    assert complete is False
+    assert 0 < len(selected) < len(items)
+
+
 def test_local_request_snapshot_operation_uses_complete_payload(tmp_path: Path) -> None:
     class ManyPendingStore(FakeStore):
         def list_approval_requests(
@@ -417,7 +434,7 @@ def test_local_request_snapshot_operation_uses_complete_payload(tmp_path: Path) 
         ) -> list[dict[str, object]]:
             del harness, cursor, search
             if status == "pending":
-                rows = [_approval_request_row(f"req-pending-{index}") for index in range(225)]
+                rows = [_approval_request_row(f"req-pending-{index}") for index in range(125)]
                 return rows if limit is None else rows[:limit]
             if status == "resolved":
                 rows = [_approval_request_row("req-resolved")]
@@ -435,11 +452,11 @@ def test_local_request_snapshot_operation_uses_complete_payload(tmp_path: Path) 
 
     assert payload["pendingComplete"] is True
     assert payload["resolvedComplete"] is True
-    assert payload["pendingCount"] == 225
-    assert len(payload["requests"]) == 226
+    assert payload["pendingCount"] == 125
+    assert len(payload["requests"]) == 126
     assert payload["requests"][0]["localRequestId"] == "req-pending-0"
-    assert payload["requests"][224]["localRequestId"] == "req-pending-224"
-    assert payload["requests"][225]["localRequestId"] == "req-resolved"
+    assert payload["requests"][124]["localRequestId"] == "req-pending-124"
+    assert payload["requests"][125]["localRequestId"] == "req-resolved"
 
 
 def test_local_request_snapshot_items_continues_when_request_claim_is_invalid(tmp_path: Path) -> None:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -405,10 +405,7 @@ def test_local_request_snapshot_payload_marks_pending_incomplete_when_truncated(
 
 
 def test_local_request_snapshot_byte_cap_truncates_large_payloads() -> None:
-    items = [
-        {"localRequestId": f"req-large-{index}", "rawCommandText": "x" * 12_000}
-        for index in range(400)
-    ]
+    items = [{"localRequestId": f"req-large-{index}", "rawCommandText": "x" * 12_000} for index in range(400)]
 
     selected, complete = command_executors._local_request_snapshot_byte_capped_items(
         items,
@@ -1857,6 +1854,7 @@ def test_executor_ignores_stale_remote_approval_request_id(tmp_path: Path) -> No
     assert result["failureCode"] == "remote_approval_request_id_mismatch"
     assert store.claimed_receipts == []
 
+
 def test_executor_releases_remote_once_receipt_when_resolution_not_applied(tmp_path: Path) -> None:
     class ApprovalStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
@@ -2135,6 +2133,7 @@ def test_executor_rejects_overbroad_signed_allow_memory_rules(tmp_path: Path) ->
     assert result["data"]["decisionMemoryAck"]["rejectedRuleIds"] == ["review-memory:receipt-team"]
     assert store.policies == [([], "2026-06-13T00:00:00+00:00", True)]
     assert store.get_sync_payload("guard_review_memory_policy_version") is None
+
 
 def test_executor_rejects_tampered_decision_memory_bundle_hash(tmp_path: Path) -> None:
     store = _oauth_store(tmp_path)


### PR DESCRIPTION
- Cap local request snapshots sent with command queue lease polling so large pending approval backlogs sync in bounded payloads instead of failing at the HTTP edge.
- Keep the existing snapshot wire schema while marking incomplete snapshots for later polls when count or byte limits truncate the batch.
- Add regression coverage for byte-capped snapshots and updated queue lease payload expectations.

Verification:
- `PYTHONPATH=src python3 -m pytest tests/test_guard_command_queue.py -k 'local_request_snapshot or poll_once' -q`
