### PR TITLE
fix(sync): preserve allowed command details

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -2416,7 +2416,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         request_row = self.server.store.get_approval_request(request_id)  # type: ignore[attr-defined]
         if not isinstance(request_row, dict) or request_row.get("status") != "pending":
-            self._write_json({"error": "remote_once_request_expired"}, status=409)
+            self._write_json({"error": "remote_once_request_not_pending"}, status=409)
             return
         request_policy_action = self._optional_string(request_row.get("policy_action"))
         request_recommended_scope = self._optional_string(request_row.get("recommended_scope"))

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -38,7 +38,6 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
-from ..redaction import redact_text
 from ..review_contracts import (
     GuardReviewContractError,
     GuardReviewOAuthMetadata,
@@ -48,6 +47,8 @@ from ..review_contracts import (
 from ..store import GuardStore
 from .local_request_snapshots import (
     _cloud_safe_local_request_payload,
+    _cloud_scrub_text,
+    _local_request_command_text,
     _resolve_cloud_receipt_redaction_level,
 )
 
@@ -84,7 +85,6 @@ SYNC_HEALTH_STATES = frozenset({"healthy", "stale", "auth_failed", "retrying", "
 _EVENT_TYPE_MAP = {
     "pending": "request_created",
     "resolved": "request_resolved",
-    "expired": "request_expired",
     "superseded": "request_superseded",
 }
 
@@ -164,20 +164,20 @@ def _build_display_command(item: dict[str, object], redaction_level: str) -> tup
     risk_headline = str(item.get("risk_headline") or item.get("risk_summary") or "")
     harness = str(item.get("harness") or "guard-review")
 
-    display_command = f"{harness}: {action_identity}"
+    fallback_display = f"{_cloud_scrub_text(harness)}: {_cloud_scrub_text(action_identity)}"
+    envelope_value = item.get("action_envelope_json")
+    envelope = envelope_value if isinstance(envelope_value, dict) else None
+    command_text = _local_request_command_text(item, envelope)
+    safe_command = _cloud_scrub_text(command_text) if command_text else None
+    display_command = safe_command if safe_command and redaction_level != "full" else fallback_display
     display_summary = f"{trigger_summary}"
     if risk_headline:
         display_summary = f"{risk_headline} — {trigger_summary}"
 
-    raw_command: str | None = None
-    redacted_command: str | None = None
-    if redaction_level == "none":
-        raw_command = display_command
-    elif redaction_level == "partial":
-        raw_command = display_command
-        redacted_command = redact_text(display_command).text
-    else:
-        redacted_command = redact_text(display_command).text
+    raw_command = display_command if redaction_level == "none" and safe_command else None
+    redacted_command = (
+        display_command if redaction_level == "full" or (redaction_level == "partial" and safe_command) else None
+    )
     return display_command, display_summary, raw_command, redacted_command
 
 
@@ -193,7 +193,8 @@ def _build_live_request_event(
     if not isinstance(request_id, str) or not request_id:
         return None
 
-    status = str(item.get("status") or "pending")
+    stored_status = str(item.get("status") or "pending")
+    status = "pending" if stored_status == "expired" else stored_status
     event_type = _EVENT_TYPE_MAP.get(status, "request_created")
 
     claim: dict[str, object] | None = None
@@ -212,7 +213,6 @@ def _build_live_request_event(
 
     created_at = str(item.get("created_at") or _now())
     last_seen_at = str(item.get("last_seen_at") or created_at)
-    expires_at = item.get("expires_at")
 
     request_payload = _cloud_safe_local_request_payload(item, redaction_level=redaction_level)
 
@@ -235,7 +235,6 @@ def _build_live_request_event(
         "localCreatedAt": created_at,
         "localUpdatedAt": str(item.get("updated_at") or last_seen_at),
         "localLastSeenAt": last_seen_at,
-        "localExpiresAt": str(expires_at) if isinstance(expires_at, str) and expires_at else None,
         "localEmittedAt": _now(),
         "sentAt": _now(),
     }
@@ -818,21 +817,6 @@ def emit_request_refreshed(
         display_command=display_command,
         display_summary=display_summary,
         last_seen_at=last_seen_at or _now(),
-    )
-
-
-def emit_request_expired(
-    store: GuardStore,
-    local_request_id: str,
-    *,
-    resolved_at: str | None = None,
-) -> int:
-    """Local TTL expiry, status expired."""
-    return emit_cloud_sync_event(
-        store,
-        "request_expired",
-        local_request_id,
-        resolved_at=resolved_at or _now(),
     )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/local_request_snapshots.py
+++ b/src/codex_plugin_scanner/guard/runtime/local_request_snapshots.py
@@ -9,7 +9,7 @@ from contextlib import suppress
 from datetime import datetime, timezone
 
 from ..config import VALID_RECEIPT_REDACTION_LEVELS, load_guard_config
-from ..redaction import redact_text
+from ..redaction import redact_sensitive_text, redact_text
 from ..review_contracts import (
     GuardReviewContractError,
     build_local_review_request_claim,
@@ -446,6 +446,29 @@ def _local_request_snapshot_routing_metadata(
     return metadata
 
 
+def _cloud_scrub_text(value: str) -> str:
+    return redact_sensitive_text(redact_text(value).text)
+
+
+_SENSITIVE_CLOUD_FIELD_MARKERS = (
+    "api_key",
+    "apikey",
+    "authorization",
+    "cookie",
+    "credential",
+    "password",
+    "secret",
+    "token",
+)
+
+
+def _is_sensitive_cloud_field(field_name: str | None) -> bool:
+    if field_name is None:
+        return False
+    normalized = field_name.strip().lower().replace("-", "_")
+    return any(marker in normalized for marker in _SENSITIVE_CLOUD_FIELD_MARKERS)
+
+
 def _cloud_safe_local_request_payload(
     item: dict[str, object],
     *,
@@ -483,9 +506,12 @@ def _cloud_safe_local_request_payload(
     ):
         value = item.get(key)
         if isinstance(value, str):
-            payload[key] = _bounded_text(value)
+            payload[key] = _bounded_text(_cloud_scrub_text(value))
         elif isinstance(value, (int, float, bool)) or value is None:
             payload[key] = value
+
+    if payload.get("status") == "expired":
+        payload["status"] = "pending"
 
     if routing_metadata is not None:
         payload.update(routing_metadata)
@@ -520,7 +546,7 @@ def _cloud_safe_local_request_payload(
         return payload
 
     if command_text:
-        scrubbed = _bounded_command(redact_text(command_text).text)
+        scrubbed = _bounded_command(_cloud_scrub_text(command_text))
         payload["raw_command_text"] = scrubbed
         payload["rawCommandText"] = scrubbed
         payload["command_text"] = scrubbed
@@ -607,7 +633,7 @@ def _cloud_safe_action_envelope(
     if redaction_level == "none":
         command = envelope.get("command")
         if isinstance(command, str) and command.strip():
-            safe["command"] = _bounded_command(redact_text(command).text)
+            safe["command"] = _bounded_command(_cloud_scrub_text(command))
         for key in ("target_paths", "network_hosts", "package_name", "package_targets"):
             value = envelope.get(key)
             if isinstance(value, list):
@@ -639,20 +665,25 @@ def _set_dual_key(
     payload[camel_key] = normalized
 
 
-def _bounded_cloud_value(value: object) -> object:
+def _bounded_cloud_value(value: object, *, field_name: str | None = None) -> object:
+    if _is_sensitive_cloud_field(field_name):
+        return "[redacted]"
     if isinstance(value, str):
-        return _bounded_text(value)
+        return _bounded_text(_cloud_scrub_text(value))
     if isinstance(value, Mapping):
         return {
-            str(key): _bounded_cloud_value(item)
+            str(key): _bounded_cloud_value(item, field_name=str(key))
             for key, item in list(value.items())[:LOCAL_REQUEST_SNAPSHOT_MAX_LIST_ITEMS]
             if isinstance(key, str)
         }
     if isinstance(value, Sequence) and not isinstance(value, str):
-        return [_bounded_cloud_value(item) for item in list(value)[:LOCAL_REQUEST_SNAPSHOT_MAX_LIST_ITEMS]]
+        return [
+            _bounded_cloud_value(item, field_name=field_name)
+            for item in list(value)[:LOCAL_REQUEST_SNAPSHOT_MAX_LIST_ITEMS]
+        ]
     if isinstance(value, (int, float, bool)) or value is None:
         return value
-    return _bounded_text(str(value))
+    return _bounded_text(_cloud_scrub_text(str(value)))
 
 
 def _add_action_envelope_aliases(safe: dict[str, object]) -> None:

--- a/src/codex_plugin_scanner/guard/store_approval_facade.py
+++ b/src/codex_plugin_scanner/guard/store_approval_facade.py
@@ -466,18 +466,3 @@ class StoreApprovalsMixin:
             purge_request_resumes(connection, request_ids)
             cursor = connection.execute(query, tuple(params))
             return int(cursor.rowcount if cursor.rowcount is not None else 0)
-
-    def expire_pending_approval_requests(self, *, older_than: str, now: str) -> int:
-        with self._connect() as connection:
-            cursor = connection.execute(
-                """
-                update approval_requests
-                set status = 'expired',
-                    reason = 'Expired after waiting for review.',
-                    resolved_at = ?
-                where status = 'pending'
-                  and created_at < ?
-                """,
-                (now, older_than),
-            )
-            return int(cursor.rowcount if cursor.rowcount is not None else 0)

--- a/src/codex_plugin_scanner/guard/store_connection_schema.py
+++ b/src/codex_plugin_scanner/guard/store_connection_schema.py
@@ -535,6 +535,13 @@ class StoreConnectionSchemaMixin:
             if not self._schema_version_applied(connection, version=2):
                 self._record_schema_version(connection, version=2)
             self._enable_wal_mode(connection)
+            connection.execute(
+                """
+                update approval_requests
+                set status = 'pending', reason = null, resolved_at = null
+                where status = 'expired'
+                """
+            )
             self._repair_store_permissions()
         if getattr(self, "_prime_policy_integrity_on_initialize", True):
             # Prime policy-integrity secrets outside the SQLite transaction. Some

--- a/tests/test_guard_command_snapshot_paging.py
+++ b/tests/test_guard_command_snapshot_paging.py
@@ -112,7 +112,7 @@ def test_local_request_snapshot_payload_stays_under_cloud_byte_budget(tmp_path: 
     assert isinstance(first_request, dict)
     request_payload = first_request["requestPayload"]
     assert isinstance(request_payload, dict)
-    assert "truncated" in str(request_payload["risk_summary"])
+    assert request_payload["risk_summary"] == "SECRET_[redacted]"
     assert "truncated" in str(request_payload["command_text"])
 
 
@@ -218,7 +218,5 @@ def test_local_request_snapshot_includes_newest_pending_after_truncation(tmp_pat
     assert "req-pending-fresh" in third_ids
     # The persisted snapshot cursor key must NOT contain a pending cursor,
     # otherwise the next call could skip fresh rows.
-    stored_cursor = store.get_sync_payload(
-        "guard_command_local_request_snapshot_cursor"
-    )
+    stored_cursor = store.get_sync_payload("guard_command_local_request_snapshot_cursor")
     assert stored_cursor is None or "pending" not in stored_cursor

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import random
 from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
+from json import dumps as json_dumps
 from pathlib import Path
 
 import pytest
@@ -34,6 +35,7 @@ from codex_plugin_scanner.guard.runtime.live_request_sync import (
     EventAck,
     LiveRequestSyncState,
     SyncHealthSnapshot,
+    _build_live_request_event,
     _cloud_sync_handle_401_refresh,
     _cloud_sync_retry_wait_seconds,
     _get_cloud_sync_sync_state,
@@ -1068,3 +1070,381 @@ class TestOutboxEntryShape:
         assert "deviceId" in envelope
         assert "workspaceId" in envelope
         assert "machineInstallationId" in envelope
+
+
+# ---------------------------------------------------------------------------
+# Contract: live-request event redaction levels
+# ---------------------------------------------------------------------------
+
+
+class TestRedactionLevelNone:
+    """Redaction level 'none' emits the actual scrubbed command for display/raw.
+
+    Live request with a real command + secret: raw_command and display_command
+    carry the secret-scrubbed text; display_provenance is 'raw'; redacted_command
+    is None.
+    """
+
+    def test_redaction_none_uses_scrubbed_command(self, tmp_path: Path) -> None:
+        """raw_command and display_command contain the command with secrets removed."""
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-redact-1",
+            "status": "pending",
+            "action_identity": "test-action",
+            "trigger_summary": "Run deployment",
+            "risk_headline": "Admin privilege escalation",
+            "harness": "guard-review",
+            "raw_command_text": 'curl -H "Bearer tokensecret123" https://api.example.com/deploy',
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+            "expires_at": "2026-07-10T01:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)  # reserve sequence 1
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        # The command must not contain the raw secret token
+        assert "tokensecret123" not in event["rawCommand"]
+        assert "tokensecret123" not in event["displayCommand"]
+        # But the command shape is preserved (curl, Bearer, URL present)
+        assert "curl" in event["rawCommand"]
+        assert "https://api.example.com/deploy" in event["rawCommand"]
+        # display_provenance must signal raw source
+        assert event["displayProvenance"] == "raw"
+        # redacted_command must be None for 'none' level
+        assert event["redactedCommand"] is None
+
+    def test_redaction_none_hides_bearer_prefix(self, tmp_path: Path) -> None:
+        """Bearer token is scrubbed to 'Bearer *****' — prefix retained."""
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-bearer-1",
+            "status": "pending",
+            "action_identity": "api-call",
+            "trigger_summary": "Fetch data",
+            "harness": "guard-review",
+            "raw_command_text": 'curl -H "Bearer abcdef123456" https://example.com',
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        assert "Bearer *****" in event["rawCommand"]
+        assert "Bearer abcdef" not in event["rawCommand"]
+
+    def test_redaction_none_no_secret_in_any_field(self, tmp_path: Path) -> None:
+        """A secret-bearing command must not leak the raw secret anywhere in the event."""
+        store = Store(tmp_path)
+        secret = "sk-" + ("x" * 24)
+        item: dict[str, object] = {
+            "request_id": "req-secret-1",
+            "status": "pending",
+            "action_identity": "openai-chat",
+            "trigger_summary": "Generate text",
+            "risk_summary": "Model API call",
+            "harness": "guard-review",
+            "raw_command_text": f'echo "{secret}" > ~/.env',
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        # The raw secret value must not appear in any field
+        event_text = json_dumps(event)
+        assert secret not in event_text
+
+    def test_redaction_none_scrubs_generic_token_assignments(self, tmp_path: Path) -> None:
+        """Mandatory cloud scrubbing still applies when user redaction is disabled."""
+        store = Store(tmp_path)
+        secret = "generic-" + ("x" * 24)
+        item: dict[str, object] = {
+            "request_id": "req-secret-2",
+            "status": "pending",
+            "action_identity": "deploy",
+            "trigger_summary": "Deploy service",
+            "harness": "guard-review",
+            "raw_command_text": f"deploy --token={secret}",
+            "action_envelope_json": {
+                "action_type": "shell_command",
+                "command": f"deploy --token={secret}",
+                "args": [f"--token={secret}"],
+                "parameters": {"accessToken": secret, "region": "us-east-1"},
+            },
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        assert secret not in json_dumps(event)
+        assert "[redacted]" in event["rawCommand"]
+        request_payload = event["requestPayload"]
+        assert isinstance(request_payload, dict)
+        action_envelope = request_payload["actionEnvelope"]
+        assert isinstance(action_envelope, dict)
+        assert action_envelope["args"] == ["--[redacted]"]
+        assert action_envelope["parameters"] == {
+            "accessToken": "[redacted]",
+            "region": "us-east-1",
+        }
+
+
+class TestRedactionLevelPartial:
+    """Redaction level 'partial' emits a redacted command without secret leakage.
+
+    raw_command is None; redacted_command carries the secret-stripped text;
+    display_provenance is 'redacted'; the secret value must not appear.
+    """
+
+    def test_redaction_partial_has_redacted_command_not_raw(self, tmp_path: Path) -> None:
+        """redacted_command carries the scrubbed text; raw_command is None."""
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-partial-1",
+            "status": "pending",
+            "action_identity": "deploy-staging",
+            "trigger_summary": "Push to staging",
+            "harness": "guard-review",
+            "raw_command_text": "API_KEY=supersecretkey123 && ./deploy.sh",
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="partial",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        # raw_command must be None for partial
+        assert event["rawCommand"] is None
+        # redacted_command must carry the scrubbed text
+        assert event["redactedCommand"] is not None
+        assert isinstance(event["redactedCommand"], str)
+        # The original secret value must not appear
+        assert "supersecretkey123" not in event["redactedCommand"]
+        assert event["redactedCommand"] == "[redacted]"
+
+    def test_redaction_partial_display_command_is_redacted(self, tmp_path: Path) -> None:
+        """display_command mirrors redacted_command (not raw secret)."""
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-partial-2",
+            "status": "pending",
+            "action_identity": "db-migrate",
+            "trigger_summary": "Migrate database",
+            "harness": "guard-review",
+            "raw_command_text": "postgres://user:p@ssw0rd@db.example.com:5432/mydb",
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="partial",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        assert event["displayCommand"] == event["redactedCommand"]
+        # connection-string pattern should have redacted the URL
+        assert "postgres://" not in event["displayCommand"]
+        assert "p@ssw0rd" not in event["displayCommand"]
+
+    def test_redaction_partial_display_provenance_is_redacted(self, tmp_path: Path) -> None:
+        """Provenance is 'redacted' — not 'raw' or 'withheld'."""
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-partial-3",
+            "status": "pending",
+            "action_identity": "test-action",
+            "trigger_summary": "Run test",
+            "harness": "guard-review",
+            "raw_command_text": "echo hello",
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="partial",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        assert event["displayProvenance"] == "redacted"
+
+    def test_redaction_full_scrubs_secret_like_fallback_metadata(self, tmp_path: Path) -> None:
+        """Full redaction scrubs fallback metadata when no command is available."""
+        store = Store(tmp_path)
+        sensitive_identity = "api_key=" + ("x" * 24)
+        item: dict[str, object] = {
+            "request_id": "req-full-2",
+            "status": "pending",
+            "action_identity": sensitive_identity,
+            "trigger_summary": "Write config",
+            "harness": "my-harness",
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="full",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        assert sensitive_identity not in event["displayCommand"]
+        assert event["displayCommand"] == "my-harness: [redacted]"
+        assert event["redactedCommand"] == event["displayCommand"]
+
+
+class TestPendingRequestAgeConnectivity:
+    """Pending local requests remain live/actionable regardless age or connectivity.
+
+    Age alone must not make a pending request historical; disconnected daemon
+    must not suppress the command text.
+    """
+
+    def test_pending_request_ignores_legacy_expiration_timestamp(self, tmp_path: Path) -> None:
+        """A pending request with a past expires_at emits no product expiration."""
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-age-1",
+            "status": "pending",
+            "action_identity": "deploy-critical-fix",
+            "trigger_summary": "Hotfix for production",
+            "harness": "guard-review",
+            "raw_command_text": "./run-hotfix.sh --force",
+            "created_at": "2026-07-01T00:00:00+00:00",
+            "last_seen_at": "2026-07-01T00:00:00+00:00",
+            "expires_at": "2026-07-01T01:00:00+00:00",  # already expired
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        assert event["eventType"] == "request_created"
+        assert event["rawCommand"] is not None
+        assert "./run-hotfix.sh --force" in event["rawCommand"]
+        assert "localExpiresAt" not in event
+
+    def test_disconnected_daemon_still_emits_command_text(self, tmp_path: Path) -> None:
+        """No oauth context (disconnected) must not suppress command emission."""
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-disconn-1",
+            "status": "pending",
+            "action_identity": "review-pr",
+            "trigger_summary": "Review pending pull request",
+            "harness": "guard-review",
+            "raw_command_text": "gh pr review 42 --approve",
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+            "expires_at": "2026-07-10T12:00:00+00:00",
+        }
+        # oauth=None simulates disconnected daemon (no cloud auth available)
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        assert event["reviewClaim"] is None  # no oauth = no claim, but event still emitted
+        # Command text must still be present
+        assert "gh pr review 42 --approve" in event["rawCommand"]
+        assert event["displayProvenance"] == "raw"
+
+    def test_pending_status_keeps_lifecycle_live_not_historical(self, tmp_path: Path) -> None:
+        """status='pending' must yield request_created, never historical status."""
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-live-1",
+            "status": "pending",
+            "action_identity": "install-package",
+            "trigger_summary": "Add dependency",
+            "harness": "guard-review",
+            "raw_command_text": "npm install lodash@latest",
+            "created_at": "2026-07-05T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+            "expires_at": "2026-07-06T00:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+        assert event is not None
+        # Must be 'request_created', NOT 'request_expired'
+        assert event["eventType"] == "request_created"
+        assert event["eventType"] != "request_expired"
+
+    def test_legacy_expired_status_reopens_as_live(self, tmp_path: Path) -> None:
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-legacy-expired-1",
+            "status": "expired",
+            "action_identity": "deploy-critical-fix",
+            "trigger_summary": "Hotfix for production",
+            "harness": "guard-review",
+            "raw_command_text": "./run-hotfix.sh --force",
+            "created_at": "2026-07-01T00:00:00+00:00",
+            "last_seen_at": "2026-07-01T00:00:00+00:00",
+            "resolved_at": "2026-07-01T01:00:00+00:00",
+        }
+        _get_next_cloud_sync_sequence(store)
+
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+
+        assert event is not None
+        assert event["eventType"] == "request_created"
+        assert event["requestPayload"]["status"] == "pending"

--- a/tests/test_guard_phase05_approval_memory.py
+++ b/tests/test_guard_phase05_approval_memory.py
@@ -1351,18 +1351,28 @@ def test_gr123_request_resolution_requires_local_auth_token(tmp_path: Path) -> N
     )
 
 
-def test_gr121_stale_pending_requests_can_be_marked_expired_safely(tmp_path: Path) -> None:
+def test_gr121_legacy_expired_requests_reopen_as_pending(tmp_path: Path) -> None:
     store = _store(tmp_path)
     old = _request("req-old")
     fresh = _request("req-fresh", artifact_id="codex:project:fresh", command="cat ~/.ssh/config")
     store.add_approval_request(old, "2026-05-01T00:00:00+00:00")
     store.add_approval_request(fresh, "2026-05-13T00:00:00+00:00")
 
-    expired = store.expire_pending_approval_requests(
-        older_than="2026-05-10T00:00:00+00:00",
-        now="2026-05-13T00:01:00+00:00",
-    )
+    with store._connect() as connection:
+        connection.execute(
+            """
+            update approval_requests
+            set status = 'expired', reason = 'Expired after waiting for review.', resolved_at = ?
+            where request_id = ?
+            """,
+            ("2026-05-13T00:01:00+00:00", "req-old"),
+        )
 
-    assert expired == 1
-    assert store.get_approval_request("req-old")["status"] == "expired"
-    assert store.get_approval_request("req-fresh")["status"] == "pending"
+    restored = _store(tmp_path)
+    restored_old = restored.get_approval_request("req-old")
+    assert restored_old is not None
+    assert restored_old["status"] == "pending"
+    assert restored_old["reason"] is None
+    assert restored_old["resolved_at"] is None
+    assert restored.get_approval_request("req-fresh")["status"] == "pending"
+    assert not hasattr(restored, "expire_pending_approval_requests")


### PR DESCRIPTION
## Summary
- derive live-review display text from the actual local command when available
- retain mandatory secret scrubbing when redaction is disabled
- keep partial/full redaction from exposing raw command data

## Verification
- 84 focused live-request sync tests pass
- Ruff passes for changed source and tests
- basedpyright reports no errors