### PR TITLE
feat(runtime): add structured command rule foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,10 @@ Command safety extensions make Guard's existing shell, Git, filesystem, data-pro
 encoded-execution, and self-protection behavior inspectable. They are built-in capability boundaries over the same
 parser used by harness hooks, not downloadable regex bundles.
 
+Each extension publishes stable rule IDs and structured rule metadata. Command inspection also returns a canonical,
+side-effect-free parse model with wrapper, pipeline, environment-override, provenance, and confidence details so
+automation can distinguish exact parsing from malformed or unsupported input.
+
 Use `command test` for a concise classification and `command explain` for the complete evaluation trace. Both are
 side-effect free: they do not execute the command, evaluate final policy, create an approval, or record a receipt.
 Use `--json` for a stable automation contract.

--- a/docs/guard/command-extension-architecture.md
+++ b/docs/guard/command-extension-architecture.md
@@ -1,0 +1,106 @@
+# Command Extension Architecture
+
+## Status and scope
+
+This document defines the target contract for Guard command safety extensions. The schema-v2 registry and canonical command model currently preserve compatibility with existing action and risk classes while rule-level evaluation migrates behind them. Extensions detect and explain command facts; Guard's existing policy, approval, memory, and receipt systems retain decision authority.
+
+## Parse-once command model
+
+Each harness adapter extracts a command and declares its input boundary before parsing:
+
+- **Dialect:** `posix`, `powershell`, `cmd`, `argv`, or `unknown`.
+- **Transport:** shell string, argument vector, or embedded script.
+- **Provenance:** harness, event, extraction method, workspace/source scope, and whether text was direct or reconstructed.
+
+The parser boundary produces one immutable `CanonicalCommand` per request. The complete contract carries normalized text, cwd and platform context, security-relevant command-local environment overrides, parse confidence, wrapper chain, source spans, embedded scripts, and ordered segments. Segments preserve separators, pipeline position, executable/path source, subcommands, flags, operands, redirects, and execution-versus-data context.
+
+Consumers receive this model; they do not retokenize raw text. Dialects never share quoting rules, parsing never expands or executes shell content, and compound-command suffixes are retained. Unsupported dialects, malformed input, and exceeded limits return typed uncertainty rather than a partial success that can imply safety.
+
+```text
+harness request
+  -> adapter extraction with dialect, transport, and provenance
+  -> canonical parser (once)
+  -> context classification and executable/keyword index
+  -> all applicable extension matchers
+  -> composite evidence artifact
+  -> existing policy and memory evaluation
+  -> one response, approval item, and receipt
+```
+
+## Matcher boundary
+
+A `CommandMatcher` is side-effect-free and evaluates the canonical invocation or one of its segments. It returns zero or more `RuleMatch` values. Matchers use structured executable, subcommand, flag, operand, path, redirect, pipeline, data-flow, platform, and embedded-script fields. Compound matchers expose explicit `all`, `any`, and `not` semantics.
+
+Safe variants are positive, rule-local predicates such as a verified dry run, preview, read-only operation, or bounded target. A safe variant cannot suppress another rule. Regex is a bounded fallback for trusted definitions: compile it at registry construction, validate complexity, constrain input and match count, and evaluate it behind a hard interruption boundary when linear behavior is not guaranteed. Timeout or budget exhaustion produces uncertainty.
+
+Every match carries stable extension and rule IDs, extension version, severity, risk classes, matched segment and source-span references, redaction-safe evidence, confidence, safe-variant results, safer alternatives, and evaluation time. Matchers emit evidence only; they never emit `allow`, approve a request, write memory, or execute commands.
+
+## Registry boundary
+
+The injected registry is the sole source for runtime hooks, command inspection, dashboard APIs, and generated reference documentation. Construction validates:
+
+- schema and semantic versions; unique extension and rule IDs; deterministic ordering;
+- required status, source authority, dependencies, conflicts, aliases, and category ownership;
+- declared action/risk compatibility during migration;
+- matcher type, complexity, count, and time budgets;
+- source attribution as built-in, local-admin, or signed managed configuration;
+- rollback protection and the rule that external definitions cannot shadow built-ins.
+
+The registry indexes executable and bounded keywords so unrelated extensions are not evaluated. It imports no code from workspace or externally supplied definitions. Declarative external rules remain constrained by the matcher schema and protected configuration authority.
+
+Schema v2 makes leaf extensions own rules. Existing extension IDs, action classes, and risk classes remain available through a single compatibility translator until all consumers migrate. Stored extension settings require an explicit, versioned migration; unknown versions fail closed to a non-weaker state.
+
+## Evidence and policy authority
+
+All matches survive evaluation. The engine creates one composite artifact containing ordered matches, the union of risk classes, parser uncertainty, safe-variant outcomes, and the controlling rule. This produces one policy evaluation and one user action, avoiding duplicate prompts and receipts.
+
+The artifact is evidence, not policy. Guard policy resolves configured risk actions, source/workspace scope, managed policy, remembered decisions, approvals, and final `allow`, `warn`, `review`, `sandbox-required`, `require-reapproval`, or `block` behavior. Extension metadata, modes, and safer alternatives cannot grant authority.
+
+Decision composition must be monotonic:
+
+1. Required critical rules establish a minimum action that lower-authority input cannot reduce.
+2. A safe variant affects only its declaring rule.
+3. Multiple matches retain all evidence and the strongest controlling requirement.
+4. Destructive-executable parser or matcher uncertainty requires at least review.
+5. Remembered allow applies only to an equivalent full security identity.
+6. Managed, local-admin, workspace, and extension inputs may strengthen an outcome only within their authority.
+
+A versioned truth table covering source authority, required status, extension mode, severity, uncertainty, safe variants, overlap, memory, and configured policy is a release artifact and executable test fixture.
+
+## Memory migration
+
+The new security identity hashes the complete canonical command semantics, not a prefix or display label. It binds dialect, transport, normalized segments and suffixes, wrappers, aliases and executable path source, security-relevant environment overrides including `PATH`, cwd scope, workspace/source scope, parser confidence, and controlling rule ID plus semantic version.
+
+New memory writes use only the versioned identity. Legacy exact-command and pattern memory may be read during a bounded migration window only when every security-relevant field can be proven equivalent. Missing context, changed rule semantics, uncertainty, or broader legacy scope yields `require-reapproval`; it never falls back to a weaker pattern. Migration records the old and new identity versions without persisting newly exposed raw command material.
+
+## Redaction and persistence
+
+Raw text, tokens, embedded payloads, environment values, and source spans are ephemeral parser inputs by default. Persistence stores stable IDs, schema and extension versions, classifications, confidence, hashes, timing, controlling-rule metadata, and redacted excerpts or span descriptors. Secret values must not enter evidence, logs, metrics, generated docs, or matcher errors.
+
+Existing receipt redaction policy controls any authorized raw-command retention. Inspection and policy simulation are side-effect-free: no receipt, approval, memory, event, queue, lease, migration write, or network refresh. Relaxing a display setting must not reconstruct data that was never retained.
+
+## Limits and performance
+
+The parser enforces independent byte, token, segment, wrapper-depth, nesting, embedded-payload, and total-time limits. The evaluator enforces per-rule, per-extension, match-count, regex, and total-request budgets. Every limit failure is typed, observable in explain output, and non-allowing for potentially destructive input.
+
+Evaluation targets are p95 below 5 ms through 1 KiB and below 20 ms through 32 KiB on supported development hardware, with no more than 10% regression in benign hook p95 from the recorded baseline. Timing is available in debug and explain output, not normal hook output.
+
+## Rollout gates
+
+1. **Contract gate:** approve models, schemas, monotonic truth table, threat model, capability matrix, and latency/false-positive baselines.
+2. **Parity gate:** ship parser, matcher library, registry v2, and compatibility translator with the existing extension set; remove no legacy path until behavior parity passes.
+3. **Required-core gate:** add critical filesystem, Git, system, self-protection, platform, and embedded-script rules only after bypass and false-positive suites pass.
+4. **Domain gate:** add infrastructure, container, package, cloud, storage, and data domains in review or monitor mode until corpus and performance evidence supports stronger enforcement.
+5. **External-definition gate:** enable declarative local-admin and signed managed definitions only after signature, rollback, authority, corpus, and resource-budget controls pass.
+
+## Acceptance tests
+
+- Assert exactly one parser invocation per harness request and the same injected registry across runtime, CLI, dashboard, and generated docs.
+- Cover each dialect/transport independently, wrappers, aliases, cwd, `PATH`, separators, suffixes, pipelines, redirects, heredocs, substitutions, malformed input, and every limit.
+- For every rule, test destructive examples, safe counterparts, explicit safe variants, reordered flags, quoted search/print examples, paths with spaces, and platform syntax.
+- Assert deterministic registry output; reject duplicate IDs, invalid dependencies, shadowing, rollback, unknown schemas, and unsafe matcher complexity.
+- Execute the monotonic truth table, cross-extension overlap, required-rule, safe-variant isolation, uncertainty, and remembered-allow cases.
+- Prove one composite artifact, decision, approval item, and receipt while retaining all ordered evidence.
+- Verify legacy policy/action compatibility and require reapproval for any non-equivalent memory migration.
+- Verify full, partial, and no-redaction persistence; assert secrets and ephemeral parse material are absent from default storage and output.
+- Benchmark benign and destructive corpora, matcher timeouts, pathological input, CLI side-effect freedom, harness contracts, and installed-package end-to-end behavior.

--- a/docs/guard/command-extension-threat-model.md
+++ b/docs/guard/command-extension-threat-model.md
@@ -1,0 +1,119 @@
+# Command Extension Threat Model
+
+## Security objective
+
+Command extensions must improve detection without becoming a second policy engine or a code-loading mechanism. Untrusted command text, workspace content, extension configuration, and remembered decisions must not weaken required protections, disclose secrets, exhaust the hook, or cross workspace/source authority boundaries.
+
+## Assets and invariants
+
+- Final policy authority, approval signing, leases, step-up checks, and managed-policy isolation remain outside extensions.
+- Built-in registry content, required status, rule semantics, enabled state, and precedence cannot be downgraded by agent- or workspace-controlled input.
+- The complete command, including suffixes, wrappers, executable resolution, cwd, and security-relevant environment, is evaluated once.
+- All relevant matches and parser uncertainty survive into one composite evidence artifact.
+- Raw command material and secrets are ephemeral unless explicit receipt policy authorizes retention.
+- Inspection and simulation never execute commands or mutate Guard state.
+
+## Trust boundaries
+
+| Boundary | Trust and permitted authority |
+| --- | --- |
+| Harness adapter | May extract text and provenance; may not choose dialect silently or declare safety. |
+| Command input and workspace | Untrusted data. Files may recommend extensions but cannot load code, disable required rules, or grant policy authority. |
+| Canonical parser | Trusted code processing hostile input under strict limits; performs no expansion or execution. |
+| Built-in registry | Trusted, versioned product content protected by existing integrity controls. |
+| Local-admin definitions | Declarative and explicitly approved from protected state; cannot shadow or weaken built-ins. |
+| Managed definitions | Declarative, signed, fresh, rollback-protected, and bound to the correct workspace/source authority. |
+| Matcher output | Untrusted evidence until schema, ownership, confidence, and budget checks pass. Never a final decision. |
+| Policy and memory | Sole decision authority, constrained by precedence, scope, identity version, and integrity checks. |
+| Receipts, dashboard, and sync | Persistence and display boundary governed by redaction and workspace/source isolation. |
+
+## Threats and controls
+
+### Parser confusion and bypass
+
+An attacker may exploit dialect confusion, quoting, separators, pipelines, nested wrappers, aliases, command substitution, heredocs, embedded scripts, symlinks, cwd, or command-local `PATH` to hide a destructive suffix or change executable resolution.
+
+**Controls:** adapters declare dialect, transport, and provenance; one parser preserves all segments and source spans; dialect parsers do not fall through to another grammar; executable path source and relevant environment are part of the model; parsing performs no expansion; malformed, unsupported, over-limit, or low-confidence destructive input requires review.
+
+### Data mistaken for execution
+
+Destructive words inside search patterns, tests, comments, echo/printf arguments, or quoted examples can cause denial of service through false approvals. Conversely, substitutions or embedded scripts can make executable content look like inert data.
+
+**Controls:** every segment has explicit execution, data, quoted-example, or unknown context; safe variants are structured positive matches; embedded execution is extracted with bounded recursion; unknown context cannot suppress a required rule; canonical corpus tests include quoted and executable counterparts.
+
+### Matcher evasion or resource exhaustion
+
+Hostile input or declarative patterns may trigger excessive tokenization, match explosions, catastrophic regex behavior, deep nesting, or timeouts. A timeout could otherwise become an allow.
+
+**Controls:** independent parser and evaluator byte, token, segment, depth, payload, match-count, and time budgets; executable/keyword indexing; registry-time regex validation and compilation; guaranteed-linear matching or interruptible isolation for non-linear cases; timeout is typed uncertainty and never automatic safety.
+
+### Registry poisoning and authority escalation
+
+A project or managed source may duplicate a built-in ID, redefine risk, mark a destructive operation safe, disable a required extension, import executable code, introduce invalid dependencies, or replay an older definition.
+
+**Controls:** immutable built-in ownership; schema and semantic-version checks; unique IDs; source attribution; dependency/conflict validation; no runtime imports from external locations; local-admin approval; managed signature, freshness, scope, and rollback checks; project definitions remain monitor-only until promoted. External input may not override built-in IDs, required rules, risk classes, or precedence.
+
+### Safe-variant and overlap downgrade
+
+A broad safe predicate or lower-severity match may suppress a critical match from another rule. First-match evaluation may discard evidence or select the weaker result.
+
+**Controls:** evaluate all indexed rules; safe variants apply only to their owner; required critical rules establish a minimum action; union risks and retain ordered evidence; select the strongest controlling requirement through an executable monotonic truth table. Lower-authority input can never reduce that minimum.
+
+### Evidence used as policy
+
+An extension may attempt to return `allow`, self-approve, alter policy state, or manufacture an authoritative source. Multiple matches may create duplicate approvals that users approve inconsistently.
+
+**Controls:** matcher schemas contain facts and safer alternatives, not final actions; extension modes are policy inputs with bounded authority; only the existing policy engine resolves outcomes. One command creates one composite artifact, one policy decision, one approval item, and one receipt.
+
+### Remembered-allow replay
+
+A remembered allow for a prefix or normalized label may be replayed with a destructive suffix, wrapper, changed cwd, alias, `PATH`, workspace source, parser confidence, or changed rule semantics.
+
+**Controls:** versioned memory identity binds the full canonical command, dialect, transport, suffixes, wrappers, executable source, relevant environment, cwd and workspace/source scope, confidence, and controlling rule semantics. Legacy memory is accepted only on proven equivalence; missing context, broader scope, semantic change, or uncertainty requires reapproval.
+
+### Secret disclosure and persistence drift
+
+Commands, environment overrides, paths, embedded payloads, source spans, errors, traces, receipts, dashboard views, or sync records may expose credentials. A later redaction change may accidentally backfill material that was intended to remain ephemeral.
+
+**Controls:** default persistence is stable IDs, hashes, classifications, confidence, timing, and redacted excerpts/span descriptors. Raw parse material is discarded after evaluation unless explicit receipt policy authorizes retention. Matcher errors and metrics contain no raw secrets. Display and sync apply the configured redaction level and workspace/source isolation; relaxed settings cannot recreate unretained data.
+
+### Simulation side effects
+
+Inspection or evaluation intended for debugging may write memory, create approvals or receipts, refresh policy, enqueue work, acquire leases, emit events, or execute a command.
+
+**Controls:** inspection is policy-independent; policy evaluation uses a frozen local snapshot. Both are read-only and have tests asserting no filesystem, database, queue, event, network, lease, or execution side effects.
+
+## Monotonic precedence requirements
+
+The release truth table must prove these invariants for every combination of source authority, required status, mode, severity, safe variant, uncertainty, overlap, remembered decision, and policy action:
+
+1. Required minimum action is never reduced.
+2. Safe evidence cannot cancel unrelated unsafe evidence.
+3. Parser or matcher uncertainty cannot become an allow for potentially destructive input.
+4. A remembered allow cannot outrank changed security identity or controlling rule semantics.
+5. External configuration cannot claim stronger source authority than its validated origin.
+6. Additional evidence or stronger policy can preserve or increase, never decrease, the controlling requirement.
+
+## Rollout and operational gates
+
+- Record benign/destructive latency and false-positive baselines before enforcement migration.
+- Freeze schemas, parser confidence semantics, memory identity, redaction invariants, and the precedence truth table before replacing legacy classification paths.
+- Require behavioral parity for existing action/risk classes and remembered-policy flows before expanding coverage.
+- Release required rules only after bypass, overlap, safe-variant, and false-positive corpora pass.
+- Default ambiguous new domains to monitor or review until coverage and performance evidence justify enforcement.
+- Admit external declarative definitions only after integrity, rollback, scope, corpus, and resource-limit tests pass.
+- Stop rollout on policy weakening, cross-workspace leakage, secret persistence, matcher budget failure, or benign hook p95 regression above the approved threshold.
+
+## Security acceptance tests
+
+- Dialect-confusion cases and independent POSIX, PowerShell, cmd, argv, and embedded-script fixtures.
+- Suffix, separator, wrapper, alias, executable-resolution, cwd, symlink, `PATH`, pipeline, substitution, redirect, heredoc, and source-workspace bypass cases.
+- Search/print/test-runner quoted examples paired with executable destructive forms.
+- Required-rule versus safe-variant and cross-extension overlap across the full monotonic truth table.
+- Duplicate/shadowed IDs, invalid source claims, dependency cycles, unknown schemas, version rollback, bad signatures, stale definitions, and wrong-scope managed content.
+- Byte, token, segment, nesting, payload, matcher-count, regex, and wall-time exhaustion with typed uncertainty and no silent allow.
+- Composite evidence retains all matches while creating exactly one decision, approval, and receipt.
+- Memory replay attempts with changed suffix, wrapper, cwd, environment, source, confidence, or rule version require reapproval.
+- Full, partial, and no-redaction tests prove default storage, logs, errors, dashboard output, and sync records contain no unauthorized secret-bearing material.
+- Inspection and simulation tests prove deterministic output and zero execution, persistence, network, queue, event, lease, or approval side effects.
+- Compatibility, harness contract, benchmark, pathological-input, packaged-install, and representative end-to-end tests pass before release.

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -483,6 +483,7 @@ def _render_command_inspection(console: Console, payload: dict[str, object]) -> 
     status = str(payload.get("status") or "invalid")
     classification = _coerce_object_dict(payload.get("classification"))
     extensions = _coerce_dict_list(payload.get("extensions"))
+    rules = _coerce_dict_list(payload.get("rules"))
     risk_classes = _coerce_string_list(payload.get("risk_classes"))
     border_style = "yellow" if status == "review" else "cyan"
     summary = Table.grid(padding=(0, 1))
@@ -491,6 +492,8 @@ def _render_command_inspection(console: Console, payload: dict[str, object]) -> 
     summary.add_row("Action class", Text(str(action_class or "No sensitive action matched")))
     if extensions:
         summary.add_row("Extension", Text(str(extensions[0].get("extension_id") or "unknown"), style="cyan"))
+    if rules:
+        summary.add_row("Rule", Text(str(rules[0].get("rule_id") or "unknown"), style="cyan"))
     if risk_classes:
         summary.add_row("Risk classes", Text(", ".join(risk_classes)))
     summary.add_row("Policy", Text("Not evaluated; this inspection creates no approvals or receipts", style="dim"))
@@ -524,12 +527,14 @@ def _render_command_extensions(console: Console, payload: dict[str, object]) -> 
     table.add_column("Extension", style="bold cyan", no_wrap=True)
     table.add_column("Version", no_wrap=True)
     table.add_column("Coverage")
+    table.add_column("Rules")
     table.add_column("Purpose")
     for extension in extensions:
         table.add_row(
             str(extension.get("extension_id") or ""),
             str(extension.get("version") or ""),
             str(len(_coerce_string_list(extension.get("action_classes")))),
+            str(extension.get("rule_count") or 0),
             str(extension.get("description") or ""),
         )
     console.print(table)
@@ -538,6 +543,7 @@ def _render_command_extensions(console: Console, payload: dict[str, object]) -> 
 def _plain_text_command_inspection(payload: PayloadDict) -> str:
     classification = _coerce_object_dict(payload.get("classification"))
     extensions = _coerce_dict_list(payload.get("extensions"))
+    rules = _coerce_dict_list(payload.get("rules"))
     lines = [
         f"HOL Guard command inspection: {str(payload.get('status') or 'invalid').upper()}",
         f"Command: {payload.get('command') or ''}",
@@ -547,6 +553,8 @@ def _plain_text_command_inspection(payload: PayloadDict) -> str:
     ]
     if extensions:
         lines.insert(3, f"Extension: {extensions[0].get('extension_id') or 'unknown'}")
+    if rules:
+        lines.insert(4, f"Rule: {rules[0].get('rule_id') or 'unknown'}")
     return "\n".join(lines)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
@@ -1,0 +1,134 @@
+"""Built-in compatibility rules for existing Guard command action classes."""
+
+from __future__ import annotations
+
+from .command_rules import CommandSafetyRule
+
+COMMAND_ACTION_RISK_CLASSES: dict[str, tuple[str, ...]] = {
+    "credential exfiltration shell command": (
+        "data_flow_exfiltration",
+        "credential_exfiltration",
+        "network_egress",
+    ),
+    "guard-managed config write": ("destructive_shell",),
+    "docker-sensitive command": ("network_egress", "destructive_shell"),
+    "docker client config access": ("local_secret_read",),
+    "encoded or encrypted shell command": ("encoded_execution",),
+    "kubernetes secret read command": ("local_secret_read",),
+    "shell file upload command": ("credential_exfiltration", "network_egress"),
+    "sensitive local file write": ("destructive_shell", "local_secret_read"),
+    "destructive shell command": ("destructive_shell",),
+    "guard approval self-authorization command": ("policy_bypass",),
+    "github pr body shell substitution": ("execution",),
+}
+
+
+def _compatibility_rule(
+    *,
+    rule_id: str,
+    title: str,
+    description: str,
+    action_class: str,
+    safer_alternative: str,
+) -> CommandSafetyRule:
+    return CommandSafetyRule(
+        rule_id=rule_id,
+        title=title,
+        description=description,
+        severity="high",
+        risk_classes=COMMAND_ACTION_RISK_CLASSES[action_class.lower()],
+        action_classes=(action_class,),
+        safer_alternatives=(safer_alternative,),
+    )
+
+
+BUILT_IN_COMMAND_RULES = (
+    _compatibility_rule(
+        rule_id="command.container-runtime.docker-sensitive",
+        title="Sensitive container operation",
+        description="Identifies container operations that can expose credentials or mutate protected state.",
+        action_class="docker-sensitive command",
+        safer_alternative="Use a pinned image, minimal privileges, and a preview where the command supports one.",
+    ),
+    _compatibility_rule(
+        rule_id="command.container-runtime.docker-config-access",
+        title="Container credential access",
+        description="Identifies reads of local container client authentication configuration.",
+        action_class="Docker client config access",
+        safer_alternative="Pass only the specific credential material required by the operation.",
+    ),
+    _compatibility_rule(
+        rule_id="command.data-protection.credential-exfiltration",
+        title="Credential data transfer",
+        description="Identifies shell flows that can send credential material to a network destination.",
+        action_class="credential exfiltration shell command",
+        safer_alternative="Send an explicit non-secret value and review the exact destination and payload.",
+    ),
+    _compatibility_rule(
+        rule_id="command.data-protection.file-upload",
+        title="Local file upload",
+        description="Identifies shell upload flows that read local files or standard input.",
+        action_class="shell file upload command",
+        safer_alternative="Upload a reviewed non-secret artifact through an allowlisted destination.",
+    ),
+    _compatibility_rule(
+        rule_id="command.encoded-execution.decode-and-execute",
+        title="Encoded execution",
+        description="Identifies decode or decrypt chains that immediately execute their output.",
+        action_class="encoded or encrypted shell command",
+        safer_alternative="Decode to a file, inspect the result, then invoke the reviewed file directly.",
+    ),
+    _compatibility_rule(
+        rule_id="command.guard-self-protection.self-authorization",
+        title="Guard self-authorization",
+        description="Identifies commands that attempt to approve or weaken their own Guard decision.",
+        action_class="Guard approval self-authorization command",
+        safer_alternative="Approve the request through Guard's authenticated approval surface.",
+    ),
+    _compatibility_rule(
+        rule_id="command.kubernetes-secrets.secret-read",
+        title="Cluster secret read",
+        description="Identifies cluster CLI operations that can reveal Secret payloads.",
+        action_class="Kubernetes secret read command",
+        safer_alternative="Request non-secret metadata or only the specific field required.",
+    ),
+    _compatibility_rule(
+        rule_id="command.shell-mutations.destructive-shell",
+        title="Destructive shell mutation",
+        description="Identifies destructive shell, filesystem, and version-control mutations.",
+        action_class="destructive shell command",
+        safer_alternative="Use a dry run or narrow preview before applying the mutation.",
+    ),
+    _compatibility_rule(
+        rule_id="command.shell-mutations.managed-config-write",
+        title="Guard-managed configuration write",
+        description="Identifies direct writes to configuration managed by Guard.",
+        action_class="guard-managed config write",
+        safer_alternative="Use Guard's setup or repair command to update managed configuration.",
+    ),
+    _compatibility_rule(
+        rule_id="command.shell-mutations.sensitive-file-write",
+        title="Sensitive local file write",
+        description="Identifies writes that can replace or expose sensitive local state.",
+        action_class="sensitive local file write",
+        safer_alternative="Write to a scoped temporary path and review the final destination.",
+    ),
+    _compatibility_rule(
+        rule_id="command.shell-mutations.github-body-substitution",
+        title="Command substitution in remote body",
+        description="Identifies shell substitution used to construct a remote request body.",
+        action_class="GitHub PR body shell substitution",
+        safer_alternative="Use a literal body file whose contents can be reviewed before submission.",
+    ),
+)
+
+_RULES_BY_EXTENSION: dict[str, tuple[CommandSafetyRule, ...]] = {}
+for _rule_definition in BUILT_IN_COMMAND_RULES:
+    _extension_id, _separator, _rule_name = _rule_definition.rule_id.rpartition(".")
+    _RULES_BY_EXTENSION[_extension_id] = (*_RULES_BY_EXTENSION.get(_extension_id, ()), _rule_definition)
+
+
+def rules_for_extension(extension_id: str) -> tuple[CommandSafetyRule, ...]:
+    """Return deterministic built-in rules owned by one extension."""
+
+    return _RULES_BY_EXTENSION.get(extension_id, ())

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -6,32 +6,17 @@ import re
 from dataclasses import dataclass
 from typing import final
 
-COMMAND_EXTENSION_SCHEMA_VERSION = 1
-_VERSION_PATTERN = re.compile(r"^[1-9][0-9]*\.[0-9]+\.[0-9]+$")
+from .command_builtin_rules import COMMAND_ACTION_RISK_CLASSES, rules_for_extension
+from .command_rules import CommandSafetyRule
 
-_ACTION_RISK_CLASSES: dict[str, tuple[str, ...]] = {
-    "credential exfiltration shell command": (
-        "data_flow_exfiltration",
-        "credential_exfiltration",
-        "network_egress",
-    ),
-    "guard-managed config write": ("destructive_shell",),
-    "docker-sensitive command": ("network_egress", "destructive_shell"),
-    "docker client config access": ("local_secret_read",),
-    "encoded or encrypted shell command": ("encoded_execution",),
-    "kubernetes secret read command": ("local_secret_read",),
-    "shell file upload command": ("credential_exfiltration", "network_egress"),
-    "sensitive local file write": ("destructive_shell", "local_secret_read"),
-    "destructive shell command": ("destructive_shell",),
-    "guard approval self-authorization command": ("policy_bypass",),
-    "github pr body shell substitution": ("execution",),
-}
+COMMAND_EXTENSION_SCHEMA_VERSION = 2
+_VERSION_PATTERN = re.compile(r"^[1-9][0-9]*\.[0-9]+\.[0-9]+$")
 
 
 def risk_classes_for_command_action(action_class: str) -> tuple[str, ...]:
     """Return the existing runtime risk classes for a command action class."""
 
-    return _ACTION_RISK_CLASSES.get(action_class.strip().lower(), ())
+    return COMMAND_ACTION_RISK_CLASSES.get(action_class.strip().lower(), ())
 
 
 @dataclass(frozen=True, slots=True)
@@ -45,6 +30,7 @@ class CommandSafetyExtension:
     action_classes: tuple[str, ...]
     risk_classes: tuple[str, ...]
     safer_alternatives: tuple[str, ...]
+    rules: tuple[CommandSafetyRule, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -58,6 +44,8 @@ class CommandSafetyExtension:
             "action_classes": list(self.action_classes),
             "risk_classes": list(self.risk_classes),
             "safer_alternatives": list(self.safer_alternatives),
+            "rule_count": len(self.rules),
+            "rules": [rule.to_dict() for rule in self.rules],
         }
 
 
@@ -69,6 +57,8 @@ class CommandSafetyExtensionRegistry:
         ordered = tuple(sorted(extensions, key=lambda extension: extension.extension_id))
         by_id: dict[str, CommandSafetyExtension] = {}
         by_action_class: dict[str, CommandSafetyExtension] = {}
+        by_action_rule: dict[str, CommandSafetyRule] = {}
+        by_rule_id: dict[str, CommandSafetyRule] = {}
         for extension in ordered:
             _validate_extension(extension)
             if extension.extension_id in by_id:
@@ -93,9 +83,45 @@ class CommandSafetyExtensionRegistry:
                         )
                     )
                     raise ValueError(message)
+            for rule in extension.rules:
+                if not rule.rule_id.startswith(f"{extension.extension_id}."):
+                    raise ValueError(
+                        f"Command safety rule {rule.rule_id} must use extension prefix {extension.extension_id}"
+                    )
+                if rule.rule_id in by_rule_id:
+                    raise ValueError(f"Duplicate command safety rule ID: {rule.rule_id}")
+                undeclared_rule_risks = set(rule.risk_classes).difference(extension.risk_classes)
+                if undeclared_rule_risks:
+                    undeclared = ", ".join(sorted(undeclared_rule_risks))
+                    raise ValueError(
+                        f"Command safety rule {rule.rule_id} declares risks outside its extension: {undeclared}"
+                    )
+                by_rule_id[rule.rule_id] = rule
+                for action_class in rule.action_classes:
+                    normalized_action_class = action_class.strip().lower()
+                    if normalized_action_class not in {item.lower() for item in extension.action_classes}:
+                        raise ValueError(
+                            f"Command safety rule {rule.rule_id} owns undeclared action class {action_class!r}"
+                        )
+                    existing_rule = by_action_rule.get(normalized_action_class)
+                    if existing_rule is not None:
+                        ownership = " and ".join((existing_rule.rule_id, rule.rule_id))
+                        raise ValueError(f"Command action class {action_class!r} is owned by rules {ownership}")
+                    by_action_rule[normalized_action_class] = rule
+            if extension.rules:
+                rule_actions = {
+                    action_class.strip().lower() for rule in extension.rules for action_class in rule.action_classes
+                }
+                extension_actions = {action_class.strip().lower() for action_class in extension.action_classes}
+                if rule_actions != extension_actions:
+                    raise ValueError(
+                        f"Command safety extension {extension.extension_id} rules must own every action class"
+                    )
         self._extensions = ordered
         self._by_id = by_id
         self._by_action_class = by_action_class
+        self._by_action_rule = by_action_rule
+        self._by_rule_id = by_rule_id
 
     @property
     def extensions(self) -> tuple[CommandSafetyExtension, ...]:
@@ -106,6 +132,12 @@ class CommandSafetyExtensionRegistry:
 
     def for_action_class(self, action_class: str) -> CommandSafetyExtension | None:
         return self._by_action_class.get(action_class.strip().lower())
+
+    def get_rule(self, rule_id: str) -> CommandSafetyRule | None:
+        return self._by_rule_id.get(rule_id.strip().lower())
+
+    def rule_for_action_class(self, action_class: str) -> CommandSafetyRule | None:
+        return self._by_action_rule.get(action_class.strip().lower())
 
 
 def _validate_extension(extension: CommandSafetyExtension) -> None:
@@ -141,6 +173,7 @@ _BUILT_IN_EXTENSIONS = (
             "Use a pinned image and a read-only container filesystem where possible.",
             "Pass only the specific secret or file required by the container.",
         ),
+        rules=rules_for_extension("command.container-runtime"),
     ),
     CommandSafetyExtension(
         extension_id="command.data-protection",
@@ -153,6 +186,7 @@ _BUILT_IN_EXTENSIONS = (
             "Send an explicit non-secret value instead of piping local files or environment output.",
             "Use a destination allowlist and review the exact payload before transmission.",
         ),
+        rules=rules_for_extension("command.data-protection"),
     ),
     CommandSafetyExtension(
         extension_id="command.encoded-execution",
@@ -164,6 +198,7 @@ _BUILT_IN_EXTENSIONS = (
         action_classes=("encoded or encrypted shell command",),
         risk_classes=("encoded_execution",),
         safer_alternatives=("Decode the payload to a file, inspect it, then invoke the reviewed file directly.",),
+        rules=rules_for_extension("command.encoded-execution"),
     ),
     CommandSafetyExtension(
         extension_id="command.guard-self-protection",
@@ -173,6 +208,7 @@ _BUILT_IN_EXTENSIONS = (
         action_classes=("Guard approval self-authorization command",),
         risk_classes=("policy_bypass",),
         safer_alternatives=("Approve the pending request through Guard's authenticated approval surface.",),
+        rules=rules_for_extension("command.guard-self-protection"),
     ),
     CommandSafetyExtension(
         extension_id="command.kubernetes-secrets",
@@ -182,6 +218,7 @@ _BUILT_IN_EXTENSIONS = (
         action_classes=("Kubernetes secret read command",),
         risk_classes=("local_secret_read",),
         safer_alternatives=("Request only the required non-secret field or metadata instead of the Secret payload.",),
+        rules=rules_for_extension("command.kubernetes-secrets"),
     ),
     CommandSafetyExtension(
         extension_id="command.shell-mutations",
@@ -200,6 +237,7 @@ _BUILT_IN_EXTENSIONS = (
             "Narrow the target path or Git ref and avoid recursive or forced mutation.",
             "Use a literal body file instead of shell substitution in command arguments.",
         ),
+        rules=rules_for_extension("command.shell-mutations"),
     ),
 )
 

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -99,7 +99,7 @@ class CommandSafetyExtensionRegistry:
                 by_rule_id[rule.rule_id] = rule
                 for action_class in rule.action_classes:
                     normalized_action_class = action_class.strip().lower()
-                    if normalized_action_class not in {item.lower() for item in extension.action_classes}:
+                    if normalized_action_class not in {item.strip().lower() for item in extension.action_classes}:
                         raise ValueError(
                             f"Command safety rule {rule.rule_id} owns undeclared action class {action_class!r}"
                         )

--- a/src/codex_plugin_scanner/guard/runtime/command_inspection.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_inspection.py
@@ -113,6 +113,7 @@ def inspect_command(
             action_class=match.action_class,
             reason=match.reason,
             command=canonical_command,
+            matcher_evidence=rule.matcher.match(canonical_command) if rule.matcher is not None else (),
         )
         if rule is not None
         else None

--- a/src/codex_plugin_scanner/guard/runtime/command_inspection.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_inspection.py
@@ -10,6 +10,8 @@ from codex_plugin_scanner.guard.runtime.command_extensions import (
     COMMAND_EXTENSION_SCHEMA_VERSION,
     risk_classes_for_command_action,
 )
+from codex_plugin_scanner.guard.runtime.command_model import parse_shell_command
+from codex_plugin_scanner.guard.runtime.command_rules import CommandRuleMatch
 from codex_plugin_scanner.guard.runtime.secret_file_requests import (
     build_tool_action_request_artifact,
     extract_sensitive_tool_action_request,
@@ -30,14 +32,15 @@ def inspect_command(
         raise ValueError("Command text cannot be empty")
     workspace = (cwd or Path.cwd()).resolve()
     home = (home_dir or Path.home()).resolve()
+    canonical_command = parse_shell_command(command_text, cwd=workspace, home_dir=home)
     arguments = {"command": command_text}
     benign = is_explicitly_benign_tool_action_request("Shell", arguments, cwd=workspace, home_dir=home)
     match = extract_sensitive_tool_action_request("Shell", arguments, cwd=workspace, home_dir=home)
     trace: list[dict[str, object]] = [
         {
-            "step": "normalize",
-            "result": "completed",
-            "detail": "Applied Guard's transparent shell-wrapper normalization.",
+            "step": "canonical-parse",
+            "result": canonical_command.confidence,
+            "detail": "Built Guard's side-effect-free canonical command model.",
         },
         {
             "step": "benign-classification",
@@ -69,12 +72,15 @@ def inspect_command(
             "risk_classes": [],
             "signals": [],
             "extensions": [],
+            "rules": [],
+            "command_model": canonical_command.to_dict(),
             "trace": trace,
             "policy_evaluation": "not_run",
             "side_effects": "none",
         }
 
     extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.for_action_class(match.action_class)
+    rule = BUILT_IN_COMMAND_EXTENSION_REGISTRY.rule_for_action_class(match.action_class)
     artifact = build_tool_action_request_artifact(
         "guard-cli",
         match,
@@ -90,11 +96,26 @@ def inspect_command(
                 "detail": "Mapped the existing action class to a versioned command safety extension.",
             },
             {
+                "step": "rule-ownership",
+                "result": rule.rule_id if rule is not None else "unowned",
+                "detail": "Mapped the compatibility action class to a stable command safety rule.",
+            },
+            {
                 "step": "risk-signal-derivation",
                 "result": "completed",
                 "detail": f"Derived {len(signals)} existing Guard risk signal(s) from the classified artifact.",
             },
         )
+    )
+    rule_match = (
+        CommandRuleMatch(
+            rule=rule,
+            action_class=match.action_class,
+            reason=match.reason,
+            command=canonical_command,
+        )
+        if rule is not None
+        else None
     )
     return {
         "schema_version": COMMAND_EXTENSION_SCHEMA_VERSION,
@@ -111,6 +132,8 @@ def inspect_command(
         "risk_classes": list(risk_classes_for_command_action(match.action_class)),
         "signals": [signal.to_dict() for signal in signals],
         "extensions": [extension.to_dict()] if extension is not None else [],
+        "rules": [rule_match.to_dict()] if rule_match is not None else [],
+        "command_model": canonical_command.to_dict(),
         "trace": trace,
         "policy_evaluation": "not_run",
         "side_effects": "none",

--- a/src/codex_plugin_scanner/guard/runtime/command_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_model.py
@@ -1,0 +1,256 @@
+"""Canonical, side-effect-free command model shared by Guard extensions."""
+
+from __future__ import annotations
+
+import re
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Literal
+
+from .data_flow import extract_command_segments, extract_pipes
+from .shell_command_wrappers import (
+    SHELL_COMMAND_NORMALIZE_MAX_BYTES,
+    normalize_transparent_shell_command,
+)
+
+CommandDialect = Literal["posix", "powershell", "cmd", "argv", "unknown"]
+CommandTransport = Literal["shell_string", "argv", "embedded_script"]
+ParseConfidence = Literal["exact", "fallback", "uncertain"]
+
+MAX_COMMAND_BYTES = 32_768
+MAX_COMMAND_SEGMENTS = 128
+MAX_COMMAND_TOKENS = 2_048
+
+_ENV_ASSIGNMENT_PATTERN = re.compile(r"^(?P<name>[A-Za-z_][A-Za-z0-9_]*)=.*$", re.DOTALL)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSegment:
+    """One executable segment from a normalized command string."""
+
+    text: str
+    tokens: tuple[str, ...]
+    executable: str | None
+    arguments: tuple[str, ...]
+    environment_names: tuple[str, ...]
+    path_overridden: bool
+    pipeline_index: int
+    start: int
+    end: int
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "text": self.text,
+            "tokens": list(self.tokens),
+            "executable": self.executable,
+            "arguments": list(self.arguments),
+            "environment_names": list(self.environment_names),
+            "path_overridden": self.path_overridden,
+            "pipeline_index": self.pipeline_index,
+            "span": {"source": "normalized", "start": self.start, "end": self.end},
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CanonicalCommand:
+    """Normalized command representation that never executes shell input."""
+
+    raw_text: str
+    normalized_text: str
+    dialect: CommandDialect
+    transport: CommandTransport
+    extraction_provenance: str
+    wrapper_chain: tuple[str, ...]
+    segments: tuple[CommandSegment, ...]
+    confidence: ParseConfidence
+    uncertainty_reason: str | None = None
+
+    @property
+    def path_overridden(self) -> bool:
+        return any(segment.path_overridden for segment in self.segments)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "normalized_text": self.normalized_text,
+            "dialect": self.dialect,
+            "transport": self.transport,
+            "extraction_provenance": self.extraction_provenance,
+            "wrapper_chain": list(self.wrapper_chain),
+            "segments": [segment.to_dict() for segment in self.segments],
+            "confidence": self.confidence,
+            "uncertainty_reason": self.uncertainty_reason,
+            "path_overridden": self.path_overridden,
+        }
+
+
+def parse_shell_command(
+    command: str,
+    *,
+    cwd: Path | None = None,
+    home_dir: Path | None = None,
+    dialect: CommandDialect = "posix",
+    transport: CommandTransport = "shell_string",
+    extraction_provenance: str = "guard-shell",
+) -> CanonicalCommand:
+    """Parse one command without expansion, execution, or persistent state."""
+
+    raw_text = command.strip()
+    if not raw_text:
+        raise ValueError("Command text cannot be empty")
+    if dialect != "posix" or transport != "shell_string":
+        return CanonicalCommand(
+            raw_text=raw_text,
+            normalized_text=raw_text,
+            dialect=dialect,
+            transport=transport,
+            extraction_provenance=extraction_provenance,
+            wrapper_chain=(),
+            segments=(),
+            confidence="uncertain",
+            uncertainty_reason=f"unsupported_{dialect}_{transport}",
+        )
+    command_bytes = len(raw_text.encode("utf-8"))
+    if command_bytes > MAX_COMMAND_BYTES:
+        return CanonicalCommand(
+            raw_text=raw_text,
+            normalized_text=raw_text,
+            dialect=dialect,
+            transport=transport,
+            extraction_provenance=extraction_provenance,
+            wrapper_chain=(),
+            segments=(),
+            confidence="uncertain",
+            uncertainty_reason="command_byte_limit_exceeded",
+        )
+
+    normalization = normalize_transparent_shell_command(raw_text, cwd=cwd, home_dir=home_dir)
+    normalized_text = normalization.normalized_command
+    confidence: ParseConfidence = "exact"
+    uncertainty_reason: str | None = None
+    if command_bytes > SHELL_COMMAND_NORMALIZE_MAX_BYTES:
+        confidence = "uncertain"
+        uncertainty_reason = "wrapper_normalization_limit_exceeded"
+
+    segment_texts = _execution_segment_texts(normalized_text)
+    if len(segment_texts) > MAX_COMMAND_SEGMENTS:
+        return CanonicalCommand(
+            raw_text=raw_text,
+            normalized_text=normalized_text,
+            dialect=dialect,
+            transport=transport,
+            extraction_provenance=extraction_provenance,
+            wrapper_chain=normalization.wrapper_chain,
+            segments=(),
+            confidence="uncertain",
+            uncertainty_reason="command_segment_limit_exceeded",
+        )
+
+    segments: list[CommandSegment] = []
+    cursor = 0
+    total_tokens = 0
+    for pipeline_index, segment_text in segment_texts:
+        tokens, exact = _shell_tokens(segment_text)
+        total_tokens += len(tokens)
+        if total_tokens > MAX_COMMAND_TOKENS:
+            return CanonicalCommand(
+                raw_text=raw_text,
+                normalized_text=normalized_text,
+                dialect=dialect,
+                transport=transport,
+                extraction_provenance=extraction_provenance,
+                wrapper_chain=normalization.wrapper_chain,
+                segments=tuple(segments),
+                confidence="uncertain",
+                uncertainty_reason="command_token_limit_exceeded",
+            )
+        if not exact and confidence == "exact":
+            confidence = "fallback"
+            uncertainty_reason = "malformed_shell_quoting"
+        environment_names, executable_index = _leading_environment(tokens)
+        executable = tokens[executable_index] if executable_index < len(tokens) else None
+        arguments = tokens[executable_index + 1 :] if executable is not None else ()
+        start = normalized_text.find(segment_text, cursor)
+        if start < 0:
+            start = normalized_text.find(segment_text)
+        if start < 0:
+            start = cursor
+        end = start + len(segment_text)
+        cursor = end
+        segments.append(
+            CommandSegment(
+                text=segment_text,
+                tokens=tokens,
+                executable=executable,
+                arguments=arguments,
+                environment_names=environment_names,
+                path_overridden="PATH" in environment_names,
+                pipeline_index=pipeline_index,
+                start=start,
+                end=end,
+            )
+        )
+
+    return CanonicalCommand(
+        raw_text=raw_text,
+        normalized_text=normalized_text,
+        dialect=dialect,
+        transport=transport,
+        extraction_provenance=extraction_provenance,
+        wrapper_chain=normalization.wrapper_chain,
+        segments=tuple(segments),
+        confidence=confidence,
+        uncertainty_reason=uncertainty_reason,
+    )
+
+
+def _execution_segment_texts(command: str) -> tuple[tuple[int, str], ...]:
+    segments: list[tuple[int, str]] = []
+    for command_segment in extract_command_segments(command):
+        pipes = extract_pipes(command_segment)
+        if not pipes:
+            stripped = command_segment.strip()
+            if stripped:
+                segments.append((0, stripped))
+            continue
+        pipe_parts = [pipes[0].left, *(pipe.right for pipe in pipes)]
+        segments.extend((index, part) for index, part in enumerate(pipe_parts) if part)
+    return tuple(segments)
+
+
+def _shell_tokens(command: str) -> tuple[tuple[str, ...], bool]:
+    try:
+        return tuple(shlex.split(command, posix=True, comments=False)), True
+    except ValueError:
+        return tuple(command.split()), False
+
+
+def _leading_environment(tokens: tuple[str, ...]) -> tuple[tuple[str, ...], int]:
+    names: list[str] = []
+    index = 0
+    while index < len(tokens):
+        match = _ENV_ASSIGNMENT_PATTERN.fullmatch(tokens[index])
+        if match is None:
+            break
+        names.append(match.group("name"))
+        index += 1
+    if index >= len(tokens) or tokens[index].rsplit("/", 1)[-1].lower() != "env":
+        return tuple(names), index
+    index += 1
+    while index < len(tokens):
+        token = tokens[index]
+        if token == "--":
+            index += 1
+            break
+        if token in {"-u", "-C", "--unset", "--chdir"}:
+            index = min(index + 2, len(tokens))
+            continue
+        if token in {"-i", "-0", "--ignore-environment", "--null"} or token.startswith(("--unset=", "--chdir=")):
+            index += 1
+            continue
+        match = _ENV_ASSIGNMENT_PATTERN.fullmatch(token)
+        if match is None:
+            break
+        names.append(match.group("name"))
+        index += 1
+    return tuple(names), index

--- a/src/codex_plugin_scanner/guard/runtime/command_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_model.py
@@ -110,6 +110,18 @@ def parse_shell_command(
             confidence="uncertain",
             uncertainty_reason=f"unsupported_{dialect}_{transport}",
         )
+    if len(raw_text) > MAX_COMMAND_BYTES:
+        return CanonicalCommand(
+            raw_text=raw_text,
+            normalized_text=raw_text,
+            dialect=dialect,
+            transport=transport,
+            extraction_provenance=extraction_provenance,
+            wrapper_chain=(),
+            segments=(),
+            confidence="uncertain",
+            uncertainty_reason="command_byte_limit_exceeded",
+        )
     command_bytes = len(raw_text.encode("utf-8"))
     if command_bytes > MAX_COMMAND_BYTES:
         return CanonicalCommand(
@@ -174,8 +186,8 @@ def parse_shell_command(
         if start < 0:
             start = normalized_text.find(segment_text)
         if start < 0:
-            start = cursor
-        end = start + len(segment_text)
+            start = min(cursor, len(normalized_text))
+        end = min(start + len(segment_text), len(normalized_text))
         cursor = end
         segments.append(
             CommandSegment(
@@ -214,7 +226,7 @@ def _execution_segment_texts(command: str) -> tuple[tuple[int, str], ...]:
                 segments.append((0, stripped))
             continue
         pipe_parts = [pipes[0].left, *(pipe.right for pipe in pipes)]
-        segments.extend((index, part) for index, part in enumerate(pipe_parts) if part)
+        segments.extend((index, part.strip()) for index, part in enumerate(pipe_parts) if part.strip())
     return tuple(segments)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -68,8 +68,8 @@ class ExecutableMatcher:
             lowered_arguments = tuple(argument.lower() for argument in segment.arguments)
             if self.subcommands and lowered_arguments[: len(self.subcommands)] != self.subcommands:
                 continue
-            argument_set = frozenset(lowered_arguments)
-            if not self.required_flags <= argument_set or self.forbidden_flags & argument_set:
+            present_flags = _present_flags(lowered_arguments)
+            if not self.required_flags <= present_flags or self.forbidden_flags & present_flags:
                 continue
             evidence.append(
                 MatcherEvidence(
@@ -191,5 +191,14 @@ class CommandRuleMatch:
 def _segment_matches_executable(segment: CommandSegment, executables: frozenset[str]) -> bool:
     if segment.executable is None:
         return False
-    executable = segment.executable.rsplit("/", 1)[-1].lower()
+    executable = segment.executable.replace("\\", "/").rsplit("/", 1)[-1].lower()
     return executable in executables
+
+
+def _present_flags(arguments: tuple[str, ...]) -> frozenset[str]:
+    flags: set[str] = set()
+    for argument in arguments:
+        flags.add(argument)
+        if argument.startswith("-") and "=" in argument:
+            flags.add(argument.split("=", 1)[0])
+    return frozenset(flags)

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -1,0 +1,195 @@
+"""Reusable command rule and matcher contracts for Guard extensions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Literal, Protocol, final
+
+from .command_model import CanonicalCommand, CommandSegment
+
+CommandRuleSeverity = Literal["critical", "high", "medium", "low"]
+CommandRuleMode = Literal["required", "enforce", "review", "monitor", "disabled"]
+
+_VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
+_VALID_MODES = frozenset({"required", "enforce", "review", "monitor", "disabled"})
+
+
+@dataclass(frozen=True, slots=True)
+class MatcherEvidence:
+    """Redaction-safe location emitted by one structured matcher."""
+
+    segment_index: int
+    executable: str | None
+    detail: str
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "segment_index": self.segment_index,
+            "executable": self.executable,
+            "detail": self.detail,
+        }
+
+
+class CommandMatcher(Protocol):
+    """Side-effect-free structured command matcher."""
+
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]: ...
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class ExecutableMatcher:
+    """Match executable names with optional subcommand and flag constraints."""
+
+    executables: frozenset[str]
+    subcommands: tuple[str, ...] = ()
+    required_flags: frozenset[str] = frozenset()
+    forbidden_flags: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        normalized = frozenset(value.strip().lower() for value in self.executables if value.strip())
+        if not normalized:
+            raise ValueError("ExecutableMatcher requires at least one executable")
+        object.__setattr__(self, "executables", normalized)
+        normalized_subcommands = tuple(value.strip().lower() for value in self.subcommands if value.strip())
+        normalized_required_flags = frozenset(value.strip().lower() for value in self.required_flags if value.strip())
+        normalized_forbidden_flags = frozenset(value.strip().lower() for value in self.forbidden_flags if value.strip())
+        object.__setattr__(self, "subcommands", normalized_subcommands)
+        object.__setattr__(self, "required_flags", normalized_required_flags)
+        object.__setattr__(self, "forbidden_flags", normalized_forbidden_flags)
+        if normalized_required_flags & normalized_forbidden_flags:
+            raise ValueError("A matcher flag cannot be both required and forbidden")
+
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        evidence: list[MatcherEvidence] = []
+        for index, segment in enumerate(command.segments):
+            if not _segment_matches_executable(segment, self.executables):
+                continue
+            lowered_arguments = tuple(argument.lower() for argument in segment.arguments)
+            if self.subcommands and lowered_arguments[: len(self.subcommands)] != self.subcommands:
+                continue
+            argument_set = frozenset(lowered_arguments)
+            if not self.required_flags <= argument_set or self.forbidden_flags & argument_set:
+                continue
+            evidence.append(
+                MatcherEvidence(
+                    segment_index=index,
+                    executable=segment.executable,
+                    detail="Matched executable and structured argument constraints.",
+                )
+            )
+        return tuple(evidence)
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class AnyMatcher:
+    """Match when any child matcher emits evidence."""
+
+    matchers: tuple[CommandMatcher, ...]
+
+    def __post_init__(self) -> None:
+        if not self.matchers:
+            raise ValueError("AnyMatcher requires at least one child matcher")
+
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        evidence: list[MatcherEvidence] = []
+        for matcher in self.matchers:
+            evidence.extend(matcher.match(command))
+        return tuple(evidence)
+
+
+@final
+@dataclass(frozen=True, slots=True)
+class AllMatcher:
+    """Match only when every child matcher emits evidence."""
+
+    matchers: tuple[CommandMatcher, ...]
+
+    def __post_init__(self) -> None:
+        if not self.matchers:
+            raise ValueError("AllMatcher requires at least one child matcher")
+
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        evidence: list[MatcherEvidence] = []
+        for matcher in self.matchers:
+            child_evidence = matcher.match(command)
+            if not child_evidence:
+                return ()
+            evidence.extend(child_evidence)
+        return tuple(evidence)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandSafetyRule:
+    """Stable rule metadata owned by one command safety extension."""
+
+    rule_id: str
+    title: str
+    description: str
+    severity: CommandRuleSeverity
+    risk_classes: tuple[str, ...]
+    action_classes: tuple[str, ...]
+    safer_alternatives: tuple[str, ...]
+    default_mode: CommandRuleMode = "review"
+    matcher: CommandMatcher | None = None
+
+    def __post_init__(self) -> None:
+        if not self.rule_id.startswith("command.") or self.rule_id != self.rule_id.lower():
+            raise ValueError("Command safety rule IDs must be lowercase and start with 'command.'")
+        if not self.title.strip() or not self.description.strip():
+            raise ValueError(f"Command safety rule {self.rule_id} requires a title and description")
+        if self.severity not in _VALID_SEVERITIES:
+            raise ValueError(f"Command safety rule {self.rule_id} has invalid severity")
+        if self.default_mode not in _VALID_MODES:
+            raise ValueError(f"Command safety rule {self.rule_id} has invalid default mode")
+        for field_name, values in (
+            ("risk classes", self.risk_classes),
+            ("action classes", self.action_classes),
+            ("safer alternatives", self.safer_alternatives),
+        ):
+            if not values or len(set(values)) != len(values):
+                raise ValueError(f"Command safety rule {self.rule_id} requires unique {field_name}")
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "rule_id": self.rule_id,
+            "title": self.title,
+            "description": self.description,
+            "severity": self.severity,
+            "risk_classes": list(self.risk_classes),
+            "action_classes": list(self.action_classes),
+            "safer_alternatives": list(self.safer_alternatives),
+            "default_mode": self.default_mode,
+            "matcher_kind": type(self.matcher).__name__ if self.matcher is not None else "compatibility",
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CommandRuleMatch:
+    """Rule-level evidence emitted without making a policy decision."""
+
+    rule: CommandSafetyRule
+    action_class: str
+    reason: str
+    command: CanonicalCommand
+    matcher_evidence: tuple[MatcherEvidence, ...] = ()
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "rule_id": self.rule.rule_id,
+            "severity": self.rule.severity,
+            "risk_classes": list(self.rule.risk_classes),
+            "action_class": self.action_class,
+            "reason": self.reason,
+            "safer_alternatives": list(self.rule.safer_alternatives),
+            "matcher_evidence": [item.to_dict() for item in self.matcher_evidence],
+            "parse_confidence": self.command.confidence,
+        }
+
+
+def _segment_matches_executable(segment: CommandSegment, executables: frozenset[str]) -> bool:
+    if segment.executable is None:
+        return False
+    executable = segment.executable.rsplit("/", 1)[-1].lower()
+    return executable in executables

--- a/src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py
+++ b/src/codex_plugin_scanner/guard/runtime/shell_command_wrappers.py
@@ -7,7 +7,7 @@ import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
-_MAX_NORMALIZE_BYTES = 8192
+SHELL_COMMAND_NORMALIZE_MAX_BYTES = 8192
 _ENV_ASSIGNMENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=.*$")
 _SHELL_CONTROL_TOKENS = frozenset({"&&", "||", ";", "|", "|&", "&"})
 _LEAN_CTX_BINARIES = frozenset({"lean-ctx"})
@@ -34,7 +34,7 @@ def normalize_transparent_shell_command(
     home_dir: Path | None = None,
 ) -> ShellCommandNormalization:
     stripped = command_text.strip()
-    if not stripped or len(stripped) > _MAX_NORMALIZE_BYTES:
+    if not stripped or len(stripped) > SHELL_COMMAND_NORMALIZE_MAX_BYTES:
         return ShellCommandNormalization(
             raw_command=stripped,
             normalized_command=stripped,

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -54,6 +54,8 @@ def test_command_inspection_maps_existing_sensitive_actions_to_extensions(
     assert payload["status"] == "review"
     assert payload["classification"]["action_class"] == action_class
     assert payload["extensions"][0]["extension_id"] == extension_id
+    assert payload["rules"][0]["rule_id"].startswith(f"{extension_id}.")
+    assert payload["command_model"]["transport"] == "shell_string"
     assert payload["policy_evaluation"] == "not_run"
     assert payload["side_effects"] == "none"
 
@@ -74,6 +76,7 @@ def test_command_inspection_preserves_existing_safe_command_classification(comma
     assert payload["status"] == "no_match"
     assert payload["classification"]["matched"] is False
     assert payload["extensions"] == []
+    assert payload["rules"] == []
 
 
 def test_command_extension_registry_is_deterministic_and_complete() -> None:
@@ -84,6 +87,8 @@ def test_command_extension_registry_is_deterministic_and_complete() -> None:
     assert payload["count"] == len(BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions)
     assert "command.shell-mutations" in ids
     assert BUILT_IN_COMMAND_EXTENSION_REGISTRY.for_action_class("destructive shell command") is not None
+    assert BUILT_IN_COMMAND_EXTENSION_REGISTRY.rule_for_action_class("destructive shell command") is not None
+    assert sum(extension["rule_count"] for extension in payload["extensions"]) == 11
 
 
 def test_command_extension_registry_rejects_duplicate_action_ownership() -> None:
@@ -137,6 +142,7 @@ def test_command_cli_emits_stable_json_without_creating_guard_state(
     assert payload["mode"] == "explain"
     assert payload["status"] == "review"
     assert payload["extensions"][0]["extension_id"] == "command.shell-mutations"
+    assert payload["rules"][0]["rule_id"] == "command.shell-mutations.destructive-shell"
     assert [item["step"] for item in payload["trace"]][-1] == "risk-signal-derivation"
     assert list(tmp_path.iterdir()) == []
 

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -45,10 +45,13 @@ def test_parse_shell_command_marks_malformed_and_unsupported_input() -> None:
 
 def test_parse_shell_command_marks_over_limit_input_uncertain() -> None:
     parsed = parse_shell_command("x" * (MAX_COMMAND_BYTES + 1))
+    multibyte = parse_shell_command("é" * ((MAX_COMMAND_BYTES // 2) + 1))
 
     assert parsed.confidence == "uncertain"
     assert parsed.uncertainty_reason == "command_byte_limit_exceeded"
     assert parsed.segments == ()
+    assert multibyte.confidence == "uncertain"
+    assert multibyte.uncertainty_reason == "command_byte_limit_exceeded"
 
 
 def test_executable_matcher_uses_structured_subcommands_and_flags() -> None:
@@ -64,6 +67,23 @@ def test_executable_matcher_uses_structured_subcommands_and_flags() -> None:
     assert len(evidence) == 1
     assert evidence[0].segment_index == 0
     assert evidence[0].executable == "docker"
+
+
+def test_executable_matcher_normalizes_flag_value_and_windows_path_forms() -> None:
+    parsed = parse_shell_command("'C:\\tools\\docker.exe' system prune --force=true")
+    matcher = ExecutableMatcher(
+        executables=frozenset({"docker.exe"}),
+        subcommands=("system", "prune"),
+        required_flags=frozenset({"--force"}),
+    )
+
+    assert matcher.match(parsed)
+
+
+def test_parse_shell_command_preserves_literal_hash_arguments() -> None:
+    parsed = parse_shell_command("printf '%s' value#fragment")
+
+    assert parsed.segments[0].arguments == ("%s", "value#fragment")
 
 
 def test_composite_matchers_have_explicit_any_and_all_semantics() -> None:

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from codex_plugin_scanner.guard.runtime.command_model import MAX_COMMAND_BYTES, parse_shell_command
+from codex_plugin_scanner.guard.runtime.command_rules import AllMatcher, AnyMatcher, ExecutableMatcher
+
+
+def test_parse_shell_command_preserves_compound_suffix_and_path_override() -> None:
+    parsed = parse_shell_command("PATH=/usr/bin:/bin npx vitest run && git reset --hard HEAD~1")
+
+    assert [segment.executable for segment in parsed.segments] == ["npx", "git"]
+    assert parsed.segments[0].environment_names == ("PATH",)
+    assert parsed.path_overridden is True
+    assert parsed.segments[1].arguments == ("reset", "--hard", "HEAD~1")
+    assert parsed.confidence == "exact"
+
+
+def test_parse_shell_command_tracks_env_wrapper_path_override() -> None:
+    parsed = parse_shell_command("env -i PATH=/usr/bin:/bin npx vitest run")
+
+    assert parsed.segments[0].executable == "npx"
+    assert parsed.segments[0].environment_names == ("PATH",)
+    assert parsed.path_overridden is True
+
+
+def test_parse_shell_command_normalizes_transparent_wrapper_once() -> None:
+    parsed = parse_shell_command("bash -lc 'git clean -fdx'")
+
+    assert parsed.normalized_text == "git clean -fdx"
+    assert parsed.wrapper_chain == ("bash",)
+    assert parsed.segments[0].executable == "git"
+    assert parsed.segments[0].start == 0
+    assert parsed.segments[0].end == len(parsed.normalized_text)
+
+
+def test_parse_shell_command_marks_malformed_and_unsupported_input() -> None:
+    malformed = parse_shell_command("git reset --hard 'unterminated")
+    unsupported = parse_shell_command("Remove-Item -Force file.txt", dialect="powershell")
+
+    assert malformed.confidence == "fallback"
+    assert malformed.uncertainty_reason == "malformed_shell_quoting"
+    assert unsupported.confidence == "uncertain"
+    assert unsupported.uncertainty_reason == "unsupported_powershell_shell_string"
+    assert unsupported.segments == ()
+
+
+def test_parse_shell_command_marks_over_limit_input_uncertain() -> None:
+    parsed = parse_shell_command("x" * (MAX_COMMAND_BYTES + 1))
+
+    assert parsed.confidence == "uncertain"
+    assert parsed.uncertainty_reason == "command_byte_limit_exceeded"
+    assert parsed.segments == ()
+
+
+def test_executable_matcher_uses_structured_subcommands_and_flags() -> None:
+    parsed = parse_shell_command("docker system prune --force && git status")
+    matcher = ExecutableMatcher(
+        executables=frozenset({"docker"}),
+        subcommands=("system", "prune"),
+        required_flags=frozenset({"--force"}),
+    )
+
+    evidence = matcher.match(parsed)
+
+    assert len(evidence) == 1
+    assert evidence[0].segment_index == 0
+    assert evidence[0].executable == "docker"
+
+
+def test_composite_matchers_have_explicit_any_and_all_semantics() -> None:
+    parsed = parse_shell_command("docker system prune --force")
+    docker = ExecutableMatcher(executables=frozenset({"docker"}))
+    force = ExecutableMatcher(executables=frozenset({"docker"}), required_flags=frozenset({"--force"}))
+    git = ExecutableMatcher(executables=frozenset({"git"}))
+
+    assert AnyMatcher((git, docker)).match(parsed)
+    assert AllMatcher((docker, force)).match(parsed)
+    assert AllMatcher((docker, git)).match(parsed) == ()


### PR DESCRIPTION
## Summary
- add a canonical side-effect-free command model with explicit provenance, wrapper, pipeline, environment-override, and parse-confidence metadata
- add reusable structured matcher contracts and stable rule IDs for existing command safety extensions
- expose rule-level inspection output and document policy, memory, redaction, and rollout boundaries

## Testing
- `python -m pytest tests/test_guard_command_model.py tests/test_guard_command_extensions.py tests/test_guard_risk.py tests/test_guard_cli_commands_facade.py tests/test_guard_commands_router.py tests/test_command_keys_and_uri_schemes.py tests/test_guard_shell_command_wrappers.py -q --tb=short`
- `python -m pytest tests/test_guard_runtime_actions.py tests/test_guard_runtime_action_harnesses.py tests/test_guard_data_flow.py tests/test_guard_source_search_redaction.py -q --tb=short`
- `python -m ruff check <changed-python-files>`
- `basedpyright <changed-runtime-modules>`
- `uv build`
