### PR TITLE
fix(guard): omit invalid memory installation reference

### DIFF
--- a/src/codex_plugin_scanner/guard/memory_decision_outbox.py
+++ b/src/codex_plugin_scanner/guard/memory_decision_outbox.py
@@ -47,7 +47,7 @@ def enqueue_memory_decision_event(
         workspace_id = _resolve_workspace_id(store)
         device_id, machine_installation_id = _resolve_device_metadata(store)
         owner_user_id = _resolve_owner_user_id(store)
-        machine_id = _resolve_oauth_machine_id(store) or machine_installation_id
+        machine_id = _resolve_oauth_machine_id(store) or device_id
         redaction_enabled = _resolve_redaction_enabled(store)
 
         enriched_request = _request_with_project_identity(store, request)
@@ -109,8 +109,7 @@ def _resolve_device_metadata(store: Any) -> tuple[str | None, str | None]:
         return None, None
     installation_id = metadata.get("installation_id")
     device_id = installation_id if isinstance(installation_id, str) and installation_id.strip() else None
-    machine_installation_id = device_id
-    return device_id, machine_installation_id
+    return device_id, None
 
 
 def _resolve_owner_user_id(store: Any) -> str | None:

--- a/tests/test_guard_memory_decision_event.py
+++ b/tests/test_guard_memory_decision_event.py
@@ -420,6 +420,9 @@ class TestMemoryDecisionOutboxEnqueue:
         assert payload["eventType"] == "approval.memory_decision"
         assert payload["payload"]["decision_action"] == "approved"
         assert payload["payload"]["contractVersion"] == MEMORY_DECISION_EVENT_CONTRACT_VERSION
+        assert payload["payload"]["device_id"] is not None
+        assert payload["payload"]["machine_id"] is not None
+        assert payload["payload"]["machine_installation_id"] is None
 
     def test_enqueue_includes_project_identity_from_guard_operation(self, tmp_path: Path) -> None:
         store = _store(tmp_path)


### PR DESCRIPTION
## Summary
- keep the local installation identifier in the device-ID field
- stop emitting that local identifier as the server-owned machine-installation primary key
- cover the cloud event payload contract

## Verification
- `python3 -m pytest tests/test_guard_memory_decision_event.py -q` (35 tests passed)
- `python3 -m ruff check src/codex_plugin_scanner/guard/memory_decision_outbox.py tests/test_guard_memory_decision_event.py`
