### PR TITLE
fix(runtime): isolate live sync from command polling

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import json
 import logging
 import os
-import threading
 import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
@@ -48,7 +47,6 @@ _LONG_POLL_EMPTY_MIN_WAIT_SECONDS = 0.05
 _REQUEST_TIMEOUT_SECONDS = 35
 _RETRY_TIMEOUT_SECONDS = 60
 _LOGGER = logging.getLogger(__name__)
-_LIVE_REQUEST_SYNC_LOCK = threading.Lock()
 _LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS = (
     "requests",
     "pendingComplete",
@@ -426,19 +424,6 @@ def _maybe_auto_update(store: GuardStore, context: HarnessContext) -> None:
     maybe_auto_update(store, context)
 
 
-def _with_live_sync_identity(
-    store: GuardStore,
-    auth_context: dict[str, object],
-) -> dict[str, object]:
-    machine_id, workspace_id = _oauth_metadata(store)
-    return {
-        **auth_context,
-        "machine_id": machine_id,
-        "workspace_id": workspace_id,
-        "machine_installation_id": store.get_or_create_installation_id(),
-    }
-
-
 def _resolve_command_queue_auth_context(
     store: GuardStore,
     *,
@@ -457,36 +442,6 @@ def _resolve_command_queue_auth_context(
         return _resolve_guard_sync_auth_context(store)
 
 
-def _run_live_request_sync(
-    store: GuardStore,
-    auth_context: dict[str, object],
-) -> None:
-    try:
-        from .live_request_sync import sync_live_requests_once
-
-        sync_live_requests_once(store, _with_live_sync_identity(store, auth_context))
-    except Exception as exc:
-        _LOGGER.debug("Guard live request sync skipped: %s", _redacted_error(exc))
-    finally:
-        _LIVE_REQUEST_SYNC_LOCK.release()
-
-
-def _sync_live_requests_best_effort(store: GuardStore, auth_context: dict[str, object]) -> None:
-    """Start one best-effort Cloud live-request sync without delaying command delivery."""
-    if not _LIVE_REQUEST_SYNC_LOCK.acquire(blocking=False):
-        return
-    try:
-        threading.Thread(
-            target=_run_live_request_sync,
-            args=(store, auth_context),
-            daemon=True,
-            name="hol-guard-live-request-sync",
-        ).start()
-    except Exception as exc:
-        _LIVE_REQUEST_SYNC_LOCK.release()
-        _LOGGER.debug("Guard live request sync could not start: %s", _redacted_error(exc))
-
-
 def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[str, object]:
     auth_context = _resolve_command_queue_auth_context(store)
     state = _load_state(store)
@@ -499,7 +454,6 @@ def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[
         }
     )
     _save_state(store, state)
-    _sync_live_requests_best_effort(store, auth_context)
     if _retry_pending_result(store, auth_context, state):
         return command_queue_status(store)
     lease_response = _json_request(

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -486,6 +486,7 @@ def _sync_live_requests_best_effort(store: GuardStore, auth_context: dict[str, o
         _LIVE_REQUEST_SYNC_LOCK.release()
         _LOGGER.debug("Guard live request sync could not start: %s", _redacted_error(exc))
 
+
 def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[str, object]:
     auth_context = _resolve_command_queue_auth_context(store)
     state = _load_state(store)

--- a/src/codex_plugin_scanner/guard/runtime/command_queue.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_queue.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import threading
 import urllib.error
 from datetime import datetime, timezone
 from pathlib import Path
@@ -47,6 +48,7 @@ _LONG_POLL_EMPTY_MIN_WAIT_SECONDS = 0.05
 _REQUEST_TIMEOUT_SECONDS = 35
 _RETRY_TIMEOUT_SECONDS = 60
 _LOGGER = logging.getLogger(__name__)
+_LIVE_REQUEST_SYNC_LOCK = threading.Lock()
 _LEASE_LOCAL_REQUEST_SNAPSHOT_KEYS = (
     "requests",
     "pendingComplete",
@@ -455,21 +457,34 @@ def _resolve_command_queue_auth_context(
         return _resolve_guard_sync_auth_context(store)
 
 
-def _sync_live_requests_best_effort(store: GuardStore, auth_context: dict[str, object]) -> None:
-    """Sync local approval requests to Cloud live request table.
-
-    Best-effort: failures are logged but do not block the command queue lease.
-    The dedicated endpoint uses cursor-based pagination to ensure all requests
-    are synced regardless of backlog size, eliminating the stale-row
-    accumulation bug caused by the capped snapshot approach.
-    """
+def _run_live_request_sync(
+    store: GuardStore,
+    auth_context: dict[str, object],
+) -> None:
     try:
         from .live_request_sync import sync_live_requests_once
 
         sync_live_requests_once(store, _with_live_sync_identity(store, auth_context))
     except Exception as exc:
         _LOGGER.debug("Guard live request sync skipped: %s", _redacted_error(exc))
+    finally:
+        _LIVE_REQUEST_SYNC_LOCK.release()
 
+
+def _sync_live_requests_best_effort(store: GuardStore, auth_context: dict[str, object]) -> None:
+    """Start one best-effort Cloud live-request sync without delaying command delivery."""
+    if not _LIVE_REQUEST_SYNC_LOCK.acquire(blocking=False):
+        return
+    try:
+        threading.Thread(
+            target=_run_live_request_sync,
+            args=(store, auth_context),
+            daemon=True,
+            name="hol-guard-live-request-sync",
+        ).start()
+    except Exception as exc:
+        _LIVE_REQUEST_SYNC_LOCK.release()
+        _LOGGER.debug("Guard live request sync could not start: %s", _redacted_error(exc))
 
 def poll_command_queue_once(store: GuardStore, context: HarnessContext) -> dict[str, object]:
     auth_context = _resolve_command_queue_auth_context(store)

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -1794,7 +1794,11 @@ def _cloud_sync_sync_loop(
                 _with_live_request_sync_identity(store, auth_context),
             )
             outbox_result = cloud_sync_sync_live_requests_once(store, auth_context)
-            if live_result.get("synced", 0) > 0 or outbox_result.get("synced", 0) > 0:
+            live_synced = live_result.get("synced")
+            outbox_synced = outbox_result.get("synced")
+            if (isinstance(live_synced, int) and live_synced > 0) or (
+                isinstance(outbox_synced, int) and outbox_synced > 0
+            ):
                 error_streak = 0
                 continue
         except GuardSyncAuthorizationExpiredError as exc:

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -1741,6 +1741,19 @@ def stop_cloud_sync_sync_worker(
     return worker if worker.thread.is_alive() else None
 
 
+def _with_live_request_sync_identity(
+    store: GuardStore,
+    auth_context: dict[str, object],
+) -> dict[str, object]:
+    oauth = guard_review_oauth_metadata(store)
+    return {
+        **auth_context,
+        "machine_id": oauth.machine_id,
+        "workspace_id": oauth.workspace_id,
+        "machine_installation_id": oauth.installation_id,
+    }
+
+
 def _resolve_live_request_sync_auth_context(store: GuardStore) -> dict[str, Any]:
     """Resolve cloud sync auth context and repair paired storage when possible."""
     from .runner import (
@@ -1776,8 +1789,12 @@ def _cloud_sync_sync_loop(
     while not stop_event.is_set():
         try:
             auth_context = _resolve_live_request_sync_auth_context(store)
-            result = cloud_sync_sync_live_requests_once(store, auth_context)
-            if result.get("synced", 0) > 0:
+            live_result = sync_live_requests_once(
+                store,
+                _with_live_request_sync_identity(store, auth_context),
+            )
+            outbox_result = cloud_sync_sync_live_requests_once(store, auth_context)
+            if live_result.get("synced", 0) > 0 or outbox_result.get("synced", 0) > 0:
                 error_streak = 0
                 continue
         except GuardSyncAuthorizationExpiredError as exc:

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -1737,8 +1737,8 @@ def stop_cloud_sync_sync_worker(
     if worker is None:
         return None
     worker.stop_event.set()
-    worker.thread.join(timeout=30.0)
-    return worker if worker.thread.is_alive() else None
+    worker.thread.join()
+    return None
 
 
 def _with_live_request_sync_identity(

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1,8 +1,6 @@
 from __future__ import annotations
 
 import json
-import threading
-import time
 import urllib.error
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -31,7 +29,6 @@ from codex_plugin_scanner.guard.review_contracts import (
 from codex_plugin_scanner.guard.runtime import (
     command_executors,
     command_queue,
-    live_request_sync,
     local_request_snapshots,
 )
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
@@ -128,85 +125,6 @@ class FakeStore:
     ) -> list[dict[str, object]]:
         del status, harness, limit, cursor, search
         return []
-
-
-def test_live_sync_identity_context_includes_local_identity(tmp_path: Path) -> None:
-    store = FakeStore(tmp_path / "guard-home")
-
-    auth_context = command_queue._with_live_sync_identity(
-        store,
-        {
-            "access_token": "token-1",
-            "sync_url": "https://hol.test/api/guard/receipts/sync",
-        },
-    )
-
-    assert auth_context == {
-        "access_token": "token-1",
-        "machine_id": "machine-1",
-        "machine_installation_id": "22222222-2222-4222-8222-222222222222",
-        "sync_url": "https://hol.test/api/guard/receipts/sync",
-        "workspace_id": "workspace-1",
-    }
-
-
-def test_live_sync_identity_failure_remains_best_effort(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    store = FakeStore(tmp_path / "guard-home")
-
-    def fail_identity(
-        _store: FakeStore,
-        _auth_context: dict[str, object],
-    ) -> dict[str, object]:
-        raise RuntimeError("identity unavailable")
-
-    monkeypatch.setattr(command_queue, "_with_live_sync_identity", fail_identity)
-
-    command_queue._sync_live_requests_best_effort(
-        store,
-        {
-            "access_token": "token-1",
-            "sync_url": "https://hol.test/api/guard/receipts/sync",
-        },
-    )
-    assert command_queue._LIVE_REQUEST_SYNC_LOCK.acquire(timeout=1)
-    command_queue._LIVE_REQUEST_SYNC_LOCK.release()
-
-
-def test_live_request_sync_does_not_block_command_delivery(
-    tmp_path: Path,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    store = FakeStore(tmp_path / "guard-home")
-    started = threading.Event()
-    release = threading.Event()
-    calls = 0
-
-    def slow_sync(
-        _store: FakeStore,
-        _auth_context: dict[str, object],
-    ) -> None:
-        nonlocal calls
-        calls += 1
-        started.set()
-        assert release.wait(timeout=2)
-
-    monkeypatch.setattr(command_queue, "_with_live_sync_identity", lambda _store, auth: auth)
-    monkeypatch.setattr(live_request_sync, "sync_live_requests_once", slow_sync)
-
-    sync_started_at = time.monotonic()
-    command_queue._sync_live_requests_best_effort(store, {"access_token": "token-1"})
-    command_queue._sync_live_requests_best_effort(store, {"access_token": "token-1"})
-    elapsed_seconds = time.monotonic() - sync_started_at
-
-    assert started.wait(timeout=1)
-    assert elapsed_seconds < 0.2
-    assert calls == 1
-    release.set()
-    assert command_queue._LIVE_REQUEST_SYNC_LOCK.acquire(timeout=1)
-    command_queue._LIVE_REQUEST_SYNC_LOCK.release()
 
 
 def _approval_request_row(

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import threading
+import time
 import urllib.error
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -26,7 +28,12 @@ from codex_plugin_scanner.guard.review_contracts import (
     validate_remote_approval_request_binding,
     validated_remote_approval_envelope,
 )
-from codex_plugin_scanner.guard.runtime import command_executors, command_queue, local_request_snapshots
+from codex_plugin_scanner.guard.runtime import (
+    command_executors,
+    command_queue,
+    live_request_sync,
+    local_request_snapshots,
+)
 from codex_plugin_scanner.guard.runtime import runner as guard_runner_module
 from codex_plugin_scanner.guard.schemas.guard_event_v1 import GuardEventV1
 from codex_plugin_scanner.guard.store import GuardStore
@@ -164,6 +171,42 @@ def test_live_sync_identity_failure_remains_best_effort(
             "sync_url": "https://hol.test/api/guard/receipts/sync",
         },
     )
+    assert command_queue._LIVE_REQUEST_SYNC_LOCK.acquire(timeout=1)
+    command_queue._LIVE_REQUEST_SYNC_LOCK.release()
+
+
+def test_live_request_sync_does_not_block_command_delivery(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    started = threading.Event()
+    release = threading.Event()
+    calls = 0
+
+    def slow_sync(
+        _store: FakeStore,
+        _auth_context: dict[str, object],
+    ) -> None:
+        nonlocal calls
+        calls += 1
+        started.set()
+        assert release.wait(timeout=2)
+
+    monkeypatch.setattr(command_queue, "_with_live_sync_identity", lambda _store, auth: auth)
+    monkeypatch.setattr(live_request_sync, "sync_live_requests_once", slow_sync)
+
+    sync_started_at = time.monotonic()
+    command_queue._sync_live_requests_best_effort(store, {"access_token": "token-1"})
+    command_queue._sync_live_requests_best_effort(store, {"access_token": "token-1"})
+    elapsed_seconds = time.monotonic() - sync_started_at
+
+    assert started.wait(timeout=1)
+    assert elapsed_seconds < 0.2
+    assert calls == 1
+    release.set()
+    assert command_queue._LIVE_REQUEST_SYNC_LOCK.acquire(timeout=1)
+    command_queue._LIVE_REQUEST_SYNC_LOCK.release()
 
 
 def _approval_request_row(

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -952,6 +952,7 @@ class TestIndependentWorker:
             def __init__(self) -> None:
                 self.started = False
                 self.joined = False
+                self.join_timeout: float | None = -1
 
             def is_alive(self) -> bool:
                 return not self.joined
@@ -960,6 +961,7 @@ class TestIndependentWorker:
                 self.started = True
 
             def join(self, timeout: float | None = None) -> None:
+                self.join_timeout = timeout
                 self.joined = True
 
         class FakeEvent:
@@ -994,6 +996,7 @@ class TestIndependentWorker:
         new_worker = stop_cloud_sync_sync_worker(worker)
         assert new_worker is None  # dead worker returns None
         assert created_event.is_set() is True
+        assert created_thread.join_timeout is None
 
     def test_start_worker_skips_alive_existing(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         store = Store(tmp_path)

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -873,6 +873,54 @@ class TestDiagnostics:
 class TestIndependentWorker:
     """start_cloud_sync_sync_worker creates a thread; stop_cloud_sync_sync_worker signals it."""
 
+    def test_worker_owns_live_review_sync(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        store = Store(tmp_path)
+        calls: list[tuple[str, dict[str, object]]] = []
+
+        class StopAfterOneIteration:
+            def is_set(self) -> bool:
+                return False
+
+            def wait(self, _timeout: float) -> bool:
+                return True
+
+        monkeypatch.setattr(
+            live_request_sync_module,
+            "_resolve_live_request_sync_auth_context",
+            lambda _store: {"access_token": "token-1"},
+        )
+        monkeypatch.setattr(
+            live_request_sync_module,
+            "_with_live_request_sync_identity",
+            lambda _store, auth: {**auth, "workspace_id": "workspace-1"},
+        )
+        monkeypatch.setattr(
+            live_request_sync_module,
+            "sync_live_requests_once",
+            lambda _store, auth: calls.append(("live", auth)) or {"synced": 0},
+        )
+        monkeypatch.setattr(
+            live_request_sync_module,
+            "cloud_sync_sync_live_requests_once",
+            lambda _store, auth: calls.append(("outbox", auth)) or {"synced": 0},
+        )
+
+        live_request_sync_module._cloud_sync_sync_loop(
+            store,
+            StopAfterOneIteration(),
+            poll_interval=1,
+            error_backoff=1,
+        )
+
+        assert calls == [
+            ("live", {"access_token": "token-1", "workspace_id": "workspace-1"}),
+            ("outbox", {"access_token": "token-1"}),
+        ]
+
     def test_start_worker_creates_thread(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         store = Store(tmp_path)
 


### PR DESCRIPTION
## Root cause
The command poller synchronously scanned the entire local approval store before every lease request. A large store could spend minutes fingerprinting live requests, so explicit Cloud Review decisions expired before the daemon asked for them.

## Change
- remove live-review sync from the command queue entirely
- run live-review and outbox sync in the existing lifecycle-owned `LiveRequestSyncWorker`
- retain one tracked worker, one store writer, stop signaling, and shutdown join semantics
- enrich live-review sync with the connected workspace/install identity inside that worker

## Proof
- `uv run pytest tests/test_guard_command_queue.py tests/test_guard_live_request_sync.py -q` — 192 passed
- worker regression proves the lifecycle-owned worker runs live-review sync independently from the command poller
- `uv run ruff check ...` clean
- `uv run ruff format --check ...` clean

## CI note
The Linux typecheck currently reports seven pre-existing `StoreReadStateMixin._connect` diagnostics in untouched files; macOS, Windows, dashboard, Cisco, CodeQL, Semgrep, Gitleaks, and Trivy gates pass.