### PR TITLE
fix(hermes): add HERMES_HOST_HOME fallback for container AIBOM detection

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -74,6 +74,56 @@ def _hermes_home(context: HarnessContext) -> Path:
     return context.home_dir / ".hermes"
 
 
+def _hermes_host_home() -> Path | None:
+    """Resolve the host's real Hermes home when running inside a container.
+
+    Hermes agents often run inside Docker containers with a minimal sandbox
+    config (``mcp_servers: {}``) and an empty skills directory.  The host's
+    real Hermes installation — with the full config.yaml and 200+ skills — is
+    not mounted into the container.
+
+    When the operator sets ``HERMES_HOST_HOME`` (e.g. via ``-e HERMES_HOST_HOME=/home/hol/.hermes``
+    or a Guard-managed env file), ``detect()`` can fall back to scanning the
+    host's real installation even from inside the container.
+
+    Returns ``None`` when the env var is unset or the path does not exist.
+    """
+    env_host = os.environ.get("HERMES_HOST_HOME")
+    if not env_host or not env_host.strip():
+        return None
+    host_path = Path(env_host.strip())
+    if not host_path.is_dir():
+        return None
+    return host_path
+
+
+def _hermes_home_has_artifacts(hermes_home: Path) -> bool:
+    """Check whether a Hermes home directory has any discoverable artifacts.
+
+    Returns True when config.yaml exists and is non-trivial (>300 bytes),
+    or when the skills directory has at least one SKILL.md file.
+    """
+    config_path = hermes_home / "config.yaml"
+    if config_path.is_file():
+        try:
+            if config_path.stat().st_size > 300:
+                return True
+        except OSError:
+            pass
+    skills_dir = hermes_home / "skills"
+    if skills_dir.is_dir():
+        try:
+            for category_dir in skills_dir.iterdir():
+                if not category_dir.is_dir():
+                    continue
+                for skill_dir in category_dir.iterdir():
+                    if skill_dir.is_dir() and (skill_dir / "SKILL.md").is_file():
+                        return True
+        except (PermissionError, OSError):
+            pass
+    return False
+
+
 def _manifest_notes(payload: dict[str, object]) -> list[str]:
     notes = payload.get("notes")
     if not isinstance(notes, list):
@@ -106,6 +156,13 @@ class HermesHarnessAdapter(HarnessAdapter):
             pretool_path=pretool_path,
         )
         source_configs = _load_mcp_server_sources(_hermes_home(context))
+        # When running inside a container with HERMES_HOST_HOME set, also
+        # load MCP server sources from the host's real Hermes config.  This
+        # ensures the manifest captures servers the container can't see.
+        host_home = _hermes_host_home()
+        if host_home and host_home != _hermes_home(context):
+            for key, config in _load_mcp_server_sources(host_home).items():
+                source_configs.setdefault(key, config)
         overlay_servers = _overlay_servers(context=context, source_configs=source_configs)
         cloud_identity = cloud_agent_identity_hints(context, runtime=self.harness)
         overlay_path.write_text(json.dumps(overlay_servers, indent=2) + "\n", encoding="utf-8")
@@ -305,6 +362,22 @@ class HermesHarnessAdapter(HarnessAdapter):
         # Discover MCP servers from both config.yaml and mcp_servers.json.
         artifacts.extend(self._scan_mcp_servers(hermes_home, found_paths))
 
+        # Container fallback: when the container's Hermes home is a minimal
+        # sandbox (empty skills, trivial config), fall back to the host's
+        # real Hermes installation via HERMES_HOST_HOME.  This is the common
+        # case for Hermes agents running inside Docker containers where the
+        # host's ~/.hermes is not mounted.
+        host_home = _hermes_host_home()
+        if host_home and host_home != hermes_home and not _hermes_home_has_artifacts(hermes_home):
+            artifacts.extend(self._scan_host_home(host_home, found_paths))
+
+        # Manifest fallback: when no MCP servers were discovered from config
+        # files, fall back to the Guard-managed manifest.json.  This covers
+        # containers where install() ran on the host and wrote the manifest,
+        # but the container's config.yaml has no mcp_servers.
+        if not any(a.artifact_type == "mcp_server" for a in artifacts):
+            artifacts.extend(self._scan_manifest_mcp_servers(context, found_paths))
+
         return HarnessDetection(
             harness=self.harness,
             installed=bool(found_paths) or _command_available(self.executable),
@@ -312,7 +385,6 @@ class HermesHarnessAdapter(HarnessAdapter):
             artifacts=tuple(artifacts),
             config_paths=tuple(found_paths),
         )
-
     def inventory_snapshot(
         self,
         context: HarnessContext,
@@ -490,6 +562,73 @@ class HermesHarnessAdapter(HarnessAdapter):
             artifacts.extend(self._mcp_artifacts(json_servers, str(json_path), source="json"))
 
         return artifacts
+
+    def _scan_host_home(
+        self,
+        host_home: Path,
+        found_paths: list[str],
+    ) -> list[GuardArtifact]:
+        """Scan the host's real Hermes home when running inside a container.
+
+        This mirrors the container-side detect() logic but targets the host's
+        installation.  Skills and MCP servers discovered here are attributed
+        to the Hermes harness — they belong to the agent even though the
+        container can't see them directly.
+        """
+        artifacts: list[GuardArtifact] = []
+
+        # Discover skills from the host's skills directory.
+        skills_dir = host_home / "skills"
+        if skills_dir.is_dir():
+            try:
+                category_dirs = sorted(skills_dir.iterdir())
+            except (PermissionError, OSError):
+                category_dirs = []
+            for category_dir in category_dirs:
+                if not category_dir.is_dir():
+                    continue
+                try:
+                    skill_dirs = sorted(category_dir.iterdir())
+                except (PermissionError, OSError):
+                    continue
+                for skill_dir in skill_dirs:
+                    if not skill_dir.is_dir():
+                        continue
+                    skill_md = skill_dir / "SKILL.md"
+                    if not skill_md.is_file():
+                        continue
+                    found_paths.append(str(skill_md))
+                    artifacts.extend(self._scan_skill(category_dir, skill_dir, skill_md))
+
+        # Discover MCP servers from the host's config files.
+        artifacts.extend(self._scan_mcp_servers(host_home, found_paths))
+
+        return artifacts
+
+    def _scan_manifest_mcp_servers(
+        self,
+        context: HarnessContext,
+        found_paths: list[str],
+    ) -> list[GuardArtifact]:
+        """Fall back to Guard-managed manifest.json for MCP server discovery.
+
+        When the container's config.yaml has no mcp_servers (common in
+        sandbox configs), the Guard-managed manifest.json written by
+        install() may contain the server definitions.  This covers the case
+        where install() ran on the host and the manifest was mounted or
+        copied into the container.
+        """
+        manifest_path = _managed_root(context) / "manifest.json"
+        if not manifest_path.is_file():
+            return []
+
+        payload = _json_payload(manifest_path)
+        servers = payload.get("servers")
+        if not isinstance(servers, dict) or not servers:
+            return []
+
+        found_paths.append(str(manifest_path))
+        return self._mcp_artifacts(servers, str(manifest_path), source="manifest")
 
     def _mcp_artifacts(
         self,

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -647,7 +647,18 @@ class HermesHarnessAdapter(HarnessAdapter):
             return []
 
         found_paths.append(str(manifest_path))
-        return self._mcp_artifacts(servers, str(manifest_path), source="manifest")
+        # Manifest stores servers keyed as "yaml:<name>" / "json:<name>".
+        # Re-key by the real server name so artifacts report the correct name.
+        real_servers: dict[str, dict[str, object]] = {}
+        for _key, server_config in servers.items():
+            if not isinstance(server_config, dict):
+                continue
+            real_name = server_config.get("name")
+            if isinstance(real_name, str) and real_name:
+                real_servers[real_name] = server_config
+            elif isinstance(_key, str):
+                real_servers[_key] = server_config
+        return self._mcp_artifacts(real_servers, str(manifest_path), source="manifest")
 
     def _mcp_artifacts(
         self,

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -100,15 +100,34 @@ def _hermes_host_home() -> Path | None:
 def _hermes_home_has_artifacts(hermes_home: Path) -> bool:
     """Check whether a Hermes home directory has any discoverable artifacts.
 
-    Returns True when config.yaml exists and is non-trivial (>300 bytes),
-    or when the skills directory has at least one SKILL.md file.
+    Returns True when config.yaml or config.toml exists and is non-trivial
+    (>300 bytes), when config.yaml contains mcp_servers entries, when
+    mcp_servers.json contains configured servers, or when the skills
+    directory has at least one SKILL.md file.
     """
-    config_path = hermes_home / "config.yaml"
-    if config_path.is_file():
+    for config_name in ("config.yaml", "config.toml"):
+        config_path = hermes_home / config_name
+        if config_path.is_file():
+            try:
+                if config_path.stat().st_size > 300:
+                    return True
+            except OSError:
+                pass
+    # Check if config.yaml has mcp_servers entries (even if small).
+    yaml_path = hermes_home / "config.yaml"
+    if yaml_path.is_file():
         try:
-            if config_path.stat().st_size > 300:
+            if _parse_mcp_from_yaml(yaml_path):
                 return True
-        except OSError:
+        except (ValueError, OSError):
+            pass
+    json_path = hermes_home / "mcp_servers.json"
+    if json_path.is_file():
+        try:
+            servers = _parse_mcp_from_json(json_path)
+            if servers:
+                return True
+        except (ValueError, OSError):
             pass
     skills_dir = hermes_home / "skills"
     if skills_dir.is_dir():
@@ -160,7 +179,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         # load MCP server sources from the host's real Hermes config.  This
         # ensures the manifest captures servers the container can't see.
         host_home = _hermes_host_home()
-        if host_home and host_home != _hermes_home(context):
+        if host_home and host_home.resolve() != _hermes_home(context).resolve():
             for key, config in _load_mcp_server_sources(host_home).items():
                 source_configs.setdefault(key, config)
         overlay_servers = _overlay_servers(context=context, source_configs=source_configs)
@@ -368,7 +387,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         # case for Hermes agents running inside Docker containers where the
         # host's ~/.hermes is not mounted.
         host_home = _hermes_host_home()
-        if host_home and host_home != hermes_home and not _hermes_home_has_artifacts(hermes_home):
+        if host_home and host_home.resolve() != hermes_home.resolve() and not _hermes_home_has_artifacts(hermes_home):
             artifacts.extend(self._scan_host_home(host_home, found_paths))
 
         # Manifest fallback: when no MCP servers were discovered from config

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -1439,6 +1439,44 @@ class TestManifestFallback:
         mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
         assert len(mcp_artifacts) == 0
 
+    def test_manifest_fallback_uses_real_server_name(self, tmp_path: Path):
+        """Manifest stores servers keyed as 'yaml:<name>' but detect()
+        should report the real server name, not the prefixed key."""
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+
+        # Manifest with prefixed keys (as written by install())
+        manifest_dir = tmp_path / "guard-home" / "hermes"
+        manifest_dir.mkdir(parents=True)
+        _write(
+            manifest_dir / "manifest.json",
+            json.dumps({
+                "servers": {
+                    "yaml:lean-ctx": {
+                        "name": "lean-ctx",
+                        "command": "npx",
+                        "args": ["-y", "@anthropic/lean-ctx"],
+                        "source": "yaml",
+                    },
+                    "json:playwright": {
+                        "name": "playwright",
+                        "command": "npx",
+                        "source": "json",
+                    },
+                },
+            }),
+        )
+
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+        mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp_artifacts) == 2
+        names = {a.name for a in mcp_artifacts}
+        assert "lean-ctx" in names
+        assert "playwright" in names
+        # Prefixed keys should NOT appear as names
+        assert "yaml:lean-ctx" not in names
+        assert "json:playwright" not in names
+
 
 class TestInstallHostHomeAwareness:
     """install() loads MCP sources from HERMES_HOST_HOME when set."""

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -1466,3 +1466,56 @@ class TestInstallHostHomeAwareness:
         server_keys = set(servers.keys())
         assert "yaml:container-server" in server_keys
         assert "yaml:host-server" in server_keys
+
+
+class TestHostHomeFallbackEdgeCases:
+    """Edge cases for the HERMES_HOST_HOME fallback."""
+
+    def test_small_config_with_mcp_servers_not_treated_as_empty(self, tmp_path: Path, monkeypatch):
+        """A small config.yaml with real MCP servers should NOT trigger
+        host home fallback, even if it's under 300 bytes."""
+        # Container config is small but has real MCP servers
+        _write(
+            tmp_path / ".hermes" / "config.yaml",
+            "mcp_servers:\n  local-server:\n    command: node\n",
+        )
+
+        # Host home has different servers
+        host_home = tmp_path / "host-hermes"
+        _write(
+            host_home / "config.yaml",
+            "mcp_servers:\n  host-server:\n    command: python\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOST_HOME", str(host_home))
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+
+        # Should find the container's server, NOT the host's
+        mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp_artifacts) == 1
+        assert mcp_artifacts[0].name == "local-server"
+
+    def test_mcp_servers_json_not_treated_as_empty(self, tmp_path: Path, monkeypatch):
+        """A container with mcp_servers.json containing servers should NOT
+        trigger host home fallback."""
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+        _write(
+            tmp_path / ".hermes" / "mcp_servers.json",
+            json.dumps({"json-server": {"command": "node"}}),
+        )
+
+        host_home = tmp_path / "host-hermes"
+        _write(
+            host_home / "config.yaml",
+            "mcp_servers:\n  host-server:\n    command: python\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOST_HOME", str(host_home))
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+
+        # Should find the container's JSON server, NOT the host's
+        mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp_artifacts) == 1
+        assert mcp_artifacts[0].name == "json-server"

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -1261,3 +1261,208 @@ class TestEdgeCases:
         detection = adapter.detect(_ctx(tmp_path))
         file_artifacts = [a for a in detection.artifacts if a.artifact_type == "skill_file"]
         assert len(file_artifacts) >= 1
+        assert len(file_artifacts) >= 1
+
+
+# ------------------------------------------------------------------
+# Container fallback: HERMES_HOST_HOME + manifest.json
+# ------------------------------------------------------------------
+
+
+class TestContainerHostHomeFallback:
+    """detect() falls back to HERMES_HOST_HOME when the container's
+    Hermes home is a minimal sandbox with no artifacts."""
+
+    def test_detect_uses_host_home_when_container_is_empty(self, tmp_path: Path, monkeypatch):
+        """Container has empty skills + trivial config; host has real skills."""
+        # Container's minimal sandbox config
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+
+        # Host's real Hermes home with skills
+        host_home = tmp_path / "host-hermes"
+        _write(
+            host_home / "skills" / "creative" / "story-writer" / "SKILL.md",
+            "---\nname: story-writer\n---\n# Story Writer\n",
+        )
+        _write(
+            host_home / "config.yaml",
+            "mcp_servers:\n  lean-ctx:\n    command: npx\n    args: ['lean-ctx']\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOST_HOME", str(host_home))
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+
+        # Should find the skill from the host home
+        skill_artifacts = [a for a in detection.artifacts if a.artifact_type == "skill"]
+        assert len(skill_artifacts) == 1
+        assert skill_artifacts[0].name == "story-writer"
+
+        # Should find the MCP server from the host config
+        mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp_artifacts) == 1
+        assert mcp_artifacts[0].name == "lean-ctx"
+
+    def test_detect_skips_host_home_when_container_has_artifacts(self, tmp_path: Path, monkeypatch):
+        """When the container already has artifacts, don't scan host home."""
+        # Container has real skills
+        _write(
+            tmp_path / ".hermes" / "skills" / "local" / "my-skill" / "SKILL.md",
+            "---\nname: my-skill\n---\n# My Skill\n",
+        )
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+
+        # Host home also has skills
+        host_home = tmp_path / "host-hermes"
+        _write(
+            host_home / "skills" / "host" / "host-skill" / "SKILL.md",
+            "---\nname: host-skill\n---\n# Host Skill\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOST_HOME", str(host_home))
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+
+        # Should only find the container's skill, not the host's
+        skill_artifacts = [a for a in detection.artifacts if a.artifact_type == "skill"]
+        assert len(skill_artifacts) == 1
+        assert skill_artifacts[0].name == "my-skill"
+
+    def test_detect_skips_host_home_when_env_unset(self, tmp_path: Path, monkeypatch):
+        """Without HERMES_HOST_HOME, no fallback occurs."""
+        monkeypatch.delenv("HERMES_HOST_HOME", raising=False)
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+        assert len(detection.artifacts) == 0
+
+    def test_detect_skips_host_home_when_path_missing(self, tmp_path: Path, monkeypatch):
+        """HERMES_HOST_HOME pointing to a nonexistent dir is ignored."""
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+        monkeypatch.setenv("HERMES_HOST_HOME", str(tmp_path / "nonexistent"))
+
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+        assert len(detection.artifacts) == 0
+
+    def test_detect_skips_host_home_when_same_as_container(self, tmp_path: Path, monkeypatch):
+        """HERMES_HOST_HOME equal to the container's home is a no-op."""
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+        monkeypatch.setenv("HERMES_HOST_HOME", str(tmp_path / ".hermes"))
+
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+        assert len(detection.artifacts) == 0
+
+
+class TestManifestFallback:
+    """detect() falls back to Guard-managed manifest.json when no MCP
+    servers are found in config files."""
+
+    def test_detect_uses_manifest_when_no_mcp_in_config(self, tmp_path: Path):
+        """Container config has no mcp_servers; manifest has servers."""
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+
+        # Guard-managed manifest with servers
+        managed_root = tmp_path / "guard-home" / "hermes"
+        _write(
+            managed_root / "manifest.json",
+            json.dumps({
+                "servers": {
+                    "lean-ctx": {
+                        "command": "npx",
+                        "args": ["lean-ctx"],
+                    },
+                    "web-search": {
+                        "command": "npx",
+                        "args": ["web-search"],
+                    },
+                },
+            }),
+        )
+
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+
+        mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp_artifacts) == 2
+        names = {a.name for a in mcp_artifacts}
+        assert names == {"lean-ctx", "web-search"}
+
+    def test_detect_skips_manifest_when_config_has_mcp(self, tmp_path: Path):
+        """When config.yaml already has MCP servers, manifest is not used."""
+        _write(
+            tmp_path / ".hermes" / "config.yaml",
+            "mcp_servers:\n  config-server:\n    command: node\n",
+        )
+
+        # Manifest with different servers
+        managed_root = tmp_path / "guard-home" / "hermes"
+        _write(
+            managed_root / "manifest.json",
+            json.dumps({
+                "servers": {
+                    "manifest-server": {
+                        "command": "python",
+                        "args": ["-m", "server"],
+                    },
+                },
+            }),
+        )
+
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+
+        mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp_artifacts) == 1
+        assert mcp_artifacts[0].name == "config-server"
+
+    def test_detect_skips_manifest_when_empty(self, tmp_path: Path):
+        """Empty manifest servers dict is ignored."""
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+
+        managed_root = tmp_path / "guard-home" / "hermes"
+        _write(managed_root / "manifest.json", json.dumps({"servers": {}}))
+
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+        mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp_artifacts) == 0
+
+    def test_detect_skips_manifest_when_missing(self, tmp_path: Path):
+        """No manifest.json file means no fallback."""
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+
+        adapter = HermesHarnessAdapter()
+        detection = adapter.detect(_ctx(tmp_path))
+        mcp_artifacts = [a for a in detection.artifacts if a.artifact_type == "mcp_server"]
+        assert len(mcp_artifacts) == 0
+
+
+class TestInstallHostHomeAwareness:
+    """install() loads MCP sources from HERMES_HOST_HOME when set."""
+
+    def test_install_merges_host_home_mcp_sources(self, tmp_path: Path, monkeypatch):
+        """install() should merge MCP sources from both container and host."""
+        # Container config has one MCP server
+        _write(
+            tmp_path / ".hermes" / "config.yaml",
+            "mcp_servers:\n  container-server:\n    command: node\n",
+        )
+
+        # Host config has a different MCP server
+        host_home = tmp_path / "host-hermes"
+        _write(
+            host_home / "config.yaml",
+            "mcp_servers:\n  host-server:\n    command: python\n",
+        )
+
+        monkeypatch.setenv("HERMES_HOST_HOME", str(host_home))
+        adapter = HermesHarnessAdapter()
+        manifest = adapter.install(_ctx(tmp_path))
+
+        servers = manifest.get("servers", {})
+        server_keys = set(servers.keys())
+        assert "yaml:container-server" in server_keys
+        assert "yaml:host-server" in server_keys

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -1261,7 +1261,6 @@ class TestEdgeCases:
         detection = adapter.detect(_ctx(tmp_path))
         file_artifacts = [a for a in detection.artifacts if a.artifact_type == "skill_file"]
         assert len(file_artifacts) >= 1
-        assert len(file_artifacts) >= 1
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Hermes agents running inside Docker containers produce empty AIBOM inventory snapshots because the container's `~/.hermes/` is a minimal sandbox (empty `mcp_servers: {}`, empty skills directory). The host's real Hermes installation is not mounted, so `detect()` finds 0 artifacts.

## Changes

- **`HERMES_HOST_HOME` env var fallback**: When the container's Hermes home has no discoverable artifacts (trivial config, empty skills), `detect()` falls back to scanning the host's real Hermes installation via `HERMES_HOST_HOME`.
- **Manifest fallback**: When no MCP servers are found in config.yaml or mcp_servers.json, `detect()` falls back to the Guard-managed `manifest.json` in `~/.hol-guard/hermes/`.
- **`install()` host-home awareness**: When `HERMES_HOST_HOME` is set, `install()` also loads MCP server sources from the host's config, ensuring the manifest captures servers the container can't see.

## Tests

10 new tests covering all fallback paths and edge cases:
- `TestContainerHostHomeFallback` (5 tests): host home used when container is empty, skipped when container has artifacts, skipped when env unset/missing/same
- `TestManifestFallback` (4 tests): manifest used when no MCP in config, skipped when config has MCP, skipped when empty/missing
- `TestInstallHostHomeAwareness` (1 test): install merges MCP sources from both container and host

All 84 hermes adapter tests pass.