### PR TITLE
fix(cli): open Guard Cloud app without local fragments

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_interaction.py
@@ -10,7 +10,6 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from ._commands_shared import _CODEX_BROWSER_APPROVAL_WAIT_MAX_SECONDS, _hook_command_text, _now
-    from .commands_support_hook_payload import _browser_url_with_guard_params
 
 
 from ._commands_shared import *
@@ -159,11 +158,8 @@ def _open_guard_cloud_app(
     opener: GuardBrowserOpener,
 ) -> dict[str, object]:
     daemon_url = ensure_guard_daemon(guard_home)
-    auth_token = load_guard_daemon_auth_token(guard_home)
     public_url, browser_url = _guard_cloud_app_urls(
         harness=harness,
-        daemon_url=daemon_url,
-        auth_token=auth_token,
     )
     browser_opened = bool(browser_url and opener(browser_url))
     payload: dict[str, object] = {
@@ -183,8 +179,6 @@ def _open_guard_cloud_app(
 def _guard_cloud_app_error_payload(*, harness: str, error: str) -> dict[str, object]:
     public_url, _browser_url = _guard_cloud_app_urls(
         harness=harness,
-        daemon_url="",
-        auth_token=None,
     )
     return {
         "app_url": public_url,
@@ -202,21 +196,12 @@ def _guard_cloud_app_error_payload(*, harness: str, error: str) -> dict[str, obj
 def _guard_cloud_app_urls(
     *,
     harness: str,
-    daemon_url: str,
-    auth_token: str | None,
-) -> tuple[str, str | None]:
+) -> tuple[str, str]:
     safe_harness = urllib.parse.quote(harness.strip() or "codex", safe="")
     parsed = urllib.parse.urlparse(f"{DEFAULT_GUARD_APPS_URL}/{safe_harness}")
     public_url = urllib.parse.urlunparse(parsed._replace(fragment=""))
-    if auth_token is None:
-        return public_url, None
-    browser_url = _browser_url_with_guard_params(
-        public_url,
-        auth_token=auth_token,
-        surface="cloud-dashboard",
-        daemon_url=daemon_url,
-    )
-    return public_url, browser_url
+    # OAuth app connect must not hand local daemon URLs or dashboard tokens to Cloud.
+    return public_url, public_url
 
 def _build_cisco_scan_options(mode: str) -> ScanOptions:
     return ScanOptions(cisco_skill_scan=mode, cisco_mcp_scan=mode)

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -719,7 +719,9 @@ def command_job_operation(job: dict[str, object]) -> str:
 
 
 def _job_payload(job: dict[str, object]) -> dict[str, object]:
-    payload = job.get("payload")
+    payload = job.get("operationPayload")
+    if not isinstance(payload, dict):
+        payload = job.get("payload")
     return dict(payload) if isinstance(payload, dict) else {}
 
 

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1762,6 +1762,42 @@ def test_executor_dispatches_app_connect(tmp_path: Path, monkeypatch) -> None:
     assert isinstance(result["data"], dict)
 
 
+def test_executor_dispatches_app_connect_from_operation_payload(tmp_path: Path, monkeypatch) -> None:
+    calls: list[tuple[str, str | None, str | None]] = []
+
+    def fake_apply_managed_install(
+        command: str,
+        requested_harness: str | None,
+        install_all: bool,
+        context: HarnessContext,
+        store: object,
+        workspace: str | None,
+        now: str,
+        *,
+        surface: str | None = None,
+    ) -> dict[str, object]:
+        del context, store, workspace, now
+        assert install_all is False
+        calls.append((command, requested_harness, surface))
+        return {"managed_install": {"harness": requested_harness}, "surface": surface}
+
+    monkeypatch.setattr(command_executors, "apply_managed_install", fake_apply_managed_install)
+
+    result = command_executors.execute_guard_command_job(
+        {
+            "operation": "guard.app.connect",
+            "operationPayload": {"harness": "codex", "surface": "cli"},
+        },
+        context=_context(tmp_path),
+        store=FakeStore(tmp_path / "guard-home"),  # type: ignore[arg-type]
+        now=lambda: "2026-06-13T00:00:00+00:00",
+    )
+
+    assert calls == [("install", "codex", "cli")]
+    assert result["generatedAt"] == "2026-06-13T00:00:00+00:00"
+    assert isinstance(result["data"], dict)
+
+
 def test_executor_returns_waiting_local_confirm_for_package_shim_remove(tmp_path: Path) -> None:
     result = command_executors.execute_guard_command_job(
         {

--- a/tests/test_guard_harness_setup.py
+++ b/tests/test_guard_harness_setup.py
@@ -424,10 +424,10 @@ def test_apps_connect_opens_guard_cloud_app_page(
     assert payload["cloud_app"]["app_url"] == "https://hol.org/guard/apps/codex"
     assert len(opened_urls) == 1
     opened_url = urllib.parse.urlparse(opened_urls[0])
-    opened_fragment = urllib.parse.parse_qs(opened_url.fragment)
     assert f"{opened_url.scheme}://{opened_url.netloc}{opened_url.path}" == "https://hol.org/guard/apps/codex"
-    assert opened_fragment["guardDaemon"] == ["http://127.0.0.1:5474"]
-    assert opened_fragment["guard-token"][0].startswith("gld1.")
+    assert opened_url.fragment == ""
+    assert "guardDaemon" not in opened_urls[0]
+    assert "guard-token" not in opened_urls[0]
     assert "local-daemon-token-1234567890" not in json.dumps(payload)
 
 


### PR DESCRIPTION
## Summary
- stop app-connect browser URLs from carrying local daemon fragments or local dashboard tokens
- accept command queue operation payloads when executing app connect jobs
- cover app-connect execution from the leased command payload shape

## Verification
- `uv run pytest -q tests/test_guard_harness_setup.py`
- `uv run pytest -q tests/test_guard_command_queue.py -k 'app_connect'`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/command_executors.py tests/test_guard_command_queue.py`
- guard-dev-testing container URL assertion for app connect
