### PR TITLE
fix(ci): prevent Python injection via directory name in devcontainer validation

### DIFF
--- a/.github/workflows/devcontainer-features.yml
+++ b/.github/workflows/devcontainer-features.yml
@@ -11,7 +11,6 @@ on:
 
 permissions:
   contents: read
-  packages: write
 
 jobs:
   validate:
@@ -25,7 +24,7 @@ jobs:
           for dir in devcontainer-features/*/; do
             if [ -f "${dir}devcontainer-feature.json" ]; then
               echo "Checking ${dir}devcontainer-feature.json"
-              python3 -c "import json; json.load(open('${dir}devcontainer-feature.json'))" \
+              python3 -m json.tool "${dir}devcontainer-feature.json" > /dev/null \
                 || { echo "Invalid JSON: ${dir}devcontainer-feature.json"; exit 1; }
               echo "  OK"
             fi
@@ -47,6 +46,9 @@ jobs:
     needs: validate
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- Replace `python3 -c` string interpolation with `python3 -m json.tool` to pass file paths as CLI arguments, preventing Python code injection via malicious directory names
- Scope `packages: write` permission to the `publish` job only; the `validate` job (runs on `pull_request`) now has `contents: read` only

## Testing
- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/devcontainer-features.yml'))"` — YAML valid
- Confirmed the old `python3 -c` pattern executes arbitrary code when a directory name contains `'+__import__('os').system('touch pwned')+'`
- Confirmed `python3 -m json.tool` does not execute code with the same directory name