### PR TITLE
fix: devcontainer feature review feedback (pipx PEP 668, non-root user, correct CLI commands)

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Options:
 | Option | Default | Description |
 | :--- | :--- | :--- |
 | `version` | `latest` | Pin to a specific release (e.g. `2.0.1004`) |
-| `initHarness` | `auto` | Configure for a specific harness: `codex`, `claude-code`, `cursor`, `gemini`, `opencode`, `pi`, `auto` (detect), or `none` (skip init) |
+| `initHarness` | `auto` | Harness to configure: `auto` (detect installed), `none` (skip init), or a specific name (`codex`, `claude-code`, `cursor`, `gemini`, `opencode`, `pi`) — informational, Guard auto-detects regardless |
 | `strictMode` | `false` | Enable strict mode on install |
 
 See [`devcontainer-features/hol-guard/README.md`](devcontainer-features/hol-guard/README.md) for details.

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ Options:
 | Option | Default | Description |
 | :--- | :--- | :--- |
 | `version` | `latest` | Pin to a specific release (e.g. `2.0.1004`) |
-| `initHarness` | `auto` | Configure for a specific harness: `codex`, `claude-code`, `cursor`, `gemini`, `opencode`, `pi`, or `auto` |
+| `initHarness` | `auto` | Configure for a specific harness: `codex`, `claude-code`, `cursor`, `gemini`, `opencode`, `pi`, `auto` (detect), or `none` (skip init) |
 | `strictMode` | `false` | Enable strict mode on install |
 
 See [`devcontainer-features/hol-guard/README.md`](devcontainer-features/hol-guard/README.md) for details.

--- a/devcontainer-features/hol-guard/README.md
+++ b/devcontainer-features/hol-guard/README.md
@@ -22,7 +22,7 @@ That's it. HOL Guard installs automatically on container build.
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `version` | string | `latest` | HOL Guard version (`latest` or specific like `2.0.1004`) |
-| `initHarness` | string | `auto` | Harness to configure: `auto`, `codex`, `claude-code`, `cursor`, `gemini`, `opencode`, `pi`, or `none` |
+| `initHarness` | string | `auto` | `auto` (detect installed harnesses), `none` (skip init), or a specific name (`codex`, `claude-code`, `cursor`, `gemini`, `opencode`, `pi`) — informational only, Guard auto-detects regardless |
 | `strictMode` | boolean | `false` | Enable strict mode (blocks untrusted tool actions by default) |
 
 ## Example: Cursor + Strict Mode

--- a/devcontainer-features/hol-guard/devcontainer-feature.json
+++ b/devcontainer-features/hol-guard/devcontainer-feature.json
@@ -16,7 +16,7 @@
       "type": "string",
       "enum": ["none", "auto", "codex", "claude-code", "cursor", "gemini", "opencode", "pi"],
       "default": "auto",
-      "description": "Which AI harness to configure HOL Guard for during install (auto = detect)"
+      "description": "Which AI harness to configure HOL Guard for during install. Guard auto-detects installed harnesses; the selected value is informational. Use 'none' to skip init."
     },
     "strictMode": {
       "type": "boolean",

--- a/devcontainer-features/hol-guard/devcontainer-feature.json
+++ b/devcontainer-features/hol-guard/devcontainer-feature.json
@@ -1,14 +1,14 @@
 {
   "name": "HOL Guard",
   "id": "hol-guard",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Installs HOL Guard — local-first security for AI coding agents. Intercepts tool actions before files change or networks are contacted.",
   "documentationURL": "https://hol.org/guard",
   "licenseURL": "https://github.com/hashgraph-online/hol-guard/blob/main/LICENSE",
   "options": {
     "version": {
       "type": "string",
-      "enum": ["latest", "2.0.1004"],
+      "proposals": ["latest", "2.0.1004"],
       "default": "latest",
       "description": "Select the HOL Guard version to install"
     },

--- a/devcontainer-features/hol-guard/install.sh
+++ b/devcontainer-features/hol-guard/install.sh
@@ -100,9 +100,12 @@ if ! user_has pipx; then
         dnf clean all
     else
         # Fallback: install into the user's site-packages.
-        # --break-system-packages without --user installs into the system
-        # site-packages (the correct path when PEP 668 is active).
-        run_as_user python3 -m pip install --break-system-packages pipx
+        # --user lands in a writable directory for non-root users.
+        # --break-system-packages bypasses PEP 668 (externally-managed-environment)
+        # on distros where it applies. Both flags together are correct:
+        # --user controls the install location, --break-system-packages
+        # bypasses the externally-managed guard.
+        run_as_user python3 -m pip install --user --break-system-packages pipx
     fi
 fi
 

--- a/devcontainer-features/hol-guard/install.sh
+++ b/devcontainer-features/hol-guard/install.sh
@@ -32,11 +32,12 @@ if [ "$MAJOR" -lt 3 ] || { [ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 10 ]; }; then
 fi
 
 # Validate VERSION to prevent shell injection via su -c.
-# Allow "latest" or PEP 440 version specifiers: digits, dots, and
-# pre/post/dev segments (e.g. 2.1, 2.0.1004, 2.0.1004.post1, 2.0.0a1,
-# 2.0.0rc1). Reject shell metacharacters, spaces, or path separators.
+# Allow "latest" or PEP 440 version specifiers: release segment (N.N*)
+# followed by any combination of pre/post/dev segments (e.g. 2.1,
+# 2.0.1004, 2.0.1004.post1, 2.0.0a1, 2.0.0rc1, 2.0.0a1.post2).
+# Reject shell metacharacters, spaces, or path separators.
 if [ "$VERSION" != "latest" ]; then
-    if ! echo "$VERSION" | grep -qE '^[0-9]+(\.[0-9]+)*((a|b|rc|c|\.post|\.dev)[0-9]*)?$'; then
+    if ! echo "$VERSION" | grep -qE '^[0-9]+(\.[0-9]+)*((a|b|rc|c|\.post|\.dev)[0-9]*)*$'; then
         echo "ERROR: Invalid version '${VERSION}'. Use 'latest' or a PEP 440 version like '2.0.1004'."
         exit 1
     fi

--- a/devcontainer-features/hol-guard/install.sh
+++ b/devcontainer-features/hol-guard/install.sh
@@ -31,11 +31,13 @@ if [ "$MAJOR" -lt 3 ] || { [ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 10 ]; }; then
     exit 1
 fi
 
-# Validate VERSION to prevent shell injection via eval/su -c.
-# Only "latest" or dotted version numbers (e.g. "2.0.1004") are allowed.
+# Validate VERSION to prevent shell injection via su -c.
+# Allow "latest" or PEP 440 version specifiers: digits, dots, and
+# pre/post/dev segments (e.g. 2.1, 2.0.1004, 2.0.1004.post1, 2.0.0a1,
+# 2.0.0rc1). Reject shell metacharacters, spaces, or path separators.
 if [ "$VERSION" != "latest" ]; then
-    if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-        echo "ERROR: Invalid version '${VERSION}'. Use 'latest' or a version like '2.0.1004'."
+    if ! echo "$VERSION" | grep -qE '^[0-9]+(\.[0-9]+)*((a|b|rc|c|\.post|\.dev)[0-9]*)?$'; then
+        echo "ERROR: Invalid version '${VERSION}'. Use 'latest' or a PEP 440 version like '2.0.1004'."
         exit 1
     fi
 fi

--- a/devcontainer-features/hol-guard/install.sh
+++ b/devcontainer-features/hol-guard/install.sh
@@ -31,35 +31,90 @@ if [ "$MAJOR" -lt 3 ] || { [ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 10 ]; }; then
     exit 1
 fi
 
-# Install pipx if not present
-if ! command -v pipx &>/dev/null; then
-    echo "Installing pipx..."
-    python3 -m pip install --user pipx
-    export PATH="${PATH}:${HOME}/.local/bin"
+# Determine the target non-root user (devcontainer provides these env vars)
+USERNAME="${_REMOTE_USER:-${_CONTAINER_USER:-auto}}"
+if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "root" ]; then
+    for u in vscode node codespace; do
+        if id "$u" &>/dev/null; then
+            USERNAME="$u"
+            break
+        fi
+    done
+fi
+if [ "${USERNAME}" = "auto" ]; then
+    USERNAME="root"
 fi
 
-# Install hol-guard
+USER_HOME=$(getent passwd "${USERNAME}" | cut -d: -f6 || echo "/home/${USERNAME}")
+echo "Installing for user: ${USERNAME} (${USER_HOME})"
+
+# Run a command as the target user
+run_as_user() {
+    if [ "${USERNAME}" = "root" ]; then
+        eval "$1"
+    else
+        su "${USERNAME}" -c "$1"
+    fi
+}
+
+# Install pipx if not present (handling PEP 668 externally-managed-environment)
+if ! command -v pipx &>/dev/null && ! run_as_user "command -v pipx &>/dev/null"; then
+    echo "Installing pipx..."
+    if command -v apt-get &>/dev/null; then
+        export DEBIAN_FRONTEND=noninteractive
+        apt-get update && apt-get install -y pipx
+    elif command -v apk &>/dev/null; then
+        apk add pipx
+    elif command -v dnf &>/dev/null; then
+        dnf install -y pipx
+    else
+        run_as_user "python3 -m pip install --user pipx || python3 -m pip install --user pipx --break-system-packages"
+    fi
+fi
+
+# Ensure pipx is in the user's PATH
+run_as_user "pipx ensurepath &>/dev/null || ${USER_HOME}/.local/bin/pipx ensurepath &>/dev/null" || true
+
+# Determine pipx binary path
+PIPX_BIN="pipx"
+if ! run_as_user "command -v pipx &>/dev/null"; then
+    PIPX_BIN="${USER_HOME}/.local/bin/pipx"
+fi
+
+# Install hol-guard (--force for idempotent re-runs)
 if [ "$VERSION" = "latest" ]; then
     echo "Installing HOL Guard (latest)..."
-    pipx install hol-guard
+    run_as_user "${PIPX_BIN} install --force hol-guard"
 else
     echo "Installing HOL Guard v${VERSION}..."
-    pipx install "hol-guard==${VERSION}"
+    run_as_user "${PIPX_BIN} install --force hol-guard==${VERSION}"
+fi
+
+# Determine hol-guard binary path
+GUARD_BIN="hol-guard"
+if ! run_as_user "command -v hol-guard &>/dev/null"; then
+    GUARD_BIN="${USER_HOME}/.local/bin/hol-guard"
 fi
 
 # Initialize for harness if requested
 if [ "$INIT_HARNESS" != "none" ]; then
     echo ""
     echo "Initializing HOL Guard for harness: ${INIT_HARNESS}..."
+    # The Guard CLI auto-detects installed harnesses. --yes makes init
+    # non-interactive for devcontainer builds.
     if [ "$INIT_HARNESS" = "auto" ]; then
-        hol-guard init
+        run_as_user "${GUARD_BIN} init --yes"
     else
-        hol-guard init --harness "$INIT_HARNESS"
+        # No --harness flag exists yet; use --yes for non-interactive auto-detect.
+        # The specified harness will be detected if installed in the container.
+        echo "Note: hol-guard init auto-detects installed harnesses."
+        echo "  Specified harness '${INIT_HARNESS}' will be configured if found."
+        run_as_user "${GUARD_BIN} init --yes"
     fi
 
     if [ "$STRICT_MODE" = "true" ]; then
         echo "Enabling strict mode..."
-        hol-guard config set strict true
+        run_as_user "${GUARD_BIN} settings set security-level strict"
     fi
 fi
 

--- a/devcontainer-features/hol-guard/install.sh
+++ b/devcontainer-features/hol-guard/install.sh
@@ -14,7 +14,7 @@ echo "  https://hol.org/guard"
 echo "================================================"
 
 # Ensure Python is available
-if ! command -v python3 &>/dev/null; then
+if ! command -v python3 >/dev/null 2>&1; then
     echo "ERROR: Python 3.10+ is required. Please install the Python feature first."
     echo "  Add to devcontainer.json: \"ghcr.io/devcontainers/features/python\""
     exit 1
@@ -31,11 +31,20 @@ if [ "$MAJOR" -lt 3 ] || { [ "$MAJOR" -eq 3 ] && [ "$MINOR" -lt 10 ]; }; then
     exit 1
 fi
 
+# Validate VERSION to prevent shell injection via eval/su -c.
+# Only "latest" or dotted version numbers (e.g. "2.0.1004") are allowed.
+if [ "$VERSION" != "latest" ]; then
+    if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+        echo "ERROR: Invalid version '${VERSION}'. Use 'latest' or a version like '2.0.1004'."
+        exit 1
+    fi
+fi
+
 # Determine the target non-root user (devcontainer provides these env vars)
 USERNAME="${_REMOTE_USER:-${_CONTAINER_USER:-auto}}"
 if [ "${USERNAME}" = "auto" ] || [ "${USERNAME}" = "root" ]; then
     for u in vscode node codespace; do
-        if id "$u" &>/dev/null; then
+        if id "$u" >/dev/null 2>&1; then
             USERNAME="$u"
             break
         fi
@@ -45,76 +54,95 @@ if [ "${USERNAME}" = "auto" ]; then
     USERNAME="root"
 fi
 
-USER_HOME=$(getent passwd "${USERNAME}" | cut -d: -f6 || echo "/home/${USERNAME}")
+# Resolve the user's home directory; never guess /home/root.
+if [ "${USERNAME}" = "root" ]; then
+    USER_HOME="/root"
+else
+    USER_HOME=$(getent passwd "${USERNAME}" 2>/dev/null | cut -d: -f6 || true)
+    if [ -z "$USER_HOME" ]; then
+        USER_HOME="/home/${USERNAME}"
+    fi
+fi
 echo "Installing for user: ${USERNAME} (${USER_HOME})"
 
-# Run a command as the target user
+# Run a command as the target user. Uses exec for root (no shell overhead)
+# and su for non-root. The command argument must be a pre-validated argv
+# string — never interpolate untrusted input.
 run_as_user() {
     if [ "${USERNAME}" = "root" ]; then
-        eval "$1"
+        "$@"
     else
-        su "${USERNAME}" -c "$1"
+        su "${USERNAME}" -c "$*"
     fi
 }
 
-# Install pipx if not present (handling PEP 668 externally-managed-environment)
-if ! command -v pipx &>/dev/null && ! run_as_user "command -v pipx &>/dev/null"; then
+# Check if a binary is available in the target user's PATH.
+user_has() {
+    if [ "${USERNAME}" = "root" ]; then
+        command -v "$1" >/dev/null 2>&1
+    else
+        su "${USERNAME}" -c "command -v $1" >/dev/null 2>&1
+    fi
+}
+
+# Install pipx if not present in the target user's PATH (PEP 668-safe).
+if ! user_has pipx; then
     echo "Installing pipx..."
-    if command -v apt-get &>/dev/null; then
+    if command -v apt-get >/dev/null 2>&1; then
         export DEBIAN_FRONTEND=noninteractive
         apt-get update && apt-get install -y pipx
-    elif command -v apk &>/dev/null; then
+        apt-get clean && rm -rf /var/lib/apt/lists/*
+    elif command -v apk >/dev/null 2>&1; then
         apk add pipx
-    elif command -v dnf &>/dev/null; then
+        rm -rf /var/cache/apk/*
+    elif command -v dnf >/dev/null 2>&1; then
         dnf install -y pipx
+        dnf clean all
     else
-        run_as_user "python3 -m pip install --user pipx || python3 -m pip install --user pipx --break-system-packages"
+        # Fallback: install into the user's site-packages.
+        # --break-system-packages without --user installs into the system
+        # site-packages (the correct path when PEP 668 is active).
+        run_as_user python3 -m pip install --break-system-packages pipx
     fi
 fi
 
 # Ensure pipx is in the user's PATH
-run_as_user "pipx ensurepath &>/dev/null || ${USER_HOME}/.local/bin/pipx ensurepath &>/dev/null" || true
+run_as_user pipx ensurepath >/dev/null 2>&1 || true
 
 # Determine pipx binary path
 PIPX_BIN="pipx"
-if ! run_as_user "command -v pipx &>/dev/null"; then
+if ! user_has pipx; then
     PIPX_BIN="${USER_HOME}/.local/bin/pipx"
 fi
 
 # Install hol-guard (--force for idempotent re-runs)
 if [ "$VERSION" = "latest" ]; then
     echo "Installing HOL Guard (latest)..."
-    run_as_user "${PIPX_BIN} install --force hol-guard"
+    run_as_user "${PIPX_BIN}" install --force hol-guard
 else
     echo "Installing HOL Guard v${VERSION}..."
-    run_as_user "${PIPX_BIN} install --force hol-guard==${VERSION}"
+    run_as_user "${PIPX_BIN}" install --force "hol-guard==${VERSION}"
 fi
 
 # Determine hol-guard binary path
 GUARD_BIN="hol-guard"
-if ! run_as_user "command -v hol-guard &>/dev/null"; then
+if ! user_has hol-guard; then
     GUARD_BIN="${USER_HOME}/.local/bin/hol-guard"
 fi
 
-# Initialize for harness if requested
+# Initialize for harness if requested.
+# The Guard CLI auto-detects installed harnesses via `init --yes`.
+# A specific harness name is informational only — it does not change
+# the init command, since the CLI has no --harness flag. The harness
+# will be configured automatically if it is installed in the container.
 if [ "$INIT_HARNESS" != "none" ]; then
     echo ""
-    echo "Initializing HOL Guard for harness: ${INIT_HARNESS}..."
-    # The Guard CLI auto-detects installed harnesses. --yes makes init
-    # non-interactive for devcontainer builds.
-    if [ "$INIT_HARNESS" = "auto" ]; then
-        run_as_user "${GUARD_BIN} init --yes"
-    else
-        # No --harness flag exists yet; use --yes for non-interactive auto-detect.
-        # The specified harness will be detected if installed in the container.
-        echo "Note: hol-guard init auto-detects installed harnesses."
-        echo "  Specified harness '${INIT_HARNESS}' will be configured if found."
-        run_as_user "${GUARD_BIN} init --yes"
-    fi
+    echo "Initializing HOL Guard (harness: ${INIT_HARNESS})..."
+    run_as_user "${GUARD_BIN}" init --yes
 
     if [ "$STRICT_MODE" = "true" ]; then
         echo "Enabling strict mode..."
-        run_as_user "${GUARD_BIN} settings set security-level strict"
+        run_as_user "${GUARD_BIN}" settings set security-level strict
     fi
 fi
 


### PR DESCRIPTION
## Summary

Addresses bot review feedback from #1359 that wasn't applied before merge.

## Changes

### `install.sh`
- **Run as non-root devcontainer user**: Detects `_REMOTE_USER`/`_CONTAINER_USER` env vars (provided by DevContainer runtime) and runs pipx install + hol-guard init as that user via `su`. Falls back to `vscode`/`node`/`codespace`/`root`.
- **pipx via system package manager**: Installs pipx via `apt-get`/`apk`/`dnf` instead of `pip install --user` to avoid PEP 668 (`externally-managed-environment`) errors on modern Python distros. Falls back to `pip install --user --break-system-packages` only if no system package manager is available.
- **`--force` on pipx install**: Makes re-runs idempotent instead of failing with "already installed".
- **Correct CLI commands**: `hol-guard init` has no `--harness` flag — use `init --yes` for non-interactive auto-detect. `hol-guard config set strict true` doesn't exist — use `settings set security-level strict`.

### `devcontainer-feature.json`
- `version` option: `enum` → `proposals` (allows users to pin any release, not just the two enumerated values)
- Feature version bump: `1.0.0` → `1.0.1`

### `README.md`
- Add `none` (skip init) to the `initHarness` options description

## Verification
- `bash -n install.sh` — syntax OK
- `python3 -c "import json; json.load(open('devcontainer-feature.json'))"` — JSON valid
- Gitleaks: no leaks found
- Pre-publish security scan: no infrastructure keywords or secrets

## Related
Follow-up to #1359