### PR TITLE
fix: show device approval code in connect output

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -1450,6 +1450,17 @@ def _render_connect(console: Console, payload: dict[str, object]) -> None:
         body = Table.grid(padding=(0, 1))
         milestone = str(payload.get("milestone") or "")
         body.add_row("Browser opened", _bool_label(bool(payload.get("browser_opened"))))
+        user_code = payload.get("user_code")
+        if isinstance(user_code, str) and user_code.strip():
+            next_action = payload.get("next_action")
+            next_action_target = next_action.get("target") if isinstance(next_action, dict) else None
+            approval_url = (
+                payload.get("verification_uri_complete") or payload.get("verification_uri") or next_action_target
+            )
+            body.add_row("Approval code", user_code.strip())
+            if isinstance(approval_url, str) and approval_url.strip():
+                body.add_row("Approval URL", approval_url.strip())
+            body.add_row("Browser prompt", f"Enter code {user_code.strip()}")
         body.add_row(
             "Browser paired",
             _bool_label(bool(payload.get("completed_at")) or str(payload.get("status") or "") == "connected"),

--- a/tests/test_guard_oauth_device_connect.py
+++ b/tests/test_guard_oauth_device_connect.py
@@ -1396,6 +1396,64 @@ def test_connect_headless_open_browser_opens_device_approval_before_polling(
     assert "browser_opened" in captured.out
 
 
+def test_connect_headless_open_browser_renders_device_code_for_install_users(
+    tmp_path: Path,
+    capsys,
+    monkeypatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    args = _HeadlessConnectArgs()
+    args.guard_home = str(guard_home)
+    args.open_browser = True
+    args.json = False
+
+    def fake_headless_flow(
+        *,
+        store: GuardStore,
+        connect_url: str,
+        wait_timeout_seconds: int = 180,
+        announce_copy=None,
+        open_browser=None,
+        ci_safe: bool = False,
+        machine_label: str | None = None,
+    ) -> dict[str, object]:
+        del store, connect_url, wait_timeout_seconds, ci_safe, machine_label
+        assert open_browser is not None
+        if announce_copy is not None:
+            announce_copy(
+                {
+                    "user_code": "ABCD-EFGH",
+                    "verification_uri": "https://guard.example.test/guard/oauth/device",
+                    "verification_uri_complete": "https://guard.example.test/guard/oauth/device?user_code=ABCD-EFGH",
+                }
+            )
+        return {
+            "status": "connected",
+            "connect_mode": "device_code",
+            "browser_opened": bool(open_browser("https://guard.example.test/guard/oauth/device")),
+            "user_code": "ABCD-EFGH",
+            "verification_uri": "https://guard.example.test/guard/oauth/device",
+            "verification_uri_complete": "https://guard.example.test/guard/oauth/device?user_code=ABCD-EFGH",
+            "next_action": {
+                "command": "open",
+                "target": "https://guard.example.test/guard/oauth/device",
+            },
+        }
+
+    monkeypatch.setattr(guard_commands, "_run_guard_device_connect_flow", fake_headless_flow)
+    monkeypatch.setattr(guard_commands.webbrowser, "open", lambda _target: True)
+
+    exit_code = run_guard_command(args)
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert "Approval code" in captured.out
+    assert "ABCD-EFGH" in captured.out
+    assert "Approval URL" in captured.out
+    assert "Enter code ABCD-EFGH" in captured.out
+    assert "device-secret-value" not in captured.out
+
+
 def test_connect_default_uses_browser_oauth_flow(tmp_path: Path, capsys, monkeypatch) -> None:
     guard_home = tmp_path / "guard-home"
     args = _ConnectArgs()


### PR DESCRIPTION
- Show the OAuth Device Code approval code and browser prompt in human `hol-guard connect` output when a headless browser approval is opened.
- Add regression coverage for non-JSON connect output so install users are not left without the code to enter.

Verification:
- `uv run pytest tests/test_guard_oauth_device_connect.py -q -k "headless_open_browser or device_authorization_copy_payload_hides_device_code_secret"`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_oauth_device_connect.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/cli/render.py tests/test_guard_oauth_device_connect.py`
