### PR TITLE
fix(guard): keep command lease payload schema-compatible

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -45,6 +45,15 @@ _MIN_RETRY_WAIT_SECONDS = 0.1
 _REQUEST_TIMEOUT_SECONDS = 35
 _RETRY_TIMEOUT_SECONDS = 60
 _LOGGER = logging.getLogger(__name__)
+_LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS = (
+    "requests",
+    "pendingComplete",
+    "resolvedComplete",
+    "pendingLimit",
+    "resolvedLimit",
+    "pendingCount",
+    "resolvedCount",
+)
 
 
 def _now() -> str:
@@ -247,10 +256,17 @@ def _lease_payload(store: GuardStore) -> dict[str, object]:
 
 def _local_requests_snapshot(store: GuardStore) -> dict[str, object]:
     try:
-        return _local_request_snapshot_payload(store)
+        payload = _local_request_snapshot_payload(store)
     except Exception as exc:
         _LOGGER.warning("Guard command local request snapshot failed: %s", _redacted_error(exc))
         return {"requests": []}
+    if not isinstance(payload, dict):
+        return {"requests": []}
+    return {
+        key: payload[key]
+        for key in _LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS
+        if key in payload
+    }
 
 
 def _repair_guard_cloud_authorization(store: GuardStore) -> dict[str, bool]:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -820,7 +820,6 @@ def test_poll_once_leases_heartbeats_executes_and_posts_result(
                 "resolvedComplete": True,
                 "pendingLimit": command_executors.LOCAL_REQUEST_PENDING_SNAPSHOT_LIMIT,
                 "resolvedLimit": command_executors.LOCAL_REQUEST_RESOLVED_SNAPSHOT_LIMIT,
-                "maxBytes": command_executors.LOCAL_REQUEST_SNAPSHOT_MAX_BYTES,
                 "pendingCount": 0,
                 "resolvedCount": 0,
             },
@@ -837,6 +836,40 @@ def test_poll_once_leases_heartbeats_executes_and_posts_result(
     assert "machineInstallationId" not in calls[1][2]
     assert "machineInstallationId" not in calls[2][2]
     assert "machineInstallationId" not in calls[3][2]
+
+
+def test_lease_payload_strips_local_snapshot_metadata(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = _oauth_store(tmp_path)
+    monkeypatch.setattr(
+        command_queue,
+        "_local_request_snapshot_payload",
+        lambda _store: {
+            "requests": [],
+            "pendingComplete": True,
+            "resolvedComplete": True,
+            "pendingLimit": 125,
+            "resolvedLimit": 25,
+            "pendingCount": 0,
+            "resolvedCount": 0,
+            "maxBytes": 900000,
+            "debugOnly": "drop-me",
+        },
+    )
+
+    payload = command_queue._lease_payload(store)
+
+    assert payload["localRequestsSnapshot"] == {
+        "requests": [],
+        "pendingComplete": True,
+        "resolvedComplete": True,
+        "pendingLimit": 125,
+        "resolvedLimit": 25,
+        "pendingCount": 0,
+        "resolvedCount": 0,
+    }
 
 
 def test_executor_app_remove_never_uses_local_daemon_client(


### PR DESCRIPTION
## Summary\n- strip non-contract snapshot metadata from Guard command lease payloads\n- preserve the lease payload fields the cloud route actually accepts\n- add regression coverage for metadata sanitization before remote polling\n\n## Testing\n- python3 -m ruff check src/codex_plugin_scanner/guard/runtime/command_queue.py tests/test_guard_command_queue.py\n- python3 -m pytest tests/test_guard_command_queue.py -q -k 'lease_payload_strips_local_snapshot_metadata or poll_once_leases_heartbeats_executes_and_posts_result'