### PR TITLE
fix(guard): bind content uploads to inventory tuples

### DIFF
--- a/src/codex_plugin_scanner/guard/aibom_content_upload.py
+++ b/src/codex_plugin_scanner/guard/aibom_content_upload.py
@@ -186,10 +186,12 @@ def _prepared_upload_item(source: GuardAibomPrimaryContentSource) -> tuple[dict[
         return None
     return (
         {
+            "agentId": source.agent_id,
             "bodyBase64": base64.b64encode(body).decode("ascii"),
             "contentHash": source.content_hash,
             "itemKind": source.item_kind,
             "itemId": source.item_id,
+            "snapshotId": source.snapshot_id,
             "versionId": source.version_id,
             "mimeType": source.mime_type,
             "evidenceAuthority": "device_claim",

--- a/tests/test_guard_aibom_content_upload.py
+++ b/tests/test_guard_aibom_content_upload.py
@@ -443,7 +443,9 @@ def test_primary_content_upload_batches_exact_bodies_and_item_count(tmp_path: Pa
     )
     first_item = json.loads(requests[0].data)["items"][0]
     assert first_item["bodyBase64"] == "IyBTa2lsbCAwCg=="
+    assert first_item["agentId"] == sources[0].agent_id
     assert first_item["contentHash"] == sources[0].content_hash
+    assert first_item["snapshotId"] == sources[0].snapshot_id
     assert first_item["versionId"] == sources[0].version_id
 
 


### PR DESCRIPTION
## Summary
- Include the inventory agent and snapshot identifiers with each content upload item.
- Preserve the exact inventory version tuple for server-side validation.

## Testing
- `pytest -q tests/test_guard_aibom_content_upload.py`
- `ruff check src/codex_plugin_scanner/guard/aibom_content_upload.py`
