### PR TITLE
fix(daemon): allow https images in dashboard CSP for cloud avatars

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -321,7 +321,7 @@ _DASHBOARD_CSP = "; ".join(
         "default-src 'self'",
         "script-src 'self'",
         "style-src 'self' 'unsafe-inline'",
-        "img-src 'self' data:",
+        "img-src 'self' data: https:",
         "font-src 'self' data:",
         "connect-src 'self'",
         "object-src 'none'",


### PR DESCRIPTION
The dashboard Content-Security-Policy restricted `img-src` to `'self' data:`, which blocked external avatar URLs (e.g. Google profile images) from loading in the CloudUserMenu.

Add `https:` to `img-src` so cloud user avatars render correctly in the local dashboard.