### PR TITLE
fix(aibom): stop attributing .agents/skills to harnesses that don't use them

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -50,6 +50,25 @@ _READ_CHUNK_BYTES = 65536
 _CURSOR_RULE_PATTERNS = ("*.mdc", "*.md")
 _CODEX_WORKSPACE_SKILL_ROOTS = (".agents/skills",)
 _CODEX_HOME_SKILL_ROOTS = (".codex/skills", ".agents/skills")
+
+# Harnesses that natively discover skills from the shared ``.agents/skills``
+# workspace directory.  Other harnesses (e.g. Hermes, Copilot, Antigravity)
+# use their own skill directories and must not pick up Codex/OpenClaw-style
+# workspace skills.
+_WORKSPACE_CODEX_SKILL_HARNESSES = frozenset(
+    {
+        "codex",
+        "openclaw",
+        "opencode",
+        "claude-code",
+        "cursor",
+        "gemini",
+        "grok",
+        "kimi",
+        "pi",
+        "zcode",
+    }
+)
 _STANDARDS_CONTEXT_ROOTS = (".", ".agents/context", "docs")
 _ROOT_INSTRUCTION_ROLE_NAMES: tuple[tuple[str, InstructionRole], ...] = (
     ("CLAUDE.md", "claude_md"),
@@ -180,7 +199,7 @@ def discover_shared_workspace_aibom_artifacts(
     artifacts.extend(_discover_agents_md(harness, workspace_dir=workspace_dir))
     artifacts.extend(_discover_standards_context_files(harness, workspace_dir=workspace_dir))
     artifacts.extend(_discover_cursor_rules(harness, workspace_dir=workspace_dir))
-    if harness != "codex":
+    if harness in _WORKSPACE_CODEX_SKILL_HARNESSES:
         artifacts.extend(
             _discover_codex_skills(
                 harness,

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -52,23 +52,18 @@ _CODEX_WORKSPACE_SKILL_ROOTS = (".agents/skills",)
 _CODEX_HOME_SKILL_ROOTS = (".codex/skills", ".agents/skills")
 
 # Harnesses that natively discover skills from the shared ``.agents/skills``
-# workspace directory.  Other harnesses (e.g. Hermes, Copilot, Antigravity)
-# use their own skill directories and must not pick up Codex/OpenClaw-style
-# workspace skills.
-_WORKSPACE_CODEX_SKILL_HARNESSES = frozenset(
-    {
-        "codex",
-        "openclaw",
-        "opencode",
-        "claude-code",
-        "cursor",
-        "gemini",
-        "grok",
-        "kimi",
-        "pi",
-        "zcode",
-    }
-)
+# workspace directory.  Other harnesses (e.g. Hermes, Copilot) use their own
+# skill directories and must not pick up Codex/OpenClaw-style workspace skills.
+# Keep this set in sync with CANONICAL_HARNESS_VALUES in product_model.py.
+_WORKSPACE_CODEX_SKILL_HARNESSES = frozenset({
+    "codex",
+    "openclaw",
+    "opencode",
+    "claude-code",
+    "cursor",
+    "gemini",
+    "pi",
+})
 _STANDARDS_CONTEXT_ROOTS = (".", ".agents/context", "docs")
 _ROOT_INSTRUCTION_ROLE_NAMES: tuple[tuple[str, InstructionRole], ...] = (
     ("CLAUDE.md", "claude_md"),

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -55,15 +55,17 @@ _CODEX_HOME_SKILL_ROOTS = (".codex/skills", ".agents/skills")
 # workspace directory.  Other harnesses (e.g. Hermes, Copilot) use their own
 # skill directories and must not pick up Codex/OpenClaw-style workspace skills.
 # Keep this set in sync with CANONICAL_HARNESS_VALUES in product_model.py.
-_WORKSPACE_CODEX_SKILL_HARNESSES = frozenset({
-    "codex",
-    "openclaw",
-    "opencode",
-    "claude-code",
-    "cursor",
-    "gemini",
-    "pi",
-})
+_WORKSPACE_CODEX_SKILL_HARNESSES = frozenset(
+    {
+        "codex",
+        "openclaw",
+        "opencode",
+        "claude-code",
+        "cursor",
+        "gemini",
+        "pi",
+    }
+)
 _STANDARDS_CONTEXT_ROOTS = (".", ".agents/context", "docs")
 _ROOT_INSTRUCTION_ROLE_NAMES: tuple[tuple[str, InstructionRole], ...] = (
     ("CLAUDE.md", "claude_md"),

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -495,3 +495,83 @@ def test_cursor_detect_extends_workspace_aibom(tmp_path: Path) -> None:
     )
 
     assert any(artifact.artifact_type == "instruction" for artifact in extended.artifacts)
+
+
+def test_workspace_skills_excluded_for_hermes(tmp_path: Path) -> None:
+    """Hermes uses ~/.hermes/skills/, not .agents/skills/.
+
+    Workspace-level ``.agents/skills/`` is a Codex/OpenClaw convention.
+    Hermes (and other harnesses that don't natively scan it) must not pick
+    up those skills in their inventory snapshots, otherwise skills from
+    one harness leak into another harness's Protection Graph.
+    """
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    skill_dir = workspace / ".agents" / "skills" / "bare-metal-server"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: bare-metal-server\ndescription: test\n---\nbody\n",
+        encoding="utf-8",
+    )
+
+    # Hermes must NOT discover .agents/skills/
+    hermes_artifacts = discover_shared_workspace_aibom_artifacts(
+        "hermes",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    hermes_skill_names = {
+        a.name for a in hermes_artifacts if a.artifact_type == "skill"
+    }
+    assert "bare-metal-server" not in hermes_skill_names
+
+    # Codex and OpenClaw SHOULD discover .agents/skills/
+    for harness in ("codex", "openclaw"):
+        artifacts = discover_shared_workspace_aibom_artifacts(
+            harness,
+            home_dir=tmp_path,
+            workspace_dir=workspace,
+        )
+        skill_names = {
+            a.name for a in artifacts if a.artifact_type == "skill"
+        }
+        assert "bare-metal-server" in skill_names, f"{harness} should discover .agents/skills/"
+
+    # Copilot and Antigravity also don't use .agents/skills/
+    for harness in ("copilot", "antigravity"):
+        artifacts = discover_shared_workspace_aibom_artifacts(
+            harness,
+            home_dir=tmp_path,
+            workspace_dir=workspace,
+        )
+        skill_names = {
+            a.name for a in artifacts if a.artifact_type == "skill"
+        }
+        assert "bare-metal-server" not in skill_names, f"{harness} should not discover .agents/skills/"
+
+
+def test_workspace_skills_excluded_for_hermes_inventory_snapshot(tmp_path: Path) -> None:
+    """Full inventory snapshot for Hermes must not include workspace .agents/skills/."""
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    skill_dir = workspace / ".agents" / "skills" / "bare-metal-server"
+    skill_dir.mkdir(parents=True)
+    (skill_dir / "SKILL.md").write_text(
+        "---\nname: bare-metal-server\ndescription: test\n---\nbody\n",
+        encoding="utf-8",
+    )
+    context = HarnessContext(
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+        guard_home=tmp_path / ".guard",
+    )
+    snapshot = HermesHarnessAdapter().inventory_snapshot(
+        context,
+        generated_at="2026-01-01T00:00:00Z",
+    )
+    skill_names = {
+        item.metadata.get("skill_name") or item.display_name
+        for item in snapshot.items
+        if item.item_kind == "skill"
+    }
+    assert "bare-metal-server" not in skill_names

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -537,8 +537,8 @@ def test_workspace_skills_excluded_for_hermes(tmp_path: Path) -> None:
         }
         assert "bare-metal-server" in skill_names, f"{harness} should discover .agents/skills/"
 
-    # Copilot and Antigravity also don't use .agents/skills/
-    for harness in ("copilot", "antigravity"):
+    # Copilot also doesn't use .agents/skills/
+    for harness in ("copilot",):
         artifacts = discover_shared_workspace_aibom_artifacts(
             harness,
             home_dir=tmp_path,


### PR DESCRIPTION
Closed. Wrong approach.