### PR TITLE
fix(aibom): sync primary Hermes content

### DIFF
--- a/src/codex_plugin_scanner/guard/adapters/hermes.py
+++ b/src/codex_plugin_scanner/guard/adapters/hermes.py
@@ -463,7 +463,7 @@ class HermesHarnessAdapter(HarnessAdapter):
                     if isinstance(hermes_related, str):
                         related = hermes_related
 
-        content_hash = _content_hash(content)
+        content_hash = _primary_content_hash(skill_md, fallback_content=content)
         env_mentions = _extract_env_mentions(content)
 
         metadata: dict[str, object] = {
@@ -866,6 +866,18 @@ def _extract_env_mentions(content: str) -> list[str]:
 def _content_hash(content: str) -> str:
     """Deterministic hash for change detection (truncated SHA-256)."""
     return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]
+
+
+def _primary_content_hash(path: Path, *, fallback_content: str) -> str:
+    """Hash the exact primary artifact body using the cloud content format."""
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            while chunk := handle.read(64 * 1024):
+                digest.update(chunk)
+    except OSError:
+        digest = hashlib.sha256(fallback_content.encode("utf-8"))
+    return f"sha256:{digest.hexdigest()}"
 
 
 def _safe_read(path: Path) -> str:

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -16,10 +16,18 @@ from typing import Any, Literal
 
 from ..version import __version__
 from .adapters.base import HarnessContext
+from .aibom_content_upload import (
+    GuardAibomPrimaryContentSource,
+    empty_content_upload_summary,
+    merge_content_upload_summary,
+    primary_content_sources_from_artifacts,
+    upload_primary_content_sources,
+)
 from .aibom_trust_metadata import apply_local_trust_metadata
 from .inventory_cisco import run_cisco_inventory_scans
 from .inventory_contract import (
     GuardAgentInventorySnapshot,
+    cloud_inventory_artifacts_from_detection,
     extract_aibom_metadata_extensions,
     inventory_snapshot_from_detection,
     redact_local_path,
@@ -60,6 +68,7 @@ def collect_aibom_snapshots(
     generated_at: str,
     options: AibomCliOptions | None = None,
     trust_attestation_context: dict[str, object] | None = None,
+    primary_content_sources: list[GuardAibomPrimaryContentSource] | None = None,
 ) -> tuple[GuardAgentInventorySnapshot, ...]:
     resolved = options or AibomCliOptions()
     snapshots: list[GuardAgentInventorySnapshot] = []
@@ -81,18 +90,31 @@ def collect_aibom_snapshots(
                 remaining_cisco_timeout_seconds - max(time.monotonic() - cisco_started, 0.0),
                 0.0,
             )
-        snapshots.append(
-            inventory_snapshot_from_detection(
-                detection,
-                generated_at=generated_at,
-                home_dir=context.home_dir,
-                workspace_dir=context.workspace_dir,
-                cisco_runs=cisco_runs,
-                include_symlinks=resolved.include_symlinks,
-                follow_unsafe_symlinks=resolved.follow_unsafe_symlinks,
-                trust_attestation_context=trust_attestation_context,
-            )
+        artifacts = cloud_inventory_artifacts_from_detection(
+            detection,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
         )
+        snapshot = inventory_snapshot_from_detection(
+            detection,
+            generated_at=generated_at,
+            home_dir=context.home_dir,
+            workspace_dir=context.workspace_dir,
+            cisco_runs=cisco_runs,
+            include_symlinks=resolved.include_symlinks,
+            follow_unsafe_symlinks=resolved.follow_unsafe_symlinks,
+            trust_attestation_context=trust_attestation_context,
+            artifacts=artifacts,
+        )
+        snapshots.append(snapshot)
+        if primary_content_sources is not None:
+            primary_content_sources.extend(
+                primary_content_sources_from_artifacts(
+                    artifacts,
+                    snapshot,
+                    workspace_dir=context.workspace_dir,
+                )
+            )
     return tuple(snapshots)
 
 
@@ -406,11 +428,13 @@ def sync_aibom_snapshots(
         generated_at=generated_at,
         include_upload_session_bindings=True,
     )
+    primary_content_sources: list[GuardAibomPrimaryContentSource] = []
     snapshots = collect_aibom_snapshots(
         context,
         generated_at=generated_at,
         options=resolved_options,
         trust_attestation_context=trust_attestation_context,
+        primary_content_sources=primary_content_sources,
     )
     if not snapshots:
         synced_at = generated_at
@@ -440,6 +464,13 @@ def sync_aibom_snapshots(
         for snapshot in snapshots
     ]
     event_batches, oversized_events = _batch_inventory_events(events)
+    content_sources_by_snapshot: dict[str, tuple[GuardAibomPrimaryContentSource, ...]] = {}
+    for snapshot in snapshots:
+        content_sources_by_snapshot[snapshot.snapshot_id] = tuple(
+            source for source in primary_content_sources if source.snapshot_id == snapshot.snapshot_id
+        )
+    content_upload_summary = empty_content_upload_summary()
+    content_uploaded_snapshot_ids: set[str] = set()
     oversized_statuses: list[dict[str, object]] = [
         {
             "eventId": str(event.get("eventId") or ""),
@@ -459,6 +490,7 @@ def sync_aibom_snapshots(
             "partial": False,
             "reason": "snapshot_too_large",
             "error": "Guard Cloud AIBOM sync failed because an inventory snapshot exceeds the request limit.",
+            "content_upload": content_upload_summary,
         }
         store.set_sync_payload("aibom_sync_summary", failure_summary, generated_at)
         return failure_summary
@@ -526,6 +558,7 @@ def sync_aibom_snapshots(
                     "statuses": all_statuses,
                     "partial": batches_sent > 0 or bool(oversized_events),
                     "reason": "guard_events_endpoint_unavailable",
+                    "content_upload": content_upload_summary,
                 }
                 if batches_sent == 0:
                     summary["skipped"] = True
@@ -540,6 +573,7 @@ def sync_aibom_snapshots(
                 "statuses": all_statuses,
                 "partial": batches_sent > 0 or bool(oversized_events),
                 "error": "Guard Cloud AIBOM sync failed due to an HTTP error.",
+                "content_upload": content_upload_summary,
             }
             store.set_sync_payload("aibom_sync_summary", failure_summary, synced_at)
             raise RuntimeError("Guard Cloud AIBOM sync failed due to an HTTP error.") from error
@@ -553,10 +587,11 @@ def sync_aibom_snapshots(
                 "statuses": all_statuses,
                 "partial": batches_sent > 0 or bool(oversized_events),
                 "error": "Guard Cloud AIBOM sync failed due to a network error.",
+                "content_upload": content_upload_summary,
             }
             store.set_sync_payload("aibom_sync_summary", failure_summary, synced_at)
             raise RuntimeError("Guard Cloud AIBOM sync failed due to a network error.") from error
-        batches_sent += 1  # noqa: SIM113
+        batches_sent += 1
         events_sent += len(batch)
         batch_accepted = payload.get("accepted")
         if isinstance(batch_accepted, int):
@@ -570,6 +605,19 @@ def sync_aibom_snapshots(
         batch_synced_at = _sync_timestamp_from_payload(payload)
         if isinstance(batch_synced_at, str):
             synced_at = batch_synced_at
+        for snapshot_id in _accepted_snapshot_ids(batch, payload):
+            if snapshot_id in content_uploaded_snapshot_ids:
+                continue
+            sources = content_sources_by_snapshot.get(snapshot_id, ())
+            upload_summary, resolved_auth_context = upload_primary_content_sources(
+                store,
+                runner,
+                resolved_auth_context,
+                sources=sources,
+                workspace_id=workspace_id,
+            )
+            merge_content_upload_summary(content_upload_summary, upload_summary)
+            content_uploaded_snapshot_ids.add(snapshot_id)
     summary: dict[str, object] = {
         "synced": True,
         "synced_at": synced_at,
@@ -577,6 +625,7 @@ def sync_aibom_snapshots(
         "accepted": total_accepted,
         "rejected": total_rejected,
         "statuses": all_statuses,
+        "content_upload": content_upload_summary,
     }
     if oversized_events:
         summary["partial"] = True
@@ -889,6 +938,32 @@ def _sync_timestamp_from_payload(payload: dict[str, object]) -> str | None:
         if isinstance(value, str) and value:
             return value
     return None
+
+
+def _accepted_snapshot_ids(
+    batch: list[dict[str, object]],
+    payload: dict[str, object],
+) -> set[str]:
+    snapshot_by_event_id: dict[str, str] = {}
+    for event in batch:
+        event_id = event.get("eventId")
+        event_payload = event.get("payload")
+        snapshot_payload = event_payload.get("snapshot") if isinstance(event_payload, dict) else None
+        snapshot_id = snapshot_payload.get("snapshotId") if isinstance(snapshot_payload, dict) else None
+        if isinstance(event_id, str) and isinstance(snapshot_id, str):
+            snapshot_by_event_id[event_id] = snapshot_id
+    accepted_event_ids = (
+        {
+            str(status.get("eventId"))
+            for status in payload.get("statuses", [])
+            if isinstance(status, dict) and status.get("status") == "accepted"
+        }
+        if isinstance(payload.get("statuses"), list)
+        else set()
+    )
+    if not accepted_event_ids and payload.get("accepted") == len(batch):
+        accepted_event_ids = set(snapshot_by_event_id)
+    return {snapshot_by_event_id[event_id] for event_id in accepted_event_ids if event_id in snapshot_by_event_id}
 
 
 def _render_aibom_markdown(payload: dict[str, object]) -> str:

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -618,18 +618,25 @@ def sync_aibom_snapshots(
             )
             merge_content_upload_summary(content_upload_summary, upload_summary)
             content_uploaded_snapshot_ids.add(snapshot_id)
+    content_eligible = int(content_upload_summary.get("eligible", 0))
+    content_stored = int(content_upload_summary.get("stored", 0))
+    content_upload_complete = content_stored == content_eligible
     summary: dict[str, object] = {
-        "synced": True,
+        "synced": content_upload_complete,
         "synced_at": synced_at,
         "snapshots": len(snapshots),
         "accepted": total_accepted,
         "rejected": total_rejected,
         "statuses": all_statuses,
         "content_upload": content_upload_summary,
+        "content_upload_complete": content_upload_complete,
     }
     if oversized_events:
         summary["partial"] = True
         summary["reason"] = "snapshot_too_large"
+    if not content_upload_complete:
+        summary["partial"] = True
+        summary["reason"] = "content_upload_incomplete"
     store.set_sync_payload("aibom_sync_summary", summary, synced_at)
     return summary
 

--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -618,8 +618,10 @@ def sync_aibom_snapshots(
             )
             merge_content_upload_summary(content_upload_summary, upload_summary)
             content_uploaded_snapshot_ids.add(snapshot_id)
-    content_eligible = int(content_upload_summary.get("eligible", 0))
-    content_stored = int(content_upload_summary.get("stored", 0))
+    content_eligible_value = content_upload_summary.get("eligible")
+    content_stored_value = content_upload_summary.get("stored")
+    content_eligible = content_eligible_value if isinstance(content_eligible_value, int) else 0
+    content_stored = content_stored_value if isinstance(content_stored_value, int) else 0
     content_upload_complete = content_stored == content_eligible
     summary: dict[str, object] = {
         "synced": content_upload_complete,
@@ -959,15 +961,15 @@ def _accepted_snapshot_ids(
         snapshot_id = snapshot_payload.get("snapshotId") if isinstance(snapshot_payload, dict) else None
         if isinstance(event_id, str) and isinstance(snapshot_id, str):
             snapshot_by_event_id[event_id] = snapshot_id
-    accepted_event_ids = (
-        {
-            str(status.get("eventId"))
-            for status in payload.get("statuses", [])
-            if isinstance(status, dict) and status.get("status") == "accepted"
-        }
-        if isinstance(payload.get("statuses"), list)
-        else set()
-    )
+    accepted_event_ids: set[str] = set()
+    statuses = payload.get("statuses")
+    if isinstance(statuses, list):
+        for status in statuses:
+            if not isinstance(status, dict) or status.get("status") != "accepted":
+                continue
+            event_id = status.get("eventId")
+            if isinstance(event_id, str):
+                accepted_event_ids.add(event_id)
     if not accepted_event_ids and payload.get("accepted") == len(batch):
         accepted_event_ids = set(snapshot_by_event_id)
     return {snapshot_by_event_id[event_id] for event_id in accepted_event_ids if event_id in snapshot_by_event_id}

--- a/src/codex_plugin_scanner/guard/aibom_content_upload.py
+++ b/src/codex_plugin_scanner/guard/aibom_content_upload.py
@@ -1,0 +1,336 @@
+"""Bounded upload of exact primary AIBOM artifact bodies."""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import re
+import urllib.error
+import urllib.parse
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from ..path_support import resolves_within_root
+from .inventory_contract import GuardAgentInventorySnapshot
+
+_CONTENT_HASH_PATTERN = re.compile(r"^sha256:[0-9a-f]{64}$")
+_MAX_CONTENT_ITEMS_PER_BATCH = 100
+_MAX_CONTENT_ITEM_BYTES = 1024 * 1024
+_MAX_CONTENT_RAW_BYTES_PER_BATCH = 5 * 1024 * 1024
+_MAX_CONTENT_REQUEST_BYTES = 7 * 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class GuardAibomPrimaryContentSource:
+    agent_id: str
+    allowed_root: Path
+    content_hash: str
+    harness_id: str
+    item_id: str
+    item_kind: str
+    mime_type: str
+    path: Path
+    snapshot_id: str
+    version_id: str
+
+
+def empty_content_upload_summary() -> dict[str, object]:
+    return {
+        "eligible": 0,
+        "attempted": 0,
+        "stored": 0,
+        "hash_only": 0,
+        "uploaded": 0,
+        "failed": 0,
+        "skipped": 0,
+        "batches": 0,
+    }
+
+
+def merge_content_upload_summary(target: dict[str, object], source: dict[str, object]) -> None:
+    for key in (
+        "eligible",
+        "attempted",
+        "stored",
+        "hash_only",
+        "uploaded",
+        "failed",
+        "skipped",
+        "batches",
+    ):
+        target[key] = int(target.get(key, 0)) + int(source.get(key, 0))
+    reason = source.get("reason")
+    if isinstance(reason, str) and reason:
+        target["reason"] = reason
+
+
+def primary_content_sources_from_artifacts(
+    artifacts: tuple[object, ...],
+    snapshot: GuardAgentInventorySnapshot,
+    *,
+    workspace_dir: Path | None,
+) -> tuple[GuardAibomPrimaryContentSource, ...]:
+    if snapshot.agent_type != "hermes":
+        return ()
+    items_by_id = {item.item_id: item for item in snapshot.items}
+    sources: list[GuardAibomPrimaryContentSource] = []
+    for artifact in artifacts:
+        artifact_type = str(getattr(artifact, "artifact_type", ""))
+        if artifact_type not in {"skill", "instruction"}:
+            continue
+        item_id = str(getattr(artifact, "artifact_id", ""))
+        item = items_by_id.get(item_id)
+        if item is None or not _CONTENT_HASH_PATTERN.fullmatch(item.content_hash):
+            continue
+        path_value = getattr(artifact, "config_path", None)
+        if not isinstance(path_value, str) or not path_value.strip():
+            continue
+        path = Path(path_value).expanduser()
+        allowed_root = _primary_allowed_root(
+            artifact_type=artifact_type,
+            path=path,
+            workspace_dir=workspace_dir,
+        )
+        if allowed_root is None or not _safe_primary_path(path, allowed_root=allowed_root):
+            continue
+        sources.append(
+            GuardAibomPrimaryContentSource(
+                agent_id=snapshot.agent_id,
+                allowed_root=allowed_root,
+                content_hash=item.content_hash,
+                harness_id=snapshot.agent_type,
+                item_id=item.item_id,
+                item_kind=item.item_kind,
+                mime_type=_content_mime_type(path),
+                path=path,
+                snapshot_id=snapshot.snapshot_id,
+                version_id=item.source_fingerprint,
+            )
+        )
+    return tuple(sources)
+
+
+def _primary_allowed_root(
+    *,
+    artifact_type: str,
+    path: Path,
+    workspace_dir: Path | None,
+) -> Path | None:
+    if artifact_type == "instruction":
+        if workspace_dir is None or path.suffix.lower() not in {".md", ".mdc"}:
+            return None
+        return workspace_dir
+    if path.name != "SKILL.md":
+        return None
+    parents = list(path.parents)
+    skills_root = next((parent for parent in parents if parent.name.lower() == "skills"), None)
+    if skills_root is None:
+        return None
+    try:
+        relative = path.relative_to(skills_root)
+    except ValueError:
+        return None
+    return skills_root if len(relative.parts) >= 2 else None
+
+
+def _safe_primary_path(path: Path, *, allowed_root: Path) -> bool:
+    if not path.is_file() or not resolves_within_root(allowed_root, path, require_exists=True):
+        return False
+    try:
+        relative = path.relative_to(allowed_root)
+    except ValueError:
+        return False
+    current = allowed_root
+    if current.is_symlink():
+        return False
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            return False
+    return True
+
+
+def _content_mime_type(path: Path) -> str:
+    if path.suffix.lower() in {".md", ".mdc"}:
+        return "text/markdown; charset=utf-8"
+    return "text/plain; charset=utf-8"
+
+
+def _prepared_upload_item(source: GuardAibomPrimaryContentSource) -> tuple[dict[str, object], int] | None:
+    if not _safe_primary_path(source.path, allowed_root=source.allowed_root):
+        return None
+    try:
+        with source.path.open("rb") as handle:
+            body = handle.read(_MAX_CONTENT_ITEM_BYTES + 1)
+    except OSError:
+        return None
+    if not body or len(body) > _MAX_CONTENT_ITEM_BYTES:
+        return None
+    content_hash = f"sha256:{hashlib.sha256(body).hexdigest()}"
+    if content_hash != source.content_hash:
+        return None
+    return (
+        {
+            "bodyBase64": base64.b64encode(body).decode("ascii"),
+            "contentHash": source.content_hash,
+            "itemKind": source.item_kind,
+            "itemId": source.item_id,
+            "versionId": source.version_id,
+            "mimeType": source.mime_type,
+        },
+        len(body),
+    )
+
+
+def _content_upload_url(sync_url: str, workspace_id: str) -> str:
+    parsed = urllib.parse.urlsplit(sync_url)
+    path = f"/api/guard/aibom/workspaces/{urllib.parse.quote(workspace_id, safe='')}/content-upload"
+    return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+def _encoded_batch(
+    *,
+    items: list[dict[str, object]],
+) -> bytes:
+    return json.dumps(
+        {
+            "items": items,
+        },
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def _bounded_response_count(
+    payload: object,
+    key: str,
+    *,
+    upper_bound: int,
+) -> int | None:
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get(key)
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if 0 <= value <= upper_bound else None
+
+
+def upload_primary_content_sources(
+    store: Any,
+    runner: Any,
+    auth_context: dict[str, object],
+    *,
+    sources: tuple[GuardAibomPrimaryContentSource, ...],
+    workspace_id: str,
+) -> tuple[dict[str, object], dict[str, object]]:
+    summary = empty_content_upload_summary()
+    summary["eligible"] = len(sources)
+    if not sources:
+        return summary, auth_context
+
+    resolved_auth_context = auth_context
+    batch_items: list[dict[str, object]] = []
+    batch_raw_bytes = 0
+
+    def send_batch() -> bool:
+        nonlocal batch_items, batch_raw_bytes, resolved_auth_context
+        if not batch_items:
+            return True
+        body = _encoded_batch(items=batch_items)
+        content_url = _content_upload_url(str(resolved_auth_context["sync_url"]), workspace_id)
+        request = runner._guard_sync_request(
+            resolved_auth_context,
+            request_url=content_url,
+            method="POST",
+            data=body,
+            extra_headers=None,
+        )
+        summary["attempted"] = int(summary["attempted"]) + len(batch_items)
+        summary["batches"] = int(summary["batches"]) + 1
+        try:
+            payload = runner._urlopen_json_with_timeout_retry(
+                request=request,
+                timeout_seconds=60,
+                retry_timeout_seconds=90,
+            )
+        except urllib.error.HTTPError as error:
+            if error.code == 401:
+                try:
+                    resolved_auth_context = runner._resolve_guard_sync_auth_context(store, force_refresh=True)
+                    content_url = _content_upload_url(str(resolved_auth_context["sync_url"]), workspace_id)
+                    request = runner._guard_sync_request(
+                        resolved_auth_context,
+                        request_url=content_url,
+                        method="POST",
+                        data=body,
+                        extra_headers=None,
+                    )
+                    payload = runner._urlopen_json_with_timeout_retry(
+                        request=request,
+                        timeout_seconds=60,
+                        retry_timeout_seconds=90,
+                    )
+                except (OSError, RuntimeError, urllib.error.HTTPError):
+                    summary["failed"] = int(summary["failed"]) + len(batch_items)
+                    summary["reason"] = "authorization_failed"
+                    return False
+            else:
+                summary["failed"] = int(summary["failed"]) + len(batch_items)
+                summary["reason"] = "endpoint_unavailable" if error.code == 404 else "http_error"
+                return False
+        except (OSError, RuntimeError):
+            summary["failed"] = int(summary["failed"]) + len(batch_items)
+            summary["reason"] = "network_error"
+            return False
+
+        batch_size = len(batch_items)
+        stored = _bounded_response_count(payload, "storedCount", upper_bound=batch_size)
+        hash_only = _bounded_response_count(payload, "hashOnlyCount", upper_bound=batch_size)
+        server_failed = _bounded_response_count(payload, "failedCount", upper_bound=batch_size)
+        if stored is None or hash_only is None or server_failed is None:
+            summary["failed"] = int(summary["failed"]) + batch_size
+            summary["reason"] = "invalid_response"
+            return False
+        accounted = stored + hash_only + server_failed
+        if accounted > batch_size:
+            summary["failed"] = int(summary["failed"]) + batch_size
+            summary["reason"] = "invalid_response"
+            return False
+        summary["stored"] = int(summary["stored"]) + stored
+        summary["hash_only"] = int(summary["hash_only"]) + hash_only
+        summary["uploaded"] = int(summary["uploaded"]) + stored + hash_only
+        summary["failed"] = int(summary["failed"]) + server_failed + batch_size - accounted
+        if accounted < batch_size:
+            summary["reason"] = "incomplete_response"
+            return False
+        batch_items = []
+        batch_raw_bytes = 0
+        return True
+
+    for index, source in enumerate(sources):
+        prepared = _prepared_upload_item(source)
+        if prepared is None:
+            summary["skipped"] = int(summary["skipped"]) + 1
+            continue
+        item, raw_bytes = prepared
+        candidate_items = [*batch_items, item]
+        candidate_body = _encoded_batch(items=candidate_items)
+        if batch_items and (
+            len(candidate_items) > _MAX_CONTENT_ITEMS_PER_BATCH
+            or batch_raw_bytes + raw_bytes > _MAX_CONTENT_RAW_BYTES_PER_BATCH
+            or len(candidate_body) > _MAX_CONTENT_REQUEST_BYTES
+        ):
+            if not send_batch():
+                summary["failed"] = int(summary["failed"]) + len(sources) - index
+                return summary, resolved_auth_context
+            candidate_items = [item]
+            candidate_body = _encoded_batch(items=candidate_items)
+        if raw_bytes > _MAX_CONTENT_RAW_BYTES_PER_BATCH or len(candidate_body) > _MAX_CONTENT_REQUEST_BYTES:
+            summary["skipped"] = int(summary["skipped"]) + 1
+            continue
+        batch_items = candidate_items
+        batch_raw_bytes += raw_bytes
+
+    send_batch()
+    return summary, resolved_auth_context

--- a/src/codex_plugin_scanner/guard/aibom_content_upload.py
+++ b/src/codex_plugin_scanner/guard/aibom_content_upload.py
@@ -10,7 +10,7 @@ import urllib.error
 import urllib.parse
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, TypedDict
 
 from ..path_support import resolves_within_root
 from .inventory_contract import GuardAgentInventorySnapshot
@@ -36,7 +36,22 @@ class GuardAibomPrimaryContentSource:
     version_id: str
 
 
-def empty_content_upload_summary() -> dict[str, object]:
+class _GuardAibomContentUploadCounts(TypedDict):
+    eligible: int
+    attempted: int
+    stored: int
+    hash_only: int
+    uploaded: int
+    failed: int
+    skipped: int
+    batches: int
+
+
+class GuardAibomContentUploadSummary(_GuardAibomContentUploadCounts, total=False):
+    reason: str
+
+
+def empty_content_upload_summary() -> GuardAibomContentUploadSummary:
     return {
         "eligible": 0,
         "attempted": 0,
@@ -49,18 +64,18 @@ def empty_content_upload_summary() -> dict[str, object]:
     }
 
 
-def merge_content_upload_summary(target: dict[str, object], source: dict[str, object]) -> None:
-    for key in (
-        "eligible",
-        "attempted",
-        "stored",
-        "hash_only",
-        "uploaded",
-        "failed",
-        "skipped",
-        "batches",
-    ):
-        target[key] = int(target.get(key, 0)) + int(source.get(key, 0))
+def merge_content_upload_summary(
+    target: GuardAibomContentUploadSummary,
+    source: GuardAibomContentUploadSummary,
+) -> None:
+    target["eligible"] += source["eligible"]
+    target["attempted"] += source["attempted"]
+    target["stored"] += source["stored"]
+    target["hash_only"] += source["hash_only"]
+    target["uploaded"] += source["uploaded"]
+    target["failed"] += source["failed"]
+    target["skipped"] += source["skipped"]
+    target["batches"] += source["batches"]
     reason = source.get("reason")
     if isinstance(reason, str) and reason:
         target["reason"] = reason
@@ -166,7 +181,7 @@ def _prepared_upload_item(source: GuardAibomPrimaryContentSource) -> tuple[dict[
             body = handle.read(_MAX_CONTENT_ITEM_BYTES + 1)
     except OSError:
         return None
-    if not body or len(body) > _MAX_CONTENT_ITEM_BYTES:
+    if len(body) > _MAX_CONTENT_ITEM_BYTES:
         return None
     content_hash = f"sha256:{hashlib.sha256(body).hexdigest()}"
     if content_hash != source.content_hash:
@@ -223,7 +238,7 @@ def upload_primary_content_sources(
     *,
     sources: tuple[GuardAibomPrimaryContentSource, ...],
     workspace_id: str,
-) -> tuple[dict[str, object], dict[str, object]]:
+) -> tuple[GuardAibomContentUploadSummary, dict[str, object]]:
     summary = empty_content_upload_summary()
     summary["eligible"] = len(sources)
     if not sources:
@@ -246,8 +261,8 @@ def upload_primary_content_sources(
             data=body,
             extra_headers=None,
         )
-        summary["attempted"] = int(summary["attempted"]) + len(batch_items)
-        summary["batches"] = int(summary["batches"]) + 1
+        summary["attempted"] += len(batch_items)
+        summary["batches"] += 1
         try:
             payload = runner._urlopen_json_with_timeout_retry(
                 request=request,
@@ -272,15 +287,15 @@ def upload_primary_content_sources(
                         retry_timeout_seconds=90,
                     )
                 except (OSError, RuntimeError, urllib.error.HTTPError):
-                    summary["failed"] = int(summary["failed"]) + len(batch_items)
+                    summary["failed"] += len(batch_items)
                     summary["reason"] = "authorization_failed"
                     return False
             else:
-                summary["failed"] = int(summary["failed"]) + len(batch_items)
+                summary["failed"] += len(batch_items)
                 summary["reason"] = "endpoint_unavailable" if error.code == 404 else "http_error"
                 return False
         except (OSError, RuntimeError):
-            summary["failed"] = int(summary["failed"]) + len(batch_items)
+            summary["failed"] += len(batch_items)
             summary["reason"] = "network_error"
             return False
 
@@ -289,18 +304,18 @@ def upload_primary_content_sources(
         hash_only = _bounded_response_count(payload, "hashOnlyCount", upper_bound=batch_size)
         server_failed = _bounded_response_count(payload, "failedCount", upper_bound=batch_size)
         if stored is None or hash_only is None or server_failed is None:
-            summary["failed"] = int(summary["failed"]) + batch_size
+            summary["failed"] += batch_size
             summary["reason"] = "invalid_response"
             return False
         accounted = stored + hash_only + server_failed
         if accounted > batch_size:
-            summary["failed"] = int(summary["failed"]) + batch_size
+            summary["failed"] += batch_size
             summary["reason"] = "invalid_response"
             return False
-        summary["stored"] = int(summary["stored"]) + stored
-        summary["hash_only"] = int(summary["hash_only"]) + hash_only
-        summary["uploaded"] = int(summary["uploaded"]) + stored + hash_only
-        summary["failed"] = int(summary["failed"]) + server_failed + batch_size - accounted
+        summary["stored"] += stored
+        summary["hash_only"] += hash_only
+        summary["uploaded"] += stored + hash_only
+        summary["failed"] += server_failed + batch_size - accounted
         if accounted < batch_size:
             summary["reason"] = "incomplete_response"
             return False
@@ -311,7 +326,7 @@ def upload_primary_content_sources(
     for index, source in enumerate(sources):
         prepared = _prepared_upload_item(source)
         if prepared is None:
-            summary["skipped"] = int(summary["skipped"]) + 1
+            summary["skipped"] += 1
             continue
         item, raw_bytes = prepared
         candidate_items = [*batch_items, item]
@@ -322,12 +337,12 @@ def upload_primary_content_sources(
             or len(candidate_body) > _MAX_CONTENT_REQUEST_BYTES
         ):
             if not send_batch():
-                summary["failed"] = int(summary["failed"]) + len(sources) - index
+                summary["failed"] += len(sources) - index
                 return summary, resolved_auth_context
             candidate_items = [item]
             candidate_body = _encoded_batch(items=candidate_items)
         if raw_bytes > _MAX_CONTENT_RAW_BYTES_PER_BATCH or len(candidate_body) > _MAX_CONTENT_REQUEST_BYTES:
-            summary["skipped"] = int(summary["skipped"]) + 1
+            summary["skipped"] += 1
             continue
         batch_items = candidate_items
         batch_raw_bytes += raw_bytes

--- a/src/codex_plugin_scanner/guard/aibom_detection.py
+++ b/src/codex_plugin_scanner/guard/aibom_detection.py
@@ -506,7 +506,8 @@ def _instruction_artifact(
     artifact_name: str | None = None,
     artifact_id: str | None = None,
 ) -> GuardArtifact:
-    content_hash = file_content_hash(path) or fingerprint_text(path.name)
+    content_digest = file_content_hash(path) or fingerprint_text(path.name)
+    content_hash = f"sha256:{content_digest}"
     name = display_name or path.name
     artifact_suffix = artifact_name or name
     resolved_artifact_id = artifact_id or f"{harness}:{scope}:instruction:{role}:{artifact_suffix}"

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -383,18 +383,17 @@ def extract_aibom_metadata_extensions(metadata: dict[str, object]) -> dict[str, 
     return extensions
 
 
-def inventory_snapshot_from_detection(
+def cloud_inventory_artifacts_from_detection(
     detection: object,
     *,
-    generated_at: str,
     home_dir: Path,
     workspace_dir: Path | None = None,
-    runtime_version: str | None = None,
-    cisco_runs: tuple[object, ...] = (),
-    include_symlinks: bool = True,
-    follow_unsafe_symlinks: bool = False,
-    trust_attestation_context: Mapping[str, object] | None = None,
-) -> GuardAgentInventorySnapshot:
+) -> tuple[object, ...]:
+    """Return artifacts eligible for the cloud inventory contract.
+
+    Hermes supplementary skill files remain part of local detection and policy
+    evaluation, but the cloud inventory represents the primary SKILL.md once.
+    """
     harness = str(getattr(detection, "harness", "unknown"))
     artifacts: list[object] = list(getattr(detection, "artifacts", ()))
     if workspace_dir is not None:
@@ -407,7 +406,34 @@ def inventory_snapshot_from_detection(
             if artifact.artifact_id not in existing_ids:
                 artifacts.append(artifact)
                 existing_ids.add(artifact.artifact_id)
-    artifact_tuple = tuple(artifacts)
+    if harness == "hermes":
+        artifacts = [artifact for artifact in artifacts if str(getattr(artifact, "artifact_type", "")) != "skill_file"]
+    return tuple(artifacts)
+
+
+def inventory_snapshot_from_detection(
+    detection: object,
+    *,
+    generated_at: str,
+    home_dir: Path,
+    workspace_dir: Path | None = None,
+    runtime_version: str | None = None,
+    cisco_runs: tuple[object, ...] = (),
+    include_symlinks: bool = True,
+    follow_unsafe_symlinks: bool = False,
+    trust_attestation_context: Mapping[str, object] | None = None,
+    artifacts: tuple[object, ...] | None = None,
+) -> GuardAgentInventorySnapshot:
+    harness = str(getattr(detection, "harness", "unknown"))
+    artifact_tuple = (
+        artifacts
+        if artifacts is not None
+        else cloud_inventory_artifacts_from_detection(
+            detection,
+            home_dir=home_dir,
+            workspace_dir=workspace_dir,
+        )
+    )
     items: list[GuardAgentInventoryItem] = []
     for artifact in artifact_tuple:
         item = _item_from_artifact(

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import base64
 import json
 from email.message import Message
 from pathlib import Path
@@ -56,7 +57,96 @@ def _seed_inventory(store: GuardStore, artifact: GuardArtifact, *, now: str) -> 
     )
 
 
-def test_aibom_status_json_includes_layer_and_trust_summary(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+@pytest.mark.parametrize("content_status", ["accepted", "missing_endpoint"])
+def test_sync_uploads_exact_primary_hermes_content_after_legacy_ack(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    content_status: str,
+) -> None:
+    import urllib.error
+
+    from codex_plugin_scanner.guard.adapters.hermes import HermesHarnessAdapter
+    from codex_plugin_scanner.guard.runtime import runner
+
+    home = tmp_path / "home"
+    workspace = tmp_path / "workspace"
+    skill_body = b"---\nname: deploy\n---\n# Deploy\n"
+    instruction_body = b"# Workspace instructions\n"
+    skill_dir = home / ".hermes" / "skills" / "dev" / "deploy"
+    _write_text(skill_dir / "SKILL.md", skill_body.decode())
+    _write_text(skill_dir / "references" / "agent_install_commands.md", "Supplementary notes.\n")
+    _write_text(workspace / "AGENTS.md", instruction_body.decode())
+    context = HarnessContext(home_dir=home, workspace_dir=workspace, guard_home=tmp_path / "guard")
+    store = GuardStore(context.guard_home)
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-1")
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
+    monkeypatch.setattr(
+        aibom_cli,
+        "detect_all",
+        lambda _context: (HermesHarnessAdapter().detect(context),),
+    )
+    requests: list[SimpleNamespace] = []
+
+    def guard_sync_request(_auth_context, *, request_url, method, data, extra_headers):
+        request = SimpleNamespace(data=data, full_url=request_url, method=method)
+        requests.append(request)
+        assert extra_headers is None
+        return request
+
+    def respond(*, request, **_kwargs):
+        if request.full_url.endswith("/api/v1/guard/events"):
+            # Older compatible portals may report aggregate acceptance without statuses.
+            return {"accepted": 1, "rejected": 0}
+        if content_status == "missing_endpoint":
+            raise urllib.error.HTTPError(
+                url=request.full_url,
+                code=404,
+                msg="Not Found",
+                hdrs=Message(),
+                fp=None,
+            )
+        payload = json.loads(request.data)
+        return {
+            "storedCount": len(payload["items"]),
+            "hashOnlyCount": 0,
+            "failedCount": 0,
+        }
+
+    monkeypatch.setattr(runner, "_guard_events_sync_url", lambda url: url)
+    monkeypatch.setattr(runner, "_guard_sync_request", guard_sync_request)
+    monkeypatch.setattr(runner, "_urlopen_json_with_timeout_retry", respond)
+
+    summary = aibom_cli.sync_aibom_snapshots(
+        store,
+        context,
+        generated_at="2026-07-10T00:00:00+00:00",
+        auth_context={"sync_url": "https://hol.test/api/v1/guard/events"},
+    )
+
+    assert summary["synced"] is True
+    upload_summary = summary["content_upload"]
+    assert isinstance(upload_summary, dict)
+    assert upload_summary["eligible"] == 2
+    content_requests = [request for request in requests if request.full_url.endswith("/content-upload")]
+    assert len(content_requests) == 1
+    if content_status == "missing_endpoint":
+        assert upload_summary["failed"] == 2
+        assert upload_summary["reason"] == "endpoint_unavailable"
+        return
+
+    assert upload_summary["uploaded"] == 2
+    assert upload_summary["stored"] == 2
+    assert upload_summary["hash_only"] == 0
+    content_payload = json.loads(content_requests[0].data)
+    assert set(content_payload) == {"items"}
+    uploaded_bodies = {base64.b64decode(item["bodyBase64"]) for item in content_payload["items"]}
+    assert uploaded_bodies == {skill_body, instruction_body}
+    assert all(str(item["contentHash"]).startswith("sha256:") for item in content_payload["items"])
+
+
+def test_aibom_status_json_includes_layer_and_trust_summary(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
     monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", raising=False)
     monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID", raising=False)
@@ -103,7 +193,9 @@ def test_aibom_status_json_includes_layer_and_trust_summary(tmp_path: Path, caps
     assert output["status"] in {"not_connected", "workspace_required", "sync_required", "synced"}
 
 
-def test_inventory_json_includes_aibom_metadata_extensions(tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_inventory_json_includes_aibom_metadata_extensions(
+    tmp_path: Path, capsys, monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "0")
     monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_PRIVATE_KEY", raising=False)
     monkeypatch.delenv("GUARD_AIBOM_TRUST_ATTESTATION_KEY_ID", raising=False)
@@ -651,9 +743,7 @@ def test_sync_aibom_snapshots_404_reports_only_remaining_batch(
     assert summary.get("synced") is False
     assert summary.get("partial") is True
     assert summary.get("accepted") == 3
-    assert summary.get("statuses") == [
-        {"eventId": f"event-{index}", "status": "accepted"} for index in range(3)
-    ]
+    assert summary.get("statuses") == [{"eventId": f"event-{index}", "status": "accepted"} for index in range(3)]
     assert isinstance(backoff, dict)
     assert backoff.get("events") == 1
     assert backoff.get("skipped") == 1

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -123,17 +123,22 @@ def test_sync_uploads_exact_primary_hermes_content_after_legacy_ack(
         auth_context={"sync_url": "https://hol.test/api/v1/guard/events"},
     )
 
-    assert summary["synced"] is True
+    assert summary["synced"] is (content_status == "accepted")
     upload_summary = summary["content_upload"]
     assert isinstance(upload_summary, dict)
     assert upload_summary["eligible"] == 2
     content_requests = [request for request in requests if request.full_url.endswith("/content-upload")]
     assert len(content_requests) == 1
     if content_status == "missing_endpoint":
+        assert summary["synced"] is False
+        assert summary["partial"] is True
+        assert summary["reason"] == "content_upload_incomplete"
+        assert summary["content_upload_complete"] is False
         assert upload_summary["failed"] == 2
         assert upload_summary["reason"] == "endpoint_unavailable"
         return
 
+    assert summary["content_upload_complete"] is True
     assert upload_summary["uploaded"] == 2
     assert upload_summary["stored"] == 2
     assert upload_summary["hash_only"] == 0

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -1,0 +1,162 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import urllib.error
+from email.message import Message
+from pathlib import Path
+from types import SimpleNamespace
+
+from codex_plugin_scanner.guard.aibom_content_upload import (
+    GuardAibomPrimaryContentSource,
+    upload_primary_content_sources,
+)
+
+
+def _source(skills_root: Path, index: int) -> GuardAibomPrimaryContentSource:
+    path = skills_root / "category" / f"skill-{index}" / "SKILL.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    body = f"# Skill {index}\n".encode()
+    path.write_bytes(body)
+    content_hash = f"sha256:{hashlib.sha256(body).hexdigest()}"
+    return GuardAibomPrimaryContentSource(
+        agent_id="hermes:local",
+        allowed_root=skills_root,
+        content_hash=content_hash,
+        harness_id="hermes",
+        item_id=f"hermes:skill:category:skill-{index}",
+        item_kind="skill",
+        mime_type="text/markdown; charset=utf-8",
+        path=path,
+        snapshot_id="hermes:snapshot:1",
+        version_id=f"fingerprint-{index}",
+    )
+
+
+def test_primary_content_upload_batches_exact_bodies_and_item_count(tmp_path: Path) -> None:
+    sources = tuple(_source(tmp_path / "skills", index) for index in range(101))
+    requests: list[SimpleNamespace] = []
+
+    def guard_sync_request(_auth_context, *, request_url, method, data, extra_headers):
+        request = SimpleNamespace(data=data, full_url=request_url, method=method)
+        requests.append(request)
+        assert extra_headers is None
+        return request
+
+    def respond(*, request, **_kwargs):
+        payload = json.loads(request.data)
+        return {
+            "storedCount": len(payload["items"]),
+            "hashOnlyCount": 0,
+            "failedCount": 0,
+        }
+
+    runner = SimpleNamespace(
+        _guard_sync_request=guard_sync_request,
+        _urlopen_json_with_timeout_retry=respond,
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=sources,
+        workspace_id="workspace-1",
+    )
+
+    assert summary == {
+        "eligible": 101,
+        "attempted": 101,
+        "uploaded": 101,
+        "stored": 101,
+        "hash_only": 0,
+        "failed": 0,
+        "skipped": 0,
+        "batches": 2,
+    }
+    assert [len(json.loads(request.data)["items"]) for request in requests] == [100, 1]
+    assert all(
+        request.full_url.endswith("/api/guard/aibom/workspaces/workspace-1/content-upload") for request in requests
+    )
+    first_item = json.loads(requests[0].data)["items"][0]
+    assert first_item["bodyBase64"] == "IyBTa2lsbCAwCg=="
+    assert first_item["contentHash"] == sources[0].content_hash
+    assert first_item["versionId"] == sources[0].version_id
+
+
+def test_primary_content_upload_failure_is_nonfatal(tmp_path: Path) -> None:
+    source = _source(tmp_path / "skills", 1)
+
+    def fail(*_args, **_kwargs):
+        raise urllib.error.HTTPError(
+            url="https://hol.test/content-upload",
+            code=404,
+            msg="Not Found",
+            hdrs=Message(),
+            fp=None,
+        )
+
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
+        _urlopen_json_with_timeout_retry=fail,
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=(source,),
+        workspace_id="workspace-1",
+    )
+
+    assert summary["attempted"] == 1
+    assert summary["uploaded"] == 0
+    assert summary["failed"] == 1
+    assert summary["reason"] == "endpoint_unavailable"
+
+
+def test_primary_content_upload_accounts_for_partial_batch_failure(tmp_path: Path) -> None:
+    sources = tuple(_source(tmp_path / "skills", index) for index in range(2))
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
+        _urlopen_json_with_timeout_retry=lambda **_kwargs: {
+            "storedCount": 1,
+            "hashOnlyCount": 0,
+            "failedCount": 1,
+        },
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=sources,
+        workspace_id="workspace-1",
+    )
+
+    assert summary["attempted"] == 2
+    assert summary["uploaded"] == 1
+    assert summary["stored"] == 1
+    assert summary["hash_only"] == 0
+    assert summary["failed"] == 1
+
+
+def test_primary_content_upload_skips_changed_body(tmp_path: Path) -> None:
+    source = _source(tmp_path / "skills", 1)
+    source.path.write_text("changed after snapshot\n", encoding="utf-8")
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **_kwargs: None,
+        _urlopen_json_with_timeout_retry=lambda **_kwargs: {},
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=(source,),
+        workspace_id="workspace-1",
+    )
+
+    assert summary["eligible"] == 1
+    assert summary["attempted"] == 0
+    assert summary["skipped"] == 1

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import hashlib
 import json
 import urllib.error
+from dataclasses import replace
 from email.message import Message
 from pathlib import Path
 from types import SimpleNamespace
@@ -160,3 +161,32 @@ def test_primary_content_upload_skips_changed_body(tmp_path: Path) -> None:
     assert summary["eligible"] == 1
     assert summary["attempted"] == 0
     assert summary["skipped"] == 1
+
+
+def test_primary_content_upload_accepts_an_empty_primary_file(tmp_path: Path) -> None:
+    source = _source(tmp_path / "skills", 1)
+    source.path.write_bytes(b"")
+    source = replace(
+        source,
+        content_hash=f"sha256:{hashlib.sha256(b'').hexdigest()}",
+    )
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
+        _urlopen_json_with_timeout_retry=lambda **_kwargs: {
+            "storedCount": 1,
+            "hashOnlyCount": 0,
+            "failedCount": 0,
+        },
+    )
+
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=(source,),
+        workspace_id="workspace-1",
+    )
+
+    assert summary["attempted"] == 1
+    assert summary["stored"] == 1
+    assert summary["failed"] == 0

--- a/tests/test_hermes_adapter.py
+++ b/tests/test_hermes_adapter.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sys
 from pathlib import Path
@@ -666,7 +667,7 @@ class TestSkillDiscovery:
         h1 = next(a for a in d1.artifacts if a.artifact_type == "skill").metadata["content_hash"]
         h2 = next(a for a in d2.artifacts if a.artifact_type == "skill").metadata["content_hash"]
         assert h1 == h2
-        assert len(h1) == 16
+        assert h1 == f"sha256:{hashlib.sha256(content.encode('utf-8')).hexdigest()}"
 
     def test_related_skills_in_metadata(self, tmp_path: Path):
         _write(
@@ -700,6 +701,33 @@ class TestSkillSubdirectoryScanning:
         assert len(file_artifacts) == 1
         assert "references" in file_artifacts[0].artifact_id
         assert "deploy/references/api-setup.md" in file_artifacts[0].name
+
+    def test_cloud_snapshot_keeps_primary_skill_and_instruction_only(self, tmp_path: Path):
+        skill_body = "---\nname: deploy\n---\n# Deploy\n"
+        instruction_body = "# Workspace instructions\nUse focused tests.\n"
+        skill_dir = tmp_path / ".hermes" / "skills" / "dev" / "deploy"
+        workspace = tmp_path / "workspace"
+        _write(skill_dir / "SKILL.md", skill_body)
+        _write(skill_dir / "references" / "agent_install_commands.md", "Install helper notes.\n")
+        _write(workspace / "AGENTS.md", instruction_body)
+        context = HarnessContext(
+            home_dir=tmp_path,
+            workspace_dir=workspace,
+            guard_home=tmp_path / "guard-home",
+        )
+        adapter = HermesHarnessAdapter()
+
+        detection = adapter.detect(context)
+        assert any(artifact.artifact_type == "skill_file" for artifact in detection.artifacts)
+
+        snapshot = adapter.inventory_snapshot(context, generated_at="2026-07-10T00:00:00Z")
+        artifact_types = {item.metadata.get("artifactType") for item in snapshot.items}
+        primary_skill = next(item for item in snapshot.items if item.metadata.get("artifactType") == "skill")
+        instruction = next(item for item in snapshot.items if item.metadata.get("artifactType") == "instruction")
+
+        assert "skill_file" not in artifact_types
+        assert primary_skill.content_hash == f"sha256:{hashlib.sha256(skill_body.encode()).hexdigest()}"
+        assert instruction.content_hash == f"sha256:{hashlib.sha256(instruction_body.encode()).hexdigest()}"
 
     def test_discovers_script_files(self, tmp_path: Path):
         skill_dir = tmp_path / ".hermes" / "skills" / "dev" / "deploy"
@@ -1381,18 +1409,20 @@ class TestManifestFallback:
         managed_root = tmp_path / "guard-home" / "hermes"
         _write(
             managed_root / "manifest.json",
-            json.dumps({
-                "servers": {
-                    "lean-ctx": {
-                        "command": "npx",
-                        "args": ["lean-ctx"],
+            json.dumps(
+                {
+                    "servers": {
+                        "lean-ctx": {
+                            "command": "npx",
+                            "args": ["lean-ctx"],
+                        },
+                        "web-search": {
+                            "command": "npx",
+                            "args": ["web-search"],
+                        },
                     },
-                    "web-search": {
-                        "command": "npx",
-                        "args": ["web-search"],
-                    },
-                },
-            }),
+                }
+            ),
         )
 
         adapter = HermesHarnessAdapter()
@@ -1414,14 +1444,16 @@ class TestManifestFallback:
         managed_root = tmp_path / "guard-home" / "hermes"
         _write(
             managed_root / "manifest.json",
-            json.dumps({
-                "servers": {
-                    "manifest-server": {
-                        "command": "python",
-                        "args": ["-m", "server"],
+            json.dumps(
+                {
+                    "servers": {
+                        "manifest-server": {
+                            "command": "python",
+                            "args": ["-m", "server"],
+                        },
                     },
-                },
-            }),
+                }
+            ),
         )
 
         adapter = HermesHarnessAdapter()
@@ -1462,21 +1494,23 @@ class TestManifestFallback:
         manifest_dir.mkdir(parents=True)
         _write(
             manifest_dir / "manifest.json",
-            json.dumps({
-                "servers": {
-                    "yaml:lean-ctx": {
-                        "name": "lean-ctx",
-                        "command": "npx",
-                        "args": ["-y", "@anthropic/lean-ctx"],
-                        "source": "yaml",
+            json.dumps(
+                {
+                    "servers": {
+                        "yaml:lean-ctx": {
+                            "name": "lean-ctx",
+                            "command": "npx",
+                            "args": ["-y", "@anthropic/lean-ctx"],
+                            "source": "yaml",
+                        },
+                        "json:playwright": {
+                            "name": "playwright",
+                            "command": "npx",
+                            "source": "json",
+                        },
                     },
-                    "json:playwright": {
-                        "name": "playwright",
-                        "command": "npx",
-                        "source": "json",
-                    },
-                },
-            }),
+                }
+            ),
         )
 
         adapter = HermesHarnessAdapter()
@@ -1494,9 +1528,7 @@ class TestManifestFallback:
 class TestInstallHostHomeAwareness:
     """install() uses host-home sources only for a minimal sandbox."""
 
-    def test_install_skips_host_home_mcp_sources_when_container_populated(
-        self, tmp_path: Path, monkeypatch
-    ):
+    def test_install_skips_host_home_mcp_sources_when_container_populated(self, tmp_path: Path, monkeypatch):
         """A stale mirror must not extend a populated container config."""
         # Container config has one MCP server
         _write(
@@ -1520,9 +1552,7 @@ class TestInstallHostHomeAwareness:
         assert "yaml:container-server" in server_keys
         assert "yaml:host-server" not in server_keys
 
-    def test_install_uses_host_home_mcp_sources_when_container_empty(
-        self, tmp_path: Path, monkeypatch
-    ):
+    def test_install_uses_host_home_mcp_sources_when_container_empty(self, tmp_path: Path, monkeypatch):
         _write(tmp_path / ".hermes" / "config.yaml", "mcp_servers: {}\n")
         host_home = tmp_path / "host-hermes"
         _write(


### PR DESCRIPTION
## Summary
- keep supplementary Hermes skill resources in local analysis while publishing only primary skill and instruction inventory records
- upload exact primary artifact bodies in bounded batches after accepted snapshots, with safe path, hash, and compatibility checks

## Tests
- `uv run pytest -q tests/test_guard_aibom_content_upload.py tests/test_guard_aibom_cli.py tests/test_hermes_adapter.py`
- `uv run ruff check src/codex_plugin_scanner/guard/adapters/hermes.py src/codex_plugin_scanner/guard/aibom_cli.py src/codex_plugin_scanner/guard/aibom_content_upload.py src/codex_plugin_scanner/guard/aibom_detection.py src/codex_plugin_scanner/guard/inventory_contract.py tests/test_guard_aibom_content_upload.py tests/test_hermes_adapter.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/adapters/hermes.py src/codex_plugin_scanner/guard/aibom_cli.py src/codex_plugin_scanner/guard/aibom_content_upload.py src/codex_plugin_scanner/guard/aibom_detection.py src/codex_plugin_scanner/guard/inventory_contract.py tests/test_guard_aibom_cli.py tests/test_guard_aibom_content_upload.py tests/test_hermes_adapter.py`
