### PR TITLE
fix(runtime): normalize Codex apply_patch file writes

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -46,7 +46,7 @@ _VALID_ACTION_TYPES: frozenset[GuardActionType] = frozenset(
 _SCHEMA_VERSION = 1
 _SHELL_TOOL_NAMES = frozenset({"bash", "shell", "sh", "zsh", "terminal", "run_command", "run_terminal_command"})
 _FILE_READ_TOOL_NAMES = frozenset({"read", "read_file", "open_file", "view", "view_file", "cat_file"})
-_FILE_WRITE_TOOL_NAMES = frozenset({"write", "edit", "multiedit", "write_file", "edit_file"})
+_FILE_WRITE_TOOL_NAMES = frozenset({"write", "edit", "multiedit", "write_file", "edit_file", "apply_patch"})
 _PATH_KEYS = (
     "path",
     "paths",
@@ -76,6 +76,8 @@ _COMMAND_KEYS = (
 )
 _EXPLICIT_COMMAND_KEYS = ("command", "cmd", "shell_command", "shellCommand")
 _SEARCH_PATTERN_KEYS = ("pattern", "query", "search", "regex")
+_PATCH_INPUT_KEYS = ("patch", "input")
+_PATCH_FILE_HEADER_PATTERN = re.compile(r"^\*\*\* (?:Add|Delete|Update) File: (?P<path>.+)$", re.MULTILINE)
 _SENSITIVE_RAW_KEYS = frozenset(
     {
         "api_key",
@@ -552,6 +554,7 @@ def _normalize_action_payload(
         mcp_server=mcp_server,
     )
     target_paths = _target_paths(
+        tool_name=tool_name,
         tool_input=tool_input,
         command=normalized_command,
         prompt_text=prompt_text,
@@ -926,6 +929,7 @@ def _action_type(
 
 def _target_paths(
     *,
+    tool_name: str | None,
     tool_input: Mapping[str, object],
     command: str | None,
     prompt_text: str | None,
@@ -938,11 +942,22 @@ def _target_paths(
             paths.append(value.strip())
         elif isinstance(value, list):
             paths.extend(item.strip() for item in value if isinstance(item, str) and item.strip())
+    if isinstance(tool_name, str) and tool_name.strip().lower() == "apply_patch":
+        paths.extend(apply_patch_target_paths(tool_input))
     for text in (command, prompt_text):
         if text is not None:
             paths.extend(match.group("path") for match in _PROMPT_PATH_PATTERN.finditer(text))
     redacted_paths = (_redacted_target_path(path, home_dir=home_dir) for path in paths)
     return tuple(dict.fromkeys(path for path in redacted_paths if path is not None))
+
+
+def apply_patch_target_paths(tool_input: Mapping[str, object]) -> tuple[str, ...]:
+    for key in _PATCH_INPUT_KEYS:
+        patch_text = tool_input.get(key)
+        if not isinstance(patch_text, str) or not patch_text.strip():
+            continue
+        return tuple(match.group("path").strip() for match in _PATCH_FILE_HEADER_PATTERN.finditer(patch_text))
+    return ()
 
 
 def _network_hosts(command: str | None, prompt_excerpt: str | None) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/actions.py
+++ b/src/codex_plugin_scanner/guard/runtime/actions.py
@@ -952,12 +952,13 @@ def _target_paths(
 
 
 def apply_patch_target_paths(tool_input: Mapping[str, object]) -> tuple[str, ...]:
+    paths: list[str] = []
     for key in _PATCH_INPUT_KEYS:
         patch_text = tool_input.get(key)
         if not isinstance(patch_text, str) or not patch_text.strip():
             continue
-        return tuple(match.group("path").strip() for match in _PATCH_FILE_HEADER_PATTERN.finditer(patch_text))
-    return ()
+        paths.extend(match.group("path").strip() for match in _PATCH_FILE_HEADER_PATTERN.finditer(patch_text))
+    return tuple(dict.fromkeys(paths))
 
 
 def _network_hosts(command: str | None, prompt_excerpt: str | None) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -747,7 +747,7 @@ def extract_sensitive_file_write_request(
         return None
     requested_tool_name = str(tool_name).strip() if isinstance(tool_name, str) and str(tool_name).strip() else "Write"
     normalized_protected_paths = protected_paths or {}
-    for candidate in _candidate_paths(arguments):
+    for candidate in _candidate_paths(arguments, include_apply_patch=normalized_tool_name == "apply_patch"):
         normalized_candidate = _normalized_candidate_path(candidate, cwd=cwd, home_dir=home_dir)
         if normalized_candidate is not None:
             protected_label = normalized_protected_paths.get(normalized_candidate)
@@ -3746,10 +3746,10 @@ def _request_with_wrapper_context(
     )
 
 
-def _candidate_paths(value: object) -> list[str]:
+def _candidate_paths(value: object, *, include_apply_patch: bool = False) -> list[str]:
     results: list[str] = []
     _collect_candidate_paths(value, results, depth=0)
-    if isinstance(value, dict):
+    if include_apply_patch and isinstance(value, dict):
         results.extend(apply_patch_target_paths(value))
     return results
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -16,7 +16,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ..models import GuardArtifact
-from .actions import GuardActionEnvelope
+from .actions import GuardActionEnvelope, apply_patch_target_paths
 from .command_evaluation import evaluate_command
 from .command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from .command_model import CanonicalCommand, parse_shell_command
@@ -61,6 +61,7 @@ _FILE_WRITE_TOOL_NAMES = frozenset(
         "multiedit",
         "write",
         "write_file",
+        "apply_patch",
     }
 )
 _PATH_KEYS = (
@@ -3748,6 +3749,8 @@ def _request_with_wrapper_context(
 def _candidate_paths(value: object) -> list[str]:
     results: list[str] = []
     _collect_candidate_paths(value, results, depth=0)
+    if isinstance(value, dict):
+        results.extend(apply_patch_target_paths(value))
     return results
 
 

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -57,7 +57,10 @@ from codex_plugin_scanner.guard.runtime.package_intent import (
     build_package_request_artifact,
     extract_package_intent_request,
 )
-from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+from codex_plugin_scanner.guard.runtime.secret_file_requests import (
+    extract_sensitive_file_write_request,
+    extract_sensitive_tool_action_request,
+)
 from codex_plugin_scanner.guard.runtime.signals import RiskSignalV2
 from codex_plugin_scanner.guard.store import (
     GuardStore,
@@ -14169,6 +14172,33 @@ def test_guard_runtime_allows_simple_pytest_module_invocation(tmp_path):
     )
 
     assert match is None
+
+
+def test_guard_runtime_allows_apply_patch_to_non_sensitive_source_file(tmp_path):
+    patch = """*** Begin Patch
+*** Update File: src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+@@
++def _shell_interpreter_flag_payload(parts: list[str], index: int) -> object:
++    return _interpreter_flag_payload(parts, index)
+*** End Patch"""
+
+    match = extract_sensitive_file_write_request("apply_patch", {"input": patch}, cwd=tmp_path)
+
+    assert match is None
+
+
+def test_guard_runtime_blocks_apply_patch_to_sensitive_file(tmp_path):
+    patch = """*** Begin Patch
+*** Update File: .env
+@@
+-TOKEN=old
++TOKEN=new
+*** End Patch"""
+
+    match = extract_sensitive_file_write_request("apply_patch", {"input": patch}, cwd=tmp_path)
+
+    assert match is not None
+    assert match.path_class == "local .env file"
 
 
 def test_guard_runtime_allows_cd_prefixed_pytest_module_invocation(tmp_path):

--- a/tests/test_guard_runtime.py
+++ b/tests/test_guard_runtime.py
@@ -14201,6 +14201,34 @@ def test_guard_runtime_blocks_apply_patch_to_sensitive_file(tmp_path):
     assert match.path_class == "local .env file"
 
 
+def test_guard_runtime_checks_all_apply_patch_payload_keys(tmp_path):
+    sensitive_patch = """*** Begin Patch
+*** Update File: .env
+@@
+-TOKEN=old
++TOKEN=new
+*** End Patch"""
+
+    match = extract_sensitive_file_write_request(
+        "apply_patch",
+        {"patch": "no patch headers", "input": sensitive_patch},
+        cwd=tmp_path,
+    )
+
+    assert match is not None
+    assert match.path_class == "local .env file"
+
+
+def test_guard_runtime_ignores_patch_syntax_for_other_write_tools(tmp_path):
+    match = extract_sensitive_file_write_request(
+        "write",
+        {"input": "*** Update File: .env\n..."},
+        cwd=tmp_path,
+    )
+
+    assert match is None
+
+
 def test_guard_runtime_allows_cd_prefixed_pytest_module_invocation(tmp_path):
     match = extract_sensitive_tool_action_request(
         "Bash",

--- a/tests/test_guard_runtime_actions.py
+++ b/tests/test_guard_runtime_actions.py
@@ -204,6 +204,29 @@ def test_normalize_codex_pre_tool_bash_payload(tmp_path: Path) -> None:
     assert envelope.raw_payload_redacted["tool_input"] == {"command": "printf ok"}
 
 
+def test_normalize_codex_apply_patch_as_file_write(tmp_path: Path) -> None:
+    patch_path = (
+        "../../../../../private/"
+        "tmp/hol-guard-p01/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py"
+    )
+    patch = f"""*** Begin Patch
+*** Update File: {patch_path}
+@@
++def _shell_interpreter_flag_payload(parts: list[str], index: int) -> object:
++    return _interpreter_flag_payload(parts, index)
+*** End Patch"""
+    payload = {
+        "hook_event_name": "PreToolUse",
+        "tool_name": "apply_patch",
+        "tool_input": {"input": patch},
+    }
+
+    envelope = normalize_codex_hook_payload(payload, workspace=tmp_path / "workspace", home_dir=tmp_path)
+
+    assert envelope.action_type == "file_write"
+    assert envelope.target_paths == (patch_path,)
+
+
 def test_normalize_codex_prompt_payload_extracts_prompt_excerpt(tmp_path: Path) -> None:
     payload = {
         "hook_event_name": "UserPromptSubmit",


### PR DESCRIPTION
## Summary
- normalize Codex `apply_patch` requests as file writes instead of configuration changes
- extract patch target paths so sensitive-file protections still apply
- cover the reported source-file patch and a sensitive-file negative control

## Testing
- `pytest tests/test_guard_runtime_actions.py -q`
- `pytest tests/test_guard_runtime.py -q`
- `ruff check src/codex_plugin_scanner/guard/runtime/actions.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_runtime_actions.py tests/test_guard_runtime.py`
- `basedpyright src/codex_plugin_scanner/guard/runtime/actions.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py`
- `uv build`
- local wheel hook evaluation of the reported patch payload
