### PR TITLE
fix(guard): severity dot shows risk level (high/medium/low)

### DIFF
--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -79,6 +79,7 @@ import {
   formatQueueRequestDate,
   queueCategoriesForItems,
   resolveQueueCategory,
+  riskScore,
   searchQueue,
   sortQueue,
   REVIEW_SEMANTIC_GROUPS,
@@ -854,7 +855,8 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
   selected?: boolean;
   onToggleSelect?: (item: GuardApprovalRequest) => void;
 }) {
-  const isBlocked = item.policy_action === "block";
+  const risk = riskScore(item);
+  const riskLevel = risk <= 2 ? "high" : risk <= 4 ? "medium" : "low";
   const category = resolveQueueCategory(item);
   const CategoryIcon = iconForQueueCategory(category.id);
   const preview = queueItemPreview(item);
@@ -947,16 +949,18 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
           </div>
           <span
             role="img"
-            aria-label={isBlocked ? "Blocked by policy" : "Allowed by policy"}
+            aria-label={`Risk: ${riskLevel}`}
             className="group/icon relative flex h-2 w-2 shrink-0 items-center justify-center"
           >
             <span
               className={`h-2 w-2 rounded-full ${
-                isBlocked ? "bg-brand-attention" : "bg-emerald-400"
+                riskLevel === "high" ? "bg-red-400"
+                : riskLevel === "medium" ? "bg-amber-400"
+                : "bg-emerald-400"
               }`}
             />
             <span className="pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100">
-              {isBlocked ? "Blocked by policy" : "Allowed by policy"}
+              {`Risk: ${riskLevel}`}
             </span>
           </span>
           <span

--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -844,6 +844,19 @@ function SemanticFilterButton(props: {
   );
 }
 
+type RiskLevel = "high" | "medium" | "low";
+
+const RISK_DOT_COLOR: Record<RiskLevel, string> = {
+  high: "bg-red-400",
+  medium: "bg-amber-400",
+  low: "bg-emerald-400",
+};
+
+function riskLevelFromScore(score: number): RiskLevel {
+  if (score <= 2) return "high";
+  if (score <= 4) return "medium";
+  return "low";
+}
 function QueueItemRow({ item, active, readState, index, onOpenRequest, selectionMode = false, selectable = false, selected = false, onToggleSelect }: {
   item: GuardApprovalRequest;
   active: boolean;
@@ -856,7 +869,8 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
   onToggleSelect?: (item: GuardApprovalRequest) => void;
 }) {
   const risk = riskScore(item);
-  const riskLevel = risk <= 2 ? "high" : risk <= 4 ? "medium" : "low";
+  const riskLevel = riskLevelFromScore(risk);
+  const riskDotColor = RISK_DOT_COLOR[riskLevel];
   const category = resolveQueueCategory(item);
   const CategoryIcon = iconForQueueCategory(category.id);
   const preview = queueItemPreview(item);
@@ -953,11 +967,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
             className="group/icon relative flex h-2 w-2 shrink-0 items-center justify-center"
           >
             <span
-              className={`h-2 w-2 rounded-full ${
-                riskLevel === "high" ? "bg-red-400"
-                : riskLevel === "medium" ? "bg-amber-400"
-                : "bg-emerald-400"
-              }`}
+              className={`h-2 w-2 rounded-full ${riskDotColor}`}
             />
             <span className="pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100">
               {`Risk: ${riskLevel}`}

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25050,9 +25050,20 @@ function SemanticFilterButton(props) {
     }
   );
 }
+const RISK_DOT_COLOR = {
+  high: "bg-red-400",
+  medium: "bg-amber-400",
+  low: "bg-emerald-400"
+};
+function riskLevelFromScore(score) {
+  if (score <= 2) return "high";
+  if (score <= 4) return "medium";
+  return "low";
+}
 function QueueItemRow({ item, active, readState, index, onOpenRequest, selectionMode = false, selectable = false, selected = false, onToggleSelect }) {
   const risk = riskScore(item);
-  const riskLevel = risk <= 2 ? "high" : risk <= 4 ? "medium" : "low";
+  const riskLevel = riskLevelFromScore(risk);
+  const riskDotColor = RISK_DOT_COLOR[riskLevel];
   const category = resolveQueueCategory(item);
   const CategoryIcon = iconForQueueCategory(category.id);
   const preview = queueItemPreview(item);
@@ -25149,7 +25160,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                     /* @__PURE__ */ jsxRuntimeExports.jsx(
                       "span",
                       {
-                        className: `h-2 w-2 rounded-full ${riskLevel === "high" ? "bg-red-400" : riskLevel === "medium" ? "bg-amber-400" : "bg-emerald-400"}`
+                        className: `h-2 w-2 rounded-full ${riskDotColor}`
                       }
                     ),
                     /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100", children: `Risk: ${riskLevel}` })

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25051,7 +25051,8 @@ function SemanticFilterButton(props) {
   );
 }
 function QueueItemRow({ item, active, readState, index, onOpenRequest, selectionMode = false, selectable = false, selected = false, onToggleSelect }) {
-  const isBlocked = item.policy_action === "block";
+  const risk = riskScore(item);
+  const riskLevel = risk <= 2 ? "high" : risk <= 4 ? "medium" : "low";
   const category = resolveQueueCategory(item);
   const CategoryIcon = iconForQueueCategory(category.id);
   const preview = queueItemPreview(item);
@@ -25142,16 +25143,16 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                 "span",
                 {
                   role: "img",
-                  "aria-label": isBlocked ? "Blocked by policy" : "Allowed by policy",
+                  "aria-label": `Risk: ${riskLevel}`,
                   className: "group/icon relative flex h-2 w-2 shrink-0 items-center justify-center",
                   children: [
                     /* @__PURE__ */ jsxRuntimeExports.jsx(
                       "span",
                       {
-                        className: `h-2 w-2 rounded-full ${isBlocked ? "bg-brand-attention" : "bg-emerald-400"}`
+                        className: `h-2 w-2 rounded-full ${riskLevel === "high" ? "bg-red-400" : riskLevel === "medium" ? "bg-amber-400" : "bg-emerald-400"}`
                       }
                     ),
-                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100", children: isBlocked ? "Blocked by policy" : "Allowed by policy" })
+                    /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100", children: `Risk: ${riskLevel}` })
                   ]
                 }
               ),

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/index.css
@@ -81,6 +81,7 @@
     --color-red-50: oklch(97.1% .013 17.38);
     --color-red-200: oklch(88.5% .062 18.334);
     --color-red-300: oklch(80.8% .114 19.571);
+    --color-red-400: oklch(70.4% .191 22.216);
     --color-red-500: oklch(63.7% .237 25.331);
     --color-red-600: oklch(57.7% .245 27.325);
     --color-red-700: oklch(50.5% .213 27.518);
@@ -3012,6 +3013,10 @@
     .bg-red-50\/80 {
       background-color: color-mix(in oklab, var(--color-red-50) 80%, transparent);
     }
+  }
+
+  .bg-red-400 {
+    background-color: var(--color-red-400);
   }
 
   .bg-rose-50 {


### PR DESCRIPTION
## Problem

The severity dot used `policy_action` (block vs allow), which showed all dots green because most queue items have `policy_action='require-reapproval'` — not "allowed" but not "blocked" either. The dot should show the **risk level** of the request, not the policy decision.

## Fix

Uses the existing `riskScore()` function from `queue-state.ts` which scores items 1–6 based on category severity and signal data:

| Score | Risk Level | Color | Examples |
|---|---|---|---|
| 1–2 | high | `bg-red-400` | Secret exfiltration, credential output, guard bypass, prompt injection, secret file read |
| 3–4 | medium | `bg-amber-400` | Persistence, destructive shell, file delete, network, container, git, package install |
| 5–6 | low | `bg-emerald-400` | Source edit, config change, shell command, file read, docs edit |

Tooltip shows "Risk: high" / "Risk: medium" / "Risk: low".

## Verification

- `pnpm run build` passes
- `pnpm test` — all dashboard tests pass