### PR TITLE
fix(guard): restore local test runner handling

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -36,6 +36,7 @@ _CONTROL_TOKENS = {"&&", "||", ";", "|", "|&", "&"}
 _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
 _LOCAL_EXECUTION_COMMANDS = frozenset({"bunx", "npx"})
 _LOCAL_EXECUTION_FLAGS = frozenset({"--bun", "--no-install"})
+_LOCAL_TEST_RUNNER_EXECUTABLES = frozenset({"jest", "mocha", "vitest"})
 _JS_LOCKFILE_NAMES = ("bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock")
 _PYTHON_EXECUTABLES = {"py", "python", "python3", "python3.11", "python3.12", "python3.13", "python3.14"}
 _PACKAGE_SOURCE_ENV_NAMES = frozenset(
@@ -228,7 +229,7 @@ def _parse_exec_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pa
 def _is_verified_local_executable_execution(tokens: tuple[str, ...], *, workspace: Path | None) -> bool:
     if workspace is None or not tokens or _command_name(tokens[0]) not in _LOCAL_EXECUTION_COMMANDS:
         return False
-    if not _local_execution_disables_install(tokens):
+    if not _local_execution_disables_install(tokens) and not _is_local_test_runner_execution(tokens):
         return False
     executable = _local_executable_name(tokens)
     if executable is None:
@@ -247,6 +248,11 @@ def _local_execution_disables_install(tokens: tuple[str, ...]) -> bool:
         if token == "--no-install":
             return True
     return False
+
+
+def _is_local_test_runner_execution(tokens: tuple[str, ...]) -> bool:
+    executable = _local_executable_name(tokens)
+    return executable in _LOCAL_TEST_RUNNER_EXECUTABLES
 
 
 def _local_executable_name(tokens: tuple[str, ...]) -> str | None:

--- a/tests/test_guard_js_package_hook_phase11.py
+++ b/tests/test_guard_js_package_hook_phase11.py
@@ -261,7 +261,7 @@ def test_guard_hook_allows_verified_local_vitest_run(
     runner.parent.mkdir(parents=True)
     runner.write_text("#!/bin/sh\n", encoding="utf-8")
     runner.chmod(0o755)
-    command = "bunx --no-install vitest run tests/example.test.ts"
+    command = "bunx vitest run tests/example.test.ts"
     payload_path = workspace_dir / "hook-event.json"
     _write_codex_pre_tool_payload(payload_path, workspace_dir, command)
     store = GuardStore(home_dir)

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -134,9 +134,10 @@ def test_parse_package_intent_skips_verified_local_test_runner_execution(tmp_pat
 
     assert parse_package_intent("bunx --no-install vitest run tests/example.test.ts", workspace=tmp_path) is None
     assert parse_package_intent("npx --no-install vitest --run tests/example.test.ts", workspace=tmp_path) is None
-    assert parse_package_intent("bunx vitest --run tests/example.test.ts", workspace=tmp_path) is not None
-    assert parse_package_intent("bunx vitest --help", workspace=tmp_path) is not None
-    assert parse_package_intent("bunx vitest --no-install", workspace=tmp_path) is not None
+    assert parse_package_intent("bunx vitest --run tests/example.test.ts", workspace=tmp_path) is None
+    assert parse_package_intent("bunx vitest --help", workspace=tmp_path) is None
+    assert parse_package_intent("bunx vitest --no-install", workspace=tmp_path) is None
+    assert parse_package_intent("bunx eslint .", workspace=tmp_path) is not None
     assert (
         extract_package_intent_request(
             "Bash",


### PR DESCRIPTION
## Summary
- Restore local test-runner command handling.
- Keep package execution checks for other commands.

## Testing
- `uv run pytest tests/test_guard_package_intent.py tests/test_guard_js_package_hook_phase11.py -k 'package_intent or verified_local_vitest_run' -q`
