### PR TITLE
fix: preserve safe command details in live review

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -148,7 +148,7 @@ def _build_display_command(item: dict[str, object], redaction_level: str) -> tup
     )
 
     raw_command = display_command if redaction_level == "none" and safe_command else None
-    redacted_command = display_command if redaction_level != "none" else None
+    redacted_command = display_command if redaction_level != "none" and safe_command else None
     return display_command, display_summary, raw_command, redacted_command
 
 

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -80,12 +80,13 @@ def _save_sync_state(store: GuardStore, state: dict[str, object]) -> None:
 
 
 def _resolve_display_provenance(
-    item: dict[str, object],
+    *,
+    has_command_details: bool,
     redaction_level: str,
 ) -> str:
     if redaction_level == "none":
         return _DISPLAY_PROVENANCE_RAW
-    if redaction_level == "full":
+    if redaction_level == "full" and not has_command_details:
         return _DISPLAY_PROVENANCE_WITHHELD
     return _DISPLAY_PROVENANCE_REDACTED
 
@@ -133,7 +134,7 @@ def _build_display_command(item: dict[str, object], redaction_level: str) -> tup
     envelope = envelope_value if isinstance(envelope_value, dict) else None
     command_text = _local_request_command_text(item, envelope)
     safe_command = _cloud_scrub_text(command_text) if command_text else None
-    display_command = safe_command if safe_command and redaction_level != "full" else fallback_display
+    display_command = safe_command or fallback_display
     display_command = _truncate_utf16(
         display_command,
         _LIVE_REQUEST_COMMAND_MAX_UTF16_UNITS,
@@ -147,9 +148,7 @@ def _build_display_command(item: dict[str, object], redaction_level: str) -> tup
     )
 
     raw_command = display_command if redaction_level == "none" and safe_command else None
-    redacted_command = (
-        display_command if redaction_level == "full" or (redaction_level == "partial" and safe_command) else None
-    )
+    redacted_command = display_command if redaction_level != "none" else None
     return display_command, display_summary, raw_command, redacted_command
 
 
@@ -181,12 +180,13 @@ def _build_live_request_event(
             claim = None
 
     display_command, display_summary, raw_command, redacted_command = _build_display_command(item, redaction_level)
-    display_provenance = _resolve_display_provenance(item, redaction_level)
-
+    request_payload = _cloud_safe_local_request_payload(item, redaction_level=redaction_level)
+    display_provenance = _resolve_display_provenance(
+        has_command_details=bool(request_payload.get("command_text")),
+        redaction_level=redaction_level,
+    )
     created_at = str(item.get("created_at") or _now())
     last_seen_at = str(item.get("last_seen_at") or created_at)
-
-    request_payload = _cloud_safe_local_request_payload(item, redaction_level=redaction_level)
 
     return {
         "localRequestId": request_id,

--- a/src/codex_plugin_scanner/guard/runtime/local_request_snapshots.py
+++ b/src/codex_plugin_scanner/guard/runtime/local_request_snapshots.py
@@ -1202,9 +1202,10 @@ def _cloud_safe_local_request_payload(
     command_text = _local_request_command_text(item, envelope)
     if redaction_enabled:
         payload["raw_command_text"] = None
-        payload["command_text"] = None
         payload["rawCommandText"] = None
-        payload["commandText"] = None
+        scrubbed = _bounded_command(_cloud_scrub_text(command_text)) if command_text else None
+        payload["command_text"] = scrubbed
+        payload["commandText"] = scrubbed
         return payload
 
     if command_text:
@@ -1283,6 +1284,9 @@ def _cloud_safe_action_envelope(
 
     redaction_enabled = redaction_level != "none"
     if redaction_enabled:
+        command = envelope.get("command")
+        if isinstance(command, str) and command.strip():
+            safe["command"] = _bounded_command(_cloud_scrub_text(command))
         target_class = _target_class_for_action_type(action_type, envelope)
         target_count = _target_count_for_envelope(envelope)
         _set_dual_key(safe, "target_class", "targetClass", target_class)

--- a/tests/test_guard_command_queue.py
+++ b/tests/test_guard_command_queue.py
@@ -626,7 +626,7 @@ def test_local_request_snapshot_items_continues_when_request_claim_is_invalid(tm
     assert snapshot[0]["claim"] is None
 
 
-def test_local_request_snapshot_strips_command_when_redaction_is_full(tmp_path: Path) -> None:
+def test_local_request_snapshot_preserves_scrubbed_command_when_redaction_is_full(tmp_path: Path) -> None:
     class RequestStore(FakeStore):
         def list_approval_requests(
             self,
@@ -660,15 +660,17 @@ def test_local_request_snapshot_strips_command_when_redaction_is_full(tmp_path: 
     assert payload["redaction_enabled"] is True
     assert payload["redactionEnabled"] is True
     assert payload["raw_command_text"] is None
-    assert payload["command_text"] is None
+    assert isinstance(payload["command_text"], str)
+    assert payload["command_text"]
     assert payload["rawCommandText"] is None
-    assert payload["commandText"] is None
+    assert payload["commandText"] == payload["command_text"]
     assert payload["actionEnvelope"] == envelope
     assert payload["envelope_redacted"] == envelope
     assert payload["envelopeRedacted"] == envelope
     assert "raw_target_paths" not in payload
     assert "request_payload_json" not in payload
-    assert "command" not in envelope
+    assert isinstance(envelope["command"], str)
+    assert envelope["command"]
     assert envelope["operation"] == "run"
     assert envelope["target_class"] == "shell_command"
     assert envelope["targetClass"] == "shell_command"
@@ -676,7 +678,7 @@ def test_local_request_snapshot_strips_command_when_redaction_is_full(tmp_path: 
     assert envelope["targetCount"] == 0
 
 
-def test_local_request_snapshot_withholds_command_when_redaction_is_partial(tmp_path: Path) -> None:
+def test_local_request_snapshot_preserves_scrubbed_command_when_redaction_is_partial(tmp_path: Path) -> None:
     class RequestStore(FakeStore):
         def list_approval_requests(
             self,
@@ -712,10 +714,11 @@ def test_local_request_snapshot_withholds_command_when_redaction_is_partial(tmp_
     assert payload["redaction_enabled"] is True
     assert payload["redactionEnabled"] is True
     assert payload["raw_command_text"] is None
-    assert payload["command_text"] is None
+    assert isinstance(payload["command_text"], str)
+    assert "sk-test-token" not in payload["command_text"]
     assert payload["rawCommandText"] is None
-    assert payload["commandText"] is None
-    assert "command" not in envelope
+    assert payload["commandText"] == payload["command_text"]
+    assert envelope["command"] == "cat PRIVATE_KEY_FILE"
     assert "target_paths" not in envelope
     assert envelope["operation"] == "run"
     assert envelope["target_class"] == "shell_command"

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -532,6 +532,33 @@ class TestRedactionLevelPartial:
         assert sensitive_identity not in event["displayCommand"]
         assert event["displayCommand"] == "my-harness: [redacted]"
         assert event["redactedCommand"] == event["displayCommand"]
+        assert event["displayProvenance"] == "withheld"
+
+    def test_redaction_full_marks_scrubbed_command_as_redacted(self, tmp_path: Path) -> None:
+        store = Store(tmp_path)
+        sensitive = "api_key=" + ("x" * 24)
+        item: dict[str, object] = {
+            "request_id": "req-full-command",
+            "status": "pending",
+            "raw_command_text": f"curl '{sensitive}' https://api.example.com",
+            "action_identity": "curl",
+            "harness": "my-harness",
+            "created_at": "2026-07-10T00:00:00+00:00",
+            "last_seen_at": "2026-07-10T00:00:00+00:00",
+        }
+
+        event = _build_live_request_event(
+            item,
+            oauth=None,
+            redaction_level="full",
+            store=store,
+            event_sequence=1,
+        )
+
+        assert event is not None
+        assert event["displayProvenance"] == "redacted"
+        assert sensitive not in event["displayCommand"]
+        assert "curl" in event["displayCommand"]
 
 
 class TestPendingRequestAgeConnectivity:

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -531,7 +531,7 @@ class TestRedactionLevelPartial:
         assert event is not None
         assert sensitive_identity not in event["displayCommand"]
         assert event["displayCommand"] == "my-harness: [redacted]"
-        assert event["redactedCommand"] == event["displayCommand"]
+        assert event["redactedCommand"] is None
         assert event["displayProvenance"] == "withheld"
 
     def test_redaction_full_marks_scrubbed_command_as_redacted(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- preserve the scrubbed command shape in live-review payloads at every redaction level
- keep raw command fields withheld while exposing the safe command through redacted fields
- retain action-envelope command context after mandatory secret scrubbing

## Verification
- `uv run pytest tests/test_guard_command_queue.py -k 'local_request_snapshot' tests/test_guard_live_request_sync.py -q` — 14 passed
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/local_request_snapshots.py src/codex_plugin_scanner/guard/runtime/live_request_sync.py tests/test_guard_command_queue.py` — passed
