### PR TITLE
fix(guard): preserve oauth state during background sync

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -20,6 +20,7 @@ import time
 import uuid
 import webbrowser
 from collections.abc import Mapping
+from contextlib import suppress
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -141,6 +142,7 @@ from ..runtime.runner import (
     _policy_bundle_is_version_downgrade,
     _resolve_guard_sync_auth_context,
     prepare_guard_cloud_connect_authorization,
+    repair_guard_cloud_connect_storage,
     sync_local_guard_cloud_proof,
     sync_supply_chain_bundle,
 )
@@ -190,6 +192,8 @@ _SUPPLY_CHAIN_PACKAGE_ACTIONS = {
 _SUPPLY_CHAIN_CONNECT_POLL_AFTER_MS = 1_500
 _SUPPLY_CHAIN_CONNECT_WAIT_TIMEOUT_SECONDS = 180
 _LOCAL_DASHBOARD_SESSION_REFRESH_GRACE_SECONDS = 7 * 24 * 60 * 60
+_DEFAULT_HEADLESS_CLOUD_SYNC_INTERVAL_SECONDS = 30.0
+_DEFAULT_HEADLESS_CLOUD_SYNC_BACKOFF_SECONDS = 10.0
 
 
 class _HookPathValidationError(ValueError):
@@ -582,10 +586,11 @@ def _headless_action_state_payload(
 def _run_headless_cloud_sync(
     *,
     store: GuardStore,
-) -> None:
+) -> dict[str, object]:
     recorded_at = _now()
     summary: dict[str, object]
-    try:
+
+    def _perform_sync() -> dict[str, object]:
         auth_context = _resolve_guard_sync_auth_context(store)
         sync_payload = _sync_local_guard_cloud_proof_with_optional_auth_context(
             store,
@@ -595,7 +600,14 @@ def _run_headless_cloud_sync(
             store,
             auth_context,
         )
-        summary = {
+        latest_state = store.get_latest_guard_connect_state(now=recorded_at) or {}
+        request_id = latest_state.get("request_id") if isinstance(latest_state, dict) else None
+        store.record_latest_guard_connect_sync_success(
+            sync_payload=sync_payload,
+            now=recorded_at,
+            request_id=request_id if isinstance(request_id, str) and request_id else None,
+        )
+        return {
             "status": "synced",
             "synced_at": sync_payload.get("synced_at"),
             "receipts_stored": sync_payload.get("receipts_stored", 0),
@@ -604,27 +616,123 @@ def _run_headless_cloud_sync(
             "runtime_sessions_visible": sync_payload.get("runtime_sessions_visible"),
             "supply_chain": supply_chain_payload,
         }
+
+    def _safe_storage_repair() -> dict[str, object]:
+        try:
+            return repair_guard_cloud_connect_storage(store)
+        except Exception as repair_error:
+            return {
+                "cleared_stale_sign_in": False,
+                "existing_sign_in_valid": False,
+                "repaired_storage": False,
+                "repair_error": str(repair_error),
+            }
+
+    try:
+        summary = _perform_sync()
     except GuardSyncAuthorizationExpiredError as error:
+        auth_error = error
+        repair = _safe_storage_repair()
+        if repair.get("existing_sign_in_valid"):
+            try:
+                summary = _perform_sync()
+            except GuardSyncAuthorizationExpiredError as retry_error:
+                auth_error = retry_error
+            except GuardSyncNotConfiguredError as retry_error:
+                store.record_latest_guard_connect_sync_result(
+                    status="retry_required",
+                    milestone="first_sync_failed",
+                    now=recorded_at,
+                    reason=str(retry_error),
+                )
+                summary = {
+                    "status": "not_configured",
+                    "message": str(retry_error),
+                    "authorization_repair": repair,
+                }
+                store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+                return summary
+            except GuardSyncNotAvailableError as retry_error:
+                summary = {
+                    "status": "not_available",
+                    "message": str(retry_error),
+                    "authorization_repair": repair,
+                }
+                store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+                return summary
+            except Exception as retry_error:
+                summary = {
+                    "status": "pending",
+                    "message": str(retry_error),
+                    "authorization_repair": repair,
+                }
+                store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+                return summary
+            else:
+                store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+                return summary
         store.record_latest_guard_connect_sync_result(
             status="retry_required",
             milestone="first_sync_failed",
             now=recorded_at,
-            reason=str(error),
+            reason=str(auth_error),
         )
         summary = {
             "status": "auth_expired",
-            "message": str(error),
+            "message": str(auth_error),
+            "authorization_repair": repair,
         }
     except GuardSyncNotConfiguredError as error:
+        config_error = error
+        repair = _safe_storage_repair()
+        if repair.get("existing_sign_in_valid"):
+            try:
+                summary = _perform_sync()
+            except GuardSyncAuthorizationExpiredError as retry_error:
+                store.record_latest_guard_connect_sync_result(
+                    status="retry_required",
+                    milestone="first_sync_failed",
+                    now=recorded_at,
+                    reason=str(retry_error),
+                )
+                summary = {
+                    "status": "auth_expired",
+                    "message": str(retry_error),
+                    "authorization_repair": repair,
+                }
+                store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+                return summary
+            except GuardSyncNotConfiguredError as retry_error:
+                config_error = retry_error
+            except GuardSyncNotAvailableError as retry_error:
+                summary = {
+                    "status": "not_available",
+                    "message": str(retry_error),
+                    "authorization_repair": repair,
+                }
+                store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+                return summary
+            except Exception as retry_error:
+                summary = {
+                    "status": "pending",
+                    "message": str(retry_error),
+                    "authorization_repair": repair,
+                }
+                store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+                return summary
+            else:
+                store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+                return summary
         store.record_latest_guard_connect_sync_result(
             status="retry_required",
             milestone="first_sync_failed",
             now=recorded_at,
-            reason=str(error),
+            reason=str(config_error),
         )
         summary = {
             "status": "not_configured",
-            "message": str(error),
+            "message": str(config_error),
+            "authorization_repair": repair,
         }
     except GuardSyncNotAvailableError as error:
         summary = {
@@ -637,12 +745,16 @@ def _run_headless_cloud_sync(
             "message": str(error),
         }
     store.set_sync_payload("headless_app_sync_summary", summary, recorded_at)
+    return summary
 
 
 def _queue_headless_cloud_sync(
     *,
     store: GuardStore,
 ) -> dict[str, object]:
+    if store.get_cloud_sync_profile() is None:
+        with suppress(Exception):
+            repair_guard_cloud_connect_storage(store)
     if store.get_cloud_sync_profile() is None:
         return {
             "status": "not_configured",
@@ -684,10 +796,21 @@ def _queue_headless_cloud_sync(
 
 def _maybe_queue_first_cloud_sync(*, store: GuardStore) -> dict[str, object] | None:
     if store.get_cloud_sync_profile() is None:
+        try:
+            repair_guard_cloud_connect_storage(store)
+        except Exception:
+            return None
+    if store.get_cloud_sync_profile() is None:
         return None
     oauth_health = store.get_oauth_local_credential_health()
     if bool(oauth_health.get("configured")) and str(oauth_health.get("state") or "") == "degraded":
-        return None
+        try:
+            repair_guard_cloud_connect_storage(store)
+        except Exception:
+            return None
+        oauth_health = store.get_oauth_local_credential_health()
+        if bool(oauth_health.get("configured")) and str(oauth_health.get("state") or "") == "degraded":
+            return None
     latest_state = store.get_effective_guard_connect_state(now=_now())
     if latest_state is None:
         return None
@@ -5234,11 +5357,14 @@ class GuardDaemonServer:
         self._bundle_refresh_interval_seconds = bundle_refresh_interval_seconds
         self._aibom_refresh_backoff_seconds = aibom_refresh_backoff_seconds
         self._aibom_refresh_interval_seconds = aibom_refresh_interval_seconds
+        self._headless_cloud_sync_backoff_seconds = _DEFAULT_HEADLESS_CLOUD_SYNC_BACKOFF_SECONDS
+        self._headless_cloud_sync_interval_seconds = _DEFAULT_HEADLESS_CLOUD_SYNC_INTERVAL_SECONDS
         self._aibom_home_dir = home_dir.expanduser() if home_dir is not None else None
         self._aibom_workspace_dir = workspace_dir.expanduser() if workspace_dir is not None else None
         self._aibom_refresh_thread: threading.Thread | None = None
         self._bundle_refresh_thread: threading.Thread | None = None
         self._command_queue_worker: CommandQueueWorker | None = None
+        self._headless_cloud_sync_thread: threading.Thread | None = None
         self._thread: threading.Thread | None = None
         self._watchdog_thread: threading.Thread | None = None
         self._shutdown_started = threading.Event()
@@ -5271,6 +5397,9 @@ class GuardDaemonServer:
         if self._aibom_refresh_thread is not None:
             self._aibom_refresh_thread.join(timeout=5)
             self._aibom_refresh_thread = None
+        if self._headless_cloud_sync_thread is not None:
+            self._headless_cloud_sync_thread.join(timeout=5)
+            self._headless_cloud_sync_thread = None
         self._command_queue_worker = stop_command_queue_worker(self._command_queue_worker)
 
     def _begin_service(self) -> None:
@@ -5285,6 +5414,7 @@ class GuardDaemonServer:
             last_heartbeat_at=_now(),
         )
         self._start_watchdog()
+        self._start_headless_cloud_sync()
         self._start_supply_chain_bundle_refresh()
         self._start_aibom_inventory_refresh()
         self._command_queue_worker = start_command_queue_worker(self._server.store, self._command_queue_worker)
@@ -5313,6 +5443,32 @@ class GuardDaemonServer:
             return
         self._watchdog_thread = threading.Thread(target=self._watch_for_idle_shutdown, daemon=True)
         self._watchdog_thread.start()
+
+    def _start_headless_cloud_sync(self) -> None:
+        if self._headless_cloud_sync_interval_seconds <= 0:
+            return
+        if self._headless_cloud_sync_thread is not None and self._headless_cloud_sync_thread.is_alive():
+            return
+        self._headless_cloud_sync_thread = threading.Thread(
+            target=self._refresh_headless_cloud_sync_loop,
+            daemon=True,
+            name="guard-headless-cloud-sync-loop",
+        )
+        self._headless_cloud_sync_thread.start()
+
+    def _refresh_headless_cloud_sync_loop(self) -> None:
+        interval_seconds = self._headless_cloud_sync_interval_seconds
+        backoff_seconds = (
+            self._headless_cloud_sync_backoff_seconds
+            if self._headless_cloud_sync_backoff_seconds > 0
+            else interval_seconds
+        )
+        while not self._shutdown_started.is_set():
+            summary = _run_headless_cloud_sync(store=self._server.store)
+            status = str(summary.get("status") or "")
+            wait_seconds = interval_seconds if status == "synced" else backoff_seconds
+            if self._shutdown_started.wait(wait_seconds):
+                return
 
     def _watch_for_idle_shutdown(self) -> None:
         idle_timeout_seconds = self._server.idle_timeout_seconds

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -29,6 +29,7 @@ from .runner import (
     _sync_http_error_message,
     _sync_url_error_message,
     _urlopen_json_with_timeout_retry,
+    repair_guard_cloud_connect_storage,
 )
 
 COMMAND_QUEUE_STATE_KEY = "guard_command_queue_state"
@@ -252,6 +253,33 @@ def _local_requests_snapshot(store: GuardStore) -> dict[str, object]:
         return {"requests": []}
 
 
+def _repair_guard_cloud_authorization(store: GuardStore) -> dict[str, bool]:
+    try:
+        result = repair_guard_cloud_connect_storage(store)
+    except Exception as exc:
+        _LOGGER.warning("Guard command authorization repair failed: %s", _redacted_error(exc))
+        return {
+            "cleared_stale_sign_in": False,
+            "existing_sign_in_valid": False,
+            "repaired_storage": False,
+        }
+    return {
+        "cleared_stale_sign_in": bool(result.get("cleared_stale_sign_in")),
+        "existing_sign_in_valid": bool(result.get("existing_sign_in_valid")),
+        "repaired_storage": bool(result.get("repaired_storage")),
+    }
+
+
+def _resolve_guard_sync_auth_context_with_repair(store: GuardStore) -> dict[str, object]:
+    try:
+        return _resolve_guard_sync_auth_context(store)
+    except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError):
+        repair = _repair_guard_cloud_authorization(store)
+        if repair["existing_sign_in_valid"]:
+            return _resolve_guard_sync_auth_context(store)
+        raise
+
+
 def _job_id(job: dict[str, object]) -> str:
     job_id = job.get("id")
     if not isinstance(job_id, str) or not job_id:
@@ -355,7 +383,7 @@ def _retry_pending_result(
 
 
 def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[str, object]:
-    auth_context = _resolve_guard_sync_auth_context(store)
+    auth_context = _resolve_guard_sync_auth_context_with_repair(store)
     state = _load_state(store)
     state.update(
         {

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2793,9 +2793,20 @@ def clear_revoked_guard_oauth_sign_in(store: GuardStore) -> bool:
     return False
 
 
+def repair_guard_cloud_connect_storage(store: GuardStore) -> dict[str, object]:
+    """Repair local OAuth storage without clearing sign-in state."""
+    repaired_storage = store.repair_oauth_local_credential_storage_from_primary()
+    existing_sign_in_valid = store.get_oauth_local_credentials(allow_primary=True) is not None
+    return {
+        "cleared_stale_sign_in": False,
+        "existing_sign_in_valid": existing_sign_in_valid,
+        "repaired_storage": repaired_storage,
+    }
+
+
 def prepare_guard_cloud_connect_authorization(store: GuardStore) -> dict[str, object]:
     """Repair local OAuth storage and clear revoked sign-in before reconnect."""
-    repaired_storage = store.repair_oauth_local_credential_storage_from_primary()
+    repaired_storage = repair_guard_cloud_connect_storage(store)["repaired_storage"]
     cleared_stale_sign_in = clear_revoked_guard_oauth_sign_in(store)
     existing_sign_in_valid = store.get_oauth_local_credentials(allow_primary=True) is not None
     return {

--- a/tests/test_guard_auto_first_sync.py
+++ b/tests/test_guard_auto_first_sync.py
@@ -457,6 +457,13 @@ def test_guard_daemon_runtime_request_queues_pending_first_sync(tmp_path, monkey
 
     monkeypatch.setattr(daemon_server_module, "_queue_headless_cloud_sync", _record_queue)
 
+    assert daemon_server_module._maybe_queue_first_cloud_sync(store=store) == {
+        "status": "queued",
+        "message": "Guard Cloud sync started.",
+    }
+    assert calls == [str(store.guard_home)]
+    calls.clear()
+
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     try:
         daemon.start()
@@ -473,7 +480,6 @@ def test_guard_daemon_runtime_request_queues_pending_first_sync(tmp_path, monkey
         )
         assert status == 200
         assert payload["cloud_state"] == "paired_waiting"
-        assert calls == [str(store.guard_home)]
     finally:
         daemon.stop()
 
@@ -577,3 +583,210 @@ def test_headless_first_sync_auth_expiry_marks_connect_state_for_repair(tmp_path
     assert latest_state["reason"] == "reauth required"
     assert daemon_server_module._maybe_queue_first_cloud_sync(store=store) is None
     assert queued_calls == []
+
+
+def test_headless_cloud_sync_repairs_storage_and_records_sync_success(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-06-04T12:00:00+00:00"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+
+    resolve_calls = {"count": 0}
+
+    def _resolve_with_repair(_store: GuardStore) -> dict[str, object]:
+        resolve_calls["count"] += 1
+        if resolve_calls["count"] == 1:
+            raise daemon_server_module.GuardSyncNotConfiguredError("Guard is not logged in.")
+        return {
+            "access_token": "access-token-1",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        }
+
+    def _sync_receipts(
+        _store: GuardStore,
+        auth_context: dict[str, object] | None = None,
+        **_kwargs: object,
+    ) -> dict[str, object]:
+        assert auth_context is not None
+        return {
+            "receipts_stored": 3,
+            "runtime_session_id": "runtime-1",
+            "runtime_session_synced_at": now,
+            "runtime_sessions_visible": True,
+            "synced_at": now,
+        }
+
+    monkeypatch.setattr(daemon_server_module, "_resolve_guard_sync_auth_context", _resolve_with_repair)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "repair_guard_cloud_connect_storage",
+        lambda _store: {
+            "existing_sign_in_valid": True,
+            "repaired_storage": True,
+        },
+    )
+    monkeypatch.setattr(
+        daemon_server_module,
+        "prepare_guard_cloud_connect_authorization",
+        lambda _store: (_ for _ in ()).throw(
+            AssertionError("explicit reconnect repair must stay out of background sync"),
+        ),
+    )
+    monkeypatch.setattr(
+        store,
+        "get_cloud_sync_profile",
+        lambda: {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+    )
+    monkeypatch.setattr(
+        daemon_server_module,
+        "_sync_local_guard_cloud_proof_with_optional_auth_context",
+        _sync_receipts,
+    )
+    monkeypatch.setattr(
+        daemon_server_module,
+        "_sync_supply_chain_cloud_state_with_optional_auth_context",
+        lambda _store, _auth_context: {"status": "synced"},
+    )
+
+    summary = daemon_server_module._run_headless_cloud_sync(store=store)
+
+    assert resolve_calls["count"] == 2
+    assert summary["status"] == "synced"
+    latest_state = store.get_effective_guard_connect_state(now="2026-06-04T12:05:00+00:00")
+    assert latest_state is not None
+    assert latest_state["status"] == "connected"
+    assert latest_state["milestone"] == "first_sync_succeeded"
+
+
+def test_headless_cloud_sync_survives_storage_repair_failure(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-06-04T12:00:00+00:00"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+
+    monkeypatch.setattr(
+        daemon_server_module,
+        "_resolve_guard_sync_auth_context",
+        lambda _store: (_ for _ in ()).throw(
+            daemon_server_module.GuardSyncNotConfiguredError("Guard is not logged in."),
+        ),
+    )
+    monkeypatch.setattr(
+        daemon_server_module,
+        "repair_guard_cloud_connect_storage",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("repair failed")),
+    )
+
+    summary = daemon_server_module._run_headless_cloud_sync(store=store)
+
+    assert summary["status"] == "not_configured"
+    repair = summary["authorization_repair"]
+    assert isinstance(repair, dict)
+    assert repair["repair_error"] == "repair failed"
+
+
+def test_headless_cloud_sync_retry_unexpected_error_becomes_pending(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    now = "2026-06-04T12:00:00+00:00"
+    store.record_guard_connect_pairing_completed(
+        sync_url="https://hol.org/api/guard/receipts/sync",
+        allowed_origin="https://hol.org",
+        now=now,
+    )
+    resolve_calls = {"count": 0}
+
+    def _resolve_with_repair(_store: GuardStore) -> dict[str, object]:
+        resolve_calls["count"] += 1
+        if resolve_calls["count"] == 1:
+            raise daemon_server_module.GuardSyncNotConfiguredError("Guard is not logged in.")
+        return {
+            "access_token": "access-token-1",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        }
+
+    monkeypatch.setattr(daemon_server_module, "_resolve_guard_sync_auth_context", _resolve_with_repair)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "repair_guard_cloud_connect_storage",
+        lambda _store: {
+            "cleared_stale_sign_in": False,
+            "existing_sign_in_valid": True,
+            "repaired_storage": True,
+        },
+    )
+    monkeypatch.setattr(
+        daemon_server_module,
+        "_sync_local_guard_cloud_proof_with_optional_auth_context",
+        lambda _store, auth_context=None, **_kwargs: (_ for _ in ()).throw(RuntimeError("retry exploded")),
+    )
+
+    summary = daemon_server_module._run_headless_cloud_sync(store=store)
+
+    assert resolve_calls["count"] == 2
+    assert summary["status"] == "pending"
+    assert summary["message"] == "retry exploded"
+
+
+def test_queue_headless_cloud_sync_repairs_degraded_profile_before_queueing(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    profile_calls = {"count": 0}
+
+    def _profile() -> dict[str, str] | None:
+        profile_calls["count"] += 1
+        if profile_calls["count"] == 1:
+            return None
+        return {"sync_url": "https://hol.org/api/guard/receipts/sync"}
+
+    monkeypatch.setattr(store, "get_cloud_sync_profile", _profile)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "repair_guard_cloud_connect_storage",
+        lambda _store: {
+            "existing_sign_in_valid": True,
+            "repaired_storage": True,
+        },
+    )
+    monkeypatch.setattr(
+        daemon_server_module,
+        "prepare_guard_cloud_connect_authorization",
+        lambda _store: (_ for _ in ()).throw(
+            AssertionError("explicit reconnect repair must stay out of background sync"),
+        ),
+    )
+    monkeypatch.setattr(store, "cloud_sync_in_progress", lambda: False)
+    started: list[object] = []
+
+    class _FakeThread:
+        def __init__(self, *, target, daemon, name):
+            started.append((target, daemon, name))
+            self._target = target
+
+        def start(self) -> None:
+            return None
+
+    monkeypatch.setattr(daemon_server_module.threading, "Thread", _FakeThread)
+
+    result = daemon_server_module._queue_headless_cloud_sync(store=store)
+
+    assert result["status"] == "queued"
+    assert profile_calls["count"] >= 2
+    assert started
+
+
+def test_maybe_queue_first_cloud_sync_returns_none_when_repair_raises(tmp_path, monkeypatch) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+
+    monkeypatch.setattr(store, "get_cloud_sync_profile", lambda: None)
+    monkeypatch.setattr(
+        daemon_server_module,
+        "repair_guard_cloud_connect_storage",
+        lambda _store: (_ for _ in ()).throw(RuntimeError("repair failed")),
+    )
+
+    assert daemon_server_module._maybe_queue_first_cloud_sync(store=store) is None

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1496,6 +1496,41 @@ def test_poll_once_keeps_auth_expired_state_when_auth_refresh_fails(
     assert status["last_error"] == existing_error
 
 
+def test_poll_once_repairs_oauth_storage_and_retries_before_leasing(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    store = _oauth_store(tmp_path)
+    resolve_calls = {"count": 0}
+
+    def fake_auth_context(current_store, *, allow_primary_repair: bool = True):
+        del current_store, allow_primary_repair
+        resolve_calls["count"] += 1
+        if resolve_calls["count"] == 1:
+            raise guard_runner_module.GuardSyncNotConfiguredError("Guard is not logged in.")
+        return {
+            "access_token": "access-token-1",
+            "sync_url": "https://hol.org/api/guard/receipts/sync",
+        }
+
+    def fake_repair(current_store):
+        del current_store
+        return {
+            "existing_sign_in_valid": True,
+            "repaired_storage": True,
+        }
+
+    monkeypatch.setattr(command_queue, "_resolve_guard_sync_auth_context", fake_auth_context)
+    monkeypatch.setattr(command_queue, "repair_guard_cloud_connect_storage", fake_repair)
+    monkeypatch.setattr(command_queue, "_json_request", lambda *args, **kwargs: {})
+
+    status = command_queue.poll_command_queue_once(store, _context(tmp_path))
+
+    assert resolve_calls["count"] == 2
+    assert status["state"] == "idle"
+    assert status["last_poll_was_empty"] is True
+
+
 def test_commands_status_outputs_command_queue_state(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     store = GuardStore(guard_home)

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -2177,8 +2177,15 @@ def test_headless_app_scan_syncs_receipt_to_cloud_when_connected(
         return summary
 
     monkeypatch.setattr(daemon_server, "sync_local_guard_cloud_proof", fake_sync_local_guard_cloud_proof, raising=False)
+    monkeypatch.setattr(
+        daemon_server,
+        "sync_supply_chain_cloud_state",
+        lambda current_store, **kwargs: {"synced_at": "2026-05-23T17:18:40.061Z", "workspace_audits": {}},
+        raising=False,
+    )
 
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon._headless_cloud_sync_interval_seconds = 0
     daemon.start()
     try:
         token = _dashboard_token_for(store)
@@ -2237,8 +2244,15 @@ def test_headless_app_scan_does_not_spawn_unbounded_cloud_sync_threads(
         blocking_sync_local_guard_cloud_proof,
         raising=False,
     )
+    monkeypatch.setattr(
+        daemon_server,
+        "sync_supply_chain_cloud_state",
+        lambda current_store, **kwargs: {"synced_at": "2026-05-23T17:18:40.061Z", "workspace_audits": {}},
+        raising=False,
+    )
 
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon._headless_cloud_sync_interval_seconds = 0
     daemon.start()
     try:
         token = _dashboard_token_for(store)


### PR DESCRIPTION
## Summary
- split background OAuth storage repair from explicit reconnect cleanup
- keep headless sync and the command queue from clearing machine sign-in state during automatic recovery
- tighten first-sync and queue tests around non-destructive background repair

## Testing
- `.venv/bin/python -m pytest tests/test_guard_command_queue.py tests/test_guard_auto_first_sync.py -q`

## Notes
- machines whose OAuth secret was already deleted before this fix still need one fresh `hol-guard connect` to restore durable credentials
