### PR TITLE
fix(guard): refresh AIBOM inventory from daemon

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_cli.py
+++ b/src/codex_plugin_scanner/guard/aibom_cli.py
@@ -123,6 +123,7 @@ def _resolve_trust_attestation_context(
     *,
     generated_at: str,
     include_upload_session_bindings: bool = False,
+    workspace_id: str | None = None,
 ) -> dict[str, object]:
     from .runtime.trust_attestation import (
         resolve_guard_oauth_trust_attestation_signing_config,
@@ -137,6 +138,7 @@ def _resolve_trust_attestation_context(
         guard_home = store.guard_home if include_upload_session_bindings else None
         signing_config = resolve_trust_attestation_signing_config(guard_home=guard_home)
     enable_v2 = trust_attestation_v2_enabled()
+    resolved_workspace_id = workspace_id or store.get_cloud_workspace_id()
     installation_id = store.get_or_create_installation_id() if enable_v2 else None
     context: dict[str, object] = {
         "analyzerId": "hol-guard" if enable_v2 else None,
@@ -151,7 +153,7 @@ def _resolve_trust_attestation_context(
         "sequence": None,
         "signingConfig": signing_config,
         "uploadId": None,
-        "workspaceId": store.get_cloud_workspace_id() if enable_v2 else None,
+        "workspaceId": resolved_workspace_id if enable_v2 else None,
     }
     if not enable_v2 or not include_upload_session_bindings:
         return context
@@ -360,14 +362,23 @@ def sync_aibom_snapshots_if_due(
     force: bool = False,
     options: AibomCliOptions | None = None,
     auth_context: dict[str, object] | None = None,
+    expected_workspace_id: str | None = None,
     home_dir: Path | None = None,
     workspace_dir: Path | None = None,
 ) -> dict[str, object]:
     runner = _runner_module()
     guard_sync_not_configured_error = runner.GuardSyncNotConfiguredError
 
-    if store.get_cloud_workspace_id() is None:
+    current_workspace_id = store.get_cloud_workspace_id()
+    if current_workspace_id is None:
         return {"synced": False, "skipped": True, "reason": "not_configured"}
+    if expected_workspace_id is not None and current_workspace_id != expected_workspace_id:
+        return {
+            "synced": False,
+            "reason": "workspace_changed",
+            "error": "Guard Cloud workspace changed before AIBOM inventory sync.",
+        }
+    bound_workspace_id = expected_workspace_id or current_workspace_id
     if _aibom_guard_events_endpoint_unavailable_recently(store):
         return {
             "synced": False,
@@ -398,6 +409,7 @@ def sync_aibom_snapshots_if_due(
             generated_at=generated_at,
             options=options,
             auth_context=auth_context,
+            expected_workspace_id=bound_workspace_id,
         )
     except guard_sync_not_configured_error:
         return {"synced": False, "skipped": True, "reason": "not_configured"}
@@ -414,20 +426,28 @@ def sync_aibom_snapshots(
     generated_at: str,
     options: AibomCliOptions | None = None,
     auth_context: dict[str, object] | None = None,
+    expected_workspace_id: str | None = None,
 ) -> dict[str, object]:
     runner = _runner_module()
     guard_sync_not_configured_error = runner.GuardSyncNotConfiguredError
 
-    workspace_id = store.get_cloud_workspace_id()
-    if workspace_id is None:
-        raise guard_sync_not_configured_error("Guard Cloud workspace is not configured. Run `hol-guard connect` first.")
+    with store.hold_oauth_credential_lock():
+        current_workspace_id = store.get_cloud_workspace_id()
+        if current_workspace_id is None:
+            raise guard_sync_not_configured_error(
+                "Guard Cloud workspace is not configured. Run `hol-guard connect` first."
+            )
+        if expected_workspace_id is not None and current_workspace_id != expected_workspace_id:
+            raise ValueError("Guard Cloud workspace changed before AIBOM inventory sync.")
+        workspace_id = expected_workspace_id or current_workspace_id
+        trust_attestation_context = _resolve_trust_attestation_context(
+            store,
+            generated_at=generated_at,
+            include_upload_session_bindings=True,
+            workspace_id=workspace_id,
+        )
 
     resolved_options = options or _AIBOM_CLOUD_SYNC_OPTIONS
-    trust_attestation_context = _resolve_trust_attestation_context(
-        store,
-        generated_at=generated_at,
-        include_upload_session_bindings=True,
-    )
     primary_content_sources: list[GuardAibomPrimaryContentSource] = []
     snapshots = collect_aibom_snapshots(
         context,

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -197,6 +197,7 @@ _SUPPLY_CHAIN_CONNECT_WAIT_TIMEOUT_SECONDS = 180
 _LOCAL_DASHBOARD_SESSION_REFRESH_GRACE_SECONDS = 7 * 24 * 60 * 60
 _DEFAULT_HEADLESS_CLOUD_SYNC_INTERVAL_SECONDS = 30.0
 _DEFAULT_HEADLESS_CLOUD_SYNC_BACKOFF_SECONDS = 10.0
+_AIBOM_REFRESH_STOP_JOIN_TIMEOUT_SECONDS = 5.0
 
 
 class _HookPathValidationError(ValueError):
@@ -5478,8 +5479,9 @@ class GuardDaemonServer:
             self._bundle_refresh_thread.join(timeout=5)
             self._bundle_refresh_thread = None
         if self._aibom_refresh_thread is not None:
-            self._aibom_refresh_thread.join(timeout=5)
-            self._aibom_refresh_thread = None
+            self._aibom_refresh_thread.join(timeout=_AIBOM_REFRESH_STOP_JOIN_TIMEOUT_SECONDS)
+            if not self._aibom_refresh_thread.is_alive():
+                self._aibom_refresh_thread = None
         if self._headless_cloud_sync_thread is not None:
             self._headless_cloud_sync_thread.join(timeout=5)
             self._headless_cloud_sync_thread = None
@@ -5487,6 +5489,8 @@ class GuardDaemonServer:
         self._live_request_sync_worker = stop_cloud_sync_sync_worker(self._live_request_sync_worker)
 
     def _begin_service(self) -> None:
+        if self._aibom_refresh_thread is not None and self._aibom_refresh_thread.is_alive():
+            raise RuntimeError("AIBOM inventory refresh is still stopping")
         self._shutdown_started.clear()
         self._server.last_activity_monotonic = time.monotonic()
         write_guard_daemon_state(self._server.store.guard_home, self.port, self._server.auth_token)
@@ -5663,6 +5667,17 @@ class GuardDaemonServer:
             if isinstance(workspace_value, str) and workspace_value.strip()
             else self._aibom_workspace_dir
         )
+        if workspace_dir is None:
+            workspace_dir = resolve_supply_chain_audit_workspace_dir(
+                workspace_dir_value=None,
+                workspace_value=None,
+                allowed_roots=(
+                    Path.home().resolve(),
+                    Path.cwd().resolve(),
+                    Path(tempfile.gettempdir()).resolve(),
+                ),
+                managed_workspace_dirs=managed_install_audit_workspace_dirs(self._server.store),
+            )
         return home_dir, workspace_dir
 
     def _refresh_aibom_inventory_loop(self) -> None:
@@ -5672,8 +5687,6 @@ class GuardDaemonServer:
         backoff_seconds = (
             self._aibom_refresh_backoff_seconds if self._aibom_refresh_backoff_seconds > 0 else interval_seconds
         )
-        if self._shutdown_started.wait(interval_seconds):
-            return
         while not self._shutdown_started.is_set():
             refreshed_at = _now()
             try:
@@ -5702,13 +5715,19 @@ class GuardDaemonServer:
                         home_dir=home_dir,
                         workspace_dir=workspace_dir,
                     )
-                status = "synced" if summary.get("synced") is True else str(summary.get("reason") or "skipped")
+                has_error = bool(summary.get("error"))
+                if has_error:
+                    status = "error"
+                elif summary.get("synced") is True:
+                    status = "synced"
+                else:
+                    status = str(summary.get("reason") or "skipped")
                 self._server.store.set_sync_payload(
                     "aibom_inventory_daemon",
                     {**summary, "status": status, "refreshed_at": refreshed_at},
                     refreshed_at,
                 )
-                wait_seconds = interval_seconds
+                wait_seconds = backoff_seconds if has_error else interval_seconds
             except GuardSyncAuthorizationExpiredError as error:
                 self._server.store.set_sync_payload(
                     "aibom_inventory_daemon",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5489,8 +5489,10 @@ class GuardDaemonServer:
         self._live_request_sync_worker = stop_cloud_sync_sync_worker(self._live_request_sync_worker)
 
     def _begin_service(self) -> None:
-        if self._aibom_refresh_thread is not None and self._aibom_refresh_thread.is_alive():
-            raise RuntimeError("AIBOM inventory refresh is still stopping")
+        if self._aibom_refresh_thread is not None:
+            if self._aibom_refresh_thread.is_alive():
+                raise RuntimeError("AIBOM inventory refresh is still stopping")
+            self._aibom_refresh_thread = None
         self._shutdown_started.clear()
         self._server.last_activity_monotonic = time.monotonic()
         write_guard_daemon_state(self._server.store.guard_home, self.port, self._server.auth_token)
@@ -5668,15 +5670,18 @@ class GuardDaemonServer:
             else self._aibom_workspace_dir
         )
         if workspace_dir is None:
+            managed_workspace_dirs = managed_install_audit_workspace_dirs(self._server.store)
+            allowed_roots: list[Path] = []
+            for managed_workspace in managed_workspace_dirs:
+                try:
+                    allowed_roots.append(Path(managed_workspace).expanduser().resolve())
+                except OSError:
+                    continue
             workspace_dir = resolve_supply_chain_audit_workspace_dir(
                 workspace_dir_value=None,
                 workspace_value=None,
-                allowed_roots=(
-                    Path.home().resolve(),
-                    Path.cwd().resolve(),
-                    Path(tempfile.gettempdir()).resolve(),
-                ),
-                managed_workspace_dirs=managed_install_audit_workspace_dirs(self._server.store),
+                allowed_roots=tuple(allowed_roots),
+                managed_workspace_dirs=managed_workspace_dirs,
             )
         return home_dir, workspace_dir
 
@@ -5727,7 +5732,9 @@ class GuardDaemonServer:
                     {**summary, "status": status, "refreshed_at": refreshed_at},
                     refreshed_at,
                 )
-                wait_seconds = backoff_seconds if has_error else interval_seconds
+                wait_seconds = (
+                    backoff_seconds if has_error or status == "not_configured" else interval_seconds
+                )
             except GuardSyncAuthorizationExpiredError as error:
                 self._server.store.set_sync_payload(
                     "aibom_inventory_daemon",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5732,9 +5732,7 @@ class GuardDaemonServer:
                     {**summary, "status": status, "refreshed_at": refreshed_at},
                     refreshed_at,
                 )
-                wait_seconds = (
-                    backoff_seconds if has_error or status == "not_configured" else interval_seconds
-                )
+                wait_seconds = backoff_seconds if has_error or status == "not_configured" else interval_seconds
             except GuardSyncAuthorizationExpiredError as error:
                 self._server.store.set_sync_payload(
                     "aibom_inventory_daemon",

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5494,6 +5494,7 @@ class GuardDaemonServer:
                 raise RuntimeError("AIBOM inventory refresh is still stopping")
             self._aibom_refresh_thread = None
         self._shutdown_started.clear()
+        self._persist_aibom_inventory_context()
         self._server.last_activity_monotonic = time.monotonic()
         write_guard_daemon_state(self._server.store.guard_home, self.port, self._server.auth_token)
         self._server.store.upsert_runtime_state(
@@ -5512,6 +5513,19 @@ class GuardDaemonServer:
             self._server.store,
             self._live_request_sync_worker,
         )
+
+    def _persist_aibom_inventory_context(self) -> None:
+        workspace_id = self._server.store.get_cloud_workspace_id()
+        if workspace_id is None or self._aibom_workspace_dir is None:
+            return
+        payload: dict[str, object] = {
+            "workspace_dir": str(self._aibom_workspace_dir),
+            "workspace_id": workspace_id,
+        }
+        if self._aibom_home_dir is not None:
+            payload["home_dir"] = str(self._aibom_home_dir)
+        now = _now()
+        self._server.store.set_sync_payload("aibom_inventory_context", payload, now)
 
     def _serve_forever(self) -> None:
         try:
@@ -5653,36 +5667,24 @@ class GuardDaemonServer:
 
     def _aibom_inventory_context_dirs(self) -> tuple[Path | None, Path | None]:
         payload = self._server.store.get_sync_payload("aibom_inventory_context")
-        if isinstance(payload, dict):
+        current_workspace_id = self._server.store.get_cloud_workspace_id()
+        payload_is_bound = (
+            isinstance(payload, dict)
+            and isinstance(payload.get("workspace_id"), str)
+            and payload.get("workspace_id") == current_workspace_id
+        )
+        if payload_is_bound:
             home_value = payload.get("home_dir")
             workspace_value = payload.get("workspace_dir")
         else:
             home_value = None
             workspace_value = None
-        home_dir = (
-            Path(home_value).expanduser()
-            if isinstance(home_value, str) and home_value.strip()
-            else self._aibom_home_dir
-        )
-        workspace_dir = (
-            Path(workspace_value).expanduser()
-            if isinstance(workspace_value, str) and workspace_value.strip()
-            else self._aibom_workspace_dir
-        )
-        if workspace_dir is None:
-            managed_workspace_dirs = managed_install_audit_workspace_dirs(self._server.store)
-            allowed_roots: list[Path] = []
-            for managed_workspace in managed_workspace_dirs:
-                try:
-                    allowed_roots.append(Path(managed_workspace).expanduser().resolve())
-                except OSError:
-                    continue
-            workspace_dir = resolve_supply_chain_audit_workspace_dir(
-                workspace_dir_value=None,
-                workspace_value=None,
-                allowed_roots=tuple(allowed_roots),
-                managed_workspace_dirs=managed_workspace_dirs,
-            )
+        home_dir = self._aibom_home_dir
+        if home_dir is None and isinstance(home_value, str) and home_value.strip():
+            home_dir = Path(home_value).expanduser()
+        workspace_dir = self._aibom_workspace_dir
+        if workspace_dir is None and isinstance(workspace_value, str) and workspace_value.strip():
+            workspace_dir = Path(workspace_value).expanduser()
         return home_dir, workspace_dir
 
     def _refresh_aibom_inventory_loop(self) -> None:

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5668,14 +5668,16 @@ class GuardDaemonServer:
     def _aibom_inventory_context_dirs(self) -> tuple[Path | None, Path | None]:
         payload = self._server.store.get_sync_payload("aibom_inventory_context")
         current_workspace_id = self._server.store.get_cloud_workspace_id()
-        payload_is_bound = (
-            isinstance(payload, dict)
-            and isinstance(payload.get("workspace_id"), str)
+        bound_payload: dict[str, object] | None = None
+        if (
+            current_workspace_id is not None
+            and isinstance(payload, dict)
             and payload.get("workspace_id") == current_workspace_id
-        )
-        if payload_is_bound:
-            home_value = payload.get("home_dir")
-            workspace_value = payload.get("workspace_dir")
+        ):
+            bound_payload = payload
+        if bound_payload is not None:
+            home_value = bound_payload.get("home_dir")
+            workspace_value = bound_payload.get("workspace_dir")
         else:
             home_value = None
             workspace_value = None

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -5444,6 +5444,9 @@ class GuardDaemonServer:
         self._headless_cloud_sync_interval_seconds = _DEFAULT_HEADLESS_CLOUD_SYNC_INTERVAL_SECONDS
         self._aibom_home_dir = home_dir.expanduser() if home_dir is not None else None
         self._aibom_workspace_dir = workspace_dir.expanduser() if workspace_dir is not None else None
+        self._aibom_context_workspace_id = (
+            store.get_cloud_workspace_id() if self._aibom_workspace_dir is not None else None
+        )
         self._aibom_refresh_thread: threading.Thread | None = None
         self._bundle_refresh_thread: threading.Thread | None = None
         self._command_queue_worker: CommandQueueWorker | None = None
@@ -5516,7 +5519,11 @@ class GuardDaemonServer:
 
     def _persist_aibom_inventory_context(self) -> None:
         workspace_id = self._server.store.get_cloud_workspace_id()
-        if workspace_id is None or self._aibom_workspace_dir is None:
+        if (
+            workspace_id is None
+            or workspace_id != self._aibom_context_workspace_id
+            or self._aibom_workspace_dir is None
+        ):
             return
         payload: dict[str, object] = {
             "workspace_dir": str(self._aibom_workspace_dir),
@@ -5665,7 +5672,7 @@ class GuardDaemonServer:
         )
         self._aibom_refresh_thread.start()
 
-    def _aibom_inventory_context_dirs(self) -> tuple[Path | None, Path | None]:
+    def _aibom_inventory_context_dirs(self) -> tuple[Path | None, Path | None, str | None]:
         payload = self._server.store.get_sync_payload("aibom_inventory_context")
         current_workspace_id = self._server.store.get_cloud_workspace_id()
         bound_payload: dict[str, object] | None = None
@@ -5681,13 +5688,17 @@ class GuardDaemonServer:
         else:
             home_value = None
             workspace_value = None
-        home_dir = self._aibom_home_dir
+        explicit_context_is_bound = (
+            self._aibom_workspace_dir is not None and self._aibom_context_workspace_id == current_workspace_id
+        )
+        home_dir = self._aibom_home_dir if explicit_context_is_bound else None
         if home_dir is None and isinstance(home_value, str) and home_value.strip():
             home_dir = Path(home_value).expanduser()
-        workspace_dir = self._aibom_workspace_dir
+        workspace_dir = self._aibom_workspace_dir if explicit_context_is_bound else None
         if workspace_dir is None and isinstance(workspace_value, str) and workspace_value.strip():
             workspace_dir = Path(workspace_value).expanduser()
-        return home_dir, workspace_dir
+        bound_workspace_id = current_workspace_id if workspace_dir is not None else None
+        return home_dir, workspace_dir, bound_workspace_id
 
     def _refresh_aibom_inventory_loop(self) -> None:
         interval_seconds = self._aibom_refresh_interval_seconds
@@ -5699,7 +5710,7 @@ class GuardDaemonServer:
         while not self._shutdown_started.is_set():
             refreshed_at = _now()
             try:
-                home_dir, workspace_dir = self._aibom_inventory_context_dirs()
+                home_dir, workspace_dir, bound_workspace_id = self._aibom_inventory_context_dirs()
                 if workspace_dir is None:
                     self._server.store.set_sync_payload(
                         "aibom_inventory_daemon",
@@ -5721,6 +5732,7 @@ class GuardDaemonServer:
                         generated_at=refreshed_at,
                         min_interval_seconds=max(int(interval_seconds), 1),
                         auth_context=auth_context,
+                        expected_workspace_id=bound_workspace_id,
                         home_dir=home_dir,
                         workspace_dir=workspace_dir,
                     )

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1599,6 +1599,9 @@ def sync_receipts(
         aibom_context["home_dir"] = str(home_dir)
     if workspace_dir is not None:
         aibom_context["workspace_dir"] = str(workspace_dir)
+        workspace_id = store.get_cloud_workspace_id()
+        if workspace_id is not None:
+            aibom_context["workspace_id"] = workspace_id
     if aibom_context:
         store.set_sync_payload("aibom_inventory_context", aibom_context, now)
     if persisted_command_detail_backfill_marker is not None:

--- a/tests/test_guard_aibom_cli.py
+++ b/tests/test_guard_aibom_cli.py
@@ -340,6 +340,48 @@ def test_sync_aibom_snapshots_if_due_skips_recent_sync(tmp_path: Path, monkeypat
     assert summary.get("reason") == "recently_synced"
 
 
+def test_sync_aibom_snapshots_if_due_rejects_changed_workspace(tmp_path: Path, monkeypatch) -> None:
+    from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots_if_due
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-beta")
+
+    summary = sync_aibom_snapshots_if_due(
+        store,
+        generated_at="2026-06-10T13:00:00+00:00",
+        expected_workspace_id="workspace-alpha",
+    )
+
+    assert summary == {
+        "synced": False,
+        "reason": "workspace_changed",
+        "error": "Guard Cloud workspace changed before AIBOM inventory sync.",
+    }
+
+
+def test_sync_aibom_snapshots_if_due_binds_current_workspace(tmp_path: Path, monkeypatch) -> None:
+    from codex_plugin_scanner.guard import aibom_cli
+
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-alpha")
+    calls: list[dict[str, object]] = []
+
+    def _fake_sync(*_args: object, **kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {"synced": True}
+
+    monkeypatch.setattr(aibom_cli, "sync_aibom_snapshots", _fake_sync)
+
+    summary = aibom_cli.sync_aibom_snapshots_if_due(
+        store,
+        generated_at="2026-06-10T13:00:00+00:00",
+        force=True,
+    )
+
+    assert summary == {"synced": True}
+    assert calls[0]["expected_workspace_id"] == "workspace-alpha"
+
+
 def test_sync_aibom_snapshots_if_due_skips_recent_empty_sync(tmp_path: Path, monkeypatch) -> None:
     from codex_plugin_scanner.guard.aibom_cli import sync_aibom_snapshots_if_due
 
@@ -489,6 +531,24 @@ def test_resolve_trust_attestation_context_includes_workspace_device_for_v2(
     assert context["installationId"] == "device-1"
     assert context["policyVersion"] == "guard-aibom-trust-policy.v1"
     assert context["uploadId"] is None
+
+
+def test_resolve_trust_attestation_context_uses_workspace_override(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    store = GuardStore(tmp_path / "guard")
+    monkeypatch.setattr(store, "get_cloud_workspace_id", lambda: "workspace-beta")
+    monkeypatch.setattr(store, "get_or_create_installation_id", lambda: "device-1")
+    monkeypatch.setenv("GUARD_AIBOM_TRUST_ATTESTATION_V2", "1")
+
+    context = aibom_cli._resolve_trust_attestation_context(
+        store,
+        generated_at="2026-06-10T12:00:00+00:00",
+        workspace_id="workspace-alpha",
+    )
+
+    assert context["workspaceId"] == "workspace-alpha"
     assert context["challengeId"] is None
     assert context["nonce"] is None
     assert context["sequence"] is None

--- a/tests/test_guard_event_schema_v1.py
+++ b/tests/test_guard_event_schema_v1.py
@@ -335,6 +335,7 @@ def test_sync_receipts_runs_aibom_when_deep_sync_is_requested(tmp_path, monkeypa
             store,
             sync_url=f"http://127.0.0.1:{server.server_port}/api/guard/receipts/sync",
             token="token-1",
+            workspace_id="workspace-alpha",
         )
         home_dir = tmp_path / "home"
         workspace_dir = tmp_path / "workspace"
@@ -351,6 +352,11 @@ def test_sync_receipts_runs_aibom_when_deep_sync_is_requested(tmp_path, monkeypa
 
     assert calls == [(home_dir, workspace_dir)]
     assert result["aibom_inventory"] == {"synced": True, "accepted": 1}
+    assert store.get_sync_payload("aibom_inventory_context") == {
+        "home_dir": str(home_dir),
+        "workspace_dir": str(workspace_dir),
+        "workspace_id": "workspace-alpha",
+    }
 
 
 def test_sync_receipts_keeps_receipt_success_when_v1_events_endpoint_is_missing(tmp_path) -> None:

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -231,6 +231,11 @@ def test_daemon_aibom_refresh_records_synced_on_success(
     assert summary["status"] == "synced"
     assert summary["synced"] is True
     assert summary["snapshots"] == 2
+    assert store.get_sync_payload("aibom_inventory_context") == {
+        "home_dir": str(home_dir),
+        "workspace_dir": str(workspace_dir),
+        "workspace_id": "workspace-alpha",
+    }
 
 
 def test_daemon_aibom_refresh_records_skipped_when_not_due(
@@ -267,11 +272,11 @@ def test_daemon_aibom_refresh_records_skipped_when_not_due(
     assert summary["skipped"] is True
 
 
-def test_daemon_aibom_refresh_resolves_managed_workspace_context(
+def test_daemon_aibom_refresh_uses_workspace_bound_persisted_context(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    """AIBOM daemon resolves an audited workspace before publishing inventory."""
+    """AIBOM daemon reuses context only when it matches the paired cloud workspace."""
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store, workspace_id="workspace-alpha")
     calls: list[dict[str, object]] = []
@@ -280,24 +285,13 @@ def test_daemon_aibom_refresh_resolves_managed_workspace_context(
         calls.append(kwargs)
         return {"synced": True, "synced_at": "2026-06-29T00:00:00Z", "snapshots": 1, "accepted": 1}
 
+    workspace_dir = tmp_path / "workspace"
+    store.set_sync_payload(
+        "aibom_inventory_context",
+        {"workspace_dir": str(workspace_dir), "workspace_id": "workspace-alpha"},
+        "2026-06-29T00:00:00Z",
+    )
     monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fake_sync)
-    resolved_workspace = tmp_path / "managed-workspace"
-    resolver_calls: list[dict[str, object]] = []
-
-    def _resolve_workspace(**kwargs: object) -> Path:
-        resolver_calls.append(kwargs)
-        return resolved_workspace
-
-    monkeypatch.setattr(
-        guard_daemon_module,
-        "managed_install_audit_workspace_dirs",
-        lambda _store: (str(resolved_workspace),),
-    )
-    monkeypatch.setattr(
-        guard_daemon_module,
-        "resolve_supply_chain_audit_workspace_dir",
-        _resolve_workspace,
-    )
     daemon = guard_daemon_module.GuardDaemonServer(
         store,
         host="127.0.0.1",
@@ -313,9 +307,47 @@ def test_daemon_aibom_refresh_resolves_managed_workspace_context(
         daemon.stop()
 
     assert calls[0]["home_dir"] is None
-    assert calls[0]["workspace_dir"] == resolved_workspace
-    assert resolver_calls[0]["allowed_roots"] == (resolved_workspace.resolve(),)
+    assert calls[0]["workspace_dir"] == workspace_dir
     assert summary["synced"] is True
+
+
+def test_daemon_aibom_refresh_rejects_mismatched_persisted_context(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Persisted paths from another cloud workspace cannot drive inventory uploads."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    store.set_sync_payload(
+        "aibom_inventory_context",
+        {
+            "workspace_dir": str(tmp_path / "wrong-workspace"),
+            "workspace_id": "workspace-beta",
+        },
+        "2026-06-29T00:00:00Z",
+    )
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        guard_daemon_module,
+        "sync_aibom_snapshots_if_due",
+        lambda _store, **kwargs: calls.append(kwargs) or {"synced": True},
+    )
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=60,
+        aibom_refresh_backoff_seconds=0.05,
+    )
+    daemon.start()
+    try:
+        summary = _wait_for_aibom_status(store, expected="missing_workspace_context")
+    finally:
+        daemon.stop()
+
+    assert calls == []
+    assert summary["reason"] == "missing_workspace_context"
 
 
 def test_daemon_aibom_refresh_skips_without_workspace_context(
@@ -331,11 +363,6 @@ def test_daemon_aibom_refresh_skips_without_workspace_context(
         guard_daemon_module,
         "sync_aibom_snapshots_if_due",
         lambda _store, **kwargs: calls.append(kwargs) or {"synced": True},
-    )
-    monkeypatch.setattr(
-        guard_daemon_module,
-        "resolve_supply_chain_audit_workspace_dir",
-        lambda **_kwargs: None,
     )
     daemon = guard_daemon_module.GuardDaemonServer(
         store,

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -282,10 +282,21 @@ def test_daemon_aibom_refresh_resolves_managed_workspace_context(
 
     monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fake_sync)
     resolved_workspace = tmp_path / "managed-workspace"
+    resolver_calls: list[dict[str, object]] = []
+
+    def _resolve_workspace(**kwargs: object) -> Path:
+        resolver_calls.append(kwargs)
+        return resolved_workspace
+
+    monkeypatch.setattr(
+        guard_daemon_module,
+        "managed_install_audit_workspace_dirs",
+        lambda _store: (str(resolved_workspace),),
+    )
     monkeypatch.setattr(
         guard_daemon_module,
         "resolve_supply_chain_audit_workspace_dir",
-        lambda **_kwargs: resolved_workspace,
+        _resolve_workspace,
     )
     daemon = guard_daemon_module.GuardDaemonServer(
         store,
@@ -303,6 +314,7 @@ def test_daemon_aibom_refresh_resolves_managed_workspace_context(
 
     assert calls[0]["home_dir"] is None
     assert calls[0]["workspace_dir"] == resolved_workspace
+    assert resolver_calls[0]["allowed_roots"] == (resolved_workspace.resolve(),)
     assert summary["synced"] is True
 
 
@@ -357,6 +369,42 @@ def test_daemon_aibom_refresh_retries_returned_error_on_backoff(
         calls += 1
         if calls == 1:
             return {"synced": False, "error": "temporary upload failure"}
+        return {"synced": True, "snapshots": 2, "accepted": 2}
+
+    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fake_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=60,
+        aibom_refresh_backoff_seconds=0.05,
+        workspace_dir=tmp_path / "workspace",
+    )
+    daemon.start()
+    try:
+        summary = _wait_for_aibom_status(store, expected="synced")
+    finally:
+        daemon.stop()
+
+    assert calls == 2
+    assert summary["synced"] is True
+
+
+def test_daemon_aibom_refresh_retries_not_configured_on_backoff(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A newly configured daemon does not wait for the normal inventory interval."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    calls = 0
+
+    def _fake_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return {"synced": False, "reason": "not_configured", "skipped": True}
         return {"synced": True, "snapshots": 2, "accepted": 2}
 
     monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fake_sync)

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import threading
 import time
 from pathlib import Path
+
+import pytest
 
 from codex_plugin_scanner.guard.daemon import server as guard_daemon_module
 from codex_plugin_scanner.guard.runtime.runner import GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError
@@ -209,7 +212,7 @@ def test_daemon_aibom_refresh_records_synced_on_success(
         host="127.0.0.1",
         port=0,
         idle_timeout_seconds=60,
-        aibom_refresh_interval_seconds=0.05,
+        aibom_refresh_interval_seconds=60,
         aibom_refresh_backoff_seconds=0.05,
         home_dir=home_dir,
         workspace_dir=workspace_dir,
@@ -264,24 +267,70 @@ def test_daemon_aibom_refresh_records_skipped_when_not_due(
     assert summary["skipped"] is True
 
 
-def test_daemon_aibom_refresh_waits_for_workspace_context(
+def test_daemon_aibom_refresh_resolves_managed_workspace_context(
     tmp_path: Path,
     monkeypatch,
 ) -> None:
-    """AIBOM daemon records a skipped status instead of syncing without a workspace."""
+    """AIBOM daemon resolves an audited workspace before publishing inventory."""
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    calls: list[dict[str, object]] = []
 
-    def _unexpected_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
-        raise AssertionError("AIBOM sync should wait for a real workspace context")
+    def _fake_sync(_store: GuardStore, **kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {"synced": True, "synced_at": "2026-06-29T00:00:00Z", "snapshots": 1, "accepted": 1}
 
-    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _unexpected_sync)
+    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fake_sync)
+    resolved_workspace = tmp_path / "managed-workspace"
+    monkeypatch.setattr(
+        guard_daemon_module,
+        "resolve_supply_chain_audit_workspace_dir",
+        lambda **_kwargs: resolved_workspace,
+    )
     daemon = guard_daemon_module.GuardDaemonServer(
         store,
         host="127.0.0.1",
         port=0,
         idle_timeout_seconds=60,
-        aibom_refresh_interval_seconds=0.05,
+        aibom_refresh_interval_seconds=60,
+        aibom_refresh_backoff_seconds=0.05,
+    )
+    daemon.start()
+    try:
+        summary = _wait_for_aibom_status(store, expected="synced")
+    finally:
+        daemon.stop()
+
+    assert calls[0]["home_dir"] is None
+    assert calls[0]["workspace_dir"] == resolved_workspace
+    assert summary["synced"] is True
+
+
+def test_daemon_aibom_refresh_skips_without_workspace_context(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """AIBOM daemon does not replace a full snapshot with a home-only scan."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    calls: list[dict[str, object]] = []
+
+    monkeypatch.setattr(
+        guard_daemon_module,
+        "sync_aibom_snapshots_if_due",
+        lambda _store, **kwargs: calls.append(kwargs) or {"synced": True},
+    )
+    monkeypatch.setattr(
+        guard_daemon_module,
+        "resolve_supply_chain_audit_workspace_dir",
+        lambda **_kwargs: None,
+    )
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=60,
         aibom_refresh_backoff_seconds=0.05,
     )
     daemon.start()
@@ -290,8 +339,44 @@ def test_daemon_aibom_refresh_waits_for_workspace_context(
     finally:
         daemon.stop()
 
-    assert summary["skipped"] is True
+    assert calls == []
     assert summary["reason"] == "missing_workspace_context"
+
+
+def test_daemon_aibom_refresh_retries_returned_error_on_backoff(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Returned sync errors retry on backoff instead of waiting for the normal interval."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    calls = 0
+
+    def _fake_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return {"synced": False, "error": "temporary upload failure"}
+        return {"synced": True, "snapshots": 2, "accepted": 2}
+
+    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _fake_sync)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=60,
+        aibom_refresh_backoff_seconds=0.05,
+        workspace_dir=tmp_path / "workspace",
+    )
+    daemon.start()
+    try:
+        summary = _wait_for_aibom_status(store, expected="synced")
+    finally:
+        daemon.stop()
+
+    assert calls == 2
+    assert summary["synced"] is True
 
 
 def test_daemon_aibom_refresh_records_error_on_exception(
@@ -357,3 +442,43 @@ def test_daemon_aibom_refresh_stops_cleanly(
 
     # Thread reference is cleared and no longer alive after stop
     assert daemon._aibom_refresh_thread is None
+
+
+def test_daemon_retains_blocked_aibom_refresh_thread_during_shutdown(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A blocked refresh remains tracked and prevents a concurrent daemon restart."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    entered = threading.Event()
+    release = threading.Event()
+
+    def _blocked_sync(_store: GuardStore, **_kwargs: object) -> dict[str, object]:
+        entered.set()
+        release.wait(timeout=5)
+        return {"synced": True}
+
+    monkeypatch.setattr(guard_daemon_module, "sync_aibom_snapshots_if_due", _blocked_sync)
+    monkeypatch.setattr(guard_daemon_module, "_AIBOM_REFRESH_STOP_JOIN_TIMEOUT_SECONDS", 0.01)
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=60,
+        workspace_dir=tmp_path / "workspace",
+    )
+    daemon.start()
+    assert entered.wait(timeout=1)
+
+    daemon.stop()
+    refresh_thread = daemon._aibom_refresh_thread
+    assert refresh_thread is not None
+    assert refresh_thread.is_alive()
+    with pytest.raises(RuntimeError, match="still stopping"):
+        daemon.start()
+
+    release.set()
+    refresh_thread.join(timeout=1)
+    assert not refresh_thread.is_alive()

--- a/tests/test_guard_supply_chain_daemon.py
+++ b/tests/test_guard_supply_chain_daemon.py
@@ -226,6 +226,7 @@ def test_daemon_aibom_refresh_records_synced_on_success(
     assert calls
     assert calls[0]["home_dir"] == home_dir
     assert calls[0]["workspace_dir"] == workspace_dir
+    assert calls[0]["expected_workspace_id"] == "workspace-alpha"
     summary = store.get_sync_payload("aibom_inventory_daemon")
     assert isinstance(summary, dict)
     assert summary["status"] == "synced"
@@ -348,6 +349,41 @@ def test_daemon_aibom_refresh_rejects_mismatched_persisted_context(
 
     assert calls == []
     assert summary["reason"] == "missing_workspace_context"
+
+
+def test_daemon_aibom_refresh_rejects_explicit_context_after_repair(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A daemon cannot reuse constructor context after pairing changes workspaces."""
+    store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-alpha")
+    calls: list[dict[str, object]] = []
+    monkeypatch.setattr(
+        guard_daemon_module,
+        "sync_aibom_snapshots_if_due",
+        lambda _store, **kwargs: calls.append(kwargs) or {"synced": True},
+    )
+    daemon = guard_daemon_module.GuardDaemonServer(
+        store,
+        host="127.0.0.1",
+        port=0,
+        idle_timeout_seconds=60,
+        aibom_refresh_interval_seconds=60,
+        aibom_refresh_backoff_seconds=0.05,
+        workspace_dir=tmp_path / "workspace-alpha",
+    )
+    _seed_guard_cloud(store, workspace_id="workspace-beta")
+
+    daemon.start()
+    try:
+        summary = _wait_for_aibom_status(store, expected="missing_workspace_context")
+    finally:
+        daemon.stop()
+
+    assert calls == []
+    assert summary["reason"] == "missing_workspace_context"
+    assert store.get_sync_payload("aibom_inventory_context") is None
 
 
 def test_daemon_aibom_refresh_skips_without_workspace_context(


### PR DESCRIPTION
## Summary

- persist AIBOM inventory context with its Guard Cloud workspace binding
- refresh immediately only from explicit or matching workspace-bound context
- keep workspace identity immutable across trust metadata, inventory events, and content upload
- retry returned errors and unconfigured state on backoff
- retain in-flight refresh threads during shutdown and prevent overlapping restarts

## Testing

- `uv run pytest -q tests/test_guard_supply_chain_daemon.py tests/test_guard_aibom_cli.py tests/test_guard_event_schema_v1.py` (57 passed)
- `uv run --extra dev basedpyright --level error`
- `uv run ruff format --check` (changed files)
- `uv run ruff check` (changed source and focused tests)
- `git diff --check`