### PR TITLE
fix(runtime): attach identity to live request sync

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -437,35 +437,22 @@ def _with_live_sync_identity(
     }
 
 
-def _resolve_guard_sync_auth_for_commands(
-    store: GuardStore,
-    *,
-    force_refresh: bool,
-) -> dict[str, object]:
-    if force_refresh:
-        return _resolve_guard_sync_auth_context(store, force_refresh=True)
-    return _resolve_guard_sync_auth_context(store)
-
-
 def _resolve_command_queue_auth_context(
     store: GuardStore,
     *,
     force_refresh: bool = False,
 ) -> dict[str, object]:
     try:
-        auth_context = _resolve_guard_sync_auth_for_commands(
-            store,
-            force_refresh=force_refresh,
-        )
+        if force_refresh:
+            return _resolve_guard_sync_auth_context(store, force_refresh=True)
+        return _resolve_guard_sync_auth_context(store)
     except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError):
         repair = _repair_guard_cloud_authorization(store)
         if not repair["existing_sign_in_valid"] and not repair["repaired_storage"]:
             raise
-        auth_context = _resolve_guard_sync_auth_for_commands(
-            store,
-            force_refresh=force_refresh,
-        )
-    return _with_live_sync_identity(store, auth_context)
+        if force_refresh:
+            return _resolve_guard_sync_auth_context(store, force_refresh=True)
+        return _resolve_guard_sync_auth_context(store)
 
 
 def _sync_live_requests_best_effort(store: GuardStore, auth_context: dict[str, object]) -> None:
@@ -479,7 +466,7 @@ def _sync_live_requests_best_effort(store: GuardStore, auth_context: dict[str, o
     try:
         from .live_request_sync import sync_live_requests_once
 
-        sync_live_requests_once(store, auth_context)
+        sync_live_requests_once(store, _with_live_sync_identity(store, auth_context))
     except Exception as exc:
         _LOGGER.debug("Guard live request sync skipped: %s", _redacted_error(exc))
 

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -424,22 +424,48 @@ def _maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
     maybe_auto_update(store, context)
 
 
+def _with_live_sync_identity(
+    store: GuardStore,
+    auth_context: dict[str, object],
+) -> dict[str, object]:
+    machine_id, workspace_id = _oauth_metadata(store)
+    return {
+        **auth_context,
+        "machine_id": machine_id,
+        "workspace_id": workspace_id,
+        "machine_installation_id": store.get_or_create_installation_id(),
+    }
+
+
+def _resolve_guard_sync_auth_for_commands(
+    store: GuardStore,
+    *,
+    force_refresh: bool,
+) -> dict[str, object]:
+    if force_refresh:
+        return _resolve_guard_sync_auth_context(store, force_refresh=True)
+    return _resolve_guard_sync_auth_context(store)
+
+
 def _resolve_command_queue_auth_context(
     store: GuardStore,
     *,
     force_refresh: bool = False,
 ) -> dict[str, object]:
     try:
-        if force_refresh:
-            return _resolve_guard_sync_auth_context(store, force_refresh=True)
-        return _resolve_guard_sync_auth_context(store)
+        auth_context = _resolve_guard_sync_auth_for_commands(
+            store,
+            force_refresh=force_refresh,
+        )
     except (GuardSyncAuthorizationExpiredError, GuardSyncNotConfiguredError):
         repair = _repair_guard_cloud_authorization(store)
-        if repair["existing_sign_in_valid"] or repair["repaired_storage"]:
-            if force_refresh:
-                return _resolve_guard_sync_auth_context(store, force_refresh=True)
-            return _resolve_guard_sync_auth_context(store)
-        raise
+        if not repair["existing_sign_in_valid"] and not repair["repaired_storage"]:
+            raise
+        auth_context = _resolve_guard_sync_auth_for_commands(
+            store,
+            force_refresh=force_refresh,
+        )
+    return _with_live_sync_identity(store, auth_context)
 
 
 def _sync_live_requests_best_effort(store: GuardStore, auth_context: dict[str, object]) -> None:

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -123,21 +123,16 @@ class FakeStore:
         return []
 
 
-def test_command_queue_auth_context_includes_live_sync_identity(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_live_sync_identity_context_includes_local_identity(tmp_path: Path) -> None:
     store = FakeStore(tmp_path / "guard-home")
-    monkeypatch.setattr(
-        command_queue,
-        "_resolve_guard_sync_auth_context",
-        lambda _store, *, force_refresh=False: {
+
+    auth_context = command_queue._with_live_sync_identity(
+        store,
+        {
             "access_token": "token-1",
             "sync_url": "https://hol.test/api/guard/receipts/sync",
         },
     )
-
-    auth_context = command_queue._resolve_command_queue_auth_context(store)
 
     assert auth_context == {
         "access_token": "token-1",
@@ -146,6 +141,29 @@ def test_command_queue_auth_context_includes_live_sync_identity(
         "sync_url": "https://hol.test/api/guard/receipts/sync",
         "workspace_id": "workspace-1",
     }
+
+
+def test_live_sync_identity_failure_remains_best_effort(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+
+    def fail_identity(
+        _store: FakeStore,
+        _auth_context: dict[str, object],
+    ) -> dict[str, object]:
+        raise RuntimeError("identity unavailable")
+
+    monkeypatch.setattr(command_queue, "_with_live_sync_identity", fail_identity)
+
+    command_queue._sync_live_requests_best_effort(
+        store,
+        {
+            "access_token": "token-1",
+            "sync_url": "https://hol.test/api/guard/receipts/sync",
+        },
+    )
 
 
 def _approval_request_row(

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -123,6 +123,31 @@ class FakeStore:
         return []
 
 
+def test_command_queue_auth_context_includes_live_sync_identity(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    monkeypatch.setattr(
+        command_queue,
+        "_resolve_guard_sync_auth_context",
+        lambda _store, *, force_refresh=False: {
+            "access_token": "token-1",
+            "sync_url": "https://hol.test/api/guard/receipts/sync",
+        },
+    )
+
+    auth_context = command_queue._resolve_command_queue_auth_context(store)
+
+    assert auth_context == {
+        "access_token": "token-1",
+        "machine_id": "machine-1",
+        "machine_installation_id": "22222222-2222-4222-8222-222222222222",
+        "sync_url": "https://hol.test/api/guard/receipts/sync",
+        "workspace_id": "workspace-1",
+    }
+
+
 def _approval_request_row(
     request_id: str,
     *,


### PR DESCRIPTION
## Problem

The command worker reused receipt-sync authentication context containing only token and URL. Live request sync requires machine, workspace, and local installation identity, so every best-effort sync was skipped before making a request.

## Fix

- enrich command authentication context with local machine, workspace, and installation identity
- preserve existing authorization repair and refresh behavior
- cover the complete live-sync identity contract

## Verification

- `uv run pytest tests/test_guard_command_queue.py -q` — 99 passed