### PR TITLE
feat(dashboard): add cloud user menu to sidebar

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -240,6 +240,16 @@ export function ApprovalCenterLayout(props: LayoutProps) {
         updatePhase={updatePhase}
         onUpdateGuard={onUpdateGuard}
         onReinstallGuard={onReinstallGuard}
+        cloudUserProfile={
+          props.runtime.kind === "ready"
+            ? props.runtime.snapshot.cloud_user_profile
+            : null
+        }
+        workspaceId={
+          props.runtime.kind === "ready"
+            ? props.runtime.snapshot.cloud_pairing_state.workspace_id ?? null
+            : null
+        }
       />
       <div
         className={`flex flex-col transition-all duration-200 lg:min-h-screen ${sidebarCollapsed ? "lg:pl-20" : "lg:pl-64"}`}

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -30,6 +30,8 @@ import {
 import { guardAwareHref } from "./guard-api";
 import { EMPTY_QUEUE_TITLE } from "./approval-center-utils";
 import { GuardUpdatePanel } from "./guard-update-panel";
+import { CloudUserMenu } from "./cloud-user-menu";
+import type { GuardCloudUserProfile } from "./guard-types";
 import { GITHUB_ISSUE_BUTTON_LABEL, GITHUB_ISSUE_LINK } from "./github-issue-link";
 import type { GuardUpdatePhase, GuardUpdateStatus } from "./guard-types";
 
@@ -175,6 +177,8 @@ export function ShellSidebar(props: {
   onUpdateGuard?: () => void;
   onReinstallGuard?: () => void;
   updatePhase?: GuardUpdatePhase;
+  cloudUserProfile?: GuardCloudUserProfile | null;
+  workspaceId?: string | null;
 }) {
   const collapsed = props.collapsed ?? false;
   return (
@@ -247,6 +251,15 @@ export function ShellSidebar(props: {
         )}
 
         <div className="mt-auto border-t border-slate-200 pt-4">
+          {props.cloudUserProfile ? (
+            <div className={`mb-3 ${collapsed ? "px-1" : "px-2"}`}>
+              <CloudUserMenu
+                userProfile={props.cloudUserProfile}
+                workspaceId={props.workspaceId}
+                collapsed={collapsed}
+              />
+            </div>
+          ) : null}
           {!collapsed ? (
             <div className="mx-2 overflow-hidden rounded-xl border border-brand-blue/25 bg-gradient-to-br from-brand-blue/[0.05] to-brand-dark/[0.03]">
               <div className="space-y-2 px-3 pb-2.5 pt-3">

--- a/dashboard/src/cloud-user-menu.tsx
+++ b/dashboard/src/cloud-user-menu.tsx
@@ -92,7 +92,7 @@ export function CloudUserMenu(props: {
 
   if (props.collapsed) {
     return (
-      <div ref={containerRef} className="flex justify-center pb-2">
+      <div ref={containerRef} className="relative flex justify-center pb-2">
         <button
           type="button"
           onClick={() => setOpen((prev) => !prev)}

--- a/dashboard/src/cloud-user-menu.tsx
+++ b/dashboard/src/cloud-user-menu.tsx
@@ -1,0 +1,202 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { HiMiniCloud, HiMiniChevronDown, HiMiniClipboardDocument, HiMiniCheck } from 'react-icons/hi2';
+import type { GuardCloudUserProfile } from './guard-types';
+
+function formatEmailDisplay(email: string): string {
+  const trimmed = email.trim();
+  if (trimmed.length <= 24) return trimmed;
+  const atIndex = trimmed.indexOf('@');
+  if (atIndex > 0 && atIndex < trimmed.length - 1) {
+    const localPart = trimmed.slice(0, atIndex);
+    const domain = trimmed.slice(atIndex);
+    if (localPart.length > 10) {
+      return `${localPart.slice(0, 8)}…${domain}`;
+    }
+  }
+  return `${trimmed.slice(0, 12)}…`;
+}
+
+function resolveInitials(name: string, email: string): string {
+  const trimmed = name.trim();
+  if (trimmed) {
+    const parts = trimmed.split(/\s+/);
+    if (parts.length >= 2) {
+      return `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase();
+    }
+    return trimmed.slice(0, 2).toUpperCase();
+  }
+  return email.trim().slice(0, 2).toUpperCase();
+}
+
+function resolveDisplayName(profile: GuardCloudUserProfile): string {
+  const name = profile.display_name?.trim();
+  if (name) return name;
+  return profile.email.split('@')[0];
+}
+
+export function CloudUserMenu(props: {
+  userProfile: GuardCloudUserProfile | null | undefined;
+  workspaceId: string | null | undefined;
+  collapsed?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const copyTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleClickOutside = useCallback((event: MouseEvent) => {
+    if (containerRef.current && !containerRef.current.contains(event.target as Node)) {
+      setOpen(false);
+      setCopied(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (open) {
+      document.addEventListener('mousedown', handleClickOutside);
+    }
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, [open, handleClickOutside]);
+
+  useEffect(() => {
+    return () => clearTimeout(copyTimeoutRef.current);
+  }, []);
+
+  const handleCopyWorkspaceId = useCallback(async () => {
+    if (!props.workspaceId) return;
+    try {
+      await navigator.clipboard.writeText(props.workspaceId);
+      setCopied(true);
+      clearTimeout(copyTimeoutRef.current);
+      copyTimeoutRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      /* clipboard unavailable */
+    }
+  }, [props.workspaceId]);
+
+  if (!props.userProfile) {
+    if (props.collapsed) {
+      return (
+        <div className="flex justify-center pb-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-slate-200">
+            <HiMiniCloud className="h-4 w-4 text-slate-400" />
+          </div>
+        </div>
+      );
+    }
+    return null;
+  }
+
+  const displayName = resolveDisplayName(props.userProfile);
+  const initials = resolveInitials(props.userProfile.display_name || '', props.userProfile.email);
+
+  if (props.collapsed) {
+    return (
+      <div ref={containerRef} className="flex justify-center pb-2">
+        <button
+          type="button"
+          onClick={() => setOpen((prev) => !prev)}
+          className="relative flex h-8 w-8 items-center justify-center overflow-hidden rounded-full ring-2 ring-brand-blue/30 transition hover:ring-brand-blue/60"
+          title={`${displayName} (${props.userProfile.email})`}
+          aria-label={`Cloud user: ${displayName}`}
+        >
+          {props.userProfile.avatar_url ? (
+            <img
+              src={props.userProfile.avatar_url}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="text-xs font-bold text-brand-blue">{initials}</span>
+          )}
+        </button>
+        {open && (
+          <div
+            className="absolute bottom-16 left-16 z-50 w-56 rounded-xl border border-slate-200 bg-white p-3 shadow-lg"
+          >
+            <div className="space-y-1 text-center">
+              <p className="text-xs font-semibold text-brand-dark">{displayName}</p>
+              <p className="text-[10px] text-slate-500">{formatEmailDisplay(props.userProfile.email)}</p>
+              {props.workspaceId ? (
+                <button
+                  type="button"
+                  onClick={handleCopyWorkspaceId}
+                  className="mt-2 flex w-full items-center justify-center gap-1.5 rounded-lg bg-slate-50 px-2 py-1.5 text-[10px] font-mono text-slate-600 transition hover:bg-slate-100"
+                >
+                  {copied ? (
+                    <HiMiniCheck className="h-3 w-3 text-green-600" />
+                  ) : (
+                    <HiMiniClipboardDocument className="h-3 w-3" />
+                  )}
+                  {props.workspaceId.slice(0, 8)}…
+                </button>
+              ) : null}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div ref={containerRef} className="relative">
+      <button
+        type="button"
+        onClick={() => setOpen((prev) => !prev)}
+        className="flex w-full items-center gap-2 rounded-xl px-2 py-1.5 transition hover:bg-slate-100"
+        aria-expanded={open}
+        aria-label={`Cloud user: ${displayName}`}
+      >
+        <div className="relative flex h-8 w-8 shrink-0 items-center justify-center overflow-hidden rounded-full ring-2 ring-brand-blue/20">
+          {props.userProfile.avatar_url ? (
+            <img
+              src={props.userProfile.avatar_url}
+              alt=""
+              className="h-full w-full object-cover"
+            />
+          ) : (
+            <span className="text-xs font-bold text-brand-blue">{initials}</span>
+          )}
+        </div>
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className="truncate text-xs font-semibold text-brand-dark">{displayName}</span>
+          <span className="truncate text-[10px] text-slate-500">{formatEmailDisplay(props.userProfile.email)}</span>
+        </div>
+        <HiMiniChevronDown
+          className={`h-3.5 w-3.5 shrink-0 text-slate-400 transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+      {open && (
+        <div className="absolute bottom-full left-0 right-0 mb-1 rounded-xl border border-slate-200 bg-white p-3 shadow-lg">
+          <div className="space-y-2">
+            <div className="flex items-center gap-1.5">
+              <HiMiniCloud className="h-3 w-3 text-brand-blue" />
+              <p className="font-mono text-[9px] font-semibold uppercase tracking-widest text-brand-blue">
+                HOL Guard Cloud
+              </p>
+            </div>
+            <div className="border-t border-slate-100 pt-2">
+              <p className="text-[10px] font-medium uppercase tracking-wider text-slate-400">Workspace ID</p>
+              {props.workspaceId ? (
+                <button
+                  type="button"
+                  onClick={handleCopyWorkspaceId}
+                  className="mt-1 flex w-full items-center justify-between gap-2 rounded-lg bg-slate-50 px-2 py-1.5 font-mono text-[10px] text-slate-600 transition hover:bg-slate-100"
+                >
+                  <span className="truncate">{props.workspaceId}</span>
+                  {copied ? (
+                    <HiMiniCheck className="h-3 w-3 shrink-0 text-green-600" />
+                  ) : (
+                    <HiMiniClipboardDocument className="h-3 w-3 shrink-0 text-slate-400" />
+                  )}
+                </button>
+              ) : (
+                <p className="mt-1 text-[10px] text-slate-400">Not available</p>
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1180,6 +1180,12 @@ export function buildDemoRuntimeSnapshot(): GuardRuntimeSnapshot {
         ? "A blocked action is waiting for review."
         : "This machine is connected to Guard Cloud and waiting for the first protected session to appear.",
     sync_configured: true,
+    cloud_user_profile: {
+      email: "demo@hol.org",
+      display_name: "Demo User",
+      avatar_url: "",
+    },
+    cloud_workspace_id: "demo-workspace-282f6ff2",
     cloud_state: cloudState,
     cloud_state_label: cloudLabel,
     cloud_state_detail: cloudDetail,
@@ -1188,6 +1194,12 @@ export function buildDemoRuntimeSnapshot(): GuardRuntimeSnapshot {
       label: cloudLabel,
       detail: cloudDetail,
       sync_configured: true,
+      cloud_user_profile: {
+        email: "demo@hol.org",
+        display_name: "Demo User",
+        avatar_url: "",
+      },
+      workspace_id: "demo-workspace-282f6ff2",
       dashboard_url: dashboardUrl,
       inbox_url: inboxUrl,
       fleet_url: fleetUrl,

--- a/dashboard/src/guard-demo.ts
+++ b/dashboard/src/guard-demo.ts
@@ -113,8 +113,7 @@ const demoDiff: GuardArtifactDiff = {
 };
 
 export function isGuardDemoMode(): boolean {
-  const meta = import.meta as ImportMeta & { env?: { DEV?: boolean } };
-  if (meta.env?.DEV !== true) {
+  if (import.meta.env?.DEV !== true) {
     return false;
   }
   return new URLSearchParams(window.location.search).get("demo") === "1";

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -233,11 +233,19 @@ export type GuardRuntimeState = {
   approval_center_url: string;
 };
 
+export type GuardCloudUserProfile = {
+  email: string;
+  display_name: string;
+  avatar_url: string;
+};
+
 export type GuardCloudPairingState = {
   state: "local_only" | "paired_waiting" | "paired_active";
   label: string;
   detail: string;
   sync_configured: boolean;
+  cloud_user_profile?: GuardCloudUserProfile | null;
+  workspace_id?: string | null;
   dashboard_url: string;
   inbox_url: string;
   fleet_url: string;
@@ -374,6 +382,8 @@ export type GuardRuntimeSnapshot = {
   headline_label: string;
   headline_detail: string;
   thread_count?: number;
+  cloud_user_profile?: GuardCloudUserProfile | null;
+  cloud_workspace_id?: string | null;
   sync_configured: boolean;
   cloud_state: "local_only" | "paired_waiting" | "paired_active";
   cloud_state_label: string;

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1390,8 +1390,17 @@ def _build_runtime_cloud_context(
         connect_retry_required=connect_retry_required,
         connect_retry_refresh_race=connect_retry_refresh_race,
     )
+    oauth_credentials = store.get_oauth_local_credentials()
+    cloud_user_profile: dict[str, str] | None = None
+    if isinstance(oauth_credentials, dict):
+        raw_profile = oauth_credentials.get("cloud_user_profile")
+        if isinstance(raw_profile, dict):
+            cloud_user_profile = {str(k): str(v) for k, v in raw_profile.items()}
+    cloud_workspace_id = store.get_cloud_workspace_id()
     return {
         "sync_configured": cloud_profile is not None,
+        "cloud_user_profile": cloud_user_profile,
+        "cloud_workspace_id": cloud_workspace_id,
         "cloud_state": cloud_state,
         "cloud_state_label": _runtime_cloud_state_label(cloud_state),
         "cloud_state_detail": _runtime_cloud_state_detail(
@@ -1413,6 +1422,8 @@ def _build_runtime_cloud_context(
                 shared_proof_recorded=bool(sync_summary) or remote_payload_active,
             ),
             "sync_configured": cloud_profile is not None,
+            "cloud_user_profile": cloud_user_profile,
+            "workspace_id": cloud_workspace_id,
             "dashboard_url": dashboard_url,
             "inbox_url": inbox_url,
             "fleet_url": fleet_url,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -101,6 +101,7 @@ class GuardOAuthTokenExchangeResult:
     machine_id: str | None
     supply_chain_entitlement: dict[str, object] | None
     workspace_id: str | None
+    cloud_user_profile: dict[str, str] | None = None
     access_token_expires_at: str | None = None
 
     def __post_init__(self) -> None:
@@ -175,6 +176,24 @@ def _read_nested_string(payload: dict[str, object], *path: str) -> str | None:
             return None
         current = current.get(segment)
     return current if isinstance(current, str) and current else None
+
+
+def _extract_cloud_user_profile(payload: dict[str, object]) -> dict[str, str] | None:
+    """Extract user profile (email, display_name, avatar_url) from guard_local_entitlement."""
+    entitlement = payload.get("guard_local_entitlement")
+    if not isinstance(entitlement, dict):
+        return None
+    profile = entitlement.get("user_profile")
+    if not isinstance(profile, dict):
+        return None
+    email = profile.get("email")
+    if not isinstance(email, str) or not email:
+        return None
+    return {
+        "email": email,
+        "display_name": str(profile.get("display_name") or ""),
+        "avatar_url": str(profile.get("avatar_url") or ""),
+    }
 
 
 def _guard_access_token_expires_at(
@@ -538,6 +557,7 @@ def _parse_guard_token_exchange_payload(payload: dict[str, object]) -> GuardOAut
             now=now,
         ),
         workspace_id=_read_nested_string(claims, "workspace", "workspaceId"),
+        cloud_user_profile=_extract_cloud_user_profile(payload),
     )
 
 
@@ -939,6 +959,7 @@ def _persist_oauth_local_credentials(
     machine_id: str | None = None,
     supply_chain_entitlement: dict[str, object] | None = None,
     workspace_id: str | None = None,
+    cloud_user_profile: dict[str, str] | None = None,
     runtime_id: str | None = None,
     runtime_label: str | None = None,
     access_token: str | None = None,
@@ -972,6 +993,7 @@ def _persist_oauth_local_credentials(
             else None
         ),
         workspace_id=workspace_id,
+        cloud_user_profile=cloud_user_profile,
         runtime_id=runtime_id,
         runtime_label=runtime_label,
         access_token=access_token,
@@ -1037,6 +1059,7 @@ def run_guard_disconnect_command(
             machine_id=_read_nested_string(credentials, "machine_id"),
             supply_chain_entitlement=token_result.supply_chain_entitlement,
             workspace_id=workspace_id,
+            cloud_user_profile=token_result.cloud_user_profile,
             runtime_id=_read_nested_string(credentials, "runtime_id"),
             runtime_label=_read_nested_string(credentials, "runtime_label"),
             access_token=token_result.access_token,
@@ -1158,6 +1181,7 @@ def run_guard_device_connect_command(
         machine_id=token_result.machine_id,
         supply_chain_entitlement=token_result.supply_chain_entitlement,
         workspace_id=token_result.workspace_id,
+        cloud_user_profile=token_result.cloud_user_profile,
         runtime_id=HEADLESS_RUNTIME_ID,
         runtime_label=HEADLESS_RUNTIME_LABEL,
         access_token=token_result.access_token,
@@ -1244,6 +1268,7 @@ def run_guard_browser_connect_command(
             machine_id=token_result.machine_id,
             supply_chain_entitlement=token_result.supply_chain_entitlement,
             workspace_id=token_result.workspace_id,
+            cloud_user_profile=token_result.cloud_user_profile,
             runtime_id=HEADLESS_RUNTIME_ID,
             runtime_label=HEADLESS_RUNTIME_LABEL,
             access_token=token_result.access_token,

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3156,6 +3156,7 @@ def _persist_rotated_oauth_refresh_token(
             else _optional_string(credentials.get("supply_chain_plan_id"))
         ),
         workspace_id=_optional_string(credentials.get("workspace_id")),
+        cloud_user_profile=_extract_dict_field(credentials, "cloud_user_profile"),
         runtime_id=_optional_string(credentials.get("runtime_id")),
         runtime_label=_optional_string(credentials.get("runtime_label")),
         access_token=access_token,
@@ -3676,6 +3677,13 @@ def _optional_string(value: object) -> str | None:
     if isinstance(value, str) and value.strip():
         return value
     return None
+
+
+def _extract_dict_field(credentials: dict[str, object], key: str) -> dict[str, str] | None:
+    value = credentials.get(key)
+    if not isinstance(value, dict):
+        return None
+    return {str(k): str(v) for k, v in value.items()}
 
 
 def _int_value(value: object) -> int | None:

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -327,6 +327,9 @@ class StoreOAuthConnectMixin:
         supply_chain_firewall = payload.get("supply_chain_firewall")
         if isinstance(supply_chain_firewall, bool):
             result["supply_chain_firewall"] = supply_chain_firewall
+        cloud_user_profile = payload.get("cloud_user_profile")
+        if isinstance(cloud_user_profile, dict):
+            result["cloud_user_profile"] = cloud_user_profile
         return result
 
     def _oauth_primary_repair_available(self) -> bool:
@@ -792,6 +795,9 @@ class StoreOAuthConnectMixin:
         supply_chain_firewall = metadata.get("supply_chain_firewall")
         if isinstance(supply_chain_firewall, bool):
             result["supply_chain_firewall"] = supply_chain_firewall
+        cloud_user_profile = metadata.get("cloud_user_profile")
+        if isinstance(cloud_user_profile, dict):
+            result["cloud_user_profile"] = cloud_user_profile
         return result
 
     def get_latest_guard_connect_state(self, *, now: str) -> dict[str, object] | None:

--- a/src/codex_plugin_scanner/guard/store_oauth.py
+++ b/src/codex_plugin_scanner/guard/store_oauth.py
@@ -88,6 +88,7 @@ class StoreOAuthConnectMixin:
         supply_chain_firewall: bool | None = None,
         supply_chain_plan_id: str | None = None,
         workspace_id: str | None = None,
+        cloud_user_profile: dict[str, str] | None = None,
         runtime_id: str | None = None,
         runtime_label: str | None = None,
         access_token: str | None = None,
@@ -109,6 +110,7 @@ class StoreOAuthConnectMixin:
                 supply_chain_firewall=supply_chain_firewall,
                 supply_chain_plan_id=supply_chain_plan_id,
                 workspace_id=workspace_id,
+                cloud_user_profile=cloud_user_profile,
                 runtime_id=runtime_id,
                 runtime_label=runtime_label,
                 access_token=access_token,
@@ -132,6 +134,7 @@ class StoreOAuthConnectMixin:
         supply_chain_firewall: bool | None = None,
         supply_chain_plan_id: str | None = None,
         workspace_id: str | None = None,
+        cloud_user_profile: dict[str, str] | None = None,
         runtime_id: str | None = None,
         runtime_label: str | None = None,
         access_token: str | None = None,
@@ -169,6 +172,8 @@ class StoreOAuthConnectMixin:
             payload["supply_chain_plan_id"] = supply_chain_plan_id
         if workspace_id:
             payload["workspace_id"] = workspace_id
+        if cloud_user_profile:
+            payload["cloud_user_profile"] = cloud_user_profile
         if runtime_id:
             payload["runtime_id"] = runtime_id
         if runtime_label:

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1069,6 +1069,8 @@ class TestGuardSurfaceServer:
             "label": "Connected",
             "detail": payload["cloud_state_detail"],
             "sync_configured": True,
+            "cloud_user_profile": None,
+            "workspace_id": None,
             "dashboard_url": "https://hol.org/guard",
             "inbox_url": "https://hol.org/guard/inbox",
             "fleet_url": "https://hol.org/guard/protect",


### PR DESCRIPTION
Add CloudUserMenu component to dashboard sidebar showing connected user avatar, name, email. Click avatar for workspace ID popover with copy-to-clipboard. Backend: extract cloud_user_profile from OAuth token exchange, store in local credentials, expose in runtime snapshot.