### PR TITLE
fix(guard): refresh AIBOM inventory during sync

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -333,6 +333,7 @@ def sync_aibom_snapshots_if_due(
     *,
     generated_at: str,
     min_interval_seconds: int = _AIBOM_AUTO_SYNC_INTERVAL_SECONDS,
+    force: bool = False,
     options: AibomCliOptions | None = None,
     auth_context: dict[str, object] | None = None,
     home_dir: Path | None = None,
@@ -349,7 +350,7 @@ def sync_aibom_snapshots_if_due(
             "skipped": True,
             "reason": "guard_events_endpoint_unavailable",
         }
-    if not _aibom_sync_is_due(
+    if not force and not _aibom_sync_is_due(
         store,
         generated_at=generated_at,
         min_interval_seconds=min_interval_seconds,

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_cloud.py
@@ -256,28 +256,23 @@ def _run_guard_sync_command(
     context = _require_guard_context(context)
     try:
         auth_context = _cloud_guard_sync_auth_context(store)
-        # Default CLI sync stays fast; --deep opts into foreground AIBOM refresh.
-        include_aibom = bool(getattr(args, "deep", False))
+        # The stale AIBOM UX tells users to run `hol-guard sync`; default sync must
+        # therefore enter the due-gated inventory refresh path. `--deep` forces an
+        # immediate foreground AIBOM refresh even when the recent-sync throttle would
+        # otherwise skip it.
+        force_aibom = bool(getattr(args, "deep", False))
         from .progress import GuardProgress
 
         with GuardProgress(total=2, title="Guard Sync") as bar:
-            bar.step("Syncing receipts and Guard events to Guard Cloud...")
-            if include_aibom:
-                with store.hold_cloud_sync_lock():
-                    payload = sync_receipts(
-                        store,
-                        auth_context=auth_context,
-                        home_dir=context.home_dir,
-                        workspace_dir=context.workspace_dir,
-                        include_aibom=True,
-                    )
-            else:
+            bar.step("Syncing receipts, Guard events, and inventory to Guard Cloud...")
+            with store.hold_cloud_sync_lock():
                 payload = sync_receipts(
                     store,
                     auth_context=auth_context,
                     home_dir=context.home_dir,
                     workspace_dir=context.workspace_dir,
-                    include_aibom=False,
+                    include_aibom=True,
+                    force_aibom=force_aibom,
                 )
             bar.step("Syncing supply chain state...")
             with suppress(GuardSyncNotConfiguredError, RuntimeError):

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1332,6 +1332,7 @@ def sync_receipts(
     home_dir: Path | None = None,
     workspace_dir: Path | None = None,
     include_aibom: bool = False,
+    force_aibom: bool = False,
 ) -> dict[str, object]:
     """Push local receipts to the configured sync endpoint."""
 
@@ -1714,6 +1715,7 @@ def sync_receipts(
             store,
             generated_at=now,
             auth_context=resolved_auth_context,
+            force=force_aibom,
             home_dir=home_dir,
             workspace_dir=workspace_dir,
         )

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -299,6 +299,38 @@ def test_sync_aibom_snapshots_if_due_retries_empty_sync_after_interval(
     assert summary.get("synced") is True
 
 
+def test_sync_aibom_snapshots_if_due_force_bypasses_recent_sync(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots_if_due
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    calls: list[str] = []
+
+    def _fake_sync(*_args, **_kwargs):
+        calls.append("sync")
+        return {"synced": True, "synced_at": "2026-06-10T12:56:00+00:00", "snapshots": 1, "accepted": 1}
+
+    monkeypatch.setattr(aibom_cli, "sync_aibom_snapshots", _fake_sync)
+    store.set_sync_payload(
+        "aibom_sync_summary",
+        {"synced": True, "synced_at": "2026-06-10T12:55:00+00:00"},
+        "2026-06-10T12:55:00+00:00",
+    )
+
+    summary = sync_aibom_snapshots_if_due(
+        store,
+        generated_at="2026-06-10T12:56:00+00:00",
+        force=True,
+    )
+
+    assert calls == ["sync"]
+    assert summary.get("synced") is True
+
+
 def test_inventory_snapshot_event_includes_device_id() -> None:
     snapshot = GuardAgentInventorySnapshot(
         snapshot_id="snapshot-aibom-1",

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -9108,6 +9108,7 @@ url = http://127.0.0.1:8787/guard-canary
         workspace_dir = tmp_path / "workspace"
         workspace_dir.mkdir()
         captured_auth_context: list[dict[str, object]] = []
+        captured_receipt_kwargs: list[dict[str, object]] = []
 
         monkeypatch.setattr(
             guard_commands_module,
@@ -9124,6 +9125,7 @@ url = http://127.0.0.1:8787/guard-canary
         )
 
         def _fake_sync_receipts(_store: GuardStore, **kwargs: object) -> dict[str, object]:
+            captured_receipt_kwargs.append(dict(kwargs))
             auth_context = kwargs.get("auth_context")
             assert isinstance(auth_context, dict)
             captured_auth_context.append(auth_context)
@@ -9162,6 +9164,53 @@ url = http://127.0.0.1:8787/guard-canary
         assert output["supply_chain"]["workspace_audits"]["completed_jobs"] == 1
         assert len(captured_auth_context) == 2
         assert captured_auth_context[0] == captured_auth_context[1]
+        assert captured_receipt_kwargs[0]["include_aibom"] is True
+        assert captured_receipt_kwargs[0]["force_aibom"] is False
+
+    def test_guard_sync_deep_forces_aibom_refresh(self, tmp_path, capsys, monkeypatch):
+        home_dir = tmp_path / "home"
+        workspace_dir = tmp_path / "workspace"
+        workspace_dir.mkdir()
+        captured_receipt_kwargs: list[dict[str, object]] = []
+
+        monkeypatch.setattr(
+            guard_commands_module,
+            "_resolve_guard_sync_auth_context",
+            lambda _store: {
+                "access_token": "token",
+                "sync_url": "https://hol.org/api/guard/receipts/sync",
+            },
+        )
+        monkeypatch.setattr(
+            guard_commands_module,
+            "_require_guard_context",
+            lambda _context: HarnessContext(home_dir=home_dir, workspace_dir=workspace_dir, guard_home=home_dir),
+        )
+
+        def _fake_sync_receipts(_store: GuardStore, **kwargs: object) -> dict[str, object]:
+            captured_receipt_kwargs.append(dict(kwargs))
+            return {
+                "synced_at": "2026-06-18T22:00:00Z",
+                "receipts_stored": 2,
+            }
+
+        monkeypatch.setattr(guard_commands_module, "sync_receipts", _fake_sync_receipts)
+        monkeypatch.setattr(
+            guard_commands_module,
+            "sync_supply_chain_cloud_state",
+            lambda *_args, **_kwargs: {
+                "synced_at": "2026-06-18T22:00:01Z",
+                "status": "synced",
+            },
+        )
+
+        sync_rc = main(["guard", "sync", "--deep", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert sync_rc == 0
+        assert output["receipts_stored"] == 2
+        assert captured_receipt_kwargs[0]["include_aibom"] is True
+        assert captured_receipt_kwargs[0]["force_aibom"] is True
 
     def test_guard_supply_chain_sync_includes_workspace_audits(self, tmp_path, capsys, monkeypatch):
         home_dir = tmp_path / "home"


### PR DESCRIPTION
## Summary
- refresh AIBOM inventory during normal Guard sync runs so due snapshots update without requiring a separate deep pass
- keep the deep sync path forcing the AIBOM refresh and add focused regression coverage for the due-gated sync behavior

## Testing
- `./.venv/bin/pytest tests/test_guard_aibom_cli.py::test_sync_aibom_snapshots_if_due_force_bypasses_recent_sync tests/test_guard_cli.py::TestGuardCli::test_guard_sync_includes_supply_chain_workspace_audits tests/test_guard_cli.py::TestGuardCli::test_guard_sync_deep_forces_aibom_refresh`
- `./.venv/bin/pytest tests/test_guard_aibom_cli.py tests/test_guard_cli.py -k 'aibom or deep_forces_aibom_refresh or includes_supply_chain_workspace_audits'`

## Notes
- Full Docker-based integration verification is currently blocked by a local Docker runtime exec-format failure; the focused pytest coverage above passed in this worktree.
