### PR TITLE
Fix package approval fingerprint for local package manager config

### DIFF
--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -67,6 +67,15 @@ _MANIFEST_CANDIDATES = (
     "composer.json",
     "Gemfile",
 )
+_PACKAGE_MANAGER_CONFIG_CANDIDATES = (
+    ".npmrc",
+    ".yarnrc",
+    ".yarnrc.yml",
+    ".pnpmfile.cjs",
+    ".pnpmfile.js",
+    ".npm-init.js",
+)
+
 _LOCKFILE_CANDIDATES = (
     "package-lock.json",
     "pnpm-lock.yaml",
@@ -1695,31 +1704,27 @@ def _package_request_artifact_hash(
 ) -> str:
     policy_gate = _package_policy_gate_context(store, artifact, evaluation)
     metadata = artifact.metadata if isinstance(artifact.metadata, dict) else {}
-    targets = metadata.get("targets")
     manifest_paths = _string_items(metadata.get("manifest_paths"))
     lockfile_paths = _string_items(metadata.get("lockfile_paths"))
-    has_targets = isinstance(targets, list) and any(isinstance(item, dict) for item in targets)
-    if has_targets or (not manifest_paths and not lockfile_paths):
-        return stable_digest_hex(
-            json.dumps(
-                {
-                    "artifact_id": artifact.artifact_id,
-                    "policy_gate": policy_gate,
-                },
-                sort_keys=True,
-                separators=(",", ":"),
-            ).encode("utf-8")
+    config_paths = existing_relative_paths(workspace_dir, _PACKAGE_MANAGER_CONFIG_CANDIDATES)
+    fingerprint_material: dict[str, object] = {
+        "artifact_id": artifact.artifact_id,
+        "config_hashes": _hash_existing_paths(workspace_dir, config_paths),
+        "config_paths": list(config_paths),
+        "policy_gate": policy_gate,
+    }
+    if manifest_paths or lockfile_paths:
+        fingerprint_material.update(
+            {
+                "manifest_hashes": _hash_existing_paths(workspace_dir, manifest_paths),
+                "manifest_paths": list(manifest_paths),
+                "lockfile_hashes": _hash_existing_paths(workspace_dir, lockfile_paths),
+                "lockfile_paths": list(lockfile_paths),
+            }
         )
     return stable_digest_hex(
         json.dumps(
-            {
-                "artifact_id": artifact.artifact_id,
-                "manifest_paths": list(manifest_paths),
-                "lockfile_paths": list(lockfile_paths),
-                "manifest_hashes": _hash_existing_paths(workspace_dir, manifest_paths),
-                "lockfile_hashes": _hash_existing_paths(workspace_dir, lockfile_paths),
-                "policy_gate": policy_gate,
-            },
+            fingerprint_material,
             sort_keys=True,
             separators=(",", ":"),
         ).encode("utf-8")

--- a/tests/test_guard_manifest_install_firewall.py
+++ b/tests/test_guard_manifest_install_firewall.py
@@ -232,6 +232,82 @@ def test_workspace_package_approval_reuses_same_lockfile_across_worktrees(tmp_pa
     )
 
 
+def test_workspace_package_approval_reprompts_when_explicit_target_registry_config_changes(tmp_path: Path) -> None:
+    store = GuardStore(tmp_path / "guard-home")
+    workspace_dir = tmp_path / "workspace"
+    worktree_dir = tmp_path / "workspace-worktree"
+    workspace_dir.mkdir()
+    worktree_dir.mkdir()
+    (workspace_dir / ".npmrc").write_text("registry=https://registry.npmjs.org/\n", encoding="utf-8")
+    (worktree_dir / ".npmrc").write_text("registry=https://packages.example.invalid/\n", encoding="utf-8")
+    command = ["pnpm", "add", "eslint"]
+
+    baseline_payload, baseline_rc = build_package_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=workspace_dir,
+        dry_run=True,
+        now="2026-06-14T00:00:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+    assert baseline_rc == 2
+    receipt = baseline_payload["receipt"]
+    assert isinstance(receipt, dict)
+    store.add_approval_request(
+        GuardApprovalRequest(
+            request_id="req-pnpm-target",
+            harness="guard-cli",
+            artifact_id=str(receipt["artifact_id"]),
+            artifact_name="pnpm add eslint",
+            artifact_type="package_request",
+            artifact_hash=str(receipt["artifact_hash"]),
+            policy_action="require-reapproval",
+            recommended_scope="workspace",
+            changed_fields=("package_request",),
+            source_scope="project",
+            config_path=str(workspace_dir / "hol-guard.toml"),
+            workspace=str(workspace_dir),
+            launch_target="pnpm add eslint",
+            review_command="hol-guard approvals approve req-pnpm-target",
+            approval_url="http://127.0.0.1:4455/approvals/req-pnpm-target",
+        ),
+        "2026-06-14T00:00:30Z",
+    )
+    apply_approval_resolution(
+        store=store,
+        request_id="req-pnpm-target",
+        action="allow",
+        scope="workspace",
+        workspace=str(workspace_dir),
+        reason="trusted registry",
+        now="2026-06-14T00:01:00Z",
+    )
+
+    retry_payload, retry_rc = build_package_protect_payload(
+        command=command,
+        store=store,
+        workspace_dir=worktree_dir,
+        dry_run=True,
+        now="2026-06-14T00:02:00Z",
+        config=None,
+        unsafe_raw_output=False,
+        timeout_seconds=30,
+    )
+
+    assert retry_rc == 2
+    assert retry_payload["verdict"]["action"] == "review"
+    retry_receipt = retry_payload["receipt"]
+    assert isinstance(retry_receipt, dict)
+    assert retry_receipt["artifact_hash"] != receipt["artifact_hash"]
+    evaluation = retry_payload["supply_chain_evaluation"]
+    assert isinstance(evaluation, dict)
+    assert not any(
+        isinstance(reason, dict) and reason.get("code") == "saved_package_approval"
+        for reason in evaluation.get("reasons", [])
+    )
+
 def test_package_policy_workspace_candidates_prefer_portable_scope(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     workspace_dir.mkdir()


### PR DESCRIPTION
### Motivation
- Portable workspace approvals were being derived only from `artifact_id` and a limited artifact hash, allowing approvals to be reused across worktrees that differ in package-manager configuration or hooks.
- The change aims to ensure package-request approvals are bound to worktree-local package-manager configuration to avoid unintended policy bypasses.

### Description
- Added `_PACKAGE_MANAGER_CONFIG_CANDIDATES` and included package-manager config file discovery (`.npmrc`, Yarn configs, pnpm hook files, etc.) in `local_supply_chain.py`. 
- Extended `_package_request_artifact_hash` to include discovered config `paths` and `config_hashes` in the fingerprint while preserving manifest and lockfile hashing when present. 
- Added a regression test `test_workspace_package_approval_reprompts_when_explicit_target_registry_config_changes` to `tests/test_guard_manifest_install_firewall.py` that verifies an approved workspace install is not reused when another worktree has a different `.npmrc` registry.

### Testing
- Ran static checks with `python -m ruff check src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_manifest_install_firewall.py`, which passed. 
- Verified syntax with `python -m py_compile src/codex_plugin_scanner/guard/local_supply_chain.py tests/test_guard_manifest_install_firewall.py`, which succeeded. 
- Ran repository checks with `git diff --check` which reported no issues. 
- Attempted `pytest tests/test_guard_manifest_install_firewall.py -q` but test collection was blocked by a missing system dependency (`cryptography`) in the container, so full test execution could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a46bc8b78c8832d9c6dd9df660d02b6)