### PR TITLE
fix(aibom): upload primary content for all harnesses

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_content_upload.py
+++ b/src/codex_plugin_scanner/guard/aibom_content_upload.py
@@ -87,8 +87,6 @@ def primary_content_sources_from_artifacts(
     *,
     workspace_dir: Path | None,
 ) -> tuple[GuardAibomPrimaryContentSource, ...]:
-    if snapshot.agent_type != "hermes":
-        return ()
     items_by_id = {item.item_id: item for item in snapshot.items}
     sources: list[GuardAibomPrimaryContentSource] = []
     for artifact in artifacts:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -1368,7 +1368,11 @@ def _primary_artifact_content_hash(
         allowed_roots = (workspace_dir,)
     else:
         return None
-    if not any(root is not None and resolves_within_root(root, path, require_exists=True) for root in allowed_roots):
+    allowed_root = next(
+        (root for root in allowed_roots if root is not None and resolves_within_root(root, path, require_exists=True)),
+        None,
+    )
+    if allowed_root is None or _path_has_symlink_component(path, allowed_root=allowed_root):
         return None
     try:
         digest = hashlib.sha256()
@@ -1378,6 +1382,21 @@ def _primary_artifact_content_hash(
     except OSError:
         return None
     return f"sha256:{digest.hexdigest()}"
+
+
+def _path_has_symlink_component(path: Path, *, allowed_root: Path) -> bool:
+    try:
+        relative = path.relative_to(allowed_root)
+    except ValueError:
+        return True
+    current = allowed_root
+    if current.is_symlink():
+        return True
+    for part in relative.parts:
+        current = current / part
+        if current.is_symlink():
+            return True
+    return False
 
 
 def _canonical_inventory_content_hash(value: str) -> str:

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -733,11 +733,10 @@ def _item_from_artifact(
         home_dir=home_dir,
         workspace_dir=workspace_dir,
     )
-    content_hash = (
-        primary_content_hash or semantic_text
-        if artifact_type in {"skill", "instruction"}
-        else _resolve_item_content_hash(safe_metadata, semantic_text)
-    )
+    if artifact_type in {"skill", "instruction"}:
+        content_hash = primary_content_hash or semantic_text
+    else:
+        content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
     from .runtime.trust_attestation import (
         GuardTrustAttestationSigningConfig,
         apply_trust_attestation_metadata,

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -15,6 +15,8 @@ from types import SimpleNamespace
 from typing import Literal
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
+from ..path_support import resolves_within_root
+
 InventoryItemKind = Literal[
     "agent",
     "daemon_plugin",
@@ -391,7 +393,7 @@ def cloud_inventory_artifacts_from_detection(
 ) -> tuple[object, ...]:
     """Return artifacts eligible for the cloud inventory contract.
 
-    Hermes supplementary skill files remain part of local detection and policy
+    Supplementary skill files remain part of local detection and policy
     evaluation, but the cloud inventory represents the primary SKILL.md once.
     """
     harness = str(getattr(detection, "harness", "unknown"))
@@ -406,8 +408,7 @@ def cloud_inventory_artifacts_from_detection(
             if artifact.artifact_id not in existing_ids:
                 artifacts.append(artifact)
                 existing_ids.add(artifact.artifact_id)
-    if harness == "hermes":
-        artifacts = [artifact for artifact in artifacts if str(getattr(artifact, "artifact_type", "")) != "skill_file"]
+    artifacts = [artifact for artifact in artifacts if str(getattr(artifact, "artifact_type", "")) != "skill_file"]
     return tuple(artifacts)
 
 
@@ -726,7 +727,12 @@ def _item_from_artifact(
             "metadata": _stable_snapshot_value(safe_metadata),
         }
     )
-    content_hash = _resolve_item_content_hash(safe_metadata, semantic_text)
+    content_hash = _primary_artifact_content_hash(
+        artifact,
+        artifact_type=artifact_type,
+        home_dir=home_dir,
+        workspace_dir=workspace_dir,
+    ) or _resolve_item_content_hash(safe_metadata, semantic_text)
     from .runtime.trust_attestation import (
         GuardTrustAttestationSigningConfig,
         apply_trust_attestation_metadata,
@@ -1332,13 +1338,53 @@ def _resolve_item_content_hash(metadata: dict[str, object], semantic_text: str) 
     for key in ("content_hash", "directory_hash"):
         candidate = metadata.get(key)
         if isinstance(candidate, str) and candidate:
-            return candidate
+            return _canonical_inventory_content_hash(candidate)
     version_info = metadata.get("versionInfo")
     if isinstance(version_info, dict):
         version_hash = version_info.get("contentHash")
         if isinstance(version_hash, str) and version_hash:
-            return version_hash
-    return semantic_text
+            return _canonical_inventory_content_hash(version_hash)
+    return _canonical_inventory_content_hash(semantic_text)
+
+
+def _primary_artifact_content_hash(
+    artifact: object,
+    *,
+    artifact_type: str,
+    home_dir: Path,
+    workspace_dir: Path | None,
+) -> str | None:
+    path_value = getattr(artifact, "config_path", None)
+    if not isinstance(path_value, str) or not path_value.strip():
+        return None
+    path = Path(path_value).expanduser()
+    if artifact_type == "skill":
+        if path.name != "SKILL.md":
+            return None
+        allowed_roots = (home_dir, workspace_dir)
+    elif artifact_type == "instruction":
+        if workspace_dir is None or path.suffix.lower() not in {".md", ".mdc"}:
+            return None
+        allowed_roots = (workspace_dir,)
+    else:
+        return None
+    if not any(root is not None and resolves_within_root(root, path, require_exists=True) for root in allowed_roots):
+        return None
+    try:
+        digest = hashlib.sha256()
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(64 * 1024), b""):
+                digest.update(chunk)
+    except OSError:
+        return None
+    return f"sha256:{digest.hexdigest()}"
+
+
+def _canonical_inventory_content_hash(value: str) -> str:
+    normalized = value.lower()
+    if re.fullmatch(r"[0-9a-f]{64}", normalized):
+        return f"sha256:{normalized}"
+    return value
 
 
 def _safe_roots_for_inspection(

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -1382,7 +1382,7 @@ def _primary_artifact_content_hash(
             ),
             None,
         )
-        if outer_root is None or _path_has_symlink_component(skills_root, allowed_root=outer_root):
+        if outer_root is None:
             return None
         allowed_roots = (skills_root,)
     elif artifact_type == "instruction":

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -1344,7 +1344,7 @@ def _resolve_item_content_hash(metadata: dict[str, object], semantic_text: str) 
         version_hash = version_info.get("contentHash")
         if isinstance(version_hash, str) and version_hash:
             return _canonical_inventory_content_hash(version_hash)
-    return _canonical_inventory_content_hash(semantic_text)
+    return semantic_text
 
 
 def _primary_artifact_content_hash(
@@ -1361,7 +1361,26 @@ def _primary_artifact_content_hash(
     if artifact_type == "skill":
         if path.name != "SKILL.md":
             return None
-        allowed_roots = (home_dir, workspace_dir)
+        skills_root = next((parent for parent in path.parents if parent.name.lower() == "skills"), None)
+        if skills_root is None:
+            return None
+        try:
+            relative = path.relative_to(skills_root)
+        except ValueError:
+            return None
+        if len(relative.parts) < 2:
+            return None
+        outer_root = next(
+            (
+                root
+                for root in (home_dir, workspace_dir)
+                if root is not None and resolves_within_root(root, skills_root, require_exists=True)
+            ),
+            None,
+        )
+        if outer_root is None or _path_has_symlink_component(skills_root, allowed_root=outer_root):
+            return None
+        allowed_roots = (skills_root,)
     elif artifact_type == "instruction":
         if workspace_dir is None or path.suffix.lower() not in {".md", ".mdc"}:
             return None

--- a/src/codex_plugin_scanner/guard/inventory_contract.py
+++ b/src/codex_plugin_scanner/guard/inventory_contract.py
@@ -727,12 +727,17 @@ def _item_from_artifact(
             "metadata": _stable_snapshot_value(safe_metadata),
         }
     )
-    content_hash = _primary_artifact_content_hash(
+    primary_content_hash = _primary_artifact_content_hash(
         artifact,
         artifact_type=artifact_type,
         home_dir=home_dir,
         workspace_dir=workspace_dir,
-    ) or _resolve_item_content_hash(safe_metadata, semantic_text)
+    )
+    content_hash = (
+        primary_content_hash or semantic_text
+        if artifact_type in {"skill", "instruction"}
+        else _resolve_item_content_hash(safe_metadata, semantic_text)
+    )
     from .runtime.trust_attestation import (
         GuardTrustAttestationSigningConfig,
         apply_trust_attestation_metadata,

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -8,10 +8,20 @@ from email.message import Message
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
+from codex_plugin_scanner.guard.adapters.base import HarnessContext
+from codex_plugin_scanner.guard.adapters.gemini import GeminiHarnessAdapter
 from codex_plugin_scanner.guard.aibom_content_upload import (
     GuardAibomPrimaryContentSource,
+    primary_content_sources_from_artifacts,
     upload_primary_content_sources,
 )
+from codex_plugin_scanner.guard.inventory_contract import (
+    cloud_inventory_artifacts_from_detection,
+    inventory_snapshot_from_detection,
+)
+from codex_plugin_scanner.guard.models import GuardArtifact, HarnessDetection
 
 
 def _source(skills_root: Path, index: int) -> GuardAibomPrimaryContentSource:
@@ -32,6 +42,243 @@ def _source(skills_root: Path, index: int) -> GuardAibomPrimaryContentSource:
         snapshot_id="hermes:snapshot:1",
         version_id=f"fingerprint-{index}",
     )
+
+
+@pytest.mark.parametrize(
+    "harness",
+    (
+        "hermes",
+        "openclaw",
+        "codex",
+        "claude-code",
+        "cursor",
+        "antigravity",
+        "gemini",
+        "opencode",
+        "kimi",
+        "grok",
+        "pi",
+        "zcode",
+    ),
+)
+def test_primary_content_sources_include_skill_bodies_for_every_harness(
+    tmp_path: Path,
+    harness: str,
+) -> None:
+    skill_path = tmp_path / f".{harness}" / "skills" / "ops" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    body = f"# {harness} review skill\n".encode()
+    skill_path.write_bytes(body)
+    raw_content_hash = hashlib.sha256(body).hexdigest()
+    item_id = f"{harness}:skill:ops:review"
+    artifact = GuardArtifact(
+        artifact_id=item_id,
+        name="review",
+        harness=harness,
+        artifact_type="skill",
+        source_scope="global",
+        config_path=str(skill_path),
+    )
+    detection = HarnessDetection(
+        harness=harness,
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_path),),
+        artifacts=(artifact,),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=None,
+    )
+
+    assert len(sources) == 1
+    assert sources[0].item_id == item_id
+    assert sources[0].content_hash == f"sha256:{raw_content_hash}"
+    assert sources[0].path == skill_path
+
+
+def test_gemini_adapter_skill_without_metadata_hash_has_uploadable_primary_content(tmp_path: Path) -> None:
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=tmp_path / "guard-home",
+    )
+    skill_path = context.home_dir / ".gemini" / "skills" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Gemini review\n", encoding="utf-8")
+
+    detection = GeminiHarnessAdapter().detect(context)
+    skill_artifact = next(artifact for artifact in detection.artifacts if artifact.artifact_type == "skill")
+    assert "content_hash" not in skill_artifact.metadata
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-10T00:00:00Z",
+        home_dir=context.home_dir,
+    )
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=None,
+    )
+
+    assert len(sources) == 1
+    assert sources[0].content_hash == f"sha256:{hashlib.sha256(skill_path.read_bytes()).hexdigest()}"
+    assert sources[0].path == skill_path
+
+    runner = SimpleNamespace(
+        _guard_sync_request=lambda *_args, **kwargs: SimpleNamespace(data=kwargs["data"]),
+        _urlopen_json_with_timeout_retry=lambda **_kwargs: {
+            "storedCount": 1,
+            "hashOnlyCount": 0,
+            "failedCount": 0,
+        },
+    )
+    summary, _auth_context = upload_primary_content_sources(
+        object(),
+        runner,
+        {"sync_url": "https://hol.test/api/v1/guard/events"},
+        sources=sources,
+        workspace_id="workspace-1",
+    )
+
+    assert summary["eligible"] == 1
+    assert summary["attempted"] == 1
+    assert summary["stored"] == 1
+    assert summary["failed"] == 0
+
+
+def test_workspace_instruction_without_metadata_hash_has_uploadable_primary_content(tmp_path: Path) -> None:
+    workspace_dir = tmp_path / "workspace"
+    instruction_path = workspace_dir / "AGENTS.md"
+    instruction_path.parent.mkdir(parents=True)
+    instruction_path.write_text("# Workspace instructions\n", encoding="utf-8")
+    artifact = GuardArtifact(
+        artifact_id="codex:project:instruction:AGENTS.md",
+        name="AGENTS.md",
+        harness="codex",
+        artifact_type="instruction",
+        source_scope="project",
+        config_path=str(instruction_path),
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=False,
+        config_paths=(str(instruction_path),),
+        artifacts=(artifact,),
+    )
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-10T00:00:00Z",
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+    )
+
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=workspace_dir,
+    )
+
+    assert len(sources) == 1
+    assert sources[0].content_hash == f"sha256:{hashlib.sha256(instruction_path.read_bytes()).hexdigest()}"
+    assert sources[0].path == instruction_path
+
+
+def test_primary_content_sources_ignore_supplementary_skill_files(tmp_path: Path) -> None:
+    skill_root = tmp_path / ".codex" / "skills" / "review"
+    primary_path = skill_root / "SKILL.md"
+    supplementary_path = skill_root / "references" / "commands.md"
+    primary_path.parent.mkdir(parents=True)
+    supplementary_path.parent.mkdir(parents=True)
+    primary_path.write_text("# Review\n", encoding="utf-8")
+    supplementary_path.write_text("Supplementary commands\n", encoding="utf-8")
+    primary_hash = hashlib.sha256(primary_path.read_bytes()).hexdigest()
+    item_id = "codex:skill:review"
+    primary = GuardArtifact(
+        artifact_id=item_id,
+        name="review",
+        harness="codex",
+        artifact_type="skill",
+        source_scope="global",
+        config_path=str(primary_path),
+        metadata={"content_hash": primary_hash},
+    )
+    supplementary = GuardArtifact(
+        artifact_id="codex:skill-file:review:references/commands.md",
+        name="commands.md",
+        harness="codex",
+        artifact_type="skill_file",
+        source_scope="global",
+        config_path=str(supplementary_path),
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=False,
+        config_paths=(str(primary_path),),
+        artifacts=(primary, supplementary),
+    )
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-10T00:00:00Z",
+        home_dir=tmp_path,
+    )
+
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=None,
+    )
+
+    assert [source.path for source in sources] == [primary_path]
+
+
+def test_openclaw_supplementary_skill_files_stay_out_of_cloud_inventory(tmp_path: Path) -> None:
+    skill_path = tmp_path / ".openclaw" / "skills" / "review" / "SKILL.md"
+    reference_path = skill_path.parent / "references" / "commands.md"
+    skill_path.parent.mkdir(parents=True)
+    reference_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Review\n", encoding="utf-8")
+    reference_path.write_text("Supplementary commands\n", encoding="utf-8")
+    primary = GuardArtifact(
+        artifact_id="openclaw:skill:review",
+        name="review",
+        harness="openclaw",
+        artifact_type="skill",
+        source_scope="global",
+        config_path=str(skill_path),
+    )
+    supplementary = GuardArtifact(
+        artifact_id="openclaw:skill:review:references/commands.md",
+        name="review/references/commands.md",
+        harness="openclaw",
+        artifact_type="skill_file",
+        source_scope="global",
+        config_path=str(reference_path),
+    )
+    detection = HarnessDetection(
+        harness="openclaw",
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_path),),
+        artifacts=(primary, supplementary),
+    )
+
+    cloud_artifacts = cloud_inventory_artifacts_from_detection(
+        detection,
+        home_dir=tmp_path,
+    )
+
+    assert [artifact.artifact_id for artifact in cloud_artifacts] == [primary.artifact_id]
 
 
 def test_primary_content_upload_batches_exact_bodies_and_item_count(tmp_path: Path) -> None:

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -321,6 +321,43 @@ def test_symlinked_primary_skill_does_not_advertise_uploadable_body_hash(tmp_pat
     body_hash = f"sha256:{hashlib.sha256(real_skill_path.read_bytes()).hexdigest()}"
 
     assert snapshot.items[0].content_hash != body_hash
+    assert not snapshot.items[0].content_hash.startswith("sha256:")
+    assert sources == ()
+
+
+def test_skill_outside_skills_root_does_not_advertise_uploadable_body_hash(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    skill_path = home_dir / ".codex" / "review" / "SKILL.md"
+    skill_path.parent.mkdir(parents=True)
+    skill_path.write_text("# Review\n", encoding="utf-8")
+    artifact = GuardArtifact(
+        artifact_id="codex:skill:review",
+        name="review",
+        harness="codex",
+        artifact_type="skill",
+        source_scope="global",
+        config_path=str(skill_path),
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=False,
+        config_paths=(str(skill_path),),
+        artifacts=(artifact,),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-10T00:00:00Z",
+        home_dir=home_dir,
+    )
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=None,
+    )
+
+    assert not snapshot.items[0].content_hash.startswith("sha256:")
     assert sources == ()
 
 

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -155,6 +155,39 @@ def test_gemini_adapter_skill_without_metadata_hash_has_uploadable_primary_conte
     assert summary["failed"] == 0
 
 
+def test_gemini_skill_through_symlinked_workspace_has_uploadable_primary_content(tmp_path: Path) -> None:
+    real_workspace = tmp_path / "workspace-real"
+    workspace_dir = tmp_path / "workspace-link"
+    skill_path = workspace_dir / ".gemini" / "skills" / "review" / "SKILL.md"
+    real_skill_path = real_workspace / ".gemini" / "skills" / "review" / "SKILL.md"
+    real_skill_path.parent.mkdir(parents=True)
+    real_skill_path.write_text("# Symlinked workspace review\n", encoding="utf-8")
+    workspace_dir.symlink_to(real_workspace, target_is_directory=True)
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=workspace_dir,
+        guard_home=tmp_path / "guard-home",
+    )
+
+    detection = GeminiHarnessAdapter().detect(context)
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-10T00:00:00Z",
+        home_dir=context.home_dir,
+        workspace_dir=workspace_dir,
+    )
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=workspace_dir,
+    )
+    expected_hash = f"sha256:{hashlib.sha256(real_skill_path.read_bytes()).hexdigest()}"
+
+    assert len(sources) == 1
+    assert sources[0].path == skill_path
+    assert sources[0].content_hash == expected_hash
+
+
 def test_workspace_instruction_without_metadata_hash_has_uploadable_primary_content(tmp_path: Path) -> None:
     workspace_dir = tmp_path / "workspace"
     instruction_path = workspace_dir / "AGENTS.md"

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -299,6 +299,7 @@ def test_symlinked_primary_skill_does_not_advertise_uploadable_body_hash(tmp_pat
         artifact_type="skill",
         source_scope="global",
         config_path=str(linked_skill_path),
+        metadata={"content_hash": hashlib.sha256(real_skill_path.read_bytes()).hexdigest()},
     )
     detection = HarnessDetection(
         harness="codex",
@@ -337,6 +338,7 @@ def test_skill_outside_skills_root_does_not_advertise_uploadable_body_hash(tmp_p
         artifact_type="skill",
         source_scope="global",
         config_path=str(skill_path),
+        metadata={"content_hash": hashlib.sha256(skill_path.read_bytes()).hexdigest()},
     )
     detection = HarnessDetection(
         harness="codex",

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -281,6 +281,49 @@ def test_openclaw_supplementary_skill_files_stay_out_of_cloud_inventory(tmp_path
     assert [artifact.artifact_id for artifact in cloud_artifacts] == [primary.artifact_id]
 
 
+def test_symlinked_primary_skill_does_not_advertise_uploadable_body_hash(tmp_path: Path) -> None:
+    home_dir = tmp_path / "home"
+    real_skill_dir = home_dir / ".codex" / "real-skills" / "review"
+    real_skill_dir.mkdir(parents=True)
+    real_skill_path = real_skill_dir / "SKILL.md"
+    real_skill_path.write_text("# Review\n", encoding="utf-8")
+    skills_root = home_dir / ".codex" / "skills"
+    skills_root.mkdir(parents=True)
+    linked_skill_dir = skills_root / "review"
+    linked_skill_dir.symlink_to(real_skill_dir, target_is_directory=True)
+    linked_skill_path = linked_skill_dir / "SKILL.md"
+    artifact = GuardArtifact(
+        artifact_id="codex:skill:review",
+        name="review",
+        harness="codex",
+        artifact_type="skill",
+        source_scope="global",
+        config_path=str(linked_skill_path),
+    )
+    detection = HarnessDetection(
+        harness="codex",
+        installed=True,
+        command_available=False,
+        config_paths=(str(linked_skill_path),),
+        artifacts=(artifact,),
+    )
+
+    snapshot = inventory_snapshot_from_detection(
+        detection,
+        generated_at="2026-07-10T00:00:00Z",
+        home_dir=home_dir,
+    )
+    sources = primary_content_sources_from_artifacts(
+        detection.artifacts,
+        snapshot,
+        workspace_dir=None,
+    )
+    body_hash = f"sha256:{hashlib.sha256(real_skill_path.read_bytes()).hexdigest()}"
+
+    assert snapshot.items[0].content_hash != body_hash
+    assert sources == ()
+
+
 def test_primary_content_upload_batches_exact_bodies_and_item_count(tmp_path: Path) -> None:
     sources = tuple(_source(tmp_path / "skills", index) for index in range(101))
     requests: list[SimpleNamespace] = []

--- a/tests/test_guard_aibom_local_trust_coverage.py
+++ b/tests/test_guard_aibom_local_trust_coverage.py
@@ -77,7 +77,7 @@ def test_inventory_snapshot_adds_local_trust_to_hooks(tmp_path: Path) -> None:
     assert hook_trust["trustComponents"]
 
 
-def test_inventory_snapshot_adds_parent_skill_trust_to_skill_files(tmp_path: Path) -> None:
+def test_inventory_snapshot_keeps_parent_skill_trust_without_supplementary_skill_files(tmp_path: Path) -> None:
     workspace = tmp_path / "repo"
     workspace.mkdir()
     skill_dir = workspace / "skills" / "compress"
@@ -97,6 +97,15 @@ def test_inventory_snapshot_adds_parent_skill_trust_to_skill_files(tmp_path: Pat
             config_paths=(str(skill_dir / "SKILL.md"),),
             artifacts=(
                 GuardArtifact(
+                    artifact_id="openclaw:skill:local:compress",
+                    name="compress",
+                    harness="openclaw",
+                    artifact_type="skill",
+                    source_scope="workspace",
+                    config_path=str(skill_dir / "SKILL.md"),
+                    metadata={"skill_dir": str(skill_dir)},
+                ),
+                GuardArtifact(
                     artifact_id="openclaw:skill:local:compress:scripts/cli.py",
                     name="compress/scripts/cli.py",
                     harness="openclaw",
@@ -113,11 +122,12 @@ def test_inventory_snapshot_adds_parent_skill_trust_to_skill_files(tmp_path: Pat
         workspace_dir=workspace,
     )
 
-    skill_file_item = next(item for item in snapshot.items if item.metadata.get("artifactType") == "skill_file")
-    skill_file_trust = skill_file_item.metadata.get("trustResolution")
-    assert isinstance(skill_file_trust, dict)
-    assert isinstance(skill_file_item.metadata.get("trustLayers"), list)
-    assert skill_file_trust["trustComponents"]
+    skill_item = next(item for item in snapshot.items if item.metadata.get("artifactType") == "skill")
+    skill_trust = skill_item.metadata.get("trustResolution")
+    assert isinstance(skill_trust, dict)
+    assert isinstance(skill_item.metadata.get("trustLayers"), list)
+    assert skill_trust["trustComponents"]
+    assert all(item.metadata.get("artifactType") != "skill_file" for item in snapshot.items)
 
 
 def test_aibom_export_adds_parent_skill_trust_to_store_only_skill_files(tmp_path: Path) -> None:


### PR DESCRIPTION
- Upload exact primary `SKILL.md` and workspace instruction bodies for every supported harness while preserving root, symlink, and hash validation.
- Canonicalize file-body SHA-256 identities and keep supplementary skill files out of cloud inventory.
- `python3 -m pytest -q tests/test_guard_aibom_content_upload.py tests/test_guard_inventory_contract.py tests/test_gemini_adapter.py tests/test_guard_aibom_local_trust_coverage.py` (94 tests)
- `python3 -m ruff check src/codex_plugin_scanner/guard/aibom_content_upload.py src/codex_plugin_scanner/guard/inventory_contract.py tests/test_guard_aibom_content_upload.py`
