### PR TITLE
fix(dashboard): honor request approval scopes

### DIFF
--- a/dashboard/src/approval-scopes.test.ts
+++ b/dashboard/src/approval-scopes.test.ts
@@ -1,5 +1,6 @@
 import {
   buildDecisionPayload,
+  normalizeDecisionScope,
   scopeChoicesForRequest,
   isAdvancedScope,
   advancedScopeChoicesForRequest,
@@ -83,6 +84,28 @@ assert(limitedScopeValues.includes("harness"), "T-AS-04: harness scope is availa
 assert(limitedScopeValues.includes("global"), "T-AS-04: global scope is available without source metadata");
 assert(!limitedScopeValues.includes("workspace"), "T-AS-04: workspace scope is hidden when the request has no workspace");
 assert(!limitedScopeValues.includes("publisher"), "T-AS-04: publisher scope is hidden when the request has no publisher");
+
+const requestWithDaemonScopeRestrictions: GuardApprovalRequest = {
+  ...BASE_REQUEST,
+  request_id: "request-restricted-by-daemon",
+  allowed_scopes: ["artifact", "workspace", "publisher"],
+};
+const daemonRestrictedScopeValues = scopeChoicesForRequest(requestWithDaemonScopeRestrictions).map(
+  (choice) => choice.value,
+);
+
+assert(
+  !daemonRestrictedScopeValues.includes("harness"),
+  "T-AS-05: This app is hidden when the daemon does not allow harness scope",
+);
+assert(
+  !daemonRestrictedScopeValues.includes("global"),
+  "T-AS-05: Everywhere is hidden when the daemon does not allow global scope",
+);
+assert(
+  normalizeDecisionScope(requestWithDaemonScopeRestrictions, "global") === "artifact",
+  "T-AS-06: a stale unsupported selection falls back to an allowed scope",
+);
 
 assert(
   ADVANCED_SCOPE_VALUES.has("global"),

--- a/dashboard/src/approval-scopes.ts
+++ b/dashboard/src/approval-scopes.ts
@@ -40,6 +40,9 @@ export const DEFAULT_SCOPE_CHOICES: ApprovalScopeChoice[] = [
 ];
 
 export function requestSupportsScope(item: GuardApprovalRequest, scope: DecisionScope): boolean {
+  if (Array.isArray(item.allowed_scopes)) {
+    return item.allowed_scopes.includes(scope);
+  }
   if (scope === "workspace") {
     return typeof item.workspace === "string" && item.workspace.trim().length > 0;
   }

--- a/dashboard/src/guard-types.ts
+++ b/dashboard/src/guard-types.ts
@@ -125,6 +125,7 @@ export type GuardApprovalRequest = {
   publisher: string | null;
   policy_action: string;
   recommended_scope: DecisionScope;
+  allowed_scopes?: DecisionScope[];
   risk_headline?: string;
   risk_summary?: string;
   risk_signals?: string[];

--- a/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
+++ b/src/codex_plugin_scanner/guard/daemon/static/assets/guard-dashboard.js
@@ -23189,6 +23189,9 @@ const DEFAULT_SCOPE_CHOICES = [
   }
 ];
 function requestSupportsScope(item, scope) {
+  if (Array.isArray(item.allowed_scopes)) {
+    return item.allowed_scopes.includes(scope);
+  }
   if (scope === "workspace") {
     return typeof item.workspace === "string" && item.workspace.trim().length > 0;
   }


### PR DESCRIPTION
## Summary
- honor daemon-provided approval scope availability in the local dashboard
- hide unsupported broad choices and normalize stale selections to a supported scope

## Testing
- `cd dashboard && bun run test`
- `uv run --no-sync pytest tests/test_guard_approvals.py tests/test_guard_approval_decisions.py --tb=short`
- `uv build`
- `uv tool run --from dist/hol_guard-2.0.1076-py3-none-any.whl hol-guard --version`
