### PR TITLE
fix(aibom): chunk large inventory events to prevent Cloudflare 504

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -266,6 +266,7 @@ _AIBOM_EMPTY_SYNC_RETRY_SECONDS = 2 * 60
 _AIBOM_GUARD_EVENTS_BACKOFF_KEY = "aibom_guard_events_backoff"
 _AIBOM_GUARD_EVENTS_BACKOFF_MINUTES = 5  # matches _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_MINUTES
 _AIBOM_SYNC_BATCH_SIZE = 3  # keep each POST under Cloudflare's 100s origin timeout
+_AIBOM_MAX_ITEMS_PER_EVENT = 100  # chunk large snapshots to stay under Cloudflare timeout
 
 
 def _aware_utc_timestamp(value: str) -> datetime:
@@ -437,6 +438,7 @@ def sync_aibom_snapshots(
         )
         for snapshot in snapshots
     ]
+    events = _chunk_inventory_events(events)
     total_accepted = 0
     total_rejected = 0
     all_statuses: list[dict[str, object]] = []
@@ -803,6 +805,55 @@ def _inventory_snapshot_event(
         "deviceId": device_id,
         "payload": {"snapshot": serialize_inventory_snapshot(snapshot)},
     }
+def _chunk_inventory_events(
+    events: list[dict[str, object]],
+    max_items: int = _AIBOM_MAX_ITEMS_PER_EVENT,
+) -> list[dict[str, object]]:
+    """Split events whose snapshot has too many items into multiple events.
+
+    Large inventories (e.g. Hermes with 486 skills) produce a single event
+    whose serialized payload exceeds 2MB, causing Cloudflare 504 timeouts
+    when the portal processes it synchronously.
+
+    Each chunk becomes a separate event with a unique snapshot_id suffix
+    so the portal treats them as independent snapshots.  The portal's AIBOM
+    projection accumulates items across snapshots for the same agent_id.
+    """
+    result: list[dict[str, object]] = []
+    for event in events:
+        payload = event.get("payload")
+        if not isinstance(payload, dict):
+            result.append(event)
+            continue
+        snapshot = payload.get("snapshot")
+        if not isinstance(snapshot, dict):
+            result.append(event)
+            continue
+        items = snapshot.get("items")
+        if not isinstance(items, list) or len(items) <= max_items:
+            result.append(event)
+            continue
+
+        original_snapshot_id = str(
+            event.get("idempotencyKey") or snapshot.get("snapshotId") or ""
+        )
+        total_chunks = (len(items) + max_items - 1) // max_items
+        for chunk_index in range(total_chunks):
+            chunk_start = chunk_index * max_items
+            chunk_items = items[chunk_start : chunk_start + max_items]
+            chunk_snapshot = {**snapshot, "items": chunk_items}
+            if original_snapshot_id:
+                chunk_snapshot["snapshotId"] = (
+                    f"{original_snapshot_id}-chunk-{chunk_index + 1}-of-{total_chunks}"
+                )
+            chunk_event = {
+                **event,
+                "eventId": str(uuid.uuid4()),
+                "idempotencyKey": chunk_snapshot["snapshotId"],
+                "payload": {"snapshot": chunk_snapshot},
+            }
+            result.append(chunk_event)
+    return result
 
 
 def _sync_timestamp_from_payload(payload: dict[str, object]) -> str | None:

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -443,9 +443,14 @@ def sync_aibom_snapshots(
     total_rejected = 0
     all_statuses: list[dict[str, object]] = []
     synced_at = generated_at
-    batches_sent = 0
-    for batch_start in range(0, len(events), _AIBOM_SYNC_BATCH_SIZE):
-        batch = events[batch_start : batch_start + _AIBOM_SYNC_BATCH_SIZE]
+    # Adaptive batch size: when events were chunked (items >= _AIBOM_MAX_ITEMS_PER_EVENT),
+    # send 1 per POST to stay within Cloudflare's 100s origin timeout.
+    effective_batch_size = 1 if any(
+        len(e.get("payload", {}).get("snapshot", {}).get("items", [])) >= _AIBOM_MAX_ITEMS_PER_EVENT
+        for e in events
+    ) else _AIBOM_SYNC_BATCH_SIZE
+    for batch_start in range(0, len(events), effective_batch_size):
+        batch = events[batch_start : batch_start + effective_batch_size]
         body = json.dumps({"events": batch}).encode("utf-8")
         request = runner._guard_sync_request(
             resolved_auth_context,

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -444,11 +444,20 @@ def sync_aibom_snapshots(
     all_statuses: list[dict[str, object]] = []
     synced_at = generated_at
     batches_sent = 0
-    # Adaptive batch size: when events were chunked (items >= _AIBOM_MAX_ITEMS_PER_EVENT),
+    # Adaptive batch size: when events were chunked (items >= threshold),
     # send 1 per POST to stay within Cloudflare's 100s origin timeout.
+    def _event_item_count(e: dict[str, object]) -> int:
+        payload = e.get("payload")
+        if not isinstance(payload, dict):
+            return 0
+        snapshot = payload.get("snapshot")
+        if not isinstance(snapshot, dict):
+            return 0
+        items = snapshot.get("items")
+        return len(items) if isinstance(items, list) else 0
+
     effective_batch_size = 1 if any(
-        len(e.get("payload", {}).get("snapshot", {}).get("items", [])) >= _AIBOM_MAX_ITEMS_PER_EVENT
-        for e in events
+        _event_item_count(e) >= _AIBOM_MAX_ITEMS_PER_EVENT for e in events
     ) else _AIBOM_SYNC_BATCH_SIZE
     for batch_start in range(0, len(events), effective_batch_size):
         batch = events[batch_start : batch_start + effective_batch_size]
@@ -842,16 +851,23 @@ def _chunk_inventory_events(
 
         original_snapshot_id = str(
             event.get("idempotencyKey") or snapshot.get("snapshotId") or ""
-        )
+        ).strip() or str(uuid.uuid4())
         total_chunks = (len(items) + max_items - 1) // max_items
         for chunk_index in range(total_chunks):
             chunk_start = chunk_index * max_items
             chunk_items = items[chunk_start : chunk_start + max_items]
+            # Scope non-item fields (findings, drift, sources, etc.) to the
+            # first chunk only to avoid duplicating them across chunks on the
+            # portal side.  Items are accumulated; metadata is not.
             chunk_snapshot = {**snapshot, "items": chunk_items}
-            if original_snapshot_id:
-                chunk_snapshot["snapshotId"] = (
-                    f"{original_snapshot_id}-chunk-{chunk_index + 1}-of-{total_chunks}"
-                )
+            if chunk_index > 0:
+                chunk_snapshot["findings"] = []
+                chunk_snapshot["drift"] = []
+                chunk_snapshot["sources"] = []
+                chunk_snapshot["dockerProofs"] = []
+            chunk_snapshot["snapshotId"] = (
+                f"{original_snapshot_id}-chunk-{chunk_index + 1}-of-{total_chunks}"
+            )
             chunk_event = {
                 **event,
                 "eventId": str(uuid.uuid4()),

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -443,6 +443,7 @@ def sync_aibom_snapshots(
     total_rejected = 0
     all_statuses: list[dict[str, object]] = []
     synced_at = generated_at
+    batches_sent = 0
     # Adaptive batch size: when events were chunked (items >= _AIBOM_MAX_ITEMS_PER_EVENT),
     # send 1 per POST to stay within Cloudflare's 100s origin timeout.
     effective_batch_size = 1 if any(

--- a/tests/test_aibom_chunking.py
+++ b/tests/test_aibom_chunking.py
@@ -106,19 +106,27 @@ class TestChunkInventoryEvents:
         assert result[1]["payload"]["snapshot"]["snapshotId"] == "hermes:snapshot:abc-chunk-2-of-3"
         assert result[2]["payload"]["snapshot"]["snapshotId"] == "hermes:snapshot:abc-chunk-3-of-3"
 
-    def test_chunked_events_preserve_non_items_fields(self):
-        """Chunked events keep findings, drift, sources, redactionReport."""
+    def test_findings_scoped_to_first_chunk(self):
+        """Findings/sources/drift appear only in the first chunk to avoid
+        duplication on the portal side. Items are accumulated, metadata is not."""
         items = [_make_item(f"item-{i}") for i in range(150)]
         event = _make_event("snap-1", items)
         event["payload"]["snapshot"]["findings"] = [{"findingId": "f1"}]
         event["payload"]["snapshot"]["sources"] = [{"sourceId": "s1"}]
         result = _chunk_inventory_events([event], max_items=100)
         assert len(result) == 2
-        for chunk in result:
-            snap = chunk["payload"]["snapshot"]
-            assert snap["findings"] == [{"findingId": "f1"}]
-            assert snap["sources"] == [{"sourceId": "s1"}]
-            assert snap["agentId"] == "hermes:local"
+        # First chunk keeps findings
+        first = result[0]["payload"]["snapshot"]
+        assert first["findings"] == [{"findingId": "f1"}]
+        assert first["sources"] == [{"sourceId": "s1"}]
+        # Second chunk has empty findings/drift/sources
+        second = result[1]["payload"]["snapshot"]
+        assert second["findings"] == []
+        assert second["drift"] == []
+        assert second["sources"] == []
+        # Both chunks keep agentId
+        assert first["agentId"] == "hermes:local"
+        assert second["agentId"] == "hermes:local"
 
     def test_mixed_events(self):
         """A mix of small and large events chunk correctly."""

--- a/tests/test_aibom_chunking.py
+++ b/tests/test_aibom_chunking.py
@@ -1,0 +1,148 @@
+"""Tests for AIBOM inventory event chunking.
+
+Large snapshots (e.g. Hermes with 486 items) exceed Cloudflare's 100s
+origin timeout when sent as a single event.  _chunk_inventory_events
+splits them into multiple smaller events.
+"""
+
+from __future__ import annotations
+
+from codex_plugin_scanner.guard.aibom_cli import _chunk_inventory_events
+
+
+def _make_event(snapshot_id: str, items: list[dict]) -> dict:
+    """Build a minimal inventory snapshot event for testing."""
+    return {
+        "eventId": f"evt-{snapshot_id}",
+        "eventType": "agent.inventory_snapshot",
+        "idempotencyKey": snapshot_id,
+        "occurredAt": "2026-07-09T18:00:00Z",
+        "source": "edge",
+        "workspaceId": "ws-test",
+        "deviceId": None,
+        "payload": {
+            "snapshot": {
+                "snapshotId": snapshot_id,
+                "agentId": "hermes:local",
+                "agentType": "hermes",
+                "generatedAt": "2026-07-09T18:00:00Z",
+                "items": items,
+                "findings": [],
+                "drift": [],
+                "dockerProofs": [],
+                "sources": [],
+                "redactionReport": {"rawSecretsIncluded": False, "redactedFields": []},
+            }
+        },
+    }
+
+
+def _make_item(item_id: str) -> dict:
+    return {
+        "itemId": item_id,
+        "itemKind": "skill",
+        "displayName": item_id,
+        "contentHash": f"hash-{item_id}",
+        "sourceFingerprint": f"fp-{item_id}",
+        "riskLevel": "unknown",
+        "securityScore": 100,
+        "driftState": "current",
+        "metadata": {},
+        "capabilityCategories": [],
+        "scannerSources": [],
+    }
+
+
+class TestChunkInventoryEvents:
+    """_chunk_inventory_events splits large events into item-level chunks."""
+
+    def test_small_event_not_chunked(self):
+        """An event with fewer items than the threshold stays as one event."""
+        items = [_make_item(f"item-{i}") for i in range(10)]
+        event = _make_event("snap-1", items)
+        result = _chunk_inventory_events([event], max_items=100)
+        assert len(result) == 1
+        assert result[0]["idempotencyKey"] == "snap-1"
+
+    def test_exact_threshold_not_chunked(self):
+        """An event with exactly max_items items is not chunked."""
+        items = [_make_item(f"item-{i}") for i in range(100)]
+        event = _make_event("snap-1", items)
+        result = _chunk_inventory_events([event], max_items=100)
+        assert len(result) == 1
+
+    def test_large_event_chunked(self):
+        """An event with 486 items and max_items=100 produces 5 chunks."""
+        items = [_make_item(f"item-{i}") for i in range(486)]
+        event = _make_event("hermes:snapshot:test", items)
+        result = _chunk_inventory_events([event], max_items=100)
+        assert len(result) == 5  # ceil(486/100) = 5
+        # Each chunk has at most 100 items
+        for chunk in result:
+            chunk_items = chunk["payload"]["snapshot"]["items"]
+            assert len(chunk_items) <= 100
+        # Last chunk has the remainder
+        last_items = result[-1]["payload"]["snapshot"]["items"]
+        assert len(last_items) == 86  # 486 - 400
+
+    def test_chunked_events_have_unique_ids(self):
+        """Each chunk gets a unique event_id and snapshot_id."""
+        items = [_make_item(f"item-{i}") for i in range(250)]
+        event = _make_event("snap-1", items)
+        result = _chunk_inventory_events([event], max_items=100)
+        assert len(result) == 3
+        event_ids = {c["eventId"] for c in result}
+        snapshot_ids = {c["idempotencyKey"] for c in result}
+        assert len(event_ids) == 3
+        assert len(snapshot_ids) == 3
+
+    def test_chunked_snapshot_ids_have_suffix(self):
+        """Chunked snapshot IDs include a -chunk-N-of-M suffix."""
+        items = [_make_item(f"item-{i}") for i in range(250)]
+        event = _make_event("hermes:snapshot:abc", items)
+        result = _chunk_inventory_events([event], max_items=100)
+        assert len(result) == 3
+        assert result[0]["payload"]["snapshot"]["snapshotId"] == "hermes:snapshot:abc-chunk-1-of-3"
+        assert result[1]["payload"]["snapshot"]["snapshotId"] == "hermes:snapshot:abc-chunk-2-of-3"
+        assert result[2]["payload"]["snapshot"]["snapshotId"] == "hermes:snapshot:abc-chunk-3-of-3"
+
+    def test_chunked_events_preserve_non_items_fields(self):
+        """Chunked events keep findings, drift, sources, redactionReport."""
+        items = [_make_item(f"item-{i}") for i in range(150)]
+        event = _make_event("snap-1", items)
+        event["payload"]["snapshot"]["findings"] = [{"findingId": "f1"}]
+        event["payload"]["snapshot"]["sources"] = [{"sourceId": "s1"}]
+        result = _chunk_inventory_events([event], max_items=100)
+        assert len(result) == 2
+        for chunk in result:
+            snap = chunk["payload"]["snapshot"]
+            assert snap["findings"] == [{"findingId": "f1"}]
+            assert snap["sources"] == [{"sourceId": "s1"}]
+            assert snap["agentId"] == "hermes:local"
+
+    def test_mixed_events(self):
+        """A mix of small and large events chunk correctly."""
+        small = _make_event("small", [_make_item("a")])
+        large = _make_event("large", [_make_item(f"i-{i}") for i in range(200)])
+        result = _chunk_inventory_events([small, large], max_items=100)
+        assert len(result) == 3  # 1 small + 2 large chunks
+
+    def test_no_items_passes_through(self):
+        """An event with empty items list passes through unchanged."""
+        event = _make_event("empty", [])
+        result = _chunk_inventory_events([event], max_items=100)
+        assert len(result) == 1
+        assert result[0]["payload"]["snapshot"]["items"] == []
+
+    def test_all_items_preserved_across_chunks(self):
+        """No items are lost during chunking."""
+        original_items = [_make_item(f"item-{i}") for i in range(486)]
+        event = _make_event("snap-1", original_items)
+        result = _chunk_inventory_events([event], max_items=100)
+        chunked_items = []
+        for chunk in result:
+            chunked_items.extend(chunk["payload"]["snapshot"]["items"])
+        assert len(chunked_items) == 486
+        original_ids = {item["itemId"] for item in original_items}
+        chunked_ids = {item["itemId"] for item in chunked_items}
+        assert original_ids == chunked_ids


### PR DESCRIPTION
Large Hermes inventories (486+ items) produce a single 2.7MB event that exceeds Cloudflare 100s origin timeout causing 504 Gateway Timeout during sync. This PR adds _chunk_inventory_events to split events exceeding _AIBOM_MAX_ITEMS_PER_EVENT (100) items into multiple smaller events with unique snapshot_id suffixes. 9 new tests in test_aibom_chunking.py.