### PR TITLE
fix(types): declare Guard store contracts

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -1672,8 +1672,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return
         if parsed.path == "/v1/read-state":
             body = self._read_delete_body()
-            if body and isinstance(body.get("request_id"), str):
-                store.mark_request_unread(body["request_id"])
+            request_id = body.get("request_id") if body else None
+            if isinstance(request_id, str):
+                store.mark_request_unread(request_id)
             elif body and body.get("clear_all"):
                 store.clear_read_state()
             self._write_json({"ok": True})

--- a/src/codex_plugin_scanner/guard/store_read_state.py
+++ b/src/codex_plugin_scanner/guard/store_read_state.py
@@ -2,13 +2,20 @@
 
 from __future__ import annotations
 
+import sqlite3
+from contextlib import AbstractContextManager
 from datetime import datetime, timezone
+from typing import TYPE_CHECKING
 
 
 class StoreReadStateMixin:
     """SQLite-backed read-state for approval requests viewed by the user."""
 
     READ_STATE_LIMIT = 50000
+
+    if TYPE_CHECKING:
+
+        def _connect(self) -> AbstractContextManager[sqlite3.Connection]: ...
 
     def mark_requests_read(self, request_ids: list[str]) -> None:
         if not request_ids:


### PR DESCRIPTION
## Summary

- Declare the existing SQLite connection contract used by the read-state mixin.
- Preserve the validated request ID type before invoking the store method.

## Verification

- `uv run ruff check src/codex_plugin_scanner/guard/store_read_state.py src/codex_plugin_scanner/guard/daemon/server.py`
- `uv run python -m compileall -q src/codex_plugin_scanner/guard/store_read_state.py src/codex_plugin_scanner/guard/daemon/server.py`
- `uv run pytest tests/test_guard_approval_store_dedup.py tests/test_guard_approval_store_phase14.py tests/test_guard_headless_daemon_api.py -q`
