### PR TITLE
Restore auth audit coverage for daemon 401s

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1458,11 +1458,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if len(path_parts) == 4 and path_parts[:2] == ["v1", "requests"] and path_parts[3] == "resume":
             if not self._header_token_is_valid():
-                self._write_json(
-                    {"error": "unauthorized"},
-                    status=401,
-                    extra_headers=self._cors_headers_for_request(),
-                )
+                self._write_unauthorized(extra_headers=self._cors_headers_for_request())
                 return
             self._handle_request_resume_read(path_parts[2])
             return
@@ -1669,11 +1665,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             self._write_json({"error": "forbidden_origin"}, status=403)
             return
         if not self._header_token_is_valid():
-            self._write_json(
-                {"error": "unauthorized"},
-                status=401,
-                extra_headers=self._cors_headers_for_request(),
-            )
+            self._write_unauthorized(extra_headers=self._cors_headers_for_request())
             return
         store = self.server.store  # type: ignore[attr-defined]
         if parsed.path == "/v1/evidence":
@@ -1736,6 +1728,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                 host = self._daemon_server().daemon_host()
                 port = self._daemon_server().daemon_port()
                 reconnect_url = _build_local_url(host, port, "/#/reconnect")
+                self._record_auth_audit_event()
                 self._write_json(
                     {
                         "error": "unauthorized",

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -512,6 +512,35 @@ def test_request_resume_retry_endpoint_requires_guard_token(tmp_path: Path) -> N
     assert events[-1]["payload"]["path"] == "/v1/requests/req-auth-post/resume"
 
 
+@pytest.mark.parametrize("action", ["approve", "block"])
+def test_request_resolution_endpoint_requires_guard_token_and_records_audit(
+    tmp_path: Path,
+    action: str,
+) -> None:
+    request_id = f"req-auth-{action}"
+    store = GuardStore(tmp_path / "guard-home")
+    store.add_approval_request(_request(request_id), "2026-05-19T10:00:00+00:00")
+    daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+    daemon.start()
+
+    try:
+        status, payload = _post_json_without_token(
+            daemon.port,
+            f"/v1/requests/{request_id}/{action}",
+            {"scope": "artifact", "reason": "reviewed"},
+        )
+    finally:
+        daemon.stop()
+
+    assert status == 401
+    assert payload["error"] == "unauthorized"
+    assert payload["recovery"]["code"] == "session_stale"
+    events = store.list_events(event_name="daemon.auth.unauthorized")
+    assert events[-1]["payload"]["method"] == "POST"
+    assert events[-1]["payload"]["path"] == f"/v1/requests/{request_id}/{action}"
+    assert events[-1]["payload"]["has_guard_token"] is False
+
+
 def test_codex_allow_resume_prompt_includes_exact_command_when_metadata_is_present(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_guard_codex_resume_endpoints.py
+++ b/tests/test_guard_codex_resume_endpoints.py
@@ -485,6 +485,9 @@ def test_request_resume_status_endpoint_requires_guard_token(tmp_path: Path) -> 
 
     assert status == 401
     assert payload["error"] == "unauthorized"
+    events = store.list_events(event_name="daemon.auth.unauthorized")
+    assert events[-1]["payload"]["method"] == "GET"
+    assert events[-1]["payload"]["path"] == "/v1/requests/req-auth/resume"
 
 
 def test_request_resume_retry_endpoint_requires_guard_token(tmp_path: Path) -> None:
@@ -504,6 +507,9 @@ def test_request_resume_retry_endpoint_requires_guard_token(tmp_path: Path) -> N
 
     assert status == 401
     assert payload["error"] == "unauthorized"
+    events = store.list_events(event_name="daemon.auth.unauthorized")
+    assert events[-1]["payload"]["method"] == "POST"
+    assert events[-1]["payload"]["path"] == "/v1/requests/req-auth-post/resume"
 
 
 def test_codex_allow_resume_prompt_includes_exact_command_when_metadata_is_present(

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1573,6 +1573,28 @@ class TestGuardSurfaceServer:
         events = store.list_events(event_name="daemon.auth.unauthorized")
         assert events[-1]["payload"]["path"] == "/v1/receipts"
 
+    def test_guard_daemon_delete_endpoint_requires_auth_and_records_audit(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            request = urllib.request.Request(
+                f"http://127.0.0.1:{daemon.port}/v1/evidence",
+                method="DELETE",
+            )
+            with pytest.raises(urllib.error.HTTPError) as error:
+                urllib.request.urlopen(request, timeout=5)
+        finally:
+            daemon.stop()
+
+        assert error.value.code == 401
+        payload = json.loads(error.value.read().decode("utf-8"))
+        assert payload["error"] == "unauthorized"
+        events = store.list_events(event_name="daemon.auth.unauthorized")
+        assert events[-1]["payload"]["method"] == "DELETE"
+        assert events[-1]["payload"]["path"] == "/v1/evidence"
+
     def test_guard_daemon_claude_hook_endpoint_accepts_empty_allow_response(self, tmp_path) -> None:
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"


### PR DESCRIPTION
## Summary
- route request-resume GET and evidence DELETE unauthorized responses through `_write_unauthorized()` so they emit `daemon.auth.unauthorized` audit events
- preserve the request-resolution recovery payload while recording the same audit event before the custom 401 response
- add regression coverage for GET, POST, and DELETE daemon unauthorized paths

Fixes #598.

## Validation
- `uv run --all-extras pytest --tb=short tests/test_guard_codex_resume_endpoints.py tests/test_guard_surface_server.py -q` (103 passed)
- `uv run --all-extras ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_surface_server.py`
- `uv run --all-extras ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_codex_resume_endpoints.py tests/test_guard_surface_server.py`
- `git diff --check origin/main...HEAD`