### PR TITLE
fix(runtime): accept durable cloud approvals

### DIFF
--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -361,14 +361,19 @@ def payload_hash_for_remote_approval_envelope(envelope: dict[str, object]) -> st
     return _sha256_hex(_canonical_signed_payload(envelope))
 
 
-def validated_remote_approval_envelope(envelope: dict[str, object], *, store) -> dict[str, object]:
+def validated_remote_approval_envelope(
+    envelope: dict[str, object],
+    *,
+    store,
+    allow_expired: bool = False,
+) -> dict[str, object]:
     if envelope.get("contractVersion") != _REMOTE_APPROVAL_CONTRACT_VERSION:
         raise GuardReviewContractError("unsupported_remote_approval_contract")
     if envelope.get("scope") not in _REMOTE_APPROVAL_ALLOWED_SCOPES:
         raise GuardReviewContractError("invalid_remote_approval_scope")
     issued_at = _parse_iso_timestamp(envelope.get("issuedAt"), field_name="issued_at")
     expires_at = _parse_iso_timestamp(envelope.get("expiresAt"), field_name="expires_at")
-    if expires_at <= issued_at or expires_at <= _now():
+    if expires_at <= issued_at or (expires_at <= _now() and not allow_expired):
         raise GuardReviewContractError("remote_approval_expired")
     payload_hash = _non_empty_string(envelope.get("payloadHash"))
     if payload_hash is None or payload_hash != payload_hash_for_remote_approval_envelope(envelope):

--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -365,7 +365,7 @@ def validated_remote_approval_envelope(
     envelope: dict[str, object],
     *,
     store,
-    allow_expired: bool = False,
+    admitted_at: object | None = None,
 ) -> dict[str, object]:
     if envelope.get("contractVersion") != _REMOTE_APPROVAL_CONTRACT_VERSION:
         raise GuardReviewContractError("unsupported_remote_approval_contract")
@@ -373,8 +373,17 @@ def validated_remote_approval_envelope(
         raise GuardReviewContractError("invalid_remote_approval_scope")
     issued_at = _parse_iso_timestamp(envelope.get("issuedAt"), field_name="issued_at")
     expires_at = _parse_iso_timestamp(envelope.get("expiresAt"), field_name="expires_at")
-    if expires_at <= issued_at or (expires_at <= _now() and not allow_expired):
+    if expires_at <= issued_at:
         raise GuardReviewContractError("remote_approval_expired")
+    if expires_at <= _now():
+        if admitted_at is None:
+            raise GuardReviewContractError("remote_approval_expired")
+        queue_admitted_at = _parse_iso_timestamp(
+            admitted_at,
+            field_name="queue_admitted_at",
+        )
+        if queue_admitted_at < issued_at or queue_admitted_at > expires_at:
+            raise GuardReviewContractError("remote_approval_expired")
     payload_hash = _non_empty_string(envelope.get("payloadHash"))
     if payload_hash is None or payload_hash != payload_hash_for_remote_approval_envelope(envelope):
         raise GuardReviewContractError("remote_approval_payload_hash_mismatch")

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -329,7 +329,11 @@ def _execute_approval_operation(
         request_row=request_row,
         local_request_id=local_request_id,
     )
-    envelope = validated_remote_approval_envelope(remote_approval, store=store)
+    envelope = validated_remote_approval_envelope(
+        remote_approval,
+        store=store,
+        allow_expired=True,
+    )
     validate_remote_approval_request_binding(
         envelope=envelope,
         request_row=request_row,

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -332,7 +332,7 @@ def _execute_approval_operation(
     envelope = validated_remote_approval_envelope(
         remote_approval,
         store=store,
-        allow_expired=True,
+        admitted_at=job.get("createdAt"),
     )
     validate_remote_approval_request_binding(
         envelope=envelope,

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -161,6 +161,7 @@ def _signed_remote_approval(
     *,
     decision: str = "allow_once",
     receipt_id: str = "cloud-receipt-1",
+    issued_at: datetime | None = None,
     scope: str | None = None,
 ) -> dict[str, object]:
     oauth = guard_review_oauth_metadata(store)
@@ -169,7 +170,7 @@ def _signed_remote_approval(
         oauth=oauth,
         store=store,
     )
-    issued_at = datetime.now(timezone.utc).replace(microsecond=0)
+    issued_at = issued_at or datetime.now(timezone.utc).replace(microsecond=0)
     expires_at = issued_at + timedelta(minutes=5)
     envelope = {
         "actionEnvelopeHash": claim["actionEnvelopeHash"],
@@ -2122,7 +2123,7 @@ def test_executor_returns_waiting_local_confirm_for_app_remove_without_surface(
     }
 
 
-def test_executor_resolves_local_approval_with_distinct_portal_routing_installation(tmp_path: Path) -> None:
+def test_executor_resolves_expired_queued_remote_approval(tmp_path: Path) -> None:
     class ApprovalStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
@@ -2174,7 +2175,11 @@ def test_executor_resolves_local_approval_with_distinct_portal_routing_installat
             self.guard_events.append(event)
 
     store = ApprovalStore(tmp_path / "guard-home")
-    remote_approval = _signed_remote_approval(store, store.request_row)
+    remote_approval = _signed_remote_approval(
+        store,
+        store.request_row,
+        issued_at=datetime(2026, 6, 12, tzinfo=timezone.utc),
+    )
     result = command_executors.execute_guard_command_job(
         {
             "operation": "guard.approval.resolve",

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -300,6 +300,23 @@ def _oauth_store(tmp_path: Path) -> GuardStore:
     return store
 
 
+def test_remote_approval_rejects_queue_admission_after_expiry(tmp_path: Path) -> None:
+    store = FakeStore(tmp_path / "guard-home")
+    request_row = _approval_request_row("request-expired")
+    envelope = _signed_remote_approval(
+        store,
+        request_row,
+        issued_at=datetime(2026, 6, 12, tzinfo=timezone.utc),
+    )
+
+    with pytest.raises(GuardReviewContractError, match="remote_approval_expired"):
+        validated_remote_approval_envelope(
+            envelope,
+            store=store,
+            admitted_at="2026-06-12T00:06:00+00:00",
+        )
+
+
 def test_guard_review_oauth_metadata_prefers_explicit_device_id(tmp_path: Path) -> None:
     class DeviceStore(FakeStore):
         def get_oauth_local_credentials(self, *, allow_primary: bool = False) -> dict[str, object]:
@@ -2182,6 +2199,7 @@ def test_executor_resolves_expired_queued_remote_approval(tmp_path: Path) -> Non
     )
     result = command_executors.execute_guard_command_job(
         {
+            "createdAt": "2026-06-12T00:02:00+00:00",
             "operation": "guard.approval.resolve",
             "targetMachineInstallationId": "portal-installation-routing-id",
             "payload": {


### PR DESCRIPTION
## Summary
- permit authenticated command-queue delivery of a signed remote approval after its delivery window elapsed
- retain strict expiry validation for direct approval-envelope consumers
- preserve signature, payload-hash, target-binding, receipt replay, and local-request policy checks

## Verification
- `uv run pytest tests/test_guard_command_queue.py -q` (98 passed)
- Ruff check clean
- Ruff format check clean