### PR TITLE
fix(hermes): discover persisted host home mirror

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -74,7 +74,7 @@ def _hermes_home(context: HarnessContext) -> Path:
     return context.home_dir / ".hermes"
 
 
-def _hermes_host_home() -> Path | None:
+def _hermes_host_home(context: HarnessContext) -> Path | None:
     """Resolve the host's real Hermes home when running inside a container.
 
     Hermes agents often run inside Docker containers with a minimal sandbox
@@ -82,19 +82,20 @@ def _hermes_host_home() -> Path | None:
     real Hermes installation — with the full config.yaml and 200+ skills — is
     not mounted into the container.
 
-    When the operator sets ``HERMES_HOST_HOME`` (e.g. via ``-e HERMES_HOST_HOME=/home/hol/.hermes``
-    or a Guard-managed env file), ``detect()`` can fall back to scanning the
-    host's real installation even from inside the container.
+    When the operator sets ``HERMES_HOST_HOME``, ``detect()`` can fall back to
+    scanning the mounted host installation even from inside the container.
+    A persisted ``~/hermes-host-home`` mirror is also recognized because
+    Hermes sandbox launchers may not preserve custom environment variables.
 
-    Returns ``None`` when the env var is unset or the path does not exist.
+    Returns ``None`` when neither location exists.
     """
     env_host = os.environ.get("HERMES_HOST_HOME")
-    if not env_host or not env_host.strip():
-        return None
-    host_path = Path(env_host.strip())
-    if not host_path.is_dir():
-        return None
-    return host_path
+    if env_host and env_host.strip():
+        host_path = Path(env_host.strip())
+        return host_path if host_path.is_dir() else None
+
+    fallback_path = context.home_dir / "hermes-host-home"
+    return fallback_path if fallback_path.is_dir() else None
 
 
 def _hermes_home_has_artifacts(hermes_home: Path) -> bool:
@@ -175,10 +176,8 @@ class HermesHarnessAdapter(HarnessAdapter):
             pretool_path=pretool_path,
         )
         source_configs = _load_mcp_server_sources(_hermes_home(context))
-        # When running inside a container with HERMES_HOST_HOME set, also
-        # load MCP server sources from the host's real Hermes config.  This
-        # ensures the manifest captures servers the container can't see.
-        host_home = _hermes_host_home()
+        # Also load MCP sources from an explicit or persisted host-home mirror.
+        host_home = _hermes_host_home(context)
         if host_home and host_home.resolve() != _hermes_home(context).resolve():
             for key, config in _load_mcp_server_sources(host_home).items():
                 source_configs.setdefault(key, config)
@@ -381,12 +380,9 @@ class HermesHarnessAdapter(HarnessAdapter):
         # Discover MCP servers from both config.yaml and mcp_servers.json.
         artifacts.extend(self._scan_mcp_servers(hermes_home, found_paths))
 
-        # Container fallback: when the container's Hermes home is a minimal
-        # sandbox (empty skills, trivial config), fall back to the host's
-        # real Hermes installation via HERMES_HOST_HOME.  This is the common
-        # case for Hermes agents running inside Docker containers where the
-        # host's ~/.hermes is not mounted.
-        host_home = _hermes_host_home()
+        # Container fallback: use an explicit or persisted host-home mirror
+        # when the sandbox has only empty skills and trivial config.
+        host_home = _hermes_host_home(context)
         if host_home and host_home.resolve() != hermes_home.resolve() and not _hermes_home_has_artifacts(hermes_home):
             artifacts.extend(self._scan_host_home(host_home, found_paths))
 

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -175,10 +175,15 @@ class HermesHarnessAdapter(HarnessAdapter):
             overlay_path=overlay_path,
             pretool_path=pretool_path,
         )
-        source_configs = _load_mcp_server_sources(_hermes_home(context))
-        # Also load MCP sources from an explicit or persisted host-home mirror.
+        hermes_home = _hermes_home(context)
+        source_configs = _load_mcp_server_sources(hermes_home)
+        # Only consult the mirror for a minimal sandbox, matching detect().
         host_home = _hermes_host_home(context)
-        if host_home and host_home.resolve() != _hermes_home(context).resolve():
+        if (
+            host_home
+            and host_home.resolve() != hermes_home.resolve()
+            and not _hermes_home_has_artifacts(hermes_home)
+        ):
             for key, config in _load_mcp_server_sources(host_home).items():
                 source_configs.setdefault(key, config)
         overlay_servers = _overlay_servers(context=context, source_configs=source_configs)

--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -179,11 +179,7 @@ class HermesHarnessAdapter(HarnessAdapter):
         source_configs = _load_mcp_server_sources(hermes_home)
         # Only consult the mirror for a minimal sandbox, matching detect().
         host_home = _hermes_host_home(context)
-        if (
-            host_home
-            and host_home.resolve() != hermes_home.resolve()
-            and not _hermes_home_has_artifacts(hermes_home)
-        ):
+        if host_home and host_home.resolve() != hermes_home.resolve() and not _hermes_home_has_artifacts(hermes_home):
             for key, config in _load_mcp_server_sources(host_home).items():
                 source_configs.setdefault(key, config)
         overlay_servers = _overlay_servers(context=context, source_configs=source_configs)

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -1492,10 +1492,12 @@ class TestManifestFallback:
 
 
 class TestInstallHostHomeAwareness:
-    """install() loads MCP sources from HERMES_HOST_HOME when set."""
+    """install() uses host-home sources only for a minimal sandbox."""
 
-    def test_install_merges_host_home_mcp_sources(self, tmp_path: Path, monkeypatch):
-        """install() should merge MCP sources from both container and host."""
+    def test_install_skips_host_home_mcp_sources_when_container_populated(
+        self, tmp_path: Path, monkeypatch
+    ):
+        """A stale mirror must not extend a populated container config."""
         # Container config has one MCP server
         _write(
             tmp_path / ".hermes" / "config.yaml",
@@ -1516,7 +1518,22 @@ class TestInstallHostHomeAwareness:
         servers = manifest.get("servers", {})
         server_keys = set(servers.keys())
         assert "yaml:container-server" in server_keys
-        assert "yaml:host-server" in server_keys
+        assert "yaml:host-server" not in server_keys
+
+    def test_install_uses_host_home_mcp_sources_when_container_empty(
+        self, tmp_path: Path, monkeypatch
+    ):
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+        host_home = tmp_path / "host-hermes"
+        _write(
+            host_home / "config.yaml",
+            "mcp_servers:\n  host-server:\n    command: python\n",
+        )
+        monkeypatch.setenv("HERMES_HOST_HOME", str(host_home))
+
+        manifest = HermesHarnessAdapter().install(_ctx(tmp_path))
+
+        assert "yaml:host-server" in manifest.get("servers", {})
 
 
 class TestHostHomeFallbackEdgeCases:

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -1336,6 +1336,20 @@ class TestContainerHostHomeFallback:
         detection = adapter.detect(_ctx(tmp_path))
         assert len(detection.artifacts) == 0
 
+    def test_detect_uses_persisted_host_home_mirror_when_env_unset(self, tmp_path: Path, monkeypatch):
+        """A conventional sandbox mirror survives launchers that drop env vars."""
+        monkeypatch.delenv("HERMES_HOST_HOME", raising=False)
+        _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
+        _write(
+            tmp_path / "hermes-host-home" / "skills" / "local" / "persisted-skill" / "SKILL.md",
+            "---\nname: persisted-skill\n---\n# Persisted Skill\n",
+        )
+
+        detection = HermesHarnessAdapter().detect(_ctx(tmp_path))
+
+        skills = [a for a in detection.artifacts if a.artifact_type == "skill"]
+        assert [skill.name for skill in skills] == ["persisted-skill"]
+
     def test_detect_skips_host_home_when_path_missing(self, tmp_path: Path, monkeypatch):
         """HERMES_HOST_HOME pointing to a nonexistent dir is ignored."""
         _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")


### PR DESCRIPTION
## Summary

- discover Hermes artifacts from the conventional `~/hermes-host-home` mirror when no explicit host-home override is set
- keep explicit `HERMES_HOST_HOME` precedence and existing sandbox behavior
- cover persisted-mirror discovery with an adapter regression test

## Verification

- `uv run ruff check src/codex_plugin_scanner/guard/adapters/hermes.py tests/test_hermes_adapter.py`
- `uv run pytest -q tests/test_hermes_adapter.py` (88 passed)
