### PR TITLE
fix(guard): sync runtime session after remote-pair

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/remote_pair_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/remote_pair_flow.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
 import re
@@ -21,6 +22,7 @@ from ..remote_pairing_constants import (
     REMOTE_PAIRING_CODE_MIN_LENGTH,
     REMOTE_PAIRING_CODE_PREFIX,
 )
+from ..runtime.runner import sync_runtime_session
 from ..store import GuardStore
 from .connect_flow import (
     CONNECT_REPAIR_COMMAND,
@@ -262,6 +264,38 @@ def build_remote_pair_status_payload(
     )
 
 
+def _sync_runtime_session_after_pair(
+    store: GuardStore,
+    *,
+    runtime: str,
+    label: str,
+) -> None:
+    """Best-effort runtime session sync so the agent appears in Guard Cloud immediately.
+
+    The remote-pair flow installs local protection but previously never pushed a runtime
+    session to Guard Cloud.  The protect dashboard reads runtime sessions to determine
+    which harnesses are "connected".  Without this sync the dashboard shows the agent as
+    unconnected even though the local install succeeded.
+
+    Failures are swallowed so that a transient network error does not roll back a
+    successful pairing.  The daemon's periodic sync will retry.
+    """
+    with contextlib.suppress(Exception):
+        sync_runtime_session(
+            store,
+            session={
+                "harness": runtime,
+                "surface": "remote-pair",
+                "status": "active",
+                "client_name": runtime,
+                "client_title": label,
+                "client_version": None,
+                "workspace": "remote-agent",
+                "capabilities": ["hosted-runtime", "guard-cloud-sync"],
+            },
+        )
+
+
 def run_guard_remote_pair_command(
     *,
     store: GuardStore,
@@ -351,6 +385,8 @@ def run_guard_remote_pair_command(
         warnings = verification_block.get("warnings")
         if isinstance(warnings, list) and warnings:
             protection_reason = str(warnings[0])
+
+    _sync_runtime_session_after_pair(store, runtime=runtime, label=resolved_label)
 
     sync_url = _oauth_sync_url_from_issuer(oauth_client.issuer)
     return _sanitize_remote_pair_payload(

--- a/tests/test_guard_remote_pair_flow.py
+++ b/tests/test_guard_remote_pair_flow.py
@@ -323,3 +323,118 @@ def test_claim_remote_pairing_intent_surfaces_api_error(monkeypatch: pytest.Monk
             public_dpop_jwk={"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"},
             urlopen=fake_urlopen,
         )
+
+
+def test_run_guard_remote_pair_command_syncs_runtime_session(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Remote-pair must push a runtime session to Guard Cloud so the protect dashboard shows it."""
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.remote_pair_flow.os.geteuid",
+        lambda: 1000,
+        raising=False,
+    )
+
+    def fake_claim(**_kwargs: object) -> dict[str, object]:
+        return {
+            "intentId": "intent-42",
+            "state": "connected",
+            "tokens": {
+                "access_token": _fake_access_token(),
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "refresh-token-value",
+                "scope": "guard:runtime.sync guard:offline_access",
+            },
+        }
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.remote_pair_flow.claim_remote_pairing_intent",
+        fake_claim,
+    )
+
+    captured_sessions: list[dict[str, object]] = []
+
+    def fake_sync(store_arg, *, session):
+        captured_sessions.append(dict(session))
+        return {"synced_at": "2025-01-01T00:00:00Z", "runtime_session_id": "rt-1"}
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.remote_pair_flow.sync_runtime_session",
+        fake_sync,
+    )
+
+    payload = run_guard_remote_pair_command(
+        store=store,
+        context=context,
+        connect_url="https://hol.org/guard/connect",
+        runtime="hermes",
+        pair_code="HLG-7K3D29",
+        label="Hosted Hermes",
+        no_root=True,
+    )
+
+    assert payload["status"] == "connected"
+    assert len(captured_sessions) == 1
+    session = captured_sessions[0]
+    assert session["harness"] == "hermes"
+    assert session["status"] == "active"
+    assert session["surface"] == "remote-pair"
+    assert session["client_title"] == "Hosted Hermes"
+
+
+def test_run_guard_remote_pair_command_swallows_sync_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A transient sync failure must not roll back a successful pairing."""
+    context = _context(tmp_path)
+    store = GuardStore(context.guard_home)
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.remote_pair_flow.os.geteuid",
+        lambda: 1000,
+        raising=False,
+    )
+
+    def fake_claim(**_kwargs: object) -> dict[str, object]:
+        return {
+            "intentId": "intent-42",
+            "state": "connected",
+            "tokens": {
+                "access_token": _fake_access_token(),
+                "token_type": "Bearer",
+                "expires_in": 3600,
+                "refresh_token": "refresh-token-value",
+                "scope": "guard:runtime.sync guard:offline_access",
+            },
+        }
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.remote_pair_flow.claim_remote_pairing_intent",
+        fake_claim,
+    )
+
+    def fake_sync(_store, *, _session):
+        raise RuntimeError("network is down")
+
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.cli.remote_pair_flow.sync_runtime_session",
+        fake_sync,
+    )
+
+    payload = run_guard_remote_pair_command(
+        store=store,
+        context=context,
+        connect_url="https://hol.org/guard/connect",
+        runtime="hermes",
+        pair_code="HLG-7K3D29",
+        label="Hosted Hermes",
+        no_root=True,
+    )
+
+    # Pairing still succeeds despite sync failure
+    assert payload["status"] == "connected"
+    assert payload["pairing"] == "connected"


### PR DESCRIPTION
## Summary

Connected remote agents (e.g., Hermes on a VPS) do not appear on the protect dashboard at `https://hol.org/guard/protect` after completing `hol-guard remote-pair`.

## Root Cause

`run_guard_remote_pair_command()` in `remote_pair_flow.py` claimed the pairing code, persisted OAuth credentials, and installed the local managed install — but **never pushed a runtime session to Guard Cloud**.

The protect dashboard reads `guard_runtime_sessions` rows (filtered by `harness`) to determine which harnesses are "connected". Without a runtime session row, the dashboard shows the agent as unconnected even though the local install succeeded.

`sync_runtime_session()` was only called from:
1. `hol-guard service sync` — the periodic daemon sync command
2. `guard_run()` in `runner.py` — the daemon's runtime loop

The remote-pair flow had no sync call at all.

## Fix

After a successful claim + managed install, call `sync_runtime_session()` with `harness: runtime` (e.g., `"hermes"`) so the agent appears in the protect dashboard immediately.

- Best-effort: failures are swallowed via `contextlib.suppress(Exception)` so transient network errors do not roll back a successful pairing. The daemon's periodic sync will retry.
- Session payload includes `harness`, `surface: "remote-pair"`, `status: "active"`, and the runtime label as `client_title`.

## Verification

- 11 tests pass in `test_guard_remote_pair_flow.py` (2 new tests):
  - `test_run_guard_remote_pair_command_syncs_runtime_session` — verifies `sync_runtime_session` is called with `harness="hermes"` after a successful remote-pair
  - `test_run_guard_remote_pair_command_swallows_sync_failure` — verifies a sync failure does not break the pairing flow
- Ruff format and lint clean
