### PR TITLE
fix(runtime): bound live sync display fields

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -61,6 +61,8 @@ _LOGGER = logging.getLogger(__name__)
 LIVE_REQUEST_SYNC_BATCH_SIZE = 200
 LIVE_REQUEST_SYNC_MAX_BATCHES = 25
 LIVE_REQUEST_SYNC_PROTOCOL_VERSION = "1"
+_LIVE_REQUEST_COMMAND_MAX_UTF16_UNITS = 2_048
+_LIVE_REQUEST_SUMMARY_MAX_UTF16_UNITS = 512
 _LIVE_REQUEST_SEQUENCE_LOCK = threading.Lock()
 LIVE_REQUEST_SYNC_CURSOR_KEY = "guard_live_request_sync_cursor"
 LIVE_REQUEST_SYNC_STATE_KEY = "guard_live_request_sync_state"
@@ -162,6 +164,15 @@ def _resolve_display_provenance(
     return _DISPLAY_PROVENANCE_REDACTED
 
 
+def _truncate_utf16(value: str, max_units: int) -> str:
+    units = 0
+    for index, character in enumerate(value):
+        units += 2 if ord(character) > 0xFFFF else 1
+        if units > max_units:
+            return value[:index]
+    return value
+
+
 def _build_display_command(item: dict[str, object], redaction_level: str) -> tuple[str, str, str | None, str | None]:
     action_identity = str(item.get("action_identity") or item.get("artifact_id") or "unknown")
     trigger_summary = str(item.get("trigger_summary") or item.get("why_now") or "Guard approval request")
@@ -174,9 +185,17 @@ def _build_display_command(item: dict[str, object], redaction_level: str) -> tup
     command_text = _local_request_command_text(item, envelope)
     safe_command = _cloud_scrub_text(command_text) if command_text else None
     display_command = safe_command if safe_command and redaction_level != "full" else fallback_display
+    display_command = _truncate_utf16(
+        display_command,
+        _LIVE_REQUEST_COMMAND_MAX_UTF16_UNITS,
+    )
     display_summary = f"{trigger_summary}"
     if risk_headline:
         display_summary = f"{risk_headline} — {trigger_summary}"
+    display_summary = _truncate_utf16(
+        display_summary,
+        _LIVE_REQUEST_SUMMARY_MAX_UTF16_UNITS,
+    )
 
     raw_command = display_command if redaction_level == "none" and safe_command else None
     redacted_command = (

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -61,7 +61,7 @@ _LOGGER = logging.getLogger(__name__)
 LIVE_REQUEST_SYNC_BATCH_SIZE = 200
 LIVE_REQUEST_SYNC_MAX_BATCHES = 25
 LIVE_REQUEST_SYNC_PROTOCOL_VERSION = "1"
-_LIVE_REQUEST_COMMAND_MAX_UTF16_UNITS = 2_048
+_LIVE_REQUEST_COMMAND_MAX_UTF16_UNITS = 65_536
 _LIVE_REQUEST_SUMMARY_MAX_UTF16_UNITS = 512
 _LIVE_REQUEST_SEQUENCE_LOCK = threading.Lock()
 LIVE_REQUEST_SYNC_CURSOR_KEY = "guard_live_request_sync_cursor"
@@ -164,13 +164,36 @@ def _resolve_display_provenance(
     return _DISPLAY_PROVENANCE_REDACTED
 
 
-def _truncate_utf16(value: str, max_units: int) -> str:
+def _utf16_units(value: str) -> int:
+    return sum(2 if ord(character) > 0xFFFF else 1 for character in value)
+
+
+def _take_utf16_prefix(value: str, max_units: int) -> str:
     units = 0
     for index, character in enumerate(value):
         units += 2 if ord(character) > 0xFFFF else 1
         if units > max_units:
             return value[:index]
     return value
+
+
+def _take_utf16_suffix(value: str, max_units: int) -> str:
+    units = 0
+    for index in range(len(value) - 1, -1, -1):
+        units += 2 if ord(value[index]) > 0xFFFF else 1
+        if units > max_units:
+            return value[index + 1 :]
+    return value
+
+
+def _truncate_utf16(value: str, max_units: int) -> str:
+    if _utf16_units(value) <= max_units:
+        return value
+    marker = " … [truncated] … "
+    available_units = max_units - _utf16_units(marker)
+    prefix_units = available_units * 3 // 4
+    suffix_units = available_units - prefix_units
+    return _take_utf16_prefix(value, prefix_units) + marker + _take_utf16_suffix(value, suffix_units)
 
 
 def _build_display_command(item: dict[str, object], redaction_level: str) -> tuple[str, str, str | None, str | None]:

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -1134,7 +1134,7 @@ class TestRedactionLevelNone:
             "trigger_summary": "😀" * 400,
             "risk_headline": "😀" * 400,
             "harness": "guard-review",
-            "raw_command_text": "😀" * 2_000,
+            "raw_command_text": ("😀" * 40_000) + " --dangerous-suffix",
             "created_at": "2026-07-10T00:00:00+00:00",
             "last_seen_at": "2026-07-10T00:00:00+00:00",
         }
@@ -1151,7 +1151,9 @@ class TestRedactionLevelNone:
         display_summary = event["displaySummary"]
         assert isinstance(raw_command, str)
         assert isinstance(display_summary, str)
-        assert len(raw_command.encode("utf-16-le")) // 2 <= 2_048
+        assert len(raw_command.encode("utf-16-le")) // 2 <= 65_536
+        assert " … [truncated] … " in raw_command
+        assert raw_command.endswith(" --dangerous-suffix")
         assert len(display_summary.encode("utf-16-le")) // 2 <= 512
 
     def test_redaction_none_hides_bearer_prefix(self, tmp_path: Path) -> None:

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -1122,6 +1122,38 @@ class TestRedactionLevelNone:
         # redacted_command must be None for 'none' level
         assert event["redactedCommand"] is None
 
+    def test_redaction_none_enforces_portal_utf16_field_limits(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        store = Store(tmp_path)
+        item: dict[str, object] = {
+            "request_id": "req-bounded-1",
+            "status": "pending",
+            "action_identity": "test-action",
+            "trigger_summary": "😀" * 400,
+            "risk_headline": "😀" * 400,
+            "harness": "guard-review",
+            "raw_command_text": "😀" * 2_000,
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="none",
+            store=store,
+            event_sequence=1,
+        )
+
+        assert event is not None
+        raw_command = event["rawCommand"]
+        display_summary = event["displaySummary"]
+        assert isinstance(raw_command, str)
+        assert isinstance(display_summary, str)
+        assert len(raw_command.encode("utf-16-le")) // 2 <= 2_048
+        assert len(display_summary.encode("utf-16-le")) // 2 <= 512
+
     def test_redaction_none_hides_bearer_prefix(self, tmp_path: Path) -> None:
         """Bearer token is scrubbed to 'Bearer *****' — prefix retained."""
         store = Store(tmp_path)


### PR DESCRIPTION
## Problem

A single local request with a command longer than the Cloud live-event schema limit caused the entire sync batch to return HTTP 400, preventing all current requests from reaching Cloud Review.

## Fix

- bound command and summary fields to the portal contract
- count UTF-16 units so limits match JavaScript/Zod semantics, including astral Unicode
- preserve redaction before truncation

## Verification

- `uv run pytest tests/test_guard_live_request_sync.py -q` — 91 passed