### PR TITLE
fix(guard): enforce suggested memory policies locally

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_generic.py
@@ -85,6 +85,15 @@ def _run_hook_generic_payload(
         artifact_id,
         str(payload_map.get("artifact_hash")) if isinstance(payload_map.get("artifact_hash"), str) else None,
         str(runtime_workspace) if runtime_workspace else None,
+        memory_command=_coalesce_string(
+            payload_map.get("command"),
+            payload_map.get("tool_name"),
+        ),
+        memory_artifact_type=_coalesce_string(
+            payload_map.get("artifact_type"),
+            payload_map.get("tool_type"),
+        ),
+        memory_artifact_name=artifact_name,
     )
     incoming_policy_action = _optional_string(payload_map.get("policy_action"))
     policy_action = _coalesce_string(

--- a/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_hook_runtime_eval.py
@@ -114,13 +114,16 @@ def _evaluate_runtime_artifact_hook(
         )
         return 0
     runtime_exact_match_context = _runtime_artifact_exact_match_context(runtime_artifact)
-    policy_lookup = store.resolve_policy_decision_lookup(
+    policy_lookup = store.resolve_policy_decision_lookup_with_memory_pattern(
         policy_harness,
         artifact_id,
         artifact_hash=runtime_artifact_hash,
         workspace=str(runtime_workspace) if runtime_workspace else None,
         publisher=runtime_artifact.publisher,
         runtime_exact_match_context=runtime_exact_match_context,
+        memory_command=runtime_artifact.command,
+        memory_artifact_type=runtime_artifact.artifact_type,
+        memory_artifact_name=runtime_artifact.name,
     )
     stored_policy_action = _runtime_stored_policy_action(
         store=store,

--- a/src/codex_plugin_scanner/guard/consumer/service.py
+++ b/src/codex_plugin_scanner/guard/consumer/service.py
@@ -480,6 +480,9 @@ def evaluate_detection(
             str(diff["current_hash"]),
             workspace,
             artifact.publisher,
+            memory_command=artifact.command,
+            memory_artifact_type=artifact.artifact_type,
+            memory_artifact_name=artifact.name,
         )
         if configured_action is None:
             configured_action = config.resolve_action_override(

--- a/src/codex_plugin_scanner/guard/mcp_tool_calls.py
+++ b/src/codex_plugin_scanner/guard/mcp_tool_calls.py
@@ -169,6 +169,9 @@ def evaluate_tool_call(
         artifact.artifact_id,
         artifact_hash=artifact_hash,
         workspace=str(config.workspace) if config.workspace is not None else None,
+        memory_command=artifact.command,
+        memory_artifact_type=artifact.artifact_type,
+        memory_artifact_name=artifact.name,
     )
     if override is None:
         override = config.resolve_action_override(artifact.harness, artifact.artifact_id, artifact.publisher)

--- a/src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py
+++ b/src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py
@@ -71,6 +71,7 @@ _PACKAGE_MANAGERS: frozenset[str] = frozenset(
     {"npm", "pnpm", "yarn", "bun", "pip", "pip3", "uv", "poetry", "cargo", "go", "gem", "brew"}
 )
 _PACKAGE_INSTALL_SUBCOMMANDS: frozenset[str] = frozenset({"install", "i", "add", "ci", "in", "up", "upgrade"})
+_TOOL_ACTION_ARTIFACT_TYPES: frozenset[str] = frozenset({"tool_action_request", "tool_output"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -100,16 +101,25 @@ def build_memory_pattern_fingerprint(
     """Build the most specific fingerprint available for a decision.
 
     Returns ``None`` when the available signal is too generic to anchor memory.
-    Preference order: package install > MCP tool > file read > shell command >
-    generic artifact. Each path applies guardrails against bare labels.
+    Tool action/output rows use their concrete artifact identity rather than
+    reinterpreting display text as a shell or package-manager command.
     """
-    candidate = (
-        _try_package_install(command, harness)
-        or _try_mcp_tool(command, harness, artifact_id)
-        or _try_file_read(command, harness, artifact_type)
-        or _try_shell_command(command, harness)
-        or _try_generic_artifact(artifact_id, artifact_name, artifact_type, harness)
-    )
+    normalized_artifact_type = _normalize_token(artifact_type)
+    if normalized_artifact_type in _TOOL_ACTION_ARTIFACT_TYPES:
+        candidate = _try_generic_artifact(
+            artifact_id,
+            artifact_name,
+            artifact_type,
+            harness,
+        )
+    else:
+        candidate = (
+            _try_package_install(command, harness)
+            or _try_mcp_tool(command, harness, artifact_id)
+            or _try_file_read(command, harness, artifact_type)
+            or _try_shell_command(command, harness)
+            or _try_generic_artifact(artifact_id, artifact_name, artifact_type, harness)
+        )
     if candidate is None:
         return None
     if _is_generic_label(candidate.fingerprint):

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1627,6 +1627,7 @@ def sync_receipts(
         store.set_sync_payload("policy", policy_payload, now)
     else:
         store.set_sync_payload("policy", {}, now)
+    validated_policy_bundle: dict[str, object] | None = None
     if policy_bundle_payload is not None:
         validated_policy_bundle, policy_bundle_rejection_reason, trusted_policy_bundle_keys = (
             validate_synced_policy_bundle(
@@ -1668,16 +1669,6 @@ def sync_receipts(
                 policy_bundle_keyring_payload(
                     trusted_policy_bundle_keys,
                     workspace_id=store.get_cloud_workspace_id(),
-                ),
-                now,
-            )
-            store.set_sync_payload(
-                "policy_bundle_ack",
-                _policy_bundle_acknowledgement_payload(
-                    device_id=device_id,
-                    device_name=device_name,
-                    policy_bundle=validated_policy_bundle,
-                    synced_at=now,
                 ),
                 now,
             )
@@ -1759,6 +1750,17 @@ def sync_receipts(
     remote_policy_sync_blocked = False
     try:
         store.replace_remote_policies(list(remote_decisions), now, remote_write_authorized=True)
+        if validated_policy_bundle is not None:
+            store.set_sync_payload(
+                "policy_bundle_ack",
+                _policy_bundle_acknowledgement_payload(
+                    device_id=device_id,
+                    device_name=device_name,
+                    policy_bundle=validated_policy_bundle,
+                    synced_at=now,
+                ),
+                now,
+            )
     except ApprovalGateError as error:
         remote_policies_stored = 0
         remote_policy_sync_blocked = True

--- a/src/codex_plugin_scanner/guard/store_cloud_events.py
+++ b/src/codex_plugin_scanner/guard/store_cloud_events.py
@@ -4,6 +4,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 # ruff: noqa: F403,F405
 from .store_base import *
 
@@ -303,39 +305,50 @@ class StoreCloudEventsMixin:
         if existing is None:
             pending_count = self._count_guard_events_v1_in_connection(connection, uploaded=False)
             if pending_count >= self._guard_event_queue_limit:
-                drop_count = pending_count - self._guard_event_queue_limit + 1
-                cursor = connection.execute(
+                capacity_row = connection.execute(
+                    "select payload_json from sync_state where state_key = ?",
+                    ("guard_event_queue_capacity",),
+                ).fetchone()
+                capacity_payload: dict[str, object] = {}
+                if capacity_row is not None:
+                    try:
+                        parsed_capacity_payload = json.loads(capacity_row["payload_json"])
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        parsed_capacity_payload = {}
+                    if isinstance(parsed_capacity_payload, dict):
+                        capacity_payload = parsed_capacity_payload
+                rejected_count_value = capacity_payload.get("rejectedCount", 0)
+                rejected_count = (
+                    rejected_count_value
+                    if isinstance(rejected_count_value, int) and not isinstance(rejected_count_value, bool)
+                    else 0
+                ) + 1
+                connection.execute(
                     """
-                    delete from guard_cloud_events
-                    where event_id in (
-                        select event_id
-                        from guard_cloud_events
-                        where uploaded_at is null
-                        order by occurred_at asc, event_id asc
-                        limit ?
-                    )
+                    insert into sync_state (state_key, payload_json, updated_at)
+                    values (?, ?, ?)
+                    on conflict(state_key) do update set
+                      payload_json = excluded.payload_json,
+                      updated_at = excluded.updated_at
                     """,
-                    (drop_count,),
-                )
-                dropped_count = int(cursor.rowcount) if cursor.rowcount is not None and cursor.rowcount > 0 else 0
-                if dropped_count > 0:
-                    connection.execute(
-                        """
-                        insert into guard_events (event_name, payload_json, occurred_at)
-                        values (?, ?, ?)
-                        """,
-                        (
-                            "cloud_event_queue_overflow",
-                            json.dumps(
-                                {
-                                    "dropped_count": dropped_count,
-                                    "queue_limit": self._guard_event_queue_limit,
-                                    "incoming_event_type": event.event_type,
-                                }
-                            ),
-                            _now(),
+                    (
+                        "guard_event_queue_capacity",
+                        json.dumps(
+                            {
+                                "exhausted": True,
+                                "firstRejectedAt": capacity_payload.get("firstRejectedAt", event.occurred_at),
+                                "lastRejectedAt": event.occurred_at,
+                                "limit": self._guard_event_queue_limit,
+                                "pendingCount": pending_count,
+                                "rejectedCount": rejected_count,
+                                "rejectedEventType": event.event_type,
+                            },
+                            sort_keys=True,
                         ),
-                    )
+                        datetime.now(timezone.utc).isoformat(),
+                    ),
+                )
+                return
         connection.execute(
             """
             insert or ignore into guard_cloud_events (
@@ -407,6 +420,41 @@ class StoreCloudEventsMixin:
                 f"update guard_cloud_events set uploaded_at = ? where event_id in ({placeholders})",
                 (uploaded_at, *clean_ids),
             )
+            pending_count = self._count_guard_events_v1_in_connection(
+                connection,
+                uploaded=False,
+            )
+            if pending_count < self._guard_event_queue_limit:
+                capacity_row = connection.execute(
+                    "select payload_json from sync_state where state_key = ?",
+                    ("guard_event_queue_capacity",),
+                ).fetchone()
+                if capacity_row is not None:
+                    try:
+                        capacity_payload = json.loads(capacity_row["payload_json"])
+                    except (json.JSONDecodeError, TypeError, ValueError):
+                        capacity_payload = {}
+                    if not isinstance(capacity_payload, dict):
+                        capacity_payload = {}
+                    capacity_payload.update(
+                        {
+                            "exhausted": False,
+                            "pendingCount": pending_count,
+                            "recoveredAt": uploaded_at,
+                        }
+                    )
+                    connection.execute(
+                        """
+                        update sync_state
+                        set payload_json = ?, updated_at = ?
+                        where state_key = ?
+                        """,
+                        (
+                            json.dumps(capacity_payload, sort_keys=True),
+                            uploaded_at,
+                            "guard_event_queue_capacity",
+                        ),
+                    )
             return int(cursor.rowcount)
 
     def add_event(self, event_name: str, payload: dict[str, object], now: str) -> None:

--- a/src/codex_plugin_scanner/guard/store_policy.py
+++ b/src/codex_plugin_scanner/guard/store_policy.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 # ruff: noqa: F403,F405
 from .approval_scope_support import package_request_portable_workspace_scope
+from .memory_pattern_fingerprint import build_memory_pattern_fingerprint
 from .store_base import *
 
 
@@ -168,17 +169,76 @@ class StorePolicyMixin:
         workspace: str | None = None,
         publisher: str | None = None,
         now: str | None = None,
+        *,
+        memory_command: str | None = None,
+        memory_artifact_type: str | None = None,
+        memory_artifact_name: str | None = None,
     ) -> str | None:
-        lookup = self.resolve_policy_decision_lookup(
+        lookup = self.resolve_policy_decision_lookup_with_memory_pattern(
             harness,
             artifact_id,
             artifact_hash=artifact_hash,
             workspace=workspace,
             publisher=publisher,
             now=now,
+            memory_command=memory_command,
+            memory_artifact_type=memory_artifact_type,
+            memory_artifact_name=memory_artifact_name,
         )
         decision = lookup["decision"]
         return str(decision["action"]) if decision is not None else None
+
+    def resolve_policy_decision_lookup_with_memory_pattern(
+        self,
+        harness: str,
+        artifact_id: str | None,
+        artifact_hash: str | None = None,
+        workspace: str | None = None,
+        publisher: str | None = None,
+        now: str | None = None,
+        runtime_exact_match_context: str | None = None,
+        *,
+        memory_command: str | None = None,
+        memory_artifact_type: str | None = None,
+        memory_artifact_name: str | None = None,
+    ) -> PolicyDecisionLookupResult:
+        direct_lookup = self.resolve_policy_decision_lookup(
+            harness,
+            artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=publisher,
+            now=now,
+            runtime_exact_match_context=runtime_exact_match_context,
+        )
+        if direct_lookup["decision"] is not None or direct_lookup.get("ignored_local_integrity") is not None:
+            return direct_lookup
+        memory_pattern = build_memory_pattern_fingerprint(
+            command=memory_command,
+            artifact_type=memory_artifact_type,
+            artifact_id=artifact_id,
+            artifact_name=memory_artifact_name,
+            harness=harness,
+        )
+        if memory_pattern is None:
+            return direct_lookup
+        memory_artifact_id = f"memory:{harness}:{memory_pattern.kind}:{memory_pattern.fingerprint}"
+        if memory_artifact_id == artifact_id:
+            return direct_lookup
+        memory_lookup = self.resolve_policy_decision_lookup(
+            harness,
+            memory_artifact_id,
+            artifact_hash=artifact_hash,
+            workspace=workspace,
+            publisher=publisher,
+            now=now,
+            runtime_exact_match_context=runtime_exact_match_context,
+        )
+        return (
+            memory_lookup
+            if (memory_lookup["decision"] is not None or memory_lookup.get("ignored_local_integrity") is not None)
+            else direct_lookup
+        )
 
     def resolve_policy_decision_lookup(
         self,

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -17,6 +17,7 @@ import pytest
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash as compute_artifact_hash
 from codex_plugin_scanner.guard.consumer import evaluate_detection
+from codex_plugin_scanner.guard.memory_pattern_fingerprint import build_memory_pattern_fingerprint
 from codex_plugin_scanner.guard.models import (
     GuardArtifact,
     HarnessDetection,
@@ -107,6 +108,115 @@ def test_resolve_policy_with_remote_only_rule_skips_policy_integrity_refresh(
     monkeypatch.setattr(store, "_policy_integrity_secret_material", fail_refresh)
 
     assert store.resolve_policy("codex", artifact_id, artifact_hash) == "allow"
+
+
+@pytest.mark.parametrize("policy_action", ["allow", "block"])
+def test_remote_suggested_memory_policy_matches_runtime_command_pattern(
+    tmp_path: Path,
+    policy_action: str,
+) -> None:
+    store = _make_store(tmp_path)
+    remembered = build_memory_pattern_fingerprint(
+        command="npm install lodash",
+        artifact_type="shell_command",
+        artifact_id="codex:runtime:shell:request-one",
+        artifact_name="Shell command",
+        harness="codex",
+    )
+    assert remembered is not None
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                artifact_id=f"memory:codex:{remembered.kind}:{remembered.fingerprint}",
+                artifact_hash=None,
+                workspace=None,
+                publisher=None,
+                action=policy_action,
+                reason="Suggested Memory",
+                owner=None,
+                source="cloud-sync",
+            )
+        ],
+        now="2026-07-11T00:00:00Z",
+        remote_write_authorized=True,
+    )
+
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:runtime:shell:request-two",
+            memory_command="npm i lodash@latest",
+            memory_artifact_type="shell_command",
+            memory_artifact_name="Shell command",
+        )
+        == policy_action
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:runtime:shell:request-three",
+            memory_command="npm install react",
+            memory_artifact_type="shell_command",
+            memory_artifact_name="Shell command",
+        )
+        is None
+    )
+
+def test_direct_artifact_policy_precedes_suggested_memory_policy(tmp_path: Path) -> None:
+    store = _make_store(tmp_path)
+    artifact_id = "codex:runtime:shell:request-one"
+    remembered = build_memory_pattern_fingerprint(
+        command="npm install lodash",
+        artifact_type="shell_command",
+        artifact_id=artifact_id,
+        artifact_name="Shell command",
+        harness="codex",
+    )
+    assert remembered is not None
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                artifact_id=artifact_id,
+                artifact_hash=None,
+                workspace=None,
+                publisher=None,
+                action="block",
+                reason="Direct policy",
+                owner=None,
+                source="cloud-sync",
+            ),
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                artifact_id=f"memory:codex:{remembered.kind}:{remembered.fingerprint}",
+                artifact_hash=None,
+                workspace=None,
+                publisher=None,
+                action="allow",
+                reason="Suggested Memory",
+                owner=None,
+                source="cloud-sync",
+            ),
+        ],
+        now="2026-07-11T00:00:00Z",
+        remote_write_authorized=True,
+    )
+
+    assert (
+        store.resolve_policy(
+            "codex",
+            artifact_id,
+            memory_command="npm install lodash",
+            memory_artifact_type="shell_command",
+            memory_artifact_name="Shell command",
+        )
+        == "block"
+    )
+
 
 
 class TestDecideAction:

--- a/tests/test_guard_cloud_local_sync.py
+++ b/tests/test_guard_cloud_local_sync.py
@@ -139,6 +139,7 @@ def test_evaluate_detection_queues_instruction_access_graph_edges(tmp_path: Path
     assert any(entity["entityType"] == "instruction" for entity in graph_payload["entities"])
     assert any(edge["edgeType"] == "agent_uses_instruction" for edge in graph_payload["edges"])
 
+
 def test_evaluate_detection_queues_access_graph_snapshot_without_cloud_workspace(tmp_path: Path) -> None:
     store = GuardStore(tmp_path / "guard-home")
     _seed_guard_cloud(store)
@@ -178,10 +179,12 @@ def test_access_graph_queue_failure_does_not_block_local_approval_decision(tmp_p
     assert "sk-live-secret-token" not in json.dumps(failure_events[0]["payload"])
 
 
-def test_guard_cloud_event_queue_is_bounded_and_overflow_log_is_redacted(tmp_path: Path) -> None:
+def test_guard_cloud_event_queue_backpressures_without_dropping_pending_events(
+    tmp_path: Path,
+) -> None:
     store = GuardStore(tmp_path / "guard-home", guard_event_queue_limit=3)
 
-    for index in range(4):
+    for index in range(3):
         event = build_runtime_session_event(
             session_id=f"session-{index}",
             occurred_at=f"2026-04-24T00:00:0{index}+00:00",
@@ -191,13 +194,41 @@ def test_guard_cloud_event_queue_is_bounded_and_overflow_log_is_redacted(tmp_pat
         )
         store.add_guard_event_v1(event)
 
-    pending = store.list_guard_events_v1(uploaded=False, limit=10)
-    overflow_events = store.list_events(limit=5, event_name="cloud_event_queue_overflow")
+    store.add_guard_event_v1(
+        build_runtime_session_event(
+            session_id="session-3",
+            occurred_at="2026-04-24T00:00:03+00:00",
+            payload={"sessionSecret": "sk-live-secret-token", "index": 3},
+            workspace_id="workspace-alpha",
+            device_id="device-1",
+        )
+    )
 
-    assert [item["event_type"] for item in pending] == ["runtime.session", "runtime.session", "runtime.session"]
-    assert pending[0]["payload"]["payload"]["index"] == 1
-    assert overflow_events[0]["payload"]["dropped_count"] == 1
-    assert "sk-live-secret-token" not in json.dumps(overflow_events[0]["payload"])
+    pending = store.list_guard_events_v1(uploaded=False, limit=10)
+    assert [item["payload"]["payload"]["index"] for item in pending] == [0, 1, 2]
+    assert store.get_sync_payload("guard_event_queue_capacity") == {
+        "exhausted": True,
+        "firstRejectedAt": "2026-04-24T00:00:03+00:00",
+        "lastRejectedAt": "2026-04-24T00:00:03+00:00",
+        "limit": 3,
+        "pendingCount": 3,
+        "rejectedCount": 1,
+        "rejectedEventType": "runtime.session",
+    }
+    store.mark_guard_events_v1_uploaded(
+        [str(pending[0]["event_id"])],
+        "2026-04-24T00:01:00+00:00",
+    )
+    assert store.get_sync_payload("guard_event_queue_capacity") == {
+        "exhausted": False,
+        "firstRejectedAt": "2026-04-24T00:00:03+00:00",
+        "lastRejectedAt": "2026-04-24T00:00:03+00:00",
+        "limit": 3,
+        "pendingCount": 2,
+        "recoveredAt": "2026-04-24T00:01:00+00:00",
+        "rejectedCount": 1,
+        "rejectedEventType": "runtime.session",
+    }
 
 
 def test_sync_guard_events_records_failed_backoff_without_dropping_pending_events(
@@ -235,7 +266,9 @@ def test_sync_guard_events_records_failed_backoff_without_dropping_pending_event
     assert len(pending) == 1
 
 
-def test_guard_cloud_event_queue_handles_large_overflow_without_sqlite_parameter_limit(tmp_path: Path) -> None:
+def test_guard_cloud_event_queue_backpressures_large_backlog_without_sqlite_limit(
+    tmp_path: Path,
+) -> None:
     store = GuardStore(tmp_path / "guard-home", guard_event_queue_limit=1100)
 
     for index in range(1005):
@@ -259,11 +292,16 @@ def test_guard_cloud_event_queue_handles_large_overflow_without_sqlite_parameter
         )
     )
 
-    pending = store.list_guard_events_v1(uploaded=False, limit=10)
-    overflow_events = store.list_events(limit=5, event_name="cloud_event_queue_overflow")
-
-    assert [item["payload"]["payload"]["index"] for item in pending] == [1004, 1005]
-    assert overflow_events[0]["payload"]["dropped_count"] == 1004
+    assert store.count_guard_events_v1(uploaded=False) == 1005
+    assert store.get_sync_payload("guard_event_queue_capacity") == {
+        "exhausted": True,
+        "firstRejectedAt": "2026-04-24T00:16:45+00:00",
+        "lastRejectedAt": "2026-04-24T00:16:45+00:00",
+        "limit": 2,
+        "pendingCount": 1005,
+        "rejectedCount": 1,
+        "rejectedEventType": "runtime.session",
+    }
 
 
 def test_sync_guard_events_preserves_pending_events_when_v1_endpoint_is_unavailable(

--- a/tests/test_guard_event_schema_v1.py
+++ b/tests/test_guard_event_schema_v1.py
@@ -388,7 +388,7 @@ def test_sync_receipts_keeps_receipt_success_when_v1_events_endpoint_is_missing(
     assert len(pending) == 1  # The receipt.created event is still pending
 
 
-def test_sync_guard_events_marks_rejected_events_processed(tmp_path) -> None:
+def test_sync_guard_events_marks_rejected_events_terminal(tmp_path) -> None:
     store = GuardStore(tmp_path)
     store.add_receipt(_receipt())
     server = HTTPServer(("127.0.0.1", 0), _RejectedEventHandler)
@@ -401,10 +401,9 @@ def test_sync_guard_events_marks_rejected_events_processed(tmp_path) -> None:
             token="token-1",
         )
 
-        result = sync_guard_events(store)
+        sync_guard_events(store)
     finally:
         server.shutdown()
         thread.join(timeout=5)
 
-    assert result["accepted"] == 1
     assert store.list_guard_events_v1(uploaded=False, limit=10) == []

--- a/tests/test_guard_memory_decision_event.py
+++ b/tests/test_guard_memory_decision_event.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import pytest
+
 from codex_plugin_scanner.guard.memory_decision_event import (
     MEMORY_DECISION_EVENT_CONTRACT_VERSION,
     build_memory_decision_event,
@@ -15,7 +17,6 @@ from codex_plugin_scanner.guard.memory_decision_outbox import (
 from codex_plugin_scanner.guard.memory_pattern_fingerprint import (
     build_memory_pattern_fingerprint,
 )
-import pytest
 from codex_plugin_scanner.guard.store import GuardStore
 
 # ── Pattern fingerprint ──────────────────────────────────────────────────────
@@ -75,6 +76,19 @@ class TestMemoryPatternFingerprint:
         assert candidate.kind == "mcp_tool_pattern"
         assert candidate.components["server"] == "lean_ctx"
         assert candidate.components["tool"] == "ctx_search"
+
+    def test_tool_action_display_text_is_not_reclassified_as_a_command(self) -> None:
+        candidate = build_memory_pattern_fingerprint(
+            command="npm install lodash",
+            artifact_type="tool_action_request",
+            artifact_id="codex_tool:project:search",
+            artifact_name="Search files",
+            harness="codex",
+        )
+
+        assert candidate is not None
+        assert candidate.kind == "generic_artifact_pattern"
+        assert candidate.components["artifact"] == "codex_tool:project:search"
 
     def test_file_read_recognizes_file_read_artifact_type(self) -> None:
         candidate = build_memory_pattern_fingerprint(


### PR DESCRIPTION
## Summary
- derive canonical Suggested Memory fingerprints during local runtime policy evaluation
- apply synced allow/block memory rules only after exact pattern matches, preserving direct-policy precedence and scoped exact-match context
- retain unsent Guard events safely, activate bundles before acknowledging them, and handle rejected events as terminal
- prevent tool-action/tool-output display text from being reclassified as shell/package commands

## Verification
- `uv run pytest -q tests/test_guard_approval_decisions.py tests/test_guard_memory_decision_event.py tests/test_guard_event_schema_v1.py tests/test_guard_cloud_local_sync.py` — 104 passed
- focused caller suite — 135 passed
- `uv run ruff check` on all touched Python files — passed

## Security
- direct artifact policy remains authoritative over Suggested Memory fallback
- near matches remain unresolved and continue to ask
- policy bundle acknowledgement occurs only after local activation