### PR TITLE
feat: add infrastructure command extensions

### DIFF
--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -50,3 +50,4 @@ Cisco AIBOM stays out of Guard runtime policy in this phase. If it returns later
 - [Command extension precedence](command-extension-precedence.md)
 - [Command extension threat model](command-extension-threat-model.md)
 - [Package command extension coverage](command-package-extension-coverage.md)
+- [Infrastructure command extension coverage](command-domain-extension-coverage.md)

--- a/docs/guard/command-domain-extension-coverage.md
+++ b/docs/guard/command-domain-extension-coverage.md
@@ -1,0 +1,38 @@
+# Infrastructure command extension coverage
+
+Guard's domain command extensions use the shared canonical parser, structured matchers, extension registry, and
+composite evaluation path. They add rule-level evidence to the same runtime artifacts, approvals, memory, receipts,
+and sync behavior used by existing command protection.
+
+## Initial coverage matrix
+
+| Extension | Reviewed operations | Safe forms |
+| --- | --- | --- |
+| `command.container-runtime` | Broad system prune, forced container removal, privileged container launch | Command help |
+| `command.kubernetes-secrets` | Secret reads through supported cluster clients | Existing metadata-only and non-secret reads |
+| `command.kubernetes-operations` | Resource deletion, node drain, Helm release removal | Help and documented dry-run forms |
+| `command.infrastructure-as-code` | Terraform/OpenTofu destroy, destroy-mode apply, Pulumi destroy | Plan and preview commands |
+
+Global command options such as Docker contexts, cluster contexts and namespaces, Terraform/OpenTofu working
+directories, and Pulumi stacks are normalized before matching. A safe variant suppresses only its owning rule and
+cannot hide an unrelated match in another command segment.
+
+## Primary command references
+
+- Container cleanup and privilege boundaries: [Docker system prune](https://docs.docker.com/reference/cli/docker/system/prune/),
+  [container removal](https://docs.docker.com/reference/cli/docker/container/rm/), and
+  [privileged container execution](https://docs.docker.com/reference/cli/docker/container/run/).
+- Cluster mutations: [kubectl delete](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete/),
+  [kubectl drain](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_drain/), and
+  [Helm uninstall](https://helm.sh/docs/helm/helm_uninstall/).
+- Infrastructure teardown: [Terraform destroy](https://developer.hashicorp.com/terraform/cli/commands/destroy),
+  [OpenTofu destroy](https://opentofu.org/docs/cli/commands/destroy/), and
+  [Pulumi destroy](https://www.pulumi.com/docs/iac/cli/commands/pulumi_destroy/).
+
+## Security and usability boundaries
+
+- Rules match canonical executable and argument structures, not raw command substrings.
+- Quoted examples and source-search commands remain data and do not trigger execution rules.
+- Destructive operations produce one composite decision even when compatibility and structured rules both match.
+- Help, plan, preview, and supported dry-run forms remain side-effect-free inspection paths.
+- Primary references and positive and safe fixtures are required when expanding the catalog.

--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .command_domain_extensions import DOMAIN_COMMAND_RULES
 from .command_rules import (
     AnyMatcher,
     ArgumentMatcher,
@@ -33,6 +34,8 @@ COMMAND_ACTION_RISK_CLASSES: dict[str, tuple[str, ...]] = {
     "git destructive command": ("destructive_shell",),
     "system destructive command": ("destructive_shell",),
     "windows destructive command": ("destructive_shell",),
+    "kubernetes destructive command": ("destructive_shell", "network_egress"),
+    "infrastructure destructive command": ("destructive_shell", "network_egress"),
 }
 _GIT_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     {"-c", "-C", "--config-env", "--exec-path", "--git-dir", "--namespace", "--super-prefix", "--work-tree"}
@@ -322,6 +325,7 @@ BUILT_IN_COMMAND_RULES = (
             ),
         ),
     ),
+    *DOMAIN_COMMAND_RULES,
 )
 
 _RULES_BY_EXTENSION: dict[str, tuple[CommandSafetyRule, ...]] = {}

--- a/src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py
@@ -118,6 +118,24 @@ def _help_variant_for_any(matcher: AnyMatcher) -> CommandSafeVariant:
     )
 
 
+def _kubernetes_dry_run_variant(subcommand: str) -> CommandSafeVariant:
+    return CommandSafeVariant(
+        variant_id="dry-run",
+        title=f"Kubernetes {subcommand} preview",
+        matcher=AnyMatcher(
+            matchers=tuple(
+                _executable_matcher(
+                    frozenset({"kubectl"}),
+                    subcommand,
+                    required_flags=frozenset({f"--dry-run={mode}"}),
+                    leading_options_with_values=_KUBECTL_GLOBAL_OPTIONS,
+                )
+                for mode in ("client", "server")
+            )
+        ),
+    )
+
+
 def _rule(
     *,
     rule_id: str,
@@ -260,16 +278,7 @@ DOMAIN_COMMAND_RULES = (
         safer_alternative="Run a client-side dry run and review the exact resource names and namespace first.",
         safe_variants=(
             _help_variant(_KUBECTL_DELETE),
-            CommandSafeVariant(
-                variant_id="dry-run",
-                title="Kubernetes delete preview",
-                matcher=_executable_matcher(
-                    frozenset({"kubectl"}),
-                    "delete",
-                    required_flags=frozenset({"--dry-run"}),
-                    leading_options_with_values=_KUBECTL_GLOBAL_OPTIONS,
-                ),
-            ),
+            _kubernetes_dry_run_variant("delete"),
         ),
     ),
     _rule(
@@ -282,16 +291,7 @@ DOMAIN_COMMAND_RULES = (
         safer_alternative="Preview the drain and verify disruption budgets, node identity, and workload scope first.",
         safe_variants=(
             _help_variant(_KUBECTL_DRAIN),
-            CommandSafeVariant(
-                variant_id="dry-run",
-                title="Kubernetes drain preview",
-                matcher=_executable_matcher(
-                    frozenset({"kubectl"}),
-                    "drain",
-                    required_flags=frozenset({"--dry-run"}),
-                    leading_options_with_values=_KUBECTL_GLOBAL_OPTIONS,
-                ),
-            ),
+            _kubernetes_dry_run_variant("drain"),
         ),
     ),
     _rule(

--- a/src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py
@@ -1,0 +1,371 @@
+"""Structured rules and metadata for infrastructure command extensions."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from .command_rules import (
+    AnyMatcher,
+    CommandRuleSeverity,
+    CommandSafetyRule,
+    CommandSafeVariant,
+    ExecutableMatcher,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class DomainCommandExtensionSpec:
+    """Static metadata for a directly enforced command domain."""
+
+    extension_id: str
+    name: str
+    description: str
+    action_classes: tuple[str, ...]
+    risk_classes: tuple[str, ...]
+    safer_alternatives: tuple[str, ...]
+    reference_urls: tuple[str, ...]
+
+
+_DOCKER_GLOBAL_OPTIONS = frozenset({"--config", "--context", "--host", "-h", "--log-level"})
+_KUBECTL_GLOBAL_OPTIONS = frozenset(
+    {"--as", "--as-group", "--cluster", "--context", "--kubeconfig", "--namespace", "-n", "--server", "--user"}
+)
+_HELM_GLOBAL_OPTIONS = frozenset({"--kube-context", "--kubeconfig", "--namespace", "-n", "--registry-config"})
+_TERRAFORM_GLOBAL_OPTIONS = frozenset({"-chdir"})
+_PULUMI_GLOBAL_OPTIONS = frozenset({"--cwd", "-c", "--stack", "-s"})
+_EMPTY_STRING_SET: frozenset[str] = frozenset()
+
+
+def _executable_matcher(
+    executables: frozenset[str],
+    *subcommands: str,
+    required_flags: frozenset[str] = _EMPTY_STRING_SET,
+    leading_options_with_values: frozenset[str] = _EMPTY_STRING_SET,
+) -> ExecutableMatcher:
+    return ExecutableMatcher(
+        executables=executables,
+        subcommands=subcommands,
+        required_flags=required_flags,
+        allow_leading_options=bool(leading_options_with_values),
+        leading_options_with_values=leading_options_with_values,
+    )
+
+
+def _help_variant(matcher: ExecutableMatcher) -> CommandSafeVariant:
+    return CommandSafeVariant(
+        variant_id="help",
+        title="Command help",
+        matcher=ExecutableMatcher(
+            executables=matcher.executables,
+            subcommands=matcher.subcommands,
+            required_flags=frozenset({"--help"}),
+            allow_leading_options=matcher.allow_leading_options,
+            leading_options_with_values=matcher.leading_options_with_values,
+        ),
+    )
+
+
+def _help_variant_for_any(matcher: AnyMatcher) -> CommandSafeVariant:
+    help_matchers = tuple(
+        ExecutableMatcher(
+            executables=child.executables,
+            subcommands=child.subcommands,
+            required_flags=frozenset({"--help"}),
+            allow_leading_options=child.allow_leading_options,
+            leading_options_with_values=child.leading_options_with_values,
+        )
+        for child in matcher.matchers
+        if isinstance(child, ExecutableMatcher)
+    )
+    if len(help_matchers) != len(matcher.matchers):
+        raise ValueError("Help variants require executable matchers")
+    return CommandSafeVariant(
+        variant_id="help",
+        title="Command help",
+        matcher=AnyMatcher(matchers=help_matchers),
+    )
+
+
+def _rule(
+    *,
+    rule_id: str,
+    title: str,
+    description: str,
+    matcher: ExecutableMatcher | AnyMatcher,
+    action_class: str,
+    risk_classes: tuple[str, ...],
+    safer_alternative: str,
+    severity: CommandRuleSeverity = "high",
+    safe_variants: tuple[CommandSafeVariant, ...] = (),
+) -> CommandSafetyRule:
+    return CommandSafetyRule(
+        rule_id=rule_id,
+        title=title,
+        description=description,
+        severity=severity,
+        risk_classes=risk_classes,
+        action_classes=(action_class,),
+        safer_alternatives=(safer_alternative,),
+        matcher=matcher,
+        safe_variants=safe_variants,
+    )
+
+
+_DOCKER_SYSTEM_PRUNE = _executable_matcher(
+    frozenset({"docker"}),
+    "system",
+    "prune",
+    leading_options_with_values=_DOCKER_GLOBAL_OPTIONS,
+)
+_DOCKER_FORCE_REMOVE = AnyMatcher(
+    matchers=(
+        _executable_matcher(
+            frozenset({"docker"}),
+            "rm",
+            required_flags=frozenset({"--force"}),
+            leading_options_with_values=_DOCKER_GLOBAL_OPTIONS,
+        ),
+        _executable_matcher(
+            frozenset({"docker"}),
+            "container",
+            "rm",
+            required_flags=frozenset({"--force"}),
+            leading_options_with_values=_DOCKER_GLOBAL_OPTIONS,
+        ),
+    )
+)
+_DOCKER_PRIVILEGED_RUN = AnyMatcher(
+    matchers=(
+        _executable_matcher(
+            frozenset({"docker"}),
+            "run",
+            required_flags=frozenset({"--privileged"}),
+            leading_options_with_values=_DOCKER_GLOBAL_OPTIONS,
+        ),
+        _executable_matcher(
+            frozenset({"docker"}),
+            "container",
+            "run",
+            required_flags=frozenset({"--privileged"}),
+            leading_options_with_values=_DOCKER_GLOBAL_OPTIONS,
+        ),
+    )
+)
+_KUBECTL_DELETE = _executable_matcher(
+    frozenset({"kubectl"}),
+    "delete",
+    leading_options_with_values=_KUBECTL_GLOBAL_OPTIONS,
+)
+_KUBECTL_DRAIN = _executable_matcher(
+    frozenset({"kubectl"}),
+    "drain",
+    leading_options_with_values=_KUBECTL_GLOBAL_OPTIONS,
+)
+_HELM_UNINSTALL = _executable_matcher(
+    frozenset({"helm"}),
+    "uninstall",
+    leading_options_with_values=_HELM_GLOBAL_OPTIONS,
+)
+_TERRAFORM_DESTROY = _executable_matcher(
+    frozenset({"terraform", "tofu"}),
+    "destroy",
+    leading_options_with_values=_TERRAFORM_GLOBAL_OPTIONS,
+)
+_TERRAFORM_APPLY_DESTROY = _executable_matcher(
+    frozenset({"terraform", "tofu"}),
+    "apply",
+    required_flags=frozenset({"-destroy"}),
+    leading_options_with_values=_TERRAFORM_GLOBAL_OPTIONS,
+)
+_PULUMI_DESTROY = _executable_matcher(
+    frozenset({"pulumi"}),
+    "destroy",
+    leading_options_with_values=_PULUMI_GLOBAL_OPTIONS,
+)
+
+
+DOMAIN_COMMAND_RULES = (
+    _rule(
+        rule_id="command.container-runtime.system-prune",
+        title="Container system prune",
+        description=(
+            "Identifies broad cleanup of unused containers, networks, images, build cache, and optional volumes."
+        ),
+        matcher=_DOCKER_SYSTEM_PRUNE,
+        action_class="docker-sensitive command",
+        risk_classes=("destructive_shell",),
+        safer_alternative="List the targeted container resources and prune one resource class at a time.",
+        safe_variants=(_help_variant(_DOCKER_SYSTEM_PRUNE),),
+    ),
+    _rule(
+        rule_id="command.container-runtime.forced-container-removal",
+        title="Forced container removal",
+        description="Identifies forced removal that can terminate a running container without a graceful stop.",
+        matcher=_DOCKER_FORCE_REMOVE,
+        action_class="docker-sensitive command",
+        risk_classes=("destructive_shell",),
+        safer_alternative="Stop the named container gracefully, inspect it, then remove that exact container.",
+        safe_variants=(_help_variant_for_any(_DOCKER_FORCE_REMOVE),),
+    ),
+    _rule(
+        rule_id="command.container-runtime.privileged-run",
+        title="Privileged container execution",
+        description="Identifies containers launched with broad host-level privileges.",
+        matcher=_DOCKER_PRIVILEGED_RUN,
+        action_class="docker-sensitive command",
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternative="Grant only the required capabilities and keep host devices and filesystems isolated.",
+        severity="critical",
+        safe_variants=(_help_variant_for_any(_DOCKER_PRIVILEGED_RUN),),
+    ),
+    _rule(
+        rule_id="command.kubernetes-operations.delete-resources",
+        title="Kubernetes resource deletion",
+        description="Identifies deletion of live cluster resources.",
+        matcher=_KUBECTL_DELETE,
+        action_class="Kubernetes destructive command",
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternative="Run a client-side dry run and review the exact resource names and namespace first.",
+        safe_variants=(
+            _help_variant(_KUBECTL_DELETE),
+            CommandSafeVariant(
+                variant_id="dry-run",
+                title="Kubernetes delete preview",
+                matcher=_executable_matcher(
+                    frozenset({"kubectl"}),
+                    "delete",
+                    required_flags=frozenset({"--dry-run"}),
+                    leading_options_with_values=_KUBECTL_GLOBAL_OPTIONS,
+                ),
+            ),
+        ),
+    ),
+    _rule(
+        rule_id="command.kubernetes-operations.drain-node",
+        title="Kubernetes node drain",
+        description="Identifies node drains that evict workloads and make a node unschedulable.",
+        matcher=_KUBECTL_DRAIN,
+        action_class="Kubernetes destructive command",
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternative="Preview the drain and verify disruption budgets, node identity, and workload scope first.",
+        safe_variants=(
+            _help_variant(_KUBECTL_DRAIN),
+            CommandSafeVariant(
+                variant_id="dry-run",
+                title="Kubernetes drain preview",
+                matcher=_executable_matcher(
+                    frozenset({"kubectl"}),
+                    "drain",
+                    required_flags=frozenset({"--dry-run"}),
+                    leading_options_with_values=_KUBECTL_GLOBAL_OPTIONS,
+                ),
+            ),
+        ),
+    ),
+    _rule(
+        rule_id="command.kubernetes-operations.helm-uninstall",
+        title="Helm release removal",
+        description="Identifies uninstall operations that remove a release and its managed cluster resources.",
+        matcher=_HELM_UNINSTALL,
+        action_class="Kubernetes destructive command",
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternative="Run Helm uninstall with dry-run and confirm the release and namespace first.",
+        safe_variants=(
+            _help_variant(_HELM_UNINSTALL),
+            CommandSafeVariant(
+                variant_id="dry-run",
+                title="Helm uninstall preview",
+                matcher=_executable_matcher(
+                    frozenset({"helm"}),
+                    "uninstall",
+                    required_flags=frozenset({"--dry-run"}),
+                    leading_options_with_values=_HELM_GLOBAL_OPTIONS,
+                ),
+            ),
+        ),
+    ),
+    _rule(
+        rule_id="command.infrastructure-as-code.destroy",
+        title="Infrastructure teardown",
+        description="Identifies infrastructure-as-code commands that destroy managed resources.",
+        matcher=AnyMatcher(matchers=(_TERRAFORM_DESTROY, _TERRAFORM_APPLY_DESTROY, _PULUMI_DESTROY)),
+        action_class="infrastructure destructive command",
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternative="Generate and review a destroy preview for the selected workspace or stack first.",
+        severity="critical",
+        safe_variants=(
+            CommandSafeVariant(
+                variant_id="help",
+                title="Command help",
+                matcher=AnyMatcher(
+                    matchers=(
+                        _executable_matcher(
+                            frozenset({"terraform", "tofu"}),
+                            "destroy",
+                            required_flags=frozenset({"--help"}),
+                            leading_options_with_values=_TERRAFORM_GLOBAL_OPTIONS,
+                        ),
+                        _executable_matcher(
+                            frozenset({"terraform", "tofu"}),
+                            "apply",
+                            required_flags=frozenset({"--help"}),
+                            leading_options_with_values=_TERRAFORM_GLOBAL_OPTIONS,
+                        ),
+                        _executable_matcher(
+                            frozenset({"pulumi"}),
+                            "destroy",
+                            required_flags=frozenset({"--help"}),
+                            leading_options_with_values=_PULUMI_GLOBAL_OPTIONS,
+                        ),
+                    )
+                ),
+            ),
+            CommandSafeVariant(
+                variant_id="preview-only",
+                title="Pulumi destroy preview",
+                matcher=_executable_matcher(
+                    frozenset({"pulumi"}),
+                    "destroy",
+                    required_flags=frozenset({"--preview-only"}),
+                    leading_options_with_values=_PULUMI_GLOBAL_OPTIONS,
+                ),
+            ),
+        ),
+    ),
+)
+
+
+DOMAIN_COMMAND_EXTENSION_SPECS = (
+    DomainCommandExtensionSpec(
+        extension_id="command.kubernetes-operations",
+        name="Kubernetes operation protection",
+        description="Reviews cluster operations that delete resources, evict workloads, or remove releases.",
+        action_classes=("Kubernetes destructive command",),
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternatives=(
+            "Use client-side dry runs and explicit namespaces before mutating cluster resources.",
+            "Review disruption budgets and exact workload scope before draining nodes.",
+        ),
+        reference_urls=(
+            "https://kubernetes.io/docs/reference/kubectl/generated/kubectl_delete/",
+            "https://kubernetes.io/docs/reference/kubectl/generated/kubectl_drain/",
+            "https://helm.sh/docs/helm/helm_uninstall/",
+        ),
+    ),
+    DomainCommandExtensionSpec(
+        extension_id="command.infrastructure-as-code",
+        name="Infrastructure-as-code protection",
+        description="Reviews infrastructure teardown through Terraform, OpenTofu, and Pulumi.",
+        action_classes=("infrastructure destructive command",),
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternatives=(
+            "Create and inspect a saved plan or preview before applying destructive changes.",
+            "Confirm the selected workspace, stack, account, and region before teardown.",
+        ),
+        reference_urls=(
+            "https://developer.hashicorp.com/terraform/cli/commands/destroy",
+            "https://opentofu.org/docs/cli/commands/destroy/",
+            "https://www.pulumi.com/docs/iac/cli/commands/pulumi_destroy/",
+        ),
+    ),
+)

--- a/src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import TypedDict
 
 from .command_rules import (
     AnyMatcher,
@@ -23,6 +24,20 @@ class DomainCommandExtensionSpec:
     action_classes: tuple[str, ...]
     risk_classes: tuple[str, ...]
     safer_alternatives: tuple[str, ...]
+    reference_urls: tuple[str, ...]
+
+
+class DomainCommandExtensionValues(TypedDict):
+    """Constructor values for one domain command extension."""
+
+    extension_id: str
+    version: str
+    name: str
+    description: str
+    action_classes: tuple[str, ...]
+    risk_classes: tuple[str, ...]
+    safer_alternatives: tuple[str, ...]
+    rules: tuple[CommandSafetyRule, ...]
     reference_urls: tuple[str, ...]
 
 
@@ -48,6 +63,23 @@ def _executable_matcher(
         required_flags=required_flags,
         allow_leading_options=bool(leading_options_with_values),
         leading_options_with_values=leading_options_with_values,
+    )
+
+
+def _flag_variants(
+    executables: frozenset[str],
+    *subcommands: str,
+    flags: frozenset[str],
+    leading_options_with_values: frozenset[str] = _EMPTY_STRING_SET,
+) -> tuple[ExecutableMatcher, ...]:
+    return tuple(
+        _executable_matcher(
+            executables,
+            *subcommands,
+            required_flags=frozenset({flag}),
+            leading_options_with_values=leading_options_with_values,
+        )
+        for flag in sorted(flags)
     )
 
 
@@ -119,17 +151,17 @@ _DOCKER_SYSTEM_PRUNE = _executable_matcher(
 )
 _DOCKER_FORCE_REMOVE = AnyMatcher(
     matchers=(
-        _executable_matcher(
+        *_flag_variants(
             frozenset({"docker"}),
             "rm",
-            required_flags=frozenset({"--force"}),
+            flags=frozenset({"--force", "-f"}),
             leading_options_with_values=_DOCKER_GLOBAL_OPTIONS,
         ),
-        _executable_matcher(
+        *_flag_variants(
             frozenset({"docker"}),
             "container",
             "rm",
-            required_flags=frozenset({"--force"}),
+            flags=frozenset({"--force", "-f"}),
             leading_options_with_values=_DOCKER_GLOBAL_OPTIONS,
         ),
     )
@@ -369,3 +401,20 @@ DOMAIN_COMMAND_EXTENSION_SPECS = (
         ),
     ),
 )
+
+
+def domain_command_extension_values(spec: DomainCommandExtensionSpec) -> DomainCommandExtensionValues:
+    """Return typed registry constructor values for one domain spec."""
+
+    rules = tuple(rule for rule in DOMAIN_COMMAND_RULES if rule.rule_id.startswith(f"{spec.extension_id}."))
+    return {
+        "extension_id": spec.extension_id,
+        "version": "1.0.0",
+        "name": spec.name,
+        "description": spec.description,
+        "action_classes": spec.action_classes,
+        "risk_classes": spec.risk_classes,
+        "safer_alternatives": spec.safer_alternatives,
+        "rules": rules,
+        "reference_urls": spec.reference_urls,
+    }

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -8,6 +8,7 @@ from pathlib import PurePosixPath
 from typing import Literal, final
 
 from .command_builtin_rules import COMMAND_ACTION_RISK_CLASSES, rules_for_extension
+from .command_domain_extensions import DOMAIN_COMMAND_EXTENSION_SPECS, DomainCommandExtensionSpec
 from .command_model import CanonicalCommand
 from .command_package_extensions import PACKAGE_COMMAND_EXTENSION_SPECS, PackageCommandExtensionSpec
 from .command_rules import CommandSafetyRule, MatcherEvidence, matcher_index_hints
@@ -350,6 +351,20 @@ def _package_command_extension(spec: PackageCommandExtensionSpec) -> CommandSafe
     )
 
 
+def _domain_command_extension(spec: DomainCommandExtensionSpec) -> CommandSafetyExtension:
+    return CommandSafetyExtension(
+        extension_id=spec.extension_id,
+        version="1.0.0",
+        name=spec.name,
+        description=spec.description,
+        action_classes=spec.action_classes,
+        risk_classes=spec.risk_classes,
+        safer_alternatives=spec.safer_alternatives,
+        rules=rules_for_extension(spec.extension_id),
+        reference_urls=spec.reference_urls,
+    )
+
+
 _BUILT_IN_EXTENSIONS = (
     CommandSafetyExtension(
         extension_id="command.filesystem",
@@ -413,6 +428,11 @@ _BUILT_IN_EXTENSIONS = (
             "Pass only the specific secret or file required by the container.",
         ),
         rules=rules_for_extension("command.container-runtime"),
+        reference_urls=(
+            "https://docs.docker.com/reference/cli/docker/system/prune/",
+            "https://docs.docker.com/reference/cli/docker/container/rm/",
+            "https://docs.docker.com/reference/cli/docker/container/run/",
+        ),
     ),
     CommandSafetyExtension(
         extension_id="command.data-protection",
@@ -459,6 +479,7 @@ _BUILT_IN_EXTENSIONS = (
         risk_classes=("local_secret_read",),
         safer_alternatives=("Request only the required non-secret field or metadata instead of the Secret payload.",),
         rules=rules_for_extension("command.kubernetes-secrets"),
+        reference_urls=("https://kubernetes.io/docs/reference/kubectl/generated/kubectl_get/",),
     ),
     CommandSafetyExtension(
         extension_id="command.shell-mutations",
@@ -479,6 +500,7 @@ _BUILT_IN_EXTENSIONS = (
         ),
         rules=rules_for_extension("command.shell-mutations"),
     ),
+    *(_domain_command_extension(spec) for spec in DOMAIN_COMMAND_EXTENSION_SPECS),
     *(_package_command_extension(spec) for spec in PACKAGE_COMMAND_EXTENSION_SPECS),
 )
 

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -8,7 +8,7 @@ from pathlib import PurePosixPath
 from typing import Literal, final
 
 from .command_builtin_rules import COMMAND_ACTION_RISK_CLASSES, rules_for_extension
-from .command_domain_extensions import DOMAIN_COMMAND_EXTENSION_SPECS, DomainCommandExtensionSpec
+from .command_domain_extensions import DOMAIN_COMMAND_EXTENSION_SPECS, domain_command_extension_values
 from .command_model import CanonicalCommand
 from .command_package_extensions import PACKAGE_COMMAND_EXTENSION_SPECS, PackageCommandExtensionSpec
 from .command_rules import CommandSafetyRule, MatcherEvidence, matcher_index_hints
@@ -351,20 +351,6 @@ def _package_command_extension(spec: PackageCommandExtensionSpec) -> CommandSafe
     )
 
 
-def _domain_command_extension(spec: DomainCommandExtensionSpec) -> CommandSafetyExtension:
-    return CommandSafetyExtension(
-        extension_id=spec.extension_id,
-        version="1.0.0",
-        name=spec.name,
-        description=spec.description,
-        action_classes=spec.action_classes,
-        risk_classes=spec.risk_classes,
-        safer_alternatives=spec.safer_alternatives,
-        rules=rules_for_extension(spec.extension_id),
-        reference_urls=spec.reference_urls,
-    )
-
-
 _BUILT_IN_EXTENSIONS = (
     CommandSafetyExtension(
         extension_id="command.filesystem",
@@ -500,7 +486,7 @@ _BUILT_IN_EXTENSIONS = (
         ),
         rules=rules_for_extension("command.shell-mutations"),
     ),
-    *(_domain_command_extension(spec) for spec in DOMAIN_COMMAND_EXTENSION_SPECS),
+    *(CommandSafetyExtension(**domain_command_extension_values(spec)) for spec in DOMAIN_COMMAND_EXTENSION_SPECS),
     *(_package_command_extension(spec) for spec in PACKAGE_COMMAND_EXTENSION_SPECS),
 )
 

--- a/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
+++ b/src/codex_plugin_scanner/guard/runtime/secret_file_requests.py
@@ -4092,6 +4092,8 @@ def _docker_sensitive_reason(command_text: str, *, _inherited_sensitive_env: boo
         )
         args = global_tokens[subcommand_index:]
         subcommand = args[0].lower()
+        if _docker_subcommand_help_requested(args):
+            continue
         if subcommand in _DOCKER_ALWAYS_SENSITIVE_SUBCOMMANDS:
             return subcommand
         if subcommand in _DOCKER_BUILD_SUBCOMMANDS and _docker_build_args_are_sensitive(args[1:]):
@@ -4112,6 +4114,14 @@ def _docker_sensitive_reason(command_text: str, *, _inherited_sensitive_env: boo
             ):
                 return "buildx-build-sensitive-flags"
     return None
+
+
+def _docker_subcommand_help_requested(args: list[str]) -> bool:
+    for index, token in enumerate(args[1:], start=1):
+        if token != "--help":
+            continue
+        return all(previous.startswith("-") for previous in args[1:index])
+    return False
 
 
 def _docker_subcommand_index(args: list[str]) -> int | None:

--- a/tests/test_guard_command_domain_extensions.py
+++ b/tests/test_guard_command_domain_extensions.py
@@ -123,6 +123,26 @@ def test_domain_preview_and_help_commands_remain_safe(command: str, tmp_path: Pa
     ) is None
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "kubectl delete deployment api --dry-run=none",
+        "kubectl drain node-a --dry-run=none",
+    ],
+)
+def test_kubernetes_dry_run_none_remains_live_execution(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert payload["classification"]["action_class"] == "Kubernetes destructive command"
+    assert extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    ) is not None
+
+
 def test_container_argument_named_help_remains_runtime_execution(tmp_path: Path) -> None:
     payload = inspect_command("docker run alpine --help", cwd=tmp_path, home_dir=tmp_path)
 

--- a/tests/test_guard_command_domain_extensions.py
+++ b/tests/test_guard_command_domain_extensions.py
@@ -1,0 +1,162 @@
+"""Structured container, cluster, and infrastructure command extension tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+
+
+@pytest.mark.parametrize(
+    ("command", "action_class", "rule_id"),
+    [
+        (
+            "docker --context local system prune -a --volumes",
+            "docker-sensitive command",
+            "command.container-runtime.system-prune",
+        ),
+        (
+            "docker container rm --force api",
+            "docker-sensitive command",
+            "command.container-runtime.forced-container-removal",
+        ),
+        (
+            "docker run --privileged alpine sh",
+            "docker-sensitive command",
+            "command.container-runtime.privileged-run",
+        ),
+        (
+            "kubectl --context prod delete deployment api",
+            "Kubernetes destructive command",
+            "command.kubernetes-operations.delete-resources",
+        ),
+        (
+            "kubectl --kubeconfig cluster.yaml drain node-a",
+            "Kubernetes destructive command",
+            "command.kubernetes-operations.drain-node",
+        ),
+        (
+            "helm --namespace prod uninstall api",
+            "Kubernetes destructive command",
+            "command.kubernetes-operations.helm-uninstall",
+        ),
+        (
+            "terraform -chdir=infra destroy -auto-approve",
+            "infrastructure destructive command",
+            "command.infrastructure-as-code.destroy",
+        ),
+        (
+            "tofu apply -destroy -auto-approve",
+            "infrastructure destructive command",
+            "command.infrastructure-as-code.destroy",
+        ),
+        (
+            "pulumi --stack prod destroy --yes",
+            "infrastructure destructive command",
+            "command.infrastructure-as-code.destroy",
+        ),
+    ],
+)
+def test_domain_rules_feed_inspection_and_runtime_hooks(
+    command: str,
+    action_class: str,
+    rule_id: str,
+    tmp_path: Path,
+) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert payload["classification"]["action_class"] == action_class
+    assert rule_id in {rule["rule_id"] for rule in payload["rules"]}
+    assert payload["controlling_rule_id"] == rule_id
+    runtime_match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert runtime_match is not None
+    assert runtime_match.action_class == action_class
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "docker system prune --help",
+        "docker rm --force --help",
+        "docker run --privileged --help",
+        "kubectl delete deployment api --dry-run=client",
+        "kubectl drain node-a --dry-run=server",
+        "helm uninstall api --dry-run",
+        "terraform plan -destroy",
+        "terraform destroy --help",
+        "tofu plan -destroy",
+        "pulumi preview",
+        "pulumi destroy --preview-only",
+        "grep 'docker system prune|kubectl delete|terraform destroy' scripts/guard-test",
+        "printf '%s\\n' 'kubectl delete namespace prod'",
+    ],
+)
+def test_domain_preview_and_help_commands_remain_safe(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "no_match"
+    assert extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    ) is None
+
+
+def test_container_argument_named_help_remains_runtime_execution(tmp_path: Path) -> None:
+    payload = inspect_command("docker run alpine --help", cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert payload["classification"]["action_class"] == "docker-sensitive command"
+
+
+def test_container_short_host_flag_remains_runtime_execution(tmp_path: Path) -> None:
+    payload = inspect_command("docker run -h api.internal alpine", cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert payload["classification"]["action_class"] == "docker-sensitive command"
+
+
+def test_container_structured_rule_controls_compatibility_evidence(tmp_path: Path) -> None:
+    payload = inspect_command("docker system prune --volumes", cwd=tmp_path, home_dir=tmp_path)
+
+    assert [rule["rule_id"] for rule in payload["rules"]] == [
+        "command.container-runtime.system-prune",
+        "command.container-runtime.docker-sensitive",
+    ]
+    assert payload["controlling_rule_id"] == "command.container-runtime.system-prune"
+
+
+def test_safe_domain_variant_does_not_hide_destructive_segment(tmp_path: Path) -> None:
+    payload = inspect_command(
+        "kubectl delete deployment api --dry-run=client && terraform destroy",
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert [rule["rule_id"] for rule in payload["rules"]] == ["command.infrastructure-as-code.destroy"]
+    assert payload["controlling_rule_id"] == "command.infrastructure-as-code.destroy"
+
+
+def test_domain_extensions_publish_primary_references() -> None:
+    for extension_id in (
+        "command.container-runtime",
+        "command.kubernetes-secrets",
+        "command.kubernetes-operations",
+        "command.infrastructure-as-code",
+    ):
+        extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.get(extension_id)
+
+        assert extension is not None
+        assert extension.reference_urls
+        assert all(url.startswith("https://") for url in extension.reference_urls)

--- a/tests/test_guard_command_domain_extensions.py
+++ b/tests/test_guard_command_domain_extensions.py
@@ -25,6 +25,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.container-runtime.forced-container-removal",
         ),
         (
+            "docker rm -f api",
+            "docker-sensitive command",
+            "command.container-runtime.forced-container-removal",
+        ),
+        (
+            "docker container rm -f api",
+            "docker-sensitive command",
+            "command.container-runtime.forced-container-removal",
+        ),
+        (
             "docker run --privileged alpine sh",
             "docker-sensitive command",
             "command.container-runtime.privileged-run",

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -93,7 +93,7 @@ def test_command_extension_registry_is_deterministic_and_complete() -> None:
     assert "command.shell-mutations" in ids
     assert BUILT_IN_COMMAND_EXTENSION_REGISTRY.for_action_class("destructive shell command") is not None
     assert BUILT_IN_COMMAND_EXTENSION_REGISTRY.rule_for_action_class("destructive shell command") is not None
-    assert sum(extension["rule_count"] for extension in payload["extensions"]) == 18
+    assert sum(extension["rule_count"] for extension in payload["extensions"]) == 25
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- add structured protection for destructive container, cluster, and infrastructure lifecycle commands
- preserve documented help, preview, and dry-run paths while emitting rule-level runtime evidence
- publish primary command references and compatibility fixtures for the new extension catalog

## Testing
- `uv run pytest -q tests/test_guard_command_domain_extensions.py tests/test_guard_command_extensions.py tests/test_guard_command_extension_registry.py`
- `uv run pytest -q tests/test_guard_runtime.py`
- `uv run pytest -q tests/docker/test_all_harness_hooks.py tests/test_guard_approval_decisions.py tests/test_guard_approval_gate.py tests/test_hook_security_regressions.py`
- `uv run --extra dev ruff check src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py src/codex_plugin_scanner/guard/runtime/secret_file_requests.py tests/test_guard_command_domain_extensions.py`
- `uv run --extra dev basedpyright src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py`
- `uv build`
- no-cache local wheel CLI smoke for destructive and preview variants
