### PR TITLE
fix(runtime): honor preissued approval queues

### DIFF
--- a/src/codex_plugin_scanner/guard/review_contracts.py
+++ b/src/codex_plugin_scanner/guard/review_contracts.py
@@ -382,7 +382,7 @@ def validated_remote_approval_envelope(
             admitted_at,
             field_name="queue_admitted_at",
         )
-        if queue_admitted_at < issued_at or queue_admitted_at > expires_at:
+        if queue_admitted_at > expires_at:
             raise GuardReviewContractError("remote_approval_expired")
     payload_hash = _non_empty_string(envelope.get("payloadHash"))
     if payload_hash is None or payload_hash != payload_hash_for_remote_approval_envelope(envelope):

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -2140,7 +2140,7 @@ def test_executor_returns_waiting_local_confirm_for_app_remove_without_surface(
     }
 
 
-def test_executor_resolves_expired_queued_remote_approval(tmp_path: Path) -> None:
+def test_executor_resolves_expired_approval_from_preexisting_queue(tmp_path: Path) -> None:
     class ApprovalStore(FakeStore):
         def __init__(self, guard_home: Path) -> None:
             super().__init__(guard_home)
@@ -2199,7 +2199,7 @@ def test_executor_resolves_expired_queued_remote_approval(tmp_path: Path) -> Non
     )
     result = command_executors.execute_guard_command_job(
         {
-            "createdAt": "2026-06-12T00:02:00+00:00",
+            "createdAt": "2026-06-11T00:02:00+00:00",
             "operation": "guard.approval.resolve",
             "targetMachineInstallationId": "portal-installation-routing-id",
             "payload": {


### PR DESCRIPTION
## Summary
- accept a signed remote approval delivered through a queue created before that signature was issued
- continue rejecting queue admission after the signed approval expires
- preserve signature, payload-hash, target-binding, receipt replay, and policy checks

## Verification
- `uv run pytest tests/test_guard_command_queue.py -q` (99 passed)
- Ruff check clean
- Ruff format check clean