### PR TITLE
fix(guard): extract cloud_user_profile during OAuth token refresh

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -21,6 +21,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 from ...version import __version__
+from ..package_firewall_defaults import extract_cloud_user_profile as _extract_cloud_user_profile
 from ..package_firewall_entitlement import (
     build_oauth_package_firewall_entitlement,
     reconcile_connect_state_with_oauth_entitlement,
@@ -176,24 +177,6 @@ def _read_nested_string(payload: dict[str, object], *path: str) -> str | None:
             return None
         current = current.get(segment)
     return current if isinstance(current, str) and current else None
-
-
-def _extract_cloud_user_profile(payload: dict[str, object]) -> dict[str, str] | None:
-    """Extract user profile (email, display_name, avatar_url) from guard_local_entitlement."""
-    entitlement = payload.get("guard_local_entitlement")
-    if not isinstance(entitlement, dict):
-        return None
-    profile = entitlement.get("user_profile")
-    if not isinstance(profile, dict):
-        return None
-    email = profile.get("email")
-    if not isinstance(email, str) or not email:
-        return None
-    return {
-        "email": email,
-        "display_name": str(profile.get("display_name") or ""),
-        "avatar_url": str(profile.get("avatar_url") or ""),
-    }
 
 
 def _guard_access_token_expires_at(

--- a/src/codex_plugin_scanner/guard/package_firewall_defaults.py
+++ b/src/codex_plugin_scanner/guard/package_firewall_defaults.py
@@ -36,3 +36,28 @@ def build_guard_local_entitlement_defaults(
         "supply_chain_firewall": allowed,
         "supply_chain_plan_id": normalized_tier,
     }
+
+
+def extract_cloud_user_profile(payload: dict[str, object]) -> dict[str, str] | None:
+    """Extract user profile (email, display_name, avatar_url) from guard_local_entitlement.
+
+    Works on both the full token-exchange payload and the raw guard_local_entitlement dict.
+    """
+    entitlement = payload.get("guard_local_entitlement")
+    if not isinstance(entitlement, dict):
+        # If payload IS the entitlement dict, use it directly
+        if "user_profile" in payload:
+            entitlement = payload
+        else:
+            return None
+    profile = entitlement.get("user_profile")
+    if not isinstance(profile, dict):
+        return None
+    email = profile.get("email")
+    if not isinstance(email, str) or not email:
+        return None
+    return {
+        "email": email,
+        "display_name": str(profile.get("display_name") or ""),
+        "avatar_url": str(profile.get("avatar_url") or ""),
+    }

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3228,12 +3228,13 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
         effective_cloud_user_profile = refreshed_cloud_user_profile or _extract_dict_field(
             oauth_credentials, "cloud_user_profile"
         )
+    stored_cloud_user_profile = _extract_dict_field(oauth_credentials, "cloud_user_profile")
+    profile_changed = effective_cloud_user_profile != stored_cloud_user_profile
     if (
         force_refresh
         or rotated_refresh_token != refresh_token
         or package_firewall_entitlement is not None
-        or effective_cloud_user_profile is not None
-        or (had_entitlement and refreshed_cloud_user_profile is None)
+        or profile_changed
         or persist_recovered_secret
     ):
         _persist_rotated_oauth_refresh_token(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -3026,6 +3026,7 @@ def _refresh_guard_oauth_access_token(
                 now=datetime.now(timezone.utc),
             ),
             "cloud_user_profile": extract_cloud_user_profile(payload),
+            "had_guard_local_entitlement": isinstance(payload.get("guard_local_entitlement"), dict),
             "refresh_token": _optional_string(payload.get("refresh_token")) or refresh_token,
         }
 
@@ -3162,7 +3163,7 @@ def _persist_rotated_oauth_refresh_token(
             else _optional_string(credentials.get("supply_chain_plan_id"))
         ),
         workspace_id=_optional_string(credentials.get("workspace_id")),
-        cloud_user_profile=cloud_user_profile or _extract_dict_field(credentials, "cloud_user_profile"),
+        cloud_user_profile=cloud_user_profile,
         runtime_id=_optional_string(credentials.get("runtime_id")),
         runtime_label=_optional_string(credentials.get("runtime_label")),
         access_token=access_token,
@@ -3216,18 +3217,30 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
     refreshed_cloud_user_profile = refreshed.get("cloud_user_profile")
     if not isinstance(refreshed_cloud_user_profile, dict):
         refreshed_cloud_user_profile = None
+    had_entitlement = bool(refreshed.get("had_guard_local_entitlement"))
+    # When the refresh response includes a guard_local_entitlement but no
+    # user_profile, clear the stale profile rather than preserving it.
+    # When there's no guard_local_entitlement at all (old server), keep existing.
+    effective_cloud_user_profile: dict[str, str] | None
+    if had_entitlement:
+        effective_cloud_user_profile = refreshed_cloud_user_profile
+    else:
+        effective_cloud_user_profile = refreshed_cloud_user_profile or _extract_dict_field(
+            oauth_credentials, "cloud_user_profile"
+        )
     if (
         force_refresh
         or rotated_refresh_token != refresh_token
         or package_firewall_entitlement is not None
-        or refreshed_cloud_user_profile is not None
+        or effective_cloud_user_profile is not None
+        or (had_entitlement and refreshed_cloud_user_profile is None)
         or persist_recovered_secret
     ):
         _persist_rotated_oauth_refresh_token(
             store=store,
             credentials=oauth_credentials,
             package_firewall_entitlement=package_firewall_entitlement,
-            cloud_user_profile=refreshed_cloud_user_profile,
+            cloud_user_profile=effective_cloud_user_profile,
             refresh_token=rotated_refresh_token,
             access_token=_optional_string(refreshed.get("access_token")),
             access_token_expires_at=_optional_string(refreshed.get("access_token_expires_at")),

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -46,6 +46,7 @@ from ..cloud_exceptions import (
 from ..config import VALID_RECEIPT_REDACTION_LEVELS, GuardConfig, load_guard_config
 from ..edge_events import build_runtime_session_event
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
+from ..package_firewall_defaults import extract_cloud_user_profile
 from ..package_firewall_entitlement import (
     build_oauth_package_firewall_entitlement,
     reconcile_connect_state_with_oauth_entitlement,
@@ -3024,6 +3025,7 @@ def _refresh_guard_oauth_access_token(
                 payload,
                 now=datetime.now(timezone.utc),
             ),
+            "cloud_user_profile": extract_cloud_user_profile(payload),
             "refresh_token": _optional_string(payload.get("refresh_token")) or refresh_token,
         }
 
@@ -3110,6 +3112,7 @@ def _persist_rotated_oauth_refresh_token(
     store: GuardStore,
     credentials: dict[str, object],
     package_firewall_entitlement: dict[str, object] | None = None,
+    cloud_user_profile: dict[str, str] | None = None,
     refresh_token: str,
     access_token: str | None = None,
     access_token_expires_at: str | None = None,
@@ -3159,7 +3162,7 @@ def _persist_rotated_oauth_refresh_token(
             else _optional_string(credentials.get("supply_chain_plan_id"))
         ),
         workspace_id=_optional_string(credentials.get("workspace_id")),
-        cloud_user_profile=_extract_dict_field(credentials, "cloud_user_profile"),
+        cloud_user_profile=cloud_user_profile or _extract_dict_field(credentials, "cloud_user_profile"),
         runtime_id=_optional_string(credentials.get("runtime_id")),
         runtime_label=_optional_string(credentials.get("runtime_label")),
         access_token=access_token,
@@ -3210,16 +3213,21 @@ def _resolve_guard_sync_auth_context_from_oauth_credentials(
     package_firewall_entitlement: dict[str, object] | None = (
         refreshed_entitlement if isinstance(refreshed_entitlement, dict) else None
     )
+    refreshed_cloud_user_profile = refreshed.get("cloud_user_profile")
+    if not isinstance(refreshed_cloud_user_profile, dict):
+        refreshed_cloud_user_profile = None
     if (
         force_refresh
         or rotated_refresh_token != refresh_token
         or package_firewall_entitlement is not None
+        or refreshed_cloud_user_profile is not None
         or persist_recovered_secret
     ):
         _persist_rotated_oauth_refresh_token(
             store=store,
             credentials=oauth_credentials,
             package_firewall_entitlement=package_firewall_entitlement,
+            cloud_user_profile=refreshed_cloud_user_profile,
             refresh_token=rotated_refresh_token,
             access_token=_optional_string(refreshed.get("access_token")),
             access_token_expires_at=_optional_string(refreshed.get("access_token_expires_at")),

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -432,3 +432,67 @@ def test_prepare_guard_cloud_connect_authorization_persists_refreshed_cloud_user
     assert profile["email"] == "user@hol.org"
     assert profile["display_name"] == "Test User"
     assert profile["avatar_url"] == "https://hol.org/avatar.png"
+
+
+def test_prepare_guard_cloud_connect_authorization_clears_stale_cloud_user_profile(tmp_path, monkeypatch) -> None:
+    """When refresh response has guard_local_entitlement but no user_profile, clear stale profile."""
+    store = _store_with_oauth_credentials(tmp_path)
+    # Seed existing cloud_user_profile in credentials
+    dpop_key_material = generate_dpop_key_pair()
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_private_key_pem=dpop_key_material.private_key_pem,
+        dpop_public_jwk=dpop_key_material.public_jwk,
+        dpop_public_jwk_thumbprint=dpop_key_material.public_jwk_thumbprint,
+        grant_id="grant-1",
+        now=datetime.now(timezone.utc).isoformat(),
+        cloud_user_profile={
+            "email": "old@hol.org",
+            "display_name": "Old User",
+            "avatar_url": "https://hol.org/old.png",
+        },
+    )
+
+    access_token = ".".join(
+        (
+            guard_runner_module._encode_jwt_segment({"alg": "ES256"}),
+            guard_runner_module._encode_jwt_segment({"exp": 9999999999}),
+            "signature",
+        )
+    )
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": access_token,
+                    "refresh_token": "refresh-token-2",
+                    "token_type": "Bearer",
+                    "guard_local_entitlement": {
+                        "plan_id": "team",
+                        "supply_chain_firewall": True,
+                    },
+                }
+            ).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        guard_runner_module.urllib.request,
+        "urlopen",
+        lambda request, timeout: _Response(),
+    )
+
+    guard_runner_module.prepare_guard_cloud_connect_authorization(store)
+
+    credentials = store.get_oauth_local_credentials(allow_primary=True)
+    assert credentials is not None
+    # Profile should be cleared (not preserved) because entitlement was present but lacked user_profile
+    profile = credentials.get("cloud_user_profile")
+    assert profile is None

--- a/tests/test_guard_oauth_reconnect.py
+++ b/tests/test_guard_oauth_reconnect.py
@@ -281,3 +281,154 @@ def test_resolve_guard_sync_auth_context_skips_primary_repair_for_package_eval(t
         guard_runner_module._resolve_guard_sync_auth_context(store, allow_primary_repair=False)
 
     assert allow_primary_calls == [False]
+
+
+def test_refresh_guard_oauth_access_token_extracts_cloud_user_profile(monkeypatch) -> None:
+    """Token refresh should extract cloud_user_profile from guard_local_entitlement in the response."""
+    access_token = ".".join(
+        (
+            guard_runner_module._encode_jwt_segment({"alg": "ES256"}),
+            guard_runner_module._encode_jwt_segment({"exp": 9999999999}),
+            "signature",
+        )
+    )
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": access_token,
+                    "refresh_token": "refresh-token-2",
+                    "token_type": "Bearer",
+                    "guard_local_entitlement": {
+                        "plan_id": "team",
+                        "supply_chain_firewall": True,
+                        "user_profile": {
+                            "email": "user@hol.org",
+                            "display_name": "Test User",
+                            "avatar_url": "https://hol.org/avatar.png",
+                        },
+                    },
+                }
+            ).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        guard_runner_module.urllib.request,
+        "urlopen",
+        lambda request, timeout: _Response(),
+    )
+
+    refreshed = guard_runner_module._refresh_guard_oauth_access_token(
+        token_endpoint="https://hol.org/api/guard/oauth/token",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_key_material=generate_dpop_key_pair(),
+    )
+
+    assert refreshed["cloud_user_profile"] == {
+        "email": "user@hol.org",
+        "display_name": "Test User",
+        "avatar_url": "https://hol.org/avatar.png",
+    }
+
+
+def test_refresh_guard_oauth_access_token_returns_none_cloud_user_profile_when_absent(monkeypatch) -> None:
+    """Token refresh should return None for cloud_user_profile when entitlement lacks user_profile."""
+    access_token = ".".join(
+        (
+            guard_runner_module._encode_jwt_segment({"alg": "ES256"}),
+            guard_runner_module._encode_jwt_segment({"exp": 9999999999}),
+            "signature",
+        )
+    )
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": access_token,
+                    "refresh_token": "refresh-token-2",
+                    "token_type": "Bearer",
+                }
+            ).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        guard_runner_module.urllib.request,
+        "urlopen",
+        lambda request, timeout: _Response(),
+    )
+
+    refreshed = guard_runner_module._refresh_guard_oauth_access_token(
+        token_endpoint="https://hol.org/api/guard/oauth/token",
+        client_id="guard-local-daemon",
+        refresh_token="refresh-token-1",
+        dpop_key_material=generate_dpop_key_pair(),
+    )
+
+    assert refreshed["cloud_user_profile"] is None
+
+
+def test_prepare_guard_cloud_connect_authorization_persists_refreshed_cloud_user_profile(tmp_path, monkeypatch) -> None:
+    """Token refresh should persist cloud_user_profile into stored OAuth credentials."""
+    store = _store_with_oauth_credentials(tmp_path)
+
+    access_token = ".".join(
+        (
+            guard_runner_module._encode_jwt_segment({"alg": "ES256"}),
+            guard_runner_module._encode_jwt_segment({"exp": 9999999999}),
+            "signature",
+        )
+    )
+
+    class _Response:
+        def read(self) -> bytes:
+            return json.dumps(
+                {
+                    "access_token": access_token,
+                    "refresh_token": "refresh-token-2",
+                    "token_type": "Bearer",
+                    "guard_local_entitlement": {
+                        "plan_id": "team",
+                        "supply_chain_firewall": True,
+                        "user_profile": {
+                            "email": "user@hol.org",
+                            "display_name": "Test User",
+                            "avatar_url": "https://hol.org/avatar.png",
+                        },
+                    },
+                }
+            ).encode("utf-8")
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+    monkeypatch.setattr(
+        guard_runner_module.urllib.request,
+        "urlopen",
+        lambda request, timeout: _Response(),
+    )
+
+    guard_runner_module.prepare_guard_cloud_connect_authorization(store)
+
+    credentials = store.get_oauth_local_credentials(allow_primary=True)
+    assert credentials is not None
+    profile = credentials.get("cloud_user_profile")
+    assert isinstance(profile, dict)
+    assert profile["email"] == "user@hol.org"
+    assert profile["display_name"] == "Test User"
+    assert profile["avatar_url"] == "https://hol.org/avatar.png"


### PR DESCRIPTION
## Problem

Users who connected to Guard Cloud **before** the portal deployed the `user_profile` field in the `guard_local_entitlement` response have `cloud_user_profile=null` in their stored OAuth credentials. This means the `CloudUserMenu` sidebar component (from #1392) never renders — users see no avatar, name, or email despite being connected.

## Root Cause

The token refresh flow (`_refresh_guard_oauth_access_token`) only preserved the **existing** `cloud_user_profile` from stored credentials via `_extract_dict_field(credentials, "cloud_user_profile")`. It never extracted the fresh `user_profile` from the refreshed `guard_local_entitlement` response.

So even after the portal deployed `user_profile` support, existing users would never get it populated unless they re-paired from scratch.

## Fix

1. **Moved** `extract_cloud_user_profile()` from `connect_flow.py` to `package_firewall_defaults.py` (shared leaf module, no circular import risk)
2. **Extract** `cloud_user_profile` from the refresh response payload in `_refresh_guard_oauth_access_token()`
3. **Prefer** the fresh `cloud_user_profile` over the stale one in `_persist_rotated_oauth_refresh_token()`
4. **Persist** when a fresh profile is received (added to the persist condition)

Any existing user who upgrades will get `cloud_user_profile` populated automatically on their next token refresh cycle — **no re-pairing needed**.

## Test Plan

- [x] `test_refresh_guard_oauth_access_token_extracts_cloud_user_profile` — verifies refresh response with `user_profile` in `guard_local_entitlement` is extracted
- [x] `test_refresh_guard_oauth_access_token_returns_none_cloud_user_profile_when_absent` — verifies `None` when entitlement lacks `user_profile`
- [x] `test_prepare_guard_cloud_connect_authorization_persists_refreshed_cloud_user_profile` — end-to-end: refresh → persist → stored credentials have `cloud_user_profile`
- [x] All 109 existing connect/oauth/surface-server tests pass
- [x] `ruff check` + `ruff format` clean