### PR TITLE
fix(aibom): preserve atomic inventory snapshots

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -440,7 +440,7 @@ def sync_aibom_snapshots(
         for snapshot in snapshots
     ]
     event_batches, oversized_events = _batch_inventory_events(events)
-    oversized_statuses = [
+    oversized_statuses: list[dict[str, object]] = [
         {
             "eventId": str(event.get("eventId") or ""),
             "status": "rejected",

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -538,7 +538,7 @@ def sync_aibom_snapshots(
                 "accepted": total_accepted,
                 "rejected": total_rejected,
                 "statuses": all_statuses,
-                "partial": batches_sent > 0,
+                "partial": batches_sent > 0 or bool(oversized_events),
                 "error": "Guard Cloud AIBOM sync failed due to an HTTP error.",
             }
             store.set_sync_payload("aibom_sync_summary", failure_summary, synced_at)
@@ -551,7 +551,7 @@ def sync_aibom_snapshots(
                 "accepted": total_accepted,
                 "rejected": total_rejected,
                 "statuses": all_statuses,
-                "partial": batches_sent > 0,
+                "partial": batches_sent > 0 or bool(oversized_events),
                 "error": "Guard Cloud AIBOM sync failed due to a network error.",
             }
             store.set_sync_payload("aibom_sync_summary", failure_summary, synced_at)

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -266,6 +266,7 @@ _AIBOM_EMPTY_SYNC_RETRY_SECONDS = 2 * 60
 _AIBOM_GUARD_EVENTS_BACKOFF_KEY = "aibom_guard_events_backoff"
 _AIBOM_GUARD_EVENTS_BACKOFF_MINUTES = 5  # matches _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_MINUTES
 _AIBOM_SYNC_BATCH_SIZE = 3  # keep each POST under Cloudflare's 100s origin timeout
+# Guard Cloud queues large projection work; preserve snapshot replacement semantics in transit.
 _AIBOM_MAX_REQUEST_BODY_BYTES = 3_900_000  # stay below the portal's 4 MB request limit
 
 
@@ -438,28 +439,36 @@ def sync_aibom_snapshots(
         )
         for snapshot in snapshots
     ]
-    try:
-        event_batches = _batch_inventory_events(events)
-    except ValueError as error:
+    event_batches, oversized_events = _batch_inventory_events(events)
+    oversized_statuses = [
+        {
+            "eventId": str(event.get("eventId") or ""),
+            "status": "rejected",
+            "reason": "snapshot_too_large",
+        }
+        for event in oversized_events
+    ]
+    if not event_batches:
         failure_summary: dict[str, object] = {
             "synced": False,
             "synced_at": generated_at,
             "snapshots": len(snapshots),
             "accepted": 0,
-            "rejected": 0,
-            "statuses": [],
+            "rejected": len(oversized_events),
+            "statuses": oversized_statuses,
             "partial": False,
             "reason": "snapshot_too_large",
             "error": "Guard Cloud AIBOM sync failed because an inventory snapshot exceeds the request limit.",
         }
         store.set_sync_payload("aibom_sync_summary", failure_summary, generated_at)
-        raise RuntimeError(str(failure_summary["error"])) from error
+        return failure_summary
     total_accepted = 0
-    total_rejected = 0
-    all_statuses: list[dict[str, object]] = []
+    total_rejected = len(oversized_events)
+    all_statuses: list[dict[str, object]] = oversized_statuses
     synced_at = generated_at
     batches_sent = 0
     events_sent = 0
+    syncable_event_count = sum(len(batch) for batch in event_batches)
 
     for batch in event_batches:
         body = _inventory_events_request_body(batch)
@@ -495,7 +504,7 @@ def sync_aibom_snapshots(
                 )
             elif error.code == 404:
                 synced_at = generated_at
-                remaining_events = len(events) - events_sent
+                remaining_events = syncable_event_count - events_sent
                 store.set_sync_payload(
                     _AIBOM_GUARD_EVENTS_BACKOFF_KEY,
                     {
@@ -508,23 +517,18 @@ def sync_aibom_snapshots(
                     },
                     synced_at,
                 )
-                if batches_sent > 0:
-                    summary: dict[str, object] = {
-                        "synced": False,
-                        "synced_at": synced_at,
-                        "snapshots": len(snapshots),
-                        "accepted": total_accepted,
-                        "rejected": total_rejected,
-                        "statuses": all_statuses,
-                        "partial": True,
-                        "reason": "guard_events_endpoint_unavailable",
-                    }
-                else:
-                    summary = {
-                        "synced": False,
-                        "skipped": True,
-                        "reason": "guard_events_endpoint_unavailable",
-                    }
+                summary: dict[str, object] = {
+                    "synced": False,
+                    "synced_at": synced_at,
+                    "snapshots": len(snapshots),
+                    "accepted": total_accepted,
+                    "rejected": total_rejected,
+                    "statuses": all_statuses,
+                    "partial": batches_sent > 0 or bool(oversized_events),
+                    "reason": "guard_events_endpoint_unavailable",
+                }
+                if batches_sent == 0:
+                    summary["skipped"] = True
                 store.set_sync_payload("aibom_sync_summary", summary, synced_at)
                 return summary
             failure_summary: dict[str, object] = {
@@ -574,6 +578,9 @@ def sync_aibom_snapshots(
         "rejected": total_rejected,
         "statuses": all_statuses,
     }
+    if oversized_events:
+        summary["partial"] = True
+        summary["reason"] = "snapshot_too_large"
     store.set_sync_payload("aibom_sync_summary", summary, synced_at)
     return summary
 
@@ -850,16 +857,18 @@ def _batch_inventory_events(
     *,
     max_batch_size: int = _AIBOM_SYNC_BATCH_SIZE,
     max_body_bytes: int = _AIBOM_MAX_REQUEST_BODY_BYTES,
-) -> list[list[dict[str, object]]]:
+) -> tuple[list[list[dict[str, object]]], list[dict[str, object]]]:
     """Batch whole inventory snapshots without changing replacement semantics."""
     if max_batch_size < 1 or max_body_bytes < 1:
         raise ValueError("AIBOM request batch limits must be positive.")
 
     batches: list[list[dict[str, object]]] = []
+    oversized_events: list[dict[str, object]] = []
     batch: list[dict[str, object]] = []
     for event in events:
         if len(_inventory_events_request_body([event])) > max_body_bytes:
-            raise ValueError("AIBOM inventory snapshot exceeds the request body limit.")
+            oversized_events.append(event)
+            continue
 
         candidate = [*batch, event]
         candidate_too_large = len(_inventory_events_request_body(candidate)) > max_body_bytes
@@ -871,7 +880,7 @@ def _batch_inventory_events(
 
     if batch:
         batches.append(batch)
-    return batches
+    return batches, oversized_events
 
 
 def _sync_timestamp_from_payload(payload: dict[str, object]) -> str | None:

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -266,7 +266,7 @@ _AIBOM_EMPTY_SYNC_RETRY_SECONDS = 2 * 60
 _AIBOM_GUARD_EVENTS_BACKOFF_KEY = "aibom_guard_events_backoff"
 _AIBOM_GUARD_EVENTS_BACKOFF_MINUTES = 5  # matches _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_MINUTES
 _AIBOM_SYNC_BATCH_SIZE = 3  # keep each POST under Cloudflare's 100s origin timeout
-_AIBOM_MAX_ITEMS_PER_EVENT = 100  # chunk large snapshots to stay under Cloudflare timeout
+_AIBOM_MAX_REQUEST_BODY_BYTES = 3_900_000  # stay below the portal's 4 MB request limit
 
 
 def _aware_utc_timestamp(value: str) -> datetime:
@@ -438,31 +438,31 @@ def sync_aibom_snapshots(
         )
         for snapshot in snapshots
     ]
-    events = _chunk_inventory_events(events)
+    try:
+        event_batches = _batch_inventory_events(events)
+    except ValueError as error:
+        failure_summary: dict[str, object] = {
+            "synced": False,
+            "synced_at": generated_at,
+            "snapshots": len(snapshots),
+            "accepted": 0,
+            "rejected": 0,
+            "statuses": [],
+            "partial": False,
+            "reason": "snapshot_too_large",
+            "error": "Guard Cloud AIBOM sync failed because an inventory snapshot exceeds the request limit.",
+        }
+        store.set_sync_payload("aibom_sync_summary", failure_summary, generated_at)
+        raise RuntimeError(str(failure_summary["error"])) from error
     total_accepted = 0
     total_rejected = 0
     all_statuses: list[dict[str, object]] = []
     synced_at = generated_at
     batches_sent = 0
+    events_sent = 0
 
-    # Adaptive batch size: when events were chunked (items >= threshold),
-    # send 1 per POST to stay within Cloudflare's 100s origin timeout.
-    def _event_item_count(e: dict[str, object]) -> int:
-        payload = e.get("payload")
-        if not isinstance(payload, dict):
-            return 0
-        snapshot = payload.get("snapshot")
-        if not isinstance(snapshot, dict):
-            return 0
-        items = snapshot.get("items")
-        return len(items) if isinstance(items, list) else 0
-
-    effective_batch_size = (
-        1 if any(_event_item_count(e) >= _AIBOM_MAX_ITEMS_PER_EVENT for e in events) else _AIBOM_SYNC_BATCH_SIZE
-    )
-    for batch_start in range(0, len(events), effective_batch_size):
-        batch = events[batch_start : batch_start + effective_batch_size]
-        body = json.dumps({"events": batch}).encode("utf-8")
+    for batch in event_batches:
+        body = _inventory_events_request_body(batch)
         request = runner._guard_sync_request(
             resolved_auth_context,
             request_url=sync_url,
@@ -495,13 +495,14 @@ def sync_aibom_snapshots(
                 )
             elif error.code == 404:
                 synced_at = generated_at
+                remaining_events = len(events) - events_sent
                 store.set_sync_payload(
                     _AIBOM_GUARD_EVENTS_BACKOFF_KEY,
                     {
                         "synced_at": synced_at,
-                        "events": len(events) - batch_start,
+                        "events": remaining_events,
                         "accepted": total_accepted,
-                        "skipped": len(events) - batch_start,
+                        "skipped": remaining_events,
                         "sync_skipped": True,
                         "sync_reason": "guard_events_endpoint_unavailable",
                     },
@@ -552,6 +553,7 @@ def sync_aibom_snapshots(
             store.set_sync_payload("aibom_sync_summary", failure_summary, synced_at)
             raise RuntimeError("Guard Cloud AIBOM sync failed due to a network error.") from error
         batches_sent += 1  # noqa: SIM113
+        events_sent += len(batch)
         batch_accepted = payload.get("accepted")
         if isinstance(batch_accepted, int):
             total_accepted += batch_accepted
@@ -839,60 +841,37 @@ def _inventory_snapshot_event(
     }
 
 
-def _chunk_inventory_events(
+def _inventory_events_request_body(events: list[dict[str, object]]) -> bytes:
+    return json.dumps({"events": events}).encode("utf-8")
+
+
+def _batch_inventory_events(
     events: list[dict[str, object]],
-    max_items: int = _AIBOM_MAX_ITEMS_PER_EVENT,
-) -> list[dict[str, object]]:
-    """Split events whose snapshot has too many items into multiple events.
+    *,
+    max_batch_size: int = _AIBOM_SYNC_BATCH_SIZE,
+    max_body_bytes: int = _AIBOM_MAX_REQUEST_BODY_BYTES,
+) -> list[list[dict[str, object]]]:
+    """Batch whole inventory snapshots without changing replacement semantics."""
+    if max_batch_size < 1 or max_body_bytes < 1:
+        raise ValueError("AIBOM request batch limits must be positive.")
 
-    Large inventories (e.g. Hermes with 486 skills) produce a single event
-    whose serialized payload exceeds 2MB, causing Cloudflare 504 timeouts
-    when the portal processes it synchronously.
-
-    Each chunk becomes a separate event with a unique snapshot_id suffix
-    so the portal treats them as independent snapshots.  The portal's AIBOM
-    projection accumulates items across snapshots for the same agent_id.
-    """
-    result: list[dict[str, object]] = []
+    batches: list[list[dict[str, object]]] = []
+    batch: list[dict[str, object]] = []
     for event in events:
-        payload = event.get("payload")
-        if not isinstance(payload, dict):
-            result.append(event)
-            continue
-        snapshot = payload.get("snapshot")
-        if not isinstance(snapshot, dict):
-            result.append(event)
-            continue
-        items = snapshot.get("items")
-        if not isinstance(items, list) or len(items) <= max_items:
-            result.append(event)
-            continue
+        if len(_inventory_events_request_body([event])) > max_body_bytes:
+            raise ValueError("AIBOM inventory snapshot exceeds the request body limit.")
 
-        original_snapshot_id = str(event.get("idempotencyKey") or snapshot.get("snapshotId") or "").strip() or str(
-            uuid.uuid4()
-        )
-        total_chunks = (len(items) + max_items - 1) // max_items
-        for chunk_index in range(total_chunks):
-            chunk_start = chunk_index * max_items
-            chunk_items = items[chunk_start : chunk_start + max_items]
-            # Scope non-item fields (findings, drift, sources, etc.) to the
-            # first chunk only to avoid duplicating them across chunks on the
-            # portal side.  Items are accumulated; metadata is not.
-            chunk_snapshot = {**snapshot, "items": chunk_items}
-            if chunk_index > 0:
-                chunk_snapshot["findings"] = []
-                chunk_snapshot["drift"] = []
-                chunk_snapshot["sources"] = []
-                chunk_snapshot["dockerProofs"] = []
-            chunk_snapshot["snapshotId"] = f"{original_snapshot_id}-chunk-{chunk_index + 1}-of-{total_chunks}"
-            chunk_event = {
-                **event,
-                "eventId": str(uuid.uuid4()),
-                "idempotencyKey": chunk_snapshot["snapshotId"],
-                "payload": {"snapshot": chunk_snapshot},
-            }
-            result.append(chunk_event)
-    return result
+        candidate = [*batch, event]
+        candidate_too_large = len(_inventory_events_request_body(candidate)) > max_body_bytes
+        if batch and (len(candidate) > max_batch_size or candidate_too_large):
+            batches.append(batch)
+            batch = [event]
+        else:
+            batch = candidate
+
+    if batch:
+        batches.append(batch)
+    return batches
 
 
 def _sync_timestamp_from_payload(payload: dict[str, object]) -> str | None:

--- a/tests/test_aibom_chunking.py
+++ b/tests/test_aibom_chunking.py
@@ -1,13 +1,14 @@
-"""Tests for AIBOM inventory event chunking.
-
-Large snapshots (e.g. Hermes with 486 items) exceed Cloudflare's 100s
-origin timeout when sent as a single event.  _chunk_inventory_events
-splits them into multiple smaller events.
-"""
+"""Tests for atomic AIBOM inventory request batching."""
 
 from __future__ import annotations
 
-from codex_plugin_scanner.guard.aibom_cli import _chunk_inventory_events
+import pytest
+
+from codex_plugin_scanner.guard.aibom_cli import (
+    _AIBOM_MAX_REQUEST_BODY_BYTES,
+    _batch_inventory_events,
+    _inventory_events_request_body,
+)
 
 
 def _make_event(snapshot_id: str, items: list[dict]) -> dict:
@@ -53,104 +54,84 @@ def _make_item(item_id: str) -> dict:
     }
 
 
-class TestChunkInventoryEvents:
-    """_chunk_inventory_events splits large events into item-level chunks."""
-
-    def test_small_event_not_chunked(self):
-        """An event with fewer items than the threshold stays as one event."""
-        items = [_make_item(f"item-{i}") for i in range(10)]
-        event = _make_event("snap-1", items)
-        result = _chunk_inventory_events([event], max_items=100)
-        assert len(result) == 1
-        assert result[0]["idempotencyKey"] == "snap-1"
-
-    def test_exact_threshold_not_chunked(self):
-        """An event with exactly max_items items is not chunked."""
-        items = [_make_item(f"item-{i}") for i in range(100)]
-        event = _make_event("snap-1", items)
-        result = _chunk_inventory_events([event], max_items=100)
-        assert len(result) == 1
-
-    def test_large_event_chunked(self):
-        """An event with 486 items and max_items=100 produces 5 chunks."""
+class TestBatchInventoryEvents:
+    def test_486_item_snapshot_remains_atomic(self) -> None:
         items = [_make_item(f"item-{i}") for i in range(486)]
         event = _make_event("hermes:snapshot:test", items)
-        result = _chunk_inventory_events([event], max_items=100)
-        assert len(result) == 5  # ceil(486/100) = 5
-        # Each chunk has at most 100 items
-        for chunk in result:
-            chunk_items = chunk["payload"]["snapshot"]["items"]
-            assert len(chunk_items) <= 100
-        # Last chunk has the remainder
-        last_items = result[-1]["payload"]["snapshot"]["items"]
-        assert len(last_items) == 86  # 486 - 400
 
-    def test_chunked_events_have_unique_ids(self):
-        """Each chunk gets a unique event_id and snapshot_id."""
-        items = [_make_item(f"item-{i}") for i in range(250)]
-        event = _make_event("snap-1", items)
-        result = _chunk_inventory_events([event], max_items=100)
-        assert len(result) == 3
-        event_ids = {c["eventId"] for c in result}
-        snapshot_ids = {c["idempotencyKey"] for c in result}
-        assert len(event_ids) == 3
-        assert len(snapshot_ids) == 3
+        batches = _batch_inventory_events([event])
 
-    def test_chunked_snapshot_ids_have_suffix(self):
-        """Chunked snapshot IDs include a -chunk-N-of-M suffix."""
-        items = [_make_item(f"item-{i}") for i in range(250)]
-        event = _make_event("hermes:snapshot:abc", items)
-        result = _chunk_inventory_events([event], max_items=100)
-        assert len(result) == 3
-        assert result[0]["payload"]["snapshot"]["snapshotId"] == "hermes:snapshot:abc-chunk-1-of-3"
-        assert result[1]["payload"]["snapshot"]["snapshotId"] == "hermes:snapshot:abc-chunk-2-of-3"
-        assert result[2]["payload"]["snapshot"]["snapshotId"] == "hermes:snapshot:abc-chunk-3-of-3"
+        assert batches == [[event]]
+        snapshot = batches[0][0]["payload"]["snapshot"]
+        assert snapshot["snapshotId"] == "hermes:snapshot:test"
+        assert len(snapshot["items"]) == 486
 
-    def test_findings_scoped_to_first_chunk(self):
-        """Findings/sources/drift appear only in the first chunk to avoid
-        duplication on the portal side. Items are accumulated, metadata is not."""
-        items = [_make_item(f"item-{i}") for i in range(150)]
-        event = _make_event("snap-1", items)
-        event["payload"]["snapshot"]["findings"] = [{"findingId": "f1"}]
-        event["payload"]["snapshot"]["sources"] = [{"sourceId": "s1"}]
-        result = _chunk_inventory_events([event], max_items=100)
-        assert len(result) == 2
-        # First chunk keeps findings
-        first = result[0]["payload"]["snapshot"]
-        assert first["findings"] == [{"findingId": "f1"}]
-        assert first["sources"] == [{"sourceId": "s1"}]
-        # Second chunk has empty findings/drift/sources
-        second = result[1]["payload"]["snapshot"]
-        assert second["findings"] == []
-        assert second["drift"] == []
-        assert second["sources"] == []
-        # Both chunks keep agentId
-        assert first["agentId"] == "hermes:local"
-        assert second["agentId"] == "hermes:local"
+    def test_small_events_share_count_bounded_batch(self) -> None:
+        events = [_make_event(f"snap-{index}", [_make_item(str(index))]) for index in range(4)]
 
-    def test_mixed_events(self):
-        """A mix of small and large events chunk correctly."""
-        small = _make_event("small", [_make_item("a")])
-        large = _make_event("large", [_make_item(f"i-{i}") for i in range(200)])
-        result = _chunk_inventory_events([small, large], max_items=100)
-        assert len(result) == 3  # 1 small + 2 large chunks
+        batches = _batch_inventory_events(events, max_batch_size=3)
 
-    def test_no_items_passes_through(self):
-        """An event with empty items list passes through unchanged."""
-        event = _make_event("empty", [])
-        result = _chunk_inventory_events([event], max_items=100)
-        assert len(result) == 1
-        assert result[0]["payload"]["snapshot"]["items"] == []
+        assert batches == [events[:3], events[3:]]
 
-    def test_all_items_preserved_across_chunks(self):
-        """No items are lost during chunking."""
-        original_items = [_make_item(f"item-{i}") for i in range(486)]
-        event = _make_event("snap-1", original_items)
-        result = _chunk_inventory_events([event], max_items=100)
-        chunked_items = []
-        for chunk in result:
-            chunked_items.extend(chunk["payload"]["snapshot"]["items"])
-        assert len(chunked_items) == 486
-        original_ids = {item["itemId"] for item in original_items}
-        chunked_ids = {item["itemId"] for item in chunked_items}
-        assert original_ids == chunked_ids
+    def test_request_limit_splits_between_snapshots(self) -> None:
+        first = _make_event("first", [_make_item("a")])
+        second = _make_event("second", [_make_item("b")])
+        single_body_limit = max(
+            len(_inventory_events_request_body([first])),
+            len(_inventory_events_request_body([second])),
+        )
+
+        batches = _batch_inventory_events(
+            [first, second],
+            max_body_bytes=single_body_limit,
+        )
+
+        assert batches == [[first], [second]]
+        assert first["idempotencyKey"] == "first"
+        assert second["idempotencyKey"] == "second"
+
+    def test_default_request_limit_accepts_just_under_and_rejects_over(self) -> None:
+        event = _make_event("boundary", [_make_item("boundary")])
+        base_size = len(_inventory_events_request_body([event]))
+        event["payload"]["snapshot"]["redactionReport"]["padding"] = "x" * (
+            _AIBOM_MAX_REQUEST_BODY_BYTES - base_size - 64
+        )
+        under_limit_size = len(_inventory_events_request_body([event]))
+
+        batches = _batch_inventory_events([event])
+
+        assert _AIBOM_MAX_REQUEST_BODY_BYTES - 100 < under_limit_size <= _AIBOM_MAX_REQUEST_BODY_BYTES
+        assert all(len(_inventory_events_request_body(batch)) <= _AIBOM_MAX_REQUEST_BODY_BYTES for batch in batches)
+
+        event["payload"]["snapshot"]["redactionReport"]["padding"] += "x" * 101
+        with pytest.raises(ValueError, match="snapshot exceeds"):
+            _batch_inventory_events([event])
+
+    def test_oversized_snapshot_fails_instead_of_splitting(self) -> None:
+        event = _make_event("oversized", [_make_item("large")])
+        body_size = len(_inventory_events_request_body([event]))
+
+        with pytest.raises(ValueError, match="snapshot exceeds"):
+            _batch_inventory_events([event], max_body_bytes=body_size - 1)
+
+        assert event["payload"]["snapshot"]["snapshotId"] == "oversized"
+        assert len(event["payload"]["snapshot"]["items"]) == 1
+
+    def test_non_item_snapshot_fields_remain_on_atomic_event(self) -> None:
+        event = _make_event("snap-1", [_make_item("item-1")])
+        snapshot = event["payload"]["snapshot"]
+        snapshot["findings"] = [{"findingId": "finding-1"}]
+        snapshot["sources"] = [{"sourceId": "source-1"}]
+
+        batches = _batch_inventory_events([event])
+
+        assert batches[0][0]["payload"]["snapshot"] == snapshot
+
+    @pytest.mark.parametrize("max_batch_size,max_body_bytes", [(0, 100), (1, 0)])
+    def test_invalid_limits_are_rejected(self, max_batch_size: int, max_body_bytes: int) -> None:
+        with pytest.raises(ValueError, match="limits must be positive"):
+            _batch_inventory_events(
+                [],
+                max_batch_size=max_batch_size,
+                max_body_bytes=max_body_bytes,
+            )

--- a/tests/test_aibom_chunking.py
+++ b/tests/test_aibom_chunking.py
@@ -59,9 +59,10 @@ class TestBatchInventoryEvents:
         items = [_make_item(f"item-{i}") for i in range(486)]
         event = _make_event("hermes:snapshot:test", items)
 
-        batches = _batch_inventory_events([event])
+        batches, oversized = _batch_inventory_events([event])
 
         assert batches == [[event]]
+        assert oversized == []
         snapshot = batches[0][0]["payload"]["snapshot"]
         assert snapshot["snapshotId"] == "hermes:snapshot:test"
         assert len(snapshot["items"]) == 486
@@ -69,9 +70,10 @@ class TestBatchInventoryEvents:
     def test_small_events_share_count_bounded_batch(self) -> None:
         events = [_make_event(f"snap-{index}", [_make_item(str(index))]) for index in range(4)]
 
-        batches = _batch_inventory_events(events, max_batch_size=3)
+        batches, oversized = _batch_inventory_events(events, max_batch_size=3)
 
         assert batches == [events[:3], events[3:]]
+        assert oversized == []
 
     def test_request_limit_splits_between_snapshots(self) -> None:
         first = _make_event("first", [_make_item("a")])
@@ -81,12 +83,13 @@ class TestBatchInventoryEvents:
             len(_inventory_events_request_body([second])),
         )
 
-        batches = _batch_inventory_events(
+        batches, oversized = _batch_inventory_events(
             [first, second],
             max_body_bytes=single_body_limit,
         )
 
         assert batches == [[first], [second]]
+        assert oversized == []
         assert first["idempotencyKey"] == "first"
         assert second["idempotencyKey"] == "second"
 
@@ -98,24 +101,30 @@ class TestBatchInventoryEvents:
         )
         under_limit_size = len(_inventory_events_request_body([event]))
 
-        batches = _batch_inventory_events([event])
+        batches, oversized = _batch_inventory_events([event])
 
         assert _AIBOM_MAX_REQUEST_BODY_BYTES - 100 < under_limit_size <= _AIBOM_MAX_REQUEST_BODY_BYTES
         assert all(len(_inventory_events_request_body(batch)) <= _AIBOM_MAX_REQUEST_BODY_BYTES for batch in batches)
+        assert oversized == []
 
         event["payload"]["snapshot"]["redactionReport"]["padding"] += "x" * 101
-        with pytest.raises(ValueError, match="snapshot exceeds"):
-            _batch_inventory_events([event])
+        batches, oversized = _batch_inventory_events([event])
+        assert batches == []
+        assert oversized == [event]
 
-    def test_oversized_snapshot_fails_instead_of_splitting(self) -> None:
-        event = _make_event("oversized", [_make_item("large")])
-        body_size = len(_inventory_events_request_body([event]))
+    def test_oversized_snapshot_is_quarantined_without_blocking_valid_snapshot(self) -> None:
+        valid = _make_event("valid", [_make_item("small")])
+        oversized = _make_event("oversized", [_make_item("large")])
+        body_size = len(_inventory_events_request_body([oversized]))
 
-        with pytest.raises(ValueError, match="snapshot exceeds"):
-            _batch_inventory_events([event], max_body_bytes=body_size - 1)
+        batches, oversized_events = _batch_inventory_events(
+            [valid, oversized],
+            max_body_bytes=body_size - 1,
+        )
 
-        assert event["payload"]["snapshot"]["snapshotId"] == "oversized"
-        assert len(event["payload"]["snapshot"]["items"]) == 1
+        assert batches == [[valid]]
+        assert oversized_events == [oversized]
+        assert oversized["payload"]["snapshot"]["snapshotId"] == "oversized"
 
     def test_non_item_snapshot_fields_remain_on_atomic_event(self) -> None:
         event = _make_event("snap-1", [_make_item("item-1")])
@@ -123,9 +132,10 @@ class TestBatchInventoryEvents:
         snapshot["findings"] = [{"findingId": "finding-1"}]
         snapshot["sources"] = [{"sourceId": "source-1"}]
 
-        batches = _batch_inventory_events([event])
+        batches, oversized = _batch_inventory_events([event])
 
         assert batches[0][0]["payload"]["snapshot"] == snapshot
+        assert oversized == []
 
     @pytest.mark.parametrize("max_batch_size,max_body_bytes", [(0, 100), (1, 0)])
     def test_invalid_limits_are_rejected(self, max_batch_size: int, max_body_bytes: int) -> None:

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -661,7 +661,7 @@ def test_sync_aibom_snapshots_404_reports_only_remaining_batch(
     assert responses == []
 
 
-def test_sync_aibom_snapshots_rejects_oversized_atomic_snapshot(
+def test_sync_aibom_snapshots_skips_oversized_snapshot_and_syncs_valid_snapshot(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -669,47 +669,164 @@ def test_sync_aibom_snapshots_rejects_oversized_atomic_snapshot(
     from codex_plugin_scanner.guard.adapters.base import HarnessContext
     from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots
     from codex_plugin_scanner.guard.inventory_contract import GuardAgentInventorySnapshot
+    from codex_plugin_scanner.guard.runtime import runner
 
     store = GuardStore(tmp_path / "guard")
     monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
-    snapshot = GuardAgentInventorySnapshot(
-        snapshot_id="hermes:oversized",
-        agent_id="hermes:local",
-        agent_type="hermes",
-        generated_at="2026-06-10T12:00:00+00:00",
-        runtime_version="test",
+    snapshots = (
+        GuardAgentInventorySnapshot(
+            snapshot_id="codex:valid",
+            agent_id="codex:local",
+            agent_type="codex",
+            generated_at="2026-06-10T12:00:00+00:00",
+            runtime_version="test",
+        ),
+        GuardAgentInventorySnapshot(
+            snapshot_id="hermes:oversized",
+            agent_id="hermes:local",
+            agent_type="hermes",
+            generated_at="2026-06-10T12:00:00+00:00",
+            runtime_version="test",
+        ),
     )
-    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", lambda *_args, **_kwargs: (snapshot,))
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", lambda *_args, **_kwargs: snapshots)
+    planned_event_ids: dict[str, str] = {}
 
-    def reject_oversized_snapshot(*_args, **_kwargs):
-        raise ValueError("snapshot exceeds limit")
+    def plan_mixed_snapshots(events, **_kwargs):
+        planned_event_ids["valid"] = str(events[0]["eventId"])
+        planned_event_ids["oversized"] = str(events[1]["eventId"])
+        return [[events[0]]], [events[1]]
 
     monkeypatch.setattr(
         aibom_cli,
         "_batch_inventory_events",
-        reject_oversized_snapshot,
+        plan_mixed_snapshots,
+    )
+    monkeypatch.setattr(runner, "_guard_events_sync_url", lambda url: url)
+    monkeypatch.setattr(runner, "_guard_sync_request", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(
+        runner,
+        "_urlopen_json_with_timeout_retry",
+        lambda *_args, **_kwargs: {
+            "accepted": 1,
+            "rejected": 0,
+            "statuses": [{"eventId": planned_event_ids["valid"], "status": "accepted"}],
+            "syncedAt": "2026-06-10T12:00:01+00:00",
+        },
     )
 
-    with pytest.raises(RuntimeError, match="snapshot exceeds the request limit"):
-        sync_aibom_snapshots(
-            store,
-            HarnessContext(
-                home_dir=tmp_path / "home",
-                workspace_dir=tmp_path / "workspace",
-                guard_home=store.guard_home,
-            ),
+    summary = sync_aibom_snapshots(
+        store,
+        HarnessContext(
+            home_dir=tmp_path / "home",
+            workspace_dir=tmp_path / "workspace",
+            guard_home=store.guard_home,
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        auth_context={
+            "sync_url": "https://hol.test/api/v1/guard/events",
+            "token": "test-token",
+        },
+    )
+
+    assert summary.get("synced") is True
+    assert summary.get("partial") is True
+    assert summary.get("reason") == "snapshot_too_large"
+    assert summary.get("accepted") == 1
+    assert summary.get("rejected") == 1
+    assert summary.get("statuses") == [
+        {
+            "eventId": planned_event_ids["oversized"],
+            "status": "rejected",
+            "reason": "snapshot_too_large",
+        },
+        {"eventId": planned_event_ids["valid"], "status": "accepted"},
+    ]
+
+
+def test_sync_aibom_snapshots_preserves_oversized_rejection_when_valid_batch_is_unavailable(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.error
+
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots
+    from codex_plugin_scanner.guard.inventory_contract import GuardAgentInventorySnapshot
+    from codex_plugin_scanner.guard.runtime import runner
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    snapshots = (
+        GuardAgentInventorySnapshot(
+            snapshot_id="codex:valid",
+            agent_id="codex:local",
+            agent_type="codex",
             generated_at="2026-06-10T12:00:00+00:00",
-            auth_context={
-                "sync_url": "https://hol.test/api/v1/guard/events",
-                "token": "test-token",
-            },
+            runtime_version="test",
+        ),
+        GuardAgentInventorySnapshot(
+            snapshot_id="hermes:oversized",
+            agent_id="hermes:local",
+            agent_type="hermes",
+            generated_at="2026-06-10T12:00:00+00:00",
+            runtime_version="test",
+        ),
+    )
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", lambda *_args, **_kwargs: snapshots)
+    planned_event_ids: dict[str, str] = {}
+
+    def plan_mixed_snapshots(events, **_kwargs):
+        planned_event_ids["valid"] = str(events[0]["eventId"])
+        planned_event_ids["oversized"] = str(events[1]["eventId"])
+        return [[events[0]]], [events[1]]
+
+    def reject_valid_batch(*_args, **_kwargs):
+        raise urllib.error.HTTPError(
+            url="https://hol.test/api/v1/guard/events",
+            code=404,
+            msg="Not Found",
+            hdrs=Message(),
+            fp=None,
         )
 
-    summary = store.get_sync_payload("aibom_sync_summary")
-    assert isinstance(summary, dict)
+    monkeypatch.setattr(aibom_cli, "_batch_inventory_events", plan_mixed_snapshots)
+    monkeypatch.setattr(runner, "_guard_events_sync_url", lambda url: url)
+    monkeypatch.setattr(runner, "_guard_sync_request", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(runner, "_urlopen_json_with_timeout_retry", reject_valid_batch)
+
+    summary = sync_aibom_snapshots(
+        store,
+        HarnessContext(
+            home_dir=tmp_path / "home",
+            workspace_dir=tmp_path / "workspace",
+            guard_home=store.guard_home,
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        auth_context={
+            "sync_url": "https://hol.test/api/v1/guard/events",
+            "token": "test-token",
+        },
+    )
+
+    backoff = store.get_sync_payload("aibom_guard_events_backoff")
     assert summary.get("synced") is False
-    assert summary.get("partial") is False
-    assert summary.get("reason") == "snapshot_too_large"
+    assert summary.get("skipped") is True
+    assert summary.get("partial") is True
+    assert summary.get("accepted") == 0
+    assert summary.get("rejected") == 1
+    assert summary.get("statuses") == [
+        {
+            "eventId": planned_event_ids["oversized"],
+            "status": "rejected",
+            "reason": "snapshot_too_large",
+        }
+    ]
+    assert isinstance(backoff, dict)
+    assert backoff.get("events") == 1
+    assert backoff.get("skipped") == 1
+    assert backoff.get("accepted") == 0
 
 
 def test_collect_aibom_snapshots_passes_cisco_runs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -582,6 +582,136 @@ def test_sync_aibom_snapshots_404_backoff_isolated_from_guard_events_summary(
     assert aibom_backoff.get("sync_reason") == "guard_events_endpoint_unavailable"
 
 
+def test_sync_aibom_snapshots_404_reports_only_remaining_batch(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import urllib.error
+
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots
+    from codex_plugin_scanner.guard.inventory_contract import GuardAgentInventorySnapshot
+    from codex_plugin_scanner.guard.runtime import runner
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    snapshots = tuple(
+        GuardAgentInventorySnapshot(
+            snapshot_id=f"snapshot-{index}",
+            agent_id=f"agent-{index}",
+            agent_type="codex",
+            generated_at="2026-06-10T12:00:00+00:00",
+            runtime_version="test",
+        )
+        for index in range(4)
+    )
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", lambda *_args, **_kwargs: snapshots)
+    responses: list[dict[str, object] | Exception] = [
+        {
+            "accepted": 3,
+            "rejected": 0,
+            "statuses": [{"eventId": f"event-{index}", "status": "accepted"} for index in range(3)],
+            "syncedAt": "2026-06-10T12:00:01+00:00",
+        },
+        urllib.error.HTTPError(
+            url="https://hol.test/api/v1/guard/events",
+            code=404,
+            msg="Not Found",
+            hdrs=Message(),
+            fp=None,
+        ),
+    ]
+
+    def respond(*_args, **_kwargs):
+        response = responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    monkeypatch.setattr(runner, "_urlopen_json_with_timeout_retry", respond)
+    monkeypatch.setattr(runner, "_guard_events_sync_url", lambda url: url)
+    monkeypatch.setattr(runner, "_guard_sync_request", lambda *_args, **_kwargs: object())
+
+    summary = sync_aibom_snapshots(
+        store,
+        HarnessContext(
+            home_dir=tmp_path / "home",
+            workspace_dir=tmp_path / "workspace",
+            guard_home=store.guard_home,
+        ),
+        generated_at="2026-06-10T12:00:00+00:00",
+        auth_context={
+            "sync_url": "https://hol.test/api/v1/guard/events",
+            "token": "test-token",
+        },
+    )
+
+    backoff = store.get_sync_payload("aibom_guard_events_backoff")
+    assert summary.get("synced") is False
+    assert summary.get("partial") is True
+    assert summary.get("accepted") == 3
+    assert summary.get("statuses") == [
+        {"eventId": f"event-{index}", "status": "accepted"} for index in range(3)
+    ]
+    assert isinstance(backoff, dict)
+    assert backoff.get("events") == 1
+    assert backoff.get("skipped") == 1
+    assert backoff.get("accepted") == 3
+    assert responses == []
+
+
+def test_sync_aibom_snapshots_rejects_oversized_atomic_snapshot(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots
+    from codex_plugin_scanner.guard.inventory_contract import GuardAgentInventorySnapshot
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    snapshot = GuardAgentInventorySnapshot(
+        snapshot_id="hermes:oversized",
+        agent_id="hermes:local",
+        agent_type="hermes",
+        generated_at="2026-06-10T12:00:00+00:00",
+        runtime_version="test",
+    )
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", lambda *_args, **_kwargs: (snapshot,))
+
+    def reject_oversized_snapshot(*_args, **_kwargs):
+        raise ValueError("snapshot exceeds limit")
+
+    monkeypatch.setattr(
+        aibom_cli,
+        "_batch_inventory_events",
+        reject_oversized_snapshot,
+    )
+
+    with pytest.raises(RuntimeError, match="snapshot exceeds the request limit"):
+        sync_aibom_snapshots(
+            store,
+            HarnessContext(
+                home_dir=tmp_path / "home",
+                workspace_dir=tmp_path / "workspace",
+                guard_home=store.guard_home,
+            ),
+            generated_at="2026-06-10T12:00:00+00:00",
+            auth_context={
+                "sync_url": "https://hol.test/api/v1/guard/events",
+                "token": "test-token",
+            },
+        )
+
+    summary = store.get_sync_payload("aibom_sync_summary")
+    assert isinstance(summary, dict)
+    assert summary.get("synced") is False
+    assert summary.get("partial") is False
+    assert summary.get("reason") == "snapshot_too_large"
+
+
 def test_collect_aibom_snapshots_passes_cisco_runs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from codex_plugin_scanner.guard import aibom_cli
     from codex_plugin_scanner.guard.adapters.base import HarnessContext

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -829,6 +829,91 @@ def test_sync_aibom_snapshots_preserves_oversized_rejection_when_valid_batch_is_
     assert backoff.get("accepted") == 0
 
 
+@pytest.mark.parametrize("failure_kind", ("http", "network"))
+def test_sync_aibom_snapshots_marks_oversized_rejection_partial_on_transport_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    failure_kind: str,
+) -> None:
+    import urllib.error
+
+    from codex_plugin_scanner.guard import aibom_cli
+    from codex_plugin_scanner.guard.adapters.base import HarnessContext
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots
+    from codex_plugin_scanner.guard.inventory_contract import GuardAgentInventorySnapshot
+    from codex_plugin_scanner.guard.runtime import runner
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    snapshots = (
+        GuardAgentInventorySnapshot(
+            snapshot_id="codex:valid",
+            agent_id="codex:local",
+            agent_type="codex",
+            generated_at="2026-06-10T12:00:00+00:00",
+            runtime_version="test",
+        ),
+        GuardAgentInventorySnapshot(
+            snapshot_id="hermes:oversized",
+            agent_id="hermes:local",
+            agent_type="hermes",
+            generated_at="2026-06-10T12:00:00+00:00",
+            runtime_version="test",
+        ),
+    )
+    monkeypatch.setattr(aibom_cli, "collect_aibom_snapshots", lambda *_args, **_kwargs: snapshots)
+    planned_event_ids: dict[str, str] = {}
+
+    def plan_mixed_snapshots(events, **_kwargs):
+        planned_event_ids["oversized"] = str(events[1]["eventId"])
+        return [[events[0]]], [events[1]]
+
+    def fail_valid_batch(*_args, **_kwargs):
+        if failure_kind == "http":
+            raise urllib.error.HTTPError(
+                url="https://hol.test/api/v1/guard/events",
+                code=500,
+                msg="Server Error",
+                hdrs=Message(),
+                fp=None,
+            )
+        raise OSError("network unavailable")
+
+    monkeypatch.setattr(aibom_cli, "_batch_inventory_events", plan_mixed_snapshots)
+    monkeypatch.setattr(runner, "_guard_events_sync_url", lambda url: url)
+    monkeypatch.setattr(runner, "_guard_sync_request", lambda *_args, **_kwargs: object())
+    monkeypatch.setattr(runner, "_urlopen_json_with_timeout_retry", fail_valid_batch)
+
+    with pytest.raises(RuntimeError):
+        sync_aibom_snapshots(
+            store,
+            HarnessContext(
+                home_dir=tmp_path / "home",
+                workspace_dir=tmp_path / "workspace",
+                guard_home=store.guard_home,
+            ),
+            generated_at="2026-06-10T12:00:00+00:00",
+            auth_context={
+                "sync_url": "https://hol.test/api/v1/guard/events",
+                "token": "test-token",
+            },
+        )
+
+    summary = store.get_sync_payload("aibom_sync_summary")
+    assert isinstance(summary, dict)
+    assert summary.get("synced") is False
+    assert summary.get("partial") is True
+    assert summary.get("accepted") == 0
+    assert summary.get("rejected") == 1
+    assert summary.get("statuses") == [
+        {
+            "eventId": planned_event_ids["oversized"],
+            "status": "rejected",
+            "reason": "snapshot_too_large",
+        }
+    ]
+
+
 def test_collect_aibom_snapshots_passes_cisco_runs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     from codex_plugin_scanner.guard import aibom_cli
     from codex_plugin_scanner.guard.adapters.base import HarnessContext


### PR DESCRIPTION
## Summary

- Preserve each inventory snapshot as one replacement unit while batching requests by count and serialized size.
- Reject a snapshot that cannot fit the request ceiling instead of splitting it into independent snapshot identities.
- Cover the real request-size boundary and partial accounting when a later request batch is unavailable.

## Verification

- `uv run pytest -q tests/test_aibom_chunking.py tests/test_guard_aibom_cli.py`
- `uv run ruff check src/codex_plugin_scanner/guard/aibom_cli.py tests/test_aibom_chunking.py`
