### PR TITLE
fix(guard): ensure Tailwind generates risk dot color classes

### DIFF
--- a/dashboard/src/review-workspace.tsx
+++ b/dashboard/src/review-workspace.tsx
@@ -846,12 +846,6 @@ function SemanticFilterButton(props: {
 
 type RiskLevel = "high" | "medium" | "low";
 
-const RISK_DOT_COLOR: Record<RiskLevel, string> = {
-  high: "bg-red-400",
-  medium: "bg-amber-400",
-  low: "bg-emerald-400",
-};
-
 function riskLevelFromScore(score: number): RiskLevel {
   if (score <= 2) return "high";
   if (score <= 4) return "medium";
@@ -870,7 +864,6 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
 }) {
   const risk = riskScore(item);
   const riskLevel = riskLevelFromScore(risk);
-  const riskDotColor = RISK_DOT_COLOR[riskLevel];
   const category = resolveQueueCategory(item);
   const CategoryIcon = iconForQueueCategory(category.id);
   const preview = queueItemPreview(item);
@@ -967,7 +960,9 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
             className="group/icon relative flex h-2 w-2 shrink-0 items-center justify-center"
           >
             <span
-              className={`h-2 w-2 rounded-full ${riskDotColor}`}
+              className={`h-2 w-2 rounded-full ${
+                riskLevel === "high" ? "bg-red-400" : riskLevel === "medium" ? "bg-amber-400" : "bg-emerald-400"
+              }`}
             />
             <span className="pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100">
               {`Risk: ${riskLevel}`}

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -25050,11 +25050,6 @@ function SemanticFilterButton(props) {
     }
   );
 }
-const RISK_DOT_COLOR = {
-  high: "bg-red-400",
-  medium: "bg-amber-400",
-  low: "bg-emerald-400"
-};
 function riskLevelFromScore(score) {
   if (score <= 2) return "high";
   if (score <= 4) return "medium";
@@ -25063,7 +25058,6 @@ function riskLevelFromScore(score) {
 function QueueItemRow({ item, active, readState, index, onOpenRequest, selectionMode = false, selectable = false, selected = false, onToggleSelect }) {
   const risk = riskScore(item);
   const riskLevel = riskLevelFromScore(risk);
-  const riskDotColor = RISK_DOT_COLOR[riskLevel];
   const category = resolveQueueCategory(item);
   const CategoryIcon = iconForQueueCategory(category.id);
   const preview = queueItemPreview(item);
@@ -25160,7 +25154,7 @@ function QueueItemRow({ item, active, readState, index, onOpenRequest, selection
                     /* @__PURE__ */ jsxRuntimeExports.jsx(
                       "span",
                       {
-                        className: `h-2 w-2 rounded-full ${riskDotColor}`
+                        className: `h-2 w-2 rounded-full ${riskLevel === "high" ? "bg-red-400" : riskLevel === "medium" ? "bg-amber-400" : "bg-emerald-400"}`
                       }
                     ),
                     /* @__PURE__ */ jsxRuntimeExports.jsx("span", { className: "pointer-events-none absolute right-0 top-full z-50 mt-1.5 whitespace-nowrap rounded-md bg-brand-blue px-2 py-1 text-[10px] font-medium text-white opacity-0 shadow-lg transition-opacity duration-150 group-hover/icon:opacity-100", children: `Risk: ${riskLevel}` })


### PR DESCRIPTION
## Problem

The risk dot color classes (`bg-red-400`, `bg-amber-400`, `bg-emerald-400`) were defined in a `Record` map object. Tailwind v4's content scanner didn't detect them there, so the CSS classes were never generated — the dots had no color.

## Fix

Moved the class names back to inline JSX ternary expressions where Tailwind's scanner reliably detects them. Verified all three `.bg-red-400`, `.bg-amber-400`, `.bg-emerald-400` CSS rules are generated in the output after a clean build.

## Verification

- `pnpm run build` passes
- `pnpm test` — all dashboard tests pass
- Confirmed `.bg-red-400 {}`, `.bg-amber-400 {}`, `.bg-emerald-400 {}` in generated CSS