### PR TITLE
fix(guard): match cloud memories by exact command

### DIFF
--- a/src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py
+++ b/src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py
@@ -28,6 +28,7 @@ MemoryPatternKind = Literal[
     "generic_artifact_pattern",
 ]
 
+
 def build_exact_command_memory_artifact_id(command: str | None) -> str | None:
     """Build a local policy key that matches only the remembered command."""
     normalized = command.strip() if command is not None else ""
@@ -35,6 +36,7 @@ def build_exact_command_memory_artifact_id(command: str | None) -> str | None:
         return None
     digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
     return f"memory:exact-command:{digest}"
+
 
 # Bare labels that are too generic to ever anchor reusable memory. They describe
 # a capability category, not a concrete behavior the user repeatedly chose.

--- a/src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py
+++ b/src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py
@@ -28,6 +28,14 @@ MemoryPatternKind = Literal[
     "generic_artifact_pattern",
 ]
 
+def build_exact_command_memory_artifact_id(command: str | None) -> str | None:
+    """Build a local policy key that matches only the remembered command."""
+    normalized = command.strip() if command is not None else ""
+    if not normalized:
+        return None
+    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    return f"memory:exact-command:{digest}"
+
 # Bare labels that are too generic to ever anchor reusable memory. They describe
 # a capability category, not a concrete behavior the user repeatedly chose.
 _GENERIC_FINGERPRINT_LABELS: frozenset[str] = frozenset(

--- a/src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py
+++ b/src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py
@@ -31,10 +31,10 @@ MemoryPatternKind = Literal[
 
 def build_exact_command_memory_artifact_id(command: str | None) -> str | None:
     """Build a local policy key that matches only the remembered command."""
-    normalized = command.strip() if command is not None else ""
-    if not normalized:
+    exact = command if command is not None else ""
+    if not exact.strip():
         return None
-    digest = hashlib.sha256(normalized.encode("utf-8")).hexdigest()
+    digest = hashlib.sha256(exact.encode("utf-8")).hexdigest()
     return f"memory:exact-command:{digest}"
 
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1157,15 +1157,21 @@ def _policy_bundle_rule_locations(rule: dict[str, object]) -> list[str]:
     return [item.strip() for item in locations if isinstance(item, str) and item.strip()]
 
 
+def _policy_bundle_non_empty_exact_command(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
 def _policy_bundle_rule_exact_command(rule: dict[str, object]) -> str | None:
     matcher = rule.get("matcher")
     if isinstance(matcher, dict):
-        command = non_empty_string(matcher.get("command"))
+        command = _policy_bundle_non_empty_exact_command(matcher.get("command"))
         if command is not None:
             return command
     scope = rule.get("scope")
     if isinstance(scope, dict):
-        return non_empty_string(scope.get("command"))
+        return _policy_bundle_non_empty_exact_command(scope.get("command"))
     return None
 
 

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -45,6 +45,7 @@ from ..cloud_exceptions import (
 )
 from ..config import VALID_RECEIPT_REDACTION_LEVELS, GuardConfig, load_guard_config
 from ..edge_events import build_runtime_session_event
+from ..memory_pattern_fingerprint import build_exact_command_memory_artifact_id
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..package_firewall_defaults import extract_cloud_user_profile
 from ..package_firewall_entitlement import (
@@ -1095,6 +1096,8 @@ def _policy_bundle_rule_saved_decision_families(rule: dict[str, object]) -> list
     family-row behavior.
     """
     families = _policy_bundle_rule_matcher_families(rule)
+    if _policy_bundle_rule_exact_command(rule) is not None:
+        families = [family for family in families if family != "tool-action"]
     if "package-request" not in families:
         return families
     if _policy_bundle_rule_has_package_scope(rule):
@@ -1154,7 +1157,25 @@ def _policy_bundle_rule_locations(rule: dict[str, object]) -> list[str]:
     return [item.strip() for item in locations if isinstance(item, str) and item.strip()]
 
 
+def _policy_bundle_rule_exact_command(rule: dict[str, object]) -> str | None:
+    matcher = rule.get("matcher")
+    if isinstance(matcher, dict):
+        command = non_empty_string(matcher.get("command"))
+        if command is not None:
+            return command
+    scope = rule.get("scope")
+    if isinstance(scope, dict):
+        return non_empty_string(scope.get("command"))
+    return None
+
+
 def _policy_bundle_rule_exact_artifact_ids(rule: dict[str, object]) -> list[str]:
+    exact_command_artifact_id = build_exact_command_memory_artifact_id(
+        _policy_bundle_rule_exact_command(rule)
+    )
+    if exact_command_artifact_id is not None:
+        return [exact_command_artifact_id]
+
     artifact_ids: list[str] = []
     matcher = rule.get("matcher")
     if isinstance(matcher, dict):

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -1170,9 +1170,7 @@ def _policy_bundle_rule_exact_command(rule: dict[str, object]) -> str | None:
 
 
 def _policy_bundle_rule_exact_artifact_ids(rule: dict[str, object]) -> list[str]:
-    exact_command_artifact_id = build_exact_command_memory_artifact_id(
-        _policy_bundle_rule_exact_command(rule)
-    )
+    exact_command_artifact_id = build_exact_command_memory_artifact_id(_policy_bundle_rule_exact_command(rule))
     if exact_command_artifact_id is not None:
         return [exact_command_artifact_id]
 

--- a/src/codex_plugin_scanner/guard/store_policy.py
+++ b/src/codex_plugin_scanner/guard/store_policy.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 # ruff: noqa: F403,F405
 from .approval_scope_support import package_request_portable_workspace_scope
-from .memory_pattern_fingerprint import build_memory_pattern_fingerprint
+from .memory_pattern_fingerprint import (
+    build_exact_command_memory_artifact_id,
+    build_memory_pattern_fingerprint,
+)
 from .store_base import *
 
 
@@ -213,6 +216,27 @@ class StorePolicyMixin:
         )
         if direct_lookup["decision"] is not None or direct_lookup.get("ignored_local_integrity") is not None:
             return direct_lookup
+        exact_command_artifact_id = build_exact_command_memory_artifact_id(
+            memory_command
+        )
+        if (
+            exact_command_artifact_id is not None
+            and exact_command_artifact_id != artifact_id
+        ):
+            exact_command_lookup = self.resolve_policy_decision_lookup(
+                harness,
+                exact_command_artifact_id,
+                artifact_hash=artifact_hash,
+                workspace=workspace,
+                publisher=publisher,
+                now=now,
+                runtime_exact_match_context=runtime_exact_match_context,
+            )
+            if (
+                exact_command_lookup["decision"] is not None
+                or exact_command_lookup.get("ignored_local_integrity") is not None
+            ):
+                return exact_command_lookup
         memory_pattern = build_memory_pattern_fingerprint(
             command=memory_command,
             artifact_type=memory_artifact_type,

--- a/src/codex_plugin_scanner/guard/store_policy.py
+++ b/src/codex_plugin_scanner/guard/store_policy.py
@@ -216,13 +216,8 @@ class StorePolicyMixin:
         )
         if direct_lookup["decision"] is not None or direct_lookup.get("ignored_local_integrity") is not None:
             return direct_lookup
-        exact_command_artifact_id = build_exact_command_memory_artifact_id(
-            memory_command
-        )
-        if (
-            exact_command_artifact_id is not None
-            and exact_command_artifact_id != artifact_id
-        ):
+        exact_command_artifact_id = build_exact_command_memory_artifact_id(memory_command)
+        if exact_command_artifact_id is not None and exact_command_artifact_id != artifact_id:
             exact_command_lookup = self.resolve_policy_decision_lookup(
                 harness,
                 exact_command_artifact_id,

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -215,6 +215,20 @@ def test_remote_exact_command_policy_rejects_command_suffix(
         )
         is None
     )
+    for whitespace_variant in (
+        " printf 'suggested-memory'",
+        "printf 'suggested-memory' ",
+    ):
+        assert (
+            store.resolve_policy(
+                "codex",
+                "codex:runtime:shell:request-whitespace",
+                memory_command=whitespace_variant,
+                memory_artifact_type="shell_command",
+                memory_artifact_name="Shell command",
+            )
+            is None
+        )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -174,9 +174,7 @@ def test_remote_exact_command_policy_rejects_command_suffix(
     policy_action: str,
 ) -> None:
     store = _make_store(tmp_path)
-    exact_artifact_id = build_exact_command_memory_artifact_id(
-        "printf 'suggested-memory'"
-    )
+    exact_artifact_id = build_exact_command_memory_artifact_id("printf 'suggested-memory'")
     assert exact_artifact_id is not None
     store.replace_remote_policies(
         [

--- a/tests/test_guard_approval_decisions.py
+++ b/tests/test_guard_approval_decisions.py
@@ -17,7 +17,10 @@ import pytest
 from codex_plugin_scanner.guard.config import GuardConfig
 from codex_plugin_scanner.guard.consumer import artifact_hash as compute_artifact_hash
 from codex_plugin_scanner.guard.consumer import evaluate_detection
-from codex_plugin_scanner.guard.memory_pattern_fingerprint import build_memory_pattern_fingerprint
+from codex_plugin_scanner.guard.memory_pattern_fingerprint import (
+    build_exact_command_memory_artifact_id,
+    build_memory_pattern_fingerprint,
+)
 from codex_plugin_scanner.guard.models import (
     GuardArtifact,
     HarnessDetection,
@@ -158,6 +161,57 @@ def test_remote_suggested_memory_policy_matches_runtime_command_pattern(
             "codex",
             "codex:runtime:shell:request-three",
             memory_command="npm install react",
+            memory_artifact_type="shell_command",
+            memory_artifact_name="Shell command",
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize("policy_action", ["allow", "block"])
+def test_remote_exact_command_policy_rejects_command_suffix(
+    tmp_path: Path,
+    policy_action: str,
+) -> None:
+    store = _make_store(tmp_path)
+    exact_artifact_id = build_exact_command_memory_artifact_id(
+        "printf 'suggested-memory'"
+    )
+    assert exact_artifact_id is not None
+    store.replace_remote_policies(
+        [
+            PolicyDecision(
+                harness="codex",
+                scope="artifact",
+                artifact_id=exact_artifact_id,
+                artifact_hash=None,
+                workspace=None,
+                publisher=None,
+                action=policy_action,
+                reason="Exact command memory",
+                owner=None,
+                source="cloud-sync",
+            )
+        ],
+        now="2026-07-11T00:00:00Z",
+        remote_write_authorized=True,
+    )
+
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:runtime:shell:request-two",
+            memory_command="printf 'suggested-memory'",
+            memory_artifact_type="shell_command",
+            memory_artifact_name="Shell command",
+        )
+        == policy_action
+    )
+    assert (
+        store.resolve_policy(
+            "codex",
+            "codex:runtime:shell:request-three",
+            memory_command="printf 'suggested-memory' extra",
             memory_artifact_type="shell_command",
             memory_artifact_name="Shell command",
         )

--- a/tests/test_guard_policy_bundle_browser_scopes.py
+++ b/tests/test_guard_policy_bundle_browser_scopes.py
@@ -210,14 +210,10 @@ class TestBrowserScopeDecisionNarrowing:
         rule["artifactId"] = "memory:codex:command_pattern:broad"
         rule["matcherFamilies"] = ["tool-action"]
         bundle = _valid_bundle_with_rules([rule])
-        decisions = _build_policy_bundle_decisions(
-            bundle, device_id="device-1", device_name="dev"
-        )
+        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
         assert len(decisions) == 1
         assert decisions[0].scope == "artifact"
-        assert decisions[0].artifact_id == build_exact_command_memory_artifact_id(
-            command
-        )
+        assert decisions[0].artifact_id == build_exact_command_memory_artifact_id(command)
 
     def test_rule_with_only_sensitive_surface_skipped(self) -> None:
         """A rule with only sensitiveSurface scope is skipped (no broad allow)."""

--- a/tests/test_guard_policy_bundle_browser_scopes.py
+++ b/tests/test_guard_policy_bundle_browser_scopes.py
@@ -204,7 +204,7 @@ class TestBrowserScopeDecisionNarrowing:
             _build_policy_bundle_decisions,
         )
 
-        command = "python -m pytest"
+        command = " python -m pytest "
         rule = self._local_match_rule()
         rule["matcher"] = {"command": command, "tool": "shell"}
         rule["artifactId"] = "memory:codex:command_pattern:broad"

--- a/tests/test_guard_policy_bundle_browser_scopes.py
+++ b/tests/test_guard_policy_bundle_browser_scopes.py
@@ -195,19 +195,29 @@ class TestBrowserScopeDecisionNarrowing:
         decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
         assert decisions == []
 
-    def test_non_browser_scoped_rule_still_produces_decisions(self) -> None:
-        """A rule without browser scope keys still generates harness-scoped family decisions."""
-        from codex_plugin_scanner.guard.runtime.runner import _build_policy_bundle_decisions
+    def test_exact_command_rule_does_not_create_family_decision(self) -> None:
+        """An exact command rule must not broaden into all tool actions."""
+        from codex_plugin_scanner.guard.memory_pattern_fingerprint import (
+            build_exact_command_memory_artifact_id,
+        )
+        from codex_plugin_scanner.guard.runtime.runner import (
+            _build_policy_bundle_decisions,
+        )
 
+        command = "python -m pytest"
         rule = self._local_match_rule()
-        rule["scope"]["command"] = "python -m pytest"
+        rule["matcher"] = {"command": command, "tool": "shell"}
+        rule["artifactId"] = "memory:codex:command_pattern:broad"
+        rule["matcherFamilies"] = ["tool-action"]
         bundle = _valid_bundle_with_rules([rule])
-        decisions = _build_policy_bundle_decisions(bundle, device_id="device-1", device_name="dev")
-        assert len(decisions) > 0
-        for decision in decisions:
-            assert decision.scope == "harness"
-            assert decision.artifact_id is not None
-            assert decision.artifact_id.startswith("family:")
+        decisions = _build_policy_bundle_decisions(
+            bundle, device_id="device-1", device_name="dev"
+        )
+        assert len(decisions) == 1
+        assert decisions[0].scope == "artifact"
+        assert decisions[0].artifact_id == build_exact_command_memory_artifact_id(
+            command
+        )
 
     def test_rule_with_only_sensitive_surface_skipped(self) -> None:
         """A rule with only sensitiveSurface scope is skipped (no broad allow)."""


### PR DESCRIPTION
## Summary
- import command-specific Guard Cloud policies as exact local policy keys
- prevent exact command memories from broadening into tool-action family rules
- prefer exact command policy lookup before generalized Suggested Memory patterns

## Verification
- `uv run pytest tests/test_guard_approval_decisions.py tests/test_guard_policy_bundle_browser_scopes.py -q` (57 passed)
- `uv run ruff check src/codex_plugin_scanner/guard/memory_pattern_fingerprint.py src/codex_plugin_scanner/guard/store_policy.py src/codex_plugin_scanner/guard/runtime/runner.py tests/test_guard_approval_decisions.py tests/test_guard_policy_bundle_browser_scopes.py`
- Dockerized portal + hol-guard Suggested Memory lifecycle: exact allow/block reused without queue; suffixed near-miss commands not reused