### PR TITLE
fix(guard): persist receipt backfill progress across sync retries

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -304,7 +304,7 @@ _RECEIPT_SYNC_BATCH_SIZE = 50
 _RECEIPT_SYNC_CURSOR_PAGE_SIZE = 200
 _RECEIPT_SYNC_CURSOR_BACKFILL_ROWS = 200
 _RECEIPT_COMMAND_DETAIL_BACKFILL_DAYS = 30
-_RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT = 1000
+_RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT = 200
 _PAIN_SIGNAL_TIMEOUT_SECONDS = 10
 _PAIN_SIGNAL_RETRY_TIMEOUT_SECONDS = 90
 _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_MINUTES = 5  # single 404 shouldn't disable sync for a full day
@@ -1370,6 +1370,7 @@ def sync_receipts(
     )
     latest_uploaded_rowid: int | None = None
     auth_refresh_retried = False
+    persisted_command_detail_backfill_marker = command_detail_backfill_marker
     for receipt_batch in _iter_receipt_sync_batches(receipts):
         body = json.dumps(
             {
@@ -1448,6 +1449,18 @@ def sync_receipts(
             if isinstance(rowid, int) and (latest_uploaded_rowid is None or rowid > latest_uploaded_rowid):
                 latest_uploaded_rowid = rowid
         batch_synced_at = _sync_timestamp(payload)
+        updated_command_detail_backfill_marker = _advance_command_detail_backfill_marker(
+            persisted_command_detail_backfill_marker,
+            receipt_batch=receipt_batch,
+            synced_at=batch_synced_at,
+        )
+        if updated_command_detail_backfill_marker is not None:
+            persisted_command_detail_backfill_marker = updated_command_detail_backfill_marker
+            store.set_sync_payload(
+                _RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER,
+                persisted_command_detail_backfill_marker,
+                batch_synced_at,
+            )
         if latest_uploaded_rowid is not None:
             _persist_receipt_sync_cursor(
                 store=store,
@@ -1486,10 +1499,10 @@ def sync_receipts(
         aibom_context["workspace_dir"] = str(workspace_dir)
     if aibom_context:
         store.set_sync_payload("aibom_inventory_context", aibom_context, now)
-    if command_detail_backfill_marker is not None:
+    if persisted_command_detail_backfill_marker is not None:
         store.set_sync_payload(
             _RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER,
-            command_detail_backfill_marker,
+            persisted_command_detail_backfill_marker,
             now,
         )
     persisted_cursor_rowid = latest_uploaded_rowid if latest_uploaded_rowid is not None else prior_receipt_cursor
@@ -4017,7 +4030,7 @@ def _receipt_sync_rows_with_command_detail_backfill(
         receipt_id = row.get("receipt_id")
         if not isinstance(receipt_id, str) or receipt_id in seen_receipt_ids:
             continue
-        merged.append(row)
+        merged.append({**row, _RECEIPT_COMMAND_DETAIL_BACKFILL_FLAG: True})
         seen_receipt_ids.add(receipt_id)
         added += 1
     backfill_rowids: list[int] = []
@@ -4049,6 +4062,28 @@ def _receipt_command_detail_backfill_before_rowid(marker: object, *, redaction_l
         parsed = int(value.strip())
         return parsed if parsed > 0 else None
     return None
+
+
+def _advance_command_detail_backfill_marker(
+    marker: dict[str, object] | None,
+    *,
+    receipt_batch: Sequence[Mapping[str, object]],
+    synced_at: str,
+) -> dict[str, object] | None:
+    if marker is None:
+        return None
+    backfill_rowids = [
+        receipt_rowid
+        for item in receipt_batch
+        if item.get(_RECEIPT_COMMAND_DETAIL_BACKFILL_FLAG) is True
+        and isinstance((receipt_rowid := item.get("receipt_rowid")), int)
+    ]
+    if not backfill_rowids:
+        return None
+    updated_marker = dict(marker)
+    updated_marker["before_rowid"] = min(backfill_rowids)
+    updated_marker["updated_at"] = synced_at
+    return updated_marker
 
 
 def _receipt_sync_cursor_rowids_from_batch(
@@ -4117,6 +4152,7 @@ _RECEIPT_REDACTION_LEVEL_RANK: dict[str, int] = {
 }
 _RELAXED_RECEIPT_REDACTION_RESYNC_MARKER = "cloud_receipt_redaction_relaxed_resync_v1"
 _RECEIPT_COMMAND_DETAIL_BACKFILL_MARKER = "cloud_receipt_command_detail_backfill_v2"
+_RECEIPT_COMMAND_DETAIL_BACKFILL_FLAG = "__command_detail_backfill"
 
 
 def _receipt_redaction_level_rank(level: str | None) -> int:

--- a/src/codex_plugin_scanner/guard/store_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_receipts.py
@@ -251,7 +251,7 @@ class StoreReceiptsRuntimeMixin:
                 (cutoff, before_rowid, max(limit, 1)) if before_rowid is not None else (cutoff, max(limit, 1))
             )
             rows = connection.execute(query, params).fetchall()
-        return [self._receipt_dict_from_row(row) for row in reversed(rows)]
+        return [self._receipt_dict_from_row(row) for row in rows]
 
     def latest_receipt_rowid(self, *, harness: str | None = None) -> int | None:
         query = "select max(rowid) as max_rowid from runtime_receipts"

--- a/tests/test_guard_receipt_command_detail_backfill.py
+++ b/tests/test_guard_receipt_command_detail_backfill.py
@@ -9,6 +9,7 @@ from codex_plugin_scanner.guard.runtime.actions import GuardActionEnvelope
 from codex_plugin_scanner.guard.runtime.runner import (
     _cloud_sync_receipt_payload,
     _receipt_sync_rows_with_command_detail_backfill,
+    sync_receipts,
 )
 from codex_plugin_scanner.guard.store import GuardStore
 
@@ -148,7 +149,7 @@ def test_command_detail_backfill_pages_historical_receipts(monkeypatch, tmp_path
         synced_at="2026-07-02T00:00:00+00:00",
     )
 
-    assert [row["receipt_id"] for row in first_rows] == ["guard-receipt-page-1", "guard-receipt-page-2"]
+    assert [row["receipt_id"] for row in first_rows] == ["guard-receipt-page-2", "guard-receipt-page-1"]
     assert first_marker is not None
     assert first_marker["queried"] == 2
     assert first_marker["receipts"] == 2
@@ -167,3 +168,75 @@ def test_command_detail_backfill_pages_historical_receipts(monkeypatch, tmp_path
     assert second_marker["queried"] == 1
     assert second_marker["receipts"] == 1
     assert second_marker["complete"] is True
+
+
+def test_sync_receipts_persists_command_detail_backfill_progress_after_partial_success(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    store = GuardStore(tmp_path)
+    for index in range(6):
+        _store_command_receipt(
+            store,
+            receipt_id=f"guard-receipt-progress-{index}",
+        )
+
+    monkeypatch.setattr(guard_runner, "_RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT", 6)
+    monkeypatch.setattr(guard_runner, "_RECEIPT_SYNC_BATCH_SIZE", 2)
+    monkeypatch.setattr(guard_runner, "_resolve_cloud_receipt_redaction_level", lambda _store: "none")
+    monkeypatch.setattr(guard_runner, "_guard_sync_request", lambda *args, **kwargs: object())
+    monkeypatch.setattr(guard_runner, "_receipt_sync_rows_for_upload", lambda _store, cursor_rowid: [])
+
+    attempted_batches = {"count": 0}
+
+    def _fake_sync(**kwargs):
+        attempted_batches["count"] += 1
+        if attempted_batches["count"] == 1:
+            return {"syncedAt": "2026-07-04T00:00:00+00:00", "receiptsStored": 2}
+        raise OSError("network down")
+
+    monkeypatch.setattr(guard_runner, "_urlopen_json_with_timeout_retry", _fake_sync)
+
+    preview_rows, preview_marker = _receipt_sync_rows_with_command_detail_backfill(
+        store,
+        receipts=[],
+        redaction_level="none",
+        synced_at="2026-07-04T00:00:00+00:00",
+    )
+    assert preview_marker is not None
+    first_batch_rowids = [
+        row["receipt_rowid"]
+        for row in preview_rows[:2]
+        if isinstance(row.get("receipt_rowid"), int)
+    ]
+    assert len(first_batch_rowids) == 2
+
+    try:
+        sync_receipts(
+            store,
+            persist_sync_summary=False,
+            persist_connect_state=False,
+            auth_context={"sync_url": "https://hol.org/api/guard/receipts/sync", "access_token": "token"},
+        )
+    except RuntimeError as error:
+        assert "network down" in str(error)
+    else:
+        raise AssertionError("sync_receipts should fail after the second batch")
+
+    marker = store.get_sync_payload("cloud_receipt_command_detail_backfill_v2")
+    assert isinstance(marker, dict)
+    assert marker["before_rowid"] == min(first_batch_rowids)
+
+    remaining_rows, _ = _receipt_sync_rows_with_command_detail_backfill(
+        store,
+        receipts=[],
+        redaction_level="none",
+        synced_at="2026-07-04T00:01:00+00:00",
+    )
+    remaining_rowids = [
+        row["receipt_rowid"]
+        for row in remaining_rows
+        if isinstance(row.get("receipt_rowid"), int)
+    ]
+    assert remaining_rowids
+    assert all(rowid < min(first_batch_rowids) for rowid in remaining_rowids)


### PR DESCRIPTION
## Summary\n- persist command-detail backfill progress after each successful receipt sync batch\n- cap each backfill pass to a smaller newest-first slice so automatic retries can keep moving\n- add regression coverage for partial-success marker persistence during receipt sync\n\n## Testing\n- python3 -m ruff check src/codex_plugin_scanner/guard/runtime/runner.py src/codex_plugin_scanner/guard/store_receipts.py tests/test_guard_receipt_command_detail_backfill.py\n- python3 -m pytest tests/test_guard_receipt_command_detail_backfill.py -q