### PR TITLE
feat: add package command extensions

### DIFF
--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -43,3 +43,10 @@ For Microsoft Copilot, Guard supports two real local boundaries only:
 That does not extend to VS Code Copilot extension-host interception.
 
 Cisco AIBOM stays out of Guard runtime policy in this phase. If it returns later, it should attach to evidence or export paths rather than launch blocking or approval flow.
+
+## Command protection references
+
+- [Command extension architecture](command-extension-architecture.md)
+- [Command extension precedence](command-extension-precedence.md)
+- [Command extension threat model](command-extension-threat-model.md)
+- [Package command extension coverage](command-package-extension-coverage.md)

--- a/docs/guard/command-package-extension-coverage.md
+++ b/docs/guard/command-package-extension-coverage.md
@@ -1,0 +1,57 @@
+# Package command extension coverage
+
+Guard exposes package ecosystems as command safety extensions while keeping the existing package firewall as the
+single enforcement engine. The extension registry supplies stable IDs, setup detection, and inspectable metadata. It
+does not duplicate package intent parsing, shim behavior, advisory policy, provenance checks, approvals, or receipts.
+
+## Setup detection
+
+Run a read-only workspace preview:
+
+```bash
+hol-guard command setup --detect --workspace .
+```
+
+Project marker names drive recommendations. Package managers found on `PATH` appear as available context but do not
+cause unrelated ecosystems to be recommended. Detection does not read manifest contents, package credentials, source
+configuration, or secret files, and it does not change Guard settings.
+
+## Coverage matrix
+
+| Extension | Managers | Project markers | Enforcement owner |
+| --- | --- | --- | --- |
+| `command.package.node` | npm, npx, pnpm, yarn, bun, bunx | `package.json` and Node lockfiles | Package firewall |
+| `command.package.python` | pip, pipx, uv, uvx, Poetry, Pipenv | `pyproject.toml`, requirements, and Python lockfiles | Package firewall |
+| `command.package.rust` | Cargo | `Cargo.toml`, `Cargo.lock` | Package firewall |
+| `command.package.go` | Go modules and tools | `go.mod`, `go.sum`, `go.work` | Package firewall |
+| `command.package.jvm` | Maven, Gradle | Maven and Gradle build or lock files | Package firewall |
+| `command.package.ruby` | RubyGems, Bundler | Gem manifests and lockfiles | Package firewall |
+| `command.package.php` | Composer | `composer.json`, `composer.lock` | Package firewall |
+| `command.package.system` | apt, yum, dnf, apk, pacman, zypper, Homebrew | `Brewfile` | Package firewall |
+
+## Command references
+
+The metadata and fixtures follow primary command documentation:
+
+- Node: [npm install](https://docs.npmjs.com/cli/install/), [pnpm add](https://pnpm.io/cli/add),
+  [Yarn add](https://yarnpkg.com/cli/add), and [Bun add](https://bun.sh/docs/pm/cli/add).
+- Python: [pip install](https://pip.pypa.io/en/stable/cli/pip_install/),
+  [uv CLI](https://docs.astral.sh/uv/reference/cli/), [Poetry CLI](https://python-poetry.org/docs/cli/), and
+  [Pipenv commands](https://pipenv.pypa.io/en/latest/commands.html).
+- Rust: [cargo install](https://doc.rust-lang.org/cargo/commands/cargo-install.html).
+- Go: [Go modules reference](https://go.dev/ref/mod#go-install).
+- JVM: [Maven dependency management](https://maven.apache.org/plugins/maven-dependency-plugin/examples/managing-dependencies.html)
+  and [Gradle dependency locking](https://docs.gradle.org/current/userguide/dependency_locking.html).
+- Ruby: [RubyGems command reference](https://guides.rubygems.org/command-reference/#gem-install) and
+  [bundle install](https://bundler.io/man/bundle-install.1.html).
+- PHP: [Composer commands](https://getcomposer.org/doc/03-cli.md#require-r).
+- System packages: [Homebrew manual](https://docs.brew.sh/Manpage#install-options-formulacask-) and
+  [apt-get manual](https://manpages.debian.org/bookworm/apt/apt-get.8.en.html).
+
+## Security invariants
+
+- A command-local `PATH` override invalidates Guard package-shim trust, including explicit local-only runner flags.
+- Project markers and lockfiles can support package intent decisions, but repository-controlled files never prove that a
+  shim or executable is trusted by themselves.
+- Package extension metadata cannot own command rules while protection is delegated to the package firewall.
+- External extension sources cannot replace required built-in command protections or become final policy authority.

--- a/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_dispatch_local.py
@@ -31,12 +31,21 @@ def _run_guard_command_inspection_command(
 
     command_command = str(getattr(args, "command_command", ""))
     try:
+        if command_command == "setup":
+            from ..runtime.command_ecosystem_detection import command_setup_detection_payload
+
+            workspace = Path(str(getattr(args, "workspace", "."))).resolve()
+            if not workspace.is_dir():
+                raise ValueError("Command setup workspace must be an existing directory")
+            payload = command_setup_detection_payload(workspace)
+            _emit("command-setup", payload, bool(getattr(args, "json", False)))
+            return 0
         if command_command == "extensions":
             payload = command_extensions_payload(getattr(args, "extension_id", None))
             _emit("command-extensions", payload, bool(getattr(args, "json", False)))
             return 0
         if command_command not in {"test", "explain"}:
-            print("Choose command test, command explain, or command extensions.", file=sys.stderr)
+            print("Choose command test, command explain, command extensions, or command setup.", file=sys.stderr)
             return 2
         payload = inspect_command(str(getattr(args, "command_text", "")), cwd=Path.cwd(), home_dir=Path.home())
     except ValueError as error:

--- a/src/codex_plugin_scanner/guard/cli/commands_parser_local.py
+++ b/src/codex_plugin_scanner/guard/cli/commands_parser_local.py
@@ -189,6 +189,13 @@ def _configure_guard_local_parsers(
     )
     extensions_parser.add_argument("extension_id", nargs="?")
     extensions_parser.add_argument("--json", action="store_true")
+    setup_parser = command_subparsers.add_parser(
+        "setup",
+        help="Detect command ecosystems and preview recommended protection",
+    )
+    setup_parser.add_argument("--detect", action="store_true", required=True)
+    setup_parser.add_argument("--workspace", default=".")
+    setup_parser.add_argument("--json", action="store_true")
 
     preflight_parser = guard_subparsers.add_parser(
         "preflight",

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -553,13 +553,21 @@ def _render_command_setup(console: Console, payload: dict[str, object]) -> None:
         evidence = [*(f"file:{name}" for name in marker_names), *(f"command:{name}" for name in executables)]
         detected = bool(detection.get("detected"))
         recommended = bool(detection.get("recommended"))
-        status = "recommended" if recommended else ("available" if detected else "not detected")
+        if recommended:
+            status = "recommended"
+            style = "green"
+        elif detected:
+            status = "available"
+            style = "cyan"
+        else:
+            status = "not detected"
+            style = "dim"
         table.add_row(
             str(detection.get("extension_id") or ""),
             status,
             ", ".join(evidence) or "none",
             str(detection.get("delegated_protection") or "command rules"),
-            style="green" if recommended else ("cyan" if detected else "dim"),
+            style=style,
         )
     console.print(table)
     console.print("[dim]Detection is read-only. No Guard settings were changed.[/dim]")

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -592,7 +592,7 @@ def _plain_text_command_extensions(payload: PayloadDict) -> str:
 
 def _plain_text_command_setup(payload: PayloadDict) -> str:
     detections = _coerce_dict_list(payload.get("detections"))
-    lines = [f"Detected command ecosystems ({payload.get('detected_count') or 0})"]
+    lines = [f"Recommended command ecosystems ({payload.get('recommended_count') or 0})"]
     for item in detections:
         if not item.get("recommended"):
             continue

--- a/src/codex_plugin_scanner/guard/cli/render.py
+++ b/src/codex_plugin_scanner/guard/cli/render.py
@@ -540,6 +540,31 @@ def _render_command_extensions(console: Console, payload: dict[str, object]) -> 
     console.print(table)
 
 
+def _render_command_setup(console: Console, payload: dict[str, object]) -> None:
+    detections = _coerce_dict_list(payload.get("detections"))
+    table = Table(title="Command ecosystem setup", box=box.SIMPLE_HEAD, show_lines=False)
+    table.add_column("Ecosystem", style="bold cyan", no_wrap=True)
+    table.add_column("Status", no_wrap=True)
+    table.add_column("Detected from")
+    table.add_column("Protection")
+    for detection in detections:
+        marker_names = _coerce_string_list(detection.get("project_markers"))
+        executables = _coerce_string_list(detection.get("available_executables"))
+        evidence = [*(f"file:{name}" for name in marker_names), *(f"command:{name}" for name in executables)]
+        detected = bool(detection.get("detected"))
+        recommended = bool(detection.get("recommended"))
+        status = "recommended" if recommended else ("available" if detected else "not detected")
+        table.add_row(
+            str(detection.get("extension_id") or ""),
+            status,
+            ", ".join(evidence) or "none",
+            str(detection.get("delegated_protection") or "command rules"),
+            style="green" if recommended else ("cyan" if detected else "dim"),
+        )
+    console.print(table)
+    console.print("[dim]Detection is read-only. No Guard settings were changed.[/dim]")
+
+
 def _plain_text_command_inspection(payload: PayloadDict) -> str:
     classification = _coerce_object_dict(payload.get("classification"))
     extensions = _coerce_dict_list(payload.get("extensions"))
@@ -562,6 +587,17 @@ def _plain_text_command_extensions(payload: PayloadDict) -> str:
     extensions = _coerce_dict_list(payload.get("extensions"))
     lines = [f"Built-in command safety extensions ({len(extensions)})"]
     lines.extend(f"{item.get('extension_id')} {item.get('version')} - {item.get('description')}" for item in extensions)
+    return "\n".join(lines)
+
+
+def _plain_text_command_setup(payload: PayloadDict) -> str:
+    detections = _coerce_dict_list(payload.get("detections"))
+    lines = [f"Detected command ecosystems ({payload.get('detected_count') or 0})"]
+    for item in detections:
+        if not item.get("recommended"):
+            continue
+        lines.append(f"{item.get('extension_id')} - recommended")
+    lines.append("Detection is read-only. No Guard settings were changed.")
     return "\n".join(lines)
 
 
@@ -2772,6 +2808,7 @@ def _clean_terminal_output(value: str) -> str:
 _PLAIN_TEXT_RENDERERS: dict[str, PlainTextRenderer] = {
     "command-extensions": _plain_text_command_extensions,
     "command-inspection": _plain_text_command_inspection,
+    "command-setup": _plain_text_command_setup,
     "protect": _plain_text_protect,
 }
 
@@ -2779,6 +2816,7 @@ _PLAIN_TEXT_RENDERERS: dict[str, PlainTextRenderer] = {
 _RENDERERS: dict[str, Renderer] = {
     "command-extensions": _render_command_extensions,
     "command-inspection": _render_command_inspection,
+    "command-setup": _render_command_setup,
     "approvals": _render_approvals,
     "init": _render_init,
     "start": _render_start,

--- a/src/codex_plugin_scanner/guard/runtime/command_ecosystem_detection.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_ecosystem_detection.py
@@ -1,0 +1,87 @@
+"""Secret-safe command ecosystem detection for setup recommendations."""
+
+from __future__ import annotations
+
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+from .command_extensions import (
+    BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    COMMAND_EXTENSION_SCHEMA_VERSION,
+    CommandSafetyExtension,
+    CommandSafetyExtensionRegistry,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CommandEcosystemDetection:
+    """One deterministic extension recommendation without sensitive values."""
+
+    extension: CommandSafetyExtension
+    project_markers: tuple[str, ...]
+    available_executables: tuple[str, ...]
+
+    @property
+    def detected(self) -> bool:
+        return bool(self.project_markers or self.available_executables)
+
+    @property
+    def recommended(self) -> bool:
+        return bool(self.project_markers)
+
+    def to_dict(self) -> dict[str, object]:
+        return {
+            "extension_id": self.extension.extension_id,
+            "name": self.extension.name,
+            "version": self.extension.version,
+            "source": self.extension.source,
+            "delegated_protection": self.extension.delegated_protection,
+            "ecosystem_ids": list(self.extension.ecosystem_ids),
+            "detected": self.detected,
+            "recommended": self.recommended,
+            "project_markers": list(self.project_markers),
+            "available_executables": list(self.available_executables),
+        }
+
+
+def detect_command_ecosystems(
+    workspace: Path,
+    *,
+    registry: CommandSafetyExtensionRegistry = BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+) -> tuple[CommandEcosystemDetection, ...]:
+    """Detect package ecosystems from marker names and command availability only."""
+
+    workspace_root = workspace.resolve()
+    detections: list[CommandEcosystemDetection] = []
+    for extension in registry.extensions:
+        if extension.delegated_protection != "package-firewall":
+            continue
+        markers = tuple(marker for marker in extension.project_markers if (workspace_root / marker).is_file())
+        executables = tuple(executable for executable in extension.executables if shutil.which(executable) is not None)
+        detections.append(
+            CommandEcosystemDetection(
+                extension=extension,
+                project_markers=markers,
+                available_executables=executables,
+            )
+        )
+    return tuple(detections)
+
+
+def command_setup_detection_payload(workspace: Path) -> dict[str, object]:
+    """Build a side-effect-free setup preview for command ecosystem protection."""
+
+    detections = detect_command_ecosystems(workspace)
+    detected = tuple(item for item in detections if item.detected)
+    recommended = tuple(item for item in detections if item.recommended)
+    return {
+        "schema_version": COMMAND_EXTENSION_SCHEMA_VERSION,
+        "mode": "detect",
+        "side_effects": "none",
+        "detected_count": len(detected),
+        "recommended_count": len(recommended),
+        "available_count": len(detections),
+        "recommended_extension_ids": [item.extension.extension_id for item in recommended],
+        "detections": [item.to_dict() for item in detections],
+    }

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 import re
 from dataclasses import dataclass
+from pathlib import PurePosixPath
 from typing import Literal, final
 
 from .command_builtin_rules import COMMAND_ACTION_RISK_CLASSES, rules_for_extension
 from .command_model import CanonicalCommand
+from .command_package_extensions import PACKAGE_COMMAND_EXTENSION_SPECS, PackageCommandExtensionSpec
 from .command_rules import CommandSafetyRule, MatcherEvidence, matcher_index_hints
 
 COMMAND_EXTENSION_SCHEMA_VERSION = 2
@@ -15,7 +17,9 @@ _VERSION_PATTERN = re.compile(r"^[1-9][0-9]*\.[0-9]+\.[0-9]+$")
 _EXTENSION_ID_PATTERN = re.compile(r"^command\.[a-z0-9]+(?:[.-][a-z0-9]+)*$")
 
 CommandExtensionSource = Literal["built-in", "local-admin", "signed-cloud"]
+CommandExtensionDelegate = Literal["package-firewall"]
 _VALID_EXTENSION_SOURCES = frozenset({"built-in", "local-admin", "signed-cloud"})
+_VALID_EXTENSION_DELEGATES = frozenset({"package-firewall"})
 
 
 def risk_classes_for_command_action(action_class: str) -> tuple[str, ...]:
@@ -41,6 +45,11 @@ class CommandSafetyExtension:
     aliases: tuple[str, ...] = ()
     dependencies: tuple[str, ...] = ()
     conflicts: tuple[str, ...] = ()
+    delegated_protection: CommandExtensionDelegate | None = None
+    ecosystem_ids: tuple[str, ...] = ()
+    executables: tuple[str, ...] = ()
+    project_markers: tuple[str, ...] = ()
+    reference_urls: tuple[str, ...] = ()
 
     def to_dict(self) -> dict[str, object]:
         return {
@@ -55,6 +64,11 @@ class CommandSafetyExtension:
             "aliases": list(self.aliases),
             "dependencies": list(self.dependencies),
             "conflicts": list(self.conflicts),
+            "delegated_protection": self.delegated_protection,
+            "ecosystem_ids": list(self.ecosystem_ids),
+            "executables": list(self.executables),
+            "project_markers": list(self.project_markers),
+            "reference_urls": list(self.reference_urls),
             "action_classes": list(self.action_classes),
             "risk_classes": list(self.risk_classes),
             "safer_alternatives": list(self.safer_alternatives),
@@ -224,8 +238,10 @@ def _validate_extension(extension: CommandSafetyExtension) -> None:
         raise ValueError(f"Invalid command safety extension version: {extension.version}")
     if not extension.name.strip() or not extension.description.strip():
         raise ValueError(f"Command safety extension {extension.extension_id} requires a name and description")
-    if not extension.action_classes and not extension.rules:
-        raise ValueError(f"Command safety extension {extension.extension_id} must own an action class or rule")
+    if not extension.action_classes and not extension.rules and extension.delegated_protection is None:
+        raise ValueError(
+            f"Command safety extension {extension.extension_id} must own an action class, rule, or delegated protection"
+        )
     if len(set(extension.action_classes)) != len(extension.action_classes):
         raise ValueError(f"Command safety extension {extension.extension_id} has duplicate action classes")
     if not extension.risk_classes:
@@ -236,6 +252,11 @@ def _validate_extension(extension: CommandSafetyExtension) -> None:
         raise ValueError(f"Command safety extension {extension.extension_id} requires safer alternatives")
     if extension.source not in _VALID_EXTENSION_SOURCES:
         raise ValueError(f"Command safety extension {extension.extension_id} has invalid source")
+    if extension.delegated_protection is not None:
+        if extension.delegated_protection not in _VALID_EXTENSION_DELEGATES:
+            raise ValueError(f"Command safety extension {extension.extension_id} has invalid delegated protection")
+        if extension.action_classes or extension.rules:
+            raise ValueError(f"Delegated command safety extension {extension.extension_id} cannot own command rules")
     if extension.required and extension.source != "built-in":
         raise ValueError(f"Required command safety extension {extension.extension_id} must be built-in")
     for field_name, values in (
@@ -245,6 +266,31 @@ def _validate_extension(extension: CommandSafetyExtension) -> None:
     ):
         if len(set(values)) != len(values) or any(not _EXTENSION_ID_PATTERN.fullmatch(value) for value in values):
             raise ValueError(f"Command safety extension {extension.extension_id} has invalid {field_name}")
+    for field_name, values in (
+        ("ecosystem IDs", extension.ecosystem_ids),
+        ("executables", extension.executables),
+        ("project markers", extension.project_markers),
+        ("reference URLs", extension.reference_urls),
+    ):
+        if len(set(values)) != len(values) or any(not value or value != value.strip() for value in values):
+            raise ValueError(f"Command safety extension {extension.extension_id} has invalid {field_name}")
+    if extension.delegated_protection is not None and (not extension.ecosystem_ids or not extension.executables):
+        raise ValueError(
+            f"Delegated command safety extension {extension.extension_id} requires ecosystem and executable metadata"
+        )
+    if extension.delegated_protection is not None and (
+        not extension.reference_urls or any(not value.startswith("https://") for value in extension.reference_urls)
+    ):
+        raise ValueError(f"Delegated command safety extension {extension.extension_id} requires HTTPS references")
+    if any("/" in value or "\\" in value for value in extension.executables):
+        raise ValueError(f"Command safety extension {extension.extension_id} executable metadata must use basenames")
+    if any(not _safe_project_marker(value) for value in extension.project_markers):
+        raise ValueError(f"Command safety extension {extension.extension_id} has unsafe project marker metadata")
+
+
+def _safe_project_marker(value: str) -> bool:
+    marker = PurePosixPath(value)
+    return not marker.is_absolute() and ".." not in marker.parts and "\\" not in value
 
 
 def _validate_registry_relationships(
@@ -282,6 +328,26 @@ def _validate_registry_relationships(
 
     for extension in extensions:
         visit(extension.extension_id)
+
+
+def _package_command_extension(spec: PackageCommandExtensionSpec) -> CommandSafetyExtension:
+    return CommandSafetyExtension(
+        extension_id=spec.extension_id,
+        version="1.0.0",
+        name=spec.name,
+        description=spec.description,
+        action_classes=(),
+        risk_classes=("supply_chain",),
+        safer_alternatives=(
+            "Use the existing project manifest and lockfile instead of an unpinned package source.",
+            "Review package provenance and advisory evidence before installation or one-shot execution.",
+        ),
+        delegated_protection="package-firewall",
+        ecosystem_ids=spec.ecosystem_ids,
+        executables=spec.executables,
+        project_markers=spec.project_markers,
+        reference_urls=spec.reference_urls,
+    )
 
 
 _BUILT_IN_EXTENSIONS = (
@@ -413,6 +479,7 @@ _BUILT_IN_EXTENSIONS = (
         ),
         rules=rules_for_extension("command.shell-mutations"),
     ),
+    *(_package_command_extension(spec) for spec in PACKAGE_COMMAND_EXTENSION_SPECS),
 )
 
 BUILT_IN_COMMAND_EXTENSION_REGISTRY = CommandSafetyExtensionRegistry(_BUILT_IN_EXTENSIONS)

--- a/src/codex_plugin_scanner/guard/runtime/command_package_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_package_extensions.py
@@ -1,0 +1,137 @@
+"""Package ecosystem metadata delegated to Guard's package firewall."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class PackageCommandExtensionSpec:
+    """Static package ecosystem metadata used by setup and inspection."""
+
+    extension_id: str
+    name: str
+    description: str
+    ecosystem_ids: tuple[str, ...]
+    executables: tuple[str, ...]
+    project_markers: tuple[str, ...]
+    reference_urls: tuple[str, ...]
+
+
+PACKAGE_COMMAND_EXTENSION_SPECS = (
+    PackageCommandExtensionSpec(
+        extension_id="command.package.node",
+        name="Node package protection",
+        description="Routes Node package installs and one-shot execution through Guard's package firewall.",
+        ecosystem_ids=("npm",),
+        executables=("npm", "npx", "pnpm", "yarn", "bun", "bunx"),
+        project_markers=(
+            "package.json",
+            "package-lock.json",
+            "pnpm-lock.yaml",
+            "yarn.lock",
+            "bun.lock",
+            "bun.lockb",
+        ),
+        reference_urls=(
+            "https://docs.npmjs.com/cli/install/",
+            "https://pnpm.io/cli/add",
+            "https://yarnpkg.com/cli/add",
+            "https://bun.sh/docs/pm/cli/add",
+        ),
+    ),
+    PackageCommandExtensionSpec(
+        extension_id="command.package.python",
+        name="Python package protection",
+        description=(
+            "Routes Python dependency installs and isolated package execution through Guard's package firewall."
+        ),
+        ecosystem_ids=("pypi",),
+        executables=("pip", "pip3", "pipx", "uv", "uvx", "poetry", "pipenv"),
+        project_markers=(
+            "pyproject.toml",
+            "requirements.txt",
+            "requirements-dev.txt",
+            "Pipfile",
+            "Pipfile.lock",
+            "poetry.lock",
+            "uv.lock",
+        ),
+        reference_urls=(
+            "https://pip.pypa.io/en/stable/cli/pip_install/",
+            "https://docs.astral.sh/uv/reference/cli/",
+            "https://python-poetry.org/docs/cli/",
+            "https://pipenv.pypa.io/en/latest/commands.html",
+        ),
+    ),
+    PackageCommandExtensionSpec(
+        extension_id="command.package.rust",
+        name="Rust package protection",
+        description="Routes Cargo dependency and binary installation requests through Guard's package firewall.",
+        ecosystem_ids=("cargo",),
+        executables=("cargo",),
+        project_markers=("Cargo.toml", "Cargo.lock"),
+        reference_urls=("https://doc.rust-lang.org/cargo/commands/cargo-install.html",),
+    ),
+    PackageCommandExtensionSpec(
+        extension_id="command.package.go",
+        name="Go package protection",
+        description="Routes Go module and tool installation requests through Guard's package firewall.",
+        ecosystem_ids=("go",),
+        executables=("go",),
+        project_markers=("go.mod", "go.sum", "go.work", "go.work.sum"),
+        reference_urls=("https://go.dev/ref/mod#go-install",),
+    ),
+    PackageCommandExtensionSpec(
+        extension_id="command.package.jvm",
+        name="JVM package protection",
+        description="Routes Maven and Gradle dependency operations through Guard's package firewall.",
+        ecosystem_ids=("maven",),
+        executables=("mvn", "mvnw", "gradle", "gradlew"),
+        project_markers=(
+            "pom.xml",
+            "build.gradle",
+            "build.gradle.kts",
+            "settings.gradle",
+            "settings.gradle.kts",
+            "gradle.lockfile",
+        ),
+        reference_urls=(
+            "https://maven.apache.org/plugins/maven-dependency-plugin/examples/managing-dependencies.html",
+            "https://docs.gradle.org/current/userguide/dependency_locking.html",
+        ),
+    ),
+    PackageCommandExtensionSpec(
+        extension_id="command.package.ruby",
+        name="Ruby package protection",
+        description="Routes RubyGem and Bundler dependency operations through Guard's package firewall.",
+        ecosystem_ids=("rubygems",),
+        executables=("gem", "bundle", "bundler"),
+        project_markers=("Gemfile", "Gemfile.lock", "gems.rb", "gems.locked"),
+        reference_urls=(
+            "https://guides.rubygems.org/command-reference/#gem-install",
+            "https://bundler.io/man/bundle-install.1.html",
+        ),
+    ),
+    PackageCommandExtensionSpec(
+        extension_id="command.package.php",
+        name="PHP package protection",
+        description="Routes Composer dependency operations through Guard's package firewall.",
+        ecosystem_ids=("composer",),
+        executables=("composer",),
+        project_markers=("composer.json", "composer.lock"),
+        reference_urls=("https://getcomposer.org/doc/03-cli.md#require-r",),
+    ),
+    PackageCommandExtensionSpec(
+        extension_id="command.package.system",
+        name="System package protection",
+        description="Routes operating-system package installation requests through Guard's package firewall.",
+        ecosystem_ids=("system", "homebrew"),
+        executables=("apt", "apt-get", "yum", "dnf", "apk", "pacman", "zypper", "brew"),
+        project_markers=("Brewfile",),
+        reference_urls=(
+            "https://docs.brew.sh/Manpage#install-options-formulacask-",
+            "https://manpages.debian.org/bookworm/apt/apt-get.8.en.html",
+        ),
+    ),
+)

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -107,6 +107,8 @@ def parse_package_intent(
         "helm": _parse_helm_intent,
     }
     intents: list[PackageIntent] = []
+    if not command_text.strip() and canonical_command is None:
+        return None
     parsed_command = canonical_command or parse_shell_command(command_text, cwd=workspace, home_dir=Path.home())
     for segment in _normalized_command_segments(command_text, canonical_command=parsed_command):
         if not segment.tokens:

--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ..protect import _collect_package_specs
+from .command_model import CanonicalCommand, CommandSegment, parse_shell_command
 from .homebrew_intent import parse_brew_intent
 from .mcp_protection import _command_name, _package_token
 from .package_intent_common import (
@@ -62,9 +63,15 @@ _PACKAGE_SOURCE_ENV_NAMES = frozenset(
 class _CommandSegment:
     tokens: tuple[str, ...]
     redacted_tokens: tuple[str, ...]
+    path_overridden: bool = False
 
 
-def parse_package_intent(command_text: str, *, workspace: Path | None = None) -> PackageIntent | None:
+def parse_package_intent(
+    command_text: str,
+    *,
+    workspace: Path | None = None,
+    canonical_command: CanonicalCommand | None = None,
+) -> PackageIntent | None:
     handlers = {
         "npm": _parse_npm_intent,
         "npx": _parse_exec_intent,
@@ -100,14 +107,22 @@ def parse_package_intent(command_text: str, *, workspace: Path | None = None) ->
         "helm": _parse_helm_intent,
     }
     intents: list[PackageIntent] = []
-    for segment in _normalized_command_segments(command_text):
+    parsed_command = canonical_command or parse_shell_command(command_text, cwd=workspace, home_dir=Path.home())
+    for segment in _normalized_command_segments(command_text, canonical_command=parsed_command):
         if not segment.tokens:
             continue
         command_name = _command_name(segment.tokens[0])
         handler = handlers.get(command_name)
         if handler is None:
             continue
-        intent = handler(segment.tokens, workspace=workspace)
+        if handler is _parse_exec_intent:
+            intent = _parse_exec_intent(
+                segment.tokens,
+                workspace=workspace,
+                path_overridden=segment.path_overridden,
+            )
+        else:
+            intent = handler(segment.tokens, workspace=workspace)
         if intent is not None:
             intents.append(replace(intent, redacted_command=redacted_command(segment.redacted_tokens)))
     return _combine_package_intents(tuple(intents))
@@ -219,8 +234,17 @@ def _parse_bun_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pac
     )
 
 
-def _parse_exec_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> PackageIntent | None:
-    if _is_verified_local_executable_execution(tokens, workspace=workspace):
+def _parse_exec_intent(
+    tokens: tuple[str, ...],
+    *,
+    workspace: Path | None,
+    path_overridden: bool = False,
+) -> PackageIntent | None:
+    if _is_verified_local_executable_execution(
+        tokens,
+        workspace=workspace,
+        path_overridden=path_overridden,
+    ):
         return None
     package_token = _exec_package_spec(tokens)
     if package_token is None:
@@ -230,8 +254,13 @@ def _parse_exec_intent(tokens: tuple[str, ...], *, workspace: Path | None) -> Pa
     return _build_intent(_command_name(tokens[0]), "execute", tokens, (target,), workspace=workspace)
 
 
-def _is_verified_local_executable_execution(tokens: tuple[str, ...], *, workspace: Path | None) -> bool:
-    if workspace is None or not tokens or _command_name(tokens[0]) not in _LOCAL_EXECUTION_COMMANDS:
+def _is_verified_local_executable_execution(
+    tokens: tuple[str, ...],
+    *,
+    workspace: Path | None,
+    path_overridden: bool,
+) -> bool:
+    if workspace is None or path_overridden or not tokens or _command_name(tokens[0]) not in _LOCAL_EXECUTION_COMMANDS:
         return False
     if not _local_execution_disables_install(tokens) and not (
         _is_local_test_runner_execution(tokens) and _guard_package_shim_is_active(tokens[0])
@@ -745,7 +774,13 @@ def _normalized_command_tokens(command_text: str) -> tuple[str, ...]:
     return segments[0].tokens if segments else ()
 
 
-def _normalized_command_segments(command_text: str) -> tuple[_CommandSegment, ...]:
+def _normalized_command_segments(
+    command_text: str,
+    *,
+    canonical_command: CanonicalCommand | None = None,
+) -> tuple[_CommandSegment, ...]:
+    if canonical_command is not None and canonical_command.segments:
+        return tuple(_command_segment_from_canonical(segment) for segment in canonical_command.segments)
     try:
         tokens = _split_shell_tokens(command_text)
     except ValueError:
@@ -756,8 +791,31 @@ def _normalized_command_segments(command_text: str) -> tuple[_CommandSegment, ..
         if not normalized_tokens:
             continue
         redacted_tokens = _redacted_segment(raw_segment)
-        segments.append(_CommandSegment(tuple(normalized_tokens), tuple(redacted_tokens)))
+        segments.append(
+            _CommandSegment(
+                tuple(normalized_tokens),
+                tuple(redacted_tokens),
+                path_overridden=_raw_segment_overrides_path(raw_segment),
+            )
+        )
     return tuple(segments)
+
+
+def _command_segment_from_canonical(segment: CommandSegment) -> _CommandSegment:
+    normalized_tokens = _normalize_segment([segment.executable or "", *segment.arguments])
+    try:
+        raw_tokens = _split_shell_tokens(segment.text)
+    except ValueError:
+        raw_tokens = list(normalized_tokens)
+    return _CommandSegment(
+        tokens=tuple(normalized_tokens),
+        redacted_tokens=tuple(_redacted_segment(raw_tokens)),
+        path_overridden=segment.path_overridden,
+    )
+
+
+def _raw_segment_overrides_path(raw_segment: list[str]) -> bool:
+    return any(token.partition("=")[0].upper() == "PATH" for token in raw_segment if _ENV_ASSIGNMENT_RE.match(token))
 
 
 def _raw_command_segments(tokens: list[str]) -> tuple[list[str], ...]:

--- a/tests/test_guard_command_ecosystem_setup.py
+++ b/tests/test_guard_command_ecosystem_setup.py
@@ -1,0 +1,175 @@
+"""Package command extension metadata and setup detection tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.runtime import command_ecosystem_detection
+from codex_plugin_scanner.guard.runtime.command_ecosystem_detection import (
+    command_setup_detection_payload,
+    detect_command_ecosystems,
+)
+from codex_plugin_scanner.guard.runtime.command_extensions import (
+    BUILT_IN_COMMAND_EXTENSION_REGISTRY,
+    CommandSafetyExtension,
+    CommandSafetyExtensionRegistry,
+)
+
+
+def test_package_extensions_delegate_to_existing_package_firewall() -> None:
+    package_extensions = tuple(
+        extension
+        for extension in BUILT_IN_COMMAND_EXTENSION_REGISTRY.extensions
+        if extension.extension_id.startswith("command.package.")
+    )
+
+    assert len(package_extensions) == 8
+    assert {extension.extension_id for extension in package_extensions} == {
+        "command.package.go",
+        "command.package.jvm",
+        "command.package.node",
+        "command.package.php",
+        "command.package.python",
+        "command.package.ruby",
+        "command.package.rust",
+        "command.package.system",
+    }
+    assert all(extension.delegated_protection == "package-firewall" for extension in package_extensions)
+    assert all(extension.ecosystem_ids for extension in package_extensions)
+    assert all(extension.executables for extension in package_extensions)
+    assert all(extension.reference_urls for extension in package_extensions)
+    assert all(
+        reference.startswith("https://") for extension in package_extensions for reference in extension.reference_urls
+    )
+    assert all(not extension.rules for extension in package_extensions)
+
+
+def test_registry_rejects_incomplete_or_rule_owning_delegated_extensions() -> None:
+    incomplete = CommandSafetyExtension(
+        extension_id="command.package.incomplete",
+        version="1.0.0",
+        name="Incomplete",
+        description="Missing delegated setup metadata.",
+        action_classes=(),
+        risk_classes=("supply_chain",),
+        safer_alternatives=("Use a lockfile.",),
+        delegated_protection="package-firewall",
+    )
+    with pytest.raises(ValueError, match="requires ecosystem and executable metadata"):
+        _ = CommandSafetyExtensionRegistry((incomplete,))
+
+    owning = CommandSafetyExtension(
+        extension_id="command.package.owning",
+        version="1.0.0",
+        name="Owning",
+        description="Incorrectly owns a compatibility action.",
+        action_classes=("package command",),
+        risk_classes=("supply_chain",),
+        safer_alternatives=("Use a lockfile.",),
+        delegated_protection="package-firewall",
+        ecosystem_ids=("example",),
+        executables=("example",),
+    )
+    with pytest.raises(ValueError, match="cannot own command rules"):
+        _ = CommandSafetyExtensionRegistry((owning,))
+
+
+@pytest.mark.parametrize(
+    ("executables", "project_markers", "message"),
+    (
+        (("../bin/tool",), ("manifest.json",), "basenames"),
+        (("tool",), ("../manifest.json",), "unsafe project marker"),
+        (("tool",), ("folder\\manifest.json",), "unsafe project marker"),
+    ),
+)
+def test_registry_rejects_path_bearing_detection_metadata(
+    executables: tuple[str, ...],
+    project_markers: tuple[str, ...],
+    message: str,
+) -> None:
+    extension = CommandSafetyExtension(
+        extension_id="command.package.unsafe",
+        version="1.0.0",
+        name="Unsafe",
+        description="Contains path-bearing detection metadata.",
+        action_classes=(),
+        risk_classes=("supply_chain",),
+        safer_alternatives=("Use safe metadata.",),
+        delegated_protection="package-firewall",
+        ecosystem_ids=("example",),
+        executables=executables,
+        project_markers=project_markers,
+        reference_urls=("https://example.invalid/reference",),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        _ = CommandSafetyExtensionRegistry((extension,))
+
+
+def test_detect_command_ecosystems_uses_only_marker_names_and_command_availability(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "package.json").write_text('{"scripts":{"test":"vitest"}}\n', encoding="utf-8")
+    (tmp_path / "Cargo.toml").write_text("[package]\nname='demo'\n", encoding="utf-8")
+    (tmp_path / ".npmrc").write_text("//registry.example.test/:_authToken=secret\n", encoding="utf-8")
+    available = {"npm", "npx", "cargo"}
+    monkeypatch.setattr(
+        command_ecosystem_detection.shutil,
+        "which",
+        lambda executable: f"/managed/bin/{executable}" if executable in available else None,
+    )
+
+    detections = detect_command_ecosystems(tmp_path)
+    detected = {item.extension.extension_id: item for item in detections if item.detected}
+    recommended = {item.extension.extension_id for item in detections if item.recommended}
+
+    assert set(detected) == {"command.package.node", "command.package.rust"}
+    assert recommended == {"command.package.node", "command.package.rust"}
+    assert detected["command.package.node"].project_markers == ("package.json",)
+    assert detected["command.package.node"].available_executables == ("npm", "npx")
+    payload_text = json.dumps(command_setup_detection_payload(tmp_path), sort_keys=True)
+    assert "secret" not in payload_text
+    assert str(tmp_path) not in payload_text
+    assert ".npmrc" not in payload_text
+
+
+def test_command_setup_detect_json_is_deterministic_and_side_effect_free(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    (tmp_path / "pyproject.toml").write_text("[project]\nname='demo'\n", encoding="utf-8")
+    monkeypatch.setattr(command_ecosystem_detection.shutil, "which", lambda _executable: None)
+
+    rc = main(["guard", "command", "setup", "--detect", "--workspace", str(tmp_path), "--json"])
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == 2
+    assert payload["mode"] == "detect"
+    assert payload["side_effects"] == "none"
+    assert payload["recommended_extension_ids"] == ["command.package.python"]
+    assert payload["recommended_count"] == 1
+    assert payload["detected_count"] == 1
+
+
+def test_command_setup_detect_rejects_missing_workspace(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    rc = main(
+        [
+            "guard",
+            "command",
+            "setup",
+            "--detect",
+            "--workspace",
+            str(tmp_path / "missing"),
+            "--json",
+        ]
+    )
+
+    assert rc == 2
+    assert "existing directory" in capsys.readouterr().err

--- a/tests/test_guard_command_ecosystem_setup.py
+++ b/tests/test_guard_command_ecosystem_setup.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.cli import main
+from codex_plugin_scanner.guard.cli.render import _plain_text_command_setup
 from codex_plugin_scanner.guard.runtime import command_ecosystem_detection
 from codex_plugin_scanner.guard.runtime.command_ecosystem_detection import (
     command_setup_detection_payload,
@@ -173,3 +174,20 @@ def test_command_setup_detect_rejects_missing_workspace(tmp_path: Path, capsys: 
 
     assert rc == 2
     assert "existing directory" in capsys.readouterr().err
+
+
+def test_command_setup_plain_text_count_matches_recommendation_rows(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        command_ecosystem_detection.shutil,
+        "which",
+        lambda executable: "/managed/bin/pip" if executable == "pip" else None,
+    )
+
+    payload = command_setup_detection_payload(tmp_path)
+    output = _plain_text_command_setup(payload)
+
+    assert "Recommended command ecosystems (0)" in output
+    assert "command.package.python - recommended" not in output

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.runtime import package_intent_parser
+from codex_plugin_scanner.guard.runtime.command_model import parse_shell_command
 from codex_plugin_scanner.guard.runtime.package_intent import (
     extract_package_intent_request,
     parse_manifest_dependency_changes,
@@ -126,7 +127,11 @@ def test_parse_package_intent_detects_package_command_after_control_operator() -
     assert parse_package_intent("echo safe && grep foo src/file.ts") is None
 
 
-def test_parse_package_intent_skips_verified_local_test_runner_execution(tmp_path: Path) -> None:
+def test_parse_package_intent_skips_verified_local_test_runner_execution(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(package_intent_parser, "_guard_package_shim_is_active", lambda _command: False)
     _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
     _write_text(tmp_path / "bun.lock", '"vitest": "4.1.8"\n')
     runner = tmp_path / "node_modules" / ".bin" / "vitest"
@@ -168,6 +173,60 @@ def test_parse_package_intent_skips_guard_shimmed_bunx_test_runner(
 
     assert parse_package_intent("bunx vitest run tests/example.test.ts", workspace=tmp_path) is None
     assert parse_package_intent("bunx --bun vitest run tests/example.test.ts", workspace=tmp_path) is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    (
+        "PATH=/usr/bin:/bin bunx vitest run tests/example.test.ts",
+        "env -i PATH=/usr/bin:/bin npx --no-install vitest run tests/example.test.ts",
+    ),
+)
+def test_parse_package_intent_does_not_trust_shim_when_command_overrides_path(
+    command: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _write_text(tmp_path / "package.json", '{"name":"demo","devDependencies":{"vitest":"^4.1.8"}}\n')
+    _write_text(tmp_path / "bun.lock", '"vitest": "4.1.8"\n')
+    runner = tmp_path / "node_modules" / ".bin" / "vitest"
+    _write_text(runner, "#!/bin/sh\n")
+    runner.chmod(0o755)
+    home_dir = tmp_path / "home"
+    shim_name = "bunx" if "bunx" in command else "npx"
+    shim_path = home_dir / ".hol-guard" / "package-shims" / "bin" / shim_name
+    _write_text(shim_path, "#!/bin/sh\n")
+    shim_path.chmod(0o755)
+    monkeypatch.setattr(package_intent_parser.Path, "home", classmethod(lambda cls: home_dir))
+    monkeypatch.setattr(
+        package_intent_parser.shutil,
+        "which",
+        lambda executable: str(shim_path) if executable == shim_name else None,
+    )
+
+    intent = parse_package_intent(command, workspace=tmp_path)
+
+    assert intent is not None
+    assert intent.package_manager == shim_name
+    assert intent.intent_kind == "execute"
+
+
+def test_parse_package_intent_reuses_injected_canonical_command(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    command = "npm install example-package"
+    canonical = parse_shell_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    def fail_reparse(*_args: object, **_kwargs: object) -> None:
+        raise AssertionError("canonical command should be reused")
+
+    monkeypatch.setattr(package_intent_parser, "parse_shell_command", fail_reparse)
+
+    intent = parse_package_intent(command, workspace=tmp_path, canonical_command=canonical)
+
+    assert intent is not None
+    assert intent.package_manager == "npm"
 
 
 def test_extract_package_intent_skips_guard_shimmed_npx_test_runner_in_pipeline(

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -21,6 +21,11 @@ def _write_text(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def test_parse_package_intent_empty_command_returns_none() -> None:
+    assert parse_package_intent("") is None
+    assert parse_package_intent("   \t\n") is None
+
+
 def test_parse_package_intent_npm_install_supports_aliases_tags_versions_and_flags(tmp_path: Path) -> None:
     _write_text(tmp_path / "package.json", '{"name":"demo"}\n')
 


### PR DESCRIPTION
## Summary
- add inspectable package ecosystem extensions backed by the existing package firewall
- add read-only command ecosystem detection and setup recommendations
- invalidate local-runner shim trust when a command overrides `PATH`
- document package extension coverage and primary command references

## Testing
- `uv run --no-sync pytest -q tests/test_guard_command_ecosystem_setup.py tests/test_guard_package_intent.py tests/test_guard_command_extensions.py tests/test_guard_command_extension_registry.py`
- `uv run --no-sync pytest -q tests/test_guard_runtime.py`
- `uv run --no-sync pytest -q tests/docker/test_all_harness_hooks.py tests/test_guard_approval_decisions.py tests/test_guard_approval_gate.py tests/test_hook_security_regressions.py`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/command_extensions.py src/codex_plugin_scanner/guard/runtime/command_package_extensions.py src/codex_plugin_scanner/guard/runtime/command_ecosystem_detection.py src/codex_plugin_scanner/guard/runtime/package_intent_parser.py`
- `basedpyright --level error src/codex_plugin_scanner/guard/runtime/command_extensions.py src/codex_plugin_scanner/guard/runtime/command_package_extensions.py src/codex_plugin_scanner/guard/runtime/command_ecosystem_detection.py src/codex_plugin_scanner/guard/runtime/package_intent_parser.py`
- `uv build`
