### PR TITLE
fix(guard): run local bunx tests without prompts

### DIFF
--- a/src/codex_plugin_scanner/guard/package_shim_gate.py
+++ b/src/codex_plugin_scanner/guard/package_shim_gate.py
@@ -10,6 +10,7 @@ _PACKAGE_SHIM_PARSER_MANAGERS = frozenset(
     {
         "brew",
         "bun",
+        "bunx",
         "bundle",
         "cargo",
         "composer",

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -6,6 +6,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 from collections.abc import Iterable
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -35,7 +36,11 @@ from .secret_file_requests import _SHELL_TOOL_NAMES, _candidate_command_texts, _
 _CONTROL_TOKENS = {"&&", "||", ";", "|", "|&", "&"}
 _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
 _LOCAL_EXECUTION_COMMANDS = frozenset({"bunx", "npx"})
-_LOCAL_EXECUTION_FLAGS = frozenset({"--bun", "--no-install"})
+_LOCAL_EXECUTION_FLAGS_BY_COMMAND = {
+    "bunx": frozenset({"--bun", "--no-install"}),
+    "npx": frozenset({"--no", "--no-install"}),
+}
+_LOCAL_TEST_RUNNER_EXECUTABLES = frozenset({"jest", "mocha", "vitest"})
 _JS_LOCKFILE_NAMES = ("bun.lock", "bun.lockb", "package-lock.json", "pnpm-lock.yaml", "yarn.lock")
 _PYTHON_EXECUTABLES = {"py", "python", "python3", "python3.11", "python3.12", "python3.13", "python3.14"}
 _PACKAGE_SOURCE_ENV_NAMES = frozenset(
@@ -228,7 +233,9 @@ def _parse_exec_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pa
 def _is_verified_local_executable_execution(tokens: tuple[str, ...], *, workspace: Path | None) -> bool:
     if workspace is None or not tokens or _command_name(tokens[0]) not in _LOCAL_EXECUTION_COMMANDS:
         return False
-    if not _local_execution_disables_install(tokens):
+    if not _local_execution_disables_install(tokens) and not (
+        _is_local_test_runner_execution(tokens) and _guard_package_shim_is_active(tokens[0])
+    ):
         return False
     executable = _local_executable_name(tokens)
     if executable is None:
@@ -241,18 +248,40 @@ def _is_verified_local_executable_execution(tokens: tuple[str, ...], *, workspac
 
 
 def _local_execution_disables_install(tokens: tuple[str, ...]) -> bool:
+    command = _command_name(tokens[0]) if tokens else ""
+    local_only_flags = _LOCAL_EXECUTION_FLAGS_BY_COMMAND.get(command, frozenset())
     for token in tokens[1:]:
         if not token.startswith("-"):
             return False
-        if token == "--no-install":
+        if token not in local_only_flags:
+            return False
+        if token in {"--no", "--no-install"}:
             return True
     return False
 
 
+def _is_local_test_runner_execution(tokens: tuple[str, ...]) -> bool:
+    executable = _local_executable_name(tokens)
+    return executable in _LOCAL_TEST_RUNNER_EXECUTABLES
+
+
+def _guard_package_shim_is_active(command: str) -> bool:
+    resolved_command = shutil.which(command)
+    if resolved_command is None:
+        return False
+    try:
+        expected_shim = Path.home() / ".hol-guard" / "package-shims" / "bin" / command
+        return Path(resolved_command).resolve() == expected_shim.resolve()
+    except (OSError, RuntimeError):
+        return False
+
+
 def _local_executable_name(tokens: tuple[str, ...]) -> str | None:
+    command = _command_name(tokens[0]) if tokens else ""
+    allowed_flags = _LOCAL_EXECUTION_FLAGS_BY_COMMAND.get(command, frozenset())
     index = 1
     while index < len(tokens) and tokens[index].startswith("-"):
-        if tokens[index] not in _LOCAL_EXECUTION_FLAGS:
+        if tokens[index] not in allowed_flags:
             return None
         index += 1
     if index >= len(tokens):

--- a/src/codex_plugin_scanner/guard/shim_probe.py
+++ b/src/codex_plugin_scanner/guard/shim_probe.py
@@ -15,6 +15,7 @@ _PACKAGE_SHIM_PROBE_ARGS: dict[str, tuple[str, ...]] = {
     "pnpm": ("add", "--dry-run", "lodash@4.17.21"),
     "yarn": ("add", "--dry-run", "lodash@4.17.21"),
     "bun": ("add", "--dry-run", "lodash@4.17.21"),
+    "bunx": ("--version",),
     "pip": ("install", "--dry-run", "requests==2.32.3"),
     "pip3": ("install", "--dry-run", "requests==2.32.3"),
     "uv": ("add", "--dry-run", "requests==2.32.3"),

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -42,6 +42,7 @@ HarnessContext = HarnessContextLike
 _PACKAGE_SHIM_COMMANDS = {
     "brew": "brew",
     "bun": "bun",
+    "bunx": "bunx",
     "bundle": "bundle",
     "cargo": "cargo",
     "composer": "composer",
@@ -61,6 +62,7 @@ _PACKAGE_SHIM_COMMANDS = {
     "yarn": "yarn",
 }
 _PACKAGE_SHIM_MANIFEST = "manifest.json"
+_LOCAL_TEST_RUNNER_COMMANDS = frozenset({"jest", "mocha", "vitest"})
 _GUARD_PROFILE_MARKER = "# HOL Guard harness launchers"
 _PACKAGE_PROFILE_MARKER = "# HOL Guard package manager shims"
 _PACKAGE_SHIM_PROBE_TIMEOUT_SECONDS = int(SQLITE_CONNECT_TIMEOUT_SECONDS) + 5
@@ -1015,6 +1017,7 @@ def _build_package_manager_python_shim(context: HarnessContext, command: str) ->
             f"guard_workspace = {str(context.workspace_dir) if context.workspace_dir is not None else None!r}",
             f"guard_has_explicit_workspace = {context.workspace_dir is not None!r}",
             f"shim_dir = {str(shim_dir.resolve())!r}",
+            f"local_test_runners = {tuple(sorted(_LOCAL_TEST_RUNNER_COMMANDS))!r}",
             "def _exec_real_manager():",
             "    path_entries = [entry for entry in os.environ.get('PATH', '').split(os.pathsep) if entry]",
             "    shim_dir_abs = os.path.abspath(shim_dir)",
@@ -1026,12 +1029,27 @@ def _build_package_manager_python_shim(context: HarnessContext, command: str) ->
             "        raise SystemExit(127)",
             "    manager_env = dict(os.environ)",
             "    manager_env['PATH'] = filtered_path",
+            "    manager_args = list(sys.argv[1:])",
+            "    local_only_flag = {'bunx': '--no-install', 'npx': '--no'}.get(command_name)",
+            "    leading_test_runner_flags = (",
+            "        {'--bun', '--no-install'} if command_name == 'bunx' else {'--no', '--no-install'}",
+            "    )",
+            "    runner_index = 0",
+            "    while runner_index < len(manager_args) and manager_args[runner_index] in leading_test_runner_flags:",
+            "        runner_index += 1",
+            "    if (",
+            "        local_only_flag is not None",
+            "        and runner_index < len(manager_args)",
+            "        and manager_args[runner_index] in local_test_runners",
+            "        and local_only_flag not in manager_args[:runner_index]",
+            "    ):",
+            "        manager_args.insert(runner_index, local_only_flag)",
             "    if os.name == 'nt':",
             "        try:",
-            "            raise SystemExit(subprocess.call([resolved_command, *sys.argv[1:]], env=manager_env))",
+            "            raise SystemExit(subprocess.call([resolved_command, *manager_args], env=manager_env))",
             "        except KeyboardInterrupt:",
             "            raise SystemExit(130)",
-            "    os.execvpe(resolved_command, [resolved_command, *sys.argv[1:]], manager_env)",
+            "    os.execvpe(resolved_command, [resolved_command, *manager_args], manager_env)",
             "def _command_requires_guard():",
             f"    if os.environ.get({SHIM_PROBE_ENV_VAR!r}) == {SHIM_PROBE_ENV_VALUE!r}:",
             "        return True",

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.runtime import package_intent_parser
 from codex_plugin_scanner.guard.runtime.package_intent import (
     extract_package_intent_request,
     parse_manifest_dependency_changes,
@@ -143,6 +144,53 @@ def test_parse_package_intent_skips_verified_local_test_runner_execution(tmp_pat
             {"command": "bunx --no-install vitest run tests/example.test.ts"},
             action_envelope_command="bunx --no-install vitest run tests/example.test.ts",
             workspace=tmp_path,
+        )
+        is None
+    )
+
+
+def test_parse_package_intent_skips_guard_shimmed_bunx_test_runner(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
+    _write_text(tmp_path / "bun.lock", '"vitest": "4.1.8"\n')
+    runner = tmp_path / "node_modules" / ".bin" / "vitest"
+    _write_text(runner, "#!/bin/sh\n")
+    runner.chmod(0o755)
+    home_dir = tmp_path / "home"
+    shim_path = home_dir / ".hol-guard" / "package-shims" / "bin" / "bunx"
+    _write_text(shim_path, "#!/bin/sh\n")
+    shim_path.chmod(0o755)
+    monkeypatch.setattr(package_intent_parser.Path, "home", classmethod(lambda cls: home_dir))
+    monkeypatch.setattr(
+        package_intent_parser.shutil, "which", lambda command: str(shim_path) if command == "bunx" else None
+    )
+
+    assert parse_package_intent("bunx vitest run tests/example.test.ts", workspace=tmp_path) is None
+    assert parse_package_intent("bunx --bun vitest run tests/example.test.ts", workspace=tmp_path) is None
+
+
+def test_extract_package_intent_skips_guard_shimmed_npx_test_runner_in_pipeline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
+    _write_text(tmp_path / "bun.lock", '"vitest": "4.1.8"\n')
+    runner = tmp_path / "node_modules" / ".bin" / "vitest"
+    _write_text(runner, "#!/bin/sh\n")
+    runner.chmod(0o755)
+    home_dir = tmp_path / "home"
+    shim_path = home_dir / ".hol-guard" / "package-shims" / "bin" / "npx"
+    _write_text(shim_path, "#!/bin/sh\n")
+    shim_path.chmod(0o755)
+    monkeypatch.setattr(package_intent_parser.Path, "home", classmethod(lambda cls: home_dir))
+    monkeypatch.setattr(
+        package_intent_parser.shutil, "which", lambda command: str(shim_path) if command == "npx" else None
+    )
+    command = "cd project && npx vitest run tests/unit.test.tsx 2>&1 | tail -15"
+
+    assert (
+        extract_package_intent_request(
+            "Bash", {"command": command}, action_envelope_command=command, workspace=tmp_path
         )
         is None
     )

--- a/tests/test_guard_package_shims.py
+++ b/tests/test_guard_package_shims.py
@@ -1312,6 +1312,28 @@ def test_guard_package_shims_block_before_manager_execution(
     assert "HOL Guard" in result.stdout
 
 
+@pytest.mark.parametrize(
+    ("manager", "expected_local_only_flag"),
+    (("bunx", "--no-install"), ("npx", "--no")),
+)
+def test_package_shim_uses_manager_specific_local_only_flag(
+    tmp_path: Path,
+    manager: str,
+    expected_local_only_flag: str,
+) -> None:
+    context = HarnessContext(
+        home_dir=Path.home(),
+        guard_home=tmp_path / ".hol-guard",
+        workspace_dir=tmp_path / "workspace",
+    )
+    shim_source = guard_shims_module._build_package_manager_python_shim(context, manager)
+
+    assert f"command_name = {manager!r}" in shim_source
+    assert "local_only_flag = {'bunx': '--no-install', 'npx': '--no'}.get(command_name)" in shim_source
+    assert "manager_args.insert(runner_index, local_only_flag)" in shim_source
+    assert expected_local_only_flag in shim_source
+
+
 def test_guard_package_shim_preserves_argv_cwd_env_exitcode_and_stdio(tmp_path: Path, capsys) -> None:
     home_dir = tmp_path / "guard-home"
     workspace_dir = tmp_path / "workspace"

--- a/tests/test_guard_package_support_matrix.py
+++ b/tests/test_guard_package_support_matrix.py
@@ -76,6 +76,7 @@ def test_supported_managers_snapshot() -> None:
         "brew",
         "bun",
         "bundle",
+        "bunx",
         "cargo",
         "composer",
         "go",


### PR DESCRIPTION
## Summary
- Route local test-runner commands through the managed package shim.
- Preserve package review for other executions.

## Testing
- `uv run pytest tests/test_guard_package_intent.py -k 'test_runner' -q`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/package_intent_parser.py src/codex_plugin_scanner/guard/shims.py tests/test_guard_package_intent.py`
