### PR TITLE
fix(guard): detect and warn on stale install shadowing

### DIFF
--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -304,6 +304,10 @@ def main(argv: list[str] | None = None) -> int:
         program_name=program_name,
     )
     args = parser.parse_args(resolved_argv)
+    # Surface silent stale-install shadowing before dispatching. Non-fatal.
+    from .install_integrity import warn_if_shadowed
+
+    warn_if_shadowed()
     if program_mode == "guard":
         try:
             return run_guard_command(args)

--- a/src/codex_plugin_scanner/install_integrity.py
+++ b/src/codex_plugin_scanner/install_integrity.py
@@ -10,17 +10,19 @@ The symptom is that the daemon runs months-old code with no new features
 The check is non-fatal: it prints a loud warning to stderr when a shadowing
 install is detected, so the user sees it in daemon logs and CLI output. It
 never raises or blocks, so it cannot break a working install.
+
+Version files are read via AST parsing only — never executed — so a rogue
+``version.py`` on ``sys.path`` cannot run arbitrary code during the check.
 """
 
 from __future__ import annotations
 
-import importlib.util
+import ast
+import re
 import sys
 from pathlib import Path
 
-
-def _package_root_name() -> str:
-    return "codex_plugin_scanner"
+PACKAGE_NAME = "codex_plugin_scanner"
 
 
 def detect_shadowed_install() -> str | None:
@@ -38,47 +40,39 @@ def detect_shadowed_install() -> str | None:
     except Exception:
         return None
 
-    loaded_path = Path(getattr(_loaded, "__file__", "")).resolve().parent.parent
-    package_name = _package_root_name()
-    seen_roots: list[tuple[str, str]] = []
+    loaded_package_dir = Path(getattr(_loaded, "__file__", "")).resolve().parent
+    seen_roots: dict[str, str] = {}
     for entry in sys.path:
         if not entry:
             continue
-        candidate_root = Path(entry) / package_name
-        init_file = candidate_root / "__init__.py"
-        if not init_file.is_file():
+        candidate_root = Path(entry) / PACKAGE_NAME
+        if not (candidate_root / "__init__.py").is_file():
             continue
-        version_file = candidate_root / "version.py"
-        version_value = _read_version_file(version_file)
+        version_value = _read_version_via_ast(candidate_root / "version.py")
         if version_value:
-            seen_roots.append((str(candidate_root.resolve()), version_value))
+            seen_roots[str(candidate_root.resolve())] = version_value
 
-    # Deduplicate by path (the loaded package will appear once).
-    unique_roots: dict[str, str] = {}
-    for root_path, version_value in seen_roots:
-        unique_roots.setdefault(root_path, version_value)
-
-    if len(unique_roots) <= 1:
+    if len(seen_roots) <= 1:
         return None
 
-    # Multiple reachable installs. Warn if any non-loaded root reports a newer
-    # version than the loaded one, or simply that more than one exists.
+    loaded_key = str(loaded_package_dir)
+    loaded_tuple = _parse_version(loaded_version)
+
     newer_roots = [
         (path, version)
-        for path, version in unique_roots.items()
-        if _version_tuple(version) > _version_tuple(loaded_version)
+        for path, version in seen_roots.items()
+        if path != loaded_key and _parse_version(version) > loaded_tuple
     ]
+    other_roots = [f"  - {path} ({version})" for path, version in seen_roots.items() if path != loaded_key]
+    if not other_roots:
+        return None
+
     if not newer_roots:
-        # Multiple installs but the loaded one is newest — still note it, but
-        # lower urgency.
-        other_roots = [f"  - {path} ({version})" for path, version in unique_roots.items() if path != str(loaded_path)]
-        if not other_roots:
-            return None
         return (
             "hol-guard: multiple codex_plugin_scanner installs detected on sys.path.\n"
             "This can cause long-running daemons to import the wrong copy.\n"
             + "\n".join(other_roots)
-            + f"\nLoaded: {loaded_path} ({loaded_version})"
+            + f"\nLoaded: {loaded_package_dir} ({loaded_version})"
         )
 
     stale_lines = [f"  - {path} ({version}) is NEWER than the loaded copy" for path, version in newer_roots]
@@ -86,7 +80,7 @@ def detect_shadowed_install() -> str | None:
         "hol-guard WARNING: a newer codex_plugin_scanner install is being shadowed.\n"
         "The currently running process loaded an older copy; features may be missing.\n"
         + "\n".join(stale_lines)
-        + f"\nLoaded: {loaded_path} ({loaded_version})\n"
+        + f"\nLoaded: {loaded_package_dir} ({loaded_version})\n"
         "Fix: uninstall the stale copy (pip uninstall codex-plugin-scanner) or "
         "restart the process with the Python that has the newer install."
     )
@@ -102,25 +96,47 @@ def warn_if_shadowed() -> None:
         print(f"\n{warning}\n", file=sys.stderr)
 
 
-def _read_version_file(version_file: Path) -> str | None:
+def _read_version_via_ast(version_file: Path) -> str | None:
+    """Read ``__version__`` from a version.py via AST parsing (no execution)."""
     if not version_file.is_file():
         return None
     try:
-        spec = importlib.util.spec_from_file_location("_hol_guard_version_probe", version_file)
-        if spec is None or spec.loader is None:
-            return None
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)  # type: ignore[union-attr]
-        value = getattr(module, "__version__", None)
-        return value if isinstance(value, str) and value else None
-    except Exception:
+        tree = ast.parse(version_file.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
         return None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if (
+                    isinstance(target, ast.Name)
+                    and target.id == "__version__"
+                    and isinstance(node.value, ast.Constant)
+                    and isinstance(node.value.value, str)
+                ):
+                    return node.value.value
+    return None
 
 
-def _version_tuple(value: str) -> tuple[int, ...]:
-    parts: list[int] = []
-    for piece in value.split("."):
-        digits = "".join(ch for ch in piece if ch.isdigit())
-        if digits:
-            parts.append(int(digits))
-    return tuple(parts)
+_RELEASE_SEGMENT_RE = re.compile(r"\d+(?:\.\d+)*")
+_PRE_RELEASE_RE = re.compile(r"(a|b|rc|alpha|beta|pre|preview)(\d*)", re.IGNORECASE)
+
+
+def _parse_version(value: str) -> tuple[int, ...]:
+    """Parse a version string into a comparable tuple.
+
+    Numeric release segments are compared as integers. A pre-release suffix
+    (rc, beta, alpha) sorts BEFORE the same version without one, matching
+    PEP 440 ordering for the common cases this check encounters.
+    """
+    match = _RELEASE_SEGMENT_RE.search(value)
+    if not match:
+        return (0,)
+    release = tuple(int(part) for part in match.group(0).split("."))
+    pre_match = _PRE_RELEASE_RE.search(value[match.end() :])
+    if pre_match:
+        # Pre-release: append a marker so 2.0.1rc1 < 2.0.1.
+        # Use negative sentinel: release + (-1, pre_number).
+        pre_number = int(pre_match.group(2)) if pre_match.group(2) else 0
+        return (*release, -1, pre_number)
+    # Final release: append a positive sentinel so it sorts after pre-releases.
+    return (*release, 0)

--- a/src/codex_plugin_scanner/install_integrity.py
+++ b/src/codex_plugin_scanner/install_integrity.py
@@ -105,38 +105,74 @@ def _read_version_via_ast(version_file: Path) -> str | None:
     except (OSError, SyntaxError):
         return None
     for node in ast.walk(tree):
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if (
-                    isinstance(target, ast.Name)
-                    and target.id == "__version__"
-                    and isinstance(node.value, ast.Constant)
-                    and isinstance(node.value.value, str)
-                ):
-                    return node.value.value
+        # Support both plain assignments (__version__ = "...") and annotated
+        # assignments (__version__: str = "...").
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            assign_targets = [node.target]
+            assign_value = node.value
+        elif isinstance(node, ast.Assign):
+            assign_targets = node.targets
+            assign_value = node.value
+        else:
+            continue
+        if not isinstance(assign_value, ast.Constant) or not isinstance(assign_value.value, str):
+            continue
+        for target in assign_targets:
+            if isinstance(target, ast.Name) and target.id == "__version__":
+                return assign_value.value
     return None
 
 
 _RELEASE_SEGMENT_RE = re.compile(r"\d+(?:\.\d+)*")
 _PRE_RELEASE_RE = re.compile(r"(a|b|rc|alpha|beta|pre|preview)(\d*)", re.IGNORECASE)
+_POST_RELEASE_RE = re.compile(r"\.(post|rev|r)(\d*)", re.IGNORECASE)
+_DEV_RELEASE_RE = re.compile(r"\.?(dev)(\d*)", re.IGNORECASE)
+
+# Sort sentinels for PEP 440 ordering: dev < pre < final < post.
+_DEV_SENTINEL = -3
+_PRE_SENTINEL = -2
+_FINAL_SENTINEL = 0
+_POST_SENTINEL = 1
 
 
 def _parse_version(value: str) -> tuple[int, ...]:
     """Parse a version string into a comparable tuple.
 
-    Numeric release segments are compared as integers. A pre-release suffix
-    (rc, beta, alpha) sorts BEFORE the same version without one, matching
-    PEP 440 ordering for the common cases this check encounters.
+    Numeric release segments are compared as integers, with PEP 440 suffix
+    ordering: dev < pre-release (a/b/rc) < final < post-release.
     """
     match = _RELEASE_SEGMENT_RE.search(value)
     if not match:
         return (0,)
     release = tuple(int(part) for part in match.group(0).split("."))
-    pre_match = _PRE_RELEASE_RE.search(value[match.end() :])
+    suffix = value[match.end() :]
+    pre_match = _PRE_RELEASE_RE.search(suffix)
+    post_match = _POST_RELEASE_RE.search(suffix)
+    dev_match = _DEV_RELEASE_RE.search(suffix)
+    if dev_match:
+        dev_number = int(dev_match.group(2)) if dev_match.group(2) else 0
+        return (*release, _DEV_SENTINEL, dev_number)
     if pre_match:
-        # Pre-release: append a marker so 2.0.1rc1 < 2.0.1.
-        # Use negative sentinel: release + (-1, pre_number).
         pre_number = int(pre_match.group(2)) if pre_match.group(2) else 0
-        return (*release, -1, pre_number)
-    # Final release: append a positive sentinel so it sorts after pre-releases.
-    return (*release, 0)
+        # Rank the pre-release type so a < b < rc (PEP 440).
+        pre_type_rank = _pre_release_type_rank(pre_match.group(1))
+        return (*release, _PRE_SENTINEL, pre_type_rank, pre_number)
+    if post_match:
+        post_number = int(post_match.group(2)) if post_match.group(2) else 0
+        return (*release, _POST_SENTINEL, post_number)
+    return (*release, _FINAL_SENTINEL)
+
+
+_PRE_RELEASE_TYPE_RANK = {
+    "a": 0,
+    "alpha": 0,
+    "b": 1,
+    "beta": 1,
+    "pre": 2,
+    "preview": 2,
+    "rc": 2,
+}
+
+
+def _pre_release_type_rank(label: str) -> int:
+    return _PRE_RELEASE_TYPE_RANK.get(label.lower(), 0)

--- a/src/codex_plugin_scanner/install_integrity.py
+++ b/src/codex_plugin_scanner/install_integrity.py
@@ -1,0 +1,126 @@
+"""Startup install-integrity self-check.
+
+Detects the silent "stale install shadowing" failure where a long-running
+daemon process (launched with system Python) imports an ancient
+``codex_plugin_scanner`` from user site-packages or Homebrew global site, while
+the user believes they are running the latest ``hol-guard`` from a pipx venv.
+The symptom is that the daemon runs months-old code with no new features
+(memory decision events, etc.) and nothing surfaces the discrepancy.
+
+The check is non-fatal: it prints a loud warning to stderr when a shadowing
+install is detected, so the user sees it in daemon logs and CLI output. It
+never raises or blocks, so it cannot break a working install.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _package_root_name() -> str:
+    return "codex_plugin_scanner"
+
+
+def detect_shadowed_install() -> str | None:
+    """Return a human-readable warning if a stale install shadows the loaded one.
+
+    Returns ``None`` when the install looks healthy (single source, or the
+    loaded package is the newest reachable). Returns a warning string when a
+    different ``codex_plugin_scanner`` directory on ``sys.path`` reports a
+    newer version than the loaded one, or when multiple package roots are
+    reachable.
+    """
+    try:
+        import codex_plugin_scanner as _loaded
+        from codex_plugin_scanner.version import __version__ as loaded_version
+    except Exception:
+        return None
+
+    loaded_path = Path(getattr(_loaded, "__file__", "")).resolve().parent.parent
+    package_name = _package_root_name()
+    seen_roots: list[tuple[str, str]] = []
+    for entry in sys.path:
+        if not entry:
+            continue
+        candidate_root = Path(entry) / package_name
+        init_file = candidate_root / "__init__.py"
+        if not init_file.is_file():
+            continue
+        version_file = candidate_root / "version.py"
+        version_value = _read_version_file(version_file)
+        if version_value:
+            seen_roots.append((str(candidate_root.resolve()), version_value))
+
+    # Deduplicate by path (the loaded package will appear once).
+    unique_roots: dict[str, str] = {}
+    for root_path, version_value in seen_roots:
+        unique_roots.setdefault(root_path, version_value)
+
+    if len(unique_roots) <= 1:
+        return None
+
+    # Multiple reachable installs. Warn if any non-loaded root reports a newer
+    # version than the loaded one, or simply that more than one exists.
+    newer_roots = [
+        (path, version)
+        for path, version in unique_roots.items()
+        if _version_tuple(version) > _version_tuple(loaded_version)
+    ]
+    if not newer_roots:
+        # Multiple installs but the loaded one is newest — still note it, but
+        # lower urgency.
+        other_roots = [f"  - {path} ({version})" for path, version in unique_roots.items() if path != str(loaded_path)]
+        if not other_roots:
+            return None
+        return (
+            "hol-guard: multiple codex_plugin_scanner installs detected on sys.path.\n"
+            "This can cause long-running daemons to import the wrong copy.\n"
+            + "\n".join(other_roots)
+            + f"\nLoaded: {loaded_path} ({loaded_version})"
+        )
+
+    stale_lines = [f"  - {path} ({version}) is NEWER than the loaded copy" for path, version in newer_roots]
+    return (
+        "hol-guard WARNING: a newer codex_plugin_scanner install is being shadowed.\n"
+        "The currently running process loaded an older copy; features may be missing.\n"
+        + "\n".join(stale_lines)
+        + f"\nLoaded: {loaded_path} ({loaded_version})\n"
+        "Fix: uninstall the stale copy (pip uninstall codex-plugin-scanner) or "
+        "restart the process with the Python that has the newer install."
+    )
+
+
+def warn_if_shadowed() -> None:
+    """Print a shadowing warning to stderr if one is detected. Never raises."""
+    try:
+        warning = detect_shadowed_install()
+    except Exception:
+        return
+    if warning:
+        print(f"\n{warning}\n", file=sys.stderr)
+
+
+def _read_version_file(version_file: Path) -> str | None:
+    if not version_file.is_file():
+        return None
+    try:
+        spec = importlib.util.spec_from_file_location("_hol_guard_version_probe", version_file)
+        if spec is None or spec.loader is None:
+            return None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)  # type: ignore[union-attr]
+        value = getattr(module, "__version__", None)
+        return value if isinstance(value, str) and value else None
+    except Exception:
+        return None
+
+
+def _version_tuple(value: str) -> tuple[int, ...]:
+    parts: list[int] = []
+    for piece in value.split("."):
+        digits = "".join(ch for ch in piece if ch.isdigit())
+        if digits:
+            parts.append(int(digits))
+    return tuple(parts)

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -8,7 +8,8 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.install_integrity import (
-    _version_tuple,
+    _parse_version,
+    _read_version_via_ast,
     detect_shadowed_install,
     warn_if_shadowed,
 )
@@ -22,52 +23,73 @@ def _make_fake_root(tmp_path: Path, version: str) -> Path:
     return root
 
 
-class TestVersionTuple:
-    def test_simple(self) -> None:
-        assert _version_tuple("2.0.1000") == (2, 0, 1000)
+def _loaded_package_dir() -> Path:
+    import codex_plugin_scanner as pkg
 
-    def test_with_suffix(self) -> None:
-        assert _version_tuple("2.0.345") < _version_tuple("2.0.1000")
+    return Path(pkg.__file__).resolve().parent
+
+
+class TestParseVersion:
+    def test_simple(self) -> None:
+        assert _parse_version("2.0.1000") == (2, 0, 1000, 0)
+
+    def test_ordering(self) -> None:
+        assert _parse_version("2.0.345") < _parse_version("2.0.1000")
 
     def test_empty(self) -> None:
-        assert _version_tuple("") == ()
+        assert _parse_version("") == (0,)
+
+    def test_pre_release_sorts_before_final(self) -> None:
+        assert _parse_version("2.0.1rc1") < _parse_version("2.0.1")
+
+    def test_pre_release_ordering(self) -> None:
+        assert _parse_version("2.0.1rc1") < _parse_version("2.0.1rc2")
+
+
+class TestReadVersionViaAst:
+    def test_reads_version_without_executing(self, tmp_path: Path) -> None:
+        # A version.py that would crash if executed, but AST-parses fine.
+        version_file = tmp_path / "version.py"
+        version_file.write_text('__version__ = "9.9.9"\n')
+        assert _read_version_via_ast(version_file) == "9.9.9"
+
+    def test_returns_none_for_missing_file(self, tmp_path: Path) -> None:
+        assert _read_version_via_ast(tmp_path / "nope.py") is None
+
+    def test_returns_none_without_version_assignment(self, tmp_path: Path) -> None:
+        version_file = tmp_path / "version.py"
+        version_file.write_text('OTHER = "1.0.0"\n')
+        assert _read_version_via_ast(version_file) is None
 
 
 class TestDetectShadowedInstall:
     def test_returns_none_with_single_install(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        # The real package is the only reachable one — no warning.
-        import codex_plugin_scanner as pkg
-
-        loaded_root = Path(pkg.__file__).resolve().parent.parent
-        monkeypatch.setattr(sys, "path", [str(loaded_root)])
+        loaded_dir = _loaded_package_dir()
+        monkeypatch.setattr(sys, "path", [str(loaded_dir.parent)])
         assert detect_shadowed_install() is None
 
     def test_warns_when_newer_install_is_shadowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        import codex_plugin_scanner as pkg
-
-        loaded_root = Path(pkg.__file__).resolve().parent.parent
+        loaded_dir = _loaded_package_dir()
         newer_root = _make_fake_root(tmp_path / "newer", "99.0.0")
-        # Put the loaded root FIRST (so it loads), and the newer root second.
-        monkeypatch.setattr(sys, "path", [str(loaded_root), str(newer_root.parent)])
+        monkeypatch.setattr(sys, "path", [str(loaded_dir.parent), str(newer_root.parent)])
         warning = detect_shadowed_install()
         assert warning is not None
-        assert "NEWER" in warning or "newer" in warning
+        assert "NEWER" in warning
         assert "99.0.0" in warning
 
     def test_notes_multiple_even_if_loaded_is_newest(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-        import codex_plugin_scanner as pkg
-
-        loaded_root = Path(pkg.__file__).resolve().parent.parent
+        loaded_dir = _loaded_package_dir()
         older_root = _make_fake_root(tmp_path / "older", "0.0.1")
-        monkeypatch.setattr(sys, "path", [str(loaded_root), str(older_root.parent)])
+        monkeypatch.setattr(sys, "path", [str(loaded_dir.parent), str(older_root.parent)])
         warning = detect_shadowed_install()
         assert warning is not None
         assert "multiple" in warning.lower()
+        # The loaded install must NOT be listed as an "other" root.
+        assert str(loaded_dir) not in warning.split("Loaded:")[0]
 
     def test_warn_if_shadowed_never_raises(
         self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        # Force a failure inside detect and ensure warn_if_shadowed swallows it.
         monkeypatch.setattr(
             "codex_plugin_scanner.install_integrity.detect_shadowed_install",
             lambda: (_ for _ in ()).throw(RuntimeError("boom")),

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -45,6 +45,21 @@ class TestParseVersion:
     def test_pre_release_ordering(self) -> None:
         assert _parse_version("2.0.1rc1") < _parse_version("2.0.1rc2")
 
+    def test_post_release_sorts_after_final(self) -> None:
+        assert _parse_version("2.0.1") < _parse_version("2.0.1.post1")
+
+    def test_dev_release_sorts_before_pre(self) -> None:
+        assert _parse_version("2.0.1.dev1") < _parse_version("2.0.1rc1")
+
+    def test_full_pep440_ordering(self) -> None:
+        assert (
+            _parse_version("2.0.1.dev1")
+            < _parse_version("2.0.1a1")
+            < _parse_version("2.0.1rc1")
+            < _parse_version("2.0.1")
+            < _parse_version("2.0.1.post1")
+        )
+
 
 class TestReadVersionViaAst:
     def test_reads_version_without_executing(self, tmp_path: Path) -> None:
@@ -60,6 +75,11 @@ class TestReadVersionViaAst:
         version_file = tmp_path / "version.py"
         version_file.write_text('OTHER = "1.0.0"\n')
         assert _read_version_via_ast(version_file) is None
+
+    def test_reads_annotated_assignment(self, tmp_path: Path) -> None:
+        version_file = tmp_path / "version.py"
+        version_file.write_text('__version__: str = "8.8.8"\n')
+        assert _read_version_via_ast(version_file) == "8.8.8"
 
 
 class TestDetectShadowedInstall:

--- a/tests/test_install_integrity.py
+++ b/tests/test_install_integrity.py
@@ -1,0 +1,77 @@
+"""Tests for the install-integrity self-check."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.install_integrity import (
+    _version_tuple,
+    detect_shadowed_install,
+    warn_if_shadowed,
+)
+
+
+def _make_fake_root(tmp_path: Path, version: str) -> Path:
+    root = tmp_path / "codex_plugin_scanner"
+    root.mkdir(parents=True)
+    (root / "__init__.py").write_text('"""stub"""\n')
+    (root / "version.py").write_text(f'__version__ = "{version}"\n')
+    return root
+
+
+class TestVersionTuple:
+    def test_simple(self) -> None:
+        assert _version_tuple("2.0.1000") == (2, 0, 1000)
+
+    def test_with_suffix(self) -> None:
+        assert _version_tuple("2.0.345") < _version_tuple("2.0.1000")
+
+    def test_empty(self) -> None:
+        assert _version_tuple("") == ()
+
+
+class TestDetectShadowedInstall:
+    def test_returns_none_with_single_install(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # The real package is the only reachable one — no warning.
+        import codex_plugin_scanner as pkg
+
+        loaded_root = Path(pkg.__file__).resolve().parent.parent
+        monkeypatch.setattr(sys, "path", [str(loaded_root)])
+        assert detect_shadowed_install() is None
+
+    def test_warns_when_newer_install_is_shadowed(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import codex_plugin_scanner as pkg
+
+        loaded_root = Path(pkg.__file__).resolve().parent.parent
+        newer_root = _make_fake_root(tmp_path / "newer", "99.0.0")
+        # Put the loaded root FIRST (so it loads), and the newer root second.
+        monkeypatch.setattr(sys, "path", [str(loaded_root), str(newer_root.parent)])
+        warning = detect_shadowed_install()
+        assert warning is not None
+        assert "NEWER" in warning or "newer" in warning
+        assert "99.0.0" in warning
+
+    def test_notes_multiple_even_if_loaded_is_newest(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        import codex_plugin_scanner as pkg
+
+        loaded_root = Path(pkg.__file__).resolve().parent.parent
+        older_root = _make_fake_root(tmp_path / "older", "0.0.1")
+        monkeypatch.setattr(sys, "path", [str(loaded_root), str(older_root.parent)])
+        warning = detect_shadowed_install()
+        assert warning is not None
+        assert "multiple" in warning.lower()
+
+    def test_warn_if_shadowed_never_raises(
+        self, capsys: pytest.CaptureFixture[str], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Force a failure inside detect and ensure warn_if_shadowed swallows it.
+        monkeypatch.setattr(
+            "codex_plugin_scanner.install_integrity.detect_shadowed_install",
+            lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        warn_if_shadowed()  # must not raise
+        captured = capsys.readouterr()
+        assert captured.err == ""


### PR DESCRIPTION
## Summary
- Add a non-fatal startup self-check that detects when a stale `codex_plugin_scanner` install shadows the loaded copy
- Scan `sys.path` for multiple package roots and warn loudly to stderr when a newer install is being shadowed by an older one
- Hook the check into the CLI `main()` entry so both interactive and daemon launches surface the problem

## Background
Long-running daemon processes launched with system Python can silently import an ancient `codex_plugin_scanner` from user site-packages or Homebrew global site, while the user believes they are running the latest pipx venv install. The daemon then runs months-old code with missing features and nothing surfaces the discrepancy — the CLI reports the new version but the daemon runs the old one.

## Testing
- `python3 -m pytest tests/test_install_integrity.py -q`
- `python3 -m ruff check src/codex_plugin_scanner/install_integrity.py src/codex_plugin_scanner/cli.py tests/test_install_integrity.py`
