### PR TITLE
fix(sync): acknowledge queued decision rejections

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -246,6 +246,12 @@ def _post_sync_events(
 
 
 def _is_terminally_superseded_result(item: dict[str, object]) -> bool:
+    """Return whether Cloud already owns a newer authoritative request state.
+
+    ``decision_queued`` means a Cloud decision was durably queued for delivery;
+    subsequent local refresh/resolution events cannot replace it. The eventual
+    ``decision_applied`` acknowledgement travels as a separate outbox event.
+    """
     if item.get("code") == "stale_sequence":
         return True
     error = item.get("error")

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -249,7 +249,7 @@ def _is_terminally_superseded_result(item: dict[str, object]) -> bool:
     if item.get("code") == "stale_sequence":
         return True
     error = item.get("error")
-    if error in {"stale_regression_rejected", "stale_sequence"}:
+    if error in {"decision_queued", "stale_regression_rejected", "stale_sequence"}:
         return True
     return isinstance(error, str) and error.startswith("stale event sequence ")
 

--- a/tests/test_guard_live_request_outbox.py
+++ b/tests/test_guard_live_request_outbox.py
@@ -279,30 +279,38 @@ def test_partial_acknowledgement_retries_only_rejected_event(tmp_path, monkeypat
     assert rows[0]["attempt_count"] == 1
 
 
-def test_stale_rejection_is_acknowledged_while_transient_rejection_retries(
+def test_terminal_rejections_are_acknowledged_while_transient_rejection_retries(
     tmp_path,
     monkeypatch,
 ) -> None:
     store = GuardStore(tmp_path / "guard")
     store.add_approval_request(_request("request-stale"), _NOW)
-    monkeypatch.setattr(live_request_sync, "LIVE_REQUEST_SYNC_BATCH_SIZE", 2)
     store.add_approval_request(_request("request-transient"), "2026-07-11T18:00:00+00:00")
-    monkeypatch.setattr(
-        live_request_sync,
-        "_post_sync_events",
-        lambda *_args, **_kwargs: {
+    store.add_approval_request(_request("request-decision-queued"), "2026-07-11T19:00:00+00:00")
+    monkeypatch.setattr(live_request_sync, "LIVE_REQUEST_SYNC_BATCH_SIZE", 3)
+
+    def post_events(*_args, **kwargs):
+        terminal_errors = {
+            "request-decision-queued": "decision_queued",
+            "request-stale": "stale_sequence",
+        }
+        return {
             "accepted": 0,
-            "rejected": 2,
+            "rejected": 3,
             "perEventResults": [
-                {"index": 0, "accepted": False, "error": "temporary failure"},
                 {
-                    "index": 1,
+                    "index": index,
                     "accepted": False,
-                    "error": "stale_sequence",
-                },
+                    "error": terminal_errors.get(
+                        event["localRequestId"],
+                        "temporary failure",
+                    ),
+                }
+                for index, event in enumerate(kwargs["events"])
             ],
-        },
-    )
+        }
+
+    monkeypatch.setattr(live_request_sync, "_post_sync_events", post_events)
 
     live_request_sync.sync_live_requests_once(store, _AUTH)
 


### PR DESCRIPTION
## Summary
- treat `decision_queued` results as terminally superseded
- remove superseded rows from the durable live-request outbox instead of retrying forever
- cover terminal and transient rejection behavior together

## Testing
- `uv run pytest tests/test_guard_live_request_sync.py tests/test_guard_live_request_outbox.py tests/test_guard_daemon_live_sync_lifecycle.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/live_request_sync.py tests/test_guard_live_request_outbox.py`
- `uv run --extra dev basedpyright src/codex_plugin_scanner/guard/runtime/live_request_sync.py` (0 errors)