### PR TITLE
fix(sync): encode live request event batches

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -1,5 +1,6 @@
 """Durable, independent synchronization for local Guard approval requests."""
 
+import base64
 import json
 import logging
 import os
@@ -68,6 +69,15 @@ def _resolve_sync_url(auth_context: dict[str, object], path: str) -> str:
         raise RuntimeError("Guard sync URL must be an absolute HTTP(S) URL.")
     normalized_path = path if path.startswith("/") else f"/{path}"
     return urllib.parse.urlunsplit((parsed.scheme, parsed.netloc, normalized_path, parsed.query, ""))
+
+
+def _encode_live_request_events(events: list[dict[str, object]]) -> str:
+    event_json = json.dumps(
+        events,
+        ensure_ascii=False,
+        separators=(",", ":"),
+    ).encode("utf-8")
+    return base64.urlsafe_b64encode(event_json).rstrip(b"=").decode("ascii")
 
 
 def _load_sync_state(store: GuardStore) -> dict[str, object]:
@@ -230,7 +240,7 @@ def _post_sync_events(
         "workspaceId": workspace_id,
         "machineInstallationId": machine_installation_id,
         "inboundCursor": cursor,
-        "events": events,
+        "eventsBase64Url": _encode_live_request_events(events),
     }
     request = _guard_sync_request(
         auth_context,

--- a/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
+++ b/src/codex_plugin_scanner/guard/runtime/live_request_sync.py
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 
 LIVE_REQUEST_SYNC_BATCH_SIZE = 1
 LIVE_REQUEST_SYNC_MAX_BATCHES = 200
-LIVE_REQUEST_SYNC_PROTOCOL_VERSION = "1"
+LIVE_REQUEST_SYNC_PROTOCOL_VERSION = "2"
 _LIVE_REQUEST_COMMAND_MAX_UTF16_UNITS = 65_536
 _LIVE_REQUEST_SUMMARY_MAX_UTF16_UNITS = 512
 LIVE_REQUEST_SYNC_STATE_KEY = "guard_live_request_sync_state"
@@ -77,7 +77,7 @@ def _encode_live_request_events(events: list[dict[str, object]]) -> str:
         ensure_ascii=False,
         separators=(",", ":"),
     ).encode("utf-8")
-    return base64.urlsafe_b64encode(event_json).rstrip(b"=").decode("ascii")
+    return base64.urlsafe_b64encode(event_json).decode("ascii")
 
 
 def _load_sync_state(store: GuardStore) -> dict[str, object]:

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -13,6 +13,7 @@ from codex_plugin_scanner.guard.runtime import live_request_sync as live_request
 from codex_plugin_scanner.guard.runtime.live_request_sync import (
     LIVE_REQUEST_SYNC_PROTOCOL_VERSION,
     _build_live_request_event,
+    _encode_live_request_events,
     _post_sync_events,
     _resolve_sync_url,
     start_cloud_sync_sync_worker,
@@ -677,6 +678,13 @@ class TestPendingRequestAgeConnectivity:
         assert event is not None
         assert event["eventType"] == "request_created"
         assert event["requestPayload"]["status"] == "pending"
+
+
+def test_event_encoder_keeps_base64url_padding() -> None:
+    encoded = _encode_live_request_events([{}])
+
+    assert encoded.endswith("==")
+    assert json_loads(urlsafe_b64decode(encoded)) == [{}]
 
 
 def test_sync_transport_encodes_waf_sensitive_event_content(

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -717,10 +717,10 @@ def test_sync_transport_encodes_waf_sensitive_event_content(
 
     encoded = captured_body["eventsBase64Url"]
     assert isinstance(encoded, str)
+    assert captured_body["protocolVersion"] == "2"
     assert "events" not in captured_body
     assert "graphql" not in encoded
-    padding = "=" * (-len(encoded) % 4)
-    assert json_loads(urlsafe_b64decode(encoded + padding)) == [event]
+    assert json_loads(urlsafe_b64decode(encoded)) == [event]
     assert response == {"accepted": 1}
 
 

--- a/tests/test_guard_live_request_sync.py
+++ b/tests/test_guard_live_request_sync.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+from base64 import urlsafe_b64decode
 from json import dumps as json_dumps
+from json import loads as json_loads
 from pathlib import Path
 
 import pytest
@@ -11,6 +13,7 @@ from codex_plugin_scanner.guard.runtime import live_request_sync as live_request
 from codex_plugin_scanner.guard.runtime.live_request_sync import (
     LIVE_REQUEST_SYNC_PROTOCOL_VERSION,
     _build_live_request_event,
+    _post_sync_events,
     _resolve_sync_url,
     start_cloud_sync_sync_worker,
     stop_cloud_sync_sync_worker,
@@ -674,6 +677,51 @@ class TestPendingRequestAgeConnectivity:
         assert event is not None
         assert event["eventType"] == "request_created"
         assert event["requestPayload"]["status"] == "pending"
+
+
+def test_sync_transport_encodes_waf_sensitive_event_content(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from codex_plugin_scanner.guard.runtime import runner
+
+    captured_body: dict[str, object] = {}
+
+    def capture_request(
+        _auth_context: dict[str, object],
+        *,
+        data: bytes,
+        **_kwargs: object,
+    ) -> object:
+        captured_body.update(json_loads(data))
+        return object()
+
+    monkeypatch.setattr(runner, "_guard_sync_request", capture_request)
+    monkeypatch.setattr(
+        runner,
+        "_urlopen_json_with_timeout_retry",
+        lambda **_kwargs: {"accepted": 1},
+    )
+    event = {
+        "localRequestId": "request-waf-sensitive",
+        "rawCommand": "gh api graphql --raw-field query=../../runtime/authorization",
+    }
+
+    response = _post_sync_events(
+        {"sync_url": "https://hol.org/api/guard/receipts/sync"},
+        workspace_id="workspace-1",
+        machine_id="machine-1",
+        machine_installation_id="installation-1",
+        cursor=None,
+        events=[event],
+    )
+
+    encoded = captured_body["eventsBase64Url"]
+    assert isinstance(encoded, str)
+    assert "events" not in captured_body
+    assert "graphql" not in encoded
+    padding = "=" * (-len(encoded) % 4)
+    assert json_loads(urlsafe_b64decode(encoded + padding)) == [event]
+    assert response == {"accepted": 1}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- send live request event batches in a base64url transport envelope
- keep event content opaque to intermediaries while preserving the existing JSON event contract
- cover WAF-sensitive command content with a transport round-trip regression

## Verification
- `uv run pytest tests/test_guard_live_request_sync.py tests/test_guard_live_request_outbox.py -q` (71 passed)
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/live_request_sync.py tests/test_guard_live_request_sync.py`