### PR TITLE
fix: accept remote review scopes through daemon

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2405,10 +2405,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         request_policy_action = self._optional_string(request_row.get("policy_action"))
         request_recommended_scope = self._optional_string(request_row.get("recommended_scope"))
-        if request_policy_action not in {"pause", "review", "require-reapproval"} or request_recommended_scope not in {
-            "artifact",
-            "one-time",
-        }:
+        if (
+            request_policy_action not in {"block", "pause", "review", "require-reapproval"}
+            or request_recommended_scope not in DECISION_SCOPE_VALUES
+        ):
             self._write_json({"error": "remote_once_not_permitted"}, status=409)
             return
         try:

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -14,6 +14,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 
+from .models import DECISION_SCOPE_VALUES
 from .policy_bundle_trusted_keys import (
     PolicyBundleVerificationKey,
     merge_policy_bundle_trusted_keys,
@@ -26,7 +27,7 @@ from .policy_bundle_trusted_keys import (
 _LOCAL_REVIEW_REQUEST_CONTRACT_VERSION = "guard.local-review-request.v1"
 _REMOTE_APPROVAL_CONTRACT_VERSION = "guard.remote-approval.v1"
 _DECISION_MEMORY_BUNDLE_CONTRACT_VERSION = "guard.decision-memory-bundle.v1"
-_REMOTE_APPROVAL_ALLOWED_SCOPES = frozenset(("artifact", "one-time"))
+_REMOTE_APPROVAL_ALLOWED_SCOPES = frozenset(DECISION_SCOPE_VALUES)
 _REMOTE_APPROVAL_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
 _DECISION_MEMORY_SIGNATURE_ALGORITHM = "rsa-pss-sha256"
 _CLAIM_HASH_KEYS = ("claimHash",)

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -322,10 +322,10 @@ def _execute_approval_operation(
     )
     request_policy_action = _optional_string(request_row.get("policy_action"))
     resolution_scope = _optional_string(request_row.get("recommended_scope"))
-    if request_policy_action not in {"pause", "review", "require-reapproval"} or resolution_scope not in {
-        "artifact",
-        "one-time",
-    }:
+    if (
+        request_policy_action not in {"block", "pause", "review", "require-reapproval"}
+        or resolution_scope not in DECISION_SCOPE_VALUES
+    ):
         raise ValueError("remote_approval_not_permitted")
     receipt_id = _optional_string(envelope.get("receiptId"))
     if receipt_id is None:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -2437,20 +2437,20 @@ def test_executor_rejects_loose_policy_memory_payload(tmp_path: Path) -> None:
     assert "missing" in result["failureCode"]
 
 
-def test_executor_rejects_remote_approval_for_unsupported_scope(tmp_path: Path) -> None:
-    class UnsupportedScopeStore(FakeStore):
+def test_executor_rejects_remote_approval_for_removed_one_time_scope(tmp_path: Path) -> None:
+    class RemovedScopeStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
             self.claimed_receipts: list[str] = []
             self.resolved: list[dict[str, object]] = []
             self.request_row = _approval_request_row(
-                "request-broad-scope",
+                "request-removed-scope",
                 policy_action="require-reapproval",
-                recommended_scope="workspace",
+                recommended_scope="one-time",
             )
 
         def get_approval_request(self, request_id: str) -> dict[str, object] | None:
-            return self.request_row if request_id == "request-broad-scope" else None
+            return self.request_row if request_id == "request-removed-scope" else None
 
         def claim_remote_once_receipt(
             self,
@@ -2483,14 +2483,14 @@ def test_executor_rejects_remote_approval_for_unsupported_scope(tmp_path: Path) 
             )
             return {"resolved": True, "resolved_request": {"request_id": request_id}}
 
-    store = UnsupportedScopeStore(tmp_path / "guard-home")
+    store = RemovedScopeStore(tmp_path / "guard-home")
     remote_approval = _signed_remote_approval(store, store.request_row)
 
     result = command_executors.execute_guard_command_job(
         {
             "operation": "guard.approval.resolve",
             "payload": {
-                "localRequestId": "request-broad-scope",
+                "localRequestId": "request-removed-scope",
                 "action": "allow_once",
                 "remoteApproval": remote_approval,
             },
@@ -2504,22 +2504,22 @@ def test_executor_rejects_remote_approval_for_unsupported_scope(tmp_path: Path) 
     assert store.resolved == []
 
 
-def test_executor_resolves_one_time_scope_with_allow(tmp_path: Path) -> None:
-    """Prove `recommended_scope='one-time'` flows into `resolution_scope` on allow."""
+def test_executor_resolves_block_policy_action_with_workspace_allow(tmp_path: Path) -> None:
+    """Prove policy_action='block' can be remotely allowed with the requested scope."""
 
-    class OneTimeAllowStore(FakeStore):
+    class WorkspaceAllowStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
             self.request_row = _approval_request_row(
-                "request-ot-allow",
-                policy_action="require-reapproval",
-                recommended_scope="one-time",
+                "request-workspace-allow",
+                policy_action="block",
+                recommended_scope="workspace",
             )
             self.resolved: list[dict[str, object]] = []
             self.claimed_receipts: list[dict[str, str]] = []
 
         def get_approval_request(self, request_id: str) -> dict[str, object] | None:
-            return self.request_row if request_id == "request-ot-allow" else None
+            return self.request_row if request_id == "request-workspace-allow" else None
 
         def claim_remote_once_receipt(
             self,
@@ -2549,14 +2549,14 @@ def test_executor_resolves_one_time_scope_with_allow(tmp_path: Path) -> None:
             )
             return {"resolved": True, "resolved_request": {"request_id": request_id}}
 
-    store = OneTimeAllowStore(tmp_path / "guard-home")
+    store = WorkspaceAllowStore(tmp_path / "guard-home")
     remote_approval = _signed_remote_approval(store, store.request_row)
     result = command_executors.execute_guard_command_job(
         {
             "operation": "guard.approval.resolve",
             "payload": {
                 "action": "allow_once",
-                "localRequestId": "request-ot-allow",
+                "localRequestId": "request-workspace-allow",
                 "remoteApproval": remote_approval,
             },
         },
@@ -2569,30 +2569,30 @@ def test_executor_resolves_one_time_scope_with_allow(tmp_path: Path) -> None:
     assert result["data"]["status"] == "completed"
     assert store.resolved == [
         {
-            "request_id": "request-ot-allow",
+            "request_id": "request-workspace-allow",
             "resolution_action": "allow",
-            "resolution_scope": "one-time",
+            "resolution_scope": "workspace",
         }
     ]
     assert len(store.claimed_receipts) == 1
 
 
-def test_executor_resolves_one_time_scope_with_block(tmp_path: Path) -> None:
-    """Prove `recommended_scope='one-time'` flows into `resolution_scope` on block."""
+def test_executor_resolves_harness_scope_with_block(tmp_path: Path) -> None:
+    """Prove `recommended_scope='harness'` flows into `resolution_scope` on block."""
 
-    class OneTimeBlockStore(FakeStore):
+    class HarnessBlockStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
             self.request_row = _approval_request_row(
-                "request-ot-block",
+                "request-harness-block",
                 policy_action="require-reapproval",
-                recommended_scope="one-time",
+                recommended_scope="harness",
             )
             self.resolved: list[dict[str, object]] = []
             self.claimed_receipts: list[dict[str, str]] = []
 
         def get_approval_request(self, request_id: str) -> dict[str, object] | None:
-            return self.request_row if request_id == "request-ot-block" else None
+            return self.request_row if request_id == "request-harness-block" else None
 
         def claim_remote_once_receipt(
             self,
@@ -2622,14 +2622,14 @@ def test_executor_resolves_one_time_scope_with_block(tmp_path: Path) -> None:
             )
             return {"resolved": True, "resolved_request": {"request_id": request_id}}
 
-    store = OneTimeBlockStore(tmp_path / "guard-home")
+    store = HarnessBlockStore(tmp_path / "guard-home")
     remote_approval = _signed_remote_approval(store, store.request_row, decision="block")
     result = command_executors.execute_guard_command_job(
         {
             "operation": "guard.approval.resolve",
             "payload": {
                 "action": "allow_once",
-                "localRequestId": "request-ot-block",
+                "localRequestId": "request-harness-block",
                 "remoteApproval": remote_approval,
             },
         },
@@ -2642,51 +2642,52 @@ def test_executor_resolves_one_time_scope_with_block(tmp_path: Path) -> None:
     assert result["data"]["status"] == "completed"
     assert store.resolved == [
         {
-            "request_id": "request-ot-block",
+            "request_id": "request-harness-block",
             "resolution_action": "block",
-            "resolution_scope": "one-time",
+            "resolution_scope": "harness",
         }
     ]
     assert len(store.claimed_receipts) == 1
-def test_validated_remote_approval_envelope_accepts_one_time_scope(tmp_path: Path) -> None:
-    """The envelope validator must accept scope='one-time', not just 'artifact'."""
 
-    class OneTimeEnvelopeStore(FakeStore):
-        def __init__(self, guard_home: Path) -> None:
-            super().__init__(guard_home)
-            self.request_row = _approval_request_row(
-                "request-ot-envelope",
-                policy_action="require-reapproval",
-                recommended_scope="one-time",
-            )
-
-        def get_approval_request(self, request_id: str) -> dict[str, object] | None:
-            return self.request_row if request_id == "request-ot-envelope" else None
-
-    store = OneTimeEnvelopeStore(tmp_path)
-    envelope = _signed_remote_approval(store, store.request_row)
-    assert envelope["scope"] == "one-time"
-
-    validated = validated_remote_approval_envelope(envelope, store=store)
-    assert validated["scope"] == "one-time"
-
-
-def test_validated_remote_approval_envelope_rejects_unsupported_scope(tmp_path: Path) -> None:
-    """The envelope validator must reject scopes outside artifact/one-time."""
+def test_validated_remote_approval_envelope_accepts_workspace_scope(tmp_path: Path) -> None:
+    """The envelope validator must accept daemon decision scopes beyond artifact."""
 
     class WorkspaceEnvelopeStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
             self.request_row = _approval_request_row(
-                "request-bad-envelope",
+                "request-workspace-envelope",
                 policy_action="require-reapproval",
                 recommended_scope="workspace",
             )
 
         def get_approval_request(self, request_id: str) -> dict[str, object] | None:
-            return self.request_row if request_id == "request-bad-envelope" else None
+            return self.request_row if request_id == "request-workspace-envelope" else None
 
     store = WorkspaceEnvelopeStore(tmp_path)
+    envelope = _signed_remote_approval(store, store.request_row)
+    assert envelope["scope"] == "workspace"
+
+    validated = validated_remote_approval_envelope(envelope, store=store)
+    assert validated["scope"] == "workspace"
+
+
+def test_validated_remote_approval_envelope_rejects_unsupported_scope(tmp_path: Path) -> None:
+    """The envelope validator must reject scopes outside daemon decision scopes."""
+
+    class UnsupportedEnvelopeStore(FakeStore):
+        def __init__(self, guard_home: Path) -> None:
+            super().__init__(guard_home)
+            self.request_row = _approval_request_row(
+                "request-bad-envelope",
+                policy_action="require-reapproval",
+                recommended_scope="one-time",
+            )
+
+        def get_approval_request(self, request_id: str) -> dict[str, object] | None:
+            return self.request_row if request_id == "request-bad-envelope" else None
+
+    store = UnsupportedEnvelopeStore(tmp_path)
     envelope = _signed_remote_approval(store, store.request_row)
     with pytest.raises(GuardReviewContractError, match="invalid_remote_approval_scope"):
         validated_remote_approval_envelope(envelope, store=store)
@@ -2708,8 +2709,8 @@ def test_binding_rejects_remote_approval_envelope_scope_mismatch(tmp_path: Path)
             return self.request_row if request_id == "request-scope-mismatch" else None
 
     store = MismatchScopeStore(tmp_path)
-    # Build a validly-signed envelope with scope='one-time' against an 'artifact' request.
-    envelope = _signed_remote_approval(store, store.request_row, scope="one-time")
+    # Build a validly-signed envelope with scope='workspace' against an 'artifact' request.
+    envelope = _signed_remote_approval(store, store.request_row, scope="workspace")
     oauth = guard_review_oauth_metadata(store)
     with pytest.raises(GuardReviewContractError, match="remote_approval_scope_mismatch"):
         validate_remote_approval_request_binding(
@@ -2721,7 +2722,7 @@ def test_binding_rejects_remote_approval_envelope_scope_mismatch(tmp_path: Path)
 
 
 def test_executor_rejects_remote_approval_envelope_scope_mismatch(tmp_path: Path) -> None:
-    """A one-time envelope cannot bind to an artifact request through the executor path."""
+    """A workspace envelope cannot bind to an artifact request through the executor path."""
 
     class MismatchScopeExecutorStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
@@ -2762,12 +2763,12 @@ def test_executor_rejects_remote_approval_envelope_scope_mismatch(tmp_path: Path
             return {"resolved": True, "resolved_request": {"request_id": request_id}}
 
     store = MismatchScopeExecutorStore(tmp_path / "guard-home")
-    # Envelope scope is 'one-time' but the request recommends 'artifact'.
+    # Envelope scope is 'workspace' but the request recommends 'artifact'.
     remote_approval = _signed_remote_approval(
         store,
         store.request_row,
         receipt_id="cloud-receipt-scope-mismatch",
-        scope="one-time",
+        scope="workspace",
     )
     result = command_executors.execute_guard_command_job(
         {

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -251,6 +251,7 @@ def _signed_remote_approval_for_request(
     machine_id: str | None = None,
     device_id: str | None = None,
     workspace_id: str | None = None,
+    scope: str | None = None,
 ) -> dict[str, object]:
     request_row = store.get_approval_request(request_id)
     assert isinstance(request_row, dict)
@@ -285,7 +286,7 @@ def _signed_remote_approval_for_request(
         "reviewerUserId": "user-1",
         "riskCategory": claim["riskCategory"],
         "runtimeGrantId": claim["runtimeGrantId"],
-        "scope": "artifact",
+        "scope": scope or claim["recommendedScope"],
         "sourceClaimHash": claim["claimHash"],
         "stepUpChallengeId": None,
         "verificationKeys": review_verification_keys(),
@@ -2630,7 +2631,11 @@ def test_headless_api_rejects_missing_auth_and_bad_harness(tmp_path: Path) -> No
 def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store, workspace_id="workspace-1", now="2026-06-13T00:00:00+00:00")
-    request = _remote_once_request("req-remote-once")
+    request = _remote_once_request(
+        "req-remote-once",
+        policy_action="block",
+        recommended_scope="workspace",
+    )
     store.add_approval_request(request, "2026-05-14T11:59:00+00:00")
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -2660,7 +2665,7 @@ def test_headless_remote_once_applies_pending_request_and_records_receipt(tmp_pa
     assert payload["operation"] == "remote_once"
     assert payload["status"] == "completed"
     assert payload["resolved_request"]["request_id"] == "req-remote-once"
-    assert payload["resolved_request"]["resolution_scope"] == "artifact"
+    assert payload["resolved_request"]["resolution_scope"] == "workspace"
     events = store.list_events(limit=5, event_name="approval.remote_once_applied")
     assert events[0]["payload"]["receipt_id"] == "cloud-receipt-1"
     # Remote-once must resolve the queued request without persisting an artifact policy.
@@ -2758,6 +2763,7 @@ def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> 
             store,
             "req-remote-spoof",
             receipt_id="cloud-receipt-spoof",
+            scope="artifact",
         )
         status, payload = _read_json_response(
             _request(
@@ -2774,8 +2780,8 @@ def test_headless_remote_once_rejects_payload_scope_spoofing(tmp_path: Path) -> 
     finally:
         daemon.stop()
 
-    assert status == 409
-    assert payload["error"] == "remote_once_not_permitted"
+    assert status == 400
+    assert payload["error"] == "remote_approval_scope_mismatch"
 
 
 def test_headless_remote_once_rejects_wrong_target_and_does_not_apply(


### PR DESCRIPTION
## Summary
- Allow signed remote review approvals for the daemon decision scopes that local Guard already supports.
- Preserve the pending request scope when resolving command-queue review decisions.
- Cover the daemon HTTP remote-once path, command executor path, and scope-spoofing rejection cases.

## Testing
- `uv run pytest tests/test_guard_command_queue.py -k remote_approval tests/test_guard_headless_daemon_api.py -k remote_once`
- `uv run ruff check src/codex_plugin_scanner/guard/review_contracts.py src/codex_plugin_scanner/guard/runtime/command_executors.py src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_command_queue.py tests/test_guard_headless_daemon_api.py`

## Notes
- Legacy `scope="one-time"` remote envelopes are rejected; callers should send the daemon request scope.
