### PR TITLE
fix(guard): allow verified local test runners

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+import os
 import re
 import shlex
 from collections.abc import Iterable
@@ -32,6 +34,9 @@ from .secret_file_requests import _SHELL_TOOL_NAMES, _candidate_command_texts, _
 
 _CONTROL_TOKENS = {"&&", "||", ";", "|", "|&", "&"}
 _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
+_LOCAL_EXECUTION_COMMANDS = frozenset({"bunx", "npx"})
+_LOCAL_EXECUTION_FLAGS = frozenset({"--bun", "--no-install"})
+_JS_LOCKFILE_NAMES = ("bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock")
 _PYTHON_EXECUTABLES = {"py", "python", "python3", "python3.11", "python3.12", "python3.13", "python3.14"}
 _PACKAGE_SOURCE_ENV_NAMES = frozenset(
     {
@@ -210,12 +215,98 @@ def _parse_bun_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
 
 
 def _parse_exec_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
+    if _is_verified_local_executable_execution(tokens, workspace=workspace):
+        return None
     package_token = _exec_package_spec(tokens)
     if package_token is None:
         return None
     ecosystem = "pypi" if _command_name(tokens[0]) in {"uvx", "pipx"} else "npm"
     target = python_target(package_token) if ecosystem == "pypi" else js_target(package_token)
     return _build_intent(_command_name(tokens[0]), "execute", tokens, (target,), workspace=workspace)
+
+
+def _is_verified_local_executable_execution(tokens: tuple[str, ...], *, workspace: Path | None) -> bool:
+    if workspace is None or not tokens or _command_name(tokens[0]) not in _LOCAL_EXECUTION_COMMANDS:
+        return False
+    executable = _local_executable_name(tokens)
+    if executable is None:
+        return False
+    return (
+        _workspace_declares_js_dependency(workspace, executable)
+        and _workspace_lockfile_records_js_dependency(workspace, executable)
+        and _workspace_has_local_executable(workspace, executable)
+    )
+
+
+def _local_executable_name(tokens: tuple[str, ...]) -> str | None:
+    index = 1
+    while index < len(tokens) and tokens[index].startswith("-"):
+        if tokens[index] not in _LOCAL_EXECUTION_FLAGS:
+            return None
+        index += 1
+    if index >= len(tokens):
+        return None
+    executable = tokens[index]
+    return executable if re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9._-]*", executable) else None
+
+
+def _workspace_declares_js_dependency(workspace: Path, package_name: str) -> bool:
+    try:
+        payload = json.loads((workspace / "package.json").read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    for key in ("dependencies", "devDependencies", "optionalDependencies", "peerDependencies"):
+        dependencies = payload.get(key)
+        if isinstance(dependencies, dict) and isinstance(dependencies.get(package_name), str):
+            return bool(dependencies[package_name].strip())
+    return False
+
+
+def _workspace_lockfile_records_js_dependency(workspace: Path, package_name: str) -> bool:
+    package_name_pattern = re.compile(rf"(?<![A-Za-z0-9._/@-]){re.escape(package_name)}(?![A-Za-z0-9._/@-])")
+    for lockfile_name in _JS_LOCKFILE_NAMES:
+        lockfile_path = workspace / lockfile_name
+        try:
+            content = lockfile_path.read_bytes()
+        except OSError:
+            continue
+        if not content.strip():
+            continue
+        if lockfile_name == "package-lock.json":
+            try:
+                payload = json.loads(content)
+            except (UnicodeDecodeError, ValueError):
+                continue
+            if not isinstance(payload, dict):
+                continue
+            packages = payload.get("packages")
+            if isinstance(packages, dict) and isinstance(packages.get(f"node_modules/{package_name}"), dict):
+                return True
+            dependencies = payload.get("dependencies")
+            if isinstance(dependencies, dict) and isinstance(dependencies.get(package_name), dict):
+                return True
+            continue
+        if lockfile_name == "bun.lockb":
+            continue
+        try:
+            text = content.decode("utf-8")
+        except UnicodeDecodeError:
+            continue
+        if package_name_pattern.search(text):
+            return True
+    return False
+
+
+def _workspace_has_local_executable(workspace: Path, package_name: str) -> bool:
+    executable_dir = workspace / "node_modules" / ".bin"
+    suffixes = ("", ".cmd", ".ps1") if os.name == "nt" else ("",)
+    for suffix in suffixes:
+        candidate = executable_dir / f"{package_name}{suffix}"
+        if candidate.is_file() and (suffix or os.access(candidate, os.X_OK)):
+            return True
+    return False
 
 
 def _parse_pip_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:

--- a/tests/test_guard_js_package_hook_phase11.py
+++ b/tests/test_guard_js_package_hook_phase11.py
@@ -13,6 +13,7 @@ from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, generate_private_key
 
+from codex_plugin_scanner import install_integrity
 from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.cli import commands as guard_commands_module
 from codex_plugin_scanner.guard.store import GuardStore
@@ -244,3 +245,46 @@ def test_guard_hook_blocks_js_exec_flows_before_subprocess(
     evidence = store.list_evidence()
     assert evidence
     assert evidence[0]["category"] == "supply-chain"
+
+
+def test_guard_hook_allows_verified_local_vitest_run(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    home_dir = tmp_path / "home"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+    (workspace_dir / "package.json").write_text(
+        '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n', encoding="utf-8"
+    )
+    (workspace_dir / "bun.lock").write_text('"vitest": "4.1.8"\n', encoding="utf-8")
+    runner = workspace_dir / "node_modules" / ".bin" / "vitest"
+    runner.parent.mkdir(parents=True)
+    runner.write_text("#!/bin/sh\n", encoding="utf-8")
+    runner.chmod(0o755)
+    command = "bunx vitest run tests/example.test.ts"
+    payload_path = workspace_dir / "hook-event.json"
+    _write_codex_pre_tool_payload(payload_path, workspace_dir, command)
+    store = GuardStore(home_dir)
+    _seed_guard_cloud(store, workspace_id=WORKSPACE_ID)
+    monkeypatch.setattr(install_integrity, "warn_if_shadowed", lambda: None)
+
+    rc = main(
+        [
+            "guard",
+            "hook",
+            "--harness",
+            "codex",
+            "--home",
+            str(home_dir),
+            "--workspace",
+            str(workspace_dir),
+            "--event-file",
+            str(payload_path),
+        ]
+    )
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    assert captured.out == ""
+    assert captured.err == ""
+    assert store.list_evidence() == []

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -2,9 +2,13 @@
 
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.runtime.package_intent import (
+    extract_package_intent_request,
     parse_manifest_dependency_changes,
     parse_package_intent,
 )
@@ -119,6 +123,133 @@ def test_parse_package_intent_detects_package_command_after_control_operator() -
         assert intent.targets[0].package_name == package_name
 
     assert parse_package_intent("echo safe && grep foo src/file.ts") is None
+
+
+def test_parse_package_intent_skips_verified_local_test_runner_execution(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
+    _write_text(tmp_path / "bun.lock", '"vitest": "4.1.8"\n')
+    runner = tmp_path / "node_modules" / ".bin" / "vitest"
+    _write_text(runner, "#!/bin/sh\n")
+    runner.chmod(0o755)
+
+    assert parse_package_intent("bunx vitest run tests/example.test.ts", workspace=tmp_path) is None
+    assert parse_package_intent("npx --no-install vitest --run tests/example.test.ts", workspace=tmp_path) is None
+    assert parse_package_intent("bunx vitest --help", workspace=tmp_path) is None
+    assert (
+        extract_package_intent_request(
+            "Bash",
+            {"command": "bunx vitest run tests/example.test.ts"},
+            action_envelope_command="bunx vitest run tests/example.test.ts",
+            workspace=tmp_path,
+        )
+        is None
+    )
+
+
+def test_parse_package_intent_keeps_unverified_or_remote_test_runner_execution_guarded(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
+    _write_text(tmp_path / "bun.lock", '"vitest": "4.1.8"\n')
+    runner = tmp_path / "node_modules" / ".bin" / "vitest"
+    _write_text(runner, "#!/bin/sh\n")
+    runner.chmod(0o755)
+
+    assert parse_package_intent("bunx vitest@latest run tests/example.test.ts", workspace=tmp_path) is not None
+    assert (
+        parse_package_intent("bunx --package vitest vitest run tests/example.test.ts", workspace=tmp_path) is not None
+    )
+    (tmp_path / "bun.lock").unlink()
+
+    assert parse_package_intent("bunx vitest run tests/example.test.ts", workspace=tmp_path) is not None
+
+
+def test_parse_package_intent_keeps_local_runner_guarded_without_lockfile_record(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
+    _write_text(tmp_path / "bun.lock", "{}\n")
+    runner = tmp_path / "node_modules" / ".bin" / "vitest"
+    _write_text(runner, "#!/bin/sh\n")
+    runner.chmod(0o755)
+
+    assert parse_package_intent("bunx vitest run tests/example.test.ts", workspace=tmp_path) is not None
+
+
+@pytest.mark.parametrize(
+    ("lockfile_name", "lockfile_content"),
+    (
+        ("bun.lock", '"vitest-helpers": "1.0.0"\n'),
+        ("bun.lockb", b"vitest"),
+    ),
+)
+def test_parse_package_intent_keeps_runner_guarded_without_exact_text_lockfile_record(
+    tmp_path: Path, lockfile_name: str, lockfile_content: str | bytes
+) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
+    lockfile_path = tmp_path / lockfile_name
+    if isinstance(lockfile_content, bytes):
+        lockfile_path.write_bytes(lockfile_content)
+    else:
+        _write_text(lockfile_path, lockfile_content)
+    runner = tmp_path / "node_modules" / ".bin" / "vitest"
+    _write_text(runner, "#!/bin/sh\n")
+    runner.chmod(0o755)
+
+    assert parse_package_intent("bunx vitest run tests/example.test.ts", workspace=tmp_path) is not None
+
+
+@pytest.mark.skipif(os.name == "nt", reason="Windows supports .cmd local launchers")
+def test_parse_package_intent_keeps_non_windows_script_wrapper_guarded(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
+    _write_text(tmp_path / "bun.lock", '"vitest": "4.1.8"\n')
+    _write_text(tmp_path / "node_modules" / ".bin" / "vitest.cmd", "@echo off\n")
+
+    assert parse_package_intent("bunx vitest run tests/example.test.ts", workspace=tmp_path) is not None
+
+
+def test_parse_package_intent_skips_verified_local_jest_and_mocha_runs(tmp_path: Path) -> None:
+    _write_text(
+        tmp_path / "package.json",
+        '{"name":"demo","peerDependencies":{"jest":"^30.0.0"},"devDependencies":{"mocha":"^11.0.0"}}\n',
+    )
+    _write_text(
+        tmp_path / "package-lock.json",
+        '{"packages":{"node_modules/jest":{"version":"30.0.0"},"node_modules/mocha":{"version":"11.0.0"}}}\n',
+    )
+    for runner_name in ("jest", "mocha"):
+        runner = tmp_path / "node_modules" / ".bin" / runner_name
+        _write_text(runner, "#!/bin/sh\n")
+        runner.chmod(0o755)
+
+    assert parse_package_intent("npx --no-install jest tests/unit.test.js", workspace=tmp_path) is None
+    assert parse_package_intent("bunx mocha test/unit.test.js", workspace=tmp_path) is None
+
+
+def test_parse_package_intent_skips_verified_local_declared_executable(tmp_path: Path) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"eslint":"^9.0.0"}}\n')
+    _write_text(tmp_path / "bun.lock", '"eslint": "9.0.0"\n')
+    executable = tmp_path / "node_modules" / ".bin" / "eslint"
+    _write_text(executable, "#!/bin/sh\n")
+    executable.chmod(0o755)
+
+    assert parse_package_intent("bunx eslint .", workspace=tmp_path) is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "pnpm exec vitest run tests/unit.test.ts",
+        "uv run pytest tests/test_unit.py",
+        "poetry run pytest tests/test_unit.py",
+        "pipenv run pytest tests/test_unit.py",
+        "python -m pytest tests/test_unit.py",
+        "cargo test",
+        "go test ./...",
+        "mvn test",
+        "./gradlew test",
+        "bundle exec rspec spec/unit_spec.rb",
+        "vendor/bin/phpunit tests/Unit",
+    ),
+)
+def test_parse_package_intent_leaves_non_js_package_executors_unclassified(command: str) -> None:
+    assert parse_package_intent(command) is None
 
 
 def test_parse_package_intent_combines_multiple_package_segments() -> None:


### PR DESCRIPTION
## Summary
- Allow verified local `bunx` and `npx` executable runs without a package approval.
- Keep versioned, selector-based, uninstalled, and otherwise unverified executable packages on the existing supply-chain gate.

## Testing
- `uv run pytest tests/test_guard_package_intent.py tests/test_guard_js_package_hook_phase11.py tests/test_guard_phase07_harness_coverage_matrix.py -k "package_intent or verified_local_vitest_run or harness_coverage"`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/package_intent_parser.py tests/test_guard_package_intent.py tests/test_guard_js_package_hook_phase11.py`
