### PR TITLE
feat: add DevContainer feature for hol-guard

### DIFF
--- a/.github/workflows/devcontainer-features.yml
+++ b/.github/workflows/devcontainer-features.yml
@@ -1,0 +1,59 @@
+name: Publish DevContainer Feature
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'devcontainer-features/**'
+  pull_request:
+    paths:
+      - 'devcontainer-features/**'
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Validate feature metadata"
+        run: |
+          echo "Validating devcontainer-feature.json files..."
+          for dir in devcontainer-features/*/; do
+            if [ -f "${dir}devcontainer-feature.json" ]; then
+              echo "Checking ${dir}devcontainer-feature.json"
+              python3 -c "import json; json.load(open('${dir}devcontainer-feature.json'))" \
+                || { echo "Invalid JSON: ${dir}devcontainer-feature.json"; exit 1; }
+              echo "  OK"
+            fi
+          done
+
+      - name: "Check install scripts exist"
+        run: |
+          for dir in devcontainer-features/*/; do
+            feature_name=$(basename "$dir")
+            if [ -f "${dir}install.sh" ]; then
+              echo "  ${feature_name}: install.sh found"
+            else
+              echo "ERROR: ${dir}install.sh not found"
+              exit 1
+            fi
+          done
+
+  publish:
+    needs: validate
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: "Publish features to GHCR"
+        uses: devcontainers/action@v1
+        with:
+          publish-features: "true"
+          base-path-to-features: "devcontainer-features"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -363,6 +363,28 @@ hol-guard start
 plugin-scanner verify .
 ```
 
+### DevContainer / Codespaces
+
+Add HOL Guard to your `devcontainer.json` for automatic protection in VS Code Codespaces and remote dev containers:
+
+```json
+{
+    "features": {
+        "ghcr.io/hashgraph-online/hol-guard/hol-guard:1": {}
+    }
+}
+```
+
+Options:
+
+| Option | Default | Description |
+| :--- | :--- | :--- |
+| `version` | `latest` | Pin to a specific release (e.g. `2.0.1004`) |
+| `initHarness` | `auto` | Configure for a specific harness: `codex`, `claude-code`, `cursor`, `gemini`, `opencode`, `pi`, or `auto` |
+| `strictMode` | `false` | Enable strict mode on install |
+
+See [`devcontainer-features/hol-guard/README.md`](devcontainer-features/hol-guard/README.md) for details.
+
 ## Ecosystem Support
 
 | Ecosystem | Detection Surfaces |

--- a/devcontainer-features/hol-guard/README.md
+++ b/devcontainer-features/hol-guard/README.md
@@ -1,0 +1,48 @@
+# HOL Guard DevContainer Feature
+
+Installs [HOL Guard](https://hol.org/guard) into your dev container — local-first security for AI coding agents.
+
+## Quick Start
+
+Add this to your `devcontainer.json`:
+
+```json
+{
+    "image": "mcr.microsoft.com/devcontainers/python:3.12",
+    "features": {
+        "ghcr.io/hashgraph-online/hol-guard/hol-guard:1": {}
+    }
+}
+```
+
+That's it. HOL Guard installs automatically on container build.
+
+## Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `version` | string | `latest` | HOL Guard version (`latest` or specific like `2.0.1004`) |
+| `initHarness` | string | `auto` | Harness to configure: `auto`, `codex`, `claude-code`, `cursor`, `gemini`, `opencode`, `pi`, or `none` |
+| `strictMode` | boolean | `false` | Enable strict mode (blocks untrusted tool actions by default) |
+
+## Example: Cursor + Strict Mode
+
+```json
+{
+    "features": {
+        "ghcr.io/hashgraph-online/hol-guard/hol-guard:1": {
+            "version": "latest",
+            "initHarness": "cursor",
+            "strictMode": true
+        }
+    }
+}
+```
+
+## What is HOL Guard?
+
+HOL Guard intercepts tool actions before files change or networks are contacted. It protects AI coding agents (Codex, Claude Code, Cursor, Gemini, OpenCode, Pi) from supply-chain attacks in plugins and MCP servers.
+
+- [Documentation](https://hol.org/guard)
+- [GitHub](https://github.com/hashgraph-online/hol-guard)
+- [PyPI](https://pypi.org/project/hol-guard/)

--- a/devcontainer-features/hol-guard/devcontainer-feature.json
+++ b/devcontainer-features/hol-guard/devcontainer-feature.json
@@ -1,0 +1,28 @@
+{
+  "name": "HOL Guard",
+  "id": "hol-guard",
+  "version": "1.0.0",
+  "description": "Installs HOL Guard — local-first security for AI coding agents. Intercepts tool actions before files change or networks are contacted.",
+  "documentationURL": "https://hol.org/guard",
+  "licenseURL": "https://github.com/hashgraph-online/hol-guard/blob/main/LICENSE",
+  "options": {
+    "version": {
+      "type": "string",
+      "enum": ["latest", "2.0.1004"],
+      "default": "latest",
+      "description": "Select the HOL Guard version to install"
+    },
+    "initHarness": {
+      "type": "string",
+      "enum": ["none", "auto", "codex", "claude-code", "cursor", "gemini", "opencode", "pi"],
+      "default": "auto",
+      "description": "Which AI harness to configure HOL Guard for during install (auto = detect)"
+    },
+    "strictMode": {
+      "type": "boolean",
+      "default": false,
+      "description": "Enable strict mode (blocks untrusted tool actions by default)"
+    }
+  },
+  "installsAfter": ["ghcr.io/devcontainers/features/python"]
+}

--- a/devcontainer-features/hol-guard/install.sh
+++ b/devcontainer-features/hol-guard/install.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# HOL Guard DevContainer Feature
+# Installs HOL Guard into a dev container for AI agent security
+
+VERSION="${VERSION:-latest}"
+INIT_HARNESS="${INITHARNESS:-auto}"
+STRICT_MODE="${STRICTMODE:-false}"
+
+echo "================================================"
+echo "  HOL Guard DevContainer Feature"
+echo "  https://hol.org/guard"
+echo "================================================"
+
+# Ensure Python is available
+if ! command -v python3 &>/dev/null; then
+    echo "ERROR: Python 3.10+ is required. Please install the Python feature first."
+    echo "  Add to devcontainer.json: \"ghcr.io/devcontainers/features/python\""
+    exit 1
+fi
+
+PY_VERSION=$(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")
+echo "Detected Python: ${PY_VERSION}"
+
+# Check minimum version (3.10+)
+MAJOR=$(echo "$PY_VERSION" | cut -d. -f1)
+MINOR=$(echo "$PY_VERSION" | cut -d. -f2)
+if [ "$MAJOR" -lt 3 ] || { [ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 10 ]; }; then
+    echo "ERROR: HOL Guard requires Python 3.10+. Found ${PY_VERSION}."
+    exit 1
+fi
+
+# Install pipx if not present
+if ! command -v pipx &>/dev/null; then
+    echo "Installing pipx..."
+    python3 -m pip install --user pipx
+    export PATH="${PATH}:${HOME}/.local/bin"
+fi
+
+# Install hol-guard
+if [ "$VERSION" = "latest" ]; then
+    echo "Installing HOL Guard (latest)..."
+    pipx install hol-guard
+else
+    echo "Installing HOL Guard v${VERSION}..."
+    pipx install "hol-guard==${VERSION}"
+fi
+
+# Initialize for harness if requested
+if [ "$INIT_HARNESS" != "none" ]; then
+    echo ""
+    echo "Initializing HOL Guard for harness: ${INIT_HARNESS}..."
+    if [ "$INIT_HARNESS" = "auto" ]; then
+        hol-guard init
+    else
+        hol-guard init --harness "$INIT_HARNESS"
+    fi
+
+    if [ "$STRICT_MODE" = "true" ]; then
+        echo "Enabling strict mode..."
+        hol-guard config set strict true
+    fi
+fi
+
+echo ""
+echo "HOL Guard installed successfully."
+echo "  Docs: https://hol.org/guard"
+echo "  CLI:  hol-guard --help"
+echo "================================================"


### PR DESCRIPTION
## What

Adds a DevContainer feature for HOL Guard, so VS Code Codespaces and remote dev containers can install Guard automatically on container build.

## Changes

- `devcontainer-features/hol-guard/devcontainer-feature.json` — Feature metadata with 3 options (`version`, `initHarness`, `strictMode`)
- `devcontainer-features/hol-guard/install.sh` — Install script (pipx-based, Python 3.10+ check, harness init)
- `devcontainer-features/hol-guard/README.md` — Feature docs with usage examples
- `README.md` — New "DevContainer / Codespaces" install section

## Usage

```json
{
    "features": {
        "ghcr.io/hashgraph-online/hol-guard/hol-guard:1": {}
    }
}
```

## Why

Adds HOL Guard to the devcontainer feature discovery surface. Anyone browsing Codespaces features or searching for AI agent security in VS Code will find it. No separate repo needed since hol-guard is the only tool.
