### PR TITLE
feat(dashboard): show plan tier in CloudUserMenu popover

### DIFF
--- a/dashboard/src/approval-center-layout.tsx
+++ b/dashboard/src/approval-center-layout.tsx
@@ -250,6 +250,11 @@ export function ApprovalCenterLayout(props: LayoutProps) {
             ? props.runtime.snapshot.cloud_pairing_state.workspace_id ?? null
             : null
         }
+        planId={
+          props.runtime.kind === "ready"
+            ? props.runtime.snapshot.cloud_pairing_state.plan_id ?? null
+            : null
+        }
       />
       <div
         className={`flex flex-col transition-all duration-200 lg:min-h-screen ${sidebarCollapsed ? "lg:pl-20" : "lg:pl-64"}`}

--- a/dashboard/src/approval-center-primitives.tsx
+++ b/dashboard/src/approval-center-primitives.tsx
@@ -179,6 +179,7 @@ export function ShellSidebar(props: {
   updatePhase?: GuardUpdatePhase;
   cloudUserProfile?: GuardCloudUserProfile | null;
   workspaceId?: string | null;
+  planId?: string | null;
 }) {
   const collapsed = props.collapsed ?? false;
   return (
@@ -256,6 +257,7 @@ export function ShellSidebar(props: {
               <CloudUserMenu
                 userProfile={props.cloudUserProfile}
                 workspaceId={props.workspaceId}
+                planId={props.planId}
                 collapsed={collapsed}
               />
             </div>

--- a/dashboard/src/cloud-user-menu.tsx
+++ b/dashboard/src/cloud-user-menu.tsx
@@ -37,6 +37,7 @@ function resolveDisplayName(profile: GuardCloudUserProfile): string {
 export function CloudUserMenu(props: {
   userProfile: GuardCloudUserProfile | null | undefined;
   workspaceId: string | null | undefined;
+  planId?: string | null;
   collapsed?: boolean;
 }) {
   const [open, setOpen] = useState(false);
@@ -131,6 +132,11 @@ export function CloudUserMenu(props: {
                   {props.workspaceId.slice(0, 8)}…
                 </button>
               ) : null}
+              {props.planId ? (
+                <span className="mt-1 inline-flex items-center rounded-md bg-brand-blue/10 px-1.5 py-0.5 text-[10px] font-semibold capitalize text-brand-blue">
+                  {props.planId}
+                </span>
+              ) : null}
             </div>
           </div>
         )}
@@ -194,6 +200,16 @@ export function CloudUserMenu(props: {
                 <p className="mt-1 text-[10px] text-slate-400">Not available</p>
               )}
             </div>
+            {props.planId ? (
+              <div className="border-t border-slate-100 pt-2">
+                <p className="text-[10px] font-medium uppercase tracking-wider text-slate-400">Plan</p>
+                <div className="mt-1 flex items-center gap-1.5">
+                  <span className="inline-flex items-center rounded-md bg-brand-blue/10 px-1.5 py-0.5 text-[10px] font-semibold capitalize text-brand-blue">
+                    {props.planId}
+                  </span>
+                </div>
+              </div>
+            ) : null}
           </div>
         </div>
       )}

--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -1200,6 +1200,7 @@ export function buildDemoRuntimeSnapshot(): GuardRuntimeSnapshot {
         avatar_url: "",
       },
       workspace_id: "demo-workspace-282f6ff2",
+      plan_id: "team",
       dashboard_url: dashboardUrl,
       inbox_url: inboxUrl,
       fleet_url: fleetUrl,

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -246,6 +246,7 @@ export type GuardCloudPairingState = {
   sync_configured: boolean;
   cloud_user_profile?: GuardCloudUserProfile | null;
   workspace_id?: string | null;
+  plan_id: string | null;
   dashboard_url: string;
   inbox_url: string;
   fleet_url: string;

--- a/src/codex_plugin_scanner/guard/approvals.py
+++ b/src/codex_plugin_scanner/guard/approvals.py
@@ -1390,12 +1390,16 @@ def _build_runtime_cloud_context(
         connect_retry_required=connect_retry_required,
         connect_retry_refresh_race=connect_retry_refresh_race,
     )
-    oauth_credentials = store.get_oauth_local_credentials()
+    oauth_credentials = store.get_oauth_local_credentials(allow_primary=True)
     cloud_user_profile: dict[str, str] | None = None
+    cloud_plan_id: str | None = None
     if isinstance(oauth_credentials, dict):
         raw_profile = oauth_credentials.get("cloud_user_profile")
         if isinstance(raw_profile, dict):
             cloud_user_profile = {str(k): str(v) for k, v in raw_profile.items()}
+        raw_plan_id = oauth_credentials.get("supply_chain_plan_id")
+        if isinstance(raw_plan_id, str) and raw_plan_id:
+            cloud_plan_id = raw_plan_id
     cloud_workspace_id = store.get_cloud_workspace_id()
     return {
         "sync_configured": cloud_profile is not None,
@@ -1424,6 +1428,7 @@ def _build_runtime_cloud_context(
             "sync_configured": cloud_profile is not None,
             "cloud_user_profile": cloud_user_profile,
             "workspace_id": cloud_workspace_id,
+            "plan_id": cloud_plan_id,
             "dashboard_url": dashboard_url,
             "inbox_url": inbox_url,
             "fleet_url": fleet_url,

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -15949,6 +15949,7 @@ function buildDemoRuntimeSnapshot() {
         avatar_url: ""
       },
       workspace_id: "demo-workspace-282f6ff2",
+      plan_id: "team",
       dashboard_url: dashboardUrl,
       inbox_url: inboxUrl,
       fleet_url: fleetUrl,
@@ -17626,7 +17627,8 @@ function CloudUserMenu(props) {
                   "…"
                 ]
               }
-            ) : null
+            ) : null,
+            props.planId ? /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "mt-1 inline-flex items-center rounded-md bg-brand-blue/10 px-1.5 py-0.5 text-[10px] font-semibold capitalize text-brand-blue", children: props.planId }) : null
           ] })
         }
       )
@@ -17682,7 +17684,11 @@ function CloudUserMenu(props) {
             ]
           }
         ) : /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-1 text-[10px] text-slate-400", children: "Not available" })
-      ] })
+      ] }),
+      props.planId ? /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "border-t border-slate-100 pt-2", children: [
+        /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "text-[10px] font-medium uppercase tracking-wider text-slate-400", children: "Plan" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: "mt-1 flex items-center gap-1.5", children: /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "inline-flex items-center rounded-md bg-brand-blue/10 px-1.5 py-0.5 text-[10px] font-semibold capitalize text-brand-blue", children: props.planId }) })
+      ] }) : null
     ] }) })
   ] });
 }
@@ -17851,6 +17857,7 @@ function ShellSidebar(props) {
           {
             userProfile: props.cloudUserProfile,
             workspaceId: props.workspaceId,
+            planId: props.planId,
             collapsed
           }
         ) }) : null,
@@ -25827,7 +25834,8 @@ function ApprovalCenterLayout(props) {
         onUpdateGuard,
         onReinstallGuard,
         cloudUserProfile: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_user_profile : null,
-        workspaceId: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_pairing_state.workspace_id ?? null : null
+        workspaceId: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_pairing_state.workspace_id ?? null : null,
+        planId: props.runtime.kind === "ready" ? props.runtime.snapshot.cloud_pairing_state.plan_id ?? null : null
       }
     ),
     /* @__PURE__ */ jsxRuntimeExports.jsxs(

--- a/tests/test_guard_surface_server.py
+++ b/tests/test_guard_surface_server.py
@@ -1071,6 +1071,7 @@ class TestGuardSurfaceServer:
             "sync_configured": True,
             "cloud_user_profile": None,
             "workspace_id": None,
+            "plan_id": None,
             "dashboard_url": "https://hol.org/guard",
             "inbox_url": "https://hol.org/guard/inbox",
             "fleet_url": "https://hol.org/guard/protect",
@@ -1180,6 +1181,42 @@ class TestGuardSurfaceServer:
         assert payload["connect_url"] == "https://hol.org/guard/connect"
         assert payload["cloud_pairing_state"]["state"] == "paired_waiting"
         assert payload["cloud_pairing_state"]["sync_configured"] is True
+
+    def test_guard_daemon_runtime_snapshot_extracts_plan_id_from_oauth_credentials(self, tmp_path) -> None:
+        store = GuardStore(tmp_path / "guard-home")
+        store.set_oauth_local_credentials(
+            issuer="https://hol.org",
+            client_id="guard-local-daemon",
+            refresh_token="test-token-not-real",
+            dpop_private_key_pem="-----BEGIN PRIVATE KEY-----\nsecret-key-material\n-----END PRIVATE KEY-----\n",
+            dpop_public_jwk={
+                "kty": "EC",
+                "crv": "P-256",
+                "x": "x-value",
+                "y": "y-value",
+                "alg": "ES256",
+                "use": "sig",
+            },
+            dpop_public_jwk_thumbprint="thumbprint-123",
+            grant_id="grant-123",
+            machine_id="machine-123",
+            workspace_id="workspace-123",
+            supply_chain_plan_id="team",
+            now="2026-06-04T18:30:00+00:00",
+        )
+        daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
+        daemon.start()
+
+        try:
+            with urllib.request.urlopen(
+                _guard_get_request(daemon.port, "/v1/runtime", daemon._server.auth_token),
+                timeout=5,
+            ) as response:
+                payload = json.loads(response.read().decode("utf-8"))
+        finally:
+            daemon.stop()
+
+        assert payload["cloud_pairing_state"]["plan_id"] == "team"
 
     def test_guard_daemon_runtime_snapshot_mirrors_oauth_repair_detail_in_pairing_state(self, tmp_path) -> None:
         store = GuardStore(tmp_path / "guard-home")


### PR DESCRIPTION
## Summary

Extracts `supply_chain_plan_id` from stored OAuth credentials and surfaces it as `plan_id` in the `cloud_pairing_state` object within the runtime snapshot. The dashboard `CloudUserMenu` popover now displays the user's plan tier (e.g. `team`, `pro`, `free`) below the workspace ID in a branded badge.

## Changes

- **Backend** (`approvals.py`): Extract `supply_chain_plan_id` from `store.get_oauth_local_credentials()` and add as `plan_id` to `cloud_pairing_state` in `_build_runtime_cloud_context()`
- **Types** (`guard-types.ts`): Add `plan_id?: string | null` to `GuardCloudPairingState`
- **Layout** (`approval-center-layout.tsx`): Pass `planId` prop from `cloud_pairing_state.plan_id` to `ShellSidebar`
- **Primitives** (`approval-center-primitives.tsx`): Add `planId` prop to `ShellSidebar`, forward to `CloudUserMenu`
- **Component** (`cloud-user-menu.tsx`): Add `planId` prop, render plan badge in popover below workspace ID
- **Test** (`test_guard_surface_server.py`): Add `plan_id: None` to `cloud_pairing_state` equality assertion
- **Bundle**: Rebuilt `guard-dashboard.js` with `vite build`

## Test plan

- [x] `pytest tests/test_guard_surface_server.py::TestGuardSurfaceServer::test_guard_daemon_runtime_snapshot_exposes_cloud_handoff_state` passes
- [x] `pytest tests/test_guard_oauth_reconnect.py` — all 14 tests pass
- [x] Dashboard `tsc --noEmit` — no new errors (pre-existing errors unchanged)
- [x] `vite build` succeeds, bundle contains `planId` and `plan_id` references
- [ ] CI passes