### PR TITLE
fix(scanner): capture MCP tool call command text in receipts

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
@@ -185,6 +185,7 @@ def _run_hook_copilot_pretool(
             signals=decision.signals,
             risk_categories=decision.risk_categories,
             remember=False,
+            arguments=runtime_arguments,
         )
         if _should_emit_copilot_hook_response(args):
             _record_harness_usage_for_hook(
@@ -205,6 +206,7 @@ def _run_hook_copilot_pretool(
                 now=now,
                 signals=decision.signals,
                 risk_categories=decision.risk_categories,
+                arguments=runtime_arguments,
             )
         if _should_emit_copilot_hook_response(args):
             _record_harness_usage_for_hook(
@@ -307,8 +309,6 @@ def _run_hook_copilot_permission_request(
         )
         response_payload["approval_requests"] = queued
         policy_action = "allow"
-        response_payload["policy_action"] = "allow"
-    if policy_action == "allow":
         allow_tool_call(
             store=store,
             artifact=runtime_artifact,
@@ -318,6 +318,7 @@ def _run_hook_copilot_permission_request(
             signals=decision.signals,
             risk_categories=decision.risk_categories,
             remember=False,
+            arguments=runtime_arguments,
         )
         if _should_emit_copilot_hook_response(args):
             _record_harness_usage_for_hook(
@@ -344,6 +345,7 @@ def _run_hook_copilot_permission_request(
         now=now,
         signals=decision.signals,
         risk_categories=decision.risk_categories,
+        arguments=runtime_arguments,
     )
     approval_center_url = ensure_guard_daemon(guard_home)
     approval_flow = get_adapter(args.harness).approval_flow(managed_install=managed_install)

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_copilot.py
@@ -309,6 +309,8 @@ def _run_hook_copilot_permission_request(
         )
         response_payload["approval_requests"] = queued
         policy_action = "allow"
+        response_payload["policy_action"] = "allow"
+    if policy_action == "allow":
         allow_tool_call(
             store=store,
             artifact=runtime_artifact,

--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -35,6 +35,58 @@ class ToolCallDecision:
     risk_categories: tuple[str, ...] = ()
 
 
+_MCP_COMMAND_ARGUMENT_KEYS: tuple[str, ...] = (
+    "command",
+    "cmd",
+    "shell_command",
+    "shellCommand",
+    "script",
+    "expression",
+    "code",
+    "query",
+)
+
+_MCP_PATH_ARGUMENT_KEYS: tuple[str, ...] = (
+    "path",
+    "file_path",
+    "filePath",
+    "filepath",
+    "directory",
+    "dir",
+    "cwd",
+    "working_dir",
+    "workingDir",
+    "url",
+    "uri",
+)
+
+
+def extract_mcp_command_text(
+    artifact: GuardArtifact,
+    arguments: object,
+) -> str | None:
+    """Extract a human-readable command string from MCP tool call arguments.
+
+    For tools like ctx_shell/bash the primary argument is a ``command`` string.
+    For file/path tools we surface the path. For other tools we return None so
+    the UI falls back to the artifact name.
+    """
+    if not isinstance(arguments, Mapping):
+        return None
+
+    tool_name = artifact.name
+    for key in _MCP_COMMAND_ARGUMENT_KEYS:
+        value = arguments.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    for key in _MCP_PATH_ARGUMENT_KEYS:
+        value = arguments.get(key)
+        if isinstance(value, str) and value.strip():
+            return f"{tool_name} {value.strip()}"
+
+    return None
+
 def build_tool_call_artifact(
     *,
     harness: str,
@@ -667,6 +719,7 @@ def allow_tool_call(
     remember: bool,
     risk_categories: tuple[str, ...] = (),
     approval_gate_grant: ApprovalGateGrant | None = None,
+    arguments: object = None,
 ) -> GuardReceipt:
     if remember:
         store.upsert_policy(
@@ -691,6 +744,7 @@ def allow_tool_call(
         now=now,
         approved=True,
     )
+    raw_command_text = extract_mcp_command_text(artifact, arguments)
     receipt = build_receipt(
         harness=artifact.harness,
         artifact_id=artifact.artifact_id,
@@ -709,6 +763,7 @@ def allow_tool_call(
                 risk_categories=risk_categories,
             ),
         ),
+        raw_command_text=raw_command_text,
     )
     store.add_receipt(receipt)
     store.add_event(
@@ -724,7 +779,6 @@ def allow_tool_call(
     )
     return receipt
 
-
 def block_tool_call(
     *,
     store: GuardStore,
@@ -734,6 +788,7 @@ def block_tool_call(
     now: str,
     signals: tuple[str, ...],
     risk_categories: tuple[str, ...] = (),
+    arguments: object = None,
 ) -> GuardReceipt:
     store.record_inventory_artifact(
         artifact=artifact,
@@ -743,6 +798,7 @@ def block_tool_call(
         now=now,
         approved=False,
     )
+    raw_command_text = extract_mcp_command_text(artifact, arguments)
     receipt = build_receipt(
         harness=artifact.harness,
         artifact_id=artifact.artifact_id,
@@ -761,6 +817,7 @@ def block_tool_call(
                 risk_categories=risk_categories,
             ),
         ),
+        raw_command_text=raw_command_text,
     )
     store.add_receipt(receipt)
     store.add_event(

--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -87,6 +87,7 @@ def extract_mcp_command_text(
 
     return None
 
+
 def build_tool_call_artifact(
     *,
     harness: str,
@@ -778,6 +779,7 @@ def allow_tool_call(
         now,
     )
     return receipt
+
 
 def block_tool_call(
     *,

--- a/src/codex_plugin_scanner/guard/models.py
+++ b/src/codex_plugin_scanner/guard/models.py
@@ -179,6 +179,7 @@ class GuardReceipt:
     approval_request_id: str | None = None
     scanner_evidence: tuple[dict[str, object], ...] = ()
     browser_intent: dict[str, object] | None = None
+    raw_command_text: str | None = None
 
     def to_dict(self) -> dict[str, object]:
         payload = asdict(self)

--- a/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
+++ b/src/codex_plugin_scanner/guard/proxy/runtime_mcp.py
@@ -389,6 +389,7 @@ class RuntimeMcpGuardProxy:
                             signals=decision.signals,
                             risk_categories=decision.risk_categories,
                             remember=True,
+                            arguments=arguments,
                         )
                     except ApprovalGateError:
                         return self._queue_approval_center_response(
@@ -423,6 +424,7 @@ class RuntimeMcpGuardProxy:
                         now=_now(),
                         signals=decision.signals,
                         risk_categories=decision.risk_categories,
+                        arguments=arguments,
                     )
                     return _blocked_tool_response(
                         message.get("id"),
@@ -441,6 +443,7 @@ class RuntimeMcpGuardProxy:
                         now=_now(),
                         signals=decision.signals,
                         risk_categories=decision.risk_categories,
+                        arguments=arguments,
                     )
                     return _blocked_tool_response(
                         message.get("id"),
@@ -544,6 +547,7 @@ class RuntimeMcpGuardProxy:
                     now=_now(),
                     signals=decision.signals,
                     risk_categories=decision.risk_categories,
+                    arguments=arguments,
                 )
                 return _blocked_tool_response(
                     message.get("id"),
@@ -562,6 +566,7 @@ class RuntimeMcpGuardProxy:
                     now=_now(),
                     signals=decision.signals,
                     risk_categories=decision.risk_categories,
+                    arguments=arguments,
                 )
                 return _blocked_tool_response(
                     message.get("id"),
@@ -672,6 +677,7 @@ class RuntimeMcpGuardProxy:
                         signals=remember_signals,
                         risk_categories=remember_risk_categories,
                         remember=True,
+                        arguments=params.get("arguments"),
                     )
                 except ApprovalGateError:
                     return self._queue_approval_center_response(
@@ -732,6 +738,7 @@ class RuntimeMcpGuardProxy:
                         signals=remember_signals,
                         risk_categories=remember_risk_categories,
                         remember=True,
+                        arguments=params.get("arguments"),
                     )
                 except ApprovalGateError:
                     return self._queue_approval_center_response(
@@ -879,6 +886,7 @@ class RuntimeMcpGuardProxy:
                 signals=signals,
                 risk_categories=risk_categories,
                 remember=remember,
+                arguments=params.get("arguments"),
             )
         except ApprovalGateError:
             if remember:
@@ -1221,6 +1229,7 @@ class RuntimeMcpGuardProxy:
             now=_now(),
             signals=signals,
             risk_categories=tool_call_risk_categories(artifact, params.get("arguments")),
+            arguments=params.get("arguments"),
         )
         request_id = str(queued[0]["request_id"]) if queued else "unknown"
         review_url = first_approval_url(queued, approval_center_url=approval_center_url) or approval_center_url

--- a/src/codex_plugin_scanner/guard/receipts/manager.py
+++ b/src/codex_plugin_scanner/guard/receipts/manager.py
@@ -91,6 +91,7 @@ def build_receipt(
     diff_summary: str | None = None,
     approval_source: str | None = None,
     approval_request_id: str | None = None,
+    raw_command_text: str | None = None,
 ) -> GuardReceipt:
     """Create a runtime receipt."""
 
@@ -116,4 +117,5 @@ def build_receipt(
         approval_source=approval_source,
         approval_request_id=approval_request_id,
         scanner_evidence=tuple(dict(item) for item in scanner_evidence),
+        raw_command_text=raw_command_text,
     )

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -4340,6 +4340,9 @@ def _cloud_sync_receipt_payload(
         "recommendation": _cloud_sync_recommendation(policy_decision),
         "summary": summary,
     }
+    raw_command_text = _optional_string(receipt.get("raw_command_text"))
+    if raw_command_text is not None:
+        payload["raw_command_text"] = _cloud_sync_command_display_part(raw_command_text)
     publisher = _optional_string(receipt.get("publisher"))
     if publisher is not None:
         payload["publisher"] = publisher

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -264,7 +264,8 @@ class StoreConnectionSchemaMixin:
               artifact_name text,
               source_scope text,
               scanner_evidence_json text not null default '[]',
-              timestamp text not null
+              timestamp text not null,
+              raw_command_text text
             )
             """,
             """
@@ -481,6 +482,7 @@ class StoreConnectionSchemaMixin:
             self._ensure_runtime_receipts_column(connection, "diff_summary", "text")
             self._ensure_runtime_receipts_column(connection, "approval_source", "text")
             self._ensure_runtime_receipts_column(connection, "approval_request_id", "text")
+            self._ensure_runtime_receipts_column(connection, "raw_command_text", "text")
             self._ensure_runtime_receipt_envelopes_table(connection)
             if not self._schema_version_applied(connection, version=5):
                 self._migrate_v5_receipt_envelopes(connection)
@@ -637,7 +639,8 @@ class StoreConnectionSchemaMixin:
               timestamp text not null,
               diff_summary text,
               approval_source text,
-              approval_request_id text
+              approval_request_id text,
+              raw_command_text text
             )
             """
         )
@@ -647,13 +650,13 @@ class StoreConnectionSchemaMixin:
               rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
               capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
               artifact_name, source_scope, scanner_evidence_json, timestamp, diff_summary,
-              approval_source, approval_request_id
+              approval_source, approval_request_id, raw_command_text
             )
             select
               rowid, receipt_id, harness, artifact_id, artifact_hash, policy_decision,
               capabilities_summary, changed_capabilities_json, provenance_summary, user_override,
               artifact_name, source_scope, scanner_evidence_json, timestamp, diff_summary,
-              approval_source, null
+              approval_source, null, null
             from runtime_receipts
             """
         )

--- a/src/codex_plugin_scanner/guard/store_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_receipts.py
@@ -24,9 +24,9 @@ class StoreReceiptsRuntimeMixin:
                   receipt_id, harness, artifact_id, artifact_hash, policy_decision, capabilities_summary,
                   changed_capabilities_json,
                   provenance_summary, user_override, artifact_name, source_scope, scanner_evidence_json,
-                  diff_summary, approval_source, approval_request_id, timestamp
+                  diff_summary, approval_source, approval_request_id, timestamp, raw_command_text
                 )
-                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """,
                 (
                     receipt.receipt_id,
@@ -45,6 +45,7 @@ class StoreReceiptsRuntimeMixin:
                     receipt.approval_source,
                     receipt.approval_request_id,
                     receipt.timestamp,
+                    receipt.raw_command_text,
                 ),
             )
             if action_envelope is not None:
@@ -156,6 +157,7 @@ class StoreReceiptsRuntimeMixin:
               r.approval_source,
               r.approval_request_id,
               r.timestamp,
+              r.raw_command_text,
               e.envelope_full_json as envelope_full_json,
               e.envelope_redacted_json as envelope_redacted_json,
               a.action_envelope_json as approval_envelope_json
@@ -189,6 +191,7 @@ class StoreReceiptsRuntimeMixin:
                 "approval_source": row["approval_source"],
                 "approval_request_id": row["approval_request_id"],
                 "timestamp": str(row["timestamp"]),
+                "raw_command_text": row["raw_command_text"],
                 "action_envelope_json": envelope,
                 "envelope_redacted_json": _json_object(row["envelope_redacted_json"]),
             }

--- a/tests/test_mcp_tool_call_raw_command_text.py
+++ b/tests/test_mcp_tool_call_raw_command_text.py
@@ -1,0 +1,180 @@
+"""Tests that MCP tool call receipts carry the actual command text.
+
+Verifies that allow_tool_call / block_tool_call extract the command from
+MCP tool call arguments and store it as raw_command_text in the receipt.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.mcp_tool_calls import (
+    allow_tool_call,
+    block_tool_call,
+    extract_mcp_command_text,
+)
+from codex_plugin_scanner.guard.models import GuardArtifact, GuardReceipt
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _make_store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard")
+
+
+def _make_artifact(
+    *,
+    name: str = "lean-ctx:ctx_shell",
+    harness: str = "codex",
+    artifact_id: str = "codex:runtime:mcp:lean-ctx:ctx_shell",
+) -> GuardArtifact:
+    return GuardArtifact(
+        artifact_id=artifact_id,
+        name=name,
+        harness=harness,
+        artifact_type="tool_call",
+        source_scope="mcp",
+        config_path="/tmp/config.json",
+        command="ctx_shell",
+        transport="stdio",
+        metadata={"server_name": "lean-ctx"},
+    )
+
+
+class TestExtractMcpCommandText:
+    def test_extracts_command_from_ctx_shell_arguments(self):
+        artifact = _make_artifact()
+        arguments = {"command": "git status --short"}
+        assert extract_mcp_command_text(artifact, arguments) == "git status --short"
+
+    def test_extracts_cmd_key(self):
+        artifact = _make_artifact()
+        arguments = {"cmd": "npm install"}
+        assert extract_mcp_command_text(artifact, arguments) == "npm install"
+
+    def test_extracts_path_from_ctx_read_arguments(self):
+        artifact = _make_artifact(name="lean-ctx:ctx_read")
+        arguments = {"path": "/src/index.ts", "mode": "full"}
+        result = extract_mcp_command_text(artifact, arguments)
+        assert result is not None
+        assert "/src/index.ts" in result
+        assert "ctx_read" in result
+
+    def test_returns_none_for_empty_command(self):
+        artifact = _make_artifact()
+        arguments = {"command": "  "}
+        assert extract_mcp_command_text(artifact, arguments) is None
+
+    def test_returns_none_for_non_mapping_arguments(self):
+        artifact = _make_artifact()
+        assert extract_mcp_command_text(artifact, None) is None
+        assert extract_mcp_command_text(artifact, "string") is None
+        assert extract_mcp_command_text(artifact, 42) is None
+
+    def test_returns_none_for_empty_arguments(self):
+        artifact = _make_artifact()
+        assert extract_mcp_command_text(artifact, {}) is None
+
+    def test_prefers_command_over_path(self):
+        artifact = _make_artifact()
+        arguments = {"command": "ls -la", "path": "/tmp"}
+        assert extract_mcp_command_text(artifact, arguments) == "ls -la"
+
+
+class TestAllowToolCallStoresRawCommandText:
+    def test_allow_stores_raw_command_text(self, tmp_path: Path):
+        store = _make_store(tmp_path)
+        artifact = _make_artifact()
+        arguments = {"command": "git status --short"}
+
+        receipt = allow_tool_call(
+            store=store,
+            artifact=artifact,
+            artifact_hash="sha256:abc",
+            decision_source="policy-allow",
+            now="2025-01-01T00:00:00Z",
+            signals=(),
+            remember=False,
+            arguments=arguments,
+        )
+
+        assert receipt.raw_command_text == "git status --short"
+
+        stored = store.list_receipts(limit=10)
+        assert len(stored) == 1
+        assert stored[0]["raw_command_text"] == "git status --short"
+
+    def test_allow_without_arguments_has_no_raw_command_text(self, tmp_path: Path):
+        store = _make_store(tmp_path)
+        artifact = _make_artifact()
+
+        receipt = allow_tool_call(
+            store=store,
+            artifact=artifact,
+            artifact_hash="sha256:abc",
+            decision_source="policy-allow",
+            now="2025-01-01T00:00:00Z",
+            signals=(),
+            remember=False,
+        )
+
+        assert receipt.raw_command_text is None
+
+        stored = store.list_receipts(limit=10)
+        assert len(stored) == 1
+        assert stored[0]["raw_command_text"] is None
+
+
+class TestBlockToolCallStoresRawCommandText:
+    def test_block_stores_raw_command_text(self, tmp_path: Path):
+        store = _make_store(tmp_path)
+        artifact = _make_artifact()
+        arguments = {"command": "rm -rf /tmp/old"}
+
+        receipt = block_tool_call(
+            store=store,
+            artifact=artifact,
+            artifact_hash="sha256:abc",
+            decision_source="inline-denied",
+            now="2025-01-01T00:00:00Z",
+            signals=(),
+            arguments=arguments,
+        )
+
+        assert receipt.raw_command_text == "rm -rf /tmp/old"
+
+        stored = store.list_receipts(limit=10)
+        assert len(stored) == 1
+        assert stored[0]["raw_command_text"] == "rm -rf /tmp/old"
+
+
+class TestReceiptToDictIncludesRawCommandText:
+    def test_to_dict_includes_raw_command_text(self):
+        receipt = GuardReceipt(
+            receipt_id="r-001",
+            timestamp="2025-01-01T00:00:00Z",
+            harness="codex",
+            artifact_id="codex:runtime:mcp:lean-ctx:ctx_shell",
+            artifact_hash="sha256:abc",
+            policy_decision="allow",
+            capabilities_summary="mcp tool call • lean-ctx:ctx_shell",
+            changed_capabilities=("runtime_tool_call",),
+            provenance_summary="runtime tool call allowed",
+            raw_command_text="git status --short",
+        )
+        payload = receipt.to_dict()
+        assert payload["raw_command_text"] == "git status --short"
+
+    def test_to_dict_includes_none_raw_command_text(self):
+        receipt = GuardReceipt(
+            receipt_id="r-002",
+            timestamp="2025-01-01T00:00:00Z",
+            harness="codex",
+            artifact_id="codex:runtime:mcp:lean-ctx:ctx_shell",
+            artifact_hash="sha256:abc",
+            policy_decision="allow",
+            capabilities_summary="mcp tool call • lean-ctx:ctx_shell",
+            changed_capabilities=("runtime_tool_call",),
+            provenance_summary="runtime tool call allowed",
+        )
+        payload = receipt.to_dict()
+        assert payload["raw_command_text"] is None


### PR DESCRIPTION
## Problem

The Guard Review UI (`/guard/review?tab=handled-by-guard`) shows `lean-ctx:ctx_shell` calls but the actual shell command that was executed is missing. Users see only the tool name (e.g., "lean-ctx:ctx_shell") instead of the actual command (e.g., "git status --short").

## Root Cause

MCP tool call receipts stored only `capabilities_summary = "mcp tool call • lean-ctx:ctx_shell"` without the actual command arguments. The `allow_tool_call` / `block_tool_call` functions never received the MCP tool call `arguments` (which contain the `command` parameter for `ctx_shell`), so the actual command was never stored in receipt metadata.

The portal already reads `raw_command_text` from receipt metadata via `readReceiptCommandText()` → `buildReceiptMetadata()`, but the guard scanner never populated it.

## Fix

**Guard scanner (Python):**
1. Added `raw_command_text` field to `GuardReceipt` dataclass
2. Added `extract_mcp_command_text()` helper that extracts the command from MCP tool call arguments:
   - Checks command-like keys: `command`, `cmd`, `shell_command`, `shellCommand`, `script`, `expression`, `code`, `query`
   - Falls back to path-like keys for file/path-oriented tools: `path`, `file_path`, `url`, `cwd`, etc.
3. Pass `arguments` through `allow_tool_call` / `block_tool_call` → `build_receipt`
4. Store `raw_command_text` in `runtime_receipts` SQLite table
5. Migration for existing databases (including v5 migration compatibility)
6. Include `raw_command_text` in cloud sync payload via `_cloud_sync_command_display_part` (redacts secrets via `redact_sensitive_text`)
7. Updated all call sites: `runtime_mcp.py` proxy (6 sites) + `commands_hook_copilot.py` CLI (4 sites)

**Portal (TypeScript):** No changes needed — the portal already reads `raw_command_text` from receipt metadata.

## Test plan

- [x] 12 new unit tests (`test_mcp_tool_call_raw_command_text.py`) — extract helper, allow/block roundtrip, to_dict
- [x] 464 existing tests pass (receipts, MCP, proxy, cloud sync, live request sync)
- [ ] E2E: Submit a `ctx_shell` tool call, verify Review UI shows the actual command