### PR TITLE
fix(scanner): prevent repo-shadowed skill_scanner imports during Guard sync

### DIFF
--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -158,7 +158,7 @@ def _validate_skill_scanner_import() -> None:
         # has __spec__ = None. Treat as not-a-real-package: if it's already
         # in sys.modules (test mock), let __import__ handle it; otherwise raise.
         if "skill_scanner" not in sys.modules:
-            raise ImportError("skill_scanner package not found")
+            raise ImportError("skill_scanner package not found") from None
         return
     if spec is None:
         # Not installed as a real package. If it's already in sys.modules
@@ -371,7 +371,8 @@ def run_cisco_skill_scan(
     except ImportError:
         if mode == "on":
             return _build_unavailable_summary(
-                "Cisco skill scanner is required but not installed or resolves to an unsafe path. Ensure package dependencies are installed from a trusted source.",
+                "Cisco skill scanner is required but not installed or resolves to an unsafe path."
+                " Ensure package dependencies are installed from a trusted source.",
                 status=CiscoIntegrationStatus.UNAVAILABLE,
             )
         return _build_unavailable_summary(

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -167,28 +167,27 @@ def _validate_skill_scanner_import() -> None:
             raise ImportError("skill_scanner package not found")
         return
     if spec.origin is None:
-        # Namespace package or already-loaded mock; let __import__ handle it.
-        return
-
-    origin = Path(spec.origin).resolve()
-    cwd = Path.cwd().resolve()
-
-    # Trust origins inside the active venv/stdlib, even if under CWD.
-    if not _is_inside_prefix(origin):
-        # Reject if the module originates from CWD or a relative path.
-        if origin == cwd:
-            raise ImportError(
-                "skill_scanner resolves to the current directory; refusing to import a shadowed module."
-            )
-        try:
-            origin.relative_to(cwd)
-            raise ImportError(
-                "skill_scanner resolves inside the current working directory; refusing to import a shadowed module."
-            )
-        except ValueError:
-            pass
-
+        # Namespace package (no __init__.py) — origin is None but search
+        # locations may still point to CWD. Fall through to check them below
+        # rather than skipping validation entirely.
+        pass
+    else:
+        origin = Path(spec.origin).resolve()
+        cwd = Path.cwd().resolve()
+        if not _is_inside_prefix(origin):
+            if origin == cwd:
+                raise ImportError(
+                    "skill_scanner resolves to the current directory; refusing to import a shadowed module."
+                )
+            try:
+                origin.relative_to(cwd)
+                raise ImportError(
+                    "skill_scanner resolves inside the current working directory; refusing to import a shadowed module."
+                )
+            except ValueError:
+                pass
     # Verify the spec's submodule search locations are also safe.
+    cwd = Path.cwd().resolve()
     search_locations = getattr(spec, "submodule_search_locations", None) or []
     for location in search_locations:
         if not location:
@@ -207,7 +206,6 @@ def _validate_skill_scanner_import() -> None:
             )
         except ValueError:
             pass
-
 
 def _safe_import_skill_scanner() -> None:
     """Validate and import ``skill_scanner`` with shadowing protection."""

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -86,6 +86,7 @@ def _build_unavailable_summary(message: str, *, status: CiscoIntegrationStatus) 
 
 
 def _scan_directory_payload(skills_dir: Path, policy_name: str) -> dict[str, object]:
+    _validate_skill_scanner_import()
     from skill_scanner import SkillScanner
     from skill_scanner.core.scan_policy import ScanPolicy
 
@@ -94,6 +95,106 @@ def _scan_directory_payload(skills_dir: Path, policy_name: str) -> dict[str, obj
     payload = report.to_dict()
     return payload if isinstance(payload, dict) else {}
 
+
+def _is_safe_sys_path_entry(entry: str) -> bool:
+    """Return True only for absolute paths inside a legitimate site-packages or venv.
+
+    Rejects empty strings, relative paths, and the current working directory,
+    which could shadow the real ``skill_scanner`` package from an attacker-controlled
+    checkout.
+    """
+    if not entry or not entry.strip():
+        return False
+    path = Path(entry)
+    if not path.is_absolute():
+        return False
+    resolved = path.resolve()
+    cwd = Path.cwd().resolve()
+    if resolved == cwd:
+        return False
+    # Reject entries that are ancestors or children of CWD (repo checkouts).
+    try:
+        resolved.relative_to(cwd)
+        return False
+    except ValueError:
+        pass
+    try:
+        cwd.relative_to(resolved)
+        return False
+    except ValueError:
+        pass
+    return True
+
+
+def _validate_skill_scanner_import() -> None:
+    """Ensure ``skill_scanner`` resolves to a legitimate installed package.
+
+    Raises ``ImportError`` if the package is shadowed by a file or directory in
+    the current working directory or a relative ``sys.path`` entry, which would
+    allow an attacker-controlled checkout to execute arbitrary code during a
+    default Guard sync.
+    """
+    import importlib.util
+
+    try:
+        spec = importlib.util.find_spec("skill_scanner")
+    except (ValueError, ModuleNotFoundError):
+        # find_spec raises ValueError when a mock module in sys.modules
+        # has __spec__ = None. Treat as not-a-real-package: if it's already
+        # in sys.modules (test mock), let __import__ handle it; otherwise raise.
+        if "skill_scanner" not in sys.modules:
+            raise ImportError("skill_scanner package not found")
+        return
+    if spec is None:
+        # Not installed as a real package. If it's already in sys.modules
+        # (e.g. test mock), let __import__ handle it. Otherwise raise.
+        if "skill_scanner" not in sys.modules:
+            raise ImportError("skill_scanner package not found")
+        return
+    if spec.origin is None:
+        # Namespace package or already-loaded mock; let __import__ handle it.
+        return
+
+    origin = Path(spec.origin).resolve()
+    cwd = Path.cwd().resolve()
+
+    # Reject if the module originates from CWD or a relative path.
+    if origin == cwd:
+        raise ImportError(
+            "skill_scanner resolves to the current directory; refusing to import a shadowed module."
+        )
+    try:
+        origin.relative_to(cwd)
+        raise ImportError(
+            "skill_scanner resolves inside the current working directory; refusing to import a shadowed module."
+        )
+    except ValueError:
+        pass
+
+    # Verify the spec's submodule search locations are also safe.
+    search_locations = getattr(spec, "submodule_search_locations", None) or []
+    for location in search_locations:
+        if not location:
+            continue
+        loc_path = Path(location).resolve()
+        if loc_path == cwd:
+            raise ImportError(
+                "skill_scanner search path includes the current directory; refusing to import a shadowed module."
+            )
+        try:
+            loc_path.relative_to(cwd)
+            raise ImportError(
+                "skill_scanner search path includes a CWD-relative entry; refusing to import a shadowed module."
+            )
+        except ValueError:
+            pass
+
+
+def _safe_import_skill_scanner() -> None:
+    """Validate and import ``skill_scanner`` with shadowing protection."""
+    _validate_skill_scanner_import()
+    __import__("skill_scanner")
+    __import__("skill_scanner.core.scan_policy")
 
 _SUBPROCESS_SCAN_SNIPPET = """
 from pathlib import Path
@@ -118,7 +219,15 @@ def _scan_directory_with_timeout(
     os.close(file_descriptor)
 
     env = os.environ.copy()
-    env["PYTHONPATH"] = os.pathsep.join(str(path) for path in sys.path)
+    # Filter sys.path to exclude CWD and relative paths that could shadow
+    # the real skill_scanner package from an attacker-controlled checkout.
+    safe_path_entries = [
+        str(path) for path in sys.path
+        if isinstance(path, str) and _is_safe_sys_path_entry(path)
+    ]
+    env["PYTHONPATH"] = os.pathsep.join(safe_path_entries)
+    # PYTHONSAFEPATH disables automatic CWD insertion into sys.path in the child.
+    env["PYTHONSAFEPATH"] = "1"
     try:
         try:
             result = subprocess.run(
@@ -241,16 +350,15 @@ def run_cisco_skill_scan(
         )
 
     try:
-        __import__("skill_scanner")
-        __import__("skill_scanner.core.scan_policy")
+        _safe_import_skill_scanner()
     except ImportError:
         if mode == "on":
             return _build_unavailable_summary(
-                "Cisco skill scanner is required but not installed. Ensure package dependencies are installed.",
+                "Cisco skill scanner is required but not installed or resolves to an unsafe path. Ensure package dependencies are installed from a trusted source.",
                 status=CiscoIntegrationStatus.UNAVAILABLE,
             )
         return _build_unavailable_summary(
-            "Cisco skill scanner not installed; deep skill scan skipped.",
+            "Cisco skill scanner not installed or resolves to an unsafe path; deep skill scan skipped.",
             status=CiscoIntegrationStatus.UNAVAILABLE,
         )
 

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -141,6 +141,7 @@ def _is_safe_sys_path_entry(entry: str) -> bool:
         pass
     return True
 
+
 def _validate_skill_scanner_import() -> None:
     """Ensure ``skill_scanner`` resolves to a legitimate installed package.
 
@@ -207,11 +208,13 @@ def _validate_skill_scanner_import() -> None:
         except ValueError:
             pass
 
+
 def _safe_import_skill_scanner() -> None:
     """Validate and import ``skill_scanner`` with shadowing protection."""
     _validate_skill_scanner_import()
     __import__("skill_scanner")
     __import__("skill_scanner.core.scan_policy")
+
 
 _SUBPROCESS_SCAN_SNIPPET = """
 from pathlib import Path
@@ -238,10 +241,7 @@ def _scan_directory_with_timeout(
     env = os.environ.copy()
     # Filter sys.path to exclude CWD and relative paths that could shadow
     # the real skill_scanner package from an attacker-controlled checkout.
-    safe_path_entries = [
-        str(path) for path in sys.path
-        if isinstance(path, str) and _is_safe_sys_path_entry(path)
-    ]
+    safe_path_entries = [str(path) for path in sys.path if isinstance(path, str) and _is_safe_sys_path_entry(path)]
     env["PYTHONPATH"] = os.pathsep.join(safe_path_entries)
     # PYTHONSAFEPATH disables automatic CWD insertion into sys.path in the child.
     env["PYTHONSAFEPATH"] = "1"

--- a/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
+++ b/src/codex_plugin_scanner/integrations/cisco_skill_scanner.py
@@ -96,12 +96,28 @@ def _scan_directory_payload(skills_dir: Path, policy_name: str) -> dict[str, obj
     return payload if isinstance(payload, dict) else {}
 
 
-def _is_safe_sys_path_entry(entry: str) -> bool:
-    """Return True only for absolute paths inside a legitimate site-packages or venv.
+def _is_inside_prefix(path: Path) -> bool:
+    """Return True if ``path`` is inside the active venv or stdlib prefix.
 
-    Rejects empty strings, relative paths, and the current working directory,
-    which could shadow the real ``skill_scanner`` package from an attacker-controlled
-    checkout.
+    Paths inside ``sys.prefix`` or ``sys.base_prefix`` are trusted even when
+    they happen to live under CWD (e.g. a local ``.venv/`` directory).
+    """
+    for prefix in (sys.prefix, sys.base_prefix):
+        try:
+            path.relative_to(Path(prefix).resolve())
+            return True
+        except ValueError:
+            pass
+    return False
+
+
+def _is_safe_sys_path_entry(entry: str) -> bool:
+    """Return True for ``sys.path`` entries safe to pass to the scanner subprocess.
+
+    Rejects empty strings, relative paths, and bare CWD — which could shadow the
+    real ``skill_scanner`` package from an attacker-controlled checkout. Paths
+    inside the active venv or stdlib prefix are always allowed, even if they
+    live under CWD (common for local ``.venv/`` setups).
     """
     if not entry or not entry.strip():
         return False
@@ -109,22 +125,21 @@ def _is_safe_sys_path_entry(entry: str) -> bool:
     if not path.is_absolute():
         return False
     resolved = path.resolve()
+
+    # Always trust venv/stdlib prefixes, even inside CWD.
+    if _is_inside_prefix(resolved):
+        return True
+
     cwd = Path.cwd().resolve()
     if resolved == cwd:
         return False
-    # Reject entries that are ancestors or children of CWD (repo checkouts).
-    try:
-        resolved.relative_to(cwd)
-        return False
-    except ValueError:
-        pass
+    # Reject entries that are ancestors of CWD (could contain shadowing dirs).
     try:
         cwd.relative_to(resolved)
         return False
     except ValueError:
         pass
     return True
-
 
 def _validate_skill_scanner_import() -> None:
     """Ensure ``skill_scanner`` resolves to a legitimate installed package.
@@ -158,18 +173,20 @@ def _validate_skill_scanner_import() -> None:
     origin = Path(spec.origin).resolve()
     cwd = Path.cwd().resolve()
 
-    # Reject if the module originates from CWD or a relative path.
-    if origin == cwd:
-        raise ImportError(
-            "skill_scanner resolves to the current directory; refusing to import a shadowed module."
-        )
-    try:
-        origin.relative_to(cwd)
-        raise ImportError(
-            "skill_scanner resolves inside the current working directory; refusing to import a shadowed module."
-        )
-    except ValueError:
-        pass
+    # Trust origins inside the active venv/stdlib, even if under CWD.
+    if not _is_inside_prefix(origin):
+        # Reject if the module originates from CWD or a relative path.
+        if origin == cwd:
+            raise ImportError(
+                "skill_scanner resolves to the current directory; refusing to import a shadowed module."
+            )
+        try:
+            origin.relative_to(cwd)
+            raise ImportError(
+                "skill_scanner resolves inside the current working directory; refusing to import a shadowed module."
+            )
+        except ValueError:
+            pass
 
     # Verify the spec's submodule search locations are also safe.
     search_locations = getattr(spec, "submodule_search_locations", None) or []
@@ -177,6 +194,8 @@ def _validate_skill_scanner_import() -> None:
         if not location:
             continue
         loc_path = Path(location).resolve()
+        if _is_inside_prefix(loc_path):
+            continue
         if loc_path == cwd:
             raise ImportError(
                 "skill_scanner search path includes the current directory; refusing to import a shadowed module."

--- a/tests/test_skill_security.py
+++ b/tests/test_skill_security.py
@@ -109,7 +109,7 @@ def test_run_cisco_skill_scan_on_mode_requires_cisco_dependency_when_missing(mon
     summary = run_cisco_skill_scan(FIXTURES / "good-plugin" / "skills", mode="on", policy_name="balanced")
 
     assert summary.status == CiscoIntegrationStatus.UNAVAILABLE
-    assert "Ensure package dependencies are installed." in summary.message
+    assert "Ensure package dependencies are installed" in summary.message
 
 
 def test_scan_plugin_includes_cisco_findings(monkeypatch):
@@ -341,3 +341,55 @@ def test_scan_plugin_ignores_symlinked_skill_files_outside_plugin_root(tmp_path)
 
     assert analyzable_check.applicable is False
     assert "outside the plugin root" in analyzable_check.message
+def test_cisco_skill_scanner_rejects_shadowed_import_from_cwd(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """A skill_scanner module shadowed in the CWD must not be imported during sync."""
+    from codex_plugin_scanner.integrations.cisco_skill_scanner import _is_safe_sys_path_entry
+
+    # CWD and relative paths are unsafe
+    assert _is_safe_sys_path_entry("") is False
+    assert _is_safe_sys_path_entry(".") is False
+    assert _is_safe_sys_path_entry("relative/path") is False
+
+    # Absolute paths outside CWD are safe
+    assert _is_safe_sys_path_entry("/usr/lib/python3.13/site-packages") is True
+
+    # CWD as absolute path is unsafe
+    cwd = str(Path.cwd().resolve())
+    assert _is_safe_sys_path_entry(cwd) is False
+
+    # Subdirectory of CWD is unsafe
+    subdir = str(Path.cwd().resolve() / "subdir")
+    assert _is_safe_sys_path_entry(subdir) is False
+
+
+def test_cisco_skill_scanner_validates_import_source(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """_validate_skill_scanner_import must reject modules originating from CWD."""
+    from codex_plugin_scanner.integrations import cisco_skill_scanner as scanner_mod
+    from codex_plugin_scanner.integrations.cisco_skill_scanner import _validate_skill_scanner_import
+    import importlib.util
+
+    # When skill_scanner is not installed and not in sys.modules, it should raise ImportError
+    monkeypatch.delitem(sys.modules, "skill_scanner", raising=False)
+    monkeypatch.delitem(sys.modules, "skill_scanner.core", raising=False)
+    monkeypatch.delitem(sys.modules, "skill_scanner.core.scan_policy", raising=False)
+
+    # Mock find_spec to return None (simulating package not installed)
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+
+    with pytest.raises(ImportError, match="skill_scanner package not found"):
+        _validate_skill_scanner_import()
+
+    # Restore real find_spec and mock a spec with CWD origin to test shadowing rejection
+    monkeypatch.undo()
+    monkeypatch.delitem(sys.modules, "skill_scanner", raising=False)
+
+    cwd_origin = str(Path.cwd().resolve() / "skill_scanner" / "__init__.py")
+    fake_spec = importlib.util.spec_from_file_location(
+        "skill_scanner",
+        cwd_origin,
+        submodule_search_locations=[str(Path.cwd().resolve() / "skill_scanner")],
+    )
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: fake_spec)
+
+    with pytest.raises(ImportError, match="shadowed module"):
+        _validate_skill_scanner_import()

--- a/tests/test_skill_security.py
+++ b/tests/test_skill_security.py
@@ -345,7 +345,7 @@ def test_cisco_skill_scanner_rejects_shadowed_import_from_cwd(tmp_path: Path, mo
     """A skill_scanner module shadowed in the CWD must not be imported during sync."""
     from codex_plugin_scanner.integrations.cisco_skill_scanner import _is_safe_sys_path_entry
 
-    # CWD and relative paths are unsafe
+    # Empty, relative, and bare CWD are unsafe
     assert _is_safe_sys_path_entry("") is False
     assert _is_safe_sys_path_entry(".") is False
     assert _is_safe_sys_path_entry("relative/path") is False
@@ -357,10 +357,9 @@ def test_cisco_skill_scanner_rejects_shadowed_import_from_cwd(tmp_path: Path, mo
     cwd = str(Path.cwd().resolve())
     assert _is_safe_sys_path_entry(cwd) is False
 
-    # Subdirectory of CWD is unsafe
-    subdir = str(Path.cwd().resolve() / "subdir")
-    assert _is_safe_sys_path_entry(subdir) is False
-
+    # Ancestor of CWD is unsafe (could contain shadowing dirs)
+    parent = str(Path.cwd().resolve().parent)
+    assert _is_safe_sys_path_entry(parent) is False
 
 def test_cisco_skill_scanner_validates_import_source(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
     """_validate_skill_scanner_import must reject modules originating from CWD."""


### PR DESCRIPTION
## Summary
- Validate `skill_scanner` import source via `importlib.util.find_spec` before importing, rejecting modules that resolve to the current working directory or a CWD-relative `sys.path` entry.
- Filter `PYTHONPATH` passed to the scanner subprocess to exclude CWD and relative paths, and set `PYTHONSAFEPATH=1` to disable automatic CWD insertion into `sys.path` in the child process.
- Wrap `find_spec` in `try/except` to handle mock modules with `__spec__=None` (used in tests) without raising `ValueError`.

## Testing
- `python3 -m pytest tests/test_skill_security.py tests/test_guard_cisco_evidence.py tests/test_guard_cisco_runtime_cli.py tests/test_guard_inventory_cisco.py tests/test_guard_aibom_trust_metadata.py -v`
