### PR TITLE
fix(guard): keep live reviews non-expiring

### DIFF
--- a/src/codex_plugin_scanner/guard/daemon/server.py
+++ b/src/codex_plugin_scanner/guard/daemon/server.py
@@ -3437,7 +3437,7 @@ class _GuardDaemonHandler(BaseHTTPRequestHandler):
     def _handle_requests_clear(self, payload: dict[str, object]) -> None:
         status = self._optional_string(payload.get("status")) or "pending"
         harness = self._optional_string(payload.get("harness"))
-        if status not in {"pending", "resolved", "expired"}:
+        if status not in {"pending", "resolved"}:
             self._write_json({"error": "invalid_status", "cleared": 0, "status": status}, status=400)
             return
         try:

--- a/tests/test_guard_approval_gate.py
+++ b/tests/test_guard_approval_gate.py
@@ -1206,6 +1206,9 @@ def test_approval_gate_clear_review_queue_route_requires_proof_and_preserves_his
         with pytest.raises(urllib.error.HTTPError) as missing_error:
             _post_daemon_json(daemon, "/v1/requests/clear", {"status": "pending"})
         missing_body = json.loads(missing_error.value.read().decode("utf-8"))
+        with pytest.raises(urllib.error.HTTPError) as expired_error:
+            _post_daemon_json(daemon, "/v1/requests/clear", {"status": "expired"})
+        expired_body = json.loads(expired_error.value.read().decode("utf-8"))
 
         clear_body = _post_daemon_json(
             daemon,
@@ -1217,6 +1220,9 @@ def test_approval_gate_clear_review_queue_route_requires_proof_and_preserves_his
 
     assert missing_error.value.code == 403
     assert missing_body["error"] == "approval_gate_required"
+    assert expired_error.value.code == 400
+    assert expired_body["error"] == "invalid_status"
+
     assert clear_body["cleared"] == 1
     assert clear_body["status"] == "pending"
     assert store.count_approval_requests(status="pending") == 0


### PR DESCRIPTION
## Summary
- reject `expired` as a live review queue clear status
- preserve legacy restart normalization to `pending`
- cover the public daemon contract with a regression assertion

## Testing
- `uv run pytest tests/test_guard_live_request_sync.py tests/test_guard_approval_gate.py::test_approval_gate_clear_review_queue_route_requires_proof_and_preserves_history -q`
- `uv run pytest tests/test_guard_phase05_approval_memory.py::test_gr121_legacy_expired_requests_reopen_as_pending -q`
- `uv run ruff check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_approval_gate.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/daemon/server.py tests/test_guard_approval_gate.py`