### PR TITLE
fix(cli): route doctor <harness> to guard doctor instead of scanner

### DIFF
--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -11,6 +11,7 @@ from .argparse_utils import FriendlyArgumentParser, should_default_to_scan_targe
 from .cli_ui import build_cli_epilog, build_plain_text, build_scan_help_epilog
 from .ecosystems.registry import list_supported_ecosystems
 from .guard.cli import add_guard_parser, add_guard_root_parser, run_guard_command
+from .guard.product_model import SUPPORTED_HARNESS_VALUES
 from .reporting import format_json as render_json
 from .rules import get_rule_spec
 from .version import __version__
@@ -212,7 +213,8 @@ def _resolve_legacy_args(
         is_hol_guard_default_doctor = _is_hol_guard_program(program_name) and (
             len(argv) == 1 or "-h" in argv[1:] or "--help" in argv[1:]
         )
-        if has_guard_doctor_flag or is_hol_guard_default_doctor:
+        has_harness_arg = len(argv) >= 2 and not argv[1].startswith("-") and argv[1] in SUPPORTED_HARNESS_VALUES
+        if has_guard_doctor_flag or is_hol_guard_default_doctor or has_harness_arg:
             return ["guard", *argv]
     known_commands = {
         "scan",

--- a/tests/test_guard_policy_integrity.py
+++ b/tests/test_guard_policy_integrity.py
@@ -3166,6 +3166,26 @@ def test_trust_cli_bare_combined_command_routes_to_guard() -> None:
     ]
 
 
+def test_doctor_harness_arg_routes_to_guard() -> None:
+    """Regression: hol-guard doctor codex (without --json) must route to guard doctor codex,
+    not fall through to the scanner-level doctor command which treats 'codex' as a
+    plugin directory path and fails with 'is not a directory'."""
+    for harness in ("codex", "claude-code", "cursor", "opencode", "gemini"):
+        assert _resolve_legacy_args(["doctor", harness], program_mode="combined", program_name="hol-guard") == [
+            "guard",
+            "doctor",
+            harness,
+        ]
+
+
+def test_doctor_non_harness_path_stays_scanner_level() -> None:
+    """doctor /path/to/plugin should still route to scanner-level doctor, not guard."""
+    assert _resolve_legacy_args(["doctor", "/path/to/plugin"], program_mode="combined", program_name="hol-guard") == [
+        "doctor",
+        "/path/to/plugin",
+    ]
+
+
 def test_trust_cli_no_ui_probe_requires_no_ui_flag(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "home"
 


### PR DESCRIPTION
## Problem

Running `hol-guard doctor codex` (without `--json`) fails with:
```
Error: "<cwd>/codex" is not a directory.
```

## Root Cause

`_resolve_legacy_args` in `cli.py` only routed `doctor` to `guard doctor` when:
- Guard-specific flags (`--json`, `--fix`, etc.) were present, OR
- It was a bare `doctor` with no arguments

A harness name argument (`codex`, `claude-code`, `cursor`, `opencode`, `gemini`) was NOT recognized as a guard argument. It fell through to the scanner-level `doctor` command, which interpreted the harness name as a plugin directory path and failed the `is_dir()` check.

## Fix

Check if the argument after `doctor` is a supported harness name (`SUPPORTED_HARNESS_VALUES`) and route to `guard doctor <harness>`.

## Verification

- `uv run ruff check` — passes
- `uv run ruff format --check` — passes
- `uv run pytest tests/test_guard_policy_integrity.py::test_doctor_harness_arg_routes_to_guard tests/test_guard_policy_integrity.py::test_doctor_non_harness_path_stays_scanner_level -v` — 2 passed
- `uv run pytest tests/test_cli.py -k doctor -v` — 3 passed (existing tests still pass)