### PR TITLE
feat: add guard.app.update and guard.app.updateCheck command operations

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/auto_update.py
+++ b/src/codex_plugin_scanner/guard/runtime/auto_update.py
@@ -64,7 +64,7 @@ def maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
         update_payload, exit_code = run_guard_update(
             dry_run=False,
             context=context,
-            store=None,
+            store=store,
             workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
             now=now_str,
         )

--- a/src/codex_plugin_scanner/guard/runtime/auto_update.py
+++ b/src/codex_plugin_scanner/guard/runtime/auto_update.py
@@ -7,7 +7,6 @@ are excluded by build_guard_update_status_payload's auto_updatable flag.
 
 from __future__ import annotations
 
-import json
 import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
@@ -25,10 +24,10 @@ _LOGGER = logging.getLogger(__name__)
 
 def maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
     """Check for available updates and self-apply if auto-update is enabled."""
-    raw = store.get_kv(AUTO_UPDATE_STATE_KEY) if hasattr(store, "get_kv") else None
+    raw = store.get_sync_payload(AUTO_UPDATE_STATE_KEY)
     try:
-        state: dict[str, object] = json.loads(raw) if isinstance(raw, str) and raw else {}
-    except (json.JSONDecodeError, TypeError):
+        state: dict[str, object] = dict(raw) if isinstance(raw, dict) else {}
+    except (TypeError, ValueError):
         state = {}
     last_check = state.get("last_check_at")
     if isinstance(last_check, str):
@@ -48,12 +47,10 @@ def maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
     state["last_check_at"] = now_str
     state["last_status"] = status
     if not status.get("auto_updatable") or status.get("blocked_reason"):
-        if hasattr(store, "set_kv"):
-            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+        store.set_sync_payload(AUTO_UPDATE_STATE_KEY, state, now_str)
         return
     if not status.get("update_available"):
-        if hasattr(store, "set_kv"):
-            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+        store.set_sync_payload(AUTO_UPDATE_STATE_KEY, state, now_str)
         return
     _LOGGER.info(
         "Auto-update: applying update %s -> %s",
@@ -75,5 +72,4 @@ def maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
         _LOGGER.warning("Auto-update failed", exc_info=True)
         state["last_update_error"] = True
     finally:
-        if hasattr(store, "set_kv"):
-            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+        store.set_sync_payload(AUTO_UPDATE_STATE_KEY, state, now_str)

--- a/src/codex_plugin_scanner/guard/runtime/auto_update.py
+++ b/src/codex_plugin_scanner/guard/runtime/auto_update.py
@@ -38,12 +38,15 @@ def maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
                 return
         except (ValueError, TypeError):
             pass
+    now_str = datetime.now(timezone.utc).isoformat()
     try:
         status = build_guard_update_status_payload()
     except Exception:
         _LOGGER.debug("Auto-update version check failed", exc_info=True)
+        state["last_check_at"] = now_str
+        state["last_check_error"] = True
+        store.set_sync_payload(AUTO_UPDATE_STATE_KEY, state, now_str)
         return
-    now_str = datetime.now(timezone.utc).isoformat()
     state["last_check_at"] = now_str
     state["last_status"] = status
     if not status.get("auto_updatable") or status.get("blocked_reason"):

--- a/src/codex_plugin_scanner/guard/runtime/auto_update.py
+++ b/src/codex_plugin_scanner/guard/runtime/auto_update.py
@@ -1,0 +1,79 @@
+"""Auto-update check for Guard Cloud command queue daemon.
+
+Throttled to once per AUTO_UPDATE_THROTTLE_HOURS. Only runs when the
+command queue is enabled and no job was leased. Source/editable installs
+are excluded by build_guard_update_status_payload's auto_updatable flag.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+from ..cli.update_commands import build_guard_update_status_payload, run_guard_update
+
+if TYPE_CHECKING:
+    from ..adapters.base import HarnessContext
+    from ..store import GuardStore
+
+AUTO_UPDATE_THROTTLE_HOURS = 6
+AUTO_UPDATE_STATE_KEY = "guard_auto_update_state"
+_LOGGER = logging.getLogger(__name__)
+
+
+def maybe_auto_update(store: "GuardStore", context: "HarnessContext") -> None:
+    """Check for available updates and self-apply if auto-update is enabled."""
+    raw = store.get_kv(AUTO_UPDATE_STATE_KEY) if hasattr(store, "get_kv") else None
+    try:
+        state: dict[str, object] = json.loads(raw) if isinstance(raw, str) and raw else {}
+    except (json.JSONDecodeError, TypeError):
+        state = {}
+    last_check = state.get("last_check_at")
+    if isinstance(last_check, str):
+        try:
+            last_dt = datetime.fromisoformat(last_check)
+            elapsed = (datetime.now(timezone.utc) - last_dt).total_seconds()
+            if elapsed < AUTO_UPDATE_THROTTLE_HOURS * 3600:
+                return
+        except (ValueError, TypeError):
+            pass
+    try:
+        status = build_guard_update_status_payload()
+    except Exception:
+        _LOGGER.debug("Auto-update version check failed", exc_info=True)
+        return
+    now_str = datetime.now(timezone.utc).isoformat()
+    state["last_check_at"] = now_str
+    state["last_status"] = status
+    if not status.get("auto_updatable") or status.get("blocked_reason"):
+        if hasattr(store, "set_kv"):
+            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+        return
+    if not status.get("update_available"):
+        if hasattr(store, "set_kv"):
+            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+        return
+    _LOGGER.info(
+        "Auto-update: applying update %s -> %s",
+        status.get("current_version"),
+        status.get("latest_version"),
+    )
+    try:
+        update_payload, exit_code = run_guard_update(
+            dry_run=False,
+            context=context,
+            store=None,
+            workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
+            now=now_str,
+        )
+        state["last_update_result"] = update_payload
+        state["last_update_exit_code"] = exit_code
+        state["last_update_at"] = now_str
+    except Exception:
+        _LOGGER.warning("Auto-update failed", exc_info=True)
+        state["last_update_error"] = True
+    finally:
+        if hasattr(store, "set_kv"):
+            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))

--- a/src/codex_plugin_scanner/guard/runtime/auto_update.py
+++ b/src/codex_plugin_scanner/guard/runtime/auto_update.py
@@ -23,7 +23,7 @@ AUTO_UPDATE_STATE_KEY = "guard_auto_update_state"
 _LOGGER = logging.getLogger(__name__)
 
 
-def maybe_auto_update(store: "GuardStore", context: "HarnessContext") -> None:
+def maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
     """Check for available updates and self-apply if auto-update is enabled."""
     raw = store.get_kv(AUTO_UPDATE_STATE_KEY) if hasattr(store, "get_kv") else None
     try:

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -211,7 +211,7 @@ def _execute_app_operation(
         return _result(build_harness_verification(harness, context, store, surface=surface), generated_at=generated_at)
     if operation == "guard.app.update":
         return _result(
-            _execute_app_update(context=context, generated_at=generated_at),
+            _execute_app_update(context=context, store=store, generated_at=generated_at),
             generated_at=generated_at,
         )
     if operation == "guard.app.updateCheck":
@@ -254,12 +254,13 @@ def _execute_app_operation(
 def _execute_app_update(
     *,
     context: HarnessContext,
+    store: GuardStore,
     generated_at: str,
 ) -> dict[str, object]:
     update_payload, exit_code = run_guard_update(
         dry_run=False,
         context=context,
-        store=None,
+        store=store,
         workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
         now=generated_at,
     )

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -16,6 +16,10 @@ from ..cli.install_commands import (
     list_harness_setup_items,
     uninstall_confirmation_token,
 )
+from ..cli.update_commands import (
+    build_guard_update_status_payload,
+    run_guard_update,
+)
 from ..config import load_guard_config
 from ..local_supply_chain import (
     build_workspace_audit_payload,
@@ -61,6 +65,8 @@ APP_OPERATIONS: tuple[str, ...] = (
     "guard.app.repair",
     "guard.app.connect",
     "guard.app.remove",
+    "guard.app.update",
+    "guard.app.updateCheck",
 )
 APPROVAL_OPERATIONS: tuple[str, ...] = (
     "guard.approval.resolve",
@@ -203,6 +209,16 @@ def _execute_app_operation(
             return _result({"items": list_harness_setup_items(context, store)}, generated_at=generated_at)
         get_adapter(harness)
         return _result(build_harness_verification(harness, context, store, surface=surface), generated_at=generated_at)
+    if operation == "guard.app.update":
+        return _result(
+            _execute_app_update(context=context, generated_at=generated_at),
+            generated_at=generated_at,
+        )
+    if operation == "guard.app.updateCheck":
+        return _result(
+            _execute_app_update_check(generated_at=generated_at),
+            generated_at=generated_at,
+        )
     if harness is None:
         return {"failureCode": "harness_required", "failureMessage": "App command requires a harness."}
     get_adapter(harness)
@@ -233,6 +249,29 @@ def _execute_app_operation(
         "failureCode": "unsupported_operation",
         "failureMessage": f"Unsupported app operation: {operation}",
     }
+
+
+def _execute_app_update(
+    *,
+    context: HarnessContext,
+    generated_at: str,
+) -> dict[str, object]:
+    update_payload, exit_code = run_guard_update(
+        dry_run=False,
+        context=context,
+        store=None,
+        workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
+        now=generated_at,
+    )
+    return {
+        "update": update_payload,
+        "exitCode": exit_code,
+        "succeeded": exit_code == 0,
+    }
+
+
+def _execute_app_update_check(generated_at: str) -> dict[str, object]:
+    return build_guard_update_status_payload()
 
 
 def _execute_approval_operation(

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -21,6 +21,7 @@ from .command_executors import (
     command_job_operation,
     execute_guard_command_job,
 )
+from ..cli.update_commands import build_guard_update_status_payload, run_guard_update
 from .runner import (
     GuardSyncAuthorizationExpiredError,
     GuardSyncNotConfiguredError,
@@ -44,6 +45,8 @@ _DEFAULT_ERROR_BACKOFF_SECONDS = 30.0
 _MIN_RETRY_WAIT_SECONDS = 0.1
 _REQUEST_TIMEOUT_SECONDS = 35
 _RETRY_TIMEOUT_SECONDS = 60
+AUTO_UPDATE_THROTTLE_HOURS = 6
+AUTO_UPDATE_STATE_KEY = "guard_auto_update_state"
 _LOGGER = logging.getLogger(__name__)
 _LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS = (
     "requests",
@@ -400,6 +403,59 @@ def _retry_pending_result(
     _save_state(store, state)
     return True
 
+def _maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
+    """Check for available updates and self-apply if auto-update is enabled.
+
+    Throttled to once per AUTO_UPDATE_THROTTLE_HOURS. Only runs when the
+    command queue is enabled and no job was leased. Source/editable installs
+    are excluded by build_guard_update_status_payload's auto_updatable flag.
+    """
+    raw = store.get_kv(AUTO_UPDATE_STATE_KEY) if hasattr(store, "get_kv") else None
+    state: dict[str, object] = json.loads(raw) if isinstance(raw, str) and raw else {}
+    last_check = state.get("last_check_at")
+    if isinstance(last_check, str):
+        try:
+            last_dt = datetime.fromisoformat(last_check)
+            elapsed = (datetime.now(timezone.utc) - last_dt).total_seconds()
+            if elapsed < AUTO_UPDATE_THROTTLE_HOURS * 3600:
+                return
+        except (ValueError, TypeError):
+            pass
+    try:
+        status = build_guard_update_status_payload()
+    except Exception:
+        _LOGGER.debug("Auto-update version check failed", exc_info=True)
+        return
+    now_str = _now()
+    state["last_check_at"] = now_str
+    state["last_status"] = status
+    if not status.get("auto_updatable") or status.get("blocked_reason"):
+        if hasattr(store, "set_kv"):
+            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+        return
+    if not status.get("update_available"):
+        if hasattr(store, "set_kv"):
+            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+        return
+    _LOGGER.info("Auto-update: applying update %s -> %s", status.get("current_version"), status.get("latest_version"))
+    try:
+        update_payload, exit_code = run_guard_update(
+            dry_run=False,
+            context=context,
+            store=None,
+            workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
+            now=now_str,
+        )
+        state["last_update_result"] = update_payload
+        state["last_update_exit_code"] = exit_code
+        state["last_update_at"] = now_str
+    except Exception:
+        _LOGGER.warning("Auto-update failed", exc_info=True)
+        state["last_update_error"] = True
+    finally:
+        if hasattr(store, "set_kv"):
+            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+
 
 def _resolve_command_queue_auth_context(
     store: GuardStore,
@@ -451,6 +507,7 @@ def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[
             }
         )
         _save_state(store, state)
+        _maybe_auto_update(store, context)
         return command_queue_status(store)
     state.update(
         {

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -21,7 +21,7 @@ from .command_executors import (
     command_job_operation,
     execute_guard_command_job,
 )
-from ..cli.update_commands import build_guard_update_status_payload, run_guard_update
+from .auto_update import maybe_auto_update
 from .runner import (
     GuardSyncAuthorizationExpiredError,
     GuardSyncNotConfiguredError,
@@ -43,10 +43,7 @@ _DEFAULT_LEASE_WAIT_MS = 25_000
 _DEFAULT_POLL_INTERVAL_SECONDS = 2.0
 _DEFAULT_ERROR_BACKOFF_SECONDS = 30.0
 _MIN_RETRY_WAIT_SECONDS = 0.1
-_REQUEST_TIMEOUT_SECONDS = 35
 _RETRY_TIMEOUT_SECONDS = 60
-AUTO_UPDATE_THROTTLE_HOURS = 6
-AUTO_UPDATE_STATE_KEY = "guard_auto_update_state"
 _LOGGER = logging.getLogger(__name__)
 _LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS = (
     "requests",
@@ -404,57 +401,8 @@ def _retry_pending_result(
     return True
 
 def _maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
-    """Check for available updates and self-apply if auto-update is enabled.
-
-    Throttled to once per AUTO_UPDATE_THROTTLE_HOURS. Only runs when the
-    command queue is enabled and no job was leased. Source/editable installs
-    are excluded by build_guard_update_status_payload's auto_updatable flag.
-    """
-    raw = store.get_kv(AUTO_UPDATE_STATE_KEY) if hasattr(store, "get_kv") else None
-    state: dict[str, object] = json.loads(raw) if isinstance(raw, str) and raw else {}
-    last_check = state.get("last_check_at")
-    if isinstance(last_check, str):
-        try:
-            last_dt = datetime.fromisoformat(last_check)
-            elapsed = (datetime.now(timezone.utc) - last_dt).total_seconds()
-            if elapsed < AUTO_UPDATE_THROTTLE_HOURS * 3600:
-                return
-        except (ValueError, TypeError):
-            pass
-    try:
-        status = build_guard_update_status_payload()
-    except Exception:
-        _LOGGER.debug("Auto-update version check failed", exc_info=True)
-        return
-    now_str = _now()
-    state["last_check_at"] = now_str
-    state["last_status"] = status
-    if not status.get("auto_updatable") or status.get("blocked_reason"):
-        if hasattr(store, "set_kv"):
-            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
-        return
-    if not status.get("update_available"):
-        if hasattr(store, "set_kv"):
-            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
-        return
-    _LOGGER.info("Auto-update: applying update %s -> %s", status.get("current_version"), status.get("latest_version"))
-    try:
-        update_payload, exit_code = run_guard_update(
-            dry_run=False,
-            context=context,
-            store=None,
-            workspace=str(context.workspace_dir) if context.workspace_dir is not None else None,
-            now=now_str,
-        )
-        state["last_update_result"] = update_payload
-        state["last_update_exit_code"] = exit_code
-        state["last_update_at"] = now_str
-    except Exception:
-        _LOGGER.warning("Auto-update failed", exc_info=True)
-        state["last_update_error"] = True
-    finally:
-        if hasattr(store, "set_kv"):
-            store.set_kv(AUTO_UPDATE_STATE_KEY, json.dumps(state))
+    """Delegate to auto_update.maybe_auto_update."""
+    maybe_auto_update(store, context)
 
 
 def _resolve_command_queue_auth_context(

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -14,6 +14,7 @@ from urllib.parse import urlparse, urlunparse
 from ...version import __version__
 from ..adapters.base import HarnessContext
 from ..store import GuardStore
+from .auto_update import maybe_auto_update
 from .command_executors import (
     COMMAND_OPERATION_SCHEMA_VERSIONS,
     SUPPORTED_COMMAND_OPERATIONS,
@@ -21,7 +22,6 @@ from .command_executors import (
     command_job_operation,
     execute_guard_command_job,
 )
-from .auto_update import maybe_auto_update
 from .runner import (
     GuardSyncAuthorizationExpiredError,
     GuardSyncNotConfiguredError,
@@ -43,6 +43,7 @@ _DEFAULT_LEASE_WAIT_MS = 25_000
 _DEFAULT_POLL_INTERVAL_SECONDS = 2.0
 _DEFAULT_ERROR_BACKOFF_SECONDS = 30.0
 _MIN_RETRY_WAIT_SECONDS = 0.1
+_REQUEST_TIMEOUT_SECONDS = 35
 _RETRY_TIMEOUT_SECONDS = 60
 _LOGGER = logging.getLogger(__name__)
 _LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS = (

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -401,6 +401,7 @@ def _retry_pending_result(
     _save_state(store, state)
     return True
 
+
 def _maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
     """Delegate to auto_update.maybe_auto_update."""
     maybe_auto_update(store, context)

--- a/tests/test_guard_command_executors_update.py
+++ b/tests/test_guard_command_executors_update.py
@@ -34,16 +34,16 @@ def _make_job(operation: str, payload: dict[str, object] | None = None) -> dict[
 
 
 class _FakeStore:
-    """Minimal fake store with get_kv/set_kv for auto-update state."""
+    """Minimal fake store with get_sync_payload/set_sync_payload for auto-update state."""
 
     def __init__(self) -> None:
-        self._kv_data: dict[str, str] = {}
+        self._kv_data: dict[str, object] = {}
 
-    def get_kv(self, key: str) -> str | None:
+    def get_sync_payload(self, key: str) -> object:
         return self._kv_data.get(key)
 
-    def set_kv(self, key: str, value: str) -> None:
-        self._kv_data[key] = value
+    def set_sync_payload(self, key: str, payload: object, now: str) -> None:
+        self._kv_data[key] = payload
 
 
 class TestAppUpdateOperations:
@@ -129,9 +129,7 @@ class TestAutoUpdateThrottle:
         context = _make_context(tmp_path)
         store = _FakeStore()
         recent = datetime.now(timezone.utc)
-        store._kv_data[auto_update.AUTO_UPDATE_STATE_KEY] = (
-            '{"last_check_at": "' + recent.isoformat() + '"}'
-        )
+        store._kv_data[auto_update.AUTO_UPDATE_STATE_KEY] = {"last_check_at": recent.isoformat()}
         with patch.object(auto_update, "build_guard_update_status_payload") as mock:
             auto_update.maybe_auto_update(store, context)
         mock.assert_not_called()
@@ -142,9 +140,7 @@ class TestAutoUpdateThrottle:
         context = _make_context(tmp_path)
         store = _FakeStore()
         old = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
-        store._kv_data[auto_update.AUTO_UPDATE_STATE_KEY] = (
-            '{"last_check_at": "' + old.isoformat() + '"}'
-        )
+        store._kv_data[auto_update.AUTO_UPDATE_STATE_KEY] = {"last_check_at": old.isoformat()}
         status = {
             "current_version": "2.0.967",
             "latest_version": "2.0.970",

--- a/tests/test_guard_command_executors_update.py
+++ b/tests/test_guard_command_executors_update.py
@@ -121,28 +121,28 @@ class TestAppUpdateOperations:
 
 
 class TestAutoUpdateThrottle:
-    """Verify auto-update throttling in _maybe_auto_update."""
+    """Verify auto-update throttling in maybe_auto_update."""
 
     def test_auto_update_skipped_within_throttle_window(self, tmp_path: Path) -> None:
-        from codex_plugin_scanner.guard.runtime import command_queue
+        from codex_plugin_scanner.guard.runtime import auto_update
 
         context = _make_context(tmp_path)
         store = _FakeStore()
         recent = datetime.now(timezone.utc)
-        store._kv_data[command_queue.AUTO_UPDATE_STATE_KEY] = (
+        store._kv_data[auto_update.AUTO_UPDATE_STATE_KEY] = (
             '{"last_check_at": "' + recent.isoformat() + '"}'
         )
-        with patch.object(command_queue, "build_guard_update_status_payload") as mock:
-            command_queue._maybe_auto_update(store, context)
+        with patch.object(auto_update, "build_guard_update_status_payload") as mock:
+            auto_update.maybe_auto_update(store, context)
         mock.assert_not_called()
 
     def test_auto_update_runs_after_throttle_window(self, tmp_path: Path) -> None:
-        from codex_plugin_scanner.guard.runtime import command_queue
+        from codex_plugin_scanner.guard.runtime import auto_update
 
         context = _make_context(tmp_path)
         store = _FakeStore()
         old = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
-        store._kv_data[command_queue.AUTO_UPDATE_STATE_KEY] = (
+        store._kv_data[auto_update.AUTO_UPDATE_STATE_KEY] = (
             '{"last_check_at": "' + old.isoformat() + '"}'
         )
         status = {
@@ -152,13 +152,13 @@ class TestAutoUpdateThrottle:
             "update_available": True,
             "blocked_reason": None,
         }
-        with patch.object(command_queue, "build_guard_update_status_payload", return_value=status):
-            with patch.object(command_queue, "run_guard_update", return_value=({"changed": True}, 0)) as mock_update:
-                command_queue._maybe_auto_update(store, context)
+        with patch.object(auto_update, "build_guard_update_status_payload", return_value=status):
+            with patch.object(auto_update, "run_guard_update", return_value=({"changed": True}, 0)) as mock_update:
+                auto_update.maybe_auto_update(store, context)
         mock_update.assert_called_once()
 
     def test_auto_update_skipped_when_not_auto_updatable(self, tmp_path: Path) -> None:
-        from codex_plugin_scanner.guard.runtime import command_queue
+        from codex_plugin_scanner.guard.runtime import auto_update
 
         context = _make_context(tmp_path)
         store = _FakeStore()
@@ -169,13 +169,13 @@ class TestAutoUpdateThrottle:
             "update_available": True,
             "blocked_reason": "This install was set up from local source code.",
         }
-        with patch.object(command_queue, "build_guard_update_status_payload", return_value=status):
-            with patch.object(command_queue, "run_guard_update") as mock_update:
-                command_queue._maybe_auto_update(store, context)
+        with patch.object(auto_update, "build_guard_update_status_payload", return_value=status):
+            with patch.object(auto_update, "run_guard_update") as mock_update:
+                auto_update.maybe_auto_update(store, context)
         mock_update.assert_not_called()
 
     def test_auto_update_skipped_when_no_update_available(self, tmp_path: Path) -> None:
-        from codex_plugin_scanner.guard.runtime import command_queue
+        from codex_plugin_scanner.guard.runtime import auto_update
 
         context = _make_context(tmp_path)
         store = _FakeStore()
@@ -186,7 +186,24 @@ class TestAutoUpdateThrottle:
             "update_available": False,
             "blocked_reason": None,
         }
-        with patch.object(command_queue, "build_guard_update_status_payload", return_value=status):
-            with patch.object(command_queue, "run_guard_update") as mock_update:
-                command_queue._maybe_auto_update(store, context)
+        with patch.object(auto_update, "build_guard_update_status_payload", return_value=status):
+            with patch.object(auto_update, "run_guard_update") as mock_update:
+                auto_update.maybe_auto_update(store, context)
         mock_update.assert_not_called()
+
+    def test_auto_update_handles_malformed_state(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.runtime import auto_update
+
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        store._kv_data[auto_update.AUTO_UPDATE_STATE_KEY] = "not valid json{{"
+        status = {
+            "current_version": "2.0.970",
+            "latest_version": "2.0.970",
+            "auto_updatable": True,
+            "update_available": False,
+            "blocked_reason": None,
+        }
+        with patch.object(auto_update, "build_guard_update_status_payload", return_value=status):
+            auto_update.maybe_auto_update(store, context)
+        # Should not crash — malformed state is treated as empty

--- a/tests/test_guard_command_executors_update.py
+++ b/tests/test_guard_command_executors_update.py
@@ -1,0 +1,192 @@
+"""Tests for guard.app.update and guard.app.updateCheck command executors."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.runtime.command_executors import (
+    APP_OPERATIONS,
+    execute_guard_command_job,
+)
+
+
+def _make_context(tmp_path: Path) -> HarnessContext:
+    return HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=tmp_path / "workspace",
+        guard_home=tmp_path / "guard",
+    )
+
+
+def _make_job(operation: str, payload: dict[str, object] | None = None) -> dict[str, object]:
+    return {
+        "id": "job-1",
+        "operation": operation,
+        "operationSchemaVersion": 1,
+        "payload": payload or {},
+    }
+
+
+class _FakeStore:
+    """Minimal fake store with get_kv/set_kv for auto-update state."""
+
+    def __init__(self) -> None:
+        self._kv_data: dict[str, str] = {}
+
+    def get_kv(self, key: str) -> str | None:
+        return self._kv_data.get(key)
+
+    def set_kv(self, key: str, value: str) -> None:
+        self._kv_data[key] = value
+
+
+class TestAppUpdateOperations:
+    """Verify guard.app.update and guard.app.updateCheck are registered and executable."""
+
+    def test_update_operations_in_app_operations(self) -> None:
+        assert "guard.app.update" in APP_OPERATIONS
+        assert "guard.app.updateCheck" in APP_OPERATIONS
+
+    def test_update_check_returns_status_payload(self, tmp_path: Path) -> None:
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        job = _make_job("guard.app.updateCheck")
+        expected_status = {
+            "current_version": "2.0.967",
+            "latest_version": "2.0.970",
+            "auto_updatable": True,
+            "update_available": True,
+            "blocked_reason": None,
+        }
+        with patch(
+            "codex_plugin_scanner.guard.runtime.command_executors.build_guard_update_status_payload",
+            return_value=expected_status,
+        ):
+            result = execute_guard_command_job(job, context=context, store=store, now=lambda: "2026-07-04T00:00:00Z")
+        assert result["data"]["current_version"] == "2.0.967"
+        assert result["data"]["latest_version"] == "2.0.970"
+        assert result["data"]["update_available"] is True
+
+    def test_update_calls_run_guard_update(self, tmp_path: Path) -> None:
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        job = _make_job("guard.app.update")
+        expected_update = {
+            "current_version": "2.0.967",
+            "latest_version": "2.0.970",
+            "status": "updated",
+            "changed": True,
+        }
+        with patch(
+            "codex_plugin_scanner.guard.runtime.command_executors.run_guard_update",
+            return_value=(expected_update, 0),
+        ):
+            result = execute_guard_command_job(job, context=context, store=store, now=lambda: "2026-07-04T00:00:00Z")
+        assert result["data"]["succeeded"] is True
+        assert result["data"]["exitCode"] == 0
+        assert result["data"]["update"]["status"] == "updated"
+        assert result["data"]["update"]["changed"] is True
+
+    def test_update_handles_failure_exit_code(self, tmp_path: Path) -> None:
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        job = _make_job("guard.app.update")
+        expected_update = {
+            "current_version": "2.0.967",
+            "status": "failed",
+            "changed": False,
+            "error": "pip install failed",
+        }
+        with patch(
+            "codex_plugin_scanner.guard.runtime.command_executors.run_guard_update",
+            return_value=(expected_update, 1),
+        ):
+            result = execute_guard_command_job(job, context=context, store=store, now=lambda: "2026-07-04T00:00:00Z")
+        assert result["data"]["succeeded"] is False
+        assert result["data"]["exitCode"] == 1
+        assert result["data"]["update"]["error"] == "pip install failed"
+
+    def test_unsupported_app_operation_returns_failure(self, tmp_path: Path) -> None:
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        job = _make_job("guard.app.unknownOperation")
+        result = execute_guard_command_job(job, context=context, store=store, now=lambda: "2026-07-04T00:00:00Z")
+        assert result["failureCode"] == "unsupported_operation"
+
+
+class TestAutoUpdateThrottle:
+    """Verify auto-update throttling in _maybe_auto_update."""
+
+    def test_auto_update_skipped_within_throttle_window(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.runtime import command_queue
+
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        recent = datetime.now(timezone.utc)
+        store._kv_data[command_queue.AUTO_UPDATE_STATE_KEY] = (
+            '{"last_check_at": "' + recent.isoformat() + '"}'
+        )
+        with patch.object(command_queue, "build_guard_update_status_payload") as mock:
+            command_queue._maybe_auto_update(store, context)
+        mock.assert_not_called()
+
+    def test_auto_update_runs_after_throttle_window(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.runtime import command_queue
+
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        old = datetime(2026, 7, 3, 0, 0, 0, tzinfo=timezone.utc)
+        store._kv_data[command_queue.AUTO_UPDATE_STATE_KEY] = (
+            '{"last_check_at": "' + old.isoformat() + '"}'
+        )
+        status = {
+            "current_version": "2.0.967",
+            "latest_version": "2.0.970",
+            "auto_updatable": True,
+            "update_available": True,
+            "blocked_reason": None,
+        }
+        with patch.object(command_queue, "build_guard_update_status_payload", return_value=status):
+            with patch.object(command_queue, "run_guard_update", return_value=({"changed": True}, 0)) as mock_update:
+                command_queue._maybe_auto_update(store, context)
+        mock_update.assert_called_once()
+
+    def test_auto_update_skipped_when_not_auto_updatable(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.runtime import command_queue
+
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        status = {
+            "current_version": "2.0.967",
+            "latest_version": "2.0.970",
+            "auto_updatable": False,
+            "update_available": True,
+            "blocked_reason": "This install was set up from local source code.",
+        }
+        with patch.object(command_queue, "build_guard_update_status_payload", return_value=status):
+            with patch.object(command_queue, "run_guard_update") as mock_update:
+                command_queue._maybe_auto_update(store, context)
+        mock_update.assert_not_called()
+
+    def test_auto_update_skipped_when_no_update_available(self, tmp_path: Path) -> None:
+        from codex_plugin_scanner.guard.runtime import command_queue
+
+        context = _make_context(tmp_path)
+        store = _FakeStore()
+        status = {
+            "current_version": "2.0.970",
+            "latest_version": "2.0.970",
+            "auto_updatable": True,
+            "update_available": False,
+            "blocked_reason": None,
+        }
+        with patch.object(command_queue, "build_guard_update_status_payload", return_value=status):
+            with patch.object(command_queue, "run_guard_update") as mock_update:
+                command_queue._maybe_auto_update(store, context)
+        mock_update.assert_not_called()


### PR DESCRIPTION
## Summary

Add two new command queue operations for remote Guard CLI updates:

1. **`guard.app.update`** — executes `run_guard_update(dry_run=False)` on the agent machine. Returns the update payload and exit code. Does not require a harness (updates hol-guard itself, not a harness adapter).

2. **`guard.app.updateCheck`** — calls `build_guard_update_status_payload()` read-only. Returns `current_version`, `latest_version`, `update_available`, `auto_updatable`, and `blocked_reason`. Used by the portal to display version status in the agent list.

## Auto-update

`_maybe_auto_update()` runs during the empty poll path when no job was leased. Throttled to once per 6 hours via `guard_auto_update_state` KV. Only self-applies when:
- `auto_updatable=True`
- `update_available=True`
- `blocked_reason=None`

Source/editable installs are excluded by the existing `auto_updatable` flag in `build_guard_update_status_payload`.

## Tests

9 new tests in `test_guard_command_executors_update.py`:
- Update check returns status payload
- Update calls run_guard_update
- Update handles failure exit code
- Unsupported app operation returns failure
- Auto-update skipped within throttle window
- Auto-update runs after throttle window
- Auto-update skipped when not auto_updatable
- Auto-update skipped when no update available
- Operations registered in APP_OPERATIONS

All 77 existing command queue tests still pass.