### PR TITLE
fix(guard): replace native title tooltips with CSS hover tooltips

### DIFF
--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -947,7 +947,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                   : "border-transparent bg-brand-blue"
               }`}
             />
-            <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100">
+            <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100">
               {isRead ? "Read" : "Unread"}
             </span>
           </span>
@@ -970,7 +970,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 isBlocked ? "bg-brand-attention" : "bg-emerald-400"
               }`}
             />
-            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100">
+            <span className="pointer-events-none absolute right-0 top-full z-40 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100">
               {isBlocked ? "Blocked by policy" : "Allowed by policy"}
             </span>
           </span>
@@ -982,7 +982,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
             }`}
           >
             <CategoryIcon className="h-4 w-4" aria-hidden="true" />
-            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100">
+            <span className="pointer-events-none absolute right-0 top-full z-30 mt-5 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100">
               {category.label}
             </span>
           </span>

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -937,14 +937,20 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
         >
           <span
             role="img"
-            className={`h-2 w-2 shrink-0 rounded-full border-2 transition-colors ${
-              isRead
-                ? "border-slate-300 bg-transparent"
-                : "border-transparent bg-brand-blue"
-            }`}
-            title={isRead ? "Read" : "Unread"}
             aria-label={isRead ? "Read" : "Unread"}
-          />
+            className="group/tt relative flex h-2 w-2 shrink-0 items-center justify-center"
+          >
+            <span
+              className={`h-2 w-2 rounded-full border-2 transition-colors ${
+                isRead
+                  ? "border-slate-300 bg-transparent"
+                  : "border-transparent bg-brand-blue"
+              }`}
+            />
+            <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100">
+              {isRead ? "Read" : "Unread"}
+            </span>
+          </span>
           <div className="min-w-0 flex-1">
             <p className={`truncate text-sm ${isRead ? "font-medium text-slate-600" : "font-bold text-brand-dark"}`}>
               {!isRead && <span className="sr-only">Unread request:</span>}
@@ -956,21 +962,29 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
           </div>
           <span
             role="img"
-            className={`inline-flex h-2 w-2 shrink-0 rounded-full ${
-              isBlocked ? "bg-brand-attention" : "bg-emerald-400"
-            }`}
-            title={isBlocked ? "Blocked by policy" : "Allowed by policy"}
             aria-label={isBlocked ? "Blocked by policy" : "Allowed by policy"}
-          />
+            className="group/tt relative flex h-2 w-2 shrink-0 items-center justify-center"
+          >
+            <span
+              className={`h-2 w-2 rounded-full ${
+                isBlocked ? "bg-brand-attention" : "bg-emerald-400"
+              }`}
+            />
+            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100">
+              {isBlocked ? "Blocked by policy" : "Allowed by policy"}
+            </span>
+          </span>
           <span
             role="img"
-            className={`inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
+            aria-label={category.label}
+            className={`group/tt relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
               active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"
             }`}
-            title={category.label}
-            aria-label={category.label}
           >
             <CategoryIcon className="h-4 w-4" aria-hidden="true" />
+            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100">
+              {category.label}
+            </span>
           </span>
         </button>
       </div>

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -947,7 +947,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                   : "border-transparent bg-brand-blue"
               }`}
             />
-            <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100">
+            <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100">
               {isRead ? "Read" : "Unread"}
             </span>
           </span>
@@ -970,7 +970,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 isBlocked ? "bg-brand-attention" : "bg-emerald-400"
               }`}
             />
-            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100">
+            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100">
               {isBlocked ? "Blocked by policy" : "Allowed by policy"}
             </span>
           </span>
@@ -982,7 +982,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
             }`}
           >
             <CategoryIcon className="h-4 w-4" aria-hidden="true" />
-            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100">
+            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100">
               {category.label}
             </span>
           </span>

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -933,12 +933,12 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
           aria-posinset={index + 1}
           aria-setsize={undefined}
           tabIndex={active ? 0 : -1}
-          className="flex min-w-0 flex-1 items-center gap-2 text-left"
+          className="group flex min-w-0 flex-1 items-center gap-2 text-left"
         >
           <span
             role="img"
             aria-label={isRead ? "Read" : "Unread"}
-            className="group/tt relative flex h-2 w-2 shrink-0 items-center justify-center"
+            className="relative flex h-2 w-2 shrink-0 items-center justify-center"
           >
             <span
               className={`h-2 w-2 rounded-full border-2 transition-colors ${
@@ -947,7 +947,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                   : "border-transparent bg-brand-blue"
               }`}
             />
-            <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100">
+            <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100">
               {isRead ? "Read" : "Unread"}
             </span>
           </span>
@@ -963,26 +963,26 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
           <span
             role="img"
             aria-label={isBlocked ? "Blocked by policy" : "Allowed by policy"}
-            className="group/tt relative flex h-2 w-2 shrink-0 items-center justify-center"
+            className="relative flex h-2 w-2 shrink-0 items-center justify-center"
           >
             <span
               className={`h-2 w-2 rounded-full ${
                 isBlocked ? "bg-brand-attention" : "bg-emerald-400"
               }`}
             />
-            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100">
+            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100">
               {isBlocked ? "Blocked by policy" : "Allowed by policy"}
             </span>
           </span>
           <span
             role="img"
             aria-label={category.label}
-            className={`group/tt relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
+            className={`relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
               active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"
             }`}
           >
             <CategoryIcon className="h-4 w-4" aria-hidden="true" />
-            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100">
+            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100">
               {category.label}
             </span>
           </span>

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25119,13 +25119,21 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
             tabIndex: active ? 0 : -1,
             className: "flex min-w-0 flex-1 items-center gap-2 text-left",
             children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
+              /* @__PURE__ */ jsxRuntimeExports.jsxs(
                 "span",
                 {
                   role: "img",
-                  className: `h-2 w-2 shrink-0 rounded-full border-2 transition-colors ${isRead ? "border-slate-300 bg-transparent" : "border-transparent bg-brand-blue"}`,
-                  title: isRead ? "Read" : "Unread",
-                  "aria-label": isRead ? "Read" : "Unread"
+                  "aria-label": isRead ? "Read" : "Unread",
+                  className: "group/tt relative flex h-2 w-2 shrink-0 items-center justify-center",
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx(
+                      "span",
+                      {
+                        className: `h-2 w-2 rounded-full border-2 transition-colors ${isRead ? "border-slate-300 bg-transparent" : "border-transparent bg-brand-blue"}`
+                      }
+                    ),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100", children: isRead ? "Read" : "Unread" })
+                  ]
                 }
               ),
               /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
@@ -25141,23 +25149,33 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                   formatQueueRequestDate(item)
                 ] })
               ] }),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
+              /* @__PURE__ */ jsxRuntimeExports.jsxs(
                 "span",
                 {
                   role: "img",
-                  className: `inline-flex h-2 w-2 shrink-0 rounded-full ${isBlocked ? "bg-brand-attention" : "bg-emerald-400"}`,
-                  title: isBlocked ? "Blocked by policy" : "Allowed by policy",
-                  "aria-label": isBlocked ? "Blocked by policy" : "Allowed by policy"
+                  "aria-label": isBlocked ? "Blocked by policy" : "Allowed by policy",
+                  className: "group/tt relative flex h-2 w-2 shrink-0 items-center justify-center",
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx(
+                      "span",
+                      {
+                        className: `h-2 w-2 rounded-full ${isBlocked ? "bg-brand-attention" : "bg-emerald-400"}`
+                      }
+                    ),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
+                  ]
                 }
               ),
-              /* @__PURE__ */ jsxRuntimeExports.jsx(
+              /* @__PURE__ */ jsxRuntimeExports.jsxs(
                 "span",
                 {
                   role: "img",
-                  className: `inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
-                  title: category.label,
                   "aria-label": category.label,
-                  children: /* @__PURE__ */ jsxRuntimeExports.jsx(CategoryIcon, { className: "h-4 w-4", "aria-hidden": "true" })
+                  className: `group/tt relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
+                  children: [
+                    /* @__PURE__ */ jsxRuntimeExports.jsx(CategoryIcon, { className: "h-4 w-4", "aria-hidden": "true" }),
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100", children: category.label })
+                  ]
                 }
               )
             ]

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25117,14 +25117,14 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
             "aria-posinset": index + 1,
             "aria-setsize": void 0,
             tabIndex: active ? 0 : -1,
-            className: "flex min-w-0 flex-1 items-center gap-2 text-left",
+            className: "group flex min-w-0 flex-1 items-center gap-2 text-left",
             children: [
               /* @__PURE__ */ jsxRuntimeExports.jsxs(
                 "span",
                 {
                   role: "img",
                   "aria-label": isRead ? "Read" : "Unread",
-                  className: "group/tt relative flex h-2 w-2 shrink-0 items-center justify-center",
+                  className: "relative flex h-2 w-2 shrink-0 items-center justify-center",
                   children: [
                     /* @__PURE__ */ jsxRuntimeExports.jsx(
                       "span",
@@ -25132,7 +25132,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                         className: `h-2 w-2 rounded-full border-2 transition-colors ${isRead ? "border-slate-300 bg-transparent" : "border-transparent bg-brand-blue"}`
                       }
                     ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100", children: isRead ? "Read" : "Unread" })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100", children: isRead ? "Read" : "Unread" })
                   ]
                 }
               ),
@@ -25154,7 +25154,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 {
                   role: "img",
                   "aria-label": isBlocked ? "Blocked by policy" : "Allowed by policy",
-                  className: "group/tt relative flex h-2 w-2 shrink-0 items-center justify-center",
+                  className: "relative flex h-2 w-2 shrink-0 items-center justify-center",
                   children: [
                     /* @__PURE__ */ jsxRuntimeExports.jsx(
                       "span",
@@ -25162,7 +25162,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                         className: `h-2 w-2 rounded-full ${isBlocked ? "bg-brand-attention" : "bg-emerald-400"}`
                       }
                     ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
                   ]
                 }
               ),
@@ -25171,10 +25171,10 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 {
                   role: "img",
                   "aria-label": category.label,
-                  className: `group/tt relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
+                  className: `relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
                   children: [
                     /* @__PURE__ */ jsxRuntimeExports.jsx(CategoryIcon, { className: "h-4 w-4", "aria-hidden": "true" }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100", children: category.label })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100", children: category.label })
                   ]
                 }
               )

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25132,7 +25132,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                         className: `h-2 w-2 rounded-full border-2 transition-colors ${isRead ? "border-slate-300 bg-transparent" : "border-transparent bg-brand-blue"}`
                       }
                     ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100", children: isRead ? "Read" : "Unread" })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100", children: isRead ? "Read" : "Unread" })
                   ]
                 }
               ),
@@ -25162,7 +25162,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                         className: `h-2 w-2 rounded-full ${isBlocked ? "bg-brand-attention" : "bg-emerald-400"}`
                       }
                     ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-40 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
                   ]
                 }
               ),
@@ -25174,7 +25174,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                   className: `relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
                   children: [
                     /* @__PURE__ */ jsxRuntimeExports.jsx(CategoryIcon, { className: "h-4 w-4", "aria-hidden": "true" }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100 group-focus:opacity-100", children: category.label })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-30 mt-5 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100", children: category.label })
                   ]
                 }
               )

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25132,7 +25132,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                         className: `h-2 w-2 rounded-full border-2 transition-colors ${isRead ? "border-slate-300 bg-transparent" : "border-transparent bg-brand-blue"}`
                       }
                     ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100", children: isRead ? "Read" : "Unread" })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100", children: isRead ? "Read" : "Unread" })
                   ]
                 }
               ),
@@ -25162,7 +25162,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                         className: `h-2 w-2 rounded-full ${isBlocked ? "bg-brand-attention" : "bg-emerald-400"}`
                       }
                     ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
                   ]
                 }
               ),
@@ -25174,7 +25174,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                   className: `group/tt relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
                   children: [
                     /* @__PURE__ */ jsxRuntimeExports.jsx(CategoryIcon, { className: "h-4 w-4", "aria-hidden": "true" }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100", children: category.label })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/tt:opacity-100 group-focus-within/tt:opacity-100", children: category.label })
                   ]
                 }
               )

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4705,10 +4705,6 @@
     --tw-ring-inset: inset;
   }
 
-  .group-focus-within\/tt\:opacity-100:is(:where(.group\/tt):focus-within *) {
-    opacity: 1;
-  }
-
   @media (hover: hover) {
     .group-hover\:bg-\[color-mix\(in_srgb\,var\(--brand-blue\)_85\%\,var\(--brand-dark\)\)\]:is(:where(.group):hover *) {
       background-color: var(--brand-blue);
@@ -4720,9 +4716,13 @@
       }
     }
 
-    .group-hover\/tt\:opacity-100:is(:where(.group\/tt):hover *) {
+    .group-hover\:opacity-100:is(:where(.group):hover *) {
       opacity: 1;
     }
+  }
+
+  .group-focus\:opacity-100:is(:where(.group):focus *) {
+    opacity: 1;
   }
 
   .placeholder\:text-slate-400::placeholder {

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -552,6 +552,10 @@
     top: calc(var(--spacing) * 6);
   }
 
+  .top-full {
+    top: 100%;
+  }
+
   .-right-3 {
     right: calc(var(--spacing) * -3);
   }
@@ -610,6 +614,10 @@
 
   .left-0\.5 {
     left: calc(var(--spacing) * .5);
+  }
+
+  .left-1\/2 {
+    left: 50%;
   }
 
   .left-2\.5 {
@@ -3149,6 +3157,10 @@
     }
   }
 
+  .bg-slate-900 {
+    background-color: var(--color-slate-900);
+  }
+
   .bg-slate-900\/45 {
     background-color: #0f172b73;
   }
@@ -4702,6 +4714,10 @@
       .group-hover\:bg-\[color-mix\(in_srgb\,var\(--brand-blue\)_85\%\,var\(--brand-dark\)\)\]:is(:where(.group):hover *) {
         background-color: color-mix(in srgb,var(--brand-blue) 85%,var(--brand-dark));
       }
+    }
+
+    .group-hover\/tt\:opacity-100:is(:where(.group\/tt):hover *) {
+      opacity: 1;
     }
   }
 

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4705,6 +4705,10 @@
     --tw-ring-inset: inset;
   }
 
+  .group-focus-within\/tt\:opacity-100:is(:where(.group\/tt):focus-within *) {
+    opacity: 1;
+  }
+
   @media (hover: hover) {
     .group-hover\:bg-\[color-mix\(in_srgb\,var\(--brand-blue\)_85\%\,var\(--brand-dark\)\)\]:is(:where(.group):hover *) {
       background-color: var(--brand-blue);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -4721,10 +4721,6 @@
     }
   }
 
-  .group-focus\:opacity-100:is(:where(.group):focus *) {
-    opacity: 1;
-  }
-
   .placeholder\:text-slate-400::placeholder {
     color: var(--color-slate-400);
   }


### PR DESCRIPTION
## Problem

Native `title` attributes on `<span>` elements are unreliable: long delay before appearing, no touch support, inconsistent across browsers. Users reported tooltips not working.

## Fix

Replaced with CSS-based hover tooltips using Tailwind named groups (`group/tt` + `group-hover/tt:opacity-100`):

- **Unread dot**: shows "Read" or "Unread"
- **Policy status dot**: shows "Blocked by policy" or "Allowed by policy"
- **Category icon**: shows full category label (e.g. "Secret file access")

Tooltips are absolutely positioned below the icon, appear instantly on hover with a 150ms opacity transition, and use `pointer-events-none` to avoid interfering with clicks.

## Verification

- `pnpm run build` passes
- `pnpm test` — all dashboard tests pass
- Verified `group-hover/tt:opacity-100` CSS rule is generated in the bundle