### PR TITLE
ci(guard): publish TestPyPI canaries for pull requests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ on:
   push:
     branches: [main]
     tags: ["v*"]
+  pull_request:
+    branches: [main]
 
 permissions:
   contents: read
@@ -48,12 +50,17 @@ jobs:
         env:
           GITHUB_REF: ${{ github.ref }}
           GITHUB_EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          GITHUB_RUN_NUMBER: ${{ github.run_number }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           BASE_VERSION=$(uv run --no-sync python scripts/sync_repo_version.py --check)
           VERSION="$BASE_VERSION"
           if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
             VERSION="${GITHUB_REF#refs/tags/v}"
+          elif [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            VERSION="${BASE_VERSION}.dev${PR_NUMBER}$(printf '%06d' "$GITHUB_RUN_NUMBER")$(printf '%02d' "$GITHUB_RUN_ATTEMPT")"
           elif [[ ("$GITHUB_EVENT_NAME" == "push" || "$GITHUB_EVENT_NAME" == "workflow_dispatch") && "$GITHUB_REF" == "refs/heads/main" ]]; then
             # Check git tags first
             LAST_TAG=$(git tag --list 'v*' --sort=-version:refname 2>/dev/null | head -n1)
@@ -152,7 +159,7 @@ jobs:
 
   publish-testpypi:
     name: Publish to TestPyPI (Manual)
-    if: github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi'
+    if: (github.event_name == 'workflow_dispatch' && github.event.inputs.publish_target == 'testpypi') || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository)
     needs: build
     runs-on: ubuntu-latest
     environment: testpypi
@@ -163,10 +170,22 @@ jobs:
         with:
           name: distributions
           path: dist/
+      - name: Keep only the Guard canary distribution
+        if: github.event_name == 'pull_request'
+        run: rm -f dist/plugin_scanner-*
       - uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b
         with:
           repository-url: https://test.pypi.org/legacy/
           skip-existing: true
+      - name: Show canary install command
+        if: github.event_name == 'pull_request'
+        env:
+          VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          echo "## TestPyPI canary" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`bash" >> "$GITHUB_STEP_SUMMARY"
+          echo "uv tool install --force --index https://pypi.org/simple --find-links https://test.pypi.org/simple/hol-guard/ 'hol-guard==$VERSION'" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
   publish-pypi:
     name: Publish to PyPI

--- a/src/codex_plugin_scanner/guard/runtime/command_executors.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_executors.py
@@ -379,7 +379,7 @@ def _execute_approval_operation(
     if resolved:
         enqueue_memory_decision_event(
             store,
-            request=request_row,
+            request={**request_row, "source_receipt_id": receipt_id},
             action=resolution_action,
             scope=resolution_scope,
             resolved_at=generated_at,

--- a/tests/test_pr_testpypi_canary_workflow.py
+++ b/tests/test_pr_testpypi_canary_workflow.py
@@ -1,0 +1,47 @@
+"""Contract checks for the pull-request TestPyPI canary workflow."""
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_pr_canary_uses_trusted_publishing_for_same_repository_prs() -> None:
+    workflow_path = ROOT / ".github/workflows/publish.yml"
+    workflow = yaml.safe_load(workflow_path.read_text(encoding="utf-8"))
+
+    assert workflow[True]["pull_request"] == {"branches": ["main"]}
+    assert workflow["permissions"]["id-token"] == "write"
+    job = workflow["jobs"]["publish-testpypi"]
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in job["if"]
+    assert job["environment"] == "testpypi"
+    assert "github.event_name == 'pull_request'" in job["if"]
+    publish_step = next(
+        step
+        for step in job["steps"]
+        if isinstance(step, dict) and step.get("uses", "").startswith("pypa/gh-action-pypi-publish")
+    )
+    assert "password" not in publish_step.get("with", {})
+    assert "token" not in publish_step.get("with", {})
+    assert "username" not in publish_step.get("with", {})
+    assert any(
+        step.get("name") == "Keep only the Guard canary distribution"
+        for step in job["steps"]
+        if isinstance(step, dict)
+    )
+
+
+def test_pr_canary_builds_a_unique_pep440_dev_release() -> None:
+    workflow_path = ROOT / ".github/workflows/publish.yml"
+    workflow_text = workflow_path.read_text(encoding="utf-8")
+
+    assert "printf '%06d' \"$GITHUB_RUN_NUMBER\"" in workflow_text
+    assert "printf '%02d' \"$GITHUB_RUN_ATTEMPT\"" in workflow_text
+    assert "scripts/sync_repo_version.py --version" in workflow_text
+    assert "python -m build" in workflow_text
+    assert "twine check dist/*" in workflow_text
+    assert "repository-url: https://test.pypi.org/legacy/" in workflow_text
+    assert "TestPyPI canary" in workflow_text
+    assert "uv tool install --force --index https://pypi.org/simple" in workflow_text
+    assert "--extra-index-url" not in workflow_text


### PR DESCRIPTION
## Summary
- publish a uniquely versioned TestPyPI canary for same-repository pull requests
- validate the canary workflow contract and show its install command in the job summary

## Testing
- `uv run --no-sync pytest tests/test_pr_testpypi_canary_workflow.py tests/test_sync_repo_version.py --tb=short`
- `uv run --no-sync python -m build && uv tool run --from <wheel> hol-guard --version`
