### PR TITLE
fix(daemon): allow https images in dashboard CSP for cloud avatars

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -321,7 +321,7 @@ _DASHBOARD_CSP = "; ".join(
         "default-src 'self'",
         "script-src 'self'",
         "style-src 'self' 'unsafe-inline'",
-        "img-src 'self' data:",
+        "img-src 'self' data: https:",
         "font-src 'self' data:",
         "connect-src 'self'",
         "object-src 'none'",


### PR DESCRIPTION
## Summary
- Add `https:` to `img-src` in the dashboard Content-Security-Policy so external avatar URLs (e.g. Google profile images) render in the CloudUserMenu.

## Testing
- `curl -sI http://127.0.0.1:5474/ | grep Content-Security-Policy` confirms `img-src 'self' data: https:`
