### PR TITLE
feat(guard): add enterprise MDM deployment support

### DIFF
--- a/.github/workflows/mdm-artifacts.yml
+++ b/.github/workflows/mdm-artifacts.yml
@@ -1,0 +1,72 @@
+name: MDM artifacts
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_id:
+        description: Immutable release build identifier
+        required: true
+
+permissions:
+  contents: read
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-14, macos-15, windows-2022, windows-2025]
+        python: ['3.12']
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --frozen --extra dev --python ${{ matrix.python }}
+      - run: uv run --no-sync pytest tests/test_guard_mdm_*.py --tb=short
+      - run: uv run --no-sync basedpyright --level error
+      - run: uv run --no-sync ruff check src/ tests/test_guard_mdm_*.py scripts/mdm/generate-release-manifest.py
+
+  unsigned-artifact:
+    needs: tests
+    strategy:
+      matrix:
+        include:
+          - os: macos-14
+            platform: macos
+          - os: windows-2022
+            platform: windows
+    runs-on: ${{ matrix.os }}
+    env:
+      HOL_GUARD_BUILD_ID: ${{ inputs.build_id }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v6
+      - run: uv sync --frozen --extra mdm-build --python 3.12
+      - shell: bash
+        run: echo "HOL_GUARD_VERSION=$(uv run python -c 'from codex_plugin_scanner.version import __version__; print(__version__)')" >> "$GITHUB_ENV"
+      - if: matrix.platform == 'macos'
+        run: scripts/mdm/macos/build-pkg.sh
+      - if: matrix.platform == 'macos'
+        shell: bash
+        run: |
+          binary="dist/mdm/macos/stage/Library/Application Support/HOL Guard/hol-guard/hol-guard"
+          "$binary" --version
+          if "$binary" mdm status --scope machine --machine-root "dist/mdm/macos/stage/Library/Application Support/HOL Guard" --json; then exit 1; fi
+      - if: matrix.platform == 'windows'
+        shell: pwsh
+        run: dotnet tool install --global wix --version 6.0.2
+      - if: matrix.platform == 'windows'
+        shell: pwsh
+        run: scripts/mdm/windows/build-msi.ps1
+      - if: matrix.platform == 'windows'
+        shell: pwsh
+        run: |
+          $binary = 'dist/mdm/windows/runtime/hol-guard/hol-guard.exe'
+          & $binary --version
+          & $binary mdm status --scope machine --machine-root 'dist/mdm/windows/runtime' --json
+          if ($LASTEXITCODE -eq 0) { throw 'Unsigned fixture must not report healthy.' }
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hol-guard-${{ matrix.platform }}-unsigned-${{ inputs.build_id }}
+          path: dist/mdm/${{ matrix.platform }}/
+          if-no-files-found: error

--- a/docs/guard/adr/0001-mdm-managed-install-contract.md
+++ b/docs/guard/adr/0001-mdm-managed-install-contract.md
@@ -1,0 +1,20 @@
+# ADR 0001: MDM managed-install contract
+
+Status: accepted for implementation; customer platform inputs remain release gates.
+
+## Decision
+
+- Package ownership is per-machine. macOS uses receipt `org.hol.guard`; Windows uses per-machine MSI upgrade code `B15D39B1-6395-4FEA-98A9-5D734DDC455D`.
+- Machine runtime/state/log paths are `/Library/Application Support/HOL Guard`, `/Library/Application Support/HOL Guard State`, `/Library/Logs/HOL Guard` and `%ProgramFiles%\HOL Guard`, `%ProgramData%\HOL Guard`.
+- User state remains `~/.hol-guard`. Mutating lifecycle commands require the target user session; root/SYSTEM cannot substitute its profile.
+- macOS uses a LaunchAgent. Windows uses Active Setup. Both call idempotent repair at user login; runtime daemons remain on-demand by default.
+- Managed policy comes only from `org.hol.guard` managed preferences or `HKLM\Software\Policies\HOL\Guard`. Machine policy wins non-action conflicts. Security actions and modes compose to the strongest outcome; local sources may tighten locks.
+- MDM owns version changes when `update.owner=mdm`. Downgrades and self-removal fail closed. Evidence is preserved by default.
+- External HTTP uses one mandatory-TLS policy supporting system, explicit, or no proxy; private CA trust is additive. Public registry intelligence can be disabled independently from Guard Cloud.
+- Production packages require both a signed Ed25519 release manifest and native platform signatures. Unsigned artifacts are CI fixtures and must fail healthy detection.
+
+## Consequences
+
+The package never guesses a user from root/SYSTEM. A device install can succeed with no logged-in user, and each eligible user converges at login without reinstalling. Customer MDM assignment details, minimum OS/CPU scope, publisher identities, signing credentials, and Cloud enrollment remain certification inputs and cannot be inferred in code.
+
+This decision implements the threat boundaries and acceptance criteria in [the MDM PRD](../mdm-compatibility-prd.md), with schemas under [`schemas/`](../schemas/), deployment operations in [mdm-deployment.md](../mdm-deployment.md), and network controls in [mdm-networking.md](../mdm-networking.md).

--- a/docs/guard/enterprise-packet.md
+++ b/docs/guard/enterprise-packet.md
@@ -14,6 +14,11 @@ Related docs:
 - [Harness support matrix](./harness-support.md)
 - [Enterprise event taxonomy](./enterprise-event-taxonomy.md)
 - [Enterprise export examples](./enterprise-export-examples.md)
+- [MDM compatibility PRD](./mdm-compatibility-prd.md)
+- [MDM compatibility implementation TODO](./mdm-compatibility-todo.md)
+- [MDM deployment and Intune contract](./mdm-deployment.md)
+- [MDM proxy, private CA, and endpoint contract](./mdm-networking.md)
+- [MDM release evidence template](./mdm-release-evidence-template.md)
 
 ## Control maps
 

--- a/docs/guard/mdm-compatibility-prd.md
+++ b/docs/guard/mdm-compatibility-prd.md
@@ -10,6 +10,7 @@
 - **Security reviewer:** TBD
 - **Audience:** Guard engineering, release engineering, security, IT administrators, and customer success
 - **Implementation tracker:** [MDM compatibility TODO](./mdm-compatibility-todo.md)
+- **General availability plan:** [MDM general availability roadmap](./mdm-general-availability-roadmap.md)
 - **Last updated:** July 15, 2026
 
 ## Summary
@@ -47,7 +48,7 @@ The current installation contract has five production blockers:
 - Adding kernel extensions, system extensions, packet filters, or broad Full Disk Access without a demonstrated requirement.
 - Automatically interpreting arbitrary proxy PAC files in the first MDM release. Static system and explicit HTTPS proxy configurations are required.
 - Supporting mobile operating systems.
-- Supporting architectures the launch customer does not use. The certified architecture set must be recorded before release.
+- Claiming support for architectures outside the published certification matrix.
 
 ## Personas
 
@@ -302,7 +303,7 @@ All Guard HTTP clients, including `requests`, `urllib`, update checks, Cloud syn
 ### Certification
 
 - CI covers the approved macOS and Windows architecture/OS matrix with standard-user and administrator contexts.
-- A real MDM validates install, detection, remediation, update, rollback, and removal on each customer platform.
+- The conformance lab validates install, detection, remediation, update, rollback, and removal across the published MDM/platform matrix.
 - Pilot telemetry meets the agreed deployment and activation success thresholds with no policy weakening or cross-user data exposure.
 
 ## Success metrics
@@ -316,13 +317,13 @@ All Guard HTTP clients, including `requests`, `urllib`, update checks, Cloud syn
 
 ## Rollout gates
 
-1. **Contract gate:** approve paths, identities, schemas, precedence, authorization, exit codes, supported OS/architectures, and customer MDM.
+1. **Contract gate:** approve paths, identities, schemas, precedence, authorization, exit codes, and the supported OS/architecture matrix.
 2. **Packaging gate:** signed offline artifacts install, upgrade, repair, and uninstall on clean VMs.
 3. **Managed-policy gate:** monotonic precedence, locks, tamper detection, and update/uninstall ownership pass adversarial tests.
 4. **User-activation gate:** multi-user, no-user-at-install, late-user, late-harness, and interrupted activation tests pass.
 5. **Network gate:** direct, system proxy, explicit proxy, private CA, blocked registry, and offline scenarios pass.
 6. **MDM lab gate:** real vendor deployment passes detection, remediation, update, rollback, and removal.
-7. **Pilot gate:** phased customer rollout shows healthy activation and no security or support stop condition.
+7. **Pilot gate:** phased multi-organization rollout shows healthy activation and no security or support stop condition.
 
 Stop rollout on signature or notarization failure, policy weakening, wrong-user ownership, cross-user data exposure, false healthy detection, unrecoverable upgrade, TLS verification bypass, or unmanaged removal.
 
@@ -340,13 +341,13 @@ Stop rollout on signature or notarization failure, policy weakening, wrong-user 
 
 Implementation defaults are frozen in [ADR 0001](./adr/0001-mdm-managed-install-contract.md): stable paths and identifiers, machine precedence for non-action conflicts, on-demand daemons, strongest-action composition, MDM-owned updates, downgrade/removal fail-closed behavior, and evidence preservation by default.
 
-The remaining items are launch-customer certification inputs rather than code decisions:
+The remaining items are release and organization onboarding inputs rather than code decisions. Organization-specific values must be supplied through signed policy, deployment profiles, or administrator configuration; they must never require a custom Guard build:
 
-- Customer MDM vendor and whether macOS, Windows, or both are in the first rollout.
+- MDM vendor and whether macOS, Windows, or both are in an organization's rollout.
 - Required macOS CPU architectures and minimum macOS version.
 - Required Windows CPU architectures, editions, and minimum Windows version.
 - Final Apple team identity and Windows Authenticode publisher identity.
-- Whether zero-touch Guard Cloud workspace enrollment is required for the first customer or remains a separate user/admin step.
+- Whether zero-touch Guard Cloud workspace enrollment is enabled or remains a separate user/admin step.
 - Required deployment and activation success thresholds if the defaults in this PRD are not accepted.
 
 ## Required deliverables

--- a/docs/guard/mdm-compatibility-prd.md
+++ b/docs/guard/mdm-compatibility-prd.md
@@ -1,0 +1,371 @@
+# HOL Guard MDM Compatibility PRD
+
+## Document control
+
+- **Status:** Proposed
+- **Priority:** P0 enterprise readiness
+- **Platforms:** macOS and Windows
+- **Product owner:** TBD
+- **Engineering owner:** TBD
+- **Security reviewer:** TBD
+- **Audience:** Guard engineering, release engineering, security, IT administrators, and customer success
+- **Implementation tracker:** [MDM compatibility TODO](./mdm-compatibility-todo.md)
+- **Last updated:** July 15, 2026
+
+## Summary
+
+HOL Guard is currently installable through PyPI and `pipx`, stores runtime state per user, and exposes useful noninteractive and JSON commands. That is sufficient for a controlled script-based pilot, but it does not provide the signed artifacts, deployment-context contract, managed policy authority, lifecycle reporting, or enterprise network controls expected from an MDM-managed security product.
+
+This PRD defines the P0 work required to make HOL Guard deployable, observable, repairable, updateable, and removable through enterprise MDM on macOS and Windows. The design separates the machine-owned product runtime from per-user harness activation so device-context installation never writes root- or SYSTEM-owned files into a developer's home directory.
+
+## Problem
+
+The current installation contract has five production blockers:
+
+1. The release is a Python wheel that requires a compatible Python runtime and package installer. There is no signed macOS installer package or signed Windows installer payload.
+2. Guard state, shims, and harness configuration live under each user's home directory. MDM commonly installs in root or SYSTEM context, which would target the wrong home and ownership.
+3. Local configuration, updates, harness disconnection, and self-uninstall remain under user control. There is no machine-managed policy source whose locked values cannot be weakened locally.
+4. There is no stable MDM detection, activation, repair, upgrade, rollback, or uninstall contract with documented exit codes and logs.
+5. Cloud, package-intelligence, and update traffic has no explicit enterprise proxy, private certificate authority, offline installation, or endpoint allowlist contract.
+
+## Goals
+
+- Provide signed, versioned, offline-capable MDM artifacts for supported macOS and Windows architectures.
+- Install a machine-owned Guard runtime without requiring customer-managed Python or `pipx`.
+- Activate Guard independently and idempotently for every eligible local user, including users or harnesses added after machine installation.
+- Add a machine-managed policy source with deterministic precedence, integrity checks, and lockable settings.
+- Prevent standard users from weakening, updating, or removing an MDM-managed installation while preserving local ability to strengthen policy.
+- Give MDM systems stable detection, health, repair, upgrade, rollback, and removal interfaces.
+- Support enterprise proxies, TLS inspection with approved private roots, offline installation, and a documented network allowlist.
+- Preserve Guard's offline local enforcement and existing user-managed PyPI installation mode.
+
+## Non-goals
+
+- Replacing Guard Cloud workspace RBAC or signed Cloud policy distribution.
+- Building a general-purpose MDM server or vendor-specific administration console.
+- Requiring an always-on privileged system daemon when per-user hooks can enforce safely.
+- Adding kernel extensions, system extensions, packet filters, or broad Full Disk Access without a demonstrated requirement.
+- Automatically interpreting arbitrary proxy PAC files in the first MDM release. Static system and explicit HTTPS proxy configurations are required.
+- Supporting mobile operating systems.
+- Supporting architectures the launch customer does not use. The certified architecture set must be recorded before release.
+
+## Personas
+
+- **Endpoint administrator:** packages Guard, assigns it to device or user groups, monitors deployment, and performs repair or removal.
+- **Security administrator:** locks minimum policy, controls update channels and network trust, and reviews tamper or drift evidence.
+- **Developer:** receives protection without installing Python, running elevated commands, or repeating setup after every update.
+- **Support engineer:** diagnoses a failed installation from stable JSON status and bounded, redacted logs.
+- **Release engineer:** produces signed, reproducible artifacts with provenance, SBOMs, checksums, and tested upgrade paths.
+
+## Support promise
+
+An MDM-compatible HOL Guard release is complete only when an administrator can install it silently on a clean managed endpoint, activate it for a standard user, verify protection without parsing presentation text, repair drift, upgrade or roll back, and remove it without leaving active hooks or sensitive state.
+
+“Installed” and “protected” are separate states:
+
+- **Machine installed:** the signed machine runtime, manifest, policy adapter, and lifecycle tools are present and valid.
+- **User activated:** the target user's Guard state exists, applicable harnesses are connected, and health checks confirm the intended protection contract.
+
+MDM reporting must never equate a valid machine package with successful per-user protection.
+
+## Target architecture
+
+```text
+MDM service
+  -> signed machine installer
+      -> immutable Guard runtime and release manifest
+      -> managed-policy adapter
+      -> lifecycle and detection commands
+      -> optional login activation registration
+  -> per-user activation
+      -> user-owned ~/.hol-guard state
+      -> user-owned harness hooks, shims, and reversible backups
+      -> local loopback daemon started on demand or at login
+  -> status / remediation
+      -> machine health + one result per eligible user
+      -> stable reason codes, versions, and redacted log locations
+```
+
+The machine package owns product binaries. The user activation layer owns user-scoped Guard state and harness integration. No package postinstall action may infer a developer home from the root or SYSTEM account.
+
+## Requirements
+
+### MDM-R001: Native, signed, self-contained artifacts
+
+The release pipeline must produce artifacts that require no preinstalled Python, `pip`, `pipx`, `uv`, compiler, or public package-registry access.
+
+Common requirements:
+
+- Bundle a pinned Python runtime and all production dependencies, or produce an equivalent standalone executable distribution.
+- Install only versioned product files plus explicit mutable state directories.
+- Include a signed release manifest containing product version, build ID, source commit, supported OS and architecture, file hashes, policy schema version, and installer identity.
+- Publish SHA-256 checksums, SBOM, and build provenance for every MDM artifact.
+- Keep credentials, customer policy, and per-user state out of the installer payload.
+- Fail installation before modifying the endpoint if signature, architecture, OS, disk-space, or payload-integrity checks fail.
+
+macOS requirements:
+
+- Produce a component `.pkg` with a payload, stable package identifier and receipt version, and valid install location.
+- Sign the package with a Developer ID Installer certificate.
+- Sign applicable executable code, notarize the distributed artifact, and staple the notarization ticket.
+- Install the machine runtime into a root-owned, non-user-writable location. The final path must be documented and stable across patch releases.
+- Support silent installation with `/usr/sbin/installer` and detection with `pkgutil` plus Guard's signed manifest.
+- If login or background items ship, provide stable bundle, team, and service identifiers suitable for Apple's Service Management MDM payload.
+
+Windows requirements:
+
+- Produce an Authenticode-signed MSI or signed bootstrapper suitable for wrapping as an Intune Win32 `.intunewin` package.
+- Install the runtime under `%ProgramFiles%` and machine state under `%ProgramData%`, protected by standard ACLs.
+- Provide silent install, repair, upgrade, and uninstall commands with conventional Windows installer return codes.
+- Publish stable MSI product and upgrade identities, display version, publisher, architecture, and detection metadata.
+- Do not depend on an interactive desktop, user profile, PowerShell execution-policy weakening, or package-registry access during machine installation.
+
+### MDM-R002: Machine and per-user deployment contexts
+
+Guard must explicitly support device-context installation followed by user-context activation.
+
+- Add an idempotent, noninteractive user activation command that accepts an explicit target home and user identity.
+- Reject root or SYSTEM as the implicit target for user activation.
+- Create user files with the target user's ownership and restrictive permissions.
+- Detect eligible local users without activating service accounts, disabled accounts, temporary accounts, or the MDM agent account.
+- Activate users at next login when no interactive user exists during machine installation.
+- Support multiple eligible users on one endpoint without sharing tokens, approval state, receipts, keyring items, or databases.
+- Detect and connect supported harnesses installed after initial activation.
+- Make activation atomic and safely repeatable after interruption, package upgrade, harness upgrade, and MDM remediation.
+- Preserve and restore preexisting harness configuration using the existing adapter backup contracts.
+- Never open a browser, connect Guard Cloud, display a notification, or prompt for approval during silent activation.
+- Report machine installation and each user's activation status separately.
+
+The first-release commands should expose a stable contract equivalent to:
+
+```text
+hol-guard mdm activate --home <absolute-home> --user <identity> --json
+hol-guard mdm status --scope machine --json
+hol-guard mdm status --scope user --home <absolute-home> --json
+hol-guard mdm repair --home <absolute-home> --json
+hol-guard mdm deactivate --home <absolute-home> --json
+```
+
+Exact command names may change during design review, but the machine/user scope separation and JSON semantics are required.
+
+### MDM-R003: Managed policy authority and self-protection
+
+Guard must load validated machine-managed configuration from platform-native policy locations:
+
+- macOS: a documented managed preferences domain, proposed as `org.hol.guard`.
+- Windows: a documented policy registry path, proposed as `HKLM\Software\Policies\HOL\Guard`.
+
+Both adapters must map to one versioned managed-policy schema. Managed input must be type-checked, size-bounded, fail-closed for locked security settings, and surfaced in status by schema version and content hash without exposing secrets.
+
+Policy composition must be monotonic:
+
+1. Built-in required protections establish a non-reducible floor.
+2. Valid machine-managed policy and signed Cloud team policy are managed authorities.
+3. For action strength, the strongest managed requirement wins.
+4. Machine-managed locks prevent user, saved-decision, home, workspace, dashboard, or CLI input from weakening the locked value.
+5. Local sources may strengthen managed policy.
+6. Conflicting non-action managed settings use documented deterministic precedence and emit a `managed_policy_conflict` diagnostic.
+7. Missing, malformed, stale, wrong-scope, or rollback policy never silently falls back to a weaker outcome.
+
+The managed schema must cover at least:
+
+- security level, mode, action overrides, receipt redaction, telemetry, and Cloud sync enablement;
+- approval and remembered-trust limits;
+- allowed Cloud issuer and workspace enrollment boundaries;
+- proxy mode and approved private CA paths;
+- update owner, channel, version ceiling/floor, and downgrade policy;
+- local setting locks and whether local users may strengthen specific controls;
+- permitted harnesses and required protection surfaces;
+- daemon startup mode and health interval;
+- uninstall, deactivate, and repair authorization policy.
+
+When `install_owner = "mdm"`:
+
+- `hol-guard update` must return a stable managed-update reason and make no changes.
+- `hol-guard uninstall --self` and user deactivation must require authorized administrator context or an MDM removal token that is bound, short-lived, and auditable.
+- Standard users must not be able to modify machine binaries, release manifests, managed policy, lifecycle registrations, or machine logs.
+- Direct deletion or corruption must produce tamper diagnostics and a repairable MDM state.
+- Removing the MDM profile must not automatically relax policy unless the administrator explicitly configures that behavior.
+
+### MDM-R004: Lifecycle, detection, remediation, and updates
+
+Every MDM artifact must ship a documented lifecycle contract.
+
+Detection and health:
+
+- A signed machine manifest and native installer identity are the authoritative installation markers.
+- A stable JSON schema must report installed version, build ID, signature state, package identity, architecture, managed-policy state, update owner, daemon state, and one activation result per eligible user.
+- Human-readable text is not an automation contract.
+- Status must distinguish absent, installed, activated, protected, degraded, repairable, policy-invalid, tampered, and unsupported states.
+- Each nonhealthy state must include stable reason codes and a safe remediation hint.
+- Detection commands must be read-only, bounded, prompt-free, and suitable for standard Intune detection scripts and MDM extension attributes.
+
+Lifecycle operations:
+
+- Install, activate, repair, deactivate, upgrade, rollback, and uninstall must be idempotent where applicable.
+- MDM owns version changes for MDM-managed installs. In-product PyPI updates must not race or overwrite the package.
+- In-place upgrades must preserve compatible user state and run explicit, versioned migrations.
+- Downgrades must be rejected by default and permitted only through an authenticated MDM rollback policy with schema compatibility checks.
+- Failed upgrades must leave either the previous healthy version or a machine-detectable repair state.
+- Uninstall must remove machine runtime, lifecycle registrations, managed hooks, shims, and temporary files while preserving or deleting user evidence according to explicit administrator policy.
+- A package uninstall must not leave a running daemon or a harness hook that references a removed runtime.
+- New users and newly installed harnesses must converge through login activation or scheduled MDM remediation without reinstalling the machine package.
+
+Operational contract:
+
+- Emit redacted machine logs to a documented machine path and user activation logs to documented user paths.
+- Bound log size and retention; never log tokens, approval secrets, proxy credentials, raw sensitive commands, or private key material.
+- Publish vendor-neutral install, detection, remediation, and uninstall scripts plus tested Intune examples.
+- Define installer and CLI exit codes, including Windows reboot-required behavior.
+- Provide a versioned JSON schema for MDM status and lifecycle results.
+
+### MDM-R005: Enterprise networking, trust, and offline behavior
+
+All Guard HTTP clients, including `requests`, `urllib`, update checks, Cloud sync, OAuth/device flows, policy bundles, advisory feeds, and package intelligence, must use one enterprise network policy.
+
+- Support platform system proxy configuration and an explicit managed HTTPS proxy.
+- Support an additive administrator-approved CA bundle without disabling normal certificate validation.
+- Keep TLS verification enabled in every mode. No managed option may set insecure verification.
+- Do not store proxy credentials in plaintext policy, logs, command arguments, or user-readable machine files.
+- Ensure detached or login-started daemon processes receive the same managed network configuration as foreground CLI commands.
+- Add a prompt-free network diagnostic that reports DNS, proxy selection, TLS trust, endpoint reachability, and redacted failure reasons.
+- Publish a machine-readable and human-readable endpoint manifest listing hostname, port, purpose, required/optional status, HTTP methods, data classification, and offline fallback.
+- Separate required Guard Cloud endpoints from optional public package-registry intelligence endpoints.
+- Allow administrators to disable direct public-registry access and use signed cached intelligence or approved internal mirrors.
+- Make the installer fully offline. Installation and rollback may not require PyPI, GitHub, or Guard Cloud.
+- Preserve local protection during proxy failure, TLS inspection failure, Cloud outage, or network isolation. Status must show stale remote data without weakening the local policy floor.
+
+## Security and privacy invariants
+
+- Standard users cannot replace a machine-owned executable or managed policy file.
+- MDM authority cannot be claimed through environment variables, workspace files, user preferences, command arguments, or unsigned local files.
+- Managed policy identifiers, hashes, and diagnostics may be logged; policy secrets and credentials may not.
+- Per-user tokens and keyring material never cross user boundaries or enter `%ProgramData%` or a shared macOS machine-state directory.
+- Repair never grants new trust, clears approval history, lowers policy, or silently reconnects Cloud identity.
+- Uninstall authorization is separate from approval authorization for agent actions.
+- Installer and lifecycle scripts quote every path and handle spaces, Unicode, and adversarial user names.
+- No release gate may require disabling Gatekeeper, notarization, Windows signature validation, antivirus, EDR, WDAC, AppLocker, or TLS verification.
+
+## User and administrator experience
+
+### Silent device deployment
+
+1. MDM validates requirements and installs the signed machine package.
+2. Installation records the native package identity and signed Guard manifest.
+3. If an eligible user is logged in, MDM invokes user activation in that user's context; otherwise activation waits for login.
+4. Detection reports machine and user states independently.
+5. No browser, notification preview, terminal window, or approval prompt appears.
+
+### Drift remediation
+
+1. MDM runs read-only status.
+2. A repairable reason code identifies a missing hook, PATH shim, lifecycle registration, permission, or versioned migration.
+3. MDM invokes scoped repair.
+4. Repair changes only Guard-owned integration material and returns before/after state.
+5. Status confirms protection or reports an actionable failure without falsely marking the app installed.
+
+### Managed removal
+
+1. MDM invokes authorized per-user deactivation for every activated user.
+2. Guard stops user daemons and restores reversible harness changes.
+3. The native package uninstall removes machine files and lifecycle registrations.
+4. Detection confirms absence and reports any intentionally retained evidence.
+
+## Acceptance criteria
+
+### Packaging
+
+- Clean macOS and Windows endpoints install without Python, package managers, public network access, or interactive UI.
+- macOS signature, notarization, staple, package receipt, payload, version, and architecture checks pass.
+- Windows Authenticode, MSI/installer metadata, silent install, repair, upgrade, uninstall, and Intune detection checks pass.
+- Files installed into machine locations are not writable by standard users.
+- Published checksums, SBOMs, and provenance match the shipped artifacts.
+
+### Activation and policy
+
+- Root/SYSTEM installation followed by standard-user activation creates no incorrectly owned user files.
+- Multiple local users receive isolated state and independent activation results.
+- New users and late-installed supported harnesses converge without reinstalling Guard.
+- Every locked setting resists CLI, dashboard, saved-decision, home, and workspace attempts to weaken it.
+- Local tightening remains possible where allowed.
+- MDM and signed Cloud policy conflicts resolve deterministically and are observable.
+- Standard users cannot self-update, deactivate required protection, or self-uninstall an MDM-owned install.
+
+### Lifecycle and networking
+
+- Detection output is schema-valid, prompt-free, read-only, and stable across patch releases.
+- Install, activation, repair, upgrade, rollback, and removal pass interruption and retry tests.
+- Proxy and private-CA tests pass for CLI and detached daemon traffic without disabling TLS verification.
+- Offline install, local enforcement during outage, and cached policy/intelligence behavior pass.
+- Logs are bounded, collectable through MDM, and pass secret-redaction tests.
+
+### Certification
+
+- CI covers the approved macOS and Windows architecture/OS matrix with standard-user and administrator contexts.
+- A real MDM validates install, detection, remediation, update, rollback, and removal on each customer platform.
+- Pilot telemetry meets the agreed deployment and activation success thresholds with no policy weakening or cross-user data exposure.
+
+## Success metrics
+
+- At least 99% successful machine installation across the supported pilot fleet.
+- At least 98% successful activation for eligible users within 15 minutes of login or MDM remediation.
+- At least 99% agreement between MDM detection state and Guard's detailed health state.
+- Zero standard-user policy downgrades, unauthorized updates, or unauthorized removals.
+- Zero secrets in installer, lifecycle, status, network diagnostic, or MDM-collected logs.
+- Failed upgrades automatically retain the previous healthy version or produce a repairable state.
+
+## Rollout gates
+
+1. **Contract gate:** approve paths, identities, schemas, precedence, authorization, exit codes, supported OS/architectures, and customer MDM.
+2. **Packaging gate:** signed offline artifacts install, upgrade, repair, and uninstall on clean VMs.
+3. **Managed-policy gate:** monotonic precedence, locks, tamper detection, and update/uninstall ownership pass adversarial tests.
+4. **User-activation gate:** multi-user, no-user-at-install, late-user, late-harness, and interrupted activation tests pass.
+5. **Network gate:** direct, system proxy, explicit proxy, private CA, blocked registry, and offline scenarios pass.
+6. **MDM lab gate:** real vendor deployment passes detection, remediation, update, rollback, and removal.
+7. **Pilot gate:** phased customer rollout shows healthy activation and no security or support stop condition.
+
+Stop rollout on signature or notarization failure, policy weakening, wrong-user ownership, cross-user data exposure, false healthy detection, unrecoverable upgrade, TLS verification bypass, or unmanaged removal.
+
+## Dependencies and risks
+
+- Code-signing and notarization certificates require protected release credentials, rotation, and incident procedures.
+- Bundled Python and native dependencies increase artifact size and cross-architecture testing requirements.
+- Harness updates can overwrite hooks or configuration, so continuous reconciliation is part of the product contract.
+- macOS Keychain and Windows Credential Manager operations must execute in the intended user session.
+- Security products may block unsigned wrappers or scripts; signed publisher identities and a process/file/network manifest are required for customer allowlisting.
+- MDM vendors differ in user-context execution, login triggers, script result handling, and package detection.
+- Existing user-managed installations need a supported migration path that preserves state without allowing a user-owned runtime to shadow the machine runtime.
+
+## Open decisions
+
+Implementation defaults are frozen in [ADR 0001](./adr/0001-mdm-managed-install-contract.md): stable paths and identifiers, machine precedence for non-action conflicts, on-demand daemons, strongest-action composition, MDM-owned updates, downgrade/removal fail-closed behavior, and evidence preservation by default.
+
+The remaining items are launch-customer certification inputs rather than code decisions:
+
+- Customer MDM vendor and whether macOS, Windows, or both are in the first rollout.
+- Required macOS CPU architectures and minimum macOS version.
+- Required Windows CPU architectures, editions, and minimum Windows version.
+- Final Apple team identity and Windows Authenticode publisher identity.
+- Whether zero-touch Guard Cloud workspace enrollment is required for the first customer or remains a separate user/admin step.
+- Required deployment and activation success thresholds if the defaults in this PRD are not accepted.
+
+## Required deliverables
+
+- Signed and notarized macOS package with uninstall and MDM examples.
+- Signed Windows installer and Intune Win32 package recipe with detection rules.
+- Self-contained runtime and reproducible packaging pipeline.
+- Versioned managed-policy and MDM status JSON schemas.
+- Per-user activation, status, repair, and deactivation commands.
+- Vendor-neutral lifecycle scripts and customer-vendor profiles/scripts.
+- Endpoint allowlist, proxy/private-CA guide, offline deployment guide, and support runbook.
+- MDM OS/architecture test matrix, release checklist, pilot plan, rollback plan, and collected evidence.
+
+## Primary references
+
+- [Apple: Distribute packages to Mac computers](https://support.apple.com/guide/deployment/dep873c25ac4/web)
+- [Apple: Manage login items and background tasks on Mac](https://support.apple.com/guide/deployment/depdca572563/web)
+- [Apple: Managed Login Items payload settings](https://support.apple.com/guide/deployment/managed-login-items-payload-settings-dep07b92494/web)
+- [Microsoft: Add macOS line-of-business apps to Intune](https://learn.microsoft.com/en-us/intune/app-management/deployment/add-lob-macos)
+- [Microsoft: Add and manage Win32 apps in Intune](https://learn.microsoft.com/en-us/intune/app-management/deployment/add-win32)
+- [Microsoft: Windows app deployment contexts](https://learn.microsoft.com/en-us/intune/app-management/deployment/deploy-windows)
+- [Requests: proxies and custom CA bundles](https://docs.python-requests.org/en/latest/user/advanced/)

--- a/docs/guard/mdm-compatibility-todo.md
+++ b/docs/guard/mdm-compatibility-todo.md
@@ -26,7 +26,7 @@ This checklist implements the P0 requirements in the [HOL Guard MDM Compatibilit
 
 The shared runtime, managed policy, lifecycle CLI, enterprise network layer, native package sources, unsigned artifact proof, schemas, CI matrix, and administrator documentation are implemented on `feat/mdm-compatibility`. Checklist boxes remain open until merge because this file defines “checked” as merged with release evidence.
 
-Production certification still requires external inputs unavailable to the repository: Apple Developer ID/notarization credentials, Windows Authenticode credentials, the launch customer's MDM vendor and OS/architecture scope, test devices, Cloud enrollment choice, and security/release/support/customer-IT sign-off. The evidence form is [mdm-release-evidence-template.md](./mdm-release-evidence-template.md).
+Production certification still requires external inputs unavailable to the repository: Apple Developer ID/notarization credentials, Windows Authenticode credentials, representative MDM vendors and OS/architecture scope, test devices, Cloud enrollment choices, and security/release/support/pilot-organization sign-off. The evidence form is [mdm-release-evidence-template.md](./mdm-release-evidence-template.md).
 
 ## Critical path
 
@@ -34,11 +34,11 @@ Production certification still requires external inputs unavailable to the repos
 2. Complete the shared foundation in group B before platform lifecycle implementations.
 3. Build the self-contained runtime in group C before finishing native packages in group D.
 4. Develop user activation, lifecycle, self-protection, and networking in groups E-H against the frozen contracts.
-5. Complete group I before customer deployment and group J before production compatibility is declared.
+5. Complete group I before an organization pilot and group J before production compatibility is declared.
 
 ## A. Contract and architecture freeze
 
-- [ ] **MDM-T001 (R001-R005):** Record the launch customer's MDM vendor, platforms, minimum OS versions, CPU architectures, device/user assignment model, proxy/TLS inspection, and required Cloud enrollment flow.
+- [ ] **MDM-T001 (R001-R005):** Publish the supported MDM/OS/architecture matrix and a reusable organization intake profile covering assignment model, proxy/TLS inspection, and Cloud enrollment flow.
 - [ ] **MDM-T002 (R001):** Approve stable macOS package, bundle, team, receipt, binary, and service identifiers.
 - [ ] **MDM-T003 (R001):** Approve stable Windows publisher, MSI product/upgrade identities, install scope, binary names, and registry roots.
 - [ ] **MDM-T004 (R001-R002):** Approve machine runtime, machine state, user state, logs, backups, and command-discovery paths for both platforms.
@@ -92,9 +92,9 @@ Likely working set: `.github/workflows/publish.yml`, a new `packaging/` tree, re
 - [ ] **MDM-T037 (R001):** Code-sign executable payloads, sign the package with Developer ID Installer, notarize, staple, and validate every release.
 - [ ] **MDM-T038 (R001-R004):** Implement silent preinstall/postinstall behavior that never targets root's home and leaves explicit machine installation state.
 - [ ] **MDM-T039 (R002-R004):** Add the approved login activation mechanism and stable Service Management identifiers when required.
-- [ ] **MDM-T040 (R004):** Provide signed install, detection, activation, remediation, and removal examples for generic Apple MDM and the customer vendor.
+- [ ] **MDM-T040 (R004):** Provide signed install, detection, activation, remediation, and removal examples for generic Apple MDM plus each certified vendor adapter.
 - [ ] **MDM-T041 (R004):** Validate package replacement, patch upgrade, authorized rollback, failed-install recovery, and complete receipt removal.
-- [ ] **MDM-T042 (R001-R004):** Verify Intune macOS LOB requirements if Intune manages customer Macs.
+- [ ] **MDM-T042 (R001-R004):** Verify Intune macOS LOB requirements as one certified vendor adapter.
 
 ### Windows
 
@@ -104,7 +104,7 @@ Likely working set: `.github/workflows/publish.yml`, a new `packaging/` tree, re
 - [ ] **MDM-T046 (R002-R004):** Add the approved user-login activation mechanism without requiring interactive administrator privileges.
 - [ ] **MDM-T047 (R004):** Create the `.intunewin` recipe, install/uninstall commands, requirements, detection rules, return-code map, and supersedence guidance.
 - [ ] **MDM-T048 (R004):** Validate user-context and device-context assignments and document the supported assignment contract.
-- [ ] **MDM-T049 (R001-R004):** Test clean install, in-place upgrade, authorized rollback, repair, uninstall, and reinstall through Intune.
+- [ ] **MDM-T049 (R001-R004):** Test clean install, in-place upgrade, authorized rollback, repair, uninstall, and reinstall through the Intune adapter.
 
 ## E. Per-user activation and reconciliation
 
@@ -174,7 +174,7 @@ Likely working set: `.github/workflows/publish.yml`, a new `packaging/` tree, re
 - [ ] **MDM-T101 (R004-R005):** Run secret-redaction tests over installer logs, lifecycle logs, status JSON, network diagnostics, and MDM-collected bundles.
 - [ ] **MDM-T102 (R005):** Test direct network, system proxy, explicit proxy, authenticated proxy, private CA, blocked registry, DNS failure, clock skew, and offline operation.
 - [ ] **MDM-T103 (R001-R004):** Validate WDAC/AppLocker and macOS Gatekeeper behavior using signed publisher identities without broad exclusions.
-- [ ] **MDM-T104 (R001-R005):** Run real-MDM install, detection, activation, remediation, update, rollback, and removal on every launch-customer platform.
+- [ ] **MDM-T104 (R001-R005):** Run real-MDM install, detection, activation, remediation, update, rollback, and removal across every combination in the published certification matrix.
 
 ## J. Documentation, release, and pilot
 
@@ -185,9 +185,9 @@ Likely working set: `.github/workflows/publish.yml`, a new `packaging/` tree, re
 - [ ] **MDM-T109 (R004):** Update the enterprise packet, architecture, testing matrix, troubleshooting, incident response, and release checklist with the managed-install contract.
 - [ ] **MDM-T110 (R001-R005):** Add an MDM release evidence template containing signatures, notarization, hashes, SBOM/provenance, platform matrix, lifecycle tests, and real-MDM results.
 - [ ] **MDM-T111 (R001-R005):** Define pilot rings, success thresholds, health dashboards, support ownership, rollback triggers, and stop conditions.
-- [ ] **MDM-T112 (R001-R005):** Run an internal canary, then customer IT canary, then limited developer pilot; record evidence for every rollout gate.
+- [ ] **MDM-T112 (R001-R005):** Run an internal canary, then at least two organization pilots with different MDM vendors, then a limited developer rollout; record evidence for every gate.
 - [ ] **MDM-T113 (R001-R005):** Close every PRD open decision or record an approved scoped deferral that does not weaken a P0 acceptance criterion.
-- [ ] **MDM-T114 (R001-R005):** Obtain security, release engineering, support, and launch-customer IT sign-off before declaring production MDM compatibility.
+- [ ] **MDM-T114 (R001-R005):** Obtain security, release engineering, support, and pilot-organization IT sign-off before declaring production MDM compatibility.
 
 ## Required verification commands
 

--- a/docs/guard/mdm-compatibility-todo.md
+++ b/docs/guard/mdm-compatibility-todo.md
@@ -1,0 +1,217 @@
+# HOL Guard MDM Compatibility TODO
+
+## Purpose
+
+This checklist implements the P0 requirements in the [HOL Guard MDM Compatibility PRD](./mdm-compatibility-prd.md). A checked item means the code, tests, documentation, and release evidence for that item are merged. Design notes or partial platform support do not count as complete.
+
+## Requirement map
+
+| Requirement | Scope | Task groups |
+| --- | --- | --- |
+| MDM-R001 | Signed self-contained artifacts | A, C, D, J |
+| MDM-R002 | Machine install and per-user activation | A, B, E, F, I |
+| MDM-R003 | Managed policy and self-protection | A, B, G, I |
+| MDM-R004 | Lifecycle, detection, remediation, updates | B, C, D, F, G, I, J |
+| MDM-R005 | Proxy, private CA, endpoint contract, offline behavior | H, I, J |
+
+## Completion rules
+
+- Keep task IDs stable in issues, commits, tests, and release evidence.
+- Add focused tests with each behavior change; do not defer all verification to the certification phase.
+- Run macOS and Windows packaging work in isolated CI jobs with protected signing credentials.
+- Never put signing material, removal tokens, proxy credentials, customer policy, or private CA keys in the repository.
+- Stop if implementation would require disabling OS security, TLS verification, antivirus, EDR, WDAC, or AppLocker.
+
+## Current implementation status
+
+The shared runtime, managed policy, lifecycle CLI, enterprise network layer, native package sources, unsigned artifact proof, schemas, CI matrix, and administrator documentation are implemented on `feat/mdm-compatibility`. Checklist boxes remain open until merge because this file defines “checked” as merged with release evidence.
+
+Production certification still requires external inputs unavailable to the repository: Apple Developer ID/notarization credentials, Windows Authenticode credentials, the launch customer's MDM vendor and OS/architecture scope, test devices, Cloud enrollment choice, and security/release/support/customer-IT sign-off. The evidence form is [mdm-release-evidence-template.md](./mdm-release-evidence-template.md).
+
+## Critical path
+
+1. Complete group A before freezing schemas or installer identities.
+2. Complete the shared foundation in group B before platform lifecycle implementations.
+3. Build the self-contained runtime in group C before finishing native packages in group D.
+4. Develop user activation, lifecycle, self-protection, and networking in groups E-H against the frozen contracts.
+5. Complete group I before customer deployment and group J before production compatibility is declared.
+
+## A. Contract and architecture freeze
+
+- [ ] **MDM-T001 (R001-R005):** Record the launch customer's MDM vendor, platforms, minimum OS versions, CPU architectures, device/user assignment model, proxy/TLS inspection, and required Cloud enrollment flow.
+- [ ] **MDM-T002 (R001):** Approve stable macOS package, bundle, team, receipt, binary, and service identifiers.
+- [ ] **MDM-T003 (R001):** Approve stable Windows publisher, MSI product/upgrade identities, install scope, binary names, and registry roots.
+- [ ] **MDM-T004 (R001-R002):** Approve machine runtime, machine state, user state, logs, backups, and command-discovery paths for both platforms.
+- [ ] **MDM-T005 (R002):** Define eligible-user discovery and exclusions for service, disabled, temporary, MDM-agent, and noninteractive accounts.
+- [ ] **MDM-T006 (R002):** Freeze machine-installed, user-activated, protected, degraded, repairable, tampered, and unsupported state definitions.
+- [ ] **MDM-T007 (R003):** Freeze the managed-policy schema, source identities, lock semantics, and monotonic merge truth table.
+- [ ] **MDM-T008 (R003):** Decide deterministic precedence for non-action conflicts between machine MDM and signed Guard Cloud policy.
+- [ ] **MDM-T009 (R003-R004):** Approve MDM update owner, channel, version floor/ceiling, downgrade, rollback, and removal authorization contracts.
+- [ ] **MDM-T010 (R004):** Freeze lifecycle CLI JSON schemas, reason codes, exit codes, and Windows reboot-required mappings.
+- [ ] **MDM-T011 (R005):** Freeze proxy modes, private-CA behavior, endpoint manifest schema, offline fallback, and internal registry/mirror behavior.
+- [ ] **MDM-T012 (R001-R005):** Add an architecture decision record linking the approved contracts and threat model.
+
+## B. Shared managed-install foundation
+
+- [ ] **MDM-T013 (R001):** Add a build-time release-manifest model with version, build ID, commit, architecture, policy schema, installer identity, and file hashes.
+- [ ] **MDM-T014 (R001):** Verify the release manifest before executing any machine-owned Guard command and return stable tamper reasons.
+- [ ] **MDM-T015 (R002-R004):** Add a typed managed-install context that separates machine paths, target user, target home, workspace, and mutable user state.
+- [ ] **MDM-T016 (R002):** Reject implicit root/SYSTEM user activation and validate that explicit homes belong to the intended local identity.
+- [ ] **MDM-T017 (R002):** Add secure target-user file creation with correct ownership, atomic writes, symlink defense, and restrictive permissions/ACLs.
+- [ ] **MDM-T018 (R003):** Add the versioned platform-neutral managed-policy model and strict external-input validation.
+- [ ] **MDM-T019 (R003):** Add macOS managed-preferences and Windows policy-registry readers behind the same interface.
+- [ ] **MDM-T020 (R003):** Implement monotonic policy composition, locked fields, strongest-action resolution, and conflict diagnostics.
+- [ ] **MDM-T021 (R003):** Prevent saved decisions, home config, workspace config, dashboard writes, CLI writes, and environment variables from weakening locked values.
+- [ ] **MDM-T022 (R003-R004):** Add managed installation metadata to `status`, `doctor`, diagnostics, receipts, and support exports without exposing policy content or secrets.
+- [ ] **MDM-T023 (R004):** Add versioned machine and user lifecycle result schemas under `schemas/`.
+- [ ] **MDM-T024 (R002-R004):** Add the `mdm` command group, or approved equivalent, with machine status and scoped activate/status/repair/deactivate commands.
+- [ ] **MDM-T025 (R004):** Make all MDM status operations read-only, prompt-free, time-bounded, and independent of browser or desktop availability.
+- [ ] **MDM-T026 (R004):** Add stable result classification and nonhealthy reason codes with safe remediation hints.
+
+Likely working set: `src/codex_plugin_scanner/guard/config.py`, `cli/commands_parser_*.py`, `cli/commands_dispatch_*.py`, `daemon/manager.py`, new `guard/mdm/` modules, `schemas/`, and focused `tests/test_guard_mdm_*.py` files.
+
+## C. Self-contained runtime and release pipeline
+
+- [ ] **MDM-T027 (R001):** Select and document the supported standalone Python/runtime packaging approach.
+- [ ] **MDM-T028 (R001):** Produce deterministic platform runtime bundles with pinned production dependencies and no install-time package resolution.
+- [ ] **MDM-T029 (R001):** Prove runtime bundles work without system Python, `pip`, `pipx`, `uv`, compilers, or user PATH changes.
+- [ ] **MDM-T030 (R001):** Generate per-artifact SHA-256 files, SBOMs, and provenance tied to the release manifest.
+- [ ] **MDM-T031 (R001):** Add dependency-license collection and review for redistributed runtimes and native libraries.
+- [ ] **MDM-T032 (R001):** Add reproducibility checks or document and gate every nondeterministic build input.
+- [ ] **MDM-T033 (R001):** Isolate protected signing and notarization jobs from untrusted pull-request code.
+- [ ] **MDM-T034 (R001):** Add signing-certificate rotation, revocation, expiry monitoring, and emergency release procedures to the release runbook.
+- [ ] **MDM-T035 (R001-R004):** Publish artifacts with consistent semantic version, manifest version, native installer version, and Cloud-visible version.
+
+Likely working set: `.github/workflows/publish.yml`, a new `packaging/` tree, release scripts under `scripts/`, and release documentation.
+
+## D. Native platform packages
+
+### macOS
+
+- [ ] **MDM-T036 (R001):** Build a component `.pkg` with a real payload, stable receipt, version, architecture requirements, and root-owned machine runtime.
+- [ ] **MDM-T037 (R001):** Code-sign executable payloads, sign the package with Developer ID Installer, notarize, staple, and validate every release.
+- [ ] **MDM-T038 (R001-R004):** Implement silent preinstall/postinstall behavior that never targets root's home and leaves explicit machine installation state.
+- [ ] **MDM-T039 (R002-R004):** Add the approved login activation mechanism and stable Service Management identifiers when required.
+- [ ] **MDM-T040 (R004):** Provide signed install, detection, activation, remediation, and removal examples for generic Apple MDM and the customer vendor.
+- [ ] **MDM-T041 (R004):** Validate package replacement, patch upgrade, authorized rollback, failed-install recovery, and complete receipt removal.
+- [ ] **MDM-T042 (R001-R004):** Verify Intune macOS LOB requirements if Intune manages customer Macs.
+
+### Windows
+
+- [ ] **MDM-T043 (R001):** Build the approved MSI or signed bootstrapper with machine runtime under `%ProgramFiles%` and machine state under `%ProgramData%`.
+- [ ] **MDM-T044 (R001):** Authenticode-sign all executable installer payloads and validate publisher identity in CI.
+- [ ] **MDM-T045 (R001-R004):** Implement silent install, repair, upgrade, rollback, and uninstall with conventional installer return codes and logs.
+- [ ] **MDM-T046 (R002-R004):** Add the approved user-login activation mechanism without requiring interactive administrator privileges.
+- [ ] **MDM-T047 (R004):** Create the `.intunewin` recipe, install/uninstall commands, requirements, detection rules, return-code map, and supersedence guidance.
+- [ ] **MDM-T048 (R004):** Validate user-context and device-context assignments and document the supported assignment contract.
+- [ ] **MDM-T049 (R001-R004):** Test clean install, in-place upgrade, authorized rollback, repair, uninstall, and reinstall through Intune.
+
+## E. Per-user activation and reconciliation
+
+- [ ] **MDM-T050 (R002):** Implement idempotent noninteractive activation for an explicit user and home.
+- [ ] **MDM-T051 (R002):** Ensure activation defaults to skipping browser launch, Cloud pairing, notification setup, and approval prompts.
+- [ ] **MDM-T052 (R002):** Reuse adapter backup/restore contracts and make partial activation rollback atomic.
+- [ ] **MDM-T053 (R002):** Isolate databases, OAuth credentials, keyring records, tokens, receipts, approval state, and daemon state per user.
+- [ ] **MDM-T054 (R002):** Activate a logged-in eligible user after device install and defer safely when nobody is logged in.
+- [ ] **MDM-T055 (R002):** Activate newly eligible users at their first login without reinstalling the machine package.
+- [ ] **MDM-T056 (R002-R004):** Detect newly installed supported harnesses and connect or report them according to managed policy.
+- [ ] **MDM-T057 (R002-R004):** Reconcile hooks, shims, PATH integration, runtime overlays, and daemon compatibility after Guard or harness upgrades.
+- [ ] **MDM-T058 (R002):** Add multi-user concurrency and interrupted-activation locking without cross-user ownership changes.
+- [ ] **MDM-T059 (R002):** Add migration from user-managed PyPI installs to the machine runtime, including shadowed-command detection and reversible state migration.
+- [ ] **MDM-T060 (R002-R004):** Add user deactivation that stops the correct daemon and restores Guard-owned harness changes without touching unrelated user data.
+
+## F. Detection, health, and remediation
+
+- [ ] **MDM-T061 (R004):** Implement machine health from native package identity, release-manifest integrity, architecture, policy adapter, and lifecycle registration.
+- [ ] **MDM-T062 (R004):** Implement per-user health from activation state, harness contracts, shims, hooks, daemon compatibility, policy status, and Cloud freshness.
+- [ ] **MDM-T063 (R004):** Return separate machine and per-user results; never report machine installation as user protection.
+- [ ] **MDM-T064 (R004):** Add repairable versus nonrepairable classification and ensure repair never grants trust or weakens policy.
+- [ ] **MDM-T065 (R004):** Implement scoped remediation for permissions, missing hooks, stale shims, lifecycle registration, and versioned migrations.
+- [ ] **MDM-T066 (R004):** Add machine and user log locations, rotation, retention, redaction, and MDM diagnostic collection guidance.
+- [ ] **MDM-T067 (R004):** Provide vendor-neutral detection and remediation scripts with shell/PowerShell linting and signature options.
+- [ ] **MDM-T068 (R004):** Provide Intune detection/remediation scripts whose stdout, stderr, and exit behavior match Intune contracts.
+- [ ] **MDM-T069 (R004):** Add schema compatibility tests so patch releases do not break deployed detection scripts.
+- [ ] **MDM-T070 (R004):** Add performance budgets for fleet status and remediation commands.
+
+## G. Managed updates, removal, and tamper response
+
+- [ ] **MDM-T071 (R003-R004):** Disable PyPI/in-product updates when managed policy declares MDM ownership and return a stable no-change result.
+- [ ] **MDM-T072 (R003-R004):** Require authorized administrator or MDM removal authorization for self-uninstall and required user deactivation.
+- [ ] **MDM-T073 (R003):** Design removal authorization so it is scoped, short-lived, replay-resistant, auditable, and absent from command-line history.
+- [ ] **MDM-T074 (R003-R004):** Protect machine binaries, manifest, policy adapter, lifecycle registrations, and logs with platform ACLs.
+- [ ] **MDM-T075 (R003-R004):** Detect deleted, modified, shadowed, downgraded, wrong-owner, or wrong-permission machine files.
+- [ ] **MDM-T076 (R003-R004):** Make tampered states fail to a non-weaker policy and expose bounded repair guidance.
+- [ ] **MDM-T077 (R004):** Add versioned state migrations with forward compatibility checks and interruption recovery.
+- [ ] **MDM-T078 (R004):** Reject downgrade by default and implement authenticated MDM rollback with schema compatibility checks.
+- [ ] **MDM-T079 (R004):** Ensure uninstall stops all owned daemons and removes or restores every Guard-owned hook, shim, overlay, login item, task, and temporary file.
+- [ ] **MDM-T080 (R004):** Implement explicit administrator choices for preserving or deleting receipts, logs, Cloud credentials, and user evidence during removal.
+
+## H. Enterprise network and offline operation
+
+- [ ] **MDM-T081 (R005):** Inventory every Guard HTTP client and route it through one enterprise network-policy abstraction.
+- [ ] **MDM-T082 (R005):** Implement platform system proxy and explicit managed HTTPS proxy modes with consistent CLI/daemon behavior.
+- [ ] **MDM-T083 (R005):** Add approved private-CA bundles additively while preserving public trust and mandatory certificate validation.
+- [ ] **MDM-T084 (R005):** Keep proxy credentials out of policy, arguments, logs, diagnostics, and user-readable machine files; use approved OS credential storage when credentials are required.
+- [ ] **MDM-T085 (R005):** Ensure detached and login-started daemons receive the same network and trust configuration as foreground commands.
+- [ ] **MDM-T086 (R005):** Add prompt-free DNS, proxy, TLS, endpoint, and clock diagnostics with stable redacted reason codes.
+- [ ] **MDM-T087 (R005):** Create versioned machine-readable and human-readable endpoint manifests with purpose, port, required status, methods, data class, and fallback.
+- [ ] **MDM-T088 (R005):** Separate Guard Cloud endpoints from optional public registry intelligence and support administrator-disabled direct registry access.
+- [ ] **MDM-T089 (R001-R005):** Prove clean install, upgrade, rollback, and uninstall work without internet access.
+- [ ] **MDM-T090 (R005):** Prove local enforcement remains active during Cloud outage, proxy failure, TLS failure, and network isolation while freshness diagnostics remain accurate.
+- [ ] **MDM-T091 (R005):** Add internal mirror and signed cached-intelligence documentation and tests.
+- [ ] **MDM-T092 (R005):** Add negative tests proving no code path disables TLS verification or accepts an unapproved CA.
+
+## I. Test matrix and adversarial verification
+
+- [ ] **MDM-T093 (R001-R005):** Expand CI to the approved macOS/Windows OS and architecture matrix; record unsupported combinations explicitly.
+- [ ] **MDM-T094 (R001-R004):** Test administrator install plus standard-user activation with no root/SYSTEM-owned user files.
+- [ ] **MDM-T095 (R002-R004):** Test no-user-at-install, first login, multiple users, fast user switching, deleted users, renamed homes, and concurrent activation.
+- [ ] **MDM-T096 (R002-R004):** Test late harness installation, harness upgrade overwrites, MDM remediation, and adapter backup restoration.
+- [ ] **MDM-T097 (R003):** Execute the full managed-policy truth table against CLI, dashboard, saved decisions, home, workspace, environment, and signed Cloud inputs.
+- [ ] **MDM-T098 (R003-R004):** Attempt standard-user update, uninstall, deactivation, binary replacement, manifest edit, policy edit, PATH shadowing, permission change, and downgrade.
+- [ ] **MDM-T099 (R001-R004):** Test installer interruption, disk exhaustion, locked files, reboot-required outcomes, rollback, repair, and retry.
+- [ ] **MDM-T100 (R004):** Validate detection against absent, healthy, degraded, repairable, tampered, policy-invalid, unsupported, and partially removed fixtures.
+- [ ] **MDM-T101 (R004-R005):** Run secret-redaction tests over installer logs, lifecycle logs, status JSON, network diagnostics, and MDM-collected bundles.
+- [ ] **MDM-T102 (R005):** Test direct network, system proxy, explicit proxy, authenticated proxy, private CA, blocked registry, DNS failure, clock skew, and offline operation.
+- [ ] **MDM-T103 (R001-R004):** Validate WDAC/AppLocker and macOS Gatekeeper behavior using signed publisher identities without broad exclusions.
+- [ ] **MDM-T104 (R001-R005):** Run real-MDM install, detection, activation, remediation, update, rollback, and removal on every launch-customer platform.
+
+## J. Documentation, release, and pilot
+
+- [ ] **MDM-T105 (R001-R004):** Publish administrator install, assignment, detection, activation, remediation, update, rollback, and uninstall guides.
+- [ ] **MDM-T106 (R001-R005):** Publish the process/file/path/identifier/network manifest for endpoint security and MDM teams.
+- [ ] **MDM-T107 (R005):** Publish proxy, TLS inspection, private CA, endpoint allowlist, internal mirror, and offline deployment guides.
+- [ ] **MDM-T108 (R002-R004):** Publish user-managed-to-MDM migration and MDM-to-user-managed rollback guidance.
+- [ ] **MDM-T109 (R004):** Update the enterprise packet, architecture, testing matrix, troubleshooting, incident response, and release checklist with the managed-install contract.
+- [ ] **MDM-T110 (R001-R005):** Add an MDM release evidence template containing signatures, notarization, hashes, SBOM/provenance, platform matrix, lifecycle tests, and real-MDM results.
+- [ ] **MDM-T111 (R001-R005):** Define pilot rings, success thresholds, health dashboards, support ownership, rollback triggers, and stop conditions.
+- [ ] **MDM-T112 (R001-R005):** Run an internal canary, then customer IT canary, then limited developer pilot; record evidence for every rollout gate.
+- [ ] **MDM-T113 (R001-R005):** Close every PRD open decision or record an approved scoped deferral that does not weaken a P0 acceptance criterion.
+- [ ] **MDM-T114 (R001-R005):** Obtain security, release engineering, support, and launch-customer IT sign-off before declaring production MDM compatibility.
+
+## Required verification commands
+
+The final command set will be implemented with the packaging work. At minimum, release evidence must include equivalents of:
+
+```bash
+# Repository quality
+uv run --no-sync python -m ruff check src/
+uv run --no-sync basedpyright --level error
+uv run --no-sync pytest tests/test_guard_mdm_*.py --tb=short
+uv run --no-sync pytest --tb=short
+
+# macOS artifact
+pkgutil --check-signature <hol-guard.pkg>
+spctl -a -vv -t install <hol-guard.pkg>
+xcrun stapler validate <hol-guard.pkg>
+sudo installer -pkg <hol-guard.pkg> -target /
+pkgutil --pkg-info <approved-package-id>
+
+# Windows artifact (PowerShell / cmd in the Windows CI or MDM lab)
+Get-AuthenticodeSignature <installer>
+msiexec /i <hol-guard.msi> /qn /norestart /l*v <install-log>
+hol-guard mdm status --scope machine --json
+msiexec /x <product-code> /qn /norestart /l*v <uninstall-log>
+```
+
+Replace artifact and package-identity placeholders only after the contract tasks freeze those values.

--- a/docs/guard/mdm-deployment.md
+++ b/docs/guard/mdm-deployment.md
@@ -1,0 +1,19 @@
+# HOL Guard MDM deployment
+
+## Supported contract
+
+HOL Guard uses package identity `org.hol.guard` on macOS and the stable MSI upgrade code `B15D39B1-6395-4FEA-98A9-5D734DDC455D` on Windows. The package owns the machine runtime; activation owns only the target user's `~/.hol-guard` state and reversible harness integrations.
+
+Builds require Python 3.12, the locked `uv` environment, and PyInstaller. macOS additionally requires Xcode command-line tools; Windows requires WiX 4 and SignTool. Production artifacts must be signed and, on macOS, notarized and stapled. Unsigned builds are test fixtures only.
+
+## Intune
+
+- macOS install: `/usr/sbin/installer -pkg hol-guard.pkg -target /`
+- macOS uninstall: run the signed `uninstall.sh` as root.
+- Windows install: `msiexec /i hol-guard.msi /qn /norestart /l*v hol-guard-install.log`
+- Windows uninstall: `msiexec /x {product-code} /qn /norestart /l*v hol-guard-uninstall.log`
+- Detection runs the platform `detect` script in device context. Exit `0` means healthy, `1` means absent/degraded, `2` means invalid input, and `3` means removal authorization is required.
+- User activation runs the platform activation command in user context. Device installation must never substitute SYSTEM/root's home.
+- Managed deactivation is two-context: the device authority creates a ≤2-minute authorization under machine state, then the user-context command consumes it and restores that user's adapters. macOS `deactivate-user.sh` performs both steps; Windows uses `authorize-deactivation.ps1`, assigns `deactivate-user.ps1` in user context, then removes the authorization in device context.
+
+Use Intune supersedence for upgrades. The MSI blocks downgrades. Rollback requires an administrator-authorized package and managed policy permitting the target version. Preserve user evidence by default; remove it only through an explicit customer retention decision.

--- a/docs/guard/mdm-deployment.md
+++ b/docs/guard/mdm-deployment.md
@@ -6,7 +6,11 @@ HOL Guard uses package identity `org.hol.guard` on macOS and the stable MSI upgr
 
 Builds require Python 3.12, the locked `uv` environment, and PyInstaller. macOS additionally requires Xcode command-line tools; Windows requires WiX 4 and SignTool. Production artifacts must be signed and, on macOS, notarized and stapled. Unsigned builds are test fixtures only.
 
-## Intune
+## Vendor-neutral deployment contract
+
+All MDM products use the same signed package, machine-policy schema, lifecycle commands, JSON status schema, and exit-code contract. Organization-specific assignment, proxy, trust, enrollment, retention, and policy values remain external configuration. Vendor adapters may translate these contracts into native packaging and detection formats, but must not fork Guard behavior or require a custom binary.
+
+## Intune adapter example
 
 - macOS install: `/usr/sbin/installer -pkg hol-guard.pkg -target /`
 - macOS uninstall: run the signed `uninstall.sh` as root.
@@ -16,4 +20,4 @@ Builds require Python 3.12, the locked `uv` environment, and PyInstaller. macOS 
 - User activation runs the platform activation command in user context. Device installation must never substitute SYSTEM/root's home.
 - Managed deactivation is two-context: the device authority creates a ≤2-minute authorization under machine state, then the user-context command consumes it and restores that user's adapters. macOS `deactivate-user.sh` performs both steps; Windows uses `authorize-deactivation.ps1`, assigns `deactivate-user.ps1` in user context, then removes the authorization in device context.
 
-Use Intune supersedence for upgrades. The MSI blocks downgrades. Rollback requires an administrator-authorized package and managed policy permitting the target version. Preserve user evidence by default; remove it only through an explicit customer retention decision.
+Use Intune supersedence for upgrades. The MSI blocks downgrades. Rollback requires an administrator-authorized package and managed policy permitting the target version. Preserve user evidence by default; remove it only through an explicit organization retention decision.

--- a/docs/guard/mdm-endpoints.v1.json
+++ b/docs/guard/mdm-endpoints.v1.json
@@ -1,0 +1,95 @@
+{
+  "schemaVersion": "hol-guard-endpoints.v1",
+  "endpoints": [
+    {
+      "hostname": "hol.org",
+      "port": 443,
+      "purpose": "Guard Cloud policy, identity, and evidence synchronization",
+      "required": false,
+      "methods": ["GET", "POST"],
+      "dataClass": "policy-and-security-evidence",
+      "offlineFallback": "Local enforcement continues with the last validated policy and freshness warning"
+    },
+    {
+      "hostname": "pypi.org",
+      "port": 443,
+      "purpose": "Optional package metadata intelligence for Python",
+      "required": false,
+      "methods": ["GET"],
+      "dataClass": "public-package-metadata",
+      "offlineFallback": "Use signed cached intelligence or an approved internal mirror"
+    },
+    {
+      "hostname": "registry.npmjs.org",
+      "port": 443,
+      "purpose": "Optional package metadata intelligence for npm",
+      "required": false,
+      "methods": ["GET"],
+      "dataClass": "public-package-metadata",
+      "offlineFallback": "Use signed cached intelligence or an approved internal mirror"
+    },
+    {
+      "hostname": "files.pythonhosted.org",
+      "port": 443,
+      "purpose": "Optional Python package artifact intelligence",
+      "required": false,
+      "methods": ["GET"],
+      "dataClass": "public-package-artifact",
+      "offlineFallback": "Use signed cached intelligence or an approved internal mirror"
+    },
+    {
+      "hostname": "registry.yarnpkg.com",
+      "port": 443,
+      "purpose": "Optional Yarn package metadata intelligence",
+      "required": false,
+      "methods": ["GET"],
+      "dataClass": "public-package-metadata",
+      "offlineFallback": "Use signed cached intelligence or an approved internal mirror"
+    },
+    {
+      "hostname": "crates.io",
+      "port": 443,
+      "purpose": "Optional Cargo package metadata intelligence",
+      "required": false,
+      "methods": ["GET"],
+      "dataClass": "public-package-metadata",
+      "offlineFallback": "Use signed cached intelligence or an approved internal mirror"
+    },
+    {
+      "hostname": "rubygems.org",
+      "port": 443,
+      "purpose": "Optional Ruby package metadata intelligence",
+      "required": false,
+      "methods": ["GET"],
+      "dataClass": "public-package-metadata",
+      "offlineFallback": "Use signed cached intelligence or an approved internal mirror"
+    },
+    {
+      "hostname": "repo.maven.apache.org",
+      "port": 443,
+      "purpose": "Optional Maven package metadata intelligence",
+      "required": false,
+      "methods": ["GET"],
+      "dataClass": "public-package-metadata",
+      "offlineFallback": "Use signed cached intelligence or an approved internal mirror"
+    },
+    {
+      "hostname": "proxy.golang.org",
+      "port": 443,
+      "purpose": "Optional Go module metadata intelligence",
+      "required": false,
+      "methods": ["GET"],
+      "dataClass": "public-package-metadata",
+      "offlineFallback": "Use signed cached intelligence or an approved internal mirror"
+    },
+    {
+      "hostname": "api.telegram.org",
+      "port": 443,
+      "purpose": "Optional administrator-configured approval notification bridge",
+      "required": false,
+      "methods": ["GET", "POST"],
+      "dataClass": "approval-notification",
+      "offlineFallback": "Use local approval center or another configured notification backend"
+    }
+  ]
+}

--- a/docs/guard/mdm-general-availability-roadmap.md
+++ b/docs/guard/mdm-general-availability-roadmap.md
@@ -1,0 +1,36 @@
+# HOL Guard MDM General Availability Roadmap
+
+HOL Guard's managed deployment contract is organization-neutral. Every organization receives the same signed artifacts and lifecycle behavior. Tenant-specific policy, trust, proxy, enrollment, assignment, and retention values enter through managed configuration rather than source changes or custom packages.
+
+## P0: production foundation
+
+1. Publish signed, notarized macOS packages and Authenticode-signed Windows installers for every supported OS/architecture combination.
+2. Publish a versioned support matrix and conformance results for package lifecycle, user activation, managed policy, enterprise networking, and removal.
+3. Freeze and version the managed-policy, deployment-profile, status, event, and exit-code schemas with backward-compatibility tests.
+4. Build a repeatable real-device lab covering generic Apple MDM and Windows MDM contracts, with Intune as an adapter rather than the product boundary.
+5. Ship an organization intake template that produces policy and deployment profiles without code changes or embedded secrets.
+6. Run pilots with at least two organizations using different MDM vendors and network models; publish anonymized pass/fail evidence.
+
+## P1: broad administrator usability
+
+1. Certify vendor adapter packs in demand order, initially Intune and one Apple-focused platform such as Jamf Pro, Kandji, or Mosyle.
+2. Provide a local validator that checks organization policy, certificates, proxy settings, package compatibility, and detection configuration before rollout.
+3. Add fleet health export and SIEM mappings based on the canonical event schema, without making Guard Cloud mandatory.
+4. Publish migration, coexistence, rollback, incident-response, certificate-rotation, and support runbooks.
+5. Define a deprecation policy for schemas, OS versions, architectures, signing identities, and vendor adapters.
+
+## P2: ecosystem scale
+
+1. Publish a vendor-adapter conformance kit so partners and customers can validate additional MDM products without changing Guard core.
+2. Automate certification evidence collection and release attestations.
+3. Add optional zero-touch workspace enrollment using short-lived, organization-scoped bootstrap credentials.
+4. Establish compatibility SLAs and a public support matrix tied to Guard release channels.
+
+## Generalization rules
+
+- One artifact per platform and architecture, never per organization.
+- One canonical policy and lifecycle contract, never vendor-specific core behavior.
+- Vendor adapters translate packaging, assignment, detection, and remediation only.
+- Organization identifiers and secrets remain outside installers and repositories.
+- Local enforcement and health reporting continue when Guard Cloud or an MDM control plane is unavailable.
+- A compatibility claim requires repeatable evidence from the published matrix, not success in a single customer environment.

--- a/docs/guard/mdm-networking.md
+++ b/docs/guard/mdm-networking.md
@@ -1,0 +1,7 @@
+# HOL Guard enterprise networking
+
+HOL Guard always validates TLS certificates. Managed policy may select the platform system proxy, an explicit HTTPS proxy, or direct networking. An administrator-approved PEM CA bundle is added to—not substituted for—the operating system trust store. Proxy URLs containing credentials are rejected; credentialed proxies must use the operating system's approved credential mechanism.
+
+Public registry intelligence is optional and can be disabled with `network.allowPublicRegistries=false`. Local enforcement remains active during DNS, proxy, TLS, Guard Cloud, or registry outages. The machine-readable allowlist is [mdm-endpoints.v1.json](mdm-endpoints.v1.json).
+
+Installers are self-contained and do not contact these endpoints. Administrators should test endpoint trust from the same user or daemon context that runs Guard; user shell environment variables are not managed-policy authority.

--- a/docs/guard/mdm-release-evidence-template.md
+++ b/docs/guard/mdm-release-evidence-template.md
@@ -1,0 +1,19 @@
+# MDM release evidence
+
+- Version / build ID / source commit:
+- macOS architectures, minimum OS, package receipt:
+- Windows architectures, minimum OS, MSI product/upgrade code:
+- SHA-256 / CycloneDX SBOM / provenance verified:
+- Manifest Ed25519 key ID and signature verified:
+- macOS executable/package signature, notarization, and staple verified:
+- Windows executable/MSI Authenticode publisher verified:
+- Clean install / silent activation / detection:
+- Upgrade / authorized rollback / failed-install recovery:
+- Repair / deactivation / uninstall / reinstall:
+- Standard-user policy, update, removal, tamper attempts:
+- Direct / system proxy / explicit proxy / private CA / offline tests:
+- Gatekeeper / WDAC / AppLocker tests:
+- Real MDM vendor, assignment context, deployment ring, result:
+- Security / release engineering / support / customer IT approvals:
+
+Unsigned CI artifacts are structural test fixtures and never satisfy production signature rows.

--- a/docs/guard/schemas/mdm-policy-v1.schema.json
+++ b/docs/guard/schemas/mdm-policy-v1.schema.json
@@ -1,0 +1,36 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hol.org/schemas/guard/mdm-policy-v1.schema.json",
+  "title": "HOL Guard managed policy v1",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion"],
+  "properties": {
+    "schemaVersion": {"const": "hol-guard-mdm-policy.v1"},
+    "settings": {"type": "object"},
+    "lockedSettings": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "requiredHarnesses": {"type": "array", "uniqueItems": true, "items": {"type": "string", "minLength": 1}},
+    "network": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "proxyMode": {"enum": ["system", "explicit", "none"]},
+        "proxyUrl": {"type": ["string", "null"]},
+        "caBundlePath": {"type": ["string", "null"]},
+        "allowPublicRegistries": {"type": "boolean"}
+      }
+    },
+    "update": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "owner": {"enum": ["user", "mdm"]},
+        "channel": {"type": "string", "minLength": 1},
+        "minimumVersion": {"type": ["string", "null"]},
+        "maximumVersion": {"type": ["string", "null"]},
+        "allowDowngrade": {"type": "boolean"}
+      }
+    },
+    "daemonStartup": {"enum": ["on-demand", "login"]}
+  }
+}

--- a/docs/guard/schemas/mdm-status-v1.schema.json
+++ b/docs/guard/schemas/mdm-status-v1.schema.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://hol.org/schemas/guard/mdm-status-v1.schema.json",
+  "title": "HOL Guard MDM lifecycle result v1",
+  "type": "object",
+  "required": ["schemaVersion", "operation"],
+  "properties": {
+    "schemaVersion": {"const": "hol-guard-mdm-status.v1"},
+    "operation": {"enum": ["status", "activate", "repair", "deactivate", "authorize-deactivation", "network-diagnose"]},
+    "scope": {"enum": ["machine", "user"]},
+    "healthy": {"type": "boolean"},
+    "state": {"enum": ["absent", "installed", "activated", "protected", "degraded", "repairable", "policy-invalid", "tampered", "unsupported"]},
+    "reasonCodes": {"type": "array", "items": {"type": ["string", "null"]}}
+  },
+  "additionalProperties": true
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,9 @@ dev = [
     "pytest-cov>=7.1.0",
     "ruff>=0.15.15",
 ]
+mdm-build = [
+    "pyinstaller>=6.16,<7",
+]
 publish = [
     "twine>=6.2.0",
 ]

--- a/scripts/mdm/generate-release-manifest.py
+++ b/scripts/mdm/generate-release-manifest.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Generate a deterministic release manifest before platform signing."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import platform
+import subprocess
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+SCHEMA = "hol-guard-release-manifest.v1"
+POLICY_SCHEMA = "hol-guard-mdm-policy.v1"
+
+
+def _commit() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
+    )
+    return result.stdout.strip()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--runtime-root", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--build-id", required=True)
+    parser.add_argument("--platform", required=True, choices=("macos", "windows"))
+    parser.add_argument("--architecture", default=platform.machine().lower())
+    parser.add_argument("--installer-identity", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--signing-key", type=Path)
+    parser.add_argument("--key-id")
+    args = parser.parse_args()
+    root = args.runtime_root.resolve(strict=True)
+    output = args.output.resolve()
+    files = []
+    for path in sorted(item for item in root.rglob("*") if item.is_file()):
+        if path.resolve() == output:
+            continue
+        files.append(
+            {
+                "path": path.relative_to(root).as_posix(),
+                "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            }
+        )
+    payload = {
+        "schemaVersion": SCHEMA,
+        "version": args.version,
+        "buildId": args.build_id,
+        "sourceCommit": _commit(),
+        "platform": args.platform,
+        "architecture": args.architecture,
+        "policySchemaVersion": POLICY_SCHEMA,
+        "installerIdentity": args.installer_identity,
+        "files": files,
+    }
+    if (args.signing_key is None) != (args.key_id is None):
+        parser.error("--signing-key and --key-id must be supplied together")
+    if args.signing_key is not None:
+        private_key = serialization.load_pem_private_key(args.signing_key.read_bytes(), password=None)
+        if not isinstance(private_key, Ed25519PrivateKey):
+            parser.error("--signing-key must contain an Ed25519 private key")
+        canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+        payload["signature"] = {
+            "keyId": args.key_id,
+            "value": base64.b64encode(private_key.sign(canonical)).decode(),
+        }
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mdm/generate-release-manifest.py
+++ b/scripts/mdm/generate-release-manifest.py
@@ -19,10 +19,11 @@ POLICY_SCHEMA = "hol-guard-mdm-policy.v1"
 
 
 def _commit() -> str:
-    result = subprocess.run(
-        ["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True
-    )
-    return result.stdout.strip()
+    try:
+        result = subprocess.run(["git", "rev-parse", "HEAD"], check=True, capture_output=True, text=True)
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+    return result.stdout.strip() or "unknown"
 
 
 def main() -> int:

--- a/scripts/mdm/generate-sbom.py
+++ b/scripts/mdm/generate-sbom.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Generate a deterministic CycloneDX dependency inventory for frozen runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.metadata
+import json
+from pathlib import Path
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--version", required=True)
+    args = parser.parse_args()
+    components = []
+    for distribution in sorted(importlib.metadata.distributions(), key=lambda item: item.metadata["Name"].lower()):
+        name = distribution.metadata["Name"]
+        if not name:
+            continue
+        components.append(
+            {
+                "type": "library",
+                "name": name,
+                "version": distribution.version,
+                "purl": f"pkg:pypi/{name.lower().replace('_', '-')}@{distribution.version}",
+            }
+        )
+    payload = {
+        "bomFormat": "CycloneDX",
+        "specVersion": "1.6",
+        "version": 1,
+        "metadata": {"component": {"type": "application", "name": "HOL Guard", "version": args.version}},
+        "components": components,
+    }
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mdm/hol-guard-entry.py
+++ b/scripts/mdm/hol-guard-entry.py
@@ -1,0 +1,6 @@
+"""PyInstaller entrypoint for the machine-owned HOL Guard runtime."""
+
+from codex_plugin_scanner.cli import main
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/mdm/macos/activate-current-user.sh
+++ b/scripts/mdm/macos/activate-current-user.sh
@@ -1,0 +1,8 @@
+#!/bin/zsh
+set -euo pipefail
+
+readonly GUARD="/Library/Application Support/HOL Guard/hol-guard/hol-guard"
+readonly USER_NAME="$(id -un)"
+readonly USER_HOME="$(dscl . -read "/Users/${USER_NAME}" NFSHomeDirectory | awk '{print $2}')"
+[[ -n "${USER_HOME}" && -d "${USER_HOME}" ]] || exit 0
+exec "${GUARD}" mdm repair --home "${USER_HOME}" --user "${USER_NAME}" --json

--- a/scripts/mdm/macos/activate-current-user.sh
+++ b/scripts/mdm/macos/activate-current-user.sh
@@ -3,6 +3,6 @@ set -euo pipefail
 
 readonly GUARD="/Library/Application Support/HOL Guard/hol-guard/hol-guard"
 readonly USER_NAME="$(id -un)"
-readonly USER_HOME="$(dscl . -read "/Users/${USER_NAME}" NFSHomeDirectory | awk '{print $2}')"
+readonly USER_HOME="$(dscl . -read "/Users/${USER_NAME}" NFSHomeDirectory | sed -n 's/^NFSHomeDirectory: //p')"
 [[ -n "${USER_HOME}" && -d "${USER_HOME}" ]] || exit 0
 exec "${GUARD}" mdm repair --home "${USER_HOME}" --user "${USER_NAME}" --json

--- a/scripts/mdm/macos/build-pkg.sh
+++ b/scripts/mdm/macos/build-pkg.sh
@@ -1,0 +1,58 @@
+#!/bin/zsh
+set -euo pipefail
+
+readonly ROOT="${0:A:h:h:h:h}"
+readonly VERSION="${HOL_GUARD_VERSION:?Set HOL_GUARD_VERSION}"
+readonly BUILD_ID="${HOL_GUARD_BUILD_ID:?Set HOL_GUARD_BUILD_ID}"
+readonly ARCH="$(uname -m)"
+readonly OUT="${ROOT}/dist/mdm/macos"
+readonly STAGE="${OUT}/stage"
+readonly RUNTIME="${STAGE}/Library/Application Support/HOL Guard"
+readonly PACKAGE_ID="org.hol.guard"
+
+rm -rf "${OUT}"
+mkdir -p "${RUNTIME}" "${STAGE}/Library/LaunchAgents" "${OUT}"
+
+uv run --no-sync pyinstaller --clean --noconfirm --onedir --name hol-guard \
+  --collect-submodules codex_plugin_scanner --collect-data codex_plugin_scanner \
+  --distpath "${RUNTIME}" --workpath "${OUT}/pyinstaller" --specpath "${OUT}" \
+  "${ROOT}/scripts/mdm/hol-guard-entry.py"
+
+cp "${ROOT}/scripts/mdm/macos/org.hol.guard.user-activation.plist" \
+  "${STAGE}/Library/LaunchAgents/org.hol.guard.user-activation.plist"
+cp "${ROOT}/scripts/mdm/macos/activate-current-user.sh" "${RUNTIME}/activate-current-user"
+typeset -a manifest_args
+manifest_args=(--runtime-root "${RUNTIME}" --version "${VERSION}" --build-id "${BUILD_ID}" \
+  --platform macos --architecture "${ARCH}" --installer-identity "${PACKAGE_ID}" \
+  --output "${RUNTIME}/release-manifest.json")
+if [[ -n "${HOL_GUARD_MANIFEST_SIGNING_KEY:-}" ]]; then
+  [[ -n "${HOL_GUARD_MANIFEST_KEY_ID:-}" && -n "${HOL_GUARD_MANIFEST_PUBLIC_KEYS:-}" ]] || exit 2
+  cp "${HOL_GUARD_MANIFEST_PUBLIC_KEYS}" "${RUNTIME}/release-trusted-keys.json"
+  manifest_args+=(--signing-key "${HOL_GUARD_MANIFEST_SIGNING_KEY}" --key-id "${HOL_GUARD_MANIFEST_KEY_ID}")
+fi
+python3 "${ROOT}/scripts/mdm/generate-release-manifest.py" "${manifest_args[@]}"
+
+find "${STAGE}" -type d -exec chmod 0755 {} +
+find "${STAGE}" -type f -exec chmod 0644 {} +
+chmod 0755 "${RUNTIME}/hol-guard/hol-guard" "${RUNTIME}/activate-current-user"
+
+typeset -a pkg_args
+pkg_args=(--root "${STAGE}" --identifier "${PACKAGE_ID}" --version "${VERSION}" \
+  --scripts "${ROOT}/scripts/mdm/macos/pkg-scripts")
+if [[ -n "${HOL_GUARD_INSTALLER_SIGN_IDENTITY:-}" ]]; then
+  [[ -n "${HOL_GUARD_MANIFEST_SIGNING_KEY:-}" ]] || exit 2
+  pkg_args+=(--sign "${HOL_GUARD_INSTALLER_SIGN_IDENTITY}")
+fi
+pkgbuild "${pkg_args[@]}" "${OUT}/hol-guard-${VERSION}-${ARCH}.pkg"
+
+if [[ -n "${HOL_GUARD_NOTARY_PROFILE:-}" ]]; then
+  xcrun notarytool submit "${OUT}/hol-guard-${VERSION}-${ARCH}.pkg" \
+    --keychain-profile "${HOL_GUARD_NOTARY_PROFILE}" --wait
+  xcrun stapler staple "${OUT}/hol-guard-${VERSION}-${ARCH}.pkg"
+fi
+
+python3 "${ROOT}/scripts/mdm/generate-sbom.py" --version "${VERSION}" --output "${OUT}/sbom.cdx.json"
+python3 "${ROOT}/scripts/mdm/write-release-evidence.py" \
+  --artifact "${OUT}/hol-guard-${VERSION}-${ARCH}.pkg" \
+  --manifest "${RUNTIME}/release-manifest.json" --sbom "${OUT}/sbom.cdx.json" \
+  --output "${OUT}/release-evidence.json"

--- a/scripts/mdm/macos/deactivate-user.sh
+++ b/scripts/mdm/macos/deactivate-user.sh
@@ -11,9 +11,10 @@ readonly AUTH_ROOT="/Library/Application Support/HOL Guard State/removal-authori
 readonly AUTH_FILE="${AUTH_ROOT}/${USER_UID}-$(uuidgen).json"
 readonly TOKEN_NAME="${AUTH_FILE:t}"
 
-trap 'rm -f "${AUTH_FILE}"' EXIT
+trap 'chmod -a "${USER_NAME} allow search,delete_child" "${AUTH_ROOT}" 2>/dev/null || true; rm -f "${AUTH_FILE}"' EXIT
 "${GUARD}" mdm authorize-deactivation --home "${USER_HOME}" --user "${USER_NAME}" \
   --token-name "${TOKEN_NAME}" --json >/dev/null
+chmod +a "${USER_NAME} allow search,delete_child" "${AUTH_ROOT}"
 launchctl asuser "${USER_UID}" sudo -u "${USER_NAME}" -- \
   "${GUARD}" mdm deactivate --home "${USER_HOME}" --user "${USER_NAME}" \
   --authorization-file "${AUTH_FILE}" --json

--- a/scripts/mdm/macos/deactivate-user.sh
+++ b/scripts/mdm/macos/deactivate-user.sh
@@ -1,0 +1,19 @@
+#!/bin/zsh
+set -euo pipefail
+
+[[ "$(id -u)" -eq 0 ]] || exit 3
+[[ "$#" -eq 2 ]] || exit 2
+readonly USER_NAME="$1"
+readonly USER_HOME="$2"
+readonly USER_UID="$(id -u "${USER_NAME}")"
+readonly GUARD="/Library/Application Support/HOL Guard/hol-guard/hol-guard"
+readonly AUTH_ROOT="/Library/Application Support/HOL Guard State/removal-authorizations"
+readonly AUTH_FILE="${AUTH_ROOT}/${USER_UID}-$(uuidgen).json"
+readonly TOKEN_NAME="${AUTH_FILE:t}"
+
+trap 'rm -f "${AUTH_FILE}"' EXIT
+"${GUARD}" mdm authorize-deactivation --home "${USER_HOME}" --user "${USER_NAME}" \
+  --token-name "${TOKEN_NAME}" --json >/dev/null
+launchctl asuser "${USER_UID}" sudo -u "${USER_NAME}" -- \
+  "${GUARD}" mdm deactivate --home "${USER_HOME}" --user "${USER_NAME}" \
+  --authorization-file "${AUTH_FILE}" --json

--- a/scripts/mdm/macos/detect.sh
+++ b/scripts/mdm/macos/detect.sh
@@ -1,0 +1,6 @@
+#!/bin/zsh
+set -u
+
+readonly GUARD="/Library/Application Support/HOL Guard/hol-guard/hol-guard"
+[[ -x "${GUARD}" ]] || exit 1
+exec "${GUARD}" mdm status --scope machine --json

--- a/scripts/mdm/macos/org.hol.guard.user-activation.plist
+++ b/scripts/mdm/macos/org.hol.guard.user-activation.plist
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>org.hol.guard.user-activation</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>/Library/Application Support/HOL Guard/activate-current-user</string>
+  </array>
+  <key>RunAtLoad</key><true/>
+  <key>ProcessType</key><string>Background</string>
+</dict>
+</plist>

--- a/scripts/mdm/macos/pkg-scripts/postinstall
+++ b/scripts/mdm/macos/pkg-scripts/postinstall
@@ -4,9 +4,12 @@ set -euo pipefail
 readonly RUNTIME="/Library/Application Support/HOL Guard"
 readonly STATE="/Library/Application Support/HOL Guard State"
 readonly LOGS="/Library/Logs/HOL Guard"
+readonly LAUNCH_AGENT="/Library/LaunchAgents/org.hol.guard.user-activation.plist"
 
 mkdir -p "${STATE}" "${LOGS}"
 chown -R root:wheel "${RUNTIME}" "${STATE}" "${LOGS}"
 chmod -R go-w "${RUNTIME}" "${STATE}" "${LOGS}"
 chmod 0755 "${RUNTIME}" "${STATE}" "${LOGS}"
+chown root:wheel "${LAUNCH_AGENT}"
+chmod 0644 "${LAUNCH_AGENT}"
 exit 0

--- a/scripts/mdm/macos/pkg-scripts/postinstall
+++ b/scripts/mdm/macos/pkg-scripts/postinstall
@@ -1,0 +1,12 @@
+#!/bin/zsh
+set -euo pipefail
+
+readonly RUNTIME="/Library/Application Support/HOL Guard"
+readonly STATE="/Library/Application Support/HOL Guard State"
+readonly LOGS="/Library/Logs/HOL Guard"
+
+mkdir -p "${STATE}" "${LOGS}"
+chown -R root:wheel "${RUNTIME}" "${STATE}" "${LOGS}"
+chmod -R go-w "${RUNTIME}" "${STATE}" "${LOGS}"
+chmod 0755 "${RUNTIME}" "${STATE}" "${LOGS}"
+exit 0

--- a/scripts/mdm/macos/pkg-scripts/preinstall
+++ b/scripts/mdm/macos/pkg-scripts/preinstall
@@ -1,0 +1,7 @@
+#!/bin/zsh
+set -euo pipefail
+
+[[ "$(uname -s)" == "Darwin" ]] || exit 1
+[[ "$(uname -m)" == "arm64" || "$(uname -m)" == "x86_64" ]] || exit 1
+df -Pk / | awk 'NR == 2 { exit !($4 >= 524288) }'
+exit 0

--- a/scripts/mdm/macos/uninstall.sh
+++ b/scripts/mdm/macos/uninstall.sh
@@ -1,0 +1,8 @@
+#!/bin/zsh
+set -euo pipefail
+
+[[ "$(id -u)" -eq 0 ]] || exit 3
+pkgutil --forget org.hol.guard >/dev/null 2>&1 || true
+rm -rf "/Library/Application Support/HOL Guard" "/Library/Application Support/HOL Guard State"
+rm -f "/Library/LaunchAgents/org.hol.guard.user-activation.plist"
+exit 0

--- a/scripts/mdm/windows/activate-user.ps1
+++ b/scripts/mdm/windows/activate-user.ps1
@@ -1,0 +1,4 @@
+$ErrorActionPreference = 'Stop'
+$Guard = Join-Path $env:ProgramFiles 'HOL Guard/hol-guard/hol-guard.exe'
+& $Guard mdm activate --home $env:USERPROFILE --user $env:USERNAME --json
+exit $LASTEXITCODE

--- a/scripts/mdm/windows/authorize-deactivation.ps1
+++ b/scripts/mdm/windows/authorize-deactivation.ps1
@@ -6,4 +6,7 @@ $ErrorActionPreference = 'Stop'
 $Guard = Join-Path $env:ProgramFiles 'HOL Guard/hol-guard/hol-guard.exe'
 $TokenName = "$User.json"
 & $Guard mdm authorize-deactivation --home $Home --user $User --token-name $TokenName --json
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+$Authorization = Join-Path $env:ProgramData "HOL Guard/removal-authorizations/$TokenName"
+& icacls.exe $Authorization /grant:r "${User}:(R,D)" | Out-Null
 exit $LASTEXITCODE

--- a/scripts/mdm/windows/authorize-deactivation.ps1
+++ b/scripts/mdm/windows/authorize-deactivation.ps1
@@ -1,0 +1,9 @@
+param(
+    [Parameter(Mandatory = $true)][string]$User,
+    [Parameter(Mandatory = $true)][string]$Home
+)
+$ErrorActionPreference = 'Stop'
+$Guard = Join-Path $env:ProgramFiles 'HOL Guard/hol-guard/hol-guard.exe'
+$TokenName = "$User.json"
+& $Guard mdm authorize-deactivation --home $Home --user $User --token-name $TokenName --json
+exit $LASTEXITCODE

--- a/scripts/mdm/windows/build-msi.ps1
+++ b/scripts/mdm/windows/build-msi.ps1
@@ -27,14 +27,14 @@ if (-not [string]::IsNullOrWhiteSpace($env:HOL_GUARD_MANIFEST_SIGNING_KEY)) {
     Copy-Item $env:HOL_GUARD_MANIFEST_PUBLIC_KEYS (Join-Path $Runtime 'release-trusted-keys.json')
     $ManifestArgs += @('--signing-key', $env:HOL_GUARD_MANIFEST_SIGNING_KEY, '--key-id', $env:HOL_GUARD_MANIFEST_KEY_ID)
 }
-python (Join-Path $Root 'scripts/mdm/generate-release-manifest.py') @ManifestArgs
-
 if (-not [string]::IsNullOrWhiteSpace($env:HOL_GUARD_SIGNTOOL_CERT_SHA1)) {
     if ([string]::IsNullOrWhiteSpace($env:HOL_GUARD_MANIFEST_SIGNING_KEY)) { throw 'Signed installers require a signed manifest.' }
     Get-ChildItem -Path $Runtime -Filter '*.exe' -Recurse | ForEach-Object {
         & signtool sign /sha1 $env:HOL_GUARD_SIGNTOOL_CERT_SHA1 /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $_.FullName
     }
 }
+python (Join-Path $Root 'scripts/mdm/generate-release-manifest.py') @ManifestArgs
+
 $Msi = Join-Path $Out "hol-guard-$Version-x64.msi"
 & wix build (Join-Path $PSScriptRoot 'hol-guard.wxs') -arch x64 -d RuntimeRoot=$Runtime -o $Msi
 if (-not [string]::IsNullOrWhiteSpace($env:HOL_GUARD_SIGNTOOL_CERT_SHA1)) {

--- a/scripts/mdm/windows/build-msi.ps1
+++ b/scripts/mdm/windows/build-msi.ps1
@@ -1,0 +1,46 @@
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$Root = (Resolve-Path (Join-Path $PSScriptRoot '../../..')).Path
+$Version = $env:HOL_GUARD_VERSION
+$BuildId = $env:HOL_GUARD_BUILD_ID
+if ([string]::IsNullOrWhiteSpace($Version) -or [string]::IsNullOrWhiteSpace($BuildId)) {
+    throw 'Set HOL_GUARD_VERSION and HOL_GUARD_BUILD_ID.'
+}
+$Out = Join-Path $Root 'dist/mdm/windows'
+$Runtime = Join-Path $Out 'runtime'
+Remove-Item -Recurse -Force $Out -ErrorAction SilentlyContinue
+New-Item -ItemType Directory -Force $Runtime | Out-Null
+
+uv run --no-sync pyinstaller --clean --noconfirm --onedir --name hol-guard `
+    --collect-submodules codex_plugin_scanner --collect-data codex_plugin_scanner `
+    --distpath $Runtime --workpath (Join-Path $Out 'pyinstaller') --specpath $Out `
+    (Join-Path $Root 'scripts/mdm/hol-guard-entry.py')
+$ManifestArgs = @(
+    '--runtime-root', $Runtime, '--version', $Version, '--build-id', $BuildId,
+    '--platform', 'windows', '--architecture', $env:PROCESSOR_ARCHITECTURE,
+    '--installer-identity', 'HOLGuardMachine', '--output', (Join-Path $Runtime 'release-manifest.json')
+)
+if (-not [string]::IsNullOrWhiteSpace($env:HOL_GUARD_MANIFEST_SIGNING_KEY)) {
+    if ([string]::IsNullOrWhiteSpace($env:HOL_GUARD_MANIFEST_KEY_ID) -or
+        [string]::IsNullOrWhiteSpace($env:HOL_GUARD_MANIFEST_PUBLIC_KEYS)) { throw 'Manifest key ID and public keys are required.' }
+    Copy-Item $env:HOL_GUARD_MANIFEST_PUBLIC_KEYS (Join-Path $Runtime 'release-trusted-keys.json')
+    $ManifestArgs += @('--signing-key', $env:HOL_GUARD_MANIFEST_SIGNING_KEY, '--key-id', $env:HOL_GUARD_MANIFEST_KEY_ID)
+}
+python (Join-Path $Root 'scripts/mdm/generate-release-manifest.py') @ManifestArgs
+
+if (-not [string]::IsNullOrWhiteSpace($env:HOL_GUARD_SIGNTOOL_CERT_SHA1)) {
+    if ([string]::IsNullOrWhiteSpace($env:HOL_GUARD_MANIFEST_SIGNING_KEY)) { throw 'Signed installers require a signed manifest.' }
+    Get-ChildItem -Path $Runtime -Filter '*.exe' -Recurse | ForEach-Object {
+        & signtool sign /sha1 $env:HOL_GUARD_SIGNTOOL_CERT_SHA1 /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $_.FullName
+    }
+}
+$Msi = Join-Path $Out "hol-guard-$Version-x64.msi"
+& wix build (Join-Path $PSScriptRoot 'hol-guard.wxs') -arch x64 -d RuntimeRoot=$Runtime -o $Msi
+if (-not [string]::IsNullOrWhiteSpace($env:HOL_GUARD_SIGNTOOL_CERT_SHA1)) {
+    & signtool sign /sha1 $env:HOL_GUARD_SIGNTOOL_CERT_SHA1 /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $Msi
+}
+python (Join-Path $Root 'scripts/mdm/generate-sbom.py') --version $Version --output (Join-Path $Out 'sbom.cdx.json')
+python (Join-Path $Root 'scripts/mdm/write-release-evidence.py') --artifact $Msi `
+    --manifest (Join-Path $Runtime 'release-manifest.json') --sbom (Join-Path $Out 'sbom.cdx.json') `
+    --output (Join-Path $Out 'release-evidence.json')

--- a/scripts/mdm/windows/deactivate-user.ps1
+++ b/scripts/mdm/windows/deactivate-user.ps1
@@ -1,0 +1,10 @@
+$ErrorActionPreference = 'Stop'
+$Guard = Join-Path $env:ProgramFiles 'HOL Guard/hol-guard/hol-guard.exe'
+$Authorization = Join-Path $env:ProgramData "HOL Guard/removal-authorizations/$env:USERNAME.json"
+if (-not (Test-Path -LiteralPath $Authorization -PathType Leaf)) { exit 3 }
+try {
+    & $Guard mdm deactivate --home $env:USERPROFILE --user $env:USERNAME --authorization-file $Authorization --json
+    exit $LASTEXITCODE
+} finally {
+    # The SYSTEM/device-context remediation removes the authorization after the user assignment completes.
+}

--- a/scripts/mdm/windows/detect.ps1
+++ b/scripts/mdm/windows/detect.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = 'Stop'
+$Guard = Join-Path $env:ProgramFiles 'HOL Guard/hol-guard/hol-guard.exe'
+if (-not (Test-Path -LiteralPath $Guard -PathType Leaf)) { exit 1 }
+& $Guard mdm status --scope machine --json
+exit $LASTEXITCODE

--- a/scripts/mdm/windows/hol-guard.wxs
+++ b/scripts/mdm/windows/hol-guard.wxs
@@ -1,0 +1,26 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="HOL Guard" Manufacturer="Hashgraph Online" Version="$(env.HOL_GUARD_VERSION)"
+           UpgradeCode="B15D39B1-6395-4FEA-98A9-5D734DDC455D" Scope="perMachine">
+    <MajorUpgrade DowngradeErrorMessage="A newer HOL Guard version is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="HOL Guard" />
+    </StandardDirectory>
+    <StandardDirectory Id="CommonAppDataFolder">
+      <Directory Id="STATEFOLDER" Name="HOL Guard">
+        <Component Id="MachineState" Guid="5CF2D38E-C3EC-4F31-BE6C-A15BDD52B279">
+          <CreateFolder />
+        </Component>
+      </Directory>
+    </StandardDirectory>
+    <Component Id="UserActivation" Directory="INSTALLFOLDER" Guid="EF2BC727-7CA8-44EC-B7A6-C82F4CE4C7BD">
+      <RegistryKey Root="HKLM" Key="Software\Microsoft\Active Setup\Installed Components\{AFA2F379-D7A2-4210-91E3-E71E43F1D994}">
+        <RegistryValue Name="Version" Value="$(env.HOL_GUARD_VERSION)" Type="string" KeyPath="yes" />
+        <RegistryValue Name="StubPath" Type="string"
+          Value="&quot;[INSTALLFOLDER]hol-guard\hol-guard.exe&quot; mdm repair --home &quot;%USERPROFILE%&quot; --user &quot;%USERNAME%&quot; --json" />
+      </RegistryKey>
+    </Component>
+    <Files Include="$(RuntimeRoot)\**" Directory="INSTALLFOLDER" />
+    <Feature Id="Main"><ComponentRef Id="MachineState" /><ComponentRef Id="UserActivation" /></Feature>
+  </Package>
+</Wix>

--- a/scripts/mdm/windows/hol-guard.wxs
+++ b/scripts/mdm/windows/hol-guard.wxs
@@ -16,7 +16,7 @@
     <Component Id="UserActivation" Directory="INSTALLFOLDER" Guid="EF2BC727-7CA8-44EC-B7A6-C82F4CE4C7BD">
       <RegistryKey Root="HKLM" Key="Software\Microsoft\Active Setup\Installed Components\{AFA2F379-D7A2-4210-91E3-E71E43F1D994}">
         <RegistryValue Name="Version" Value="$(env.HOL_GUARD_VERSION)" Type="string" KeyPath="yes" />
-        <RegistryValue Name="StubPath" Type="string"
+        <RegistryValue Name="StubPath" Type="expandable"
           Value="&quot;[INSTALLFOLDER]hol-guard\hol-guard.exe&quot; mdm repair --home &quot;%USERPROFILE%&quot; --user &quot;%USERNAME%&quot; --json" />
       </RegistryKey>
     </Component>

--- a/scripts/mdm/write-release-evidence.py
+++ b/scripts/mdm/write-release-evidence.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+"""Write artifact checksums and provenance without reading signing secrets."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--artifact", type=Path, required=True)
+    parser.add_argument("--manifest", type=Path, required=True)
+    parser.add_argument("--sbom", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    artifact_hash = _sha256(args.artifact)
+    args.artifact.with_suffix(args.artifact.suffix + ".sha256").write_text(
+        f"{artifact_hash}  {args.artifact.name}\n", encoding="utf-8"
+    )
+    payload = {
+        "schemaVersion": "hol-guard-release-evidence.v1",
+        "generatedAt": datetime.now(timezone.utc).isoformat(),
+        "artifact": {"name": args.artifact.name, "sha256": artifact_hash},
+        "releaseManifestSha256": _sha256(args.manifest),
+        "sbomSha256": _sha256(args.sbom),
+    }
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/codex_plugin_scanner/cli.py
+++ b/src/codex_plugin_scanner/cli.py
@@ -240,6 +240,7 @@ def _resolve_legacy_args(
         "bootstrap",
         "detect",
         "install",
+        "mdm",
         "update",
         "uninstall",
         "package-shims",

--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -18,7 +18,7 @@ import requests
 
 from ..config import resolve_guard_home
 from ..daemon.manager import load_guard_daemon_auth_token
-from ..mdm.network import managed_requests_kwargs, managed_requests_session
+from ..mdm.network import managed_requests_required, managed_requests_session
 from ..store import GuardStore
 
 
@@ -148,7 +148,7 @@ class WebhookBackend(NotificationBackend):
 
 
 def _managed_post(url: str, *, payload: Mapping[str, object], timeout: int) -> requests.Response:
-    if not managed_requests_kwargs():
+    if not managed_requests_required():
         return requests.post(url, json=payload, timeout=timeout)
     return managed_requests_session().post(url, json=payload, timeout=timeout)
 

--- a/src/codex_plugin_scanner/guard/bridge/__init__.py
+++ b/src/codex_plugin_scanner/guard/bridge/__init__.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 import time
 from abc import ABC, abstractmethod
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import urlparse
@@ -17,6 +18,7 @@ import requests
 
 from ..config import resolve_guard_home
 from ..daemon.manager import load_guard_daemon_auth_token
+from ..mdm.network import managed_requests_kwargs, managed_requests_session
 from ..store import GuardStore
 
 
@@ -102,9 +104,9 @@ class TelegramBackend(NotificationBackend):
 
     def send_notification(self, request: PendingRequest, message: str) -> bool:
         try:
-            resp = requests.post(
+            resp = _managed_post(
                 f"{self.api_url}/sendMessage",
-                json={"chat_id": self.chat_id, "text": message, "parse_mode": "Markdown"},
+                payload={"chat_id": self.chat_id, "text": message, "parse_mode": "Markdown"},
                 timeout=10,
             )
             return resp.status_code == 200
@@ -133,7 +135,7 @@ class WebhookBackend(NotificationBackend):
         if self.include_artifact_details:
             payload["text"] = message
         try:
-            resp = requests.post(self.url, json=payload, timeout=10)
+            resp = _managed_post(self.url, payload=payload, timeout=10)
             return resp.status_code in (200, 201)
         except Exception:
             return False
@@ -143,6 +145,12 @@ class WebhookBackend(NotificationBackend):
         if match:
             return (match.group(1), match.group(2))
         return (None, None)
+
+
+def _managed_post(url: str, *, payload: Mapping[str, object], timeout: int) -> requests.Response:
+    if not managed_requests_kwargs():
+        return requests.post(url, json=payload, timeout=timeout)
+    return managed_requests_session().post(url, json=payload, timeout=timeout)
 
 
 def _parse_pending_request(data: dict[str, Any]) -> PendingRequest | None:

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
@@ -115,6 +115,25 @@ def _run_guard_update_command(
 ) -> int:
     if guard_home is None:
         raise RuntimeError("Guard home is required")
+    from ..mdm.policy import load_managed_policy
+
+    managed_policy = load_managed_policy()
+    if managed_policy.status in {"invalid", "inaccessible", "tampered"} or (
+        managed_policy.policy is not None and managed_policy.policy.install_owner == "mdm"
+    ):
+        _emit(
+            "update",
+            {
+                "status": "managed",
+                "changed": False,
+                "reason_code": (
+                    "managed_policy_invalid" if managed_policy.policy is None else "managed_update_owned_by_mdm"
+                ),
+                "message": "Version changes are owned by the device management service.",
+            },
+            getattr(args, "json", False),
+        )
+        return 0
     dry_run = bool(getattr(args, "dry_run", False))
     store: GuardStore | None
     update_store_error: OSError | RuntimeError | sqlite3.Error | None = None

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
@@ -50,8 +50,7 @@ def _run_guard_mdm_command(
                 "results": results,
             }
             payload["healthy"] = all(
-                isinstance(result, dict) and result.get("reasonCode") == "endpoint_reachable"
-                for result in results
+                isinstance(result, dict) and result.get("reasonCode") == "endpoint_reachable" for result in results
             )
         elif command == "status" and args.scope == "machine":
             root = Path(args.machine_root).resolve() if getattr(args, "machine_root", None) else None

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
@@ -1,0 +1,97 @@
+"""Early MDM lifecycle command dispatch."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from ..mdm.lifecycle import (
+    activate_user,
+    authorize_deactivation,
+    deactivate_user,
+    machine_status,
+    repair_user,
+    user_status,
+    validate_removal_authorization,
+    validate_user_home,
+)
+from ..mdm.network import diagnose_endpoint
+from ..mdm.policy import load_managed_policy
+
+
+def _emit_mdm(payload: dict[str, object], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(payload, sort_keys=True))
+    else:
+        print(f"{payload.get('operation')}: {payload.get('state', 'complete')}")
+
+
+def _run_guard_mdm_command(
+    args: argparse.Namespace, *, input_text: str | None = None, output_stream: object | None = None
+) -> int:
+    del input_text, output_stream
+    command = str(args.mdm_command)
+    payload: dict[str, object]
+    try:
+        if command == "authorize-deactivation":
+            payload = authorize_deactivation(
+                Path(str(args.home)).resolve(), str(args.user), token_name=getattr(args, "token_name", None)
+            )
+        elif command == "network-diagnose":
+            policy_state = load_managed_policy()
+            network_policy = policy_state.policy.network if policy_state.policy is not None else None
+            results = [diagnose_endpoint(endpoint, network_policy).to_dict() for endpoint in args.endpoint]
+            payload = {
+                "schemaVersion": "hol-guard-mdm-status.v1",
+                "operation": command,
+                "healthy": True,
+                "managedPolicy": policy_state.to_public_dict(),
+                "results": results,
+            }
+            payload["healthy"] = all(
+                isinstance(result, dict) and result.get("reasonCode") == "endpoint_reachable"
+                for result in results
+            )
+        elif command == "status" and args.scope == "machine":
+            root = Path(args.machine_root).resolve() if getattr(args, "machine_root", None) else None
+            payload = machine_status(machine_root=root)
+        else:
+            if command == "status" and not getattr(args, "home", None):
+                raise ValueError("mdm_home_required_for_user_scope")
+            home = validate_user_home(str(args.home), getattr(args, "user", None))
+            if command == "status":
+                payload = user_status(home)
+            elif command == "activate":
+                payload = activate_user(home, str(args.user))
+            elif command == "repair":
+                payload = repair_user(home, str(args.user))
+            elif command == "deactivate":
+                policy = load_managed_policy()
+                authorization_fingerprint = None
+                removal_is_managed = policy.status in {"invalid", "inaccessible", "tampered"} or (
+                    policy.policy is not None and policy.policy.install_owner == "mdm"
+                )
+                if removal_is_managed and not args.authorization_file:
+                    raise PermissionError("mdm_removal_authorization_required")
+                if removal_is_managed:
+                    authorization_fingerprint = validate_removal_authorization(
+                        Path(str(args.authorization_file)), home=home, user=str(args.user)
+                    )
+                payload = deactivate_user(home, authorization_fingerprint=authorization_fingerprint)
+            else:
+                raise ValueError("mdm_command_invalid")
+    except (OSError, RuntimeError, ValueError, PermissionError) as exc:
+        payload = {
+            "schemaVersion": "hol-guard-mdm-status.v1",
+            "operation": command,
+            "healthy": False,
+            "reasonCodes": [str(exc)],
+        }
+        _emit_mdm(payload, bool(args.json))
+        return 2
+    _emit_mdm(payload, bool(args.json))
+    return 0 if payload.get("healthy", True) else 1
+
+
+__all__ = ["_run_guard_mdm_command"]

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_mdm.py
@@ -66,17 +66,11 @@ def _run_guard_mdm_command(
             elif command == "repair":
                 payload = repair_user(home, str(args.user))
             elif command == "deactivate":
-                policy = load_managed_policy()
-                authorization_fingerprint = None
-                removal_is_managed = policy.status in {"invalid", "inaccessible", "tampered"} or (
-                    policy.policy is not None and policy.policy.install_owner == "mdm"
-                )
-                if removal_is_managed and not args.authorization_file:
+                if not args.authorization_file:
                     raise PermissionError("mdm_removal_authorization_required")
-                if removal_is_managed:
-                    authorization_fingerprint = validate_removal_authorization(
-                        Path(str(args.authorization_file)), home=home, user=str(args.user)
-                    )
+                authorization_fingerprint = validate_removal_authorization(
+                    Path(str(args.authorization_file)), home=home, user=str(args.user)
+                )
                 payload = deactivate_user(home, authorization_fingerprint=authorization_fingerprint)
             else:
                 raise ValueError("mdm_command_invalid")

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_proxy.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_proxy.py
@@ -167,6 +167,23 @@ def _run_guard_uninstall_command(
     context = _require_guard_context(context)
     store = _require_guard_store(store)
     if bool(getattr(args, "self_uninstall", False)):
+        from ..mdm.policy import load_managed_policy
+
+        managed_policy = load_managed_policy()
+        if managed_policy.status in {"invalid", "inaccessible", "tampered"} or (
+            managed_policy.policy is not None and managed_policy.policy.install_owner == "mdm"
+        ):
+            _emit(
+                "uninstall",
+                {
+                    "status": "managed",
+                    "changed": False,
+                    "reason_code": "managed_removal_authorization_required",
+                    "message": "Removal is owned by the device management service.",
+                },
+                getattr(args, "json", False),
+            )
+            return 3
         if getattr(args, "harness", None) is not None or bool(getattr(args, "all", False)):
             print("Guard self uninstall does not accept a harness or --all.", file=sys.stderr)
             return 2

--- a/src/codex_plugin_scanner/guard/cli/commands_parser.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser.py
@@ -20,6 +20,7 @@ from .commands_parser_helpers import (
     _guard_http_url,
 )
 from .commands_parser_local import _configure_guard_local_parsers
+from .commands_parser_mdm import _configure_guard_mdm_parsers
 from .commands_parser_policy import _configure_guard_policy_parsers
 
 
@@ -51,13 +52,14 @@ def _configure_guard_parser(guard_parser: argparse.ArgumentParser) -> None:
         parser_class=FriendlyArgumentParser,
         metavar=(
             "{start,status,dashboard,init,apps,bootstrap,detect,install,update,uninstall,package-shims,run,protect,preflight,scan,diff,"
-            "test-eval,command,"
+            "test-eval,command,mdm,"
             "receipts,inventory,abom,aibom,approvals,explain,allow,deny,policies,trust,exceptions,advisories,events,doctor,connect,"
             "remote-pair,disconnect,"
             "login,sync,device,commands,bridge,mcp}"
         ),
     )
     _configure_guard_local_parsers(guard_subparsers)
+    _configure_guard_mdm_parsers(guard_subparsers)
     _configure_guard_policy_parsers(guard_subparsers)
     _configure_guard_cloud_parsers(guard_subparsers)
 

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_mdm.py
@@ -1,0 +1,49 @@
+"""Stable, prompt-free MDM lifecycle parser contract."""
+
+from __future__ import annotations
+
+import argparse
+
+
+def _add_json(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--json", action="store_true", help="Emit the versioned JSON automation contract")
+
+
+def _add_user(parser: argparse.ArgumentParser, *, require_user: bool = False) -> None:
+    parser.add_argument("--home", required=True, help="Absolute home directory for the target user")
+    parser.add_argument("--user", required=require_user, help="Target operating-system user identity")
+    _add_json(parser)
+
+
+def _configure_guard_mdm_parsers(
+    guard_subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    mdm = guard_subparsers.add_parser("mdm", help="Prompt-free enterprise deployment lifecycle")
+    commands = mdm.add_subparsers(dest="mdm_command", required=True)
+
+    status = commands.add_parser("status", help="Read machine or per-user deployment health")
+    status.add_argument("--scope", required=True, choices=("machine", "user"))
+    status.add_argument("--home", help="Absolute target home; required for user scope")
+    status.add_argument("--machine-root", help="Machine runtime root override for test and remediation scripts")
+    _add_json(status)
+
+    for name in ("activate", "repair"):
+        command = commands.add_parser(name, help=f"Idempotently {name} Guard for one user")
+        _add_user(command, require_user=True)
+
+    deactivate = commands.add_parser("deactivate", help="Restore Guard-owned user integrations")
+    _add_user(deactivate, require_user=True)
+    deactivate.add_argument("--authorization-file", help="Short-lived MDM removal authorization file")
+
+    authorize = commands.add_parser(
+        "authorize-deactivation", help="Create a short-lived machine-owned user removal authorization"
+    )
+    _add_user(authorize, require_user=True)
+    authorize.add_argument("--token-name", help="Machine-state token filename selected by the MDM wrapper")
+
+    network = commands.add_parser("network-diagnose", help="Test managed DNS, proxy, and TLS without prompts")
+    network.add_argument("--endpoint", action="append", required=True, help="Approved HTTPS endpoint to test")
+    _add_json(network)
+
+
+__all__ = ["_configure_guard_mdm_parsers"]

--- a/src/codex_plugin_scanner/guard/cli/commands_router.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_router.py
@@ -16,6 +16,7 @@ from ._commands_shared import *
 from .commands_parser_helpers import *
 
 _EARLY_HANDLERS = {
+    "mdm": "_run_guard_mdm_command",
     "command": "_run_guard_command_inspection_command",
     "scan": "_run_guard_scan_command",
     "preflight": "_run_guard_preflight_command",

--- a/src/codex_plugin_scanner/guard/cli/commands_support.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_support.py
@@ -28,6 +28,7 @@ from . import commands_support_runtime_resolution as _commands_support_runtime_r
 from . import commands_support_connect as _commands_support_connect
 from . import commands_support_service as _commands_support_service
 from . import commands_dispatch_local as _commands_dispatch_local
+from . import commands_dispatch_mdm as _commands_dispatch_mdm
 from . import commands_dispatch_proxy as _commands_dispatch_proxy
 from . import commands_dispatch_records as _commands_dispatch_records
 from . import commands_dispatch_trust as _commands_dispatch_trust
@@ -62,6 +63,7 @@ _SOURCE_MODULES: tuple[ModuleType, ...] = (
     _commands_support_connect,
     _commands_support_service,
     _commands_dispatch_local,
+    _commands_dispatch_mdm,
     _commands_dispatch_proxy,
     _commands_dispatch_records,
     _commands_dispatch_trust,

--- a/src/codex_plugin_scanner/guard/cli/connect_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/connect_flow.py
@@ -21,6 +21,7 @@ from cryptography.hazmat.primitives.asymmetric import ec
 from cryptography.hazmat.primitives.asymmetric.utils import decode_dss_signature
 
 from ...version import __version__
+from ..mdm.network import managed_urlopen
 from ..package_firewall_defaults import extract_cloud_user_profile as _extract_cloud_user_profile
 from ..package_firewall_entitlement import (
     build_oauth_package_firewall_entitlement,
@@ -627,7 +628,7 @@ def request_device_authorization(url: str, body: str) -> dict[str, object]:
         method="POST",
         headers=_guard_oauth_request_headers(),
     )
-    with urllib.request.urlopen(request, timeout=20) as response:
+    with managed_urlopen(request, timeout=20) as response:
         payload = json.loads(response.read().decode("utf-8"))
     if not isinstance(payload, dict):
         raise RuntimeError("Guard Device Code authorization failed: invalid response.")
@@ -643,7 +644,7 @@ def exchange_guard_device_code(
     interval_seconds: int,
     expires_in_seconds: int,
     wait_timeout_seconds: float | None = None,
-    urlopen=urllib.request.urlopen,
+    urlopen=managed_urlopen,
     sleep=time.sleep,
     now: datetime | None = None,
 ) -> GuardOAuthTokenExchangeResult:
@@ -721,7 +722,7 @@ def exchange_guard_authorization_code(
     redirect_uri: str,
     code_verifier: str,
     dpop_key_material: GuardDpopKeyMaterial,
-    urlopen=urllib.request.urlopen,
+    urlopen=managed_urlopen,
     now: datetime | None = None,
 ) -> GuardOAuthTokenExchangeResult:
     request_body = urllib.parse.urlencode(
@@ -771,7 +772,7 @@ def refresh_guard_access_token(
     client_id: str,
     refresh_token: str,
     dpop_key_material: GuardDpopKeyMaterial,
-    urlopen=urllib.request.urlopen,
+    urlopen=managed_urlopen,
     now: datetime | None = None,
 ) -> GuardOAuthTokenExchangeResult:
     dpop_nonce: str | None = None
@@ -861,7 +862,7 @@ def revoke_guard_self_oauth_grant(
     workspace_id: str,
     revoke_cloud_grant: bool,
     dpop_key_material: GuardDpopKeyMaterial,
-    urlopen=urllib.request.urlopen,
+    urlopen=managed_urlopen,
     now: datetime | None = None,
 ) -> None:
     revoke_url = f"{oauth_client.issuer.rstrip('/')}/api/guard/oauth/revoke/self"
@@ -991,7 +992,7 @@ def run_guard_disconnect_command(
     store: GuardStore,
     revoke_cloud_grant: bool,
     now: str | None = None,
-    urlopen=urllib.request.urlopen,
+    urlopen=managed_urlopen,
 ) -> dict[str, object]:
     store.repair_oauth_local_credential_storage_from_primary()
     credentials = store.get_oauth_local_credentials(allow_primary=True)
@@ -1096,7 +1097,7 @@ def run_guard_device_connect_command(
     store: GuardStore,
     connect_url: str,
     request_device_authorization=request_device_authorization,
-    token_urlopen=urllib.request.urlopen,
+    token_urlopen=managed_urlopen,
     sleep=time.sleep,
     now: str | None = None,
     wait_timeout_seconds: float | None = None,

--- a/src/codex_plugin_scanner/guard/cli/remote_pair_flow.py
+++ b/src/codex_plugin_scanner/guard/cli/remote_pair_flow.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import Literal
 
 from ..adapters.base import HarnessContext
+from ..mdm.network import managed_urlopen
 from ..redaction import redact_sensitive_text
 from ..remote_pairing_constants import (
     REMOTE_PAIRING_CODE_ALPHABET,
@@ -144,7 +145,7 @@ def claim_remote_pairing_intent(
     label: str | None,
     public_dpop_jwk: dict[str, str],
     capability_summary: dict[str, object] | None = None,
-    urlopen=urllib.request.urlopen,
+    urlopen=managed_urlopen,
 ) -> dict[str, object]:
     normalized_code = normalize_remote_pairing_code(pair_code)
     if not is_remote_pairing_code_shape(normalized_code):
@@ -306,7 +307,7 @@ def run_guard_remote_pair_command(
     label: str | None,
     no_root: bool,
     now: str | None = None,
-    urlopen=urllib.request.urlopen,
+    urlopen=managed_urlopen,
 ) -> dict[str, object]:
     store.repair_oauth_local_credential_storage_from_primary()
     _assert_no_root_install_allowed(no_root=no_root)

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -109,7 +109,10 @@ def run_guard_update(
         "dry_run": dry_run,
     }
     managed_policy = load_managed_policy()
-    if managed_policy.policy is not None and managed_policy.policy.update.owner == "mdm":
+    managed_update_blocked = managed_policy.status != "absent" and (
+        managed_policy.policy is None or managed_policy.policy.update.owner == "mdm"
+    )
+    if managed_update_blocked:
         payload.update(
             {
                 "status": "skipped",

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -30,6 +30,7 @@ from ..adapters.opencode_pretool import (
     managed_plugin_path,
     pretool_plugin_source,
 )
+from ..mdm.network import managed_urlopen
 from ..redaction import redact_sensitive_text
 from ..shims import _trusted_import_root, _trusted_python_flags
 from ..store import GuardStore
@@ -664,7 +665,7 @@ def _latest_version_from_pypi() -> str | None:
     global _last_pypi_payload
     request = urllib.request.Request(_PYPI_JSON_URL, headers={"Accept": "application/json"})
     try:
-        with urllib.request.urlopen(request, timeout=_PYPI_TIMEOUT_SECONDS) as response:
+        with managed_urlopen(request, timeout=_PYPI_TIMEOUT_SECONDS) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except (
         OSError,

--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -31,6 +31,7 @@ from ..adapters.opencode_pretool import (
     pretool_plugin_source,
 )
 from ..mdm.network import managed_urlopen
+from ..mdm.policy import load_managed_policy
 from ..redaction import redact_sensitive_text
 from ..shims import _trusted_import_root, _trusted_python_flags
 from ..store import GuardStore
@@ -107,6 +108,17 @@ def run_guard_update(
         "installer": installer,
         "dry_run": dry_run,
     }
+    managed_policy = load_managed_policy()
+    if managed_policy.policy is not None and managed_policy.policy.update.owner == "mdm":
+        payload.update(
+            {
+                "status": "skipped",
+                "changed": False,
+                "reason_code": "mdm_update_owned",
+                "message": "HOL Guard updates are managed by the organization.",
+            }
+        )
+        return payload, 0
     requested_wheel_path, requested_wheel_error = _resolve_requested_wheel_path(wheel)
     if requested_wheel_error is not None:
         payload["status"] = "failed"

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -21,6 +21,8 @@ else:  # pragma: no cover - runtime compatibility
     tomllib = importlib.import_module("tomllib" if sys.version_info >= (3, 11) else "tomli")
 
 from .approval_gate import ApprovalGateGrant, public_config, require_settings_write
+from .mdm.contracts import ManagedPolicy, ManagedPolicyState
+from .mdm.policy import apply_managed_policy, fail_closed_managed_policy, load_managed_policy
 from .models import GuardAction, GuardMode
 
 DEFAULT_GUARD_DIRNAME = ".hol-guard"
@@ -325,6 +327,11 @@ class GuardConfig:
     publisher_actions: dict[str, GuardAction] | None = None
     artifact_actions: dict[str, GuardAction] | None = None
     evidence_retain_days: int = 90
+    managed_policy_status: str = "absent"
+    managed_policy_hash: str | None = None
+    managed_locked_settings: tuple[str, ...] = ()
+    install_owner: str = "user"
+    managed_policy: ManagedPolicy | None = None
 
     def resolve_action_override(
         self,
@@ -380,7 +387,12 @@ def _coerce_loaded_receipt_redaction_level(value: object) -> str:
     return "full"
 
 
-def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardConfig:
+def load_guard_config(
+    guard_home: Path,
+    workspace: Path | None = None,
+    *,
+    managed_policy_state: ManagedPolicyState | None = None,
+) -> GuardConfig:
     """Load Guard config from home and workspace overrides."""
 
     guard_home.mkdir(parents=True, exist_ok=True)
@@ -388,6 +400,12 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
     workspace_config = _load_workspace_guard_config(workspace)
 
     merged = _merge_config_payload(home_config, workspace_config)
+    managed_state = managed_policy_state or load_managed_policy()
+    effective_managed_policy = managed_state.policy
+    if effective_managed_policy is None and managed_state.status in {"invalid", "inaccessible", "tampered"}:
+        effective_managed_policy = fail_closed_managed_policy()
+    if effective_managed_policy is not None:
+        merged = apply_managed_policy(merged, effective_managed_policy)
     return GuardConfig(
         guard_home=guard_home,
         workspace=workspace,
@@ -437,6 +455,13 @@ def load_guard_config(guard_home: Path, workspace: Path | None = None) -> GuardC
         receipt_redaction_level=_coerce_loaded_receipt_redaction_level(
             merged.get("receipt_redaction_level"),
         ),
+        managed_policy_status=managed_state.status,
+        managed_policy_hash=effective_managed_policy.content_hash if effective_managed_policy is not None else None,
+        managed_locked_settings=tuple(sorted(effective_managed_policy.locked_settings))
+        if effective_managed_policy is not None
+        else (),
+        install_owner=effective_managed_policy.install_owner if effective_managed_policy is not None else "user",
+        managed_policy=effective_managed_policy,
     )
 
 
@@ -464,6 +489,10 @@ def editable_guard_settings(config: GuardConfig) -> dict[str, object]:
         "receipt_redaction_level": config.receipt_redaction_level,
         "billing": config.billing,
         "approval_gate": public_config(config.guard_home).to_dict(),
+        "managed_policy_status": config.managed_policy_status,
+        "managed_policy_hash": config.managed_policy_hash,
+        "managed_locked_settings": list(config.managed_locked_settings),
+        "install_owner": config.install_owner,
     }
 
 
@@ -490,6 +519,15 @@ def update_guard_settings(
         if key not in EDITABLE_GUARD_SETTING_KEYS:
             continue
         next_payload[key] = _coerce_editable_setting(key, value)
+    if current_config.managed_policy is not None:
+        composed = apply_managed_policy(next_payload, current_config.managed_policy)
+        weakened = [
+            key
+            for key in current_config.managed_locked_settings
+            if key in next_payload and composed.get(key) != next_payload.get(key)
+        ]
+        if weakened:
+            raise ValueError(f"Managed policy locks prevent weakening: {', '.join(sorted(weakened))}")
     if next_payload.get("sync") is True and next_payload.get("billing") is not True:
         raise ValueError("Cloud sync requires a paid team plan.")
     _write_guard_config(guard_home / "config.toml", next_payload)
@@ -782,7 +820,7 @@ def overlay_synced_guard_policy(
     )
     sync_enabled = payload.get("syncEnabled")
     cloud_redaction_level = payload.get("receiptRedactionLevel")
-    return replace(
+    overlaid = replace(
         config,
         mode=next_mode,
         default_action=default_action,
@@ -795,6 +833,46 @@ def overlay_synced_guard_policy(
             cloud_redaction_level
             if cloud_redaction_level in VALID_RECEIPT_REDACTION_LEVELS
             else config.receipt_redaction_level
+        ),
+    )
+    return _reapply_managed_config(overlaid)
+
+
+def _reapply_managed_config(config: GuardConfig) -> GuardConfig:
+    if config.managed_policy is None:
+        return config
+    local = {
+        "mode": config.mode,
+        "default_action": config.default_action,
+        "unknown_publisher_action": config.unknown_publisher_action,
+        "changed_hash_action": config.changed_hash_action,
+        "new_network_domain_action": config.new_network_domain_action,
+        "subprocess_action": config.subprocess_action,
+        "telemetry": config.telemetry,
+        "sync": config.sync,
+        "receipt_redaction_level": config.receipt_redaction_level,
+    }
+    composed = apply_managed_policy(local, config.managed_policy)
+    return replace(
+        config,
+        mode=_coerce_loaded_guard_mode(composed.get("mode"), config.mode),
+        default_action=_coerce_loaded_guard_action_or_default(composed.get("default_action"), config.default_action),
+        unknown_publisher_action=_coerce_loaded_guard_action_or_default(
+            composed.get("unknown_publisher_action"), config.unknown_publisher_action
+        ),
+        changed_hash_action=_coerce_loaded_guard_action_or_default(
+            composed.get("changed_hash_action"), config.changed_hash_action
+        ),
+        new_network_domain_action=_coerce_loaded_guard_action_or_default(
+            composed.get("new_network_domain_action"), config.new_network_domain_action
+        ),
+        subprocess_action=_coerce_loaded_guard_action_or_default(
+            composed.get("subprocess_action"), config.subprocess_action
+        ),
+        telemetry=_coerce_loaded_bool(composed.get("telemetry", config.telemetry)),
+        sync=_coerce_loaded_bool(composed.get("sync", config.sync)),
+        receipt_redaction_level=_coerce_loaded_receipt_redaction_level(
+            composed.get("receipt_redaction_level", config.receipt_redaction_level)
         ),
     )
 

--- a/src/codex_plugin_scanner/guard/config.py
+++ b/src/codex_plugin_scanner/guard/config.py
@@ -521,10 +521,12 @@ def update_guard_settings(
         next_payload[key] = _coerce_editable_setting(key, value)
     if current_config.managed_policy is not None:
         composed = apply_managed_policy(next_payload, current_config.managed_policy)
+        missing = object()
         weakened = [
             key
             for key in current_config.managed_locked_settings
-            if key in next_payload and composed.get(key) != next_payload.get(key)
+            if (requested := _nested_setting_value(next_payload, key, missing)) is not missing
+            and _nested_setting_value(composed, key, missing) != requested
         ]
         if weakened:
             raise ValueError(f"Managed policy locks prevent weakening: {', '.join(sorted(weakened))}")
@@ -843,11 +845,14 @@ def _reapply_managed_config(config: GuardConfig) -> GuardConfig:
         return config
     local = {
         "mode": config.mode,
+        "security_level": config.security_level,
         "default_action": config.default_action,
         "unknown_publisher_action": config.unknown_publisher_action,
         "changed_hash_action": config.changed_hash_action,
         "new_network_domain_action": config.new_network_domain_action,
         "subprocess_action": config.subprocess_action,
+        "risk_actions": config.risk_actions or {},
+        "harness_risk_actions": config.harness_risk_actions or {},
         "telemetry": config.telemetry,
         "sync": config.sync,
         "receipt_redaction_level": config.receipt_redaction_level,
@@ -856,6 +861,7 @@ def _reapply_managed_config(config: GuardConfig) -> GuardConfig:
     return replace(
         config,
         mode=_coerce_loaded_guard_mode(composed.get("mode"), config.mode),
+        security_level=_coerce_loaded_security_level(composed.get("security_level")),
         default_action=_coerce_loaded_guard_action_or_default(composed.get("default_action"), config.default_action),
         unknown_publisher_action=_coerce_loaded_guard_action_or_default(
             composed.get("unknown_publisher_action"), config.unknown_publisher_action
@@ -869,12 +875,23 @@ def _reapply_managed_config(config: GuardConfig) -> GuardConfig:
         subprocess_action=_coerce_loaded_guard_action_or_default(
             composed.get("subprocess_action"), config.subprocess_action
         ),
+        risk_actions=_coerce_risk_action_map(composed.get("risk_actions")),
+        harness_risk_actions=_coerce_harness_risk_action_map(composed.get("harness_risk_actions")),
         telemetry=_coerce_loaded_bool(composed.get("telemetry", config.telemetry)),
         sync=_coerce_loaded_bool(composed.get("sync", config.sync)),
         receipt_redaction_level=_coerce_loaded_receipt_redaction_level(
             composed.get("receipt_redaction_level", config.receipt_redaction_level)
         ),
     )
+
+
+def _nested_setting_value(payload: dict[str, object], path: str, missing: object) -> object:
+    current: object = payload
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return missing
+        current = current[part]
+    return current
 
 
 def _coerce_action_value(value: object, fallback: GuardAction) -> GuardAction:

--- a/src/codex_plugin_scanner/guard/local_supply_chain.py
+++ b/src/codex_plugin_scanner/guard/local_supply_chain.py
@@ -28,6 +28,7 @@ from .adapters.base import HarnessContext
 from .advisory_model import ProtectTargetIdentity, advisory_matches_target, build_package_url
 from .approval_scope_support import package_request_portable_workspace_scope
 from .config import GuardConfig, resolve_risk_action
+from .mdm.network import managed_urlopen
 from .models import GuardAction, GuardArtifact, GuardReceipt
 from .redaction import redact_local_path, redact_text
 from .runtime.package_intent_common import (
@@ -2350,7 +2351,7 @@ def _run_cloud_workspace_audit(
             method="POST",
         )
         try:
-            with urllib.request.urlopen(request, timeout=_CLOUD_AUDIT_TIMEOUT_SECONDS) as response:
+            with managed_urlopen(request, timeout=_CLOUD_AUDIT_TIMEOUT_SECONDS) as response:
                 response_payload = json.load(response)
         except urllib.error.HTTPError as error:
             return (
@@ -2564,7 +2565,7 @@ def _execute_cloud_workspace_audit_request(
         method=method,
     )
     try:
-        with urllib.request.urlopen(request, timeout=_CLOUD_AUDIT_TIMEOUT_SECONDS) as response:
+        with managed_urlopen(request, timeout=_CLOUD_AUDIT_TIMEOUT_SECONDS) as response:
             response_payload = json.load(response)
     except urllib.error.HTTPError as error:
         if error.code == 403:

--- a/src/codex_plugin_scanner/guard/mdm/__init__.py
+++ b/src/codex_plugin_scanner/guard/mdm/__init__.py
@@ -1,0 +1,26 @@
+"""Enterprise MDM contracts for machine-owned HOL Guard installations."""
+
+from .contracts import (
+    MDM_POLICY_SCHEMA_VERSION,
+    MDM_STATUS_SCHEMA_VERSION,
+    RELEASE_MANIFEST_SCHEMA_VERSION,
+    MachinePaths,
+    ManagedPolicy,
+    ManagedPolicyState,
+    default_machine_paths,
+)
+from .manifest import verify_release_manifest
+from .policy import apply_managed_policy, load_managed_policy
+
+__all__ = [
+    "MDM_POLICY_SCHEMA_VERSION",
+    "MDM_STATUS_SCHEMA_VERSION",
+    "RELEASE_MANIFEST_SCHEMA_VERSION",
+    "MachinePaths",
+    "ManagedPolicy",
+    "ManagedPolicyState",
+    "apply_managed_policy",
+    "default_machine_paths",
+    "load_managed_policy",
+    "verify_release_manifest",
+]

--- a/src/codex_plugin_scanner/guard/mdm/contracts.py
+++ b/src/codex_plugin_scanner/guard/mdm/contracts.py
@@ -1,0 +1,177 @@
+"""Typed MDM policy, machine path, and status contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import platform
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+MDM_POLICY_SCHEMA_VERSION = "hol-guard-mdm-policy.v1"
+MDM_STATUS_SCHEMA_VERSION = "hol-guard-mdm-status.v1"
+RELEASE_MANIFEST_SCHEMA_VERSION = "hol-guard-release-manifest.v1"
+
+InstallOwner = Literal["user", "mdm"]
+ProxyMode = Literal["system", "explicit", "none"]
+ManagedPolicyStatus = Literal["absent", "active", "invalid", "inaccessible", "tampered"]
+
+
+@dataclass(frozen=True, slots=True)
+class MachinePaths:
+    """Platform machine-owned locations used by native installers."""
+
+    runtime_root: Path
+    state_root: Path
+    policy_path: Path | None
+    log_root: Path
+    manifest_path: Path
+
+    def to_dict(self) -> dict[str, str | None]:
+        return {
+            "runtimeRoot": str(self.runtime_root),
+            "stateRoot": str(self.state_root),
+            "policyPath": str(self.policy_path) if self.policy_path is not None else None,
+            "logRoot": str(self.log_root),
+            "manifestPath": str(self.manifest_path),
+        }
+
+
+def default_machine_paths(*, system_name: str | None = None) -> MachinePaths:
+    """Resolve stable machine paths without consulting user-controlled environment overrides."""
+
+    resolved_system = system_name or platform.system()
+    if resolved_system == "Darwin":
+        runtime_root = Path("/Library/Application Support/HOL Guard")
+        return MachinePaths(
+            runtime_root=runtime_root,
+            state_root=Path("/Library/Application Support/HOL Guard State"),
+            policy_path=Path("/Library/Managed Preferences/org.hol.guard.plist"),
+            log_root=Path("/Library/Logs/HOL Guard"),
+            manifest_path=runtime_root / "release-manifest.json",
+        )
+    if resolved_system == "Windows":
+        program_files = Path(os.environ.get("PROGRAMFILES", r"C:\Program Files"))
+        program_data = Path(os.environ.get("PROGRAMDATA", r"C:\ProgramData"))
+        runtime_root = program_files / "HOL Guard"
+        state_root = program_data / "HOL Guard"
+        return MachinePaths(
+            runtime_root=runtime_root,
+            state_root=state_root,
+            policy_path=None,
+            log_root=state_root / "Logs",
+            manifest_path=runtime_root / "release-manifest.json",
+        )
+    runtime_root = Path("/opt/hol-guard")
+    state_root = Path("/var/lib/hol-guard")
+    return MachinePaths(
+        runtime_root=runtime_root,
+        state_root=state_root,
+        policy_path=Path("/etc/hol-guard/managed-policy.json"),
+        log_root=Path("/var/log/hol-guard"),
+        manifest_path=runtime_root / "release-manifest.json",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedNetworkPolicy:
+    proxy_mode: ProxyMode = "system"
+    proxy_url: str | None = None
+    ca_bundle_path: str | None = None
+    allow_public_registries: bool = True
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "proxyMode": self.proxy_mode,
+            "proxyConfigured": self.proxy_url is not None,
+            "caBundleConfigured": self.ca_bundle_path is not None,
+            "allowPublicRegistries": self.allow_public_registries,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedUpdatePolicy:
+    owner: InstallOwner = "user"
+    channel: str = "stable"
+    minimum_version: str | None = None
+    maximum_version: str | None = None
+    allow_downgrade: bool = False
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "owner": self.owner,
+            "channel": self.channel,
+            "minimumVersion": self.minimum_version,
+            "maximumVersion": self.maximum_version,
+            "allowDowngrade": self.allow_downgrade,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedPolicy:
+    schema_version: str
+    settings: dict[str, object]
+    locked_settings: frozenset[str]
+    required_harnesses: tuple[str, ...] = ()
+    network: ManagedNetworkPolicy = field(default_factory=ManagedNetworkPolicy)
+    update: ManagedUpdatePolicy = field(default_factory=ManagedUpdatePolicy)
+    daemon_startup: Literal["on-demand", "login"] = "on-demand"
+    content_hash: str = ""
+
+    @property
+    def install_owner(self) -> InstallOwner:
+        return self.update.owner
+
+    def to_public_dict(self) -> dict[str, object]:
+        return {
+            "schemaVersion": self.schema_version,
+            "contentHash": self.content_hash,
+            "lockedSettings": sorted(self.locked_settings),
+            "requiredHarnesses": list(self.required_harnesses),
+            "network": self.network.to_dict(),
+            "update": self.update.to_dict(),
+            "daemonStartup": self.daemon_startup,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class ManagedPolicyState:
+    status: ManagedPolicyStatus
+    source: str
+    policy: ManagedPolicy | None = None
+    reason_code: str | None = None
+    detail: str | None = None
+
+    def to_public_dict(self) -> dict[str, object]:
+        payload: dict[str, object] = {
+            "status": self.status,
+            "source": self.source,
+            "reasonCode": self.reason_code,
+        }
+        if self.policy is not None:
+            payload["policy"] = self.policy.to_public_dict()
+        if self.detail is not None:
+            payload["detail"] = self.detail
+        return payload
+
+
+def canonical_payload_hash(payload: dict[str, object]) -> str:
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+__all__ = [
+    "MDM_POLICY_SCHEMA_VERSION",
+    "MDM_STATUS_SCHEMA_VERSION",
+    "RELEASE_MANIFEST_SCHEMA_VERSION",
+    "InstallOwner",
+    "MachinePaths",
+    "ManagedNetworkPolicy",
+    "ManagedPolicy",
+    "ManagedPolicyState",
+    "ManagedUpdatePolicy",
+    "canonical_payload_hash",
+    "default_machine_paths",
+]

--- a/src/codex_plugin_scanner/guard/mdm/contracts.py
+++ b/src/codex_plugin_scanner/guard/mdm/contracts.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import hashlib
 import json
-import os
 import platform
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -53,8 +52,8 @@ def default_machine_paths(*, system_name: str | None = None) -> MachinePaths:
             manifest_path=runtime_root / "release-manifest.json",
         )
     if resolved_system == "Windows":
-        program_files = Path(os.environ.get("PROGRAMFILES", r"C:\Program Files"))
-        program_data = Path(os.environ.get("PROGRAMDATA", r"C:\ProgramData"))
+        program_files = Path(r"C:\Program Files")
+        program_data = Path(r"C:\ProgramData")
         runtime_root = program_files / "HOL Guard"
         state_root = program_data / "HOL Guard"
         return MachinePaths(

--- a/src/codex_plugin_scanner/guard/mdm/lifecycle.py
+++ b/src/codex_plugin_scanner/guard/mdm/lifecycle.py
@@ -151,7 +151,10 @@ def validate_removal_authorization(
     """Validate a root/MDM-owned, short-lived, user-bound removal authorization."""
 
     resolved_root = authorization_root or default_machine_paths().state_root / "removal-authorizations"
-    resolved = path.resolve(strict=True)
+    try:
+        resolved = path.resolve(strict=True)
+    except FileNotFoundError as exc:
+        raise ValueError("mdm_removal_authorization_consumed_or_missing") from exc
     if not resolved.is_relative_to(resolved_root.resolve()) or not resolved.is_file():
         raise ValueError("mdm_removal_authorization_wrong_scope")
     metadata = resolved.stat()
@@ -182,9 +185,10 @@ def validate_removal_authorization(
     if (expires - issued).total_seconds() > 300 or (now - issued).total_seconds() > 300:
         raise ValueError("mdm_removal_authorization_expired")
     fingerprint = hashlib.sha256(resolved.read_bytes()).hexdigest()
-    consumed = home / ".hol-guard" / "mdm-removal-consumed"
-    if consumed.is_file() and fingerprint in consumed.read_text(encoding="utf-8").splitlines():
-        raise ValueError("mdm_removal_authorization_replayed")
+    try:
+        resolved.unlink()
+    except OSError as exc:
+        raise PermissionError("mdm_removal_authorization_not_consumable") from exc
     return fingerprint
 
 
@@ -391,11 +395,6 @@ def deactivate_user(home: Path, *, authorization_fingerprint: str | None = None)
         retired_pids = retire_all_guard_daemons_for_home(guard_home)
         result = apply_managed_install("uninstall", None, True, context, store, None, _now())
         (guard_home / "mdm-activation.json").unlink(missing_ok=True)
-        if authorization_fingerprint is not None:
-            consumed = guard_home / "mdm-removal-consumed"
-            with consumed.open("a", encoding="utf-8") as handle:
-                handle.write(f"{authorization_fingerprint}\n")
-            consumed.chmod(0o600)
         _audit(guard_home / "logs" / "mdm-lifecycle.log", operation="deactivate", status="complete", scope="user")
     payload = _base("deactivate")
     payload.update(

--- a/src/codex_plugin_scanner/guard/mdm/lifecycle.py
+++ b/src/codex_plugin_scanner/guard/mdm/lifecycle.py
@@ -209,25 +209,34 @@ def _activation_lock(guard_home: Path) -> Iterator[None]:
         os.close(descriptor)
 
 
+def _load_trusted_keys(path: Path) -> dict[str, bytes]:
+    trusted_keys: dict[str, bytes] = {}
+    if not path.is_file():
+        return trusted_keys
+    try:
+        raw_keys = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return trusted_keys
+    if not isinstance(raw_keys, dict):
+        return trusted_keys
+    for key_id, value in raw_keys.items():
+        if not isinstance(key_id, str) or not isinstance(value, str):
+            continue
+        try:
+            trusted_keys[key_id] = base64.b64decode(value, validate=True)
+        except ValueError:
+            continue
+    return trusted_keys
+
+
 def machine_status(
     *, machine_root: Path | None = None, policy_path: Path | None = None, allow_unsigned: bool = False
 ) -> dict[str, object]:
     paths = default_machine_paths()
     runtime_root = (machine_root or paths.runtime_root).resolve()
     manifest_path = runtime_root / "release-manifest.json"
-    trusted_keys: dict[str, bytes] = {}
     trusted_keys_path = runtime_root / "release-trusted-keys.json"
-    if trusted_keys_path.is_file():
-        try:
-            raw_keys = json.loads(trusted_keys_path.read_text(encoding="utf-8"))
-            if isinstance(raw_keys, dict):
-                trusted_keys = {
-                    key_id: base64.b64decode(value, validate=True)
-                    for key_id, value in raw_keys.items()
-                    if isinstance(key_id, str) and isinstance(value, str)
-                }
-        except (OSError, ValueError):
-            trusted_keys = {}
+    trusted_keys = _load_trusted_keys(trusted_keys_path)
     expected_platform = {"Darwin": "macos", "Windows": "windows"}.get(platform.system())
     verification = verify_release_manifest(
         manifest_path,

--- a/src/codex_plugin_scanner/guard/mdm/lifecycle.py
+++ b/src/codex_plugin_scanner/guard/mdm/lifecycle.py
@@ -388,6 +388,8 @@ def repair_user(home: Path, user: str | None = None) -> dict[str, object]:
 
 
 def deactivate_user(home: Path, *, authorization_fingerprint: str | None = None) -> dict[str, object]:
+    if authorization_fingerprint is None:
+        raise PermissionError("mdm_removal_authorization_required")
     guard_home = home / ".hol-guard"
     with _activation_lock(guard_home):
         context = HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)

--- a/src/codex_plugin_scanner/guard/mdm/lifecycle.py
+++ b/src/codex_plugin_scanner/guard/mdm/lifecycle.py
@@ -246,9 +246,7 @@ def machine_status(
     )
     payload = _base("status")
     healthy = (
-        verification.healthy
-        and policy.status in {"active", "absent"}
-        and (native.healthy or machine_root is not None)
+        verification.healthy and policy.status in {"active", "absent"} and (native.healthy or machine_root is not None)
     )
     if verification.healthy and policy.status == "invalid":
         state = "policy-invalid"
@@ -349,19 +347,11 @@ def activate_user(home: Path, user: str) -> dict[str, object]:
     with _activation_lock(guard_home):
         context = HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)
         store = GuardStore(guard_home)
-        before = {
-            str(item.get("harness"))
-            for item in store.list_managed_installs()
-            if bool(item.get("active"))
-        }
+        before = {str(item.get("harness")) for item in store.list_managed_installs() if bool(item.get("active"))}
         try:
             result = apply_managed_install("install", None, True, context, store, None, _now())
         except (OSError, RuntimeError, ValueError):
-            after = {
-                str(item.get("harness"))
-                for item in store.list_managed_installs()
-                if bool(item.get("active"))
-            }
+            after = {str(item.get("harness")) for item in store.list_managed_installs() if bool(item.get("active"))}
             for harness in sorted(after - before):
                 try:
                     apply_managed_install("uninstall", harness, False, context, store, None, _now())

--- a/src/codex_plugin_scanner/guard/mdm/lifecycle.py
+++ b/src/codex_plugin_scanner/guard/mdm/lifecycle.py
@@ -1,0 +1,423 @@
+"""Prompt-free per-user activation and machine/user health operations."""
+
+from __future__ import annotations
+
+import base64
+import getpass
+import hashlib
+import json
+import logging
+import os
+import platform
+import re
+import secrets
+import shutil
+import stat
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+
+from ..adapters.base import HarnessContext
+from ..cli.install_commands import apply_managed_install
+from ..daemon.manager import retire_all_guard_daemons_for_home
+from ..store import GuardStore
+from .contracts import MDM_STATUS_SCHEMA_VERSION, default_machine_paths
+from .manifest import verify_release_manifest
+from .native import NativeInstallVerification, verify_native_install
+from .policy import load_managed_policy
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _base(operation: str) -> dict[str, object]:
+    return {"schemaVersion": MDM_STATUS_SCHEMA_VERSION, "operation": operation, "generatedAt": _now()}
+
+
+def _audit(path: Path, *, operation: str, status: str, scope: str) -> None:
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    handler = RotatingFileHandler(path, maxBytes=1024 * 1024, backupCount=5, encoding="utf-8")
+    try:
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        record = logging.LogRecord("hol-guard-mdm", logging.INFO, "", 0, "", (), None)
+        record.msg = json.dumps(
+            {"timestamp": _now(), "operation": operation, "status": status, "scope": scope}, sort_keys=True
+        )
+        handler.emit(record)
+    finally:
+        handler.close()
+    path.chmod(0o600)
+
+
+def validate_user_home(home: str, user: str | None = None) -> Path:
+    path = Path(home)
+    if not path.is_absolute():
+        raise ValueError("mdm_home_must_be_absolute")
+    resolved = path.resolve()
+    if not resolved.is_dir():
+        raise ValueError("mdm_home_not_found")
+    if user is not None and platform.system() != "Windows":
+        import pwd
+
+        try:
+            account = pwd.getpwnam(user)
+        except KeyError as exc:
+            raise ValueError("mdm_user_not_found") from exc
+        if resolved.stat().st_uid != account.pw_uid:
+            raise ValueError("mdm_home_owner_mismatch")
+        if os.geteuid() != account.pw_uid:
+            raise ValueError("mdm_user_context_mismatch")
+    elif user is not None and getpass.getuser().casefold() != user.casefold():
+        raise ValueError("mdm_user_context_mismatch")
+    return resolved
+
+
+def _is_administrator() -> bool:
+    if platform.system() != "Windows":
+        return os.geteuid() == 0
+    import ctypes
+
+    return bool(ctypes.windll.shell32.IsUserAnAdmin())
+
+
+def authorize_deactivation(home: Path, user: str, *, token_name: str | None = None) -> dict[str, object]:
+    """Create machine-owned authority without putting authorization material in arguments."""
+
+    if not _is_administrator():
+        raise PermissionError("mdm_administrator_context_required")
+    if not home.is_absolute() or not home.is_dir():
+        raise ValueError("mdm_home_not_found")
+    if platform.system() != "Windows":
+        import pwd
+
+        try:
+            account = pwd.getpwnam(user)
+        except KeyError as exc:
+            raise ValueError("mdm_user_not_found") from exc
+        if home.resolve().stat().st_uid != account.pw_uid:
+            raise ValueError("mdm_home_owner_mismatch")
+    root = default_machine_paths().state_root / "removal-authorizations"
+    root.mkdir(mode=0o700, parents=True, exist_ok=True)
+    root.chmod(0o700)
+    now = datetime.now(timezone.utc)
+    resolved_name = token_name or f"{user}-{secrets.token_hex(8)}.json"
+    if re.fullmatch(r"[A-Za-z0-9_.-]{1,128}\.json", resolved_name) is None:
+        raise ValueError("mdm_removal_authorization_name_invalid")
+    target = root / resolved_name
+    target.write_text(
+        json.dumps(
+            {
+                "operation": "deactivate",
+                "user": user,
+                "home": str(home.resolve()),
+                "nonce": secrets.token_urlsafe(24),
+                "issuedAt": now.isoformat(),
+                "expiresAt": (now + timedelta(minutes=2)).isoformat(),
+            },
+            sort_keys=True,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    target.chmod(0o644)
+    _audit(
+        default_machine_paths().log_root / "mdm-lifecycle.log",
+        operation="authorize-deactivation",
+        status="authorized",
+        scope="machine",
+    )
+    payload = _base("authorize-deactivation")
+    payload.update(
+        {
+            "scope": "user",
+            "home": str(home.resolve()),
+            "user": user,
+            "authorizationPath": str(target),
+        }
+    )
+    return payload
+
+
+def validate_removal_authorization(
+    path: Path,
+    *,
+    home: Path,
+    user: str,
+    authorization_root: Path | None = None,
+) -> str:
+    """Validate a root/MDM-owned, short-lived, user-bound removal authorization."""
+
+    resolved_root = authorization_root or default_machine_paths().state_root / "removal-authorizations"
+    resolved = path.resolve(strict=True)
+    if not resolved.is_relative_to(resolved_root.resolve()) or not resolved.is_file():
+        raise ValueError("mdm_removal_authorization_wrong_scope")
+    metadata = resolved.stat()
+    if metadata.st_size > 16 * 1024:
+        raise ValueError("mdm_removal_authorization_invalid")
+    if platform.system() != "Windows" and (metadata.st_uid != 0 or metadata.st_mode & 0o022):
+        raise ValueError("mdm_removal_authorization_untrusted_owner")
+    payload = json.loads(resolved.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("mdm_removal_authorization_invalid")
+    if payload.get("operation") != "deactivate" or payload.get("user") != user:
+        raise ValueError("mdm_removal_authorization_wrong_scope")
+    if payload.get("home") != str(home):
+        raise ValueError("mdm_removal_authorization_wrong_scope")
+    nonce = payload.get("nonce")
+    issued_raw = payload.get("issuedAt")
+    expires_raw = payload.get("expiresAt")
+    if not all(isinstance(value, str) and value for value in (nonce, issued_raw, expires_raw)):
+        raise ValueError("mdm_removal_authorization_invalid")
+    try:
+        issued = datetime.fromisoformat(str(issued_raw))
+        expires = datetime.fromisoformat(str(expires_raw))
+    except ValueError as exc:
+        raise ValueError("mdm_removal_authorization_invalid") from exc
+    now = datetime.now(timezone.utc)
+    if issued.tzinfo is None or expires.tzinfo is None or issued > now or expires <= now:
+        raise ValueError("mdm_removal_authorization_expired")
+    if (expires - issued).total_seconds() > 300 or (now - issued).total_seconds() > 300:
+        raise ValueError("mdm_removal_authorization_expired")
+    fingerprint = hashlib.sha256(resolved.read_bytes()).hexdigest()
+    consumed = home / ".hol-guard" / "mdm-removal-consumed"
+    if consumed.is_file() and fingerprint in consumed.read_text(encoding="utf-8").splitlines():
+        raise ValueError("mdm_removal_authorization_replayed")
+    return fingerprint
+
+
+@contextmanager
+def _activation_lock(guard_home: Path) -> Iterator[None]:
+    guard_home.mkdir(mode=0o700, parents=True, exist_ok=True)
+    lock_path = guard_home / "mdm-activation.lock"
+    descriptor = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+    try:
+        if platform.system() == "Windows":
+            import msvcrt
+
+            msvcrt.locking(descriptor, msvcrt.LK_NBLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        yield
+    except (BlockingIOError, OSError) as exc:
+        raise RuntimeError("mdm_activation_in_progress") from exc
+    finally:
+        os.close(descriptor)
+
+
+def machine_status(
+    *, machine_root: Path | None = None, policy_path: Path | None = None, allow_unsigned: bool = False
+) -> dict[str, object]:
+    paths = default_machine_paths()
+    runtime_root = (machine_root or paths.runtime_root).resolve()
+    manifest_path = runtime_root / "release-manifest.json"
+    trusted_keys: dict[str, bytes] = {}
+    trusted_keys_path = runtime_root / "release-trusted-keys.json"
+    if trusted_keys_path.is_file():
+        try:
+            raw_keys = json.loads(trusted_keys_path.read_text(encoding="utf-8"))
+            if isinstance(raw_keys, dict):
+                trusted_keys = {
+                    key_id: base64.b64decode(value, validate=True)
+                    for key_id, value in raw_keys.items()
+                    if isinstance(key_id, str) and isinstance(value, str)
+                }
+        except (OSError, ValueError):
+            trusted_keys = {}
+    expected_platform = {"Darwin": "macos", "Windows": "windows"}.get(platform.system())
+    verification = verify_release_manifest(
+        manifest_path,
+        runtime_root,
+        trusted_keys=trusted_keys,
+        require_signature=not allow_unsigned,
+        expected_platform=expected_platform,
+        expected_architecture=platform.machine().lower(),
+        expected_owner_uid=0 if machine_root is None and platform.system() != "Windows" else None,
+    )
+    policy = load_managed_policy(policy_path=policy_path)
+    native = (
+        verify_native_install(runtime_root)
+        if machine_root is None
+        else NativeInstallVerification("fixture", "native_check_not_applicable", "fixture", "not-applicable")
+    )
+    payload = _base("status")
+    healthy = (
+        verification.healthy
+        and policy.status in {"active", "absent"}
+        and (native.healthy or machine_root is not None)
+    )
+    if verification.healthy and policy.status == "invalid":
+        state = "policy-invalid"
+    elif verification.healthy and policy.status == "inaccessible":
+        state = "degraded"
+    elif verification.healthy and not native.healthy and machine_root is None:
+        state = native.status
+    elif healthy:
+        state = "protected"
+    else:
+        state = verification.status
+    reason_codes = [
+        code for code in (verification.reason_code, policy.reason_code, native.reason_code) if code is not None
+    ]
+    update_owner = policy.policy.install_owner if policy.policy is not None else "user"
+    if policy.policy is None and policy.status in {"invalid", "inaccessible", "tampered"}:
+        update_owner = "mdm"
+    payload.update(
+        {
+            "scope": "machine",
+            "state": state,
+            "healthy": healthy,
+            "runtimeRoot": str(runtime_root),
+            "manifest": verification.to_public_dict(),
+            "nativeInstall": native.to_dict(),
+            "managedPolicy": policy.to_public_dict(),
+            "updateOwner": update_owner,
+            "reasonCodes": [] if healthy else reason_codes,
+        }
+    )
+    return payload
+
+
+def user_status(home: Path) -> dict[str, object]:
+    guard_home = home / ".hol-guard"
+    payload = _base("status")
+    if not guard_home.is_dir():
+        payload.update(
+            {
+                "scope": "user",
+                "home": str(home),
+                "state": "absent",
+                "healthy": False,
+                "reasonCodes": ["user_not_activated"],
+            }
+        )
+        return payload
+    try:
+        store = GuardStore(guard_home)
+        installs = store.list_managed_installs()
+    except (OSError, ValueError) as exc:
+        payload.update(
+            {
+                "scope": "user",
+                "home": str(home),
+                "state": "degraded",
+                "healthy": False,
+                "reasonCodes": ["user_state_unreadable"],
+                "detail": str(exc)[:256],
+            }
+        )
+        return payload
+    active = [item for item in installs if item.get("active")]
+    resolved_command = shutil.which("hol-guard")
+    expected_runtime = default_machine_paths().runtime_root.resolve()
+    shadowed = False
+    if resolved_command is not None:
+        try:
+            shadowed = not Path(resolved_command).resolve().is_relative_to(expected_runtime)
+        except OSError:
+            shadowed = True
+    healthy = bool(active) and not shadowed
+    reason_codes: list[str] = []
+    if not active:
+        reason_codes.append("no_protected_harnesses")
+    if shadowed:
+        reason_codes.append("machine_command_shadowed")
+    user_state = "protected" if healthy else "activated"
+    if shadowed:
+        user_state = "repairable"
+    payload.update(
+        {
+            "scope": "user",
+            "home": str(home),
+            "state": user_state,
+            "healthy": healthy,
+            "activated": True,
+            "harnesses": [str(item.get("harness")) for item in active],
+            "commandShadowing": {"detected": shadowed},
+            "reasonCodes": reason_codes,
+        }
+    )
+    return payload
+
+
+def activate_user(home: Path, user: str) -> dict[str, object]:
+    guard_home = home / ".hol-guard"
+    with _activation_lock(guard_home):
+        context = HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)
+        store = GuardStore(guard_home)
+        before = {
+            str(item.get("harness"))
+            for item in store.list_managed_installs()
+            if bool(item.get("active"))
+        }
+        try:
+            result = apply_managed_install("install", None, True, context, store, None, _now())
+        except (OSError, RuntimeError, ValueError):
+            after = {
+                str(item.get("harness"))
+                for item in store.list_managed_installs()
+                if bool(item.get("active"))
+            }
+            for harness in sorted(after - before):
+                try:
+                    apply_managed_install("uninstall", harness, False, context, store, None, _now())
+                except (OSError, RuntimeError, ValueError):
+                    continue
+            raise
+        marker = guard_home / "mdm-activation.json"
+        marker.write_text(
+            json.dumps({"schemaVersion": MDM_STATUS_SCHEMA_VERSION, "user": user, "activatedAt": _now()}) + "\n",
+            encoding="utf-8",
+        )
+        marker.chmod(stat.S_IRUSR | stat.S_IWUSR)
+        _audit(guard_home / "logs" / "mdm-lifecycle.log", operation="activate", status="complete", scope="user")
+    payload = _base("activate")
+    payload.update({"scope": "user", "home": str(home), "user": user, "changed": True, "result": result})
+    return payload
+
+
+def repair_user(home: Path, user: str | None = None) -> dict[str, object]:
+    return activate_user(home, user or getpass.getuser()) | {"operation": "repair"}
+
+
+def deactivate_user(home: Path, *, authorization_fingerprint: str | None = None) -> dict[str, object]:
+    guard_home = home / ".hol-guard"
+    with _activation_lock(guard_home):
+        context = HarnessContext(home_dir=home, workspace_dir=None, guard_home=guard_home)
+        store = GuardStore(guard_home)
+        retired_pids = retire_all_guard_daemons_for_home(guard_home)
+        result = apply_managed_install("uninstall", None, True, context, store, None, _now())
+        (guard_home / "mdm-activation.json").unlink(missing_ok=True)
+        if authorization_fingerprint is not None:
+            consumed = guard_home / "mdm-removal-consumed"
+            with consumed.open("a", encoding="utf-8") as handle:
+                handle.write(f"{authorization_fingerprint}\n")
+            consumed.chmod(0o600)
+        _audit(guard_home / "logs" / "mdm-lifecycle.log", operation="deactivate", status="complete", scope="user")
+    payload = _base("deactivate")
+    payload.update(
+        {
+            "scope": "user",
+            "home": str(home),
+            "changed": True,
+            "retiredDaemonCount": len(retired_pids),
+            "result": result,
+        }
+    )
+    return payload
+
+
+__all__ = [
+    "activate_user",
+    "authorize_deactivation",
+    "deactivate_user",
+    "machine_status",
+    "repair_user",
+    "user_status",
+    "validate_removal_authorization",
+    "validate_user_home",
+]

--- a/src/codex_plugin_scanner/guard/mdm/manifest.py
+++ b/src/codex_plugin_scanner/guard/mdm/manifest.py
@@ -1,0 +1,186 @@
+"""Signed release-manifest verification for machine-owned runtimes."""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import cast
+
+from cryptography.exceptions import InvalidSignature
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
+
+from .contracts import RELEASE_MANIFEST_SCHEMA_VERSION
+
+_MAX_MANIFEST_BYTES = 1024 * 1024
+
+
+@dataclass(frozen=True, slots=True)
+class ManifestVerification:
+    status: str
+    reason_code: str
+    version: str | None = None
+    build_id: str | None = None
+    installer_identity: str | None = None
+    signature_state: str = "unverified"
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == "healthy"
+
+    def to_public_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "reasonCode": self.reason_code,
+            "version": self.version,
+            "buildId": self.build_id,
+            "installerIdentity": self.installer_identity,
+            "signatureState": self.signature_state,
+        }
+
+
+def _canonical_unsigned_payload(payload: Mapping[str, object]) -> bytes:
+    unsigned = dict(payload)
+    unsigned.pop("signature", None)
+    return json.dumps(unsigned, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+
+
+def _valid_relative_path(value: object) -> str | None:
+    if not isinstance(value, str) or not value:
+        return None
+    path = PurePosixPath(value)
+    if path.is_absolute() or ".." in path.parts or "\\" in value:
+        return None
+    return value
+
+
+def verify_release_manifest(
+    manifest_path: Path,
+    runtime_root: Path,
+    *,
+    trusted_keys: Mapping[str, bytes] | None = None,
+    require_signature: bool = True,
+    expected_platform: str | None = None,
+    expected_architecture: str | None = None,
+    expected_owner_uid: int | None = None,
+) -> ManifestVerification:
+    """Verify manifest schema, signature, and every runtime file hash."""
+
+    if not manifest_path.exists():
+        return ManifestVerification("absent", "release_manifest_absent")
+    try:
+        if manifest_path.stat().st_size > _MAX_MANIFEST_BYTES:
+            raise ValueError("manifest exceeds size limit")
+        manifest_metadata = manifest_path.stat()
+        if expected_owner_uid is not None and manifest_metadata.st_uid != expected_owner_uid:
+            return ManifestVerification("tampered", "release_manifest_wrong_owner")
+        if expected_owner_uid is not None and manifest_metadata.st_mode & 0o022:
+            return ManifestVerification("tampered", "release_manifest_insecure_permissions")
+        raw: object = json.loads(manifest_path.read_bytes())
+        if not isinstance(raw, dict):
+            raise ValueError("manifest must be an object")
+        payload = cast(dict[str, object], raw)
+        if payload.get("schemaVersion") != RELEASE_MANIFEST_SCHEMA_VERSION:
+            raise ValueError("unsupported manifest schema")
+        version = payload.get("version")
+        build_id = payload.get("buildId")
+        installer_identity = payload.get("installerIdentity")
+        source_commit = payload.get("sourceCommit")
+        manifest_platform = payload.get("platform")
+        architecture = payload.get("architecture")
+        policy_schema = payload.get("policySchemaVersion")
+        if not all(
+            isinstance(value, str) and value
+            for value in (
+                version,
+                build_id,
+                installer_identity,
+                source_commit,
+                manifest_platform,
+                architecture,
+                policy_schema,
+            )
+        ):
+            raise ValueError("manifest identity fields are required")
+        version = cast(str, version)
+        build_id = cast(str, build_id)
+        installer_identity = cast(str, installer_identity)
+        if expected_platform is not None and manifest_platform != expected_platform:
+            return ManifestVerification(
+                "unsupported", "release_manifest_platform_mismatch", version, build_id, installer_identity
+            )
+        if expected_architecture is not None and str(architecture).lower() != expected_architecture.lower():
+            return ManifestVerification(
+                "unsupported", "release_manifest_architecture_mismatch", version, build_id, installer_identity
+            )
+
+        signature_state = "unsigned"
+        signature = payload.get("signature")
+        if signature is not None:
+            if not isinstance(signature, dict):
+                raise ValueError("signature must be an object")
+            key_id = signature.get("keyId")
+            encoded = signature.get("value")
+            if not isinstance(key_id, str) or not isinstance(encoded, str):
+                raise ValueError("signature keyId and value are required")
+            key_bytes = (trusted_keys or {}).get(key_id)
+            if key_bytes is None:
+                return ManifestVerification(
+                    "tampered", "release_manifest_untrusted_key", version, build_id, installer_identity
+                )
+            Ed25519PublicKey.from_public_bytes(key_bytes).verify(
+                base64.b64decode(encoded, validate=True), _canonical_unsigned_payload(payload)
+            )
+            signature_state = "valid"
+        elif require_signature:
+            return ManifestVerification(
+                "tampered", "release_manifest_unsigned", version, build_id, installer_identity, signature_state
+            )
+
+        files = payload.get("files")
+        if not isinstance(files, list) or not files:
+            raise ValueError("files must be a non-empty array")
+        resolved_root = runtime_root.resolve(strict=True)
+        for entry in files:
+            if not isinstance(entry, dict):
+                raise ValueError("file entry must be an object")
+            relative = _valid_relative_path(entry.get("path"))
+            digest = entry.get("sha256")
+            if relative is None or not isinstance(digest, str) or len(digest) != 64:
+                raise ValueError("invalid file entry")
+            candidate = (resolved_root / relative).resolve(strict=True)
+            if not candidate.is_relative_to(resolved_root) or not candidate.is_file():
+                return ManifestVerification(
+                    "tampered", "release_manifest_path_escape", version, build_id, installer_identity, signature_state
+                )
+            metadata = candidate.stat()
+            if expected_owner_uid is not None and metadata.st_uid != expected_owner_uid:
+                return ManifestVerification(
+                    "tampered", "release_runtime_wrong_owner", version, build_id, installer_identity, signature_state
+                )
+            if expected_owner_uid is not None and metadata.st_mode & 0o022:
+                return ManifestVerification(
+                    "tampered",
+                    "release_runtime_insecure_permissions",
+                    version,
+                    build_id,
+                    installer_identity,
+                    signature_state,
+                )
+            actual = hashlib.sha256(candidate.read_bytes()).hexdigest()
+            if actual != digest.lower():
+                return ManifestVerification(
+                    "tampered", "release_manifest_hash_mismatch", version, build_id, installer_identity, signature_state
+                )
+        return ManifestVerification(
+            "healthy", "release_manifest_valid", version, build_id, installer_identity, signature_state
+        )
+    except (OSError, ValueError, json.JSONDecodeError, InvalidSignature, binascii.Error):
+        return ManifestVerification("tampered", "release_manifest_invalid")
+
+
+__all__ = ["ManifestVerification", "verify_release_manifest"]

--- a/src/codex_plugin_scanner/guard/mdm/native.py
+++ b/src/codex_plugin_scanner/guard/mdm/native.py
@@ -1,0 +1,97 @@
+"""Native package identity and publisher-signature verification."""
+
+from __future__ import annotations
+
+import json
+import platform
+import plistlib
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True, slots=True)
+class NativeInstallVerification:
+    status: str
+    reason_code: str
+    package_identity: str
+    signature_state: str
+    version: str | None = None
+
+    @property
+    def healthy(self) -> bool:
+        return self.status == "healthy"
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "status": self.status,
+            "reasonCode": self.reason_code,
+            "packageIdentity": self.package_identity,
+            "signatureState": self.signature_state,
+            "version": self.version,
+        }
+
+
+def verify_native_install(runtime_root: Path) -> NativeInstallVerification:
+    if platform.system() == "Darwin":
+        return _verify_macos(runtime_root)
+    if platform.system() == "Windows":
+        return _verify_windows(runtime_root)
+    return NativeInstallVerification("unsupported", "native_platform_unsupported", "unknown", "unsupported")
+
+
+def _verify_macos(runtime_root: Path) -> NativeInstallVerification:
+    identity = "org.hol.guard"
+    executable = runtime_root / "hol-guard" / "hol-guard"
+    try:
+        receipt = subprocess.run(
+            ["/usr/sbin/pkgutil", "--pkg-info-plist", identity],
+            check=True,
+            capture_output=True,
+            timeout=5,
+        )
+        receipt_payload = plistlib.loads(receipt.stdout)
+        version = receipt_payload.get("pkg-version") if isinstance(receipt_payload, dict) else None
+        signature = subprocess.run(
+            ["/usr/bin/codesign", "--verify", "--deep", "--strict", str(executable)],
+            check=False,
+            capture_output=True,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError, plistlib.InvalidFileException):
+        return NativeInstallVerification("absent", "native_package_receipt_absent", identity, "unknown")
+    if signature.returncode != 0:
+        return NativeInstallVerification(
+            "tampered", "native_publisher_signature_invalid", identity, "invalid", str(version) if version else None
+        )
+    return NativeInstallVerification(
+        "healthy", "native_install_valid", identity, "valid", str(version) if version else None
+    )
+
+
+def _verify_windows(runtime_root: Path) -> NativeInstallVerification:
+    identity = "HOLGuardMachine"
+    executable = runtime_root / "hol-guard" / "hol-guard.exe"
+    escaped = str(executable).replace("'", "''")
+    command = (
+        f"$s=Get-AuthenticodeSignature -LiteralPath '{escaped}';"
+        "@{Status=$s.Status.ToString();Signer=if($s.SignerCertificate){$s.SignerCertificate.Subject}else{$null}}"
+        "|ConvertTo-Json -Compress"
+    )
+    try:
+        result = subprocess.run(
+            ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", command],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        payload: object = json.loads(result.stdout)
+    except (OSError, subprocess.SubprocessError, json.JSONDecodeError):
+        return NativeInstallVerification("absent", "native_package_identity_absent", identity, "unknown")
+    if not isinstance(payload, dict) or payload.get("Status") != "Valid" or not payload.get("Signer"):
+        return NativeInstallVerification("tampered", "native_publisher_signature_invalid", identity, "invalid")
+    return NativeInstallVerification("healthy", "native_install_valid", identity, "valid")
+
+
+__all__ = ["NativeInstallVerification", "verify_native_install"]

--- a/src/codex_plugin_scanner/guard/mdm/network.py
+++ b/src/codex_plugin_scanner/guard/mdm/network.py
@@ -1,0 +1,248 @@
+"""Enterprise proxy and additive trust policy for Guard HTTP clients."""
+
+from __future__ import annotations
+
+import platform
+import re
+import socket
+import ssl
+import subprocess
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from pathlib import Path
+from typing import IO
+
+import requests
+
+from .contracts import ManagedNetworkPolicy
+from .policy import load_managed_policy
+
+_PUBLIC_REGISTRIES = frozenset(
+    {
+        "pypi.org",
+        "files.pythonhosted.org",
+        "registry.npmjs.org",
+        "api.npmjs.org",
+        "registry.yarnpkg.com",
+        "crates.io",
+        "static.crates.io",
+        "rubygems.org",
+        "repo1.maven.org",
+        "repo.maven.apache.org",
+        "proxy.golang.org",
+        "goproxy.io",
+    }
+)
+
+
+class ManagedNetworkError(RuntimeError):
+    """A managed network policy blocked or could not establish a request."""
+
+
+def active_network_policy() -> ManagedNetworkPolicy:
+    state = load_managed_policy()
+    return state.policy.network if state.policy is not None else ManagedNetworkPolicy()
+
+
+def _resolved_policy(policy: ManagedNetworkPolicy | None) -> tuple[ManagedNetworkPolicy, bool]:
+    if policy is not None:
+        return policy, True
+    state = load_managed_policy()
+    if state.policy is not None:
+        return state.policy.network, True
+    return ManagedNetworkPolicy(), False
+
+
+def platform_system_proxies() -> dict[str, str]:
+    """Read OS proxy configuration without treating user environment as managed authority."""
+
+    if platform.system() == "Darwin":
+        try:
+            result = subprocess.run(
+                ["/usr/sbin/scutil", "--proxy"], check=True, capture_output=True, text=True, timeout=5
+            )
+        except (OSError, subprocess.SubprocessError):
+            return {}
+        values = dict(re.findall(r"^\s*([A-Za-z]+)\s*:\s*(.+?)\s*$", result.stdout, re.MULTILINE))
+        proxies: dict[str, str] = {}
+        for scheme, prefix in (("http", "HTTP"), ("https", "HTTPS")):
+            if values.get(f"{prefix}Enable") == "1" and values.get(f"{prefix}Proxy"):
+                port = values.get(f"{prefix}Port", "443" if scheme == "https" else "80")
+                proxies[scheme] = f"http://{values[f'{prefix}Proxy']}:{port}"
+        return proxies
+    if platform.system() == "Windows":
+        try:
+            import winreg
+
+            with winreg.OpenKey(
+                winreg.HKEY_CURRENT_USER,
+                r"Software\Microsoft\Windows\CurrentVersion\Internet Settings",
+            ) as key:
+                enabled, _ = winreg.QueryValueEx(key, "ProxyEnable")
+                server, _ = winreg.QueryValueEx(key, "ProxyServer")
+        except (ImportError, OSError):
+            return {}
+        if not enabled or not isinstance(server, str):
+            return {}
+        if "=" not in server:
+            return {"http": f"http://{server}", "https": f"http://{server}"}
+        return {
+            scheme: f"http://{address}"
+            for item in server.split(";")
+            if "=" in item
+            for scheme, address in [item.split("=", 1)]
+            if scheme in {"http", "https"} and address
+        }
+    return {}
+
+
+def _request_url(request: str | urllib.request.Request) -> str:
+    return request.full_url if isinstance(request, urllib.request.Request) else request
+
+
+def _validate_destination(url: str, policy: ManagedNetworkPolicy) -> None:
+    hostname = (urllib.parse.urlsplit(url).hostname or "").lower()
+    if not policy.allow_public_registries and hostname in _PUBLIC_REGISTRIES:
+        raise ManagedNetworkError("managed_public_registry_disabled")
+
+
+def managed_ssl_context(policy: ManagedNetworkPolicy | None = None) -> ssl.SSLContext:
+    """Create mandatory TLS verification with an optional additive private CA."""
+
+    resolved = policy or active_network_policy()
+    context = ssl.create_default_context()
+    if resolved.ca_bundle_path is not None:
+        bundle = Path(resolved.ca_bundle_path)
+        if not bundle.is_absolute() or not bundle.is_file():
+            raise ManagedNetworkError("managed_ca_bundle_invalid")
+        context.load_verify_locations(cafile=str(bundle))
+    return context
+
+
+def managed_opener(policy: ManagedNetworkPolicy | None = None) -> urllib.request.OpenerDirector:
+    resolved = policy or active_network_policy()
+    if resolved.proxy_mode == "explicit":
+        proxies = {"http": resolved.proxy_url or "", "https": resolved.proxy_url or ""}
+        proxy_handler = urllib.request.ProxyHandler(proxies)
+    elif resolved.proxy_mode == "none":
+        proxy_handler = urllib.request.ProxyHandler({})
+    else:
+        proxy_handler = urllib.request.ProxyHandler(platform_system_proxies())
+    return urllib.request.build_opener(
+        proxy_handler,
+        urllib.request.HTTPSHandler(context=managed_ssl_context(resolved)),
+    )
+
+
+def managed_urlopen(
+    request: str | urllib.request.Request,
+    *,
+    timeout: float | None = None,
+    policy: ManagedNetworkPolicy | None = None,
+) -> IO[bytes]:
+    resolved, managed = _resolved_policy(policy)
+    _validate_destination(_request_url(request), resolved)
+    if (
+        not managed
+        and resolved.proxy_mode == "system"
+        and resolved.ca_bundle_path is None
+        and resolved.allow_public_registries
+    ):
+        return urllib.request.urlopen(request, timeout=timeout)
+    return managed_opener(resolved).open(request, timeout=timeout)
+
+
+def managed_requests_session(policy: ManagedNetworkPolicy | None = None) -> requests.Session:
+    resolved, managed = _resolved_policy(policy)
+    session = requests.Session()
+    session.trust_env = not managed
+    if resolved.proxy_mode == "explicit":
+        session.proxies.update({"http": resolved.proxy_url or "", "https": resolved.proxy_url or ""})
+    elif resolved.proxy_mode == "system" and managed:
+        session.proxies.update(platform_system_proxies())
+    if resolved.ca_bundle_path is not None:
+        bundle = Path(resolved.ca_bundle_path)
+        if not bundle.is_absolute() or not bundle.is_file():
+            raise ManagedNetworkError("managed_ca_bundle_invalid")
+        session.verify = str(bundle)
+    else:
+        session.verify = True
+    return session
+
+
+def managed_requests_kwargs(policy: ManagedNetworkPolicy | None = None) -> dict[str, object]:
+    """Return requests-compatible enterprise transport arguments while preserving call-site injection."""
+
+    resolved, managed = _resolved_policy(policy)
+    kwargs: dict[str, object] = {}
+    if resolved.proxy_mode == "explicit":
+        kwargs["proxies"] = {"http": resolved.proxy_url or "", "https": resolved.proxy_url or ""}
+    elif resolved.proxy_mode == "none":
+        kwargs["proxies"] = {"http": "", "https": ""}
+    elif managed:
+        system_proxies = platform_system_proxies()
+        kwargs["proxies"] = {
+            "http": system_proxies.get("http", ""),
+            "https": system_proxies.get("https", ""),
+        }
+    if resolved.ca_bundle_path is not None:
+        bundle = Path(resolved.ca_bundle_path)
+        if not bundle.is_absolute() or not bundle.is_file():
+            raise ManagedNetworkError("managed_ca_bundle_invalid")
+        kwargs["verify"] = str(bundle)
+    return kwargs
+
+
+@dataclass(frozen=True, slots=True)
+class NetworkDiagnostic:
+    endpoint: str
+    dns: str
+    proxy_mode: str
+    tls: str
+    reason_code: str
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "endpoint": self.endpoint,
+            "dns": self.dns,
+            "proxyMode": self.proxy_mode,
+            "tls": self.tls,
+            "reasonCode": self.reason_code,
+        }
+
+
+def diagnose_endpoint(endpoint: str, policy: ManagedNetworkPolicy | None = None) -> NetworkDiagnostic:
+    resolved = policy or active_network_policy()
+    parsed = urllib.parse.urlsplit(endpoint)
+    hostname = parsed.hostname
+    if parsed.scheme != "https" or hostname is None:
+        return NetworkDiagnostic("redacted", "invalid", resolved.proxy_mode, "not-tested", "endpoint_invalid")
+    try:
+        _validate_destination(endpoint, resolved)
+        socket.getaddrinfo(hostname, parsed.port or 443, type=socket.SOCK_STREAM)
+    except socket.gaierror:
+        return NetworkDiagnostic(hostname, "failed", resolved.proxy_mode, "not-tested", "dns_resolution_failed")
+    except ManagedNetworkError as exc:
+        return NetworkDiagnostic(hostname, "not-tested", resolved.proxy_mode, "not-tested", str(exc))
+    request = urllib.request.Request(endpoint, method="HEAD")
+    try:
+        with managed_urlopen(request, timeout=10, policy=resolved):
+            return NetworkDiagnostic(hostname, "ok", resolved.proxy_mode, "trusted", "endpoint_reachable")
+    except urllib.error.URLError as exc:
+        reason = "tls_trust_failed" if isinstance(exc.reason, ssl.SSLError) else "endpoint_unreachable"
+        return NetworkDiagnostic(hostname, "ok", resolved.proxy_mode, "failed", reason)
+
+
+__all__ = [
+    "ManagedNetworkError",
+    "NetworkDiagnostic",
+    "active_network_policy",
+    "diagnose_endpoint",
+    "managed_opener",
+    "managed_requests_kwargs",
+    "managed_requests_session",
+    "managed_ssl_context",
+    "managed_urlopen",
+]

--- a/src/codex_plugin_scanner/guard/mdm/network.py
+++ b/src/codex_plugin_scanner/guard/mdm/network.py
@@ -15,6 +15,7 @@ from pathlib import Path
 from typing import IO
 
 import requests
+from requests.adapters import HTTPAdapter
 
 from .contracts import ManagedNetworkPolicy
 from .policy import load_managed_policy
@@ -161,6 +162,26 @@ def managed_urlopen(
     return managed_opener(resolved).open(request, timeout=timeout)
 
 
+class _AdditiveCAAdapter(HTTPAdapter):
+    def __init__(self, context: ssl.SSLContext) -> None:
+        self._managed_context = context
+        super().__init__()
+
+    def init_poolmanager(
+        self,
+        connections: int,
+        maxsize: int,
+        block: bool = False,
+        **pool_kwargs: object,
+    ) -> None:
+        pool_kwargs["ssl_context"] = self._managed_context
+        super().init_poolmanager(connections, maxsize, block=block, **pool_kwargs)
+
+    def proxy_manager_for(self, proxy: str, **proxy_kwargs: object) -> object:
+        proxy_kwargs["ssl_context"] = self._managed_context
+        return super().proxy_manager_for(proxy, **proxy_kwargs)
+
+
 def managed_requests_session(policy: ManagedNetworkPolicy | None = None) -> requests.Session:
     resolved, managed = _resolved_policy(policy)
     session = requests.Session()
@@ -170,13 +191,16 @@ def managed_requests_session(policy: ManagedNetworkPolicy | None = None) -> requ
     elif resolved.proxy_mode == "system" and managed:
         session.proxies.update(platform_system_proxies())
     if resolved.ca_bundle_path is not None:
-        bundle = Path(resolved.ca_bundle_path)
-        if not bundle.is_absolute() or not bundle.is_file():
-            raise ManagedNetworkError("managed_ca_bundle_invalid")
-        session.verify = str(bundle)
-    else:
-        session.verify = True
+        session.mount("https://", _AdditiveCAAdapter(managed_ssl_context(resolved)))
+    session.verify = True
     return session
+
+
+def managed_requests_required(policy: ManagedNetworkPolicy | None = None) -> bool:
+    """Return whether requests must use the managed session transport."""
+
+    _resolved, managed = _resolved_policy(policy)
+    return managed
 
 
 def managed_requests_kwargs(policy: ManagedNetworkPolicy | None = None) -> dict[str, object]:
@@ -195,10 +219,7 @@ def managed_requests_kwargs(policy: ManagedNetworkPolicy | None = None) -> dict[
             "https": system_proxies.get("https", ""),
         }
     if resolved.ca_bundle_path is not None:
-        bundle = Path(resolved.ca_bundle_path)
-        if not bundle.is_absolute() or not bundle.is_file():
-            raise ManagedNetworkError("managed_ca_bundle_invalid")
-        kwargs["verify"] = str(bundle)
+        managed_ssl_context(resolved)
     return kwargs
 
 
@@ -249,6 +270,7 @@ __all__ = [
     "diagnose_endpoint",
     "managed_opener",
     "managed_requests_kwargs",
+    "managed_requests_required",
     "managed_requests_session",
     "managed_ssl_context",
     "managed_urlopen",

--- a/src/codex_plugin_scanner/guard/mdm/network.py
+++ b/src/codex_plugin_scanner/guard/mdm/network.py
@@ -75,16 +75,23 @@ def platform_system_proxies() -> dict[str, str]:
     if platform.system() == "Windows":
         try:
             import winreg
-
-            with winreg.OpenKey(
-                winreg.HKEY_CURRENT_USER,
-                r"Software\Microsoft\Windows\CurrentVersion\Internet Settings",
-            ) as key:
-                enabled, _ = winreg.QueryValueEx(key, "ProxyEnable")
-                server, _ = winreg.QueryValueEx(key, "ProxyServer")
-        except (ImportError, OSError):
+        except ImportError:
             return {}
-        if not enabled or not isinstance(server, str):
+        server: object = None
+        for hive in (winreg.HKEY_CURRENT_USER, winreg.HKEY_LOCAL_MACHINE):
+            try:
+                with winreg.OpenKey(
+                    hive,
+                    r"Software\Microsoft\Windows\CurrentVersion\Internet Settings",
+                ) as key:
+                    enabled, _ = winreg.QueryValueEx(key, "ProxyEnable")
+                    candidate, _ = winreg.QueryValueEx(key, "ProxyServer")
+            except OSError:
+                continue
+            if enabled and isinstance(candidate, str):
+                server = candidate
+                break
+        if not isinstance(server, str):
             return {}
         if "=" not in server:
             return {"http": f"http://{server}", "https": f"http://{server}"}

--- a/src/codex_plugin_scanner/guard/mdm/policy.py
+++ b/src/codex_plugin_scanner/guard/mdm/policy.py
@@ -217,9 +217,7 @@ def _load_policy_cache(system_name: str) -> ManagedPolicyState | None:
         if metadata.st_size > _MAX_POLICY_BYTES:
             raise ManagedPolicyError("managed policy cache exceeds size limit")
         if not _cache_owner_is_trusted(path, system_name):
-            return ManagedPolicyState(
-                "tampered", str(path), reason_code="managed_policy_cache_tampered"
-            )
+            return ManagedPolicyState("tampered", str(path), reason_code="managed_policy_cache_tampered")
         policy = parse_managed_policy(json.loads(path.read_bytes()))
         return ManagedPolicyState(
             "active", str(path), policy=policy, reason_code="managed_policy_profile_removed_cached"

--- a/src/codex_plugin_scanner/guard/mdm/policy.py
+++ b/src/codex_plugin_scanner/guard/mdm/policy.py
@@ -318,6 +318,15 @@ def _strongest_security_value(local: object, managed: object) -> object:
     return managed
 
 
+def _compose_managed_value(local: object, managed: object) -> object:
+    if isinstance(local, dict) and isinstance(managed, dict):
+        composed = dict(local)
+        for key, managed_value in managed.items():
+            composed[key] = _compose_managed_value(composed.get(key), managed_value)
+        return composed
+    return _strongest_security_value(local, managed)
+
+
 def apply_managed_policy(local_payload: Mapping[str, object], policy: ManagedPolicy) -> dict[str, object]:
     """Compose local configuration without allowing a managed requirement to weaken."""
 
@@ -327,7 +336,7 @@ def apply_managed_policy(local_payload: Mapping[str, object], policy: ManagedPol
         if key == "actions" or key.endswith("Actions"):
             composed[key] = _merge_strongest_actions(local_value, managed_value)
         elif key in composed:
-            composed[key] = _strongest_security_value(local_value, managed_value)
+            composed[key] = _compose_managed_value(local_value, managed_value)
         else:
             composed[key] = managed_value
     for setting_path in policy.locked_settings:

--- a/src/codex_plugin_scanner/guard/mdm/policy.py
+++ b/src/codex_plugin_scanner/guard/mdm/policy.py
@@ -1,0 +1,374 @@
+"""Validated platform-managed policy loading and monotonic composition."""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import plistlib
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Literal, cast
+
+from .contracts import (
+    MDM_POLICY_SCHEMA_VERSION,
+    InstallOwner,
+    ManagedNetworkPolicy,
+    ManagedPolicy,
+    ManagedPolicyState,
+    ManagedUpdatePolicy,
+    ProxyMode,
+    canonical_payload_hash,
+    default_machine_paths,
+)
+
+_MAX_POLICY_BYTES = 1024 * 1024
+_ACTION_STRENGTH = {
+    "allow": 0,
+    "warn": 1,
+    "review": 2,
+    "require-reapproval": 3,
+    "sandbox-required": 4,
+    "block": 5,
+}
+_MODE_STRENGTH = {"observe": 0, "prompt": 1, "enforce": 2}
+_TOP_LEVEL_KEYS = {
+    "schemaVersion",
+    "settings",
+    "lockedSettings",
+    "requiredHarnesses",
+    "network",
+    "update",
+    "daemonStartup",
+}
+
+
+class ManagedPolicyError(ValueError):
+    """A managed policy failed strict validation."""
+
+
+def _expect_mapping(value: object, name: str) -> Mapping[str, object]:
+    if not isinstance(value, dict) or not all(isinstance(key, str) for key in value):
+        raise ManagedPolicyError(f"{name} must be an object")
+    return cast(Mapping[str, object], value)
+
+
+def _optional_string(value: object, name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value.strip():
+        raise ManagedPolicyError(f"{name} must be a non-empty string or null")
+    return value
+
+
+def _validate_settings(value: object) -> dict[str, object]:
+    settings = dict(_expect_mapping(value, "settings"))
+    try:
+        json.dumps(settings, allow_nan=False)
+    except (TypeError, ValueError) as exc:
+        raise ManagedPolicyError("settings must contain only JSON values") from exc
+    return settings
+
+
+def parse_managed_policy(payload: object) -> ManagedPolicy:
+    """Parse a policy object using the stable v1 contract."""
+
+    root = _expect_mapping(payload, "policy")
+    unknown = set(root) - _TOP_LEVEL_KEYS
+    if unknown:
+        raise ManagedPolicyError(f"unknown policy keys: {', '.join(sorted(unknown))}")
+    if root.get("schemaVersion") != MDM_POLICY_SCHEMA_VERSION:
+        raise ManagedPolicyError("unsupported managed policy schema")
+
+    settings = _validate_settings(root.get("settings", {}))
+    locked_raw = root.get("lockedSettings", [])
+    if not isinstance(locked_raw, list) or not all(isinstance(item, str) and item for item in locked_raw):
+        raise ManagedPolicyError("lockedSettings must be an array of setting paths")
+    locked = frozenset(cast(list[str], locked_raw))
+    for setting_path in locked:
+        if _get_path(settings, setting_path) is _MISSING:
+            raise ManagedPolicyError(f"locked setting has no managed value: {setting_path}")
+
+    harnesses_raw = root.get("requiredHarnesses", [])
+    if not isinstance(harnesses_raw, list) or not all(isinstance(item, str) and item for item in harnesses_raw):
+        raise ManagedPolicyError("requiredHarnesses must be an array of names")
+
+    network_raw = _expect_mapping(root.get("network", {}), "network")
+    proxy_mode = network_raw.get("proxyMode", "system")
+    if proxy_mode not in {"system", "explicit", "none"}:
+        raise ManagedPolicyError("network.proxyMode is invalid")
+    proxy_mode = cast(ProxyMode, proxy_mode)
+    proxy_url = _optional_string(network_raw.get("proxyUrl"), "network.proxyUrl")
+    if proxy_mode == "explicit" and proxy_url is None:
+        raise ManagedPolicyError("network.proxyUrl is required for explicit proxy mode")
+    if proxy_url is not None and "@" in proxy_url:
+        raise ManagedPolicyError("proxy credentials are forbidden in managed policy")
+    allow_registries = network_raw.get("allowPublicRegistries", True)
+    if not isinstance(allow_registries, bool):
+        raise ManagedPolicyError("network.allowPublicRegistries must be boolean")
+    network = ManagedNetworkPolicy(
+        proxy_mode=proxy_mode,
+        proxy_url=proxy_url,
+        ca_bundle_path=_optional_string(network_raw.get("caBundlePath"), "network.caBundlePath"),
+        allow_public_registries=allow_registries,
+    )
+
+    update_raw = _expect_mapping(root.get("update", {}), "update")
+    owner = update_raw.get("owner", "user")
+    if owner not in {"user", "mdm"}:
+        raise ManagedPolicyError("update.owner is invalid")
+    owner = cast(InstallOwner, owner)
+    channel = update_raw.get("channel", "stable")
+    if not isinstance(channel, str) or not channel:
+        raise ManagedPolicyError("update.channel must be a non-empty string")
+    allow_downgrade = update_raw.get("allowDowngrade", False)
+    if not isinstance(allow_downgrade, bool):
+        raise ManagedPolicyError("update.allowDowngrade must be boolean")
+    update = ManagedUpdatePolicy(
+        owner=owner,
+        channel=channel,
+        minimum_version=_optional_string(update_raw.get("minimumVersion"), "update.minimumVersion"),
+        maximum_version=_optional_string(update_raw.get("maximumVersion"), "update.maximumVersion"),
+        allow_downgrade=allow_downgrade,
+    )
+    daemon_startup = root.get("daemonStartup", "on-demand")
+    if daemon_startup not in {"on-demand", "login"}:
+        raise ManagedPolicyError("daemonStartup is invalid")
+    daemon_startup = cast(Literal["on-demand", "login"], daemon_startup)
+
+    canonical = dict(root)
+    return ManagedPolicy(
+        schema_version=MDM_POLICY_SCHEMA_VERSION,
+        settings=settings,
+        locked_settings=locked,
+        required_harnesses=tuple(sorted(set(cast(list[str], harnesses_raw)))),
+        network=network,
+        update=update,
+        daemon_startup=daemon_startup,
+        content_hash=canonical_payload_hash(canonical),
+    )
+
+
+def _read_policy_file(path: Path) -> object:
+    size = path.stat().st_size
+    if size > _MAX_POLICY_BYTES:
+        raise ManagedPolicyError("managed policy exceeds size limit")
+    data = path.read_bytes()
+    if path.suffix.lower() == ".plist":
+        return plistlib.loads(data)
+    return json.loads(data)
+
+
+def _read_windows_policy() -> tuple[object | None, str]:
+    try:
+        import winreg
+    except ImportError:
+        return None, r"HKLM\Software\Policies\HOL\Guard"
+    source = r"HKLM\Software\Policies\HOL\Guard"
+    try:
+        with winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, r"Software\Policies\HOL\Guard") as key:
+            payload, value_type = winreg.QueryValueEx(key, "PolicyJson")
+    except FileNotFoundError:
+        return None, source
+    if value_type not in {winreg.REG_SZ, winreg.REG_EXPAND_SZ} or not isinstance(payload, str):
+        raise ManagedPolicyError("PolicyJson registry value must be a string")
+    if len(payload.encode("utf-8")) > _MAX_POLICY_BYTES:
+        raise ManagedPolicyError("managed policy exceeds size limit")
+    return json.loads(payload), source
+
+
+def _cache_path(system_name: str) -> Path:
+    return default_machine_paths(system_name=system_name).state_root / "managed-policy-cache.json"
+
+
+def _administrator_context(system_name: str) -> bool:
+    if system_name != "Windows":
+        return os.geteuid() == 0
+    try:
+        import ctypes
+
+        return bool(ctypes.windll.shell32.IsUserAnAdmin())
+    except (AttributeError, OSError):
+        return False
+
+
+def _write_policy_cache(payload: object, system_name: str) -> None:
+    if not _administrator_context(system_name) or not isinstance(payload, dict):
+        return
+    path = _cache_path(system_name)
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    temporary = path.with_suffix(".tmp")
+    temporary.write_text(json.dumps(payload, sort_keys=True) + "\n", encoding="utf-8")
+    temporary.chmod(0o600)
+    temporary.replace(path)
+
+
+def _cache_owner_is_trusted(path: Path, system_name: str) -> bool:
+    metadata = path.stat()
+    return system_name == "Windows" or (metadata.st_uid == 0 and not metadata.st_mode & 0o022)
+
+
+def _load_policy_cache(system_name: str) -> ManagedPolicyState | None:
+    path = _cache_path(system_name)
+    if not path.is_file():
+        return None
+    try:
+        metadata = path.stat()
+        if metadata.st_size > _MAX_POLICY_BYTES:
+            raise ManagedPolicyError("managed policy cache exceeds size limit")
+        if not _cache_owner_is_trusted(path, system_name):
+            return ManagedPolicyState(
+                "tampered", str(path), reason_code="managed_policy_cache_tampered"
+            )
+        policy = parse_managed_policy(json.loads(path.read_bytes()))
+        return ManagedPolicyState(
+            "active", str(path), policy=policy, reason_code="managed_policy_profile_removed_cached"
+        )
+    except (OSError, json.JSONDecodeError, ManagedPolicyError) as exc:
+        return ManagedPolicyState(
+            "invalid", str(path), reason_code="managed_policy_cache_invalid", detail=str(exc)[:256]
+        )
+
+
+def load_managed_policy(*, policy_path: Path | None = None, system_name: str | None = None) -> ManagedPolicyState:
+    """Load machine authority only from an explicit test path or native machine source."""
+
+    resolved_system = system_name or platform.system()
+    source = str(policy_path) if policy_path is not None else ""
+    try:
+        if policy_path is not None:
+            if not policy_path.exists():
+                return ManagedPolicyState("absent", source, reason_code="managed_policy_absent")
+            payload = _read_policy_file(policy_path)
+        elif resolved_system == "Windows":
+            payload, source = _read_windows_policy()
+            if payload is None:
+                cached = _load_policy_cache(resolved_system)
+                return cached or ManagedPolicyState("absent", source, reason_code="managed_policy_absent")
+        else:
+            native_path = default_machine_paths(system_name=resolved_system).policy_path
+            if native_path is None:
+                return ManagedPolicyState("absent", "native", reason_code="managed_policy_absent")
+            source = str(native_path)
+            if not native_path.exists():
+                cached = _load_policy_cache(resolved_system)
+                return cached or ManagedPolicyState("absent", source, reason_code="managed_policy_absent")
+            payload = _read_policy_file(native_path)
+        policy = parse_managed_policy(payload)
+        if policy_path is None:
+            _write_policy_cache(payload, resolved_system)
+        return ManagedPolicyState("active", source, policy=policy)
+    except PermissionError:
+        return ManagedPolicyState("inaccessible", source, reason_code="managed_policy_inaccessible")
+    except (ManagedPolicyError, json.JSONDecodeError, plistlib.InvalidFileException, OSError) as exc:
+        return ManagedPolicyState("invalid", source, reason_code="managed_policy_invalid", detail=str(exc)[:256])
+
+
+class _Missing:
+    pass
+
+
+_MISSING = _Missing()
+
+
+def _get_path(payload: Mapping[str, object], path: str) -> object:
+    current: object = payload
+    for part in path.split("."):
+        if not isinstance(current, dict) or part not in current:
+            return _MISSING
+        current = current[part]
+    return current
+
+
+def _set_path(payload: dict[str, object], path: str, value: object) -> None:
+    parts = path.split(".")
+    current = payload
+    for part in parts[:-1]:
+        child = current.get(part)
+        if not isinstance(child, dict):
+            child = {}
+            current[part] = child
+        current = cast(dict[str, object], child)
+    current[parts[-1]] = value
+
+
+def _merge_strongest_actions(local: object, managed: object) -> object:
+    if (
+        isinstance(local, str)
+        and isinstance(managed, str)
+        and local in _ACTION_STRENGTH
+        and managed in _ACTION_STRENGTH
+    ):
+        return max((local, managed), key=_ACTION_STRENGTH.__getitem__)
+    if isinstance(local, dict) and isinstance(managed, dict):
+        merged = dict(local)
+        for key, value in managed.items():
+            merged[key] = _merge_strongest_actions(merged.get(key), value)
+        return merged
+    return managed
+
+
+def _strongest_security_value(local: object, managed: object) -> object:
+    if isinstance(local, str) and isinstance(managed, str):
+        if local in _ACTION_STRENGTH and managed in _ACTION_STRENGTH:
+            return max((local, managed), key=_ACTION_STRENGTH.__getitem__)
+        if local in _MODE_STRENGTH and managed in _MODE_STRENGTH:
+            return max((local, managed), key=_MODE_STRENGTH.__getitem__)
+    return managed
+
+
+def apply_managed_policy(local_payload: Mapping[str, object], policy: ManagedPolicy) -> dict[str, object]:
+    """Compose local configuration without allowing a managed requirement to weaken."""
+
+    composed = dict(local_payload)
+    for key, managed_value in policy.settings.items():
+        local_value = composed.get(key)
+        if key == "actions" or key.endswith("Actions"):
+            composed[key] = _merge_strongest_actions(local_value, managed_value)
+        elif isinstance(local_value, str) and isinstance(managed_value, str):
+            composed[key] = _strongest_security_value(local_value, managed_value)
+        elif key not in composed:
+            composed[key] = managed_value
+    for setting_path in policy.locked_settings:
+        managed_value = _get_path(policy.settings, setting_path)
+        if managed_value is not _MISSING:
+            local_value = _get_path(composed, setting_path)
+            _set_path(
+                composed,
+                setting_path,
+                _strongest_security_value(local_value, managed_value),
+            )
+    return composed
+
+
+def fail_closed_managed_policy() -> ManagedPolicy:
+    """Return the non-weaker floor used when configured machine authority is unreadable."""
+
+    settings: dict[str, object] = {
+        "mode": "enforce",
+        "security_level": "paranoid",
+        "default_action": "block",
+        "unknown_publisher_action": "block",
+        "changed_hash_action": "block",
+        "new_network_domain_action": "block",
+        "subprocess_action": "block",
+        "sync": False,
+    }
+    return ManagedPolicy(
+        schema_version=MDM_POLICY_SCHEMA_VERSION,
+        settings=settings,
+        locked_settings=frozenset(settings),
+        update=ManagedUpdatePolicy(owner="mdm", allow_downgrade=False),
+        content_hash=canonical_payload_hash(
+            {"schemaVersion": MDM_POLICY_SCHEMA_VERSION, "settings": settings, "failClosed": True}
+        ),
+    )
+
+
+__all__ = [
+    "ManagedPolicyError",
+    "apply_managed_policy",
+    "fail_closed_managed_policy",
+    "load_managed_policy",
+    "parse_managed_policy",
+]

--- a/src/codex_plugin_scanner/guard/mdm/policy.py
+++ b/src/codex_plugin_scanner/guard/mdm/policy.py
@@ -6,6 +6,7 @@ import json
 import os
 import platform
 import plistlib
+import urllib.parse
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Literal, cast
@@ -101,8 +102,10 @@ def parse_managed_policy(payload: object) -> ManagedPolicy:
     proxy_url = _optional_string(network_raw.get("proxyUrl"), "network.proxyUrl")
     if proxy_mode == "explicit" and proxy_url is None:
         raise ManagedPolicyError("network.proxyUrl is required for explicit proxy mode")
-    if proxy_url is not None and "@" in proxy_url:
-        raise ManagedPolicyError("proxy credentials are forbidden in managed policy")
+    if proxy_url is not None:
+        parsed_proxy = urllib.parse.urlsplit(proxy_url)
+        if parsed_proxy.username is not None or parsed_proxy.password is not None:
+            raise ManagedPolicyError("proxy credentials are forbidden in managed policy")
     allow_registries = network_raw.get("allowPublicRegistries", True)
     if not isinstance(allow_registries, bool):
         raise ManagedPolicyError("network.allowPublicRegistries must be boolean")
@@ -323,9 +326,9 @@ def apply_managed_policy(local_payload: Mapping[str, object], policy: ManagedPol
         local_value = composed.get(key)
         if key == "actions" or key.endswith("Actions"):
             composed[key] = _merge_strongest_actions(local_value, managed_value)
-        elif isinstance(local_value, str) and isinstance(managed_value, str):
+        elif key in composed:
             composed[key] = _strongest_security_value(local_value, managed_value)
-        elif key not in composed:
+        else:
             composed[key] = managed_value
     for setting_path in policy.locked_settings:
         managed_value = _get_path(policy.settings, setting_path)

--- a/src/codex_plugin_scanner/guard/provenance.py
+++ b/src/codex_plugin_scanner/guard/provenance.py
@@ -14,6 +14,8 @@ import urllib.parse
 import urllib.request
 from typing import Any
 
+from .mdm.network import managed_urlopen
+
 _HARD_RISK_CODES = frozenset(
     {
         "known_malware",
@@ -65,7 +67,7 @@ def _fetch_npm_attestations(package: str, version: str) -> dict[str, Any]:
     encoded = urllib.parse.quote(f"{package}/-/{package}-{version}.tgz", safe="@/")
     url = f"https://registry.npmjs.org/-/npm/v1/attestations/{encoded}"
     req = urllib.request.Request(url, headers={"Accept": "application/json"})
-    with urllib.request.urlopen(req, timeout=10) as resp:
+    with managed_urlopen(req, timeout=10) as resp:
         return json.loads(resp.read())
 
 
@@ -73,7 +75,7 @@ def _fetch_pypi_attestations(package: str, version: str) -> dict[str, Any]:
     """Fetch PyPI attestation data from the PyPI API."""
     url = f"https://pypi.org/integrity/{package}/{version}/attestations.json"
     req = urllib.request.Request(url, headers={"Accept": "application/json"})
-    with urllib.request.urlopen(req, timeout=10) as resp:
+    with managed_urlopen(req, timeout=10) as resp:
         return json.loads(resp.read())
 
 

--- a/src/codex_plugin_scanner/guard/proxy/remote.py
+++ b/src/codex_plugin_scanner/guard/proxy/remote.py
@@ -7,6 +7,7 @@ import urllib.request
 from typing import Any
 from urllib.parse import urljoin, urlsplit
 
+from ..mdm.network import managed_urlopen
 from .stdio import _redact_json
 
 
@@ -40,7 +41,7 @@ class RemoteGuardProxy:
             headers=request_headers,
             method="POST",
         )
-        with urllib.request.urlopen(request, timeout=10) as response:
+        with managed_urlopen(request, timeout=10) as response:
             raw_response = response.read().decode("utf-8")
         response_payload = json.loads(raw_response) if expect_response and raw_response.strip() else None
         self.events.append(

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -45,6 +45,7 @@ from ..cloud_exceptions import (
 )
 from ..config import VALID_RECEIPT_REDACTION_LEVELS, GuardConfig, load_guard_config
 from ..edge_events import build_runtime_session_event
+from ..mdm.network import managed_urlopen
 from ..memory_pattern_fingerprint import build_exact_command_memory_artifact_id
 from ..models import GuardArtifact, HarnessDetection, PolicyDecision
 from ..package_firewall_defaults import extract_cloud_user_profile
@@ -3014,7 +3015,7 @@ def _refresh_guard_oauth_access_token(
             },
         )
         try:
-            with urllib.request.urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
+            with managed_urlopen(request, timeout=_SYNC_HTTP_TIMEOUT_SECONDS) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             payload = _http_error_payload(error) if error.code in {400, 401, 403} else None
@@ -3591,7 +3592,7 @@ def _urlopen_json_with_timeout_retry(
     gateway_retry_count = 0
     while True:
         try:
-            with urllib.request.urlopen(current_request, timeout=current_timeout_seconds) as response:
+            with managed_urlopen(current_request, timeout=current_timeout_seconds) as response:
                 payload = json.loads(response.read().decode("utf-8"))
         except urllib.error.HTTPError as error:
             if error.code == 429 and rate_limit_retry_count < 2:
@@ -3656,7 +3657,7 @@ def _urlopen_with_timeout_retry(
     gateway_retry_count = 0
     while True:
         try:
-            with urllib.request.urlopen(current_request, timeout=current_timeout_seconds):
+            with managed_urlopen(current_request, timeout=current_timeout_seconds):
                 return
         except urllib.error.HTTPError as error:
             if error.code == 401:

--- a/src/codex_plugin_scanner/guard/runtime/runner.py
+++ b/src/codex_plugin_scanner/guard/runtime/runner.py
@@ -2750,10 +2750,15 @@ def _sign_guard_dpop_proof(
         if normalized_nonce:
             claims["nonce"] = normalized_nonce
     signing_input = f"{_encode_jwt_segment(header)}.{_encode_jwt_segment(claims)}".encode("ascii")
-    private_key = serialization.load_pem_private_key(
-        dpop_key_material.private_key_pem.encode("ascii"),
-        password=None,
-    )
+    try:
+        private_key = serialization.load_pem_private_key(
+            dpop_key_material.private_key_pem.encode("ascii"),
+            password=None,
+        )
+    except (TypeError, ValueError) as exc:
+        raise GuardSyncAuthorizationExpiredError(
+            "Guard Cloud authorization key is invalid. Reconnect Guard Cloud."
+        ) from exc
     if not isinstance(private_key, ec.EllipticCurvePrivateKey) or not isinstance(private_key.curve, ec.SECP256R1):
         raise RuntimeError("Guard DPoP key must be a P-256 (SECP256R1) EC private key.")
     der_signature = private_key.sign(signing_input, ec.ECDSA(hashes.SHA256()))

--- a/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
+++ b/src/codex_plugin_scanner/guard/runtime/supply_chain_package_eval.py
@@ -28,6 +28,7 @@ from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
 from ..config import load_guard_config, resolve_risk_action
+from ..mdm.network import managed_urlopen
 from ..models import GuardArtifact
 from ..stable_digest import stable_digest_hex
 from ..store import GuardStore
@@ -2708,7 +2709,7 @@ def _scan_external_tarball(source_url: str) -> dict[str, str] | None:
 def _download_external_tarball(source_url: str) -> bytes | None:
     request = urllib.request.Request(source_url, method="GET")
     try:
-        with urllib.request.urlopen(request, timeout=_TARBALL_SCAN_TIMEOUT_SECONDS) as response:
+        with managed_urlopen(request, timeout=_TARBALL_SCAN_TIMEOUT_SECONDS) as response:
             payload = response.read(_TARBALL_SCAN_MAX_BYTES + 1)
     except OSError:
         return None

--- a/tests/test_guard_mdm_cli.py
+++ b/tests/test_guard_mdm_cli.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner import cli
+
+
+def test_user_status_cli_is_versioned_read_only_and_nonhealthy(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    exit_code = cli.main(["mdm", "status", "--scope", "user", "--home", str(tmp_path), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 1
+    assert payload["schemaVersion"] == "hol-guard-mdm-status.v1"
+    assert payload["scope"] == "user"
+    assert payload["state"] == "absent"
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_mutating_cli_rejects_relative_or_wrong_user_home(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    del tmp_path
+    exit_code = cli.main(
+        ["mdm", "activate", "--home", "relative", "--user", "not-the-current-user", "--json"]
+    )
+    payload = json.loads(capsys.readouterr().out)
+    assert exit_code == 2
+    assert payload["reasonCodes"] == ["mdm_home_must_be_absolute"]
+
+
+def test_cli_cannot_claim_managed_authority_from_a_policy_argument(tmp_path: Path) -> None:
+    with pytest.raises(SystemExit) as error:
+        cli.main(
+            [
+                "mdm",
+                "status",
+                "--scope",
+                "machine",
+                "--policy-path",
+                str(tmp_path / "policy.json"),
+                "--json",
+            ]
+        )
+    assert error.value.code == 2

--- a/tests/test_guard_mdm_lifecycle.py
+++ b/tests/test_guard_mdm_lifecycle.py
@@ -1,0 +1,170 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+from jsonschema import Draft202012Validator
+
+from codex_plugin_scanner.guard.mdm import lifecycle
+from codex_plugin_scanner.guard.mdm.contracts import MDM_STATUS_SCHEMA_VERSION, MachinePaths
+
+
+def test_user_status_does_not_conflate_machine_installation(tmp_path: Path) -> None:
+    payload = lifecycle.user_status(tmp_path)
+    assert payload["schemaVersion"] == MDM_STATUS_SCHEMA_VERSION
+    assert payload["scope"] == "user"
+    assert payload["state"] == "absent"
+    assert payload["healthy"] is False
+
+
+def test_user_home_must_be_absolute_and_exist(tmp_path: Path) -> None:
+    with pytest.raises(ValueError, match="mdm_home_must_be_absolute"):
+        lifecycle.validate_user_home("relative")
+    with pytest.raises(ValueError, match="mdm_home_not_found"):
+        lifecycle.validate_user_home(str(tmp_path / "missing"))
+
+
+def test_activation_is_idempotent_and_writes_user_only_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[str] = []
+
+    def fake_install(command: str, *_args: object, **_kwargs: object) -> dict[str, object]:
+        calls.append(command)
+        return {"managed_installs": []}
+
+    monkeypatch.setattr(lifecycle, "apply_managed_install", fake_install)
+    first = lifecycle.activate_user(tmp_path, "developer")
+    second = lifecycle.repair_user(tmp_path, "developer")
+    marker = tmp_path / ".hol-guard" / "mdm-activation.json"
+
+    assert calls == ["install", "install"]
+    assert first["operation"] == "activate"
+    assert second["operation"] == "repair"
+    assert json.loads(marker.read_text())["user"] == "developer"
+    assert marker.stat().st_mode & 0o077 == 0
+
+
+def test_partial_activation_rolls_back_new_harnesses(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    class FakeStore:
+        active = False
+
+        def __init__(self, _guard_home: Path) -> None:
+            pass
+
+        def list_managed_installs(self) -> list[dict[str, object]]:
+            return [{"harness": "codex", "active": True}] if self.active else []
+
+    commands: list[str] = []
+
+    def fake_install(command: str, *_args: object, **_kwargs: object) -> dict[str, object]:
+        commands.append(command)
+        if command == "install":
+            FakeStore.active = True
+            raise RuntimeError("interrupted")
+        FakeStore.active = False
+        return {}
+
+    monkeypatch.setattr(lifecycle, "GuardStore", FakeStore)
+    monkeypatch.setattr(lifecycle, "apply_managed_install", fake_install)
+
+    with pytest.raises(RuntimeError, match="interrupted"):
+        lifecycle.activate_user(tmp_path, "developer")
+
+    assert commands == ["install", "uninstall"]
+    assert FakeStore.active is False
+
+
+def test_deactivation_restores_integrations_and_removes_marker(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    guard_home = tmp_path / ".hol-guard"
+    guard_home.mkdir()
+    (guard_home / "mdm-activation.json").write_text("{}")
+    commands: list[str] = []
+
+    def fake_install(command: str, *_args: object, **_kwargs: object) -> dict[str, object]:
+        commands.append(command)
+        return {"managed_installs": []}
+
+    monkeypatch.setattr(lifecycle, "apply_managed_install", fake_install)
+    payload = lifecycle.deactivate_user(tmp_path)
+
+    assert commands == ["uninstall"]
+    assert payload["operation"] == "deactivate"
+    assert not (guard_home / "mdm-activation.json").exists()
+
+
+def test_status_schema_accepts_stable_user_contract(tmp_path: Path) -> None:
+    schema_path = Path(__file__).parents[1] / "docs" / "guard" / "schemas" / "mdm-status-v1.schema.json"
+    schema = json.loads(schema_path.read_text())
+    Draft202012Validator(schema).validate(lifecycle.user_status(tmp_path))
+
+
+def test_removal_authorization_is_scoped_short_lived_and_single_use(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    authorization_root = tmp_path / "authorizations"
+    authorization_root.mkdir()
+    home = tmp_path / "home"
+    home.mkdir()
+    now = datetime.now(timezone.utc)
+    token = authorization_root / "token.json"
+    token.write_text(
+        json.dumps(
+            {
+                "operation": "deactivate",
+                "user": "developer",
+                "home": str(home),
+                "nonce": "unique-removal-nonce",
+                "issuedAt": now.isoformat(),
+                "expiresAt": (now + timedelta(minutes=2)).isoformat(),
+            }
+        )
+    )
+    monkeypatch.setattr(lifecycle.platform, "system", lambda: "Windows")
+
+    fingerprint = lifecycle.validate_removal_authorization(
+        token, home=home, user="developer", authorization_root=authorization_root
+    )
+    guard_home = home / ".hol-guard"
+    guard_home.mkdir()
+    (guard_home / "mdm-removal-consumed").write_text(f"{fingerprint}\n")
+
+    with pytest.raises(ValueError, match="mdm_removal_authorization_replayed"):
+        lifecycle.validate_removal_authorization(
+            token, home=home, user="developer", authorization_root=authorization_root
+        )
+
+
+def test_removal_authorization_rejects_arbitrary_path(tmp_path: Path) -> None:
+    token = tmp_path / "token.json"
+    token.write_text("{}")
+    with pytest.raises(ValueError, match="mdm_removal_authorization_wrong_scope"):
+        lifecycle.validate_removal_authorization(
+            token,
+            home=tmp_path,
+            user="developer",
+            authorization_root=tmp_path / "trusted",
+        )
+
+
+def test_authorization_creation_requires_admin_and_safe_name(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    paths = MachinePaths(tmp_path, tmp_path / "state", None, tmp_path / "logs", tmp_path / "manifest")
+    monkeypatch.setattr(lifecycle, "default_machine_paths", lambda: paths)
+    monkeypatch.setattr(lifecycle, "_is_administrator", lambda: False)
+    with pytest.raises(PermissionError, match="mdm_administrator_context_required"):
+        lifecycle.authorize_deactivation(tmp_path, "developer")
+
+    monkeypatch.setattr(lifecycle, "_is_administrator", lambda: True)
+    monkeypatch.setattr(lifecycle.platform, "system", lambda: "Windows")
+    with pytest.raises(ValueError, match="mdm_removal_authorization_name_invalid"):
+        lifecycle.authorize_deactivation(tmp_path, "developer", token_name="../escape.json")
+    payload = lifecycle.authorize_deactivation(tmp_path, "developer", token_name="developer.json")
+    assert Path(str(payload["authorizationPath"])).is_file()

--- a/tests/test_guard_mdm_lifecycle.py
+++ b/tests/test_guard_mdm_lifecycle.py
@@ -26,9 +26,7 @@ def test_user_home_must_be_absolute_and_exist(tmp_path: Path) -> None:
         lifecycle.validate_user_home(str(tmp_path / "missing"))
 
 
-def test_activation_is_idempotent_and_writes_user_only_marker(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_activation_is_idempotent_and_writes_user_only_marker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     calls: list[str] = []
 
     def fake_install(command: str, *_args: object, **_kwargs: object) -> dict[str, object]:
@@ -47,9 +45,7 @@ def test_activation_is_idempotent_and_writes_user_only_marker(
     assert marker.stat().st_mode & 0o077 == 0
 
 
-def test_partial_activation_rolls_back_new_harnesses(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_partial_activation_rolls_back_new_harnesses(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     class FakeStore:
         active = False
 
@@ -79,9 +75,7 @@ def test_partial_activation_rolls_back_new_harnesses(
     assert FakeStore.active is False
 
 
-def test_deactivation_restores_integrations_and_removes_marker(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_deactivation_restores_integrations_and_removes_marker(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     guard_home = tmp_path / ".hol-guard"
     guard_home.mkdir()
     (guard_home / "mdm-activation.json").write_text("{}")
@@ -153,9 +147,7 @@ def test_removal_authorization_rejects_arbitrary_path(tmp_path: Path) -> None:
         )
 
 
-def test_authorization_creation_requires_admin_and_safe_name(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_authorization_creation_requires_admin_and_safe_name(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     paths = MachinePaths(tmp_path, tmp_path / "state", None, tmp_path / "logs", tmp_path / "manifest")
     monkeypatch.setattr(lifecycle, "default_machine_paths", lambda: paths)
     monkeypatch.setattr(lifecycle, "_is_administrator", lambda: False)
@@ -168,3 +160,10 @@ def test_authorization_creation_requires_admin_and_safe_name(
         lifecycle.authorize_deactivation(tmp_path, "developer", token_name="../escape.json")
     payload = lifecycle.authorize_deactivation(tmp_path, "developer", token_name="developer.json")
     assert Path(str(payload["authorizationPath"])).is_file()
+
+
+def test_trusted_key_loader_skips_only_malformed_entries(tmp_path: Path) -> None:
+    path = tmp_path / "release-trusted-keys.json"
+    path.write_text(json.dumps({"valid": "a2V5", "invalid": "%%%"}))
+
+    assert lifecycle._load_trusted_keys(path) == {"valid": b"key"}

--- a/tests/test_guard_mdm_lifecycle.py
+++ b/tests/test_guard_mdm_lifecycle.py
@@ -125,11 +125,10 @@ def test_removal_authorization_is_scoped_short_lived_and_single_use(
     fingerprint = lifecycle.validate_removal_authorization(
         token, home=home, user="developer", authorization_root=authorization_root
     )
-    guard_home = home / ".hol-guard"
-    guard_home.mkdir()
-    (guard_home / "mdm-removal-consumed").write_text(f"{fingerprint}\n")
+    assert len(fingerprint) == 64
+    assert not token.exists()
 
-    with pytest.raises(ValueError, match="mdm_removal_authorization_replayed"):
+    with pytest.raises(ValueError, match="mdm_removal_authorization_consumed_or_missing"):
         lifecycle.validate_removal_authorization(
             token, home=home, user="developer", authorization_root=authorization_root
         )

--- a/tests/test_guard_mdm_lifecycle.py
+++ b/tests/test_guard_mdm_lifecycle.py
@@ -86,11 +86,16 @@ def test_deactivation_restores_integrations_and_removes_marker(tmp_path: Path, m
         return {"managed_installs": []}
 
     monkeypatch.setattr(lifecycle, "apply_managed_install", fake_install)
-    payload = lifecycle.deactivate_user(tmp_path)
+    payload = lifecycle.deactivate_user(tmp_path, authorization_fingerprint="consumed-token")
 
     assert commands == ["uninstall"]
     assert payload["operation"] == "deactivate"
     assert not (guard_home / "mdm-activation.json").exists()
+
+
+def test_deactivation_requires_machine_authorization(tmp_path: Path) -> None:
+    with pytest.raises(PermissionError, match="mdm_removal_authorization_required"):
+        lifecycle.deactivate_user(tmp_path)
 
 
 def test_status_schema_accepts_stable_user_contract(tmp_path: Path) -> None:

--- a/tests/test_guard_mdm_manifest.py
+++ b/tests/test_guard_mdm_manifest.py
@@ -1,0 +1,144 @@
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+from pathlib import Path
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+from codex_plugin_scanner.guard.mdm.contracts import RELEASE_MANIFEST_SCHEMA_VERSION
+from codex_plugin_scanner.guard.mdm.manifest import verify_release_manifest
+
+
+def _manifest(runtime: Path) -> dict[str, object]:
+    executable = runtime / "bin" / "hol-guard"
+    executable.parent.mkdir(parents=True)
+    executable.write_bytes(b"guard-runtime")
+    return {
+        "schemaVersion": RELEASE_MANIFEST_SCHEMA_VERSION,
+        "version": "2.1.0",
+        "buildId": "build-1",
+        "sourceCommit": "a" * 40,
+        "platform": "macos",
+        "architecture": "arm64",
+        "policySchemaVersion": "hol-guard-mdm-policy.v1",
+        "installerIdentity": "org.hol.guard",
+        "files": [{"path": "bin/hol-guard", "sha256": hashlib.sha256(executable.read_bytes()).hexdigest()}],
+    }
+
+
+def _write_signed(path: Path, payload: dict[str, object], private_key: Ed25519PrivateKey) -> None:
+    canonical = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode()
+    signed = dict(payload)
+    signed["signature"] = {"keyId": "release-1", "value": base64.b64encode(private_key.sign(canonical)).decode()}
+    path.write_text(json.dumps(signed))
+
+
+def test_verifies_signature_and_runtime_hashes(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    manifest = _manifest(runtime)
+    key = Ed25519PrivateKey.generate()
+    manifest_path = runtime / "release-manifest.json"
+    _write_signed(manifest_path, manifest, key)
+    public = key.public_key().public_bytes(serialization.Encoding.Raw, serialization.PublicFormat.Raw)
+
+    result = verify_release_manifest(manifest_path, runtime, trusted_keys={"release-1": public})
+
+    assert result.healthy
+    assert result.signature_state == "valid"
+    assert result.reason_code == "release_manifest_valid"
+
+
+def test_unsigned_manifest_is_not_healthy(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    manifest = _manifest(runtime)
+    manifest_path = runtime / "release-manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    result = verify_release_manifest(manifest_path, runtime)
+
+    assert not result.healthy
+    assert result.reason_code == "release_manifest_unsigned"
+
+
+def test_detects_modified_runtime_file(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    manifest = _manifest(runtime)
+    manifest_path = runtime / "release-manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    (runtime / "bin" / "hol-guard").write_bytes(b"tampered")
+
+    result = verify_release_manifest(manifest_path, runtime, require_signature=False)
+
+    assert result.reason_code == "release_manifest_hash_mismatch"
+
+
+def test_rejects_manifest_path_traversal(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    manifest = _manifest(runtime)
+    manifest["files"] = [{"path": "../outside", "sha256": "0" * 64}]
+    manifest_path = runtime / "release-manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    result = verify_release_manifest(manifest_path, runtime, require_signature=False)
+
+    assert result.reason_code == "release_manifest_invalid"
+
+
+def test_rejects_symlink_escape(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    outside = tmp_path / "outside"
+    outside.write_bytes(b"outside")
+    runtime.mkdir()
+    (runtime / "link").symlink_to(outside)
+    manifest = {
+        "schemaVersion": RELEASE_MANIFEST_SCHEMA_VERSION,
+        "version": "2.1.0",
+        "buildId": "build-1",
+        "sourceCommit": "a" * 40,
+        "platform": "macos",
+        "architecture": "arm64",
+        "policySchemaVersion": "hol-guard-mdm-policy.v1",
+        "installerIdentity": "org.hol.guard",
+        "files": [{"path": "link", "sha256": hashlib.sha256(outside.read_bytes()).hexdigest()}],
+    }
+    manifest_path = runtime / "release-manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    result = verify_release_manifest(manifest_path, runtime, require_signature=False)
+
+    assert result.reason_code == "release_manifest_path_escape"
+
+
+def test_rejects_wrong_platform_or_architecture(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    manifest = _manifest(runtime)
+    manifest_path = runtime / "release-manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+
+    platform_result = verify_release_manifest(
+        manifest_path, runtime, require_signature=False, expected_platform="windows"
+    )
+    arch_result = verify_release_manifest(
+        manifest_path, runtime, require_signature=False, expected_architecture="x86_64"
+    )
+
+    assert platform_result.reason_code == "release_manifest_platform_mismatch"
+    assert arch_result.reason_code == "release_manifest_architecture_mismatch"
+
+
+def test_detects_insecure_machine_file_permissions(tmp_path: Path) -> None:
+    runtime = tmp_path / "runtime"
+    manifest = _manifest(runtime)
+    manifest_path = runtime / "release-manifest.json"
+    manifest_path.write_text(json.dumps(manifest))
+    (runtime / "bin" / "hol-guard").chmod(0o777)
+
+    result = verify_release_manifest(
+        manifest_path, runtime, require_signature=False, expected_owner_uid=os.getuid()
+    )
+
+    assert result.reason_code == "release_runtime_insecure_permissions"

--- a/tests/test_guard_mdm_native.py
+++ b/tests/test_guard_mdm_native.py
@@ -1,16 +1,31 @@
 from __future__ import annotations
 
 from pathlib import Path
+from xml.etree import ElementTree
 
 import pytest
 
 from codex_plugin_scanner.guard.mdm import native
 
 
-def test_unsupported_platform_never_reports_healthy(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_unsupported_platform_never_reports_healthy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(native.platform, "system", lambda: "Linux")
     result = native.verify_native_install(tmp_path)
     assert not result.healthy
     assert result.reason_code == "native_platform_unsupported"
+
+
+def test_windows_manifest_is_generated_after_runtime_signing() -> None:
+    script = Path("scripts/mdm/windows/build-msi.ps1").read_text(encoding="utf-8")
+
+    signing = script.index("/td SHA256 $_.FullName")
+    manifest = script.index("generate-release-manifest.py') @ManifestArgs")
+    assert signing < manifest
+
+
+def test_windows_active_setup_expands_user_environment() -> None:
+    root = ElementTree.parse("scripts/mdm/windows/hol-guard.wxs").getroot()
+    registry_values = root.findall(".//{http://wixtoolset.org/schemas/v4/wxs}RegistryValue")
+    stub_path = next(value for value in registry_values if value.attrib.get("Name") == "StubPath")
+
+    assert stub_path.attrib["Type"] == "expandable"

--- a/tests/test_guard_mdm_native.py
+++ b/tests/test_guard_mdm_native.py
@@ -29,3 +29,10 @@ def test_windows_active_setup_expands_user_environment() -> None:
     stub_path = next(value for value in registry_values if value.attrib.get("Name") == "StubPath")
 
     assert stub_path.attrib["Type"] == "expandable"
+
+
+def test_macos_activation_preserves_spaced_home_paths() -> None:
+    script = Path("scripts/mdm/macos/activate-current-user.sh").read_text(encoding="utf-8")
+
+    assert "sed -n 's/^NFSHomeDirectory: //p'" in script
+    assert "awk '{print $2}'" not in script

--- a/tests/test_guard_mdm_native.py
+++ b/tests/test_guard_mdm_native.py
@@ -6,6 +6,7 @@ from xml.etree import ElementTree
 import pytest
 
 from codex_plugin_scanner.guard.mdm import native
+from codex_plugin_scanner.guard.mdm.contracts import default_machine_paths
 
 
 def test_unsupported_platform_never_reports_healthy(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -36,3 +37,13 @@ def test_macos_activation_preserves_spaced_home_paths() -> None:
 
     assert "sed -n 's/^NFSHomeDirectory: //p'" in script
     assert "awk '{print $2}'" not in script
+
+
+def test_windows_machine_paths_ignore_process_environment(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PROGRAMFILES", r"C:\Users\attacker\runtime")
+    monkeypatch.setenv("PROGRAMDATA", r"C:\Users\attacker\state")
+
+    paths = default_machine_paths(system_name="Windows")
+
+    assert paths.runtime_root == Path(r"C:\Program Files") / "HOL Guard"
+    assert paths.state_root == Path(r"C:\ProgramData") / "HOL Guard"

--- a/tests/test_guard_mdm_native.py
+++ b/tests/test_guard_mdm_native.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.mdm import native
+
+
+def test_unsupported_platform_never_reports_healthy(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(native.platform, "system", lambda: "Linux")
+    result = native.verify_native_install(tmp_path)
+    assert not result.healthy
+    assert result.reason_code == "native_platform_unsupported"

--- a/tests/test_guard_mdm_network.py
+++ b/tests/test_guard_mdm_network.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import ssl
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.mdm.contracts import ManagedNetworkPolicy
+from codex_plugin_scanner.guard.mdm.network import (
+    ManagedNetworkError,
+    managed_requests_kwargs,
+    managed_requests_session,
+    managed_ssl_context,
+    managed_urlopen,
+)
+
+
+def test_tls_verification_cannot_be_disabled() -> None:
+    context = managed_ssl_context(ManagedNetworkPolicy(proxy_mode="none"))
+    assert context.verify_mode == ssl.CERT_REQUIRED
+    assert context.check_hostname is True
+    session = managed_requests_session(ManagedNetworkPolicy(proxy_mode="none"))
+    assert session.verify is True
+    assert session.trust_env is False
+
+
+def test_explicit_proxy_is_applied_without_credentials() -> None:
+    policy = ManagedNetworkPolicy(proxy_mode="explicit", proxy_url="https://proxy.example:8443")
+    session = managed_requests_session(policy)
+    assert session.proxies == {
+        "http": "https://proxy.example:8443",
+        "https": "https://proxy.example:8443",
+    }
+    assert managed_requests_kwargs(policy)["proxies"] == session.proxies
+
+
+def test_private_ca_must_be_an_absolute_readable_file(tmp_path: Path) -> None:
+    with pytest.raises(ManagedNetworkError, match="managed_ca_bundle_invalid"):
+        managed_ssl_context(ManagedNetworkPolicy(ca_bundle_path="relative.pem"))
+    with pytest.raises(ManagedNetworkError, match="managed_ca_bundle_invalid"):
+        managed_requests_session(ManagedNetworkPolicy(ca_bundle_path=str(tmp_path / "missing.pem")))
+
+
+def test_disabled_public_registry_fails_before_network() -> None:
+    policy = ManagedNetworkPolicy(allow_public_registries=False)
+    with pytest.raises(ManagedNetworkError, match="managed_public_registry_disabled"):
+        managed_urlopen("https://pypi.org/pypi/hol-guard/json", timeout=1, policy=policy)
+
+
+def test_managed_system_proxy_uses_platform_configuration_not_environment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "codex_plugin_scanner.guard.mdm.network.platform_system_proxies",
+        lambda: {"https": "http://system-proxy.example:8080"},
+    )
+    kwargs = managed_requests_kwargs(ManagedNetworkPolicy(proxy_mode="system"))
+    assert kwargs["proxies"] == {
+        "http": "",
+        "https": "http://system-proxy.example:8080",
+    }

--- a/tests/test_guard_mdm_network.py
+++ b/tests/test_guard_mdm_network.py
@@ -5,6 +5,7 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import certifi
 import pytest
 
 from codex_plugin_scanner.guard.mdm.contracts import ManagedNetworkPolicy
@@ -42,6 +43,14 @@ def test_private_ca_must_be_an_absolute_readable_file(tmp_path: Path) -> None:
         managed_ssl_context(ManagedNetworkPolicy(ca_bundle_path="relative.pem"))
     with pytest.raises(ManagedNetworkError, match="managed_ca_bundle_invalid"):
         managed_requests_session(ManagedNetworkPolicy(ca_bundle_path=str(tmp_path / "missing.pem")))
+
+
+def test_private_ca_is_added_without_replacing_public_trust() -> None:
+    session = managed_requests_session(ManagedNetworkPolicy(ca_bundle_path=certifi.where()))
+
+    assert session.verify is True
+    assert session.adapters["https://"].__class__.__name__ == "_AdditiveCAAdapter"
+    assert "verify" not in managed_requests_kwargs(ManagedNetworkPolicy(ca_bundle_path=certifi.where()))
 
 
 def test_disabled_public_registry_fails_before_network() -> None:

--- a/tests/test_guard_mdm_network.py
+++ b/tests/test_guard_mdm_network.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
 import ssl
+import sys
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -12,6 +14,7 @@ from codex_plugin_scanner.guard.mdm.network import (
     managed_requests_session,
     managed_ssl_context,
     managed_urlopen,
+    platform_system_proxies,
 )
 
 
@@ -58,4 +61,33 @@ def test_managed_system_proxy_uses_platform_configuration_not_environment(
     assert kwargs["proxies"] == {
         "http": "",
         "https": "http://system-proxy.example:8080",
+    }
+
+
+def test_windows_system_proxy_falls_back_to_machine_scope(monkeypatch: pytest.MonkeyPatch) -> None:
+    class FakeKey:
+        def __enter__(self) -> FakeKey:
+            return self
+
+        def __exit__(self, *_args: object) -> None:
+            return None
+
+    def open_key(hive: object, _path: str) -> FakeKey:
+        if hive == "current-user":
+            raise OSError
+        return FakeKey()
+
+    values = iter(((1, 0), ("proxy.example:8080", 0)))
+    fake_winreg = SimpleNamespace(
+        HKEY_CURRENT_USER="current-user",
+        HKEY_LOCAL_MACHINE="local-machine",
+        OpenKey=open_key,
+        QueryValueEx=lambda _key, _name: next(values),
+    )
+    monkeypatch.setitem(sys.modules, "winreg", fake_winreg)
+    monkeypatch.setattr("codex_plugin_scanner.guard.mdm.network.platform.system", lambda: "Windows")
+
+    assert platform_system_proxies() == {
+        "http": "http://proxy.example:8080",
+        "https": "http://proxy.example:8080",
     }

--- a/tests/test_guard_mdm_policy.py
+++ b/tests/test_guard_mdm_policy.py
@@ -85,6 +85,30 @@ def test_managed_value_replaces_invalid_local_type(tmp_path: Path) -> None:
     assert apply_managed_policy({"mode": True}, state.policy)["mode"] == "enforce"
 
 
+def test_partial_managed_nested_policy_preserves_local_strengthening(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+    path.write_text(
+        json.dumps(
+            _policy(
+                settings={"risk_actions": {"network_egress": "block"}},
+                lockedSettings=["risk_actions.network_egress"],
+            )
+        )
+    )
+    state = load_managed_policy(policy_path=path)
+    assert state.policy is not None
+
+    composed = apply_managed_policy(
+        {"risk_actions": {"network_egress": "review", "credential_access": "block"}},
+        state.policy,
+    )
+
+    assert composed["risk_actions"] == {
+        "network_egress": "block",
+        "credential_access": "block",
+    }
+
+
 def test_proxy_credentials_are_rejected_when_encoded() -> None:
     payload = _policy(
         network={

--- a/tests/test_guard_mdm_policy.py
+++ b/tests/test_guard_mdm_policy.py
@@ -76,6 +76,27 @@ def test_locked_values_override_local_and_actions_only_strengthen(tmp_path: Path
     }
 
 
+def test_managed_value_replaces_invalid_local_type(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(_policy()))
+    state = load_managed_policy(policy_path=path)
+    assert state.policy is not None
+
+    assert apply_managed_policy({"mode": True}, state.policy)["mode"] == "enforce"
+
+
+def test_proxy_credentials_are_rejected_when_encoded() -> None:
+    payload = _policy(
+        network={
+            "proxyMode": "explicit",
+            "proxyUrl": "https://user%40example:secret@proxy.example:8443",
+        }
+    )
+
+    with pytest.raises(ValueError, match="proxy credentials"):
+        policy_module.parse_managed_policy(payload)
+
+
 def test_missing_policy_reports_absent(tmp_path: Path) -> None:
     state = load_managed_policy(policy_path=tmp_path / "missing.json")
     assert state.status == "absent"
@@ -129,9 +150,7 @@ def test_invalid_machine_policy_fails_closed_in_runtime_config(tmp_path: Path) -
     assert config.install_owner == "mdm"
 
 
-def test_removed_profile_retains_last_valid_machine_floor(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
+def test_removed_profile_retains_last_valid_machine_floor(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     native_path = tmp_path / "managed-policy.json"
     paths = MachinePaths(
         tmp_path / "runtime",

--- a/tests/test_guard_mdm_policy.py
+++ b/tests/test_guard_mdm_policy.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard import config as config_module
 from codex_plugin_scanner.guard.config import load_guard_config, overlay_synced_guard_policy
 from codex_plugin_scanner.guard.mdm import policy as policy_module
 from codex_plugin_scanner.guard.mdm.contracts import MDM_POLICY_SCHEMA_VERSION, MachinePaths
@@ -109,6 +110,26 @@ def test_partial_managed_nested_policy_preserves_local_strengthening(tmp_path: P
     }
 
 
+def test_nested_managed_lock_rejects_persisted_weakening(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    path = tmp_path / "policy.json"
+    path.write_text(
+        json.dumps(
+            _policy(
+                settings={"risk_actions": {"network_egress": "block"}},
+                lockedSettings=["risk_actions.network_egress"],
+            )
+        )
+    )
+    state = load_managed_policy(policy_path=path)
+    monkeypatch.setattr(config_module, "load_managed_policy", lambda: state)
+
+    with pytest.raises(ValueError, match=r"risk_actions\.network_egress"):
+        config_module.update_guard_settings(
+            tmp_path / "guard-home",
+            {"risk_actions": {"network_egress": "warn"}},
+        )
+
+
 def test_proxy_credentials_are_rejected_when_encoded() -> None:
     payload = _policy(
         network={
@@ -132,8 +153,14 @@ def test_managed_policy_survives_local_and_cloud_weakening(tmp_path: Path) -> No
     path.write_text(
         json.dumps(
             _policy(
-                settings={"mode": "enforce", "default_action": "block"},
-                lockedSettings=["mode", "default_action"],
+                settings={
+                    "mode": "enforce",
+                    "security_level": "paranoid",
+                    "default_action": "block",
+                    "risk_actions": {"network_egress": "block"},
+                    "harness_risk_actions": {"codex": {"network_egress": "block"}},
+                },
+                lockedSettings=["mode", "security_level", "default_action", "risk_actions.network_egress"],
             )
         )
     )
@@ -146,7 +173,10 @@ def test_managed_policy_survives_local_and_cloud_weakening(tmp_path: Path) -> No
     overlaid = overlay_synced_guard_policy(config, {"mode": "prompt", "defaultAction": "warn"})
 
     assert overlaid.mode == "enforce"
+    assert overlaid.security_level == "paranoid"
     assert overlaid.default_action == "block"
+    assert overlaid.risk_actions == {"network_egress": "block"}
+    assert overlaid.harness_risk_actions == {"codex": {"network_egress": "block"}}
     assert overlaid.install_owner == "mdm"
 
 

--- a/tests/test_guard_mdm_policy.py
+++ b/tests/test_guard_mdm_policy.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.config import load_guard_config, overlay_synced_guard_policy
+from codex_plugin_scanner.guard.mdm import policy as policy_module
+from codex_plugin_scanner.guard.mdm.contracts import MDM_POLICY_SCHEMA_VERSION, MachinePaths
+from codex_plugin_scanner.guard.mdm.policy import apply_managed_policy, load_managed_policy
+
+
+def _policy(**overrides: object) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "schemaVersion": MDM_POLICY_SCHEMA_VERSION,
+        "settings": {"mode": "enforce", "actions": {"shell": "block", "read": "warn"}},
+        "lockedSettings": ["mode"],
+        "update": {"owner": "mdm"},
+    }
+    payload.update(overrides)
+    return payload
+
+
+def test_loads_active_policy_and_redacts_network_secrets(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(_policy(network={"proxyMode": "explicit", "proxyUrl": "https://proxy:8443"})))
+
+    state = load_managed_policy(policy_path=path)
+
+    assert state.status == "active"
+    assert state.policy is not None
+    assert state.policy.install_owner == "mdm"
+    assert state.policy.to_public_dict()["network"] == {
+        "proxyMode": "explicit",
+        "proxyConfigured": True,
+        "caBundleConfigured": False,
+        "allowPublicRegistries": True,
+    }
+
+
+def test_rejects_unknown_keys_and_proxy_credentials(tmp_path: Path) -> None:
+    for index, payload in enumerate(
+        (
+            _policy(unknown=True),
+            _policy(network={"proxyMode": "explicit", "proxyUrl": "https://user:secret@proxy"}),
+        )
+    ):
+        path = tmp_path / f"policy-{index}.json"
+        path.write_text(json.dumps(payload))
+        state = load_managed_policy(policy_path=path)
+        assert state.status == "invalid"
+        assert state.reason_code == "managed_policy_invalid"
+
+
+def test_policy_is_size_bounded(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+    path.write_bytes(b" " * (1024 * 1024 + 1))
+    assert load_managed_policy(policy_path=path).status == "invalid"
+
+
+def test_locked_values_override_local_and_actions_only_strengthen(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(_policy()))
+    state = load_managed_policy(policy_path=path)
+    assert state.policy is not None
+
+    composed = apply_managed_policy(
+        {"mode": "monitor", "actions": {"shell": "allow", "read": "block", "write": "review"}},
+        state.policy,
+    )
+
+    assert composed == {
+        "mode": "enforce",
+        "actions": {"shell": "block", "read": "block", "write": "review"},
+    }
+
+
+def test_missing_policy_reports_absent(tmp_path: Path) -> None:
+    state = load_managed_policy(policy_path=tmp_path / "missing.json")
+    assert state.status == "absent"
+    assert state.reason_code == "managed_policy_absent"
+
+
+def test_managed_policy_survives_local_and_cloud_weakening(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+    path.write_text(
+        json.dumps(
+            _policy(
+                settings={"mode": "enforce", "default_action": "block"},
+                lockedSettings=["mode", "default_action"],
+            )
+        )
+    )
+    state = load_managed_policy(policy_path=path)
+    guard_home = tmp_path / "home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text('mode = "observe"\ndefault_action = "allow"\n')
+
+    config = load_guard_config(guard_home, managed_policy_state=state)
+    overlaid = overlay_synced_guard_policy(config, {"mode": "prompt", "defaultAction": "warn"})
+
+    assert overlaid.mode == "enforce"
+    assert overlaid.default_action == "block"
+    assert overlaid.install_owner == "mdm"
+
+
+def test_local_policy_can_strengthen_locked_action(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+    path.write_text(json.dumps(_policy(settings={"default_action": "warn"}, lockedSettings=["default_action"])))
+    state = load_managed_policy(policy_path=path)
+    assert state.policy is not None
+    assert apply_managed_policy({"default_action": "block"}, state.policy)["default_action"] == "block"
+
+
+def test_invalid_machine_policy_fails_closed_in_runtime_config(tmp_path: Path) -> None:
+    path = tmp_path / "policy.json"
+    path.write_text("not-json")
+    state = load_managed_policy(policy_path=path)
+    guard_home = tmp_path / "home"
+    guard_home.mkdir()
+    (guard_home / "config.toml").write_text('mode = "observe"\ndefault_action = "allow"\n')
+
+    config = load_guard_config(guard_home, managed_policy_state=state)
+
+    assert config.managed_policy_status == "invalid"
+    assert config.mode == "enforce"
+    assert config.default_action == "block"
+    assert config.install_owner == "mdm"
+
+
+def test_removed_profile_retains_last_valid_machine_floor(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    native_path = tmp_path / "managed-policy.json"
+    paths = MachinePaths(
+        tmp_path / "runtime",
+        tmp_path / "state",
+        native_path,
+        tmp_path / "logs",
+        tmp_path / "manifest",
+    )
+    monkeypatch.setattr(policy_module, "default_machine_paths", lambda **_kwargs: paths)
+    monkeypatch.setattr(policy_module, "_administrator_context", lambda _system: True)
+    monkeypatch.setattr(policy_module, "_cache_owner_is_trusted", lambda _path, _system: True)
+    native_path.write_text(json.dumps(_policy()))
+
+    active = load_managed_policy(system_name="Linux")
+    native_path.unlink()
+    cached = load_managed_policy(system_name="Linux")
+
+    assert active.status == "active"
+    assert active.policy is not None
+    assert cached.status == "active"
+    assert cached.reason_code == "managed_policy_profile_removed_cached"
+    assert cached.policy is not None
+    assert cached.policy.content_hash == active.policy.content_hash

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import http.client
 import json
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -20,6 +21,24 @@ def _context(tmp_path: Path) -> HarnessContext:
     guard_home = tmp_path / "guard-home"
     workspace.mkdir(parents=True, exist_ok=True)
     return HarnessContext(home_dir=home, workspace_dir=workspace, guard_home=guard_home)
+
+
+def test_update_is_skipped_when_managed_policy_owns_updates(monkeypatch: pytest.MonkeyPatch) -> None:
+    policy = SimpleNamespace(update=SimpleNamespace(owner="mdm"))
+    monkeypatch.setattr(
+        update_commands,
+        "load_managed_policy",
+        lambda: SimpleNamespace(policy=policy),
+    )
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["status"] == "skipped"
+    assert payload["changed"] is False
+    assert payload["reason_code"] == "mdm_update_owned"
 
 
 def test_update_detects_uv_tool_install_and_plans_uv_upgrade(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -28,7 +28,24 @@ def test_update_is_skipped_when_managed_policy_owns_updates(monkeypatch: pytest.
     monkeypatch.setattr(
         update_commands,
         "load_managed_policy",
-        lambda: SimpleNamespace(policy=policy),
+        lambda: SimpleNamespace(status="active", policy=policy),
+    )
+    monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
+    monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")
+
+    payload, exit_code = update_commands.run_guard_update(dry_run=True)
+
+    assert exit_code == 0
+    assert payload["status"] == "skipped"
+    assert payload["changed"] is False
+    assert payload["reason_code"] == "mdm_update_owned"
+
+
+def test_update_is_skipped_when_managed_policy_is_invalid(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        update_commands,
+        "load_managed_policy",
+        lambda: SimpleNamespace(status="invalid", policy=None),
     )
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
     monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pipx")

--- a/uv.lock
+++ b/uv.lock
@@ -192,6 +192,15 @@ wheels = [
 ]
 
 [[package]]
+name = "altgraph"
+version = "0.17.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/f8/97fdf103f38fed6792a1601dbc16cc8aac56e7459a9fff08c812d8ae177a/altgraph-0.17.5.tar.gz", hash = "sha256:c87b395dd12fabde9c99573a9749d67da8d29ef9de0125c7f536699b4a9bc9e7", size = 48428, upload-time = "2025-11-21T20:35:50.583Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a9/ba/000a1996d4308bc65120167c21241a3b205464a2e0b58deda26ae8ac21d1/altgraph-0.17.5-py2.py3-none-any.whl", hash = "sha256:f3a22400bce1b0c701683820ac4f3b159cd301acab067c51c653e06961600597", size = 21228, upload-time = "2025-11-21T20:35:49.444Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1188,6 +1197,9 @@ dev = [
     { name = "pyyaml" },
     { name = "ruff" },
 ]
+mdm-build = [
+    { name = "pyinstaller" },
+]
 publish = [
     { name = "twine" },
 ]
@@ -1208,6 +1220,7 @@ requires-dist = [
     { name = "litellm", marker = "python_full_version >= '3.11' and python_full_version < '3.14' and extra == 'cisco'", specifier = "==1.91.3" },
     { name = "mcp", marker = "python_full_version >= '3.10'", specifier = ">=1.27.0,<2" },
     { name = "packaging", specifier = ">=24.0" },
+    { name = "pyinstaller", marker = "extra == 'mdm-build'", specifier = ">=6.16,<7" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.3" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=7.1.0" },
     { name = "pyyaml", marker = "extra == 'dev'", specifier = ">=6.0.3" },
@@ -1217,7 +1230,7 @@ requires-dist = [
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "twine", marker = "extra == 'publish'", specifier = ">=6.2.0" },
 ]
-provides-extras = ["cisco", "dev", "publish"]
+provides-extras = ["cisco", "dev", "mdm-build", "publish"]
 
 [package.metadata.requires-dev]
 cisco-mcp = [{ name = "cisco-ai-mcp-scanner", marker = "python_full_version >= '3.11' and python_full_version < '3.14'", specifier = "==4.7.3" }]
@@ -1620,6 +1633,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/36/33/879369fe202498a307e1130bae1f59c5f226362afc07829ba5a0279a563d/litellm-1.91.3.tar.gz", hash = "sha256:096cee401dfd353f050422adc6ed9b25da0fc5e110fc923ce3f0ffa5bc5c2957", size = 14875767, upload-time = "2026-07-11T22:43:32.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d6/3c/157c54c924f9e6025797545a0cd915a98e98ad8d3f9011502a575781d4b5/litellm-1.91.3-py3-none-any.whl", hash = "sha256:5be4df2bdf5459f46a6224a75046f365dc979995a37a81f5aa3ce29f92f534cf", size = 16674504, upload-time = "2026-07-11T22:43:30.517Z" },
+]
+
+[[package]]
+name = "macholib"
+version = "1.16.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph", marker = "sys_platform != 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/2f/97589876ea967487978071c9042518d28b958d87b17dceb7cdc1d881f963/macholib-1.16.4.tar.gz", hash = "sha256:f408c93ab2e995cd2c46e34fe328b130404be143469e41bc366c807448979362", size = 59427, upload-time = "2025-11-22T08:28:38.373Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/d1/a9f36f8ecdf0fb7c9b1e78c8d7af12b8c8754e74851ac7b94a8305540fc7/macholib-1.16.4-py2.py3-none-any.whl", hash = "sha256:da1a3fa8266e30f0ce7e97c6a54eefaae8edd1e5f86f3eb8b95457cae90265ea", size = 38117, upload-time = "2025-11-22T08:28:36.939Z" },
 ]
 
 [[package]]
@@ -2365,6 +2390,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pefile"
+version = "2024.8.26"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/03/4f/2750f7f6f025a1507cd3b7218691671eecfd0bbebebe8b39aa0fe1d360b8/pefile-2024.8.26.tar.gz", hash = "sha256:3ff6c5d8b43e8c37bb6e6dd5085658d658a7a0bdcd20b6a07b1fcfc1c4e9d632", size = 76008, upload-time = "2024-08-26T20:58:38.155Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/16/12b82f791c7f50ddec566873d5bdd245baa1491bac11d15ffb98aecc8f8b/pefile-2024.8.26-py3-none-any.whl", hash = "sha256:76f8b485dcd3b1bb8166f1128d395fa3d87af26360c2358fb75b80019b957c6f", size = 74766, upload-time = "2024-08-26T21:01:02.632Z" },
+]
+
+[[package]]
 name = "pip"
 version = "26.1.2"
 source = { registry = "https://pypi.org/simple" }
@@ -2769,6 +2803,48 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyinstaller"
+version = "6.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altgraph" },
+    { name = "importlib-metadata" },
+    { name = "macholib", marker = "sys_platform == 'darwin'" },
+    { name = "packaging" },
+    { name = "pefile", marker = "sys_platform == 'win32'" },
+    { name = "pyinstaller-hooks-contrib" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "setuptools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d5/4d/ec706c3fcf39e26888c35b39615ff4d5865d184069666c47492cff1fbe50/pyinstaller-6.21.0.tar.gz", hash = "sha256:bb9fab705983e393a2d1cac77d6972513057ad800215fd861dc15ff5272e98fd", size = 4061519, upload-time = "2026-06-13T14:15:06.25Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/4a/53cf98bf66daed012dc9cd78c8203f19a675d696f2fc12afcf8c5049a0e0/pyinstaller-6.21.0-py3-none-macosx_10_13_universal2.whl", hash = "sha256:327d132389f37912609e01be62810cf96b5aa95b613903e4b8692e0d12fb0eda", size = 1052350, upload-time = "2026-06-13T14:13:55.88Z" },
+    { url = "https://files.pythonhosted.org/packages/30/83/b591295c352ef464c50b4c6ffff1c4f771d875c9e833f578d1b9f564f6b3/pyinstaller-6.21.0-py3-none-manylinux2014_aarch64.whl", hash = "sha256:7071d4b094d5b40deeef5fa3d3b98a1b846087f7562b49209663d5f9281fe251", size = 748477, upload-time = "2026-06-13T14:14:00.327Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/8f/88fff4e403873b1e22286911350e75ff00db014aa08e57045da9d4328993/pyinstaller-6.21.0-py3-none-manylinux2014_i686.whl", hash = "sha256:6b6374d652107dd4a2eeece903ff82bb4045bb5e1006c5a158a6dcdbefe84bf2", size = 760877, upload-time = "2026-06-13T14:14:04.836Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/13/f0e48fbdfd1d05d948157121cea8b1b823dcb89efe6934b71fdd8bdb3f0f/pyinstaller-6.21.0-py3-none-manylinux2014_ppc64le.whl", hash = "sha256:4e3108b3f02384560da70e39b8bf22b0ad597d02bd68a40d76ea91c1cfa00cad", size = 759194, upload-time = "2026-06-13T14:14:10.61Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d5/ea7878cf9924ed30d946d8288777424e6d069d94f5bde56b4d0890069664/pyinstaller-6.21.0-py3-none-manylinux2014_s390x.whl", hash = "sha256:697532279f535ad572bda613db4f821540e235c7854ca6da4d3bf0373f4415ee", size = 754979, upload-time = "2026-06-13T14:14:15.226Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/09/51b8905714b733bac66dbc041a7821372d70d888d273ae474c4037d4202d/pyinstaller-6.21.0-py3-none-manylinux2014_x86_64.whl", hash = "sha256:605169523a6b5ace39f13dfbff21add9f2bc43df99c7daf9394fefb2c45e8b6f", size = 754812, upload-time = "2026-06-13T14:14:20.264Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/43/d77779439d8c6c2e27a77bcfbd1d5cc0f568ebb611bb472b11af81b5f177/pyinstaller-6.21.0-py3-none-musllinux_1_1_aarch64.whl", hash = "sha256:5fa56746c1e76f93634d018502301378a2d0c382553d37d8c3c34ff436c12dd1", size = 753887, upload-time = "2026-06-13T14:14:25.268Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/c22df1f6837784ac349057ba693f08e7b1ca7a0e06f9c33c63bc6280007b/pyinstaller-6.21.0-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:42395ec76df8e8120c36b13339d9db8cab83e316a12839ee303cc00fc941bb74", size = 753779, upload-time = "2026-06-13T14:14:29.445Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/76/1ce8a27ce62ba8cf3a87c9ce6d575610f4e55d7cb0123e7512fc3f4b921a/pyinstaller-6.21.0-py3-none-win32.whl", hash = "sha256:c6b28d30d8fd99ce162ff3aab5013ed44dbfb747566b1f01b9bed7964d7c14e9", size = 1336462, upload-time = "2026-06-13T14:14:35.785Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/fa/ca1d7e5257dd8566a9dfc0dfb02f8a8075eeb53d4b2d3c579f1276759042/pyinstaller-6.21.0-py3-none-win_amd64.whl", hash = "sha256:7fae06c494ce0ebfe6bd3055c0e409def884f63af2e3705d06bd431ad9237fc7", size = 1397487, upload-time = "2026-06-13T14:14:42.328Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/75/21b51523ce8d96629b71311775a0a65f5f5a872124ab0de33e5c848f8bff/pyinstaller-6.21.0-py3-none-win_arm64.whl", hash = "sha256:f13c95c9c03fb567217135919f93815c305813126780b0ed6e0123cb8acaf025", size = 1346094, upload-time = "2026-06-13T14:14:48.914Z" },
+]
+
+[[package]]
+name = "pyinstaller-hooks-contrib"
+version = "2026.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/5b/c9fe0db5e83ee1c39b2258fa21d23b15e1a60786b6c5990ee5074ead8bb6/pyinstaller_hooks_contrib-2026.6.tar.gz", hash = "sha256:bef5002c32f4f50bd55b005da12cff64eca8783e7eaf86a06a62410164bab725", size = 173354, upload-time = "2026-06-08T22:37:16.152Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/31/f2d7343d8ed5f7c4678377886f6ce533e6eaaa131b252ce950114c2a7efa/pyinstaller_hooks_contrib-2026.6-py3-none-any.whl", hash = "sha256:fd13b8ac126b35361175edacd41a0d97080b75dd5f4b594ecefefff969509dd3", size = 457159, upload-time = "2026-06-08T22:37:14.722Z" },
 ]
 
 [[package]]
@@ -3323,6 +3399,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
+]
+
+[[package]]
+name = "setuptools"
+version = "83.0.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/34/26/f5d29e25ffdb535afef2d35cdb55b325298f96debd670da4c325e08d70f4/setuptools-83.0.0.tar.gz", hash = "sha256:025bccbbf0fa05b6192bc64ae1e7b16e001fd6d6d4d5de03c97b1c1ade523bef", size = 1154254, upload-time = "2026-07-04T15:31:22.699Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5d/40/e1e72872c6354b306daef1703549e8e83b4d43cfea356311bf722a043752/setuptools-83.0.0-py3-none-any.whl", hash = "sha256:29b23c360f22f414dc7336bb39178cc7bcbf6021ed2733cde173f09dba19abb3", size = 1008090, upload-time = "2026-07-04T15:31:20.885Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add signed-artifact verification, native macOS/Windows package sources, and a machine-owned runtime contract for managed deployment
- add managed policy, per-user activation, lifecycle status/repair/removal, enterprise network controls, and stable JSON schemas
- add vendor-neutral deployment guidance, conformance requirements, release evidence, and an MDM general-availability roadmap

## Testing
- `uv run --no-sync pytest tests/test_guard_mdm_*.py --tb=short`
- `uv run --no-sync python -m ruff check src/ tests/test_guard_mdm_*.py`
- `uv run --no-sync basedpyright --level error`
- unsigned macOS package build and frozen-runtime smoke verification

## Notes
- Production compatibility remains gated on protected release signing identities and real-device evidence across the published MDM, OS, and architecture matrix.
