### PR TITLE
fix(guard): one severity dot, unread bg, per-icon tooltips

### DIFF
--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -904,7 +904,9 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
           ? "border border-brand-blue/60 bg-brand-blue/[0.08] ring-1 ring-brand-blue/20"
           : active
             ? "border border-brand-blue bg-brand-blue/[0.06]"
-            : "border border-transparent bg-white hover:bg-slate-50"
+            : isRead
+              ? "border border-transparent bg-white hover:bg-slate-50"
+              : "border border-transparent bg-slate-50 hover:bg-slate-100"
       }`}
     >
       <div className="flex items-center justify-between gap-2">
@@ -933,26 +935,10 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
           aria-posinset={index + 1}
           aria-setsize={undefined}
           tabIndex={active ? 0 : -1}
-          className="group flex min-w-0 flex-1 items-center gap-2 text-left"
+          className="flex min-w-0 flex-1 items-center gap-2 text-left"
         >
-          <span
-            role="img"
-            aria-label={isRead ? "Read" : "Unread"}
-            className="relative flex h-2 w-2 shrink-0 items-center justify-center"
-          >
-            <span
-              className={`h-2 w-2 rounded-full border-2 transition-colors ${
-                isRead
-                  ? "border-slate-300 bg-transparent"
-                  : "border-transparent bg-brand-blue"
-              }`}
-            />
-            <span className="pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100">
-              {isRead ? "Read" : "Unread"}
-            </span>
-          </span>
           <div className="min-w-0 flex-1">
-            <p className={`truncate text-sm ${isRead ? "font-medium text-slate-600" : "font-bold text-brand-dark"}`}>
+            <p className={`truncate text-sm ${isRead ? "font-medium text-slate-500" : "font-bold text-brand-dark"}`}>
               {!isRead && <span className="sr-only">Unread request:</span>}
               {preview}
             </p>
@@ -963,26 +949,26 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
           <span
             role="img"
             aria-label={isBlocked ? "Blocked by policy" : "Allowed by policy"}
-            className="relative flex h-2 w-2 shrink-0 items-center justify-center"
+            className="group/icon relative flex h-2 w-2 shrink-0 items-center justify-center"
           >
             <span
               className={`h-2 w-2 rounded-full ${
                 isBlocked ? "bg-brand-attention" : "bg-emerald-400"
               }`}
             />
-            <span className="pointer-events-none absolute right-0 top-full z-40 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100">
+            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100">
               {isBlocked ? "Blocked by policy" : "Allowed by policy"}
             </span>
           </span>
           <span
             role="img"
             aria-label={category.label}
-            className={`relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
+            className={`group/icon relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${
               active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"
             }`}
           >
             <CategoryIcon className="h-4 w-4" aria-hidden="true" />
-            <span className="pointer-events-none absolute right-0 top-full z-30 mt-5 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100">
+            <span className="pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100">
               {category.label}
             </span>
           </span>

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -896,18 +896,17 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
     ? `Select ${preview} for bulk approval`
     : `Not eligible for bulk approval: ${category.shortLabel.toLowerCase()}`;
 
+  const rowClassName = (() => {
+    if (selected) return "border border-brand-blue/60 bg-brand-blue/[0.08] ring-1 ring-brand-blue/20";
+    if (active) return "border border-brand-blue bg-brand-blue/[0.06]";
+    if (isRead) return "border border-transparent bg-white hover:bg-slate-50";
+    return "border border-transparent bg-slate-50 hover:bg-slate-100";
+  })();
+
   return (
     <div
       role="none"
-      className={`group w-full rounded-lg py-2.5 px-2 transition-all ${
-        selected
-          ? "border border-brand-blue/60 bg-brand-blue/[0.08] ring-1 ring-brand-blue/20"
-          : active
-            ? "border border-brand-blue bg-brand-blue/[0.06]"
-            : isRead
-              ? "border border-transparent bg-white hover:bg-slate-50"
-              : "border border-transparent bg-slate-50 hover:bg-slate-100"
-      }`}
+      className={`group w-full rounded-lg py-2.5 px-2 transition-all ${rowClassName}`}
     >
       <div className="flex items-center justify-between gap-2">
         {showCheckbox ? (

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25085,7 +25085,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
     "div",
     {
       role: "none",
-      className: `group w-full rounded-lg py-2.5 px-2 transition-all ${selected ? "border border-brand-blue/60 bg-brand-blue/[0.08] ring-1 ring-brand-blue/20" : active ? "border border-brand-blue bg-brand-blue/[0.06]" : "border border-transparent bg-white hover:bg-slate-50"}`,
+      className: `group w-full rounded-lg py-2.5 px-2 transition-all ${selected ? "border border-brand-blue/60 bg-brand-blue/[0.08] ring-1 ring-brand-blue/20" : active ? "border border-brand-blue bg-brand-blue/[0.06]" : isRead ? "border border-transparent bg-white hover:bg-slate-50" : "border border-transparent bg-slate-50 hover:bg-slate-100"}`,
       children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
         showCheckbox ? /* @__PURE__ */ jsxRuntimeExports.jsx(
           "label",
@@ -25117,27 +25117,10 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
             "aria-posinset": index + 1,
             "aria-setsize": void 0,
             tabIndex: active ? 0 : -1,
-            className: "group flex min-w-0 flex-1 items-center gap-2 text-left",
+            className: "flex min-w-0 flex-1 items-center gap-2 text-left",
             children: [
-              /* @__PURE__ */ jsxRuntimeExports.jsxs(
-                "span",
-                {
-                  role: "img",
-                  "aria-label": isRead ? "Read" : "Unread",
-                  className: "relative flex h-2 w-2 shrink-0 items-center justify-center",
-                  children: [
-                    /* @__PURE__ */ jsxRuntimeExports.jsx(
-                      "span",
-                      {
-                        className: `h-2 w-2 rounded-full border-2 transition-colors ${isRead ? "border-slate-300 bg-transparent" : "border-transparent bg-brand-blue"}`
-                      }
-                    ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute left-1/2 top-full z-50 mt-1 -translate-x-1/2 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100", children: isRead ? "Read" : "Unread" })
-                  ]
-                }
-              ),
               /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0 flex-1", children: [
-                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: `truncate text-sm ${isRead ? "font-medium text-slate-600" : "font-bold text-brand-dark"}`, children: [
+                /* @__PURE__ */ jsxRuntimeExports.jsxs("p", { className: `truncate text-sm ${isRead ? "font-medium text-slate-500" : "font-bold text-brand-dark"}`, children: [
                   !isRead && /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "sr-only", children: "Unread request:" }),
                   preview
                 ] }),
@@ -25154,7 +25137,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 {
                   role: "img",
                   "aria-label": isBlocked ? "Blocked by policy" : "Allowed by policy",
-                  className: "relative flex h-2 w-2 shrink-0 items-center justify-center",
+                  className: "group/icon relative flex h-2 w-2 shrink-0 items-center justify-center",
                   children: [
                     /* @__PURE__ */ jsxRuntimeExports.jsx(
                       "span",
@@ -25162,7 +25145,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                         className: `h-2 w-2 rounded-full ${isBlocked ? "bg-brand-attention" : "bg-emerald-400"}`
                       }
                     ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-40 mt-1 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
                   ]
                 }
               ),
@@ -25171,10 +25154,10 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 {
                   role: "img",
                   "aria-label": category.label,
-                  className: `relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
+                  className: `group/icon relative inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-lg ${active ? "bg-brand-blue/10 text-brand-blue" : "bg-slate-50 text-slate-500"}`,
                   children: [
                     /* @__PURE__ */ jsxRuntimeExports.jsx(CategoryIcon, { className: "h-4 w-4", "aria-hidden": "true" }),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-30 mt-5 whitespace-nowrap rounded-md bg-slate-900 px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover:opacity-100", children: category.label })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100", children: category.label })
                   ]
                 }
               )

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25081,11 +25081,17 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
     [item, onToggleSelect, canSelect]
   );
   const checkboxLabel = canSelect ? `Select ${preview} for bulk approval` : `Not eligible for bulk approval: ${category.shortLabel.toLowerCase()}`;
+  const rowClassName = (() => {
+    if (selected) return "border border-brand-blue/60 bg-brand-blue/[0.08] ring-1 ring-brand-blue/20";
+    if (active) return "border border-brand-blue bg-brand-blue/[0.06]";
+    if (isRead) return "border border-transparent bg-white hover:bg-slate-50";
+    return "border border-transparent bg-slate-50 hover:bg-slate-100";
+  })();
   return /* @__PURE__ */ jsxRuntimeExports.jsx(
     "div",
     {
       role: "none",
-      className: `group w-full rounded-lg py-2.5 px-2 transition-all ${selected ? "border border-brand-blue/60 bg-brand-blue/[0.08] ring-1 ring-brand-blue/20" : active ? "border border-brand-blue bg-brand-blue/[0.06]" : isRead ? "border border-transparent bg-white hover:bg-slate-50" : "border border-transparent bg-slate-50 hover:bg-slate-100"}`,
+      className: `group w-full rounded-lg py-2.5 px-2 transition-all ${rowClassName}`,
       children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-center justify-between gap-2", children: [
         showCheckbox ? /* @__PURE__ */ jsxRuntimeExports.jsx(
           "label",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -616,10 +616,6 @@
     left: calc(var(--spacing) * .5);
   }
 
-  .left-1\/2 {
-    left: 50%;
-  }
-
   .left-2\.5 {
     left: calc(var(--spacing) * 2.5);
   }
@@ -1838,11 +1834,6 @@
   .border-0 {
     border-style: var(--tw-border-style);
     border-width: 0;
-  }
-
-  .border-2 {
-    border-style: var(--tw-border-style);
-    border-width: 2px;
   }
 
   .border-t {
@@ -3155,10 +3146,6 @@
     .bg-slate-300\/80 {
       background-color: color-mix(in oklab, var(--color-slate-300) 80%, transparent);
     }
-  }
-
-  .bg-slate-900 {
-    background-color: var(--color-slate-900);
   }
 
   .bg-slate-900\/45 {
@@ -4716,7 +4703,7 @@
       }
     }
 
-    .group-hover\:opacity-100:is(:where(.group):hover *) {
+    .group-hover\/icon\:opacity-100:is(:where(.group\/icon):hover *) {
       opacity: 1;
     }
   }


### PR DESCRIPTION
## Problem

1. Hovering a row showed ALL tooltips simultaneously instead of per-icon.
2. Tooltip background was black (bg-slate-900) instead of the dashboard's brand blue.
3. Two indicator dots (unread + policy status) were confusing; only one severity dot is needed.

## Changes

1. **One severity dot**: Removed the separate unread dot. The single remaining dot shows policy severity — amber (`bg-brand-attention`) = blocked, green (`bg-emerald-400`) = allowed. Tooltip shows "Blocked by policy" or "Allowed by policy".

2. **Gmail-style unread background**: Unread rows get `bg-slate-50` (light gray), read rows get `bg-white`. Title stays `font-bold` for unread, `font-medium` for read. No separate unread indicator needed — the background tint + bold title is the gmail convention.

3. **Per-icon tooltips**: Each icon wrapper uses `group/icon` so only the hovered icon's tooltip appears, not all at once.

4. **Brand-blue tooltip color**: Replaced `bg-slate-900` with `bg-brand-blue` (#5599fe) to match the dashboard's light-blue design language.

## Verification

- `pnpm run build` passes
- `pnpm test` — all dashboard tests pass
- Verified `group-hover/icon:opacity-100` CSS rule is generated in the bundle