### PR TITLE
fix(runtime): accept portal routing installation ids

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -449,14 +449,6 @@ def _validate_approval_resolve_target(
     _validate_target_field(
         job,
         payload,
-        keys=("targetMachineInstallationId", "target_machine_installation_id", "machineInstallationId"),
-        expected=getattr(oauth, "installation_id", None),
-        failure_code="approval_target_machine_installation_mismatch",
-        require_expected=True,
-    )
-    _validate_target_field(
-        job,
-        payload,
         keys=("targetRuntimeGrantId", "target_runtime_grant_id", "runtimeGrantId", "runtime_grant_id"),
         expected=getattr(oauth, "runtime_id", None),
         failure_code="approval_target_runtime_grant_mismatch",

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -2118,7 +2118,7 @@ def test_executor_returns_waiting_local_confirm_for_app_remove_without_surface(
     }
 
 
-def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:
+def test_executor_resolves_local_approval_with_distinct_portal_routing_installation(tmp_path: Path) -> None:
     class ApprovalStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
@@ -2174,9 +2174,11 @@ def test_executor_resolves_local_approval_request(tmp_path: Path) -> None:
     result = command_executors.execute_guard_command_job(
         {
             "operation": "guard.approval.resolve",
+            "targetMachineInstallationId": "portal-installation-routing-id",
             "payload": {
                 "localRequestId": "request-1",
                 "action": "allow_once",
+                "targetMachineInstallationId": "portal-installation-routing-id",
                 "remoteApproval": remote_approval,
                 "scope": "artifact",
             },
@@ -2335,11 +2337,6 @@ def test_executor_ignores_stale_remote_approval_request_id(tmp_path: Path) -> No
     ("job_extra", "payload_extra", "failure_code"),
     [
         ({}, {"targetGrantId": "grant-other"}, "approval_target_grant_mismatch"),
-        (
-            {},
-            {"targetMachineInstallationId": "33333333-3333-4333-8333-333333333333"},
-            "approval_target_machine_installation_mismatch",
-        ),
         ({}, {"targetRuntimeGrantId": "runtime-other"}, "approval_target_runtime_grant_mismatch"),
         ({}, {"workspaceId": "workspace-other"}, "approval_target_workspace_mismatch"),
         ({"localRequestId": "request-other"}, {}, "approval_target_local_request_mismatch"),


### PR DESCRIPTION
## Problem

Guard command leases carry a server routing installation identifier that is intentionally distinct from the local Guard installation identity bound inside the signed remote approval envelope. The executor compared the outer routing identifier to the local installation identity, so valid approval commands failed before signed-envelope validation.

## Fix

- treat the outer installation identifier as opaque routing metadata
- preserve grant, runtime, workspace, request, signature, replay, and local approval binding checks
- cover a successful approval with distinct routing and local installation identifiers

## Verification

- `uv run pytest tests/test_guard_command_queue.py -q` — 98 passed