### PR TITLE
fix(aibom): raise atomic snapshot request ceiling

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -267,7 +267,7 @@ _AIBOM_GUARD_EVENTS_BACKOFF_KEY = "aibom_guard_events_backoff"
 _AIBOM_GUARD_EVENTS_BACKOFF_MINUTES = 5  # matches _GUARD_EVENTS_ENDPOINT_UNAVAILABLE_RETRY_MINUTES
 _AIBOM_SYNC_BATCH_SIZE = 3  # keep each POST under Cloudflare's 100s origin timeout
 # Guard Cloud queues large projection work; preserve snapshot replacement semantics in transit.
-_AIBOM_MAX_REQUEST_BODY_BYTES = 3_900_000  # stay below the portal's 4 MB request limit
+_AIBOM_MAX_REQUEST_BODY_BYTES = 7_500_000  # stay below the portal's 8 MB request limit
 
 
 def _aware_utc_timestamp(value: str) -> datetime:

--- a/tests/test_aibom_chunking.py
+++ b/tests/test_aibom_chunking.py
@@ -10,6 +10,9 @@ from codex_plugin_scanner.guard.aibom_cli import (
     _inventory_events_request_body,
 )
 
+_LEGACY_AIBOM_MAX_REQUEST_BODY_BYTES = 3_900_000
+_LARGE_ITEM_CONTENT_SUMMARY_BYTES = 11_300
+
 
 def _make_event(snapshot_id: str, items: list[dict]) -> dict:
     """Build a minimal inventory snapshot event for testing."""
@@ -58,13 +61,14 @@ class TestBatchInventoryEvents:
     def test_large_486_item_snapshot_remains_atomic(self) -> None:
         items = [_make_item(f"item-{i}") for i in range(486)]
         for item in items:
-            item["metadata"]["contentSummary"] = "x" * 11_300
+            item["metadata"]["contentSummary"] = "x" * _LARGE_ITEM_CONTENT_SUMMARY_BYTES
         event = _make_event("hermes:snapshot:test", items)
         request_size = len(_inventory_events_request_body([event]))
 
         batches, oversized = _batch_inventory_events([event])
 
-        assert 5_500_000 < request_size < _AIBOM_MAX_REQUEST_BODY_BYTES
+        assert _LARGE_ITEM_CONTENT_SUMMARY_BYTES * len(items) > _LEGACY_AIBOM_MAX_REQUEST_BODY_BYTES
+        assert request_size <= _AIBOM_MAX_REQUEST_BODY_BYTES
         assert batches == [[event]]
         assert oversized == []
         snapshot = batches[0][0]["payload"]["snapshot"]

--- a/tests/test_aibom_chunking.py
+++ b/tests/test_aibom_chunking.py
@@ -45,9 +45,9 @@ def _make_item(item_id: str) -> dict:
         "displayName": item_id,
         "contentHash": f"hash-{item_id}",
         "sourceFingerprint": f"fp-{item_id}",
-        "riskLevel": "unknown",
+        "riskLevel": "info",
         "securityScore": 100,
-        "driftState": "current",
+        "driftState": "unchanged",
         "metadata": {},
         "capabilityCategories": [],
         "scannerSources": [],
@@ -55,12 +55,16 @@ def _make_item(item_id: str) -> dict:
 
 
 class TestBatchInventoryEvents:
-    def test_486_item_snapshot_remains_atomic(self) -> None:
+    def test_large_486_item_snapshot_remains_atomic(self) -> None:
         items = [_make_item(f"item-{i}") for i in range(486)]
+        for item in items:
+            item["metadata"]["contentSummary"] = "x" * 11_300
         event = _make_event("hermes:snapshot:test", items)
+        request_size = len(_inventory_events_request_body([event]))
 
         batches, oversized = _batch_inventory_events([event])
 
+        assert 5_500_000 < request_size < _AIBOM_MAX_REQUEST_BODY_BYTES
         assert batches == [[event]]
         assert oversized == []
         snapshot = batches[0][0]["payload"]["snapshot"]


### PR DESCRIPTION
## Summary
- raise the atomic AIBOM request ceiling to 7.5 MB while preserving whole-snapshot replacement semantics
- retain oversized-snapshot quarantine and bounded multi-event batching
- add a schema-valid 486-item regression above 5.5 MB that preserves the original snapshot identity

## Verification
- `uv run pytest -q tests/test_aibom_chunking.py tests/test_guard_aibom_cli.py` (35 passed)
- `uv run ruff check src/codex_plugin_scanner/guard/aibom_cli.py tests/test_aibom_chunking.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/aibom_cli.py tests/test_aibom_chunking.py`
- `basedpyright --level error` (0 errors)