### PR TITLE
fix(deps): pin litellm to 1.91.3 to keep cisco extra resolver-safe

### DIFF
--- a/docker-requirements.txt
+++ b/docker-requirements.txt
@@ -986,16 +986,9 @@ linkify-it-py==2.1.0 \
     --hash=sha256:0d252c1594ecba2ecedc444053db5d3a9b7ec1b0dd929c8f1d74dce89f86c05e \
     --hash=sha256:43360231720999c10e9328dc3691160e27a718e280673d444c38d7d3aaa3b98b
     # via markdown-it-py
-litellm==1.92.0 \
-    --hash=sha256:437a0e403136996430795ead76502103dcf74769b6909e12d3e2511061ea8ff8 \
-    --hash=sha256:679a6287f9c3f829750e308cd7215a3d2da7b2e9a5bedae6d3ad4465edefdbe1 \
-    --hash=sha256:773adf5503ee1793289689c899394a83df8122993760d9acd782e32aa798db9d \
-    --hash=sha256:7fdba218ffd5dd56a18eeb57db805fa887484d0adedfb9f282b61e0b97c62de0 \
-    --hash=sha256:8f03047a73154f33c2733899e4bf9b5ed129e2e345caa305895a318452e4a807 \
-    --hash=sha256:9c7b2849591a35f7039dc7386a81a8e68fccb5ac2fecaa5122192c1172556b29 \
-    --hash=sha256:b4b65395c5d7b15fa24e08a13871c0617f6d156c46cee0eb920f3a5954e50adf \
-    --hash=sha256:f0ec8327aacc7914cc16310a1a3cc14340f1140b0a761403c5a4a98b01684373 \
-    --hash=sha256:f17499155366afd1eaaeb6fd0c7b55cbd2239dcd72f2fe1f8071a969cc402fae
+litellm==1.91.3 \
+    --hash=sha256:096cee401dfd353f050422adc6ed9b25da0fc5e110fc923ce3f0ffa5bc5c2957 \
+    --hash=sha256:5be4df2bdf5459f46a6224a75046f365dc979995a37a81f5aa3ce29f92f534cf
     # via
     #   --override (workspace)
     #   hol-guard (pyproject.toml)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ dependencies = [
 
 [project.optional-dependencies]
 cisco = [
-    "litellm==1.89.1; python_version >= '3.11' and python_version < '3.14'",
+    "litellm==1.91.3; python_version >= '3.11' and python_version < '3.14'",
 ]
 dev = [
     "basedpyright>=1.39.8",
@@ -68,7 +68,7 @@ override-dependencies = [
     "fastapi==0.137.1",
     "importlib-metadata==9.0.0",
     "jsonschema==4.26.0",
-    "litellm==1.89.1",
+    "litellm==1.91.3",
     "openai==2.41.1",
     "pyjwt==2.13.0",
     "python-dotenv==1.2.2",

--- a/tests/test_cisco_install_surfaces.py
+++ b/tests/test_cisco_install_surfaces.py
@@ -27,7 +27,7 @@ def test_pyproject_keeps_cisco_mcp_scanner_optional() -> None:
     assert "cisco-ai-mcp-scanner" not in dependencies
     assert "cisco-ai-mcp-scanner" not in cisco_extra
     assert "cisco-ai-mcp-scanner==4.7.3" in cisco_mcp_group
-    assert "litellm==1.89.1" in cisco_extra
+    assert "litellm==1.91.3" in cisco_extra
     assert "python_version >= '3.11'" in cisco_extra
     assert "python_version < '3.14'" in cisco_extra
     assert "python_version < '3.14'" in cisco_mcp_group
@@ -38,7 +38,7 @@ def test_pyproject_keeps_cisco_mcp_scanner_optional() -> None:
     assert "cisco-ai-skill-scanner==2.0.11" in override_entries
     assert "importlib-metadata==9.0.0" in override_entries
     assert "jsonschema==4.26.0" in override_entries
-    assert "litellm==1.89.1" in override_entries
+    assert "litellm==1.91.3" in override_entries
     assert "openai==2.41.1" in override_entries
     assert "pyjwt==2.13.0" in override_entries
     assert "python-dotenv==1.2.2" in override_entries
@@ -113,7 +113,7 @@ def test_repo_controlled_surfaces_prefer_cisco_extra_where_supported() -> None:
     assert "aiohttp==3.14.1" in docker_requirements
     assert "cisco-ai-mcp-scanner==" in docker_requirements
     assert "importlib-metadata==9.0.0" in docker_requirements
-    assert "litellm==1.89.1" in docker_requirements
+    assert "litellm==1.91.3" in docker_requirements
     assert "python-dotenv==1.2.2" in docker_requirements
     assert "python-multipart==0.0.32" in docker_requirements
     assert "pyjwt==2.13.0" in docker_requirements

--- a/tests/test_live_cisco_smoke.py
+++ b/tests/test_live_cisco_smoke.py
@@ -40,7 +40,7 @@ def test_live_cisco_mcp_scan_on_bad_plugin() -> None:
     except importlib_metadata.PackageNotFoundError:
         pytest.skip("cisco-ai-mcp-scanner is not installed in this environment")
 
-    assert importlib_metadata.version("litellm") == "1.89.1"
+    assert importlib_metadata.version("litellm") == "1.91.3"
 
     result = scan_plugin(FIXTURES / "bad-plugin", ScanOptions(cisco_mcp_scan="on"))
 

--- a/uv.lock
+++ b/uv.lock
@@ -22,7 +22,7 @@ overrides = [
     { name = "fastapi", specifier = "==0.137.1" },
     { name = "importlib-metadata", specifier = "==9.0.0" },
     { name = "jsonschema", specifier = "==4.26.0" },
-    { name = "litellm", specifier = "==1.89.1" },
+    { name = "litellm", specifier = "==1.91.3" },
     { name = "openai", specifier = "==2.41.1" },
     { name = "pyjwt", specifier = "==2.13.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },
@@ -1205,7 +1205,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=49.0.0" },
     { name = "jsonschema", marker = "extra == 'dev'", specifier = ">=4.26.0" },
     { name = "keyring", specifier = ">=25.0" },
-    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'cisco'", specifier = "==1.89.1" },
+    { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'cisco'", specifier = "==1.91.3" },
     { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.27.0,<2" },
     { name = "packaging", specifier = ">=24.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
@@ -1601,7 +1601,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.89.1"
+version = "1.91.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1617,9 +1617,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e8/1b/de398e6cef46d4cbc4395c895330f30eab05439bf6d0c5c53b0203661eeb/litellm-1.89.1.tar.gz", hash = "sha256:eb9292f90afe46dcce4bfef6bbeaa54494945813763e1c0917f4e9a1c584c1a4", size = 14071586, upload-time = "2026-06-16T03:12:52.997Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/36/33/879369fe202498a307e1130bae1f59c5f226362afc07829ba5a0279a563d/litellm-1.91.3.tar.gz", hash = "sha256:096cee401dfd353f050422adc6ed9b25da0fc5e110fc923ce3f0ffa5bc5c2957", size = 14875767, upload-time = "2026-07-11T22:43:32.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/24/81f03088876a13b628fdbaf746ee746e1dff127d63f339ef72f1a3801c91/litellm-1.89.1-py3-none-any.whl", hash = "sha256:a52a67625d89cb1787ef48c4b3c1ab9c2574ea304f56900bc631844297a13bd4", size = 15484855, upload-time = "2026-06-16T03:12:49.457Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/3c/157c54c924f9e6025797545a0cd915a98e98ad8d3f9011502a575781d4b5/litellm-1.91.3-py3-none-any.whl", hash = "sha256:5be4df2bdf5459f46a6224a75046f365dc979995a37a81f5aa3ce29f92f534cf", size = 16674504, upload-time = "2026-07-11T22:43:30.517Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `litellm` to `1.91.3` across the `cisco` extra, `uv` override-dependencies, `uv.lock`, and `docker-requirements.txt`, and align the cisco install-surface and live cisco smoke test assertions
- Keep the published `cisco` extra resolver-safe: `litellm` 1.92.0 dropped its portable `py3-none-any` wheel and ships only `manylinux` wheels built with a maturin/Rust backend, which would force macOS and Windows `pip install "hol-guard[cisco]"` to build the sdist with a Rust toolchain

The dependabot pip-patch-minor bump moved `docker-requirements.txt` to `litellm==1.92.0`, but the source pins, lockfile, and tests still referenced `1.89.1`, leaving the repo-controlled Cisco surfaces inconsistent and breaking the `cisco-full` and `ci` jobs. `1.91.3` is the last `litellm` release that ships a portable wheel, so it restores cross-platform resolver-safety while picking up the minor updates since `1.89.1`. The `docker-requirements.txt` change is limited to the `litellm` block; the rest of the dependabot lockfile update is preserved.

## Testing
- `uv run --no-sync pytest tests/test_cisco_install_surfaces.py tests/test_mcp_security.py tests/test_cli.py tests/test_action_runner.py tests/test_live_cisco_smoke.py --tb=short`
- `uv lock --check`
- `python -m pip install --dry-run --no-deps --require-hashes -r docker-requirements.txt`
