### PR TITLE
fix(aibom): gate all workspace artifact discovery behind harness set

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -51,11 +51,13 @@ _CURSOR_RULE_PATTERNS = ("*.mdc", "*.md")
 _CODEX_WORKSPACE_SKILL_ROOTS = (".agents/skills",)
 _CODEX_HOME_SKILL_ROOTS = (".codex/skills", ".agents/skills")
 
-# Harnesses that natively discover skills from the shared ``.agents/skills``
-# workspace directory.  Other harnesses (e.g. Hermes, Copilot) use their own
-# skill directories and must not pick up Codex/OpenClaw-style workspace skills.
+# Harnesses that natively use shared workspace AIBOM artifacts — skills in
+# ``.agents/skills``, instruction files (CLAUDE.md, PRODUCT.md, …), cursor
+# rules, and marketplace plugins.  Hosted runtime harnesses (Hermes,
+# OpenClaw, Copilot) run on remote servers and must not pick up local
+# workspace files that belong to other harnesses on the developer's machine.
 # Keep this set in sync with CANONICAL_HARNESS_VALUES in product_model.py.
-_WORKSPACE_CODEX_SKILL_HARNESSES = frozenset(
+_WORKSPACE_AIBOM_HARNESSES = frozenset(
     {
         "codex",
         "openclaw",
@@ -179,13 +181,14 @@ def instruction_role_for_path(path: Path) -> InstructionRole | None:
                         return role
     return None
 
-
 def discover_shared_workspace_aibom_artifacts(
     harness: str,
     *,
     home_dir: Path,
     workspace_dir: Path,
 ) -> tuple[GuardArtifact, ...]:
+    if harness not in _WORKSPACE_AIBOM_HARNESSES:
+        return ()
     if not workspace_dir.is_dir():
         return ()
     try:
@@ -196,17 +199,16 @@ def discover_shared_workspace_aibom_artifacts(
     artifacts.extend(_discover_agents_md(harness, workspace_dir=workspace_dir))
     artifacts.extend(_discover_standards_context_files(harness, workspace_dir=workspace_dir))
     artifacts.extend(_discover_cursor_rules(harness, workspace_dir=workspace_dir))
-    if harness in _WORKSPACE_CODEX_SKILL_HARNESSES:
-        artifacts.extend(
-            _discover_codex_skills(
-                harness,
-                workspace_dir=workspace_dir,
-                home_dir=home_dir,
-                skill_roots=_CODEX_WORKSPACE_SKILL_ROOTS,
-                source_scope="project",
-                artifact_scope="project",
-            )
+    artifacts.extend(
+        _discover_codex_skills(
+            harness,
+            workspace_dir=workspace_dir,
+            home_dir=home_dir,
+            skill_roots=_CODEX_WORKSPACE_SKILL_ROOTS,
+            source_scope="project",
+            artifact_scope="project",
         )
+    )
     artifacts.extend(_discover_codex_marketplace_plugins(harness, workspace_dir=workspace_dir))
     return tuple(artifacts)
 

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -181,6 +181,7 @@ def instruction_role_for_path(path: Path) -> InstructionRole | None:
                         return role
     return None
 
+
 def discover_shared_workspace_aibom_artifacts(
     harness: str,
     *,

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -218,10 +218,9 @@ def test_inventory_snapshot_includes_workspace_instructions(tmp_path: Path) -> N
     workspace = tmp_path / "repo"
     workspace.mkdir()
     (workspace / "AGENTS.md").write_text("repo policy\n", encoding="utf-8")
-
     snapshot = inventory_snapshot_from_detection(
         HarnessDetection(
-            harness="hermes",
+            harness="codex",
             installed=True,
             command_available=False,
             config_paths=(),
@@ -283,13 +282,11 @@ def test_inventory_snapshot_items_include_descriptions(tmp_path: Path) -> None:
     assert first_payload_item["description"] == skill_items[0].description
 
 
-def test_hermes_and_openclaw_inventory_snapshots_include_workspace_agents_md(tmp_path: Path) -> None:
+def test_openclaw_inventory_snapshot_includes_workspace_agents_md(tmp_path: Path) -> None:
+    """OpenClaw natively uses workspace artifacts — should discover AGENTS.md."""
     workspace = tmp_path / "repo"
     workspace.mkdir()
     (workspace / "AGENTS.md").write_text("shared policy\n", encoding="utf-8")
-    hermes_home = tmp_path / "home" / ".hermes"
-    hermes_home.mkdir(parents=True)
-    (hermes_home / "config.yaml").write_text("mcp_servers: {}\n", encoding="utf-8")
     openclaw_home = tmp_path / "home" / ".openclaw"
     openclaw_home.mkdir(parents=True)
     (openclaw_home / "openclaw.json").write_text(
@@ -302,10 +299,28 @@ def test_hermes_and_openclaw_inventory_snapshots_include_workspace_agents_md(tmp
         guard_home=tmp_path / ".hol-guard",
     )
 
-    for adapter in (HermesHarnessAdapter(), OpenClawHarnessAdapter()):
-        snapshot = adapter.inventory_snapshot(context, generated_at="2026-06-10T00:00:00Z")
-        overlay_items = [item for item in snapshot.items if item.item_kind == "overlay"]
-        assert any(item.metadata.get("instructionRole") == "agents_md" for item in overlay_items)
+    snapshot = OpenClawHarnessAdapter().inventory_snapshot(context, generated_at="2026-06-10T00:00:00Z")
+    overlay_items = [item for item in snapshot.items if item.item_kind == "overlay"]
+    assert any(item.metadata.get("instructionRole") == "agents_md" for item in overlay_items)
+
+
+def test_hermes_inventory_snapshot_excludes_workspace_agents_md(tmp_path: Path) -> None:
+    """Hermes runs on a remote server — must not pick up local AGENTS.md."""
+    workspace = tmp_path / "repo"
+    workspace.mkdir()
+    (workspace / "AGENTS.md").write_text("shared policy\n", encoding="utf-8")
+    hermes_home = tmp_path / "home" / ".hermes"
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text("mcp_servers: {}\n", encoding="utf-8")
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace,
+        guard_home=tmp_path / ".hol-guard",
+    )
+
+    snapshot = HermesHarnessAdapter().inventory_snapshot(context, generated_at="2026-06-10T00:00:00Z")
+    overlay_items = [item for item in snapshot.items if item.item_kind == "overlay"]
+    assert not any(item.metadata.get("instructionRole") == "agents_md" for item in overlay_items)
 
 
 def test_instruction_role_ignores_unrelated_rules_paths(tmp_path: Path) -> None:
@@ -497,16 +512,17 @@ def test_cursor_detect_extends_workspace_aibom(tmp_path: Path) -> None:
     assert any(artifact.artifact_type == "instruction" for artifact in extended.artifacts)
 
 
-def test_workspace_skills_excluded_for_hermes(tmp_path: Path) -> None:
-    """Hermes uses ~/.hermes/skills/, not .agents/skills/.
+def test_workspace_artifacts_excluded_for_hermes(tmp_path: Path) -> None:
+    """Hermes runs on a remote server and must not pick up local workspace files.
 
-    Workspace-level ``.agents/skills/`` is a Codex/OpenClaw convention.
-    Hermes (and other harnesses that don't natively scan it) must not pick
-    up those skills in their inventory snapshots, otherwise skills from
-    one harness leak into another harness's Protection Graph.
+    Hermes uses ~/.hermes/skills/, not .agents/skills/, and must not discover
+    PRODUCT.md, SECURITY.md, .cursor/rules, or marketplace plugins from the
+    local developer workspace.
     """
     workspace = tmp_path / "repo"
     workspace.mkdir()
+
+    # Workspace skill (Codex/OpenClaw style)
     skill_dir = workspace / ".agents" / "skills" / "bare-metal-server"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
@@ -514,52 +530,89 @@ def test_workspace_skills_excluded_for_hermes(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    # Hermes must NOT discover .agents/skills/
+    # Instruction files
+    (workspace / "PRODUCT.md").write_text("# Product\n", encoding="utf-8")
+    (workspace / "SECURITY.md").write_text("# Security\n", encoding="utf-8")
+    (workspace / "AGENTS.md").write_text("# Agents\n", encoding="utf-8")
+    (workspace / "CLAUDE.md").write_text("# Claude\n", encoding="utf-8")
+
+    # Cursor rules
+    cursor_rules = workspace / ".cursor" / "rules"
+    cursor_rules.mkdir(parents=True)
+    (cursor_rules / "lean-ctx.mdc").write_text("# lean-ctx\n", encoding="utf-8")
+
+    # Hermes must NOT discover any workspace AIBOM artifacts
     hermes_artifacts = discover_shared_workspace_aibom_artifacts(
         "hermes",
         home_dir=tmp_path,
         workspace_dir=workspace,
     )
-    hermes_skill_names = {
-        a.name for a in hermes_artifacts if a.artifact_type == "skill"
+    assert hermes_artifacts == (), (
+        f"Hermes must not discover workspace artifacts, got: "
+        f"{[(a.artifact_type, a.name) for a in hermes_artifacts]}"
+    )
+
+    # OpenClaw natively uses .agents/skills — confirm it discovers skills.
+    openclaw_artifacts = discover_shared_workspace_aibom_artifacts(
+        "openclaw",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    openclaw_skill_names = {
+        a.name for a in openclaw_artifacts if a.artifact_type == "skill"
     }
-    assert "bare-metal-server" not in hermes_skill_names
+    assert "bare-metal-server" in openclaw_skill_names
 
-    # Codex and OpenClaw SHOULD discover .agents/skills/
-    for harness in ("codex", "openclaw"):
-        artifacts = discover_shared_workspace_aibom_artifacts(
-            harness,
-            home_dir=tmp_path,
-            workspace_dir=workspace,
-        )
-        skill_names = {
-            a.name for a in artifacts if a.artifact_type == "skill"
-        }
-        assert "bare-metal-server" in skill_names, f"{harness} should discover .agents/skills/"
+    # Codex should also discover everything
+    codex_artifacts = discover_shared_workspace_aibom_artifacts(
+        "codex",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    codex_names = {a.name for a in codex_artifacts}
+    assert "bare-metal-server" in codex_names
+    assert "PRODUCT.md" in codex_names
+    assert "SECURITY.md" in codex_names
+    assert "AGENTS.md" in codex_names
 
-    # Copilot also doesn't use .agents/skills/
-    for harness in ("copilot",):
-        artifacts = discover_shared_workspace_aibom_artifacts(
-            harness,
-            home_dir=tmp_path,
-            workspace_dir=workspace,
-        )
-        skill_names = {
-            a.name for a in artifacts if a.artifact_type == "skill"
-        }
-        assert "bare-metal-server" not in skill_names, f"{harness} should not discover .agents/skills/"
+    # Copilot also doesn't use workspace AIBOM
+    copilot_artifacts = discover_shared_workspace_aibom_artifacts(
+        "copilot",
+        home_dir=tmp_path,
+        workspace_dir=workspace,
+    )
+    assert copilot_artifacts == (), (
+        f"Copilot must not discover workspace artifacts, got: "
+        f"{[(a.artifact_type, a.name) for a in copilot_artifacts]}"
+    )
 
 
-def test_workspace_skills_excluded_for_hermes_inventory_snapshot(tmp_path: Path) -> None:
-    """Full inventory snapshot for Hermes must not include workspace .agents/skills/."""
+def test_workspace_artifacts_excluded_for_hermes_inventory_snapshot(tmp_path: Path) -> None:
+    """Full inventory snapshot for Hermes must not include any workspace artifacts.
+
+    Hermes inventory_snapshot() calls inventory_snapshot_from_detection() which
+    must not pick up PRODUCT.md, SECURITY.md, .cursor/rules, or .agents/skills.
+    """
     workspace = tmp_path / "repo"
     workspace.mkdir()
+
+    # Workspace skill
     skill_dir = workspace / ".agents" / "skills" / "bare-metal-server"
     skill_dir.mkdir(parents=True)
     (skill_dir / "SKILL.md").write_text(
         "---\nname: bare-metal-server\ndescription: test\n---\nbody\n",
         encoding="utf-8",
     )
+
+    # Instruction files
+    (workspace / "PRODUCT.md").write_text("# Product\n", encoding="utf-8")
+    (workspace / "SECURITY.md").write_text("# Security\n", encoding="utf-8")
+
+    # Cursor rules
+    cursor_rules = workspace / ".cursor" / "rules"
+    cursor_rules.mkdir(parents=True)
+    (cursor_rules / "lean-ctx.mdc").write_text("# lean-ctx\n", encoding="utf-8")
+
     context = HarnessContext(
         home_dir=tmp_path,
         workspace_dir=workspace,
@@ -569,9 +622,10 @@ def test_workspace_skills_excluded_for_hermes_inventory_snapshot(tmp_path: Path)
         context,
         generated_at="2026-01-01T00:00:00Z",
     )
-    skill_names = {
-        item.metadata.get("skill_name") or item.display_name
-        for item in snapshot.items
-        if item.item_kind == "skill"
-    }
-    assert "bare-metal-server" not in skill_names
+
+    # No workspace artifacts should appear in the inventory snapshot
+    item_names = {item.display_name for item in snapshot.items}
+    assert "bare-metal-server" not in item_names
+    assert "PRODUCT.md" not in item_names
+    assert "SECURITY.md" not in item_names
+    assert "lean-ctx" not in item_names

--- a/tests/test_guard_aibom_detection.py
+++ b/tests/test_guard_aibom_detection.py
@@ -548,8 +548,7 @@ def test_workspace_artifacts_excluded_for_hermes(tmp_path: Path) -> None:
         workspace_dir=workspace,
     )
     assert hermes_artifacts == (), (
-        f"Hermes must not discover workspace artifacts, got: "
-        f"{[(a.artifact_type, a.name) for a in hermes_artifacts]}"
+        f"Hermes must not discover workspace artifacts, got: {[(a.artifact_type, a.name) for a in hermes_artifacts]}"
     )
 
     # OpenClaw natively uses .agents/skills — confirm it discovers skills.
@@ -558,9 +557,7 @@ def test_workspace_artifacts_excluded_for_hermes(tmp_path: Path) -> None:
         home_dir=tmp_path,
         workspace_dir=workspace,
     )
-    openclaw_skill_names = {
-        a.name for a in openclaw_artifacts if a.artifact_type == "skill"
-    }
+    openclaw_skill_names = {a.name for a in openclaw_artifacts if a.artifact_type == "skill"}
     assert "bare-metal-server" in openclaw_skill_names
 
     # Codex should also discover everything
@@ -582,8 +579,7 @@ def test_workspace_artifacts_excluded_for_hermes(tmp_path: Path) -> None:
         workspace_dir=workspace,
     )
     assert copilot_artifacts == (), (
-        f"Copilot must not discover workspace artifacts, got: "
-        f"{[(a.artifact_type, a.name) for a in copilot_artifacts]}"
+        f"Copilot must not discover workspace artifacts, got: {[(a.artifact_type, a.name) for a in copilot_artifacts]}"
     )
 
 


### PR DESCRIPTION
## Problem

Hosted runtime harnesses (Hermes, OpenClaw, Copilot) run on remote servers with their own ecosystems. However, `discover_shared_workspace_aibom_artifacts()` was picking up local workspace files (PRODUCT.md, SECURITY.md, AGENTS.md, .cursor/rules, marketplace plugins) for ALL harnesses via `inventory_snapshot_from_detection()`.

This caused instruction files, MCP configs, and other workspace artifacts from a developer's local machine to be attributed to remote harnesses in their AIBOM inventory snapshots.

## Root Cause

`discover_shared_workspace_aibom_artifacts()` only gated `.agents/skills/` discovery behind `_WORKSPACE_CODEX_SKILL_HARNESSES`. The rest of the function — AGENTS.md, standards context files (CLAUDE.md, PRODUCT.md, SECURITY.md, etc.), .cursor/rules, and marketplace plugins — ran for ALL harnesses unconditionally.

Only Hermes and OpenClaw call `inventory_snapshot_from_detection()`, and both inherited the workspace discovery without being in the intended set.

## Fix

Rename `_WORKSPACE_CODEX_SKILL_HARNESSES` → `_WORKSPACE_AIBOM_HARNESSES` and move the harness gate to the top of `discover_shared_workspace_aibom_artifacts()`. The entire function now returns early `()` for harnesses not in the set, preventing any workspace artifact leakage.

## Verification

- 22 AIBOM detection tests pass (including new broader exclusion tests)
- 54 AIBOM-related tests pass across all test files
- Ruff lint passes
- New tests verify Hermes excludes ALL workspace artifacts (skills, instruction files, cursor rules) while Codex/OpenClaw still discover them