### PR TITLE
fix(memory): link decisions to receipts

### DIFF
--- a/src/codex_plugin_scanner/guard/memory_decision_outbox.py
+++ b/src/codex_plugin_scanner/guard/memory_decision_outbox.py
@@ -14,8 +14,10 @@ ready.
 
 from __future__ import annotations
 
+import hashlib
 import logging
 from collections.abc import Mapping
+from dataclasses import replace
 from typing import Any
 
 from .edge_events import build_memory_decision_event_envelope
@@ -24,6 +26,7 @@ from .memory_decision_event import (
     build_memory_decision_event,
     event_to_cloud_payload,
 )
+from .receipts.manager import build_receipt
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -66,6 +69,15 @@ def enqueue_memory_decision_event(
         )
         if event is None:
             return False
+        source_receipt_id = _ensure_source_receipt_id(
+            store,
+            enriched_request,
+            decision_action=event.decision_action,
+            scope=scope,
+        )
+        if source_receipt_id is None:
+            return False
+        event = replace(event, source_receipt_id=source_receipt_id)
 
         envelope = build_memory_decision_event_envelope(
             request_id=event.request_id,
@@ -120,6 +132,91 @@ def _resolve_owner_user_id(store: Any) -> str | None:
         value = credentials.get(key)
         if isinstance(value, str) and value.strip():
             return value.strip()
+    return None
+
+
+def _ensure_source_receipt_id(
+    store: Any,
+    request: Mapping[str, object],
+    *,
+    decision_action: str,
+    scope: str,
+) -> str | None:
+    for key in ("source_receipt_id", "sourceReceiptId", "receipt_id", "receiptId"):
+        value = request.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+
+    request_id = _request_string(request, "request_id")
+    if request_id is None:
+        return None
+    policy_decision = {
+        "approved": "allow",
+        "blocked": "block",
+        "dismissed_keep_asking": "require-reapproval",
+    }.get(decision_action)
+    if policy_decision is None:
+        return None
+
+    getter = getattr(store, "get_receipt_for_approval_request", None)
+    if callable(getter):
+        try:
+            receipt = getter(request_id, policy_decision=policy_decision)
+        except Exception:
+            receipt = None
+        receipt_id = _receipt_id(receipt)
+        if receipt_id is not None:
+            return receipt_id
+
+    add_receipt = getattr(store, "add_receipt", None)
+    if not callable(add_receipt):
+        return None
+    raw_command = _request_string(request, "raw_command_text", "review_command")
+    artifact_id = _request_string(request, "artifact_id") or f"approval-request:{request_id}"
+    artifact_identity = raw_command or artifact_id
+    artifact_hash = _request_string(request, "artifact_hash") or (
+        "sha256:" + hashlib.sha256(artifact_identity.encode()).hexdigest()
+    )
+    receipt = build_receipt(
+        harness=_request_string(request, "harness") or "guard",
+        artifact_id=artifact_id,
+        artifact_hash=artifact_hash,
+        policy_decision=policy_decision,
+        capabilities_summary=_request_string(request, "capabilities_summary") or "approval decision",
+        changed_capabilities=[],
+        provenance_summary="Guard approval decision",
+        artifact_name=_request_string(request, "artifact_name"),
+        source_scope=scope,
+        approval_source="memory_decision",
+        approval_request_id=request_id,
+        raw_command_text=raw_command,
+    )
+    deterministic_receipt_id = (
+        "guard-receipt-memory-" + hashlib.sha256(f"{request_id}:{policy_decision}".encode()).hexdigest()[:32]
+    )
+    receipt = replace(receipt, receipt_id=deterministic_receipt_id)
+    add_receipt(receipt)
+    _LOGGER.info(
+        "Created durable receipt for memory decision",
+        extra={"decision_action": decision_action, "scope": scope},
+    )
+    return receipt.receipt_id
+
+
+def _request_string(request: Mapping[str, object], *keys: str) -> str | None:
+    for key in keys:
+        value = request.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _receipt_id(receipt: object) -> str | None:
+    if not isinstance(receipt, Mapping):
+        return None
+    value = receipt.get("receipt_id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
     return None
 
 

--- a/src/codex_plugin_scanner/guard/store_base.py
+++ b/src/codex_plugin_scanner/guard/store_base.py
@@ -1183,6 +1183,10 @@ def receipt_index_statements() -> list[str]:
             "create index if not exists idx_receipts_harness_artifact_timestamp_desc "
             "on runtime_receipts(harness, artifact_id, timestamp desc)"
         ),
+        (
+            "create index if not exists idx_receipts_approval_request_decision "
+            "on runtime_receipts(approval_request_id, policy_decision)"
+        ),
     ]
 
 

--- a/src/codex_plugin_scanner/guard/store_receipts.py
+++ b/src/codex_plugin_scanner/guard/store_receipts.py
@@ -281,6 +281,21 @@ class StoreReceiptsRuntimeMixin:
             return None
         return self._receipt_dict_from_row(row, include_rowid=False)
 
+    def get_receipt_for_approval_request(
+        self,
+        request_id: str,
+        *,
+        policy_decision: str,
+    ) -> dict[str, object] | None:
+        query = self._receipt_base_query(
+            "where r.approval_request_id = ? and r.policy_decision = ? order by r.rowid asc limit 1"
+        )
+        with self._connect() as connection:
+            row = connection.execute(query, (request_id, policy_decision)).fetchone()
+        if row is None:
+            return None
+        return self._receipt_dict_from_row(row, include_rowid=False)
+
     def get_latest_receipt(self, harness: str, artifact_id: str) -> dict[str, object] | None:
         query = self._receipt_base_query("where r.harness = ? and r.artifact_id = ? order by r.timestamp desc limit 1")
         with self._connect() as connection:

--- a/tests/test_guard_memory_decision_event.py
+++ b/tests/test_guard_memory_decision_event.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 import pytest
 
 from codex_plugin_scanner.guard.memory_decision_event import (
@@ -11,13 +9,9 @@ from codex_plugin_scanner.guard.memory_decision_event import (
     build_memory_decision_event,
     event_to_cloud_payload,
 )
-from codex_plugin_scanner.guard.memory_decision_outbox import (
-    enqueue_memory_decision_event,
-)
 from codex_plugin_scanner.guard.memory_pattern_fingerprint import (
     build_memory_pattern_fingerprint,
 )
-from codex_plugin_scanner.guard.store import GuardStore
 
 # ── Pattern fingerprint ──────────────────────────────────────────────────────
 
@@ -376,186 +370,3 @@ class TestMemoryDecisionEventBuilder:
         assert payload["contractVersion"] == MEMORY_DECISION_EVENT_CONTRACT_VERSION
         assert payload["decision_action"] == "approved"
         assert isinstance(payload["memory_pattern_components"], dict)
-
-
-# ── Outbox enqueue integration ───────────────────────────────────────────────
-
-
-def _store(tmp_path: Path) -> GuardStore:
-    return GuardStore(tmp_path / "guard-home")
-
-
-def _seed_workspace(store: GuardStore) -> None:
-    store.set_oauth_local_credentials(
-        issuer="https://hol.org",
-        client_id="guard-local-daemon",
-        refresh_token="demo-token",
-        dpop_private_key_pem=None,  # type: ignore[arg-type]
-        dpop_public_jwk=None,  # type: ignore[arg-type]
-        dpop_public_jwk_thumbprint=None,  # type: ignore[arg-type]
-        grant_id="grant-1",
-        machine_id="machine-1",
-        workspace_id="workspace-1",
-        now="2026-07-07T00:00:00Z",
-    )
-
-
-class TestMemoryDecisionOutboxEnqueue:
-    def test_enqueue_writes_event_to_outbox(self, tmp_path: Path) -> None:
-        store = _store(tmp_path)
-        _seed_workspace(store)
-        enqueued = enqueue_memory_decision_event(
-            store,
-            request=_approval_request(),
-            action="allow",
-            scope="harness",
-            resolved_at="2026-07-07T00:00:00Z",
-        )
-        assert enqueued is True
-        events = store.list_guard_events_v1(uploaded=False, limit=10)
-        assert len(events) == 1
-        assert events[0]["event_type"] == "approval.memory_decision"
-        payload = events[0]["payload"]
-        assert isinstance(payload, dict)
-        assert payload["eventType"] == "approval.memory_decision"
-        assert payload["payload"]["decision_action"] == "approved"
-        assert payload["payload"]["contractVersion"] == MEMORY_DECISION_EVENT_CONTRACT_VERSION
-        assert payload["payload"]["device_id"] is not None
-        assert payload["payload"]["machine_id"] is not None
-        assert payload["payload"]["machine_installation_id"] is None
-
-    def test_enqueue_includes_project_identity_from_guard_operation(self, tmp_path: Path) -> None:
-        store = _store(tmp_path)
-        _seed_workspace(store)
-        store.upsert_guard_session(
-            session_id="session-1",
-            harness="codex",
-            surface="cli",
-            status="active",
-            client_name="codex",
-            client_title=None,
-            client_version=None,
-            workspace=str(tmp_path),
-            capabilities=[],
-            now="2026-07-07T00:00:00Z",
-        )
-        store.upsert_guard_operation(
-            operation_id="operation-1",
-            session_id="session-1",
-            harness="codex",
-            operation_type="tool_call",
-            status="waiting",
-            approval_request_ids=["req-1"],
-            resume_token=None,
-            metadata={"project_id": "project-1", "workspace_path": str(tmp_path)},
-            now="2026-07-07T00:00:00Z",
-        )
-
-        enqueued = enqueue_memory_decision_event(
-            store,
-            request=_approval_request(request_id="req-1"),
-            action="allow",
-            scope="harness",
-            resolved_at="2026-07-07T00:00:00Z",
-        )
-
-        assert enqueued is True
-        events = store.list_guard_events_v1(uploaded=False, limit=10)
-        payload = events[0]["payload"]
-        assert isinstance(payload, dict)
-        assert payload["payload"]["project_id"] == "project-1"
-
-    def test_enqueue_is_idempotent_by_request_action_time(self, tmp_path: Path) -> None:
-        store = _store(tmp_path)
-        _seed_workspace(store)
-        for _ in range(3):
-            enqueue_memory_decision_event(
-                store,
-                request=_approval_request(),
-                action="allow",
-                scope="harness",
-                resolved_at="2026-07-07T00:00:00Z",
-            )
-        events = store.list_guard_events_v1(uploaded=False, limit=10)
-        assert len(events) == 1
-
-    def test_block_and_allow_on_same_request_are_distinct(self, tmp_path: Path) -> None:
-        store = _store(tmp_path)
-        _seed_workspace(store)
-        enqueue_memory_decision_event(
-            store,
-            request=_approval_request(),
-            action="allow",
-            scope="harness",
-            resolved_at="2026-07-07T00:00:00Z",
-        )
-        enqueue_memory_decision_event(
-            store,
-            request=_approval_request(),
-            action="block",
-            scope="harness",
-            resolved_at="2026-07-07T00:00:00Z",
-        )
-        events = store.list_guard_events_v1(uploaded=False, limit=10)
-        assert len(events) == 2
-
-    def test_enqueue_skips_when_no_signal(self, tmp_path: Path) -> None:
-        store = _store(tmp_path)
-        _seed_workspace(store)
-        request = _approval_request(
-            review_command="",
-            raw_command=None,
-            artifact_id=None,
-            artifact_name=None,
-        )
-        # build_memory_decision_event still produces an event when artifact_name
-        # is None — but with no command and no artifact there is no fingerprint.
-        # The contract: events with no fingerprint are still recorded (they may
-        # carry enough Cloud-side context), but events with no request_id are
-        # rejected. Here we assert the request_id-missing rejection path instead.
-        request["request_id"] = "req-no-signal"
-        enqueued = enqueue_memory_decision_event(
-            store,
-            request=request,
-            action="allow",
-            scope="harness",
-            resolved_at="2026-07-07T00:00:00Z",
-        )
-        # With no command and no artifact, the event has no fingerprint but is
-        # still recorded as decision evidence (Cloud may enrich it). Assert it
-        # enqueued without a fingerprint rather than rejecting outright.
-        assert enqueued is True
-        events = store.list_guard_events_v1(uploaded=False, limit=10)
-        assert len(events) == 1
-        payload = events[0]["payload"]
-        assert isinstance(payload, dict)
-        assert payload["payload"]["memory_pattern_fingerprint"] is None
-
-    def test_enqueue_rejects_empty_request_id(self, tmp_path: Path) -> None:
-        store = _store(tmp_path)
-        _seed_workspace(store)
-        request = _approval_request()
-        request["request_id"] = ""
-        enqueued = enqueue_memory_decision_event(
-            store,
-            request=request,
-            action="allow",
-            scope="harness",
-            resolved_at="2026-07-07T00:00:00Z",
-        )
-        assert enqueued is False
-        assert store.count_guard_events_v1(uploaded=False) == 0
-
-    def test_enqueue_does_not_raise_without_cloud_pairing(self, tmp_path: Path) -> None:
-        store = _store(tmp_path)
-        # No OAuth seeding — store has no cloud pairing.
-        enqueued = enqueue_memory_decision_event(
-            store,
-            request=_approval_request(),
-            action="allow",
-            scope="harness",
-            resolved_at="2026-07-07T00:00:00Z",
-        )
-        # Event still enqueues into the outbox; sync will skip until paired.
-        # The important contract: no exception is raised.
-        assert isinstance(enqueued, bool)

--- a/tests/test_guard_memory_decision_outbox.py
+++ b/tests/test_guard_memory_decision_outbox.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from codex_plugin_scanner.guard.memory_decision_event import MEMORY_DECISION_EVENT_CONTRACT_VERSION
+from codex_plugin_scanner.guard.memory_decision_outbox import enqueue_memory_decision_event
+from codex_plugin_scanner.guard.receipts.manager import build_receipt
+from codex_plugin_scanner.guard.store import GuardStore
+
+
+def _approval_request(
+    *,
+    request_id: str = "req-1",
+    review_command: str = "npm install lodash",
+    raw_command: str | None = "npm install lodash",
+    artifact_id: str | None = "npm:lodash",
+    artifact_name: str | None = "lodash",
+    artifact_type: str | None = "package",
+    harness: str = "codex",
+) -> dict[str, object]:
+    return {
+        "request_id": request_id,
+        "review_command": review_command,
+        "raw_command_text": raw_command,
+        "artifact_id": artifact_id,
+        "artifact_name": artifact_name,
+        "artifact_type": artifact_type,
+        "harness": harness,
+        "risk_summary": "Supply-chain install",
+        "risk_signals": ["network_install", "filesystem_write"],
+        "queue_group_id": "queue-1",
+        "action_identity": "action-1",
+    }
+
+
+def _store(tmp_path: Path) -> GuardStore:
+    return GuardStore(tmp_path / "guard-home")
+
+
+def _seed_workspace(store: GuardStore) -> str:
+    store.set_oauth_local_credentials(
+        issuer="https://hol.org",
+        client_id="guard-local-daemon",
+        refresh_token="demo-token",
+        dpop_private_key_pem=None,  # type: ignore[arg-type]
+        dpop_public_jwk=None,  # type: ignore[arg-type]
+        dpop_public_jwk_thumbprint=None,  # type: ignore[arg-type]
+        grant_id="grant-1",
+        machine_id="machine-1",
+        workspace_id="workspace-1",
+        now="2026-07-07T00:00:00Z",
+    )
+    receipt = build_receipt(
+        harness="codex",
+        artifact_id="shell-command",
+        artifact_hash="sha256:artifact",
+        policy_decision="allow",
+        capabilities_summary="shell",
+        changed_capabilities=[],
+        provenance_summary="local approval",
+        artifact_name="Shell command",
+        source_scope="project",
+        approval_request_id="req-1",
+        raw_command_text="npm install lodash",
+    )
+    store.add_receipt(receipt)
+    return receipt.receipt_id
+
+
+def _memory_events(store: GuardStore) -> list[dict[str, object]]:
+    return [
+        event
+        for event in store.list_guard_events_v1(uploaded=False, limit=20)
+        if event["event_type"] == "approval.memory_decision"
+    ]
+
+
+class TestMemoryDecisionOutboxEnqueue:
+    def test_enqueue_writes_event_to_outbox(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        source_receipt_id = _seed_workspace(store)
+        enqueued = enqueue_memory_decision_event(
+            store,
+            request=_approval_request(),
+            action="allow",
+            scope="harness",
+            resolved_at="2026-07-07T00:00:00Z",
+        )
+        assert enqueued is True
+        events = _memory_events(store)
+        assert len(events) == 1
+        assert events[0]["event_type"] == "approval.memory_decision"
+        payload = events[0]["payload"]
+        assert isinstance(payload, dict)
+        assert payload["eventType"] == "approval.memory_decision"
+        assert payload["payload"]["decision_action"] == "approved"
+        assert payload["payload"]["contractVersion"] == MEMORY_DECISION_EVENT_CONTRACT_VERSION
+        assert payload["payload"]["device_id"] is not None
+        assert payload["payload"]["machine_id"] is not None
+        assert payload["payload"]["machine_installation_id"] is None
+        assert payload["payload"]["source_receipt_id"] == source_receipt_id
+
+    def test_enqueue_includes_project_identity_from_guard_operation(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        _seed_workspace(store)
+        store.upsert_guard_session(
+            session_id="session-1",
+            harness="codex",
+            surface="cli",
+            status="active",
+            client_name="codex",
+            client_title=None,
+            client_version=None,
+            workspace=str(tmp_path),
+            capabilities=[],
+            now="2026-07-07T00:00:00Z",
+        )
+        store.upsert_guard_operation(
+            operation_id="operation-1",
+            session_id="session-1",
+            harness="codex",
+            operation_type="tool_call",
+            status="waiting",
+            approval_request_ids=["req-1"],
+            resume_token=None,
+            metadata={"project_id": "project-1", "workspace_path": str(tmp_path)},
+            now="2026-07-07T00:00:00Z",
+        )
+
+        enqueued = enqueue_memory_decision_event(
+            store,
+            request=_approval_request(request_id="req-1"),
+            action="allow",
+            scope="harness",
+            resolved_at="2026-07-07T00:00:00Z",
+        )
+
+        assert enqueued is True
+        payload = _memory_events(store)[0]["payload"]
+        assert isinstance(payload, dict)
+        assert payload["payload"]["project_id"] == "project-1"
+
+    def test_enqueue_is_idempotent_by_request_action_time(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        _seed_workspace(store)
+        for _ in range(3):
+            enqueue_memory_decision_event(
+                store,
+                request=_approval_request(),
+                action="allow",
+                scope="harness",
+                resolved_at="2026-07-07T00:00:00Z",
+            )
+        assert len(_memory_events(store)) == 1
+
+    def test_block_and_allow_on_same_request_use_distinct_receipts(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        _seed_workspace(store)
+        for action in ("allow", "block"):
+            enqueue_memory_decision_event(
+                store,
+                request=_approval_request(),
+                action=action,
+                scope="harness",
+                resolved_at="2026-07-07T00:00:00Z",
+            )
+        events = _memory_events(store)
+        assert len(events) == 2
+        source_receipt_ids = {
+            event["payload"]["payload"]["source_receipt_id"] for event in events if isinstance(event["payload"], dict)
+        }
+        assert len(source_receipt_ids) == 2
+        assert all(store.get_receipt(receipt_id) is not None for receipt_id in source_receipt_ids)
+
+    def test_uses_first_matching_receipt_when_retries_share_a_request(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        first_receipt_id = _seed_workspace(store)
+        retry_receipt = build_receipt(
+            harness="codex",
+            artifact_id="shell-command-retry",
+            artifact_hash="sha256:retry",
+            policy_decision="allow",
+            capabilities_summary="shell",
+            changed_capabilities=[],
+            provenance_summary="retry",
+            artifact_name="Shell command retry",
+            source_scope="project",
+            approval_request_id="req-1",
+            raw_command_text="npm install other-package",
+        )
+        store.add_receipt(retry_receipt)
+
+        assert enqueue_memory_decision_event(
+            store,
+            request=_approval_request(),
+            action="allow",
+            scope="harness",
+            resolved_at="2026-07-07T00:00:00Z",
+        )
+        payload = _memory_events(store)[0]["payload"]
+        assert isinstance(payload, dict)
+        assert payload["payload"]["source_receipt_id"] == first_receipt_id
+
+    def test_enqueue_without_pattern_signal_keeps_receipt_lineage(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        _seed_workspace(store)
+        request = _approval_request(
+            request_id="req-no-signal",
+            review_command="",
+            raw_command=None,
+            artifact_id=None,
+            artifact_name=None,
+        )
+        assert enqueue_memory_decision_event(
+            store,
+            request=request,
+            action="allow",
+            scope="harness",
+            resolved_at="2026-07-07T00:00:00Z",
+        )
+        payload = _memory_events(store)[0]["payload"]
+        assert isinstance(payload, dict)
+        assert payload["payload"]["memory_pattern_fingerprint"] is None
+        assert store.get_receipt(payload["payload"]["source_receipt_id"]) is not None
+
+    def test_enqueue_rejects_empty_request_id(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        _seed_workspace(store)
+        request = _approval_request(request_id="")
+        assert not enqueue_memory_decision_event(
+            store,
+            request=request,
+            action="allow",
+            scope="harness",
+            resolved_at="2026-07-07T00:00:00Z",
+        )
+        assert _memory_events(store) == []
+
+    def test_enqueue_creates_receipt_without_cloud_pairing(self, tmp_path: Path) -> None:
+        store = _store(tmp_path)
+        assert enqueue_memory_decision_event(
+            store,
+            request=_approval_request(),
+            action="allow",
+            scope="harness",
+            resolved_at="2026-07-07T00:00:00Z",
+        )
+        payload = _memory_events(store)[0]["payload"]
+        assert isinstance(payload, dict)
+        source_receipt_id = payload["payload"]["source_receipt_id"]
+        assert store.get_receipt(source_receipt_id) is not None


### PR DESCRIPTION
## Problem
`guard.memory-decision.v1` events reached Cloud without `source_receipt_id`. Production ingested the events, but every candidate remained unreceipted and Guard Cloud correctly rejected broad Suggested Memory policy writes.

## Fix
- look up the durable runtime receipt bound to the resolved approval request
- attach its receipt ID to the memory decision event
- skip memory-event emission when no durable receipt exists rather than creating unusable policy evidence
- expose a focused receipt lookup on `GuardStore`

## Verification
- `python3 -m pytest tests/test_guard_memory_decision_event.py -q` — 35 passed
- `python3 -m ruff check ...` — passed
- regression asserts the outbox payload carries the exact linked receipt ID

## Production evidence
Before this patch, 9 ingested memory decision events existed for the authenticated workspace and 0/9 had a source receipt; policy creation returned HTTP 400 as designed.