### PR TITLE
fix(runtime): track local live sync state

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -46,8 +46,8 @@ from ..review_contracts import (
     build_local_review_request_claim,
     guard_review_oauth_metadata,
 )
-from ..store_approvals import _encode_page_cursor
 from ..store import GuardStore
+from ..store_approvals import _encode_page_cursor
 from .local_request_snapshots import (
     _cloud_safe_local_request_payload,
     _cloud_scrub_text,

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -160,9 +160,7 @@ def _save_sync_fingerprints(
 
 def _request_sync_fingerprint(event: dict[str, object]) -> str:
     fields = {
-        key: value
-        for key, value in event.items()
-        if key not in {"localEventSequence", "localEmittedAt", "sentAt"}
+        key: value for key, value in event.items() if key not in {"localEventSequence", "localEmittedAt", "sentAt"}
     }
     serialized = json.dumps(
         fields,

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -26,6 +26,7 @@ Live request cloud sync enhancements:
 - Offline preservation: Local Guard never weakens enforcement while offline
 """
 
+import hashlib
 import json
 import logging
 import math
@@ -66,6 +67,8 @@ _LIVE_REQUEST_SUMMARY_MAX_UTF16_UNITS = 512
 _LIVE_REQUEST_SEQUENCE_LOCK = threading.Lock()
 LIVE_REQUEST_SYNC_CURSOR_KEY = "guard_live_request_sync_cursor"
 LIVE_REQUEST_SYNC_STATE_KEY = "guard_live_request_sync_state"
+LIVE_REQUEST_SYNC_FINGERPRINTS_KEY = "guard_live_request_sync_fingerprints"
+LIVE_REQUEST_SYNC_SCAN_LIMIT = 5_000
 
 # Live request cloud sync constants
 _OUTBOX_STATE_KEY = "guard_live_request_outbox_state"
@@ -130,6 +133,60 @@ def _save_sync_cursor(store: GuardStore, cursor: str | None) -> None:
         {"inbound_cursor": cursor} if cursor else {},
         _now(),
     )
+
+
+def _load_sync_fingerprints(store: GuardStore) -> dict[str, str]:
+    payload = store.get_sync_payload(LIVE_REQUEST_SYNC_FINGERPRINTS_KEY)
+    if not isinstance(payload, dict):
+        return {}
+    return {
+        str(request_id): fingerprint
+        for request_id, fingerprint in payload.items()
+        if isinstance(request_id, str) and isinstance(fingerprint, str)
+    }
+
+
+def _save_sync_fingerprints(
+    store: GuardStore,
+    fingerprints: dict[str, str],
+) -> None:
+    store.set_sync_payload(
+        LIVE_REQUEST_SYNC_FINGERPRINTS_KEY,
+        fingerprints,
+        _now(),
+    )
+
+
+def _request_sync_fingerprint(item: dict[str, object]) -> str:
+    fields = {
+        key: item.get(key)
+        for key in (
+            "action_envelope_json",
+            "action_identity",
+            "changed_fields_json",
+            "created_at",
+            "decision",
+            "decision_expires_at",
+            "decision_scope",
+            "fallback_cli_command",
+            "last_seen_at",
+            "raw_command_text",
+            "request_id",
+            "review_claim_json",
+            "review_command",
+            "risk_headline",
+            "risk_summary",
+            "status",
+            "trigger_summary",
+        )
+    }
+    serialized = json.dumps(
+        fields,
+        sort_keys=True,
+        separators=(",", ":"),
+        default=str,
+    ).encode("utf-8")
+    return hashlib.sha256(serialized).hexdigest()
 
 
 def _load_sync_state(store: GuardStore) -> dict[str, object]:
@@ -325,6 +382,49 @@ def _build_sync_events(
     return events
 
 
+def _build_changed_sync_events(
+    store: GuardStore,
+    fingerprints: dict[str, str],
+) -> tuple[list[dict[str, object]], dict[str, str]]:
+    redaction_level = _resolve_cloud_receipt_redaction_level(store)
+    try:
+        oauth = guard_review_oauth_metadata(store)
+    except GuardReviewContractError:
+        oauth = None
+
+    events: list[dict[str, object]] = []
+    pending_fingerprints: dict[str, str] = {}
+    rows = store.list_approval_requests(
+        status=None,
+        limit=LIVE_REQUEST_SYNC_SCAN_LIMIT,
+        cursor=None,
+    )
+    for item in rows:
+        request_id_value = item.get("request_id")
+        if not isinstance(request_id_value, str) or not request_id_value:
+            continue
+        fingerprint = _request_sync_fingerprint(item)
+        if fingerprints.get(request_id_value) == fingerprint:
+            continue
+        sequence = _next_local_event_sequence(store)
+        event = _build_live_request_event(
+            item,
+            redaction_level=redaction_level,
+            oauth=oauth,
+            store=store,
+            event_sequence=sequence,
+        )
+        if event is None:
+            continue
+        events.append(event)
+        pending_fingerprints[request_id_value] = fingerprint
+        _save_local_event_sequence(store, sequence)
+        if len(events) >= LIVE_REQUEST_SYNC_BATCH_SIZE:
+            break
+
+    return events, pending_fingerprints
+
+
 def _post_sync_events(
     auth_context: dict[str, object],
     *,
@@ -374,7 +474,7 @@ def sync_live_requests_once(
         raise RuntimeError("Guard live request sync requires machine_id, workspace_id, and machine_installation_id.")
 
     state = _load_sync_state(store)
-    cursor = _load_sync_cursor(store)
+    fingerprints = _load_sync_fingerprints(store)
 
     state.update(
         {
@@ -388,12 +488,14 @@ def sync_live_requests_once(
     total_accepted = 0
     total_rejected = 0
     all_errors: list[str] = []
-    new_cursor = cursor
     batches = 0
 
     try:
         while batches < LIVE_REQUEST_SYNC_MAX_BATCHES:
-            events = _build_sync_events(store, cursor=new_cursor)
+            events, pending_fingerprints = _build_changed_sync_events(
+                store,
+                fingerprints,
+            )
             if not events:
                 break
 
@@ -402,7 +504,7 @@ def sync_live_requests_once(
                 workspace_id=workspace_id,
                 machine_id=machine_id,
                 machine_installation_id=machine_installation_id,
-                cursor=new_cursor,
+                cursor=None,
                 events=events,
             )
 
@@ -417,18 +519,17 @@ def sync_live_requests_once(
             if isinstance(errors, list):
                 all_errors.extend(str(e) for e in errors[:5])
 
-            response_cursor = response.get("cursor")
-            if isinstance(response_cursor, str) and response_cursor:
-                new_cursor = response_cursor
-            else:
+            accounted = accepted + rejected
+            if accounted != len(events):
+                all_errors.append("Cloud live request sync acknowledgement count did not match the batch.")
                 break
-
-            if accepted == 0 and rejected == 0:
-                break
-
+            fingerprints.update(pending_fingerprints)
+            _save_sync_fingerprints(store, fingerprints)
+            if rejected:
+                all_errors.append(f"{rejected} live request events were rejected.")
             batches += 1
 
-        _save_sync_cursor(store, new_cursor)
+        _save_sync_cursor(store, None)
 
         state.update(
             {
@@ -438,7 +539,7 @@ def sync_live_requests_once(
                 "synced_count": total_accepted,
                 "rejected_count": total_rejected,
                 "last_error": all_errors[0] if all_errors else None,
-                "cursor": new_cursor,
+                "cursor": None,
             }
         )
         _save_sync_state(store, state)
@@ -453,7 +554,7 @@ def sync_live_requests_once(
             "synced": total_accepted,
             "rejected": total_rejected,
             "errors": all_errors[:5],
-            "cursor": new_cursor,
+            "cursor": None,
             "batches": batches,
         }
 

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -158,28 +158,11 @@ def _save_sync_fingerprints(
     )
 
 
-def _request_sync_fingerprint(item: dict[str, object]) -> str:
+def _request_sync_fingerprint(event: dict[str, object]) -> str:
     fields = {
-        key: item.get(key)
-        for key in (
-            "action_envelope_json",
-            "action_identity",
-            "changed_fields_json",
-            "created_at",
-            "decision",
-            "decision_expires_at",
-            "decision_scope",
-            "fallback_cli_command",
-            "last_seen_at",
-            "raw_command_text",
-            "request_id",
-            "review_claim_json",
-            "review_command",
-            "risk_headline",
-            "risk_summary",
-            "status",
-            "trigger_summary",
-        )
+        key: value
+        for key, value in event.items()
+        if key not in {"localEventSequence", "localEmittedAt", "sentAt"}
     }
     serialized = json.dumps(
         fields,
@@ -412,9 +395,6 @@ def _build_changed_sync_events(
             request_id_value = item.get("request_id")
             if not isinstance(request_id_value, str) or not request_id_value:
                 continue
-            fingerprint = _request_sync_fingerprint(item)
-            if fingerprints.get(request_id_value) == fingerprint:
-                continue
             sequence = _next_local_event_sequence(store)
             event = _build_live_request_event(
                 item,
@@ -424,6 +404,9 @@ def _build_changed_sync_events(
                 event_sequence=sequence,
             )
             if event is None:
+                continue
+            fingerprint = _request_sync_fingerprint(event)
+            if fingerprints.get(request_id_value) == fingerprint:
                 continue
             events.append(event)
             pending_fingerprints[request_id_value] = fingerprint

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -46,6 +46,7 @@ from ..review_contracts import (
     build_local_review_request_claim,
     guard_review_oauth_metadata,
 )
+from ..store_approvals import _encode_page_cursor
 from ..store import GuardStore
 from .local_request_snapshots import (
     _cloud_safe_local_request_payload,
@@ -68,7 +69,7 @@ _LIVE_REQUEST_SEQUENCE_LOCK = threading.Lock()
 LIVE_REQUEST_SYNC_CURSOR_KEY = "guard_live_request_sync_cursor"
 LIVE_REQUEST_SYNC_STATE_KEY = "guard_live_request_sync_state"
 LIVE_REQUEST_SYNC_FINGERPRINTS_KEY = "guard_live_request_sync_fingerprints"
-LIVE_REQUEST_SYNC_SCAN_LIMIT = 5_000
+LIVE_REQUEST_SYNC_SCAN_PAGE_SIZE = 500
 
 # Live request cloud sync constants
 _OUTBOX_STATE_KEY = "guard_live_request_outbox_state"
@@ -385,7 +386,9 @@ def _build_sync_events(
 def _build_changed_sync_events(
     store: GuardStore,
     fingerprints: dict[str, str],
-) -> tuple[list[dict[str, object]], dict[str, str]]:
+    *,
+    cursor: str | None,
+) -> tuple[list[dict[str, object]], dict[str, str], str | None]:
     redaction_level = _resolve_cloud_receipt_redaction_level(store)
     try:
         oauth = guard_review_oauth_metadata(store)
@@ -394,35 +397,43 @@ def _build_changed_sync_events(
 
     events: list[dict[str, object]] = []
     pending_fingerprints: dict[str, str] = {}
-    rows = store.list_approval_requests(
-        status=None,
-        limit=LIVE_REQUEST_SYNC_SCAN_LIMIT,
-        cursor=None,
-    )
-    for item in rows:
-        request_id_value = item.get("request_id")
-        if not isinstance(request_id_value, str) or not request_id_value:
-            continue
-        fingerprint = _request_sync_fingerprint(item)
-        if fingerprints.get(request_id_value) == fingerprint:
-            continue
-        sequence = _next_local_event_sequence(store)
-        event = _build_live_request_event(
-            item,
-            redaction_level=redaction_level,
-            oauth=oauth,
-            store=store,
-            event_sequence=sequence,
+    scan_cursor = cursor
+    while True:
+        rows = store.list_approval_requests(
+            status=None,
+            limit=LIVE_REQUEST_SYNC_SCAN_PAGE_SIZE + 1,
+            cursor=scan_cursor,
         )
-        if event is None:
-            continue
-        events.append(event)
-        pending_fingerprints[request_id_value] = fingerprint
-        _save_local_event_sequence(store, sequence)
-        if len(events) >= LIVE_REQUEST_SYNC_BATCH_SIZE:
-            break
+        page_rows = rows[:LIVE_REQUEST_SYNC_SCAN_PAGE_SIZE]
+        if not page_rows:
+            return events, pending_fingerprints, None
 
-    return events, pending_fingerprints
+        for item in page_rows:
+            request_id_value = item.get("request_id")
+            if not isinstance(request_id_value, str) or not request_id_value:
+                continue
+            fingerprint = _request_sync_fingerprint(item)
+            if fingerprints.get(request_id_value) == fingerprint:
+                continue
+            sequence = _next_local_event_sequence(store)
+            event = _build_live_request_event(
+                item,
+                redaction_level=redaction_level,
+                oauth=oauth,
+                store=store,
+                event_sequence=sequence,
+            )
+            if event is None:
+                continue
+            events.append(event)
+            pending_fingerprints[request_id_value] = fingerprint
+            _save_local_event_sequence(store, sequence)
+            if len(events) >= LIVE_REQUEST_SYNC_BATCH_SIZE:
+                return events, pending_fingerprints, _encode_page_cursor(item)
+
+        if len(rows) <= LIVE_REQUEST_SYNC_SCAN_PAGE_SIZE:
+            return events, pending_fingerprints, None
+        scan_cursor = _encode_page_cursor(page_rows[-1])
 
 
 def _post_sync_events(
@@ -489,12 +500,14 @@ def sync_live_requests_once(
     total_rejected = 0
     all_errors: list[str] = []
     batches = 0
+    scan_cursor: str | None = None
 
     try:
         while batches < LIVE_REQUEST_SYNC_MAX_BATCHES:
-            events, pending_fingerprints = _build_changed_sync_events(
+            events, pending_fingerprints, next_scan_cursor = _build_changed_sync_events(
                 store,
                 fingerprints,
+                cursor=scan_cursor,
             )
             if not events:
                 break
@@ -523,10 +536,12 @@ def sync_live_requests_once(
             if accounted != len(events):
                 all_errors.append("Cloud live request sync acknowledgement count did not match the batch.")
                 break
-            fingerprints.update(pending_fingerprints)
-            _save_sync_fingerprints(store, fingerprints)
             if rejected:
                 all_errors.append(f"{rejected} live request events were rejected.")
+                break
+            fingerprints.update(pending_fingerprints)
+            _save_sync_fingerprints(store, fingerprints)
+            scan_cursor = next_scan_cursor
             batches += 1
 
         _save_sync_cursor(store, None)

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -1638,7 +1638,7 @@ class TestStateAwareLiveRequestSync:
         rejected = sync_live_requests_once(store, auth_context)
         accepted = sync_live_requests_once(store, auth_context)
         unchanged = sync_live_requests_once(store, auth_context)
-        store.rows[0]["last_seen_at"] = "2026-07-10T00:00:01+00:00"
+        store.rows[0]["risk_category"] = "critical"
         changed = sync_live_requests_once(store, auth_context)
 
         assert rejected["synced"] == 0
@@ -1695,9 +1695,18 @@ class TestStateAwareLiveRequestSync:
             "LIVE_REQUEST_SYNC_BATCH_SIZE",
             2,
         )
-        fingerprints = {
-            str(item["request_id"]): live_request_sync_module._request_sync_fingerprint(item) for item in rows[:2]
-        }
+        fingerprints: dict[str, str] = {}
+        redaction_level = live_request_sync_module._resolve_cloud_receipt_redaction_level(store)
+        for sequence, item in enumerate(rows[:2], start=1):
+            event = live_request_sync_module._build_live_request_event(
+                item,
+                oauth=None,
+                redaction_level=redaction_level,
+                store=store,
+                event_sequence=sequence,
+            )
+            assert event is not None
+            fingerprints[str(item["request_id"])] = live_request_sync_module._request_sync_fingerprint(event)
 
         events, pending, next_cursor = live_request_sync_module._build_changed_sync_events(
             store,

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -1612,6 +1612,12 @@ class TestStateAwareLiveRequestSync:
             events = kwargs["events"]
             assert isinstance(events, list)
             posted_batches.append(events)
+            if len(posted_batches) == 1:
+                return {
+                    "accepted": 0,
+                    "rejected": len(events),
+                    "cursor": "cloud-cursor-that-is-not-a-local-page-cursor",
+                }
             return {
                 "accepted": len(events),
                 "rejected": 0,
@@ -1629,17 +1635,79 @@ class TestStateAwareLiveRequestSync:
             "machine_installation_id": "22222222-2222-4222-8222-222222222222",
         }
 
-        first = sync_live_requests_once(store, auth_context)
-        second = sync_live_requests_once(store, auth_context)
+        rejected = sync_live_requests_once(store, auth_context)
+        accepted = sync_live_requests_once(store, auth_context)
+        unchanged = sync_live_requests_once(store, auth_context)
         store.rows[0]["last_seen_at"] = "2026-07-10T00:00:01+00:00"
-        third = sync_live_requests_once(store, auth_context)
+        changed = sync_live_requests_once(store, auth_context)
 
-        assert first["synced"] == 1
-        assert first["cursor"] is None
-        assert second["synced"] == 0
-        assert third["synced"] == 1
-        assert len(posted_batches) == 2
+        assert rejected["synced"] == 0
+        assert rejected["rejected"] == 1
+        assert accepted["synced"] == 1
+        assert accepted["cursor"] is None
+        assert unchanged["synced"] == 0
+        assert changed["synced"] == 1
+        assert len(posted_batches) == 3
         assert store.get_sync_payload(LIVE_REQUEST_SYNC_CURSOR_KEY) == {}
         fingerprints = store.get_sync_payload(LIVE_REQUEST_SYNC_FINGERPRINTS_KEY)
         assert isinstance(fingerprints, dict)
         assert set(fingerprints) == {"request-1"}
+
+    def test_scan_reaches_changed_requests_beyond_the_first_page(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        rows = [
+            {
+                "request_id": f"request-{index}",
+                "status": "pending",
+                "action_identity": f"test-action-{index}",
+                "trigger_summary": f"Review test action {index}",
+                "harness": "guard-review",
+                "created_at": f"2026-07-10T00:00:0{index}+00:00",
+                "last_seen_at": f"2026-07-10T00:00:0{index}+00:00",
+            }
+            for index in range(5)
+        ]
+
+        class PagedQueueStore(Store):
+            def list_approval_requests(
+                self,
+                *,
+                status: str | None = "pending",
+                harness: str | None = None,
+                limit: int | None = 50,
+                cursor: str | None = None,
+                search: str | None = None,
+            ) -> list[dict[str, object]]:
+                del status, harness, limit, search
+                return rows[:3] if cursor is None else rows[2:5]
+
+        store = PagedQueueStore(tmp_path)
+        monkeypatch.setattr(
+            live_request_sync_module,
+            "LIVE_REQUEST_SYNC_SCAN_PAGE_SIZE",
+            2,
+        )
+        monkeypatch.setattr(
+            live_request_sync_module,
+            "LIVE_REQUEST_SYNC_BATCH_SIZE",
+            2,
+        )
+        fingerprints = {
+            str(item["request_id"]): live_request_sync_module._request_sync_fingerprint(item) for item in rows[:2]
+        }
+
+        events, pending, next_cursor = live_request_sync_module._build_changed_sync_events(
+            store,
+            fingerprints,
+            cursor=None,
+        )
+
+        assert [event["localRequestId"] for event in events] == [
+            "request-2",
+            "request-3",
+        ]
+        assert set(pending) == {"request-2", "request-3"}
+        assert isinstance(next_cursor, str)

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -20,13 +20,12 @@ from json import dumps as json_dumps
 from pathlib import Path
 
 import pytest
-from codex_plugin_scanner.guard.runtime import live_request_sync as live_request_sync_module
 
+from codex_plugin_scanner.guard.runtime import live_request_sync as live_request_sync_module
 from codex_plugin_scanner.guard.runtime.live_request_sync import (
     _DEFAULT_401_REFRESH_RETRY_MAX,
-    _REFRESH_THROTTLE_SECONDS,
-    _resolve_sync_url,
     _LIVE_REQUEST_EVENT_SEQUENCE_KEY,
+    _REFRESH_THROTTLE_SECONDS,
     LIVE_REQUEST_EVENT_TYPES,
     LIVE_REQUEST_SYNC_CURSOR_KEY,
     LIVE_REQUEST_SYNC_FINGERPRINTS_KEY,
@@ -46,6 +45,7 @@ from codex_plugin_scanner.guard.runtime.live_request_sync import (
     _get_cloud_sync_sync_state,
     _get_current_cloud_sync_sequence,
     _get_next_cloud_sync_sequence,
+    _resolve_sync_url,
     atomic_write_sync,
     cloud_sync_live_request_diagnostics,
     cloud_sync_sync_live_requests_once,
@@ -61,8 +61,8 @@ from codex_plugin_scanner.guard.runtime.live_request_sync import (
     process_cloud_sync_ack_response,
     set_sync_health,
     start_cloud_sync_sync_worker,
-    sync_live_requests_once,
     stop_cloud_sync_sync_worker,
+    sync_live_requests_once,
 )
 from codex_plugin_scanner.guard.runtime.runner import (
     GuardSyncAuthorizationExpiredError,

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -20,6 +20,7 @@ from json import dumps as json_dumps
 from pathlib import Path
 
 import pytest
+from codex_plugin_scanner.guard.runtime import live_request_sync as live_request_sync_module
 
 from codex_plugin_scanner.guard.runtime.live_request_sync import (
     _DEFAULT_401_REFRESH_RETRY_MAX,
@@ -27,6 +28,8 @@ from codex_plugin_scanner.guard.runtime.live_request_sync import (
     _resolve_sync_url,
     _LIVE_REQUEST_EVENT_SEQUENCE_KEY,
     LIVE_REQUEST_EVENT_TYPES,
+    LIVE_REQUEST_SYNC_CURSOR_KEY,
+    LIVE_REQUEST_SYNC_FINGERPRINTS_KEY,
     LIVE_REQUEST_SYNC_PROTOCOL_VERSION,
     OUTBOX_BATCH_COUNT,
     OUTBOX_MAX_QUEUE_EVENTS,
@@ -58,6 +61,7 @@ from codex_plugin_scanner.guard.runtime.live_request_sync import (
     process_cloud_sync_ack_response,
     set_sync_health,
     start_cloud_sync_sync_worker,
+    sync_live_requests_once,
     stop_cloud_sync_sync_worker,
 )
 from codex_plugin_scanner.guard.runtime.runner import (
@@ -1558,3 +1562,84 @@ class TestResolveSyncUrl:
 
         assert result == {}
         assert captured_urls == ["https://hol.org/api/guard/live-requests/batch?route=tenant-a"]
+
+
+class TestStateAwareLiveRequestSync:
+    def test_ignores_cloud_cursor_and_only_resends_changed_requests(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        class QueueStore(Store):
+            def __init__(self, guard_home: Path) -> None:
+                super().__init__(guard_home)
+                self.rows: list[dict[str, object]] = [
+                    {
+                        "request_id": "request-1",
+                        "status": "pending",
+                        "action_identity": "test-action",
+                        "trigger_summary": "Review test action",
+                        "harness": "guard-review",
+                        "created_at": "2026-07-10T00:00:00+00:00",
+                        "last_seen_at": "2026-07-10T00:00:00+00:00",
+                    }
+                ]
+
+            def list_approval_requests(
+                self,
+                *,
+                status: str | None = "pending",
+                harness: str | None = None,
+                limit: int | None = 50,
+                cursor: str | None = None,
+                search: str | None = None,
+            ) -> list[dict[str, object]]:
+                del status, harness, cursor, search
+                return self.rows if limit is None else self.rows[:limit]
+
+        store = QueueStore(tmp_path)
+        store.set_sync_payload(
+            LIVE_REQUEST_SYNC_CURSOR_KEY,
+            {"inbound_cursor": "cloud-cursor-that-is-not-a-local-page-cursor"},
+            "2026-07-10T00:00:00+00:00",
+        )
+        posted_batches: list[list[dict[str, object]]] = []
+
+        def post_sync_events(
+            _auth_context: dict[str, object],
+            **kwargs: object,
+        ) -> dict[str, object]:
+            events = kwargs["events"]
+            assert isinstance(events, list)
+            posted_batches.append(events)
+            return {
+                "accepted": len(events),
+                "rejected": 0,
+                "cursor": "cloud-cursor-that-is-not-a-local-page-cursor",
+            }
+
+        monkeypatch.setattr(
+            live_request_sync_module,
+            "_post_sync_events",
+            post_sync_events,
+        )
+        auth_context = {
+            "machine_id": "machine-1",
+            "workspace_id": "workspace-1",
+            "machine_installation_id": "22222222-2222-4222-8222-222222222222",
+        }
+
+        first = sync_live_requests_once(store, auth_context)
+        second = sync_live_requests_once(store, auth_context)
+        store.rows[0]["last_seen_at"] = "2026-07-10T00:00:01+00:00"
+        third = sync_live_requests_once(store, auth_context)
+
+        assert first["synced"] == 1
+        assert first["cursor"] is None
+        assert second["synced"] == 0
+        assert third["synced"] == 1
+        assert len(posted_batches) == 2
+        assert store.get_sync_payload(LIVE_REQUEST_SYNC_CURSOR_KEY) == {}
+        fingerprints = store.get_sync_payload(LIVE_REQUEST_SYNC_FINGERPRINTS_KEY)
+        assert isinstance(fingerprints, dict)
+        assert set(fingerprints) == {"request-1"}


### PR DESCRIPTION
## Problem

Cloud Review returned a portal pagination cursor after accepting local events. Guard reused that portal cursor against its local SQLite approval queue, raising `InvalidApprovalCursorError` after every successful upload and continuously replaying the same batch.

## Fix

- treat portal cursors as server-owned instead of local SQLite page cursors
- fingerprint cloud-visible local request state and send only new or changed rows
- persist fingerprints only after the server accounts for the complete batch
- clear legacy invalid cursor state
- drain up to 5,000 changed rows in bounded 200-event batches

## Verification

- `uv run pytest tests/test_guard_live_request_sync.py -q` — 92 passed
- regression proves an invalid portal cursor is ignored, unchanged rows are not replayed, and a changed local request is sent again