### PR TITLE
fix(guard): satisfy ruff format and repair stale/flaky tests

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -262,11 +262,7 @@ def _local_requests_snapshot(store: GuardStore) -> dict[str, object]:
         return {"requests": []}
     if not isinstance(payload, dict):
         return {"requests": []}
-    return {
-        key: payload[key]
-        for key in _LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS
-        if key in payload
-    }
+    return {key: payload[key] for key in _LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS if key in payload}
 
 
 def _repair_guard_cloud_authorization(store: GuardStore) -> dict[str, bool]:

--- a/tests/test_guard_receipt_redaction_cursor.py
+++ b/tests/test_guard_receipt_redaction_cursor.py
@@ -361,7 +361,7 @@ def test_relaxed_redaction_sync_adds_recent_blocked_command_detail_backfill(tmp_
         "level": "partial",
         "updated_at": "2026-04-15T00:01:00Z",
         "days": 30,
-        "limit": 1000,
+        "limit": 200,
         "receipts": 1,
         "queried": 1,
         "before_rowid": 1,

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -174,7 +174,7 @@ def test_daemon_bundle_refresh_reports_retryable_error(
     assert "oauth upstream down" in str(summary["error"])
 
 
-def _wait_for_aibom_status(store, *, expected: str, timeout: float = 1.0) -> dict[str, object]:
+def _wait_for_aibom_status(store, *, expected: str, timeout: float = 5.0) -> dict[str, object]:
     """Poll until the AIBOM daemon payload carries the expected status string."""
     deadline = time.time() + timeout
     while time.time() < deadline:


### PR DESCRIPTION
## Summary

CI failed on the `ruff format --check src/` step. After fixing the formatting, two additional pre-existing test failures surfaced that were previously hidden because the format check blocked them from running.

## Changes

1. **`src/codex_plugin_scanner/guard/runtime/command_queue.py`** — collapse the multi-line dict comprehension returned by `_local_requests_snapshot` into the single-line form `ruff format` expects. Formatting-only; no behavior change.

2. **`tests/test_guard_receipt_redaction_cursor.py`** — fix stale assertion. `_RECEIPT_COMMAND_DETAIL_BACKFILL_LIMIT` was reduced from 1000 to 200 in the receipt backfill persistence change, but this test still expected `limit: 1000`. Updated to `200` to match the constant.

3. **`tests/test_guard_supply_chain_daemon.py`** — increase `_wait_for_aibom_status` default timeout from 1.0s to 5.0s. The 1.0s timeout was too tight for shared CI runners under full-suite load, causing intermittent failures in `test_daemon_aibom_refresh_records_synced_on_success`. The happy path still returns in ~20ms.

## Verification

- `ruff format --check src/` → 334 files already formatted ✅
- `ruff check src/` → OK ✅
- `basedpyright --level error` on modified source → OK ✅
- `pytest tests/test_guard_command_queue.py tests/test_guard_command_queue_stale_pending_result.py tests/test_guard_headless_daemon_api.py` → 129 passed ✅
- `pytest tests/test_guard_receipt_redaction_cursor.py tests/test_guard_supply_chain_daemon.py` → all passed ✅

## CI fix

Resolves the failure on run https://github.com/hashgraph-online/hol-guard/actions/runs/28718065590/job/85162822350 — step 7 `ruff format --check src/`, plus two pre-existing test failures that were hidden behind the format check.