### PR TITLE
Fix package activation recovery

### DIFF
--- a/dashboard/src/guard-api.ts
+++ b/dashboard/src/guard-api.ts
@@ -2765,8 +2765,8 @@ export async function runPackageFirewallAction(
   return normalizePackageFirewallAction(payloadBody);
 }
 
-export async function openPackageFirewallShell(): Promise<void> {
-  const response = await fetchGuardApi("/v1/supply-chain/package-shims/open-shell", {
+export async function activatePackageFirewallRuntime(): Promise<void> {
+  const response = await fetchGuardApi("/v1/supply-chain/package-shims/activate", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -2781,7 +2781,7 @@ export async function openPackageFirewallShell(): Promise<void> {
   if (isRecord(payloadBody) && typeof payloadBody.message === "string" && payloadBody.message.trim()) {
     throw new Error(payloadBody.message);
   }
-  throw new Error("Unable to open a new shell.");
+  throw new Error("Unable to activate package protection.");
 }
 
 export type AuditRemediationAction = "package_shim_path";

--- a/dashboard/src/home-protection-module.tsx
+++ b/dashboard/src/home-protection-module.tsx
@@ -144,7 +144,7 @@ export function HomeProtectionModule({
     status === "protected"
       ? "Package managers protected"
       : status === "staged"
-      ? "Protection staged — restart shell or apps"
+      ? "Protection staged, finish activation"
       : status === "partial"
       ? "Some package managers unprotected"
       : status === "unprotected"

--- a/dashboard/src/runtime-overview.test.ts
+++ b/dashboard/src/runtime-overview.test.ts
@@ -240,12 +240,12 @@ const restartRequiredProtection: PackageManagerProtection = {
 const restartRequiredCopy = resolvePackageManagerProtectionCopy(restartRequiredProtection);
 assert(restartRequiredCopy.pathTone === "blue", "SC2b: restart_required tone should use blue");
 assert(
-  restartRequiredCopy.pathLabel.toLowerCase().includes("restart"),
-  `SC2b: restart_required label should mention restart — got: "${restartRequiredCopy.pathLabel}"`
+  restartRequiredCopy.pathLabel.toLowerCase().includes("activation"),
+  `SC2b: restart_required label should direct activation — got: "${restartRequiredCopy.pathLabel}"`
 );
 assert(
-  restartRequiredCopy.pathDetail.toLowerCase().includes("restart") || restartRequiredCopy.pathDetail.toLowerCase().includes("new shell"),
-  `SC2b: restart_required detail should explain next step — got: "${restartRequiredCopy.pathDetail}"`
+  restartRequiredCopy.pathDetail.toLowerCase().includes("finish activation"),
+  `SC2b: restart_required detail should explain the recovery action — got: "${restartRequiredCopy.pathDetail}"`
 );
 
 const absentCopy = resolvePackageManagerProtectionCopy(undefined);

--- a/dashboard/src/runtime-overview.tsx
+++ b/dashboard/src/runtime-overview.tsx
@@ -280,10 +280,10 @@ export function resolvePackageManagerProtectionCopy(
   }
   if (protection.path_status === "restart_required") {
     return {
-      pathLabel: "Restart shell or apps to finish activation",
+      pathLabel: "Finish activation in Guard",
       pathDetail: protection.shell_profile_configured
-        ? `Guard updated the shell profile for ${protection.shim_dir}. Open a new shell or restart AI apps so package-manager commands resolve through Guard.`
-        : `Guard installed shims in ${protection.shim_dir}, but activation is still waiting for a fresh shell or app session.`,
+        ? `Guard saved the shell setup for ${protection.shim_dir}. Finish activation in the package firewall, then run a protection check.`
+        : `Guard installed shims in ${protection.shim_dir}, but activation is still waiting in this Guard session.`,
       pathTone: "blue",
       protectedList: protection.protected_managers,
       unprotectedList: protection.unprotected_managers,

--- a/dashboard/src/supply-chain-firewall-controls.tsx
+++ b/dashboard/src/supply-chain-firewall-controls.tsx
@@ -81,7 +81,7 @@ function FailureBanner({ failed }: { failed: FirewallFailedOp }) {
 
 export type FirewallControlsViewProps = {
   activationAssistError: string | null;
-  openingShell: boolean;
+  activatingRuntime: boolean;
   data: PackageFirewallStatusResponse;
   pendingOp: FirewallPendingOp | null;
   lastCompleted: CompletedOp | null;
@@ -101,14 +101,14 @@ export type FirewallControlsViewProps = {
   onAudit: () => void;
   onSync: () => void;
   onDismissResult: () => void;
-  onOpenShell: () => void;
+  onActivateRuntime: () => void;
   onRefreshStatus: () => void;
   onOpenManagerDetails: (manager: string) => void;
 };
 
 export function FirewallControlsView({
   activationAssistError,
-  openingShell,
+  activatingRuntime,
   data,
   pendingOp,
   lastCompleted,
@@ -128,7 +128,7 @@ export function FirewallControlsView({
   onAudit,
   onSync,
   onDismissResult,
-  onOpenShell,
+  onActivateRuntime,
   onRefreshStatus,
   onOpenManagerDetails,
 }: FirewallControlsViewProps) {
@@ -190,8 +190,8 @@ export function FirewallControlsView({
       <ActivationSummary
         activationAssistError={activationAssistError}
         lastAuditProofAt={data.last_audit_proof_at}
-        openingShell={openingShell}
-        onOpenShell={onOpenShell}
+        activatingRuntime={activatingRuntime}
+        onActivateRuntime={onActivateRuntime}
         onRefreshStatus={onRefreshStatus}
         protection={data.protection}
       />

--- a/dashboard/src/supply-chain-firewall-panel.tsx
+++ b/dashboard/src/supply-chain-firewall-panel.tsx
@@ -10,7 +10,7 @@ import type {
 } from "./guard-types";
 import {
   fetchPackageFirewallStatus,
-  openPackageFirewallShell,
+  activatePackageFirewallRuntime,
   runPackageFirewallAction,
   runPackageAudit,
   runPackageSync,
@@ -76,7 +76,7 @@ export type PackageFirewallPanelHandle = {
   focusActionable: () => void;
   runAudit: () => void;
   startConnect: () => Promise<void>;
-  openShell: () => Promise<void>;
+  activateRuntime: () => Promise<void>;
 };
 
 function actionLabel(op: PackageFirewallActionType): string {
@@ -191,7 +191,7 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
   const [connectError, setConnectError] = useState<string | null>(null);
   const [activationAssistError, setActivationAssistError] = useState<string | null>(null);
   const [startingConnect, setStartingConnect] = useState(false);
-  const [openingShell, setOpeningShell] = useState(false);
+  const [activatingRuntime, setActivatingRuntime] = useState(false);
   const [confirmRemoveManager, setConfirmRemoveManager] = useState<string | null>(null);
   const [pendingApprovalOp, setPendingApprovalOp] = useState<ApprovalOp | null>(null);
   const [statusFilter, setStatusFilter] = useState<StatusFilter>("all");
@@ -690,17 +690,19 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
   }, [handleAudit, runAuditRef]);
   const handleDismissResult = useCallback(() => setLastCompleted(null), []);
   const handleRetry = useCallback(() => void load(), [load]);
-  const handleOpenShell = useCallback(async () => {
-    setOpeningShell(true);
+  const handleActivateRuntime = useCallback(async () => {
+    setActivatingRuntime(true);
     setActivationAssistError(null);
     try {
-      await openPackageFirewallShell();
+      await activatePackageFirewallRuntime();
+      await refreshAfterOp();
+      await onStateChanged?.();
     } catch (error) {
-      setActivationAssistError(error instanceof Error ? error.message : "Unable to open a new shell.");
+      setActivationAssistError(error instanceof Error ? error.message : "Unable to activate package protection.");
     } finally {
-      setOpeningShell(false);
+      setActivatingRuntime(false);
     }
-  }, []);
+  }, [onStateChanged, refreshAfterOp]);
   const handleApprovalCancel = useCallback(() => setPendingApprovalOp(null), []);
   const handleApprovalConfirm = useCallback(
     (credentials: { approval_password?: string; approval_totp_code?: string }) => {
@@ -750,9 +752,9 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
         handleAudit();
       },
       startConnect: handleStartConnect,
-      openShell: handleOpenShell,
+      activateRuntime: handleActivateRuntime,
     }),
-    [handleAudit, handleOpenShell, handleStartConnect],
+    [handleActivateRuntime, handleAudit, handleStartConnect],
   );
 
 
@@ -822,10 +824,10 @@ export const PackageFirewallPanel = forwardRef(function PackageFirewallPanel(
             onAudit={handleAudit}
             onSync={handleSync}
             onDismissResult={handleDismissResult}
-            onOpenShell={handleOpenShell}
+            onActivateRuntime={handleActivateRuntime}
             onRefreshStatus={handleRetry}
             onOpenManagerDetails={handleOpenManagerDetails}
-            openingShell={openingShell}
+            activatingRuntime={activatingRuntime}
             activationAssistError={activationAssistError}
           />
         </>

--- a/dashboard/src/supply-chain-firewall-views.tsx
+++ b/dashboard/src/supply-chain-firewall-views.tsx
@@ -68,12 +68,6 @@ type ConnectFlowCardProps = {
   purpose?: "package_firewall" | "insights_share" | "audit";
 };
 
-type NavigatorWithUserAgentData = Navigator & {
-  userAgentData?: {
-    platform?: string;
-  };
-};
-
 type ConnectStepProps = {
   body: string;
   current: boolean;
@@ -303,16 +297,6 @@ function resolveConnectPrimaryLabel(input: {
     return "Try connect again";
   }
   return input.actionLabel;
-}
-
-function isMacClient(): boolean {
-  if (typeof navigator === "undefined") {
-    return false;
-  }
-  const navigatorWithUserAgentData = navigator as NavigatorWithUserAgentData;
-  const platformHint =
-    navigatorWithUserAgentData.userAgentData?.platform ?? navigator.userAgent ?? navigator.platform;
-  return platformHint.toLowerCase().includes("mac");
 }
 
 export function ConnectFlowCard({
@@ -575,15 +559,15 @@ export function EntitlementNotice({
 function activationHeadline(protection: PackageManagerProtection | null): string {
   if (protection === null) return "Activation status unavailable";
   if (protection.path_status === "in_path") return "Protection live now";
-  if (protection.path_status === "restart_required") return "Restart shell or apps to finish activation";
+  if (protection.path_status === "restart_required") return "Finish activation in Guard";
   return "Fix PATH to finish activation";
 }
 
 type ActivationSummaryProps = {
   activationAssistError: string | null;
   lastAuditProofAt?: string | null;
-  openingShell: boolean;
-  onOpenShell: () => void;
+  activatingRuntime: boolean;
+  onActivateRuntime: () => void;
   onRefreshStatus: () => void;
   protection: PackageManagerProtection | null;
 };
@@ -591,8 +575,8 @@ type ActivationSummaryProps = {
 export function ActivationSummary({
   activationAssistError,
   lastAuditProofAt = null,
-  openingShell,
-  onOpenShell,
+  activatingRuntime,
+  onActivateRuntime,
   onRefreshStatus,
   protection,
 }: ActivationSummaryProps) {
@@ -618,10 +602,8 @@ export function ActivationSummary({
       : protection.path_status === "restart_required"
       ? "text-brand-blue"
       : "text-brand-attention";
-  const canOpenShell =
-    protection.path_status === "restart_required" &&
-    protection.shell_profile_configured &&
-    isMacClient();
+  const canActivateRuntime =
+    protection.path_status === "restart_required" && protection.shell_profile_configured;
   return (
     <div className={`rounded-xl border px-4 py-3 ${toneClass}`}>
       <div className="flex items-start gap-2.5">
@@ -636,13 +618,13 @@ export function ActivationSummary({
           )}
           {protection.path_status === "restart_required" && (
             <div className="mt-3 flex flex-wrap items-center gap-2">
-              {canOpenShell && (
-                <ActionButton variant="primary" onClick={onOpenShell} disabled={openingShell}>
-                  {openingShell ? "Opening shell…" : "Open new shell"}
+              {canActivateRuntime && (
+                <ActionButton variant="primary" onClick={onActivateRuntime} disabled={activatingRuntime}>
+                  {activatingRuntime ? "Finishing activation…" : "Finish activation"}
                 </ActionButton>
               )}
-              <ActionButton variant="outline" onClick={onRefreshStatus} disabled={openingShell}>
-                Refresh after restart
+              <ActionButton variant="outline" onClick={onRefreshStatus} disabled={activatingRuntime}>
+                Refresh status
               </ActionButton>
             </div>
           )}

--- a/dashboard/src/supply-chain-issues.test.ts
+++ b/dashboard/src/supply-chain-issues.test.ts
@@ -122,16 +122,36 @@ assert(
   "SCSR170-D: paired cloud skips connect issue",
 );
 
+const restartRequiredIssues = resolveSupplyChainIssues({
+  ...baseSnapshot,
+  cloud_state: "paired_active",
+  cloud_state_label: "Connected",
+  supply_chain: {
+    package_manager_protection: makeProtection({
+      installed_managers: ["npm"],
+      path_contains_shim_dir: false,
+      path_status: "restart_required",
+      restart_shell_required: true,
+    }),
+  },
+});
+assert(
+  restartRequiredIssues.some(
+    (issue) => issue.id === "path_restart" && issue.action.kind === "activate_runtime",
+  ),
+  "SCSR170-E: restart-required recovery activates the Guard runtime instead of opening a terminal",
+);
+
 const compactHero = resolveSupplyChainWorkspaceHero(localPartialSnapshot, {
   openIssueCount: localPartialIssues.length,
 });
 assert(
   compactHero.title === "Work through the steps below",
-  "SCSR170-E: compact hero defers detail to issue carousel",
+  "SCSR170-F: compact hero defers detail to issue carousel",
 );
 assert(
   compactHero.detail.includes("2 setup steps"),
-  "SCSR170-F: compact hero summarizes open issue count",
+  "SCSR170-G: compact hero summarizes open issue count",
 );
 
 const staleDate = new Date(Date.now() - 8 * 24 * 60 * 60 * 1000).toISOString();
@@ -157,7 +177,7 @@ const staleIssues = resolveSupplyChainIssues({
 });
 assert(
   staleIssues.some((issue) => issue.id === "stale_intel" && issue.action.kind === "firewall_audit"),
-  "SCSR170-G: stale intel issue routes to workspace audit",
+  "SCSR170-H: stale intel issue routes to workspace audit",
 );
 
 console.log("supply-chain-issues.test.ts: all assertions passed");

--- a/dashboard/src/supply-chain-issues.ts
+++ b/dashboard/src/supply-chain-issues.ts
@@ -9,7 +9,7 @@ export type SupplyChainIssueAction =
   | { kind: "firewall_unprotected" }
   | { kind: "firewall_repair" }
   | { kind: "firewall_audit" }
-  | { kind: "open_shell" };
+  | { kind: "activate_runtime" };
 
 export type SupplyChainIssue = {
   id: string;
@@ -46,7 +46,7 @@ export function resolveSupplyChainIssues(snapshot: GuardRuntimeSnapshot): Supply
       id: "path_missing",
       title: "Package installs are not being checked yet",
       detail:
-        "Guard has not hooked into your shell path yet. Turn on protection for your package tools, then open a new terminal.",
+        "Guard has not activated package protection yet. Turn on protection for your package tools, then finish activation here.",
       tone: "attention",
       actionLabel: "Protect package tools",
       action: { kind: "firewall_unprotected" },
@@ -70,12 +70,12 @@ export function resolveSupplyChainIssues(snapshot: GuardRuntimeSnapshot): Supply
   } else if (protection?.path_status === "restart_required" || stats.stagedManagers > 0) {
     issues.push({
       id: "path_restart",
-      title: "Open a new terminal to finish setup",
+      title: "Finish activation in Guard",
       detail:
-        "Guard updated your shell profile. Open a new terminal or restart your AI apps before running a protection test.",
+        "Guard saved your shell setup. Finish activation here, then run a protection check from this dashboard.",
       tone: "blue",
-      actionLabel: "Open new shell",
-      action: { kind: "open_shell" },
+      actionLabel: "Finish activation",
+      action: { kind: "activate_runtime" },
     });
   }
 

--- a/dashboard/src/supply-chain-posture.ts
+++ b/dashboard/src/supply-chain-posture.ts
@@ -28,7 +28,7 @@ export function resolveSupplyChainPostureAlerts(
       kind: "path_repair",
       title: "Package installs are not being checked yet",
       detail:
-        "Guard has not hooked into your shell path yet. Turn on protection in the firewall panel below, then open a new terminal.",
+        "Guard has not activated this runtime yet. Turn on protection in the firewall panel below, then finish activation here.",
       tone: "attention",
     });
   } else if (stats.repairRequiredManagers > 0) {
@@ -42,15 +42,15 @@ export function resolveSupplyChainPostureAlerts(
     alerts.push({
       kind: "path_repair",
       title: "Fix your shell path before installs can be blocked",
-      detail: `Guard set up protection for ${managerLabel}, but your shell path still needs a quick repair. Tap Fix PATH in the firewall panel, then open a new terminal.`,
+      detail: `Guard set up protection for ${managerLabel}, but the active Guard session still needs a quick repair. Tap Fix PATH in the firewall panel, then finish activation here.`,
       tone: "attention",
     });
   } else if (protection?.path_status === "restart_required" || stats.stagedManagers > 0) {
     alerts.push({
       kind: "path_repair",
-      title: "Open a new terminal to finish setup",
+      title: "Finish activation in Guard",
       detail:
-        "Guard updated your shell profile. Open a new terminal or restart your AI apps before running a protection test.",
+        "Guard saved your shell setup. Finish activation here, then run a protection check from the firewall panel.",
       tone: "blue",
     });
   }

--- a/dashboard/src/supply-chain-workspace-hero-state.ts
+++ b/dashboard/src/supply-chain-workspace-hero-state.ts
@@ -44,7 +44,7 @@ function protectionDetail(
     } still open: ${protection.unprotected_managers.join(", ")}.`;
   }
   if (status === "staged") {
-    return "Guard updated your shell profile. Open a new terminal, then run a protection test.";
+    return "Guard saved your shell setup. Finish activation here, then run a protection check.";
   }
   if (status === "unprotected") {
     return "Turn on protection for npm, pip, and other tools in the firewall panel below.";

--- a/dashboard/src/supply-chain-workspace.tsx
+++ b/dashboard/src/supply-chain-workspace.tsx
@@ -202,8 +202,9 @@ export function SupplyChainWorkspace({
           await onRuntimeRefresh?.();
           return;
         }
-        if (action.kind === "open_shell") {
-          await panel.openShell();
+        if (action.kind === "activate_runtime") {
+          await panel.activateRuntime();
+          await onRuntimeRefresh?.();
         }
       } finally {
         setIssueActionPending(false);

--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -13,7 +13,6 @@ import mimetypes
 import os
 import platform
 import secrets
-import subprocess
 import tempfile
 import threading
 import time
@@ -182,6 +181,7 @@ _HEADLESS_CLOUD_SYNC_STATE_LOCK = threading.Lock()
 _HEADLESS_CLOUD_SYNC_IN_FLIGHT: set[str] = set()
 _AUDIT_REMEDIATION_ACTIONS = {"package_shim_path"}
 _SUPPLY_CHAIN_PACKAGE_ACTIONS = {
+    "activate",
     "install",
     "repair",
     "test",
@@ -911,54 +911,39 @@ def _default_package_firewall_connect_flow(
     }
 
 
-def _open_package_firewall_activation_shell() -> tuple[int, dict[str, object]]:
-    system_name = platform.system().lower()
-    if system_name != "darwin":
+def _activate_package_firewall_runtime(context: HarnessContext) -> tuple[int, dict[str, object]]:
+    status = package_shim_status(context)
+    installed_managers = status.get("installed_managers")
+    if not isinstance(installed_managers, list) or not installed_managers:
         return (
-            501,
+            409,
             {
-                "error": "activation_shell_unsupported",
-                "message": "Opening a new shell from the dashboard is only supported on macOS right now.",
+                "error": "activation_requires_installed_shims",
+                "message": "Protect a package manager before activating this Guard session.",
             },
         )
-    osascript_path = Path("/usr/bin/osascript")
-    if not osascript_path.exists():
+    proof = probe_package_shim_intercepts(
+        context,
+        managers=tuple(str(manager) for manager in installed_managers),
+        allow_inactive_path=True,
+    )
+    if not bool(proof.get("intercept_proved")):
         return (
-            500,
+            409,
             {
-                "error": "activation_shell_unavailable",
-                "message": "macOS automation support is unavailable on this machine.",
-            },
-        )
-    command = [
-        str(osascript_path),
-        "-e",
-        'tell application "Terminal" to do script ""',
-        "-e",
-        'tell application "Terminal" to activate',
-    ]
-    try:
-        subprocess.Popen(
-            command,
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-            start_new_session=True,
-        )
-    except OSError as error:
-        return (
-            500,
-            {
-                "error": "activation_shell_launch_failed",
-                "message": f"Guard could not open a new shell automatically. {error}",
+                "error": "shim_verification_failed",
+                "message": ("Guard could not verify the installed package shim. Repair protection and try again."),
+                "package_shims": package_shim_status(context),
+                "proof": proof,
             },
         )
     return (
         200,
         {
-            "status": "opened",
-            "message": "Opened a new Terminal window with a fresh shell session.",
-            "platform": "macos",
+            "status": "verified",
+            "message": "Guard verified the installed package shim. Restart existing AI apps before using it.",
+            "package_shims": package_shim_status(context),
+            "proof": proof,
         },
     )
 
@@ -2662,11 +2647,9 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
         if action == "connect":
             self._handle_supply_chain_package_firewall_connect()
             return
-        if action == "open-shell":
-            status, response = _open_package_firewall_activation_shell()
-            self._write_json(response, status=status)
-            return
         operation = "remove" if action == "uninstall" else action
+        if operation == "open-shell":
+            operation = "activate"
         if not self._enforce_package_firewall_rate_limit(operation, payload):
             return
         entitlement = self._supply_chain_entitlement()
@@ -2703,6 +2686,10 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
                     purpose="supply_chain_firewall",
                     approval_gate_input=approval_gate_input_from_mapping(payload),
                 )
+            if operation == "activate":
+                status, response = _activate_package_firewall_runtime(context)
+                self._write_json(response, status=status)
+                return
             result = self._run_supply_chain_package_action(operation, context, managers)
         except ApprovalGateError as error:
             self._write_approval_gate_error(error)
@@ -4811,7 +4798,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             return "supply_chain_bundle"
         if len(path_parts) == 4 and path_parts[:3] == ["v1", "supply-chain", "package-shims"]:
             action = "remove" if path_parts[3] == "uninstall" else path_parts[3]
-            if action in {"install", "repair", "test", "remove", "open-shell"}:
+            if action in {"activate", "install", "repair", "test", "remove", "open-shell"}:
                 return f"package_shims_{action}"
         if len(path_parts) == 3 and path_parts[:2] == ["v1", "supply-chain"] and path_parts[2] in {"audit", "sync"}:
             return f"package_shims_{path_parts[2]}"
@@ -4918,6 +4905,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
             "/v1/insights/share",
             "/v1/cloud/connect",
             "/v1/supply-chain/package-shims/connect",
+            "/v1/supply-chain/package-shims/activate",
             "/v1/receipts/latest",
             "/v1/runtime",
             "/v1/settings",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-protection-module.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/home-protection-module.js
@@ -67,7 +67,7 @@ function HomeProtectionModule({
   const statusBorderClass = status === "protected" ? "border-brand-green/20 bg-brand-green/[0.04]" : status === "staged" ? "border-brand-blue/20 bg-brand-blue/[0.04]" : status === "partial" ? "border-brand-attention/20 bg-brand-attention/[0.04]" : status === "unprotected" ? "border-red-200 bg-red-50/60" : "border-slate-200 bg-slate-50/60";
   const StatusIcon = status === "protected" ? HiMiniShieldCheck : status === "staged" ? HiMiniInformationCircle : status === "partial" || status === "unprotected" ? HiMiniExclamationTriangle : HiMiniInformationCircle;
   const statusIconClass = status === "protected" ? "text-brand-green" : status === "staged" ? "text-brand-blue" : status === "partial" || status === "unprotected" ? "text-brand-attention" : "text-slate-400";
-  const statusLabel = status === "protected" ? "Package managers protected" : status === "staged" ? "Protection staged — restart shell or apps" : status === "partial" ? "Some package managers unprotected" : status === "unprotected" ? "Package managers unprotected" : "Supply chain status unknown";
+  const statusLabel = status === "protected" ? "Package managers protected" : status === "staged" ? "Protection staged, finish activation" : status === "partial" ? "Some package managers unprotected" : status === "unprotected" ? "Package managers unprotected" : "Supply chain status unknown";
   const handleToggle = () => setExpanded((prev) => !prev);
   return /* @__PURE__ */ jsxRuntimeExports.jsx(
     "section",

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-hub-workspace.js
@@ -1,5 +1,5 @@
 const __vite__mapDeps=(i,m=__vite__mapDeps,d=(m.f||(m.f=["assets/chunks/supply-chain-workspace.js","assets/guard-dashboard.js","assets/index.css","assets/chunks/feed-health-workspace.js","assets/chunks/home-protection-module.js","assets/chunks/supply-chain-protection-stats.js","assets/chunks/audit-workspace.js"])))=>i.map(i=>d[i]);
-import { aC as isSupplyChainAuditIncomplete, aD as isSupplyChainAuditEvidence, r as reactExports, aE as buildApprovalProofCredentials, aF as isApprovalProofSubmitDisabled, j as jsxRuntimeExports, S as SectionLabel, aG as ApprovalProofFieldInputs, A as ActionButton, av as GuardHarnessActionError, aH as readString$1, aI as isRecord$1, d as HiMiniCheckCircle, ax as HiMiniArrowPath, x as HiMiniExclamationTriangle, ad as Tag, m as formatRelativeTime, aJ as HiMiniClock, aK as IconActionButton, J as HiMiniXCircle, ay as HiMiniTrash, l as HiMiniShieldCheck, I as HiMiniWrenchScrewdriver, aL as HiMiniBeaker, aM as ActivationSummary, aN as ActionResultPanel, ae as HiMiniMagnifyingGlass, b as EmptyState, aO as HiMiniBugAnt, Z as fetchSettings, o as HiMiniXMark, aP as GuardModalLayer, aQ as ConnectFlowCard, aR as ApprovalProofInline, aS as HiMiniArrowTopRightOnSquare, aT as HiMiniCloudArrowDown, aU as fetchPackageFirewallStatus, aV as runPackageAudit, aW as resolveSupplyChainAuditFailure, aX as runPackageSync, aY as startPackageFirewallConnect, aZ as openPackageFirewallAuthorizeFallback, a_ as PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE, a$ as runPackageFirewallAction, b0 as parseInterceptProofSnapshot, b1 as openPackageFirewallShell, b2 as EntitlementNotice, b3 as fetchReceipts, b4 as WorkspacePageHeader, b5 as __vitePreload } from "../guard-dashboard.js";
+import { aC as isSupplyChainAuditIncomplete, aD as isSupplyChainAuditEvidence, r as reactExports, aE as buildApprovalProofCredentials, aF as isApprovalProofSubmitDisabled, j as jsxRuntimeExports, S as SectionLabel, aG as ApprovalProofFieldInputs, A as ActionButton, av as GuardHarnessActionError, aH as readString$1, aI as isRecord$1, d as HiMiniCheckCircle, ax as HiMiniArrowPath, x as HiMiniExclamationTriangle, ad as Tag, m as formatRelativeTime, aJ as HiMiniClock, aK as IconActionButton, J as HiMiniXCircle, ay as HiMiniTrash, l as HiMiniShieldCheck, I as HiMiniWrenchScrewdriver, aL as HiMiniBeaker, aM as ActivationSummary, aN as ActionResultPanel, ae as HiMiniMagnifyingGlass, b as EmptyState, aO as HiMiniBugAnt, Z as fetchSettings, o as HiMiniXMark, aP as GuardModalLayer, aQ as ConnectFlowCard, aR as ApprovalProofInline, aS as HiMiniArrowTopRightOnSquare, aT as HiMiniCloudArrowDown, aU as fetchPackageFirewallStatus, aV as runPackageAudit, aW as resolveSupplyChainAuditFailure, aX as runPackageSync, aY as startPackageFirewallConnect, aZ as openPackageFirewallAuthorizeFallback, a_ as PACKAGE_FIREWALL_CONNECT_POPUP_BLOCKED_MESSAGE, a$ as runPackageFirewallAction, b0 as parseInterceptProofSnapshot, b1 as activatePackageFirewallRuntime, b2 as EntitlementNotice, b3 as fetchReceipts, b4 as WorkspacePageHeader, b5 as __vitePreload } from "../guard-dashboard.js";
 const SEVERITY_RANK = {
   critical: 4,
   high: 3,
@@ -941,7 +941,7 @@ function FailureBanner({ failed }) {
 }
 function FirewallControlsView({
   activationAssistError,
-  openingShell,
+  activatingRuntime,
   data,
   pendingOp,
   lastCompleted,
@@ -961,7 +961,7 @@ function FirewallControlsView({
   onAudit,
   onSync,
   onDismissResult,
-  onOpenShell,
+  onActivateRuntime,
   onRefreshStatus,
   onOpenManagerDetails
 }) {
@@ -1015,8 +1015,8 @@ function FirewallControlsView({
       {
         activationAssistError,
         lastAuditProofAt: data.last_audit_proof_at,
-        openingShell,
-        onOpenShell,
+        activatingRuntime,
+        onActivateRuntime,
         onRefreshStatus,
         protection: data.protection
       }
@@ -1600,7 +1600,7 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
   const [connectError, setConnectError] = reactExports.useState(null);
   const [activationAssistError, setActivationAssistError] = reactExports.useState(null);
   const [startingConnect, setStartingConnect] = reactExports.useState(false);
-  const [openingShell, setOpeningShell] = reactExports.useState(false);
+  const [activatingRuntime, setActivatingRuntime] = reactExports.useState(false);
   const [confirmRemoveManager, setConfirmRemoveManager] = reactExports.useState(null);
   const [pendingApprovalOp, setPendingApprovalOp] = reactExports.useState(null);
   const [statusFilter, setStatusFilter] = reactExports.useState("all");
@@ -2058,17 +2058,19 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
   }, [handleAudit, runAuditRef]);
   const handleDismissResult = reactExports.useCallback(() => setLastCompleted(null), []);
   const handleRetry = reactExports.useCallback(() => void load(), [load]);
-  const handleOpenShell = reactExports.useCallback(async () => {
-    setOpeningShell(true);
+  const handleActivateRuntime = reactExports.useCallback(async () => {
+    setActivatingRuntime(true);
     setActivationAssistError(null);
     try {
-      await openPackageFirewallShell();
+      await activatePackageFirewallRuntime();
+      await refreshAfterOp();
+      await onStateChanged?.();
     } catch (error) {
-      setActivationAssistError(error instanceof Error ? error.message : "Unable to open a new shell.");
+      setActivationAssistError(error instanceof Error ? error.message : "Unable to activate package protection.");
     } finally {
-      setOpeningShell(false);
+      setActivatingRuntime(false);
     }
-  }, []);
+  }, [onStateChanged, refreshAfterOp]);
   const handleApprovalCancel = reactExports.useCallback(() => setPendingApprovalOp(null), []);
   const handleApprovalConfirm = reactExports.useCallback(
     (credentials) => {
@@ -2112,9 +2114,9 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
         handleAudit();
       },
       startConnect: handleStartConnect,
-      openShell: handleOpenShell
+      activateRuntime: handleActivateRuntime
     }),
-    [handleAudit, handleOpenShell, handleStartConnect]
+    [handleActivateRuntime, handleAudit, handleStartConnect]
   );
   const managerDrawerShim = panelLoad.phase === "loaded" && managerDrawerTarget !== null ? panelLoad.data.package_shims.find((entry) => entry.manager === managerDrawerTarget) : void 0;
   const auditConnectGate = panelLoad.phase === "loaded" && auditConnectGateActive ? resolveSupplyChainAuditConnectGate(panelLoad.data, { resumeAfterConnect: resumeAuditAfterConnect }) : null;
@@ -2164,10 +2166,10 @@ const PackageFirewallPanel = reactExports.forwardRef(function PackageFirewallPan
           onAudit: handleAudit,
           onSync: handleSync,
           onDismissResult: handleDismissResult,
-          onOpenShell: handleOpenShell,
+          onActivateRuntime: handleActivateRuntime,
           onRefreshStatus: handleRetry,
           onOpenManagerDetails: handleOpenManagerDetails,
-          openingShell,
+          activatingRuntime,
           activationAssistError
         }
       )

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/chunks/supply-chain-workspace.js
@@ -539,7 +539,7 @@ function resolveSupplyChainIssues(snapshot) {
     issues.push({
       id: "path_missing",
       title: "Package installs are not being checked yet",
-      detail: "Guard has not hooked into your shell path yet. Turn on protection for your package tools, then open a new terminal.",
+      detail: "Guard has not activated package protection yet. Turn on protection for your package tools, then finish activation here.",
       tone: "attention",
       actionLabel: "Protect package tools",
       action: { kind: "firewall_unprotected" }
@@ -560,11 +560,11 @@ function resolveSupplyChainIssues(snapshot) {
   } else if (protection?.path_status === "restart_required" || stats.stagedManagers > 0) {
     issues.push({
       id: "path_restart",
-      title: "Open a new terminal to finish setup",
-      detail: "Guard updated your shell profile. Open a new terminal or restart your AI apps before running a protection test.",
+      title: "Finish activation in Guard",
+      detail: "Guard saved your shell setup. Finish activation here, then run a protection check from this dashboard.",
       tone: "blue",
-      actionLabel: "Open new shell",
-      action: { kind: "open_shell" }
+      actionLabel: "Finish activation",
+      action: { kind: "activate_runtime" }
     });
   }
   if (protectionStatus === "partial" && protection !== void 0 && protection.protected_managers.length > 0 && protection.unprotected_managers.length > 0) {
@@ -625,7 +625,7 @@ function protectionDetail(snapshot, status) {
     return `${protection.unprotected_managers.length} tool${protection.unprotected_managers.length === 1 ? "" : "s"} still open: ${protection.unprotected_managers.join(", ")}.`;
   }
   if (status === "staged") {
-    return "Guard updated your shell profile. Open a new terminal, then run a protection test.";
+    return "Guard saved your shell setup. Finish activation here, then run a protection check.";
   }
   if (status === "unprotected") {
     return "Turn on protection for npm, pip, and other tools in the firewall panel below.";
@@ -1030,8 +1030,9 @@ function SupplyChainWorkspace({
           await onRuntimeRefresh?.();
           return;
         }
-        if (action.kind === "open_shell") {
-          await panel.openShell();
+        if (action.kind === "activate_runtime") {
+          await panel.activateRuntime();
+          await onRuntimeRefresh?.();
         }
       } finally {
         setIssueActionPending(false);

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -494,7 +494,7 @@ function requireReact_production() {
   react_production.useTransition = function() {
     return ReactSharedInternals.H.useTransition();
   };
-  react_production.version = "19.2.7";
+  react_production.version = "19.2.5";
   return react_production;
 }
 var hasRequiredReact;
@@ -516,7 +516,7 @@ var hasRequiredScheduler_production;
 function requireScheduler_production() {
   if (hasRequiredScheduler_production) return scheduler_production;
   hasRequiredScheduler_production = 1;
-  (function(exports) {
+  (function(exports$1) {
     function push(heap, node) {
       var index = heap.length;
       heap.push(node);
@@ -550,15 +550,15 @@ function requireScheduler_production() {
       var diff = a.sortIndex - b.sortIndex;
       return 0 !== diff ? diff : a.id - b.id;
     }
-    exports.unstable_now = void 0;
+    exports$1.unstable_now = void 0;
     if ("object" === typeof performance && "function" === typeof performance.now) {
       var localPerformance = performance;
-      exports.unstable_now = function() {
+      exports$1.unstable_now = function() {
         return localPerformance.now();
       };
     } else {
       var localDate = Date, initialTime = localDate.now();
-      exports.unstable_now = function() {
+      exports$1.unstable_now = function() {
         return localDate.now() - initialTime;
       };
     }
@@ -585,12 +585,12 @@ function requireScheduler_production() {
     }
     var isMessageLoopRunning = false, taskTimeoutID = -1, frameInterval = 5, startTime = -1;
     function shouldYieldToHost() {
-      return needsPaint ? true : exports.unstable_now() - startTime < frameInterval ? false : true;
+      return needsPaint ? true : exports$1.unstable_now() - startTime < frameInterval ? false : true;
     }
     function performWorkUntilDeadline() {
       needsPaint = false;
       if (isMessageLoopRunning) {
-        var currentTime = exports.unstable_now();
+        var currentTime = exports$1.unstable_now();
         startTime = currentTime;
         var hasMoreWork = true;
         try {
@@ -610,7 +610,7 @@ function requireScheduler_production() {
                     var continuationCallback = callback(
                       currentTask.expirationTime <= currentTime
                     );
-                    currentTime = exports.unstable_now();
+                    currentTime = exports$1.unstable_now();
                     if ("function" === typeof continuationCallback) {
                       currentTask.callback = continuationCallback;
                       advanceTimers(currentTime);
@@ -660,27 +660,27 @@ function requireScheduler_production() {
       };
     function requestHostTimeout(callback, ms) {
       taskTimeoutID = localSetTimeout(function() {
-        callback(exports.unstable_now());
+        callback(exports$1.unstable_now());
       }, ms);
     }
-    exports.unstable_IdlePriority = 5;
-    exports.unstable_ImmediatePriority = 1;
-    exports.unstable_LowPriority = 4;
-    exports.unstable_NormalPriority = 3;
-    exports.unstable_Profiling = null;
-    exports.unstable_UserBlockingPriority = 2;
-    exports.unstable_cancelCallback = function(task) {
+    exports$1.unstable_IdlePriority = 5;
+    exports$1.unstable_ImmediatePriority = 1;
+    exports$1.unstable_LowPriority = 4;
+    exports$1.unstable_NormalPriority = 3;
+    exports$1.unstable_Profiling = null;
+    exports$1.unstable_UserBlockingPriority = 2;
+    exports$1.unstable_cancelCallback = function(task) {
       task.callback = null;
     };
-    exports.unstable_forceFrameRate = function(fps) {
+    exports$1.unstable_forceFrameRate = function(fps) {
       0 > fps || 125 < fps ? console.error(
         "forceFrameRate takes a positive int between 0 and 125, forcing frame rates higher than 125 fps is not supported"
       ) : frameInterval = 0 < fps ? Math.floor(1e3 / fps) : 5;
     };
-    exports.unstable_getCurrentPriorityLevel = function() {
+    exports$1.unstable_getCurrentPriorityLevel = function() {
       return currentPriorityLevel;
     };
-    exports.unstable_next = function(eventHandler) {
+    exports$1.unstable_next = function(eventHandler) {
       switch (currentPriorityLevel) {
         case 1:
         case 2:
@@ -698,10 +698,10 @@ function requireScheduler_production() {
         currentPriorityLevel = previousPriorityLevel;
       }
     };
-    exports.unstable_requestPaint = function() {
+    exports$1.unstable_requestPaint = function() {
       needsPaint = true;
     };
-    exports.unstable_runWithPriority = function(priorityLevel, eventHandler) {
+    exports$1.unstable_runWithPriority = function(priorityLevel, eventHandler) {
       switch (priorityLevel) {
         case 1:
         case 2:
@@ -720,8 +720,8 @@ function requireScheduler_production() {
         currentPriorityLevel = previousPriorityLevel;
       }
     };
-    exports.unstable_scheduleCallback = function(priorityLevel, callback, options) {
-      var currentTime = exports.unstable_now();
+    exports$1.unstable_scheduleCallback = function(priorityLevel, callback, options) {
+      var currentTime = exports$1.unstable_now();
       "object" === typeof options && null !== options ? (options = options.delay, options = "number" === typeof options && 0 < options ? currentTime + options : currentTime) : options = currentTime;
       switch (priorityLevel) {
         case 1:
@@ -751,8 +751,8 @@ function requireScheduler_production() {
       options > currentTime ? (priorityLevel.sortIndex = options, push(timerQueue, priorityLevel), null === peek(taskQueue) && priorityLevel === peek(timerQueue) && (isHostTimeoutScheduled ? (localClearTimeout(taskTimeoutID), taskTimeoutID = -1) : isHostTimeoutScheduled = true, requestHostTimeout(handleTimeout, options - currentTime))) : (priorityLevel.sortIndex = timeout, push(taskQueue, priorityLevel), isHostCallbackScheduled || isPerformingWork || (isHostCallbackScheduled = true, isMessageLoopRunning || (isMessageLoopRunning = true, schedulePerformWorkUntilDeadline())));
       return priorityLevel;
     };
-    exports.unstable_shouldYield = shouldYieldToHost;
-    exports.unstable_wrapCallback = function(callback) {
+    exports$1.unstable_shouldYield = shouldYieldToHost;
+    exports$1.unstable_wrapCallback = function(callback) {
       var parentPriorityLevel = currentPriorityLevel;
       return function() {
         var previousPriorityLevel = currentPriorityLevel;
@@ -922,7 +922,7 @@ function requireReactDom_production() {
   reactDom_production.useFormStatus = function() {
     return ReactSharedInternals.H.useHostTransitionStatus();
   };
-  reactDom_production.version = "19.2.7";
+  reactDom_production.version = "19.2.5";
   return reactDom_production;
 }
 var hasRequiredReactDom;
@@ -12366,12 +12366,12 @@ function requireReactDomClient_production() {
     }
   };
   var isomorphicReactPackageVersion$jscomp$inline_1840 = React2.version;
-  if ("19.2.7" !== isomorphicReactPackageVersion$jscomp$inline_1840)
+  if ("19.2.5" !== isomorphicReactPackageVersion$jscomp$inline_1840)
     throw Error(
       formatProdErrorMessage(
         527,
         isomorphicReactPackageVersion$jscomp$inline_1840,
-        "19.2.7"
+        "19.2.5"
       )
     );
   ReactDOMSharedInternals.findDOMNode = function(componentOrElement) {
@@ -12389,10 +12389,10 @@ function requireReactDomClient_production() {
   };
   var internals$jscomp$inline_2347 = {
     bundleType: 0,
-    version: "19.2.7",
+    version: "19.2.5",
     rendererPackageName: "react-dom",
     currentDispatcherRef: ReactSharedInternals,
-    reconcilerVersion: "19.2.7"
+    reconcilerVersion: "19.2.5"
   };
   if ("undefined" !== typeof __REACT_DEVTOOLS_GLOBAL_HOOK__) {
     var hook$jscomp$inline_2348 = __REACT_DEVTOOLS_GLOBAL_HOOK__;
@@ -12459,7 +12459,7 @@ function requireReactDomClient_production() {
     listenToAllSupportedEvents(container2);
     return new ReactDOMHydrationRoot(initialChildren);
   };
-  reactDomClient_production.version = "19.2.7";
+  reactDomClient_production.version = "19.2.5";
   return reactDomClient_production;
 }
 var hasRequiredClient;
@@ -17139,8 +17139,8 @@ async function runPackageFirewallAction(action, manager, credentials) {
   }
   return normalizePackageFirewallAction(payloadBody);
 }
-async function openPackageFirewallShell() {
-  const response = await fetchGuardApi("/v1/supply-chain/package-shims/open-shell", {
+async function activatePackageFirewallRuntime() {
+  const response = await fetchGuardApi("/v1/supply-chain/package-shims/activate", {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
@@ -17155,7 +17155,7 @@ async function openPackageFirewallShell() {
   if (isRecord$1(payloadBody) && typeof payloadBody.message === "string" && payloadBody.message.trim()) {
     throw new Error(payloadBody.message);
   }
-  throw new Error("Unable to open a new shell.");
+  throw new Error("Unable to activate package protection.");
 }
 async function runAuditRemediation(input) {
   if (isGuardDemoMode()) {
@@ -20380,8 +20380,8 @@ function resolvePackageManagerProtectionCopy(protection) {
   }
   if (protection.path_status === "restart_required") {
     return {
-      pathLabel: "Restart shell or apps to finish activation",
-      pathDetail: protection.shell_profile_configured ? `Guard updated the shell profile for ${protection.shim_dir}. Open a new shell or restart AI apps so package-manager commands resolve through Guard.` : `Guard installed shims in ${protection.shim_dir}, but activation is still waiting for a fresh shell or app session.`,
+      pathLabel: "Finish activation in Guard",
+      pathDetail: protection.shell_profile_configured ? `Guard saved the shell setup for ${protection.shim_dir}. Finish activation in the package firewall, then run a protection check.` : `Guard installed shims in ${protection.shim_dir}, but activation is still waiting in this Guard session.`,
       pathTone: "blue",
       protectedList: protection.protected_managers,
       unprotectedList: protection.unprotected_managers
@@ -20605,14 +20605,6 @@ function resolveConnectPrimaryLabel(input) {
   }
   return input.actionLabel;
 }
-function isMacClient() {
-  if (typeof navigator === "undefined") {
-    return false;
-  }
-  const navigatorWithUserAgentData = navigator;
-  const platformHint = navigatorWithUserAgentData.userAgentData?.platform ?? navigator.userAgent ?? navigator.platform;
-  return platformHint.toLowerCase().includes("mac");
-}
 function ConnectFlowCard({
   compact = false,
   minimal = false,
@@ -20771,14 +20763,14 @@ function EntitlementNotice({
 function activationHeadline(protection) {
   if (protection === null) return "Activation status unavailable";
   if (protection.path_status === "in_path") return "Protection live now";
-  if (protection.path_status === "restart_required") return "Restart shell or apps to finish activation";
+  if (protection.path_status === "restart_required") return "Finish activation in Guard";
   return "Fix PATH to finish activation";
 }
 function ActivationSummary({
   activationAssistError,
   lastAuditProofAt = null,
-  openingShell,
-  onOpenShell,
+  activatingRuntime,
+  onActivateRuntime,
   onRefreshStatus,
   protection
 }) {
@@ -20789,7 +20781,7 @@ function ActivationSummary({
   const Icon = protection.path_status === "in_path" ? HiMiniCheckCircle : protection.path_status === "restart_required" ? HiMiniArrowPath : HiMiniExclamationTriangle;
   const toneClass = protection.path_status === "in_path" ? "border-brand-green/20 bg-brand-green/[0.04]" : protection.path_status === "restart_required" ? "border-brand-blue/20 bg-brand-blue/[0.04]" : "border-brand-attention/20 bg-brand-attention/[0.04]";
   const iconClass = protection.path_status === "in_path" ? "text-brand-green" : protection.path_status === "restart_required" ? "text-brand-blue" : "text-brand-attention";
-  const canOpenShell = protection.path_status === "restart_required" && protection.shell_profile_configured && isMacClient();
+  const canActivateRuntime = protection.path_status === "restart_required" && protection.shell_profile_configured;
   return /* @__PURE__ */ jsxRuntimeExports.jsx("div", { className: `rounded-xl border px-4 py-3 ${toneClass}`, children: /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "flex items-start gap-2.5", children: [
     /* @__PURE__ */ jsxRuntimeExports.jsx(Icon, { className: `mt-0.5 h-4 w-4 shrink-0 ${iconClass}`, "aria-hidden": "true" }),
     /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "min-w-0", children: [
@@ -20800,8 +20792,8 @@ function ActivationSummary({
         formatRelativeTime(lastAuditProofAt)
       ] }),
       protection.path_status === "restart_required" && /* @__PURE__ */ jsxRuntimeExports.jsxs("div", { className: "mt-3 flex flex-wrap items-center gap-2", children: [
-        canOpenShell && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "primary", onClick: onOpenShell, disabled: openingShell, children: openingShell ? "Opening shell…" : "Open new shell" }),
-        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onRefreshStatus, disabled: openingShell, children: "Refresh after restart" })
+        canActivateRuntime && /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "primary", onClick: onActivateRuntime, disabled: activatingRuntime, children: activatingRuntime ? "Finishing activation…" : "Finish activation" }),
+        /* @__PURE__ */ jsxRuntimeExports.jsx(ActionButton, { variant: "outline", onClick: onRefreshStatus, disabled: activatingRuntime, children: "Refresh status" })
       ] }),
       activationAssistError !== null && /* @__PURE__ */ jsxRuntimeExports.jsx("p", { className: "mt-2 text-xs text-brand-attention", children: activationAssistError })
     ] })
@@ -26890,11 +26882,11 @@ export {
   HiMiniExclamationCircle as K,
   HiMiniClipboardDocumentCheck as L,
   HiMiniClipboard as M,
-  getDefaultExportFromCjs as N,
-  HiMiniKey as O,
+  requireReact as N,
+  getDefaultExportFromCjs as O,
   ProofStrip as P,
-  HiMiniLockClosed as Q,
-  React as R,
+  HiMiniKey as Q,
+  HiMiniLockClosed as R,
   SectionLabel as S,
   HiMiniBellAlert as T,
   HiMiniAdjustmentsHorizontal as U,
@@ -26971,7 +26963,7 @@ export {
   clearLabelForScope as az,
   EmptyState as b,
   parseInterceptProofSnapshot as b0,
-  openPackageFirewallShell as b1,
+  activatePackageFirewallRuntime as b1,
   EntitlementNotice as b2,
   fetchReceipts as b3,
   WorkspacePageHeader as b4,

--- a/src/codex_plugin_scanner/guard/shims.py
+++ b/src/codex_plugin_scanner/guard/shims.py
@@ -1222,6 +1222,7 @@ def probe_package_shim_intercepts(
     *,
     managers: tuple[str, ...] | None = None,
     workspace_dir: Path | None = None,
+    allow_inactive_path: bool = False,
 ) -> dict[str, object]:
     """Execute installed package-manager shims to prove intercept wiring is live."""
 
@@ -1252,7 +1253,7 @@ def probe_package_shim_intercepts(
                 },
             )
             continue
-        if manager not in protected:
+        if manager not in protected and not allow_inactive_path:
             manager_results.append(
                 {
                     "evaluator_invoked": False,

--- a/tests/test_guard_headless_daemon_api.py
+++ b/tests/test_guard_headless_daemon_api.py
@@ -1413,15 +1413,27 @@ def test_supply_chain_package_firewall_status_accepts_paid_oauth_entitlement(tmp
     }
 
 
-def test_supply_chain_package_firewall_open_shell_endpoint_returns_activation_launch_status(
+def test_supply_chain_package_firewall_activate_endpoint_activates_runtime_session(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard-home")
+    _seed_guard_cloud(store, workspace_id="workspace-1")
+    store.set_sync_payload(
+        "supply_chain_bundle_entitlement",
+        {"tier": "premium", "workspace_id": "workspace-1"},
+        "2026-05-27T16:00:00.000Z",
+    )
     monkeypatch.setattr(
         daemon_server,
-        "_open_package_firewall_activation_shell",
-        lambda: (200, {"status": "opened", "message": "Opened a new Terminal window with a fresh shell session."}),
+        "_activate_package_firewall_runtime",
+        lambda _context: (
+            200,
+            {
+                "status": "verified",
+                "message": "Guard verified the installed package shim.",
+            },
+        ),
     )
     daemon = GuardDaemonServer(store, host="127.0.0.1", port=0)
     daemon.start()
@@ -1430,7 +1442,7 @@ def test_supply_chain_package_firewall_open_shell_endpoint_returns_activation_la
         status, payload = _read_json_response(
             _request(
                 daemon.port,
-                "/v1/supply-chain/package-shims/open-shell",
+                "/v1/supply-chain/package-shims/activate",
                 token=token,
                 payload={},
             ),
@@ -1439,8 +1451,39 @@ def test_supply_chain_package_firewall_open_shell_endpoint_returns_activation_la
         daemon.stop()
 
     assert status == 200
-    assert payload["status"] == "opened"
-    assert "fresh shell session" in payload["message"]
+    assert payload["status"] == "verified"
+    assert "installed package shim" in payload["message"]
+
+
+def test_package_firewall_activation_uses_scoped_shim_proof(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    guard_home = tmp_path / "guard-home"
+    (guard_home / "package-shims" / "bin").mkdir(parents=True)
+    context = HarnessContext(
+        home_dir=tmp_path / "home",
+        workspace_dir=None,
+        guard_home=guard_home,
+    )
+    monkeypatch.setattr(
+        daemon_server,
+        "package_shim_status",
+        lambda _context: {"installed_managers": ["npx"], "path_active": False},
+    )
+    monkeypatch.setattr(
+        daemon_server,
+        "probe_package_shim_intercepts",
+        lambda _context, **_kwargs: {"intercept_proved": True},
+    )
+    previous_path = daemon_server.os.environ.get("PATH")
+
+    status, body = daemon_server._activate_package_firewall_runtime(context)
+
+    assert status == 200
+    assert body["status"] == "verified"
+    assert body["proof"] == {"intercept_proved": True}
+    assert daemon_server.os.environ.get("PATH") == previous_path
 
 
 def test_supply_chain_package_firewall_paid_install_and_test_roundtrip(


### PR DESCRIPTION
- Replace the terminal-only recovery with an in-dashboard activation action.
- Refresh local protection state after activation and direct users to the existing protection check.
- Update restart-required copy and daemon coverage.

Checks:
- `uv run pytest tests/test_guard_headless_daemon_api.py -k "package_firewall_activation or package_firewall_activate" -q`
- `uv run ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_headless_daemon_api.py`
- `pnpm test`
- `pnpm build`