### PR TITLE
feat(runtime): add cloud command extensions

### DIFF
--- a/docs/guard/architecture.md
+++ b/docs/guard/architecture.md
@@ -51,3 +51,4 @@ Cisco AIBOM stays out of Guard runtime policy in this phase. If it returns later
 - [Command extension threat model](command-extension-threat-model.md)
 - [Package command extension coverage](command-package-extension-coverage.md)
 - [Infrastructure command extension coverage](command-domain-extension-coverage.md)
+- [Cloud command extension coverage](command-cloud-extension-coverage.md)

--- a/docs/guard/command-cloud-extension-coverage.md
+++ b/docs/guard/command-cloud-extension-coverage.md
@@ -1,0 +1,23 @@
+# Cloud Command Extension Coverage
+
+Guard evaluates cloud CLI operations from the canonical parsed command model. Rules match executable and subcommand structure, remain independent of shell text examples, and feed the existing policy, approval, memory, receipt, and sync pipeline.
+
+## Extensions
+
+| Extension | Reviewed operations | Safe counterparts |
+| --- | --- | --- |
+| `command.cloud.aws` | EC2 instance termination, RDS instance or cluster deletion, EKS cluster deletion | Help, request skeleton generation, EC2 permission-only dry run, describe operations |
+| `command.cloud.gcp` | Compute Engine instance deletion and Cloud SQL instance deletion, including alpha, beta, and preview tracks | Help and describe operations |
+| `command.cloud.azure` | Virtual machine deletion | Help and show operations |
+
+Global account, project, subscription, profile, region, output, and query options are normalized before subcommand matching. Reordered operation flags do not change the result.
+
+## References
+
+- [AWS EC2 terminate-instances](https://docs.aws.amazon.com/cli/latest/reference/ec2/terminate-instances.html)
+- [AWS RDS delete-db-instance](https://docs.aws.amazon.com/cli/latest/reference/rds/delete-db-instance.html)
+- [AWS RDS delete-db-cluster](https://docs.aws.amazon.com/cli/latest/reference/rds/delete-db-cluster.html)
+- [AWS EKS delete-cluster](https://docs.aws.amazon.com/cli/latest/reference/eks/delete-cluster.html)
+- [Google Cloud compute instances delete](https://cloud.google.com/sdk/gcloud/reference/compute/instances/delete)
+- [Google Cloud SQL instances delete](https://cloud.google.com/sdk/gcloud/reference/sql/instances/delete)
+- [Azure vm delete](https://learn.microsoft.com/cli/azure/vm#az-vm-delete)

--- a/docs/guard/command-cloud-extension-coverage.md
+++ b/docs/guard/command-cloud-extension-coverage.md
@@ -7,10 +7,10 @@ Guard evaluates cloud CLI operations from the canonical parsed command model. Ru
 | Extension | Reviewed operations | Safe counterparts |
 | --- | --- | --- |
 | `command.cloud.aws` | EC2 instance termination, RDS instance or cluster deletion, EKS cluster deletion | Help, request skeleton generation, EC2 permission-only dry run, describe operations |
-| `command.cloud.gcp` | Compute Engine instance deletion and Cloud SQL instance deletion, including alpha, beta, and preview tracks | Help and describe operations |
+| `command.cloud.gcp` | Compute Engine instance deletion, including alpha, beta, and preview tracks; Cloud SQL instance deletion, including alpha and beta tracks | Help and describe operations |
 | `command.cloud.azure` | Virtual machine deletion | Help and show operations |
 
-Global account, project, subscription, profile, region, output, and query options are normalized before subcommand matching. Reordered operation flags do not change the result.
+Global account, project, subscription, profile, region, output, and query options are normalized wherever the CLI accepts them. Reordered operation flags do not change the result. Native Windows launcher suffixes are recognized.
 
 ## References
 

--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_extension_catalog.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_extension_catalog.py
@@ -1,0 +1,16 @@
+"""Directly enforced built-in command extension constructor values."""
+
+from __future__ import annotations
+
+from .command_cloud_extensions import CLOUD_COMMAND_EXTENSION_SPECS, CLOUD_COMMAND_RULES
+from .command_domain_extensions import DOMAIN_COMMAND_EXTENSION_SPECS, DOMAIN_COMMAND_RULES
+from .command_extension_specs import CommandExtensionValues, command_extension_values
+
+_DIRECT_EXTENSION_CATALOGS = (
+    (DOMAIN_COMMAND_EXTENSION_SPECS, DOMAIN_COMMAND_RULES),
+    (CLOUD_COMMAND_EXTENSION_SPECS, CLOUD_COMMAND_RULES),
+)
+
+DIRECT_COMMAND_EXTENSION_VALUES: tuple[CommandExtensionValues, ...] = tuple(
+    command_extension_values(spec, rules) for specs, rules in _DIRECT_EXTENSION_CATALOGS for spec in specs
+)

--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from .command_cloud_extensions import CLOUD_COMMAND_RULES
 from .command_domain_extensions import DOMAIN_COMMAND_RULES
 from .command_rules import (
     AnyMatcher,
@@ -36,6 +37,9 @@ COMMAND_ACTION_RISK_CLASSES: dict[str, tuple[str, ...]] = {
     "windows destructive command": ("destructive_shell",),
     "kubernetes destructive command": ("destructive_shell", "network_egress"),
     "infrastructure destructive command": ("destructive_shell", "network_egress"),
+    "aws destructive command": ("destructive_shell", "network_egress"),
+    "google cloud destructive command": ("destructive_shell", "network_egress"),
+    "azure destructive command": ("destructive_shell", "network_egress"),
 }
 _GIT_GLOBAL_OPTIONS_WITH_VALUES = frozenset(
     {"-c", "-C", "--config-env", "--exec-path", "--git-dir", "--namespace", "--super-prefix", "--work-tree"}
@@ -326,6 +330,7 @@ BUILT_IN_COMMAND_RULES = (
         ),
     ),
     *DOMAIN_COMMAND_RULES,
+    *CLOUD_COMMAND_RULES,
 )
 
 _RULES_BY_EXTENSION: dict[str, tuple[CommandSafetyRule, ...]] = {}

--- a/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
+from .command_extension_matchers import executable_matcher, safe_flag_variant
 from .command_extension_specs import CommandExtensionSpec
-from .command_rules import AnyMatcher, CommandSafetyRule, CommandSafeVariant, ExecutableMatcher
+from .command_rules import AnyMatcher, CommandSafetyRule, CommandSafeVariant
 
 _AWS_GLOBAL_OPTIONS = frozenset(
     {
@@ -39,120 +40,71 @@ _GCLOUD_GLOBAL_FLAGS = frozenset(
 )
 _AZURE_GLOBAL_OPTIONS = frozenset({"--output", "-o", "--query", "--subscription"})
 _AZURE_GLOBAL_FLAGS = frozenset({"--debug", "--only-show-errors", "--verbose"})
-_EMPTY_STRING_SET: frozenset[str] = frozenset()
-
-
-def _matcher(
-    executable: str,
-    *subcommands: str,
-    required_flags: frozenset[str] = _EMPTY_STRING_SET,
-    leading_options_with_values: frozenset[str] = _EMPTY_STRING_SET,
-    interspersed_flags: frozenset[str] = _EMPTY_STRING_SET,
-) -> ExecutableMatcher:
-    return ExecutableMatcher(
-        executables=frozenset({executable, f"{executable}.cmd", f"{executable}.exe"}),
-        subcommands=subcommands,
-        required_flags=required_flags,
-        interspersed_options_with_values=leading_options_with_values,
-        interspersed_flags=interspersed_flags,
-    )
-
-
-def _same_commands_with_flag(matcher: AnyMatcher, flag: str) -> AnyMatcher:
-    if not all(isinstance(child, ExecutableMatcher) for child in matcher.matchers):
-        raise ValueError("Cloud safe variants require executable matcher children")
-    return AnyMatcher(
-        matchers=tuple(
-            ExecutableMatcher(
-                executables=child.executables,
-                subcommands=child.subcommands,
-                required_flags=frozenset({flag}),
-                allow_leading_options=child.allow_leading_options,
-                leading_options_with_values=child.leading_options_with_values,
-                interspersed_options_with_values=child.interspersed_options_with_values,
-                interspersed_flags=child.interspersed_flags,
-                options_with_values=child.options_with_values,
-                required_flags_in_all_arguments=True,
-            )
-            for child in matcher.matchers
-            if isinstance(child, ExecutableMatcher)
-        )
-    )
-
-
-def _safe_flag_variant(matcher: AnyMatcher, *, variant_id: str, title: str, flag: str) -> CommandSafeVariant:
-    return CommandSafeVariant(
-        variant_id=variant_id,
-        title=title,
-        matcher=_same_commands_with_flag(matcher, flag),
-    )
-
-
 _AWS_RESOURCE_DELETE = AnyMatcher(
     matchers=(
-        _matcher(
+        executable_matcher(
             "aws",
             "ec2",
             "terminate-instances",
-            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
-            interspersed_flags=_AWS_GLOBAL_FLAGS,
+            global_options_with_values=_AWS_GLOBAL_OPTIONS,
+            global_flags=_AWS_GLOBAL_FLAGS,
         ),
-        _matcher(
+        executable_matcher(
             "aws",
             "rds",
             "delete-db-instance",
-            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
-            interspersed_flags=_AWS_GLOBAL_FLAGS,
+            global_options_with_values=_AWS_GLOBAL_OPTIONS,
+            global_flags=_AWS_GLOBAL_FLAGS,
         ),
-        _matcher(
+        executable_matcher(
             "aws",
             "rds",
             "delete-db-cluster",
-            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
-            interspersed_flags=_AWS_GLOBAL_FLAGS,
+            global_options_with_values=_AWS_GLOBAL_OPTIONS,
+            global_flags=_AWS_GLOBAL_FLAGS,
         ),
-        _matcher(
+        executable_matcher(
             "aws",
             "eks",
             "delete-cluster",
-            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
-            interspersed_flags=_AWS_GLOBAL_FLAGS,
+            global_options_with_values=_AWS_GLOBAL_OPTIONS,
+            global_flags=_AWS_GLOBAL_FLAGS,
         ),
     )
 )
 _AWS_EC2_TERMINATE = AnyMatcher(
     matchers=(
-        _matcher(
+        executable_matcher(
             "aws",
             "ec2",
             "terminate-instances",
-            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
-            interspersed_flags=_AWS_GLOBAL_FLAGS,
+            global_options_with_values=_AWS_GLOBAL_OPTIONS,
+            global_flags=_AWS_GLOBAL_FLAGS,
         ),
     )
 )
 _GCLOUD_RESOURCE_DELETE = AnyMatcher(
     matchers=(
         *(
-            _matcher(
+            executable_matcher(
                 "gcloud",
                 *track,
                 *operation,
-                leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS,
-                interspersed_flags=_GCLOUD_GLOBAL_FLAGS,
+                global_options_with_values=_GCLOUD_GLOBAL_OPTIONS,
+                global_flags=_GCLOUD_GLOBAL_FLAGS,
             )
             for track in ((), ("alpha",), ("beta",), ("preview",))
             for operation in (("compute", "instances", "delete"),)
         ),
         *(
-            _matcher(
+            executable_matcher(
                 "gcloud",
                 *track,
                 "sql",
                 "instances",
                 "delete",
-                leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS,
-                interspersed_flags=_GCLOUD_GLOBAL_FLAGS,
+                global_options_with_values=_GCLOUD_GLOBAL_OPTIONS,
+                global_flags=_GCLOUD_GLOBAL_FLAGS,
             )
             for track in ((), ("alpha",), ("beta",))
         ),
@@ -160,12 +112,12 @@ _GCLOUD_RESOURCE_DELETE = AnyMatcher(
 )
 _AZURE_RESOURCE_DELETE = AnyMatcher(
     matchers=(
-        _matcher(
+        executable_matcher(
             "az",
             "vm",
             "delete",
-            leading_options_with_values=_AZURE_GLOBAL_OPTIONS,
-            interspersed_flags=_AZURE_GLOBAL_FLAGS,
+            global_options_with_values=_AZURE_GLOBAL_OPTIONS,
+            global_flags=_AZURE_GLOBAL_FLAGS,
         ),
     )
 )
@@ -203,14 +155,14 @@ CLOUD_COMMAND_RULES = (
         action_class="AWS destructive command",
         safer_alternative="Describe the exact resources and confirm the active account and region before deletion.",
         safe_variants=(
-            _safe_flag_variant(_AWS_RESOURCE_DELETE, variant_id="help", title="AWS command help", flag="--help"),
-            _safe_flag_variant(
+            safe_flag_variant(_AWS_RESOURCE_DELETE, variant_id="help", title="AWS command help", flag="--help"),
+            safe_flag_variant(
                 _AWS_RESOURCE_DELETE,
                 variant_id="generate-cli-skeleton",
                 title="AWS request skeleton",
                 flag="--generate-cli-skeleton",
             ),
-            _safe_flag_variant(
+            safe_flag_variant(
                 _AWS_EC2_TERMINATE,
                 variant_id="dry-run",
                 title="EC2 termination permission check",
@@ -226,7 +178,7 @@ CLOUD_COMMAND_RULES = (
         action_class="Google Cloud destructive command",
         safer_alternative="Describe the exact resources and confirm the active project and location before deletion.",
         safe_variants=(
-            _safe_flag_variant(
+            safe_flag_variant(
                 _GCLOUD_RESOURCE_DELETE,
                 variant_id="help",
                 title="Google Cloud command help",
@@ -244,7 +196,7 @@ CLOUD_COMMAND_RULES = (
             "Show the exact resource and confirm the active subscription and resource group before deletion."
         ),
         safe_variants=(
-            _safe_flag_variant(
+            safe_flag_variant(
                 _AZURE_RESOURCE_DELETE,
                 variant_id="help",
                 title="Azure command help",

--- a/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
@@ -9,7 +9,9 @@ _AWS_GLOBAL_OPTIONS = frozenset(
     {
         "--ca-bundle",
         "--cli-connect-timeout",
+        "--cli-binary-format",
         "--cli-read-timeout",
+        "--color",
         "--endpoint-url",
         "--output",
         "--profile",
@@ -42,11 +44,10 @@ def _matcher(
     leading_options_with_values: frozenset[str] = _EMPTY_STRING_SET,
 ) -> ExecutableMatcher:
     return ExecutableMatcher(
-        executables=frozenset({executable}),
+        executables=frozenset({executable, f"{executable}.cmd", f"{executable}.exe"}),
         subcommands=subcommands,
         required_flags=required_flags,
-        allow_leading_options=bool(leading_options_with_values),
-        leading_options_with_values=leading_options_with_values,
+        interspersed_options_with_values=leading_options_with_values,
     )
 
 
@@ -59,6 +60,7 @@ def _same_commands_with_flag(matcher: AnyMatcher, flag: str) -> AnyMatcher:
                 required_flags=frozenset({flag}),
                 allow_leading_options=child.allow_leading_options,
                 leading_options_with_values=child.leading_options_with_values,
+                interspersed_options_with_values=child.interspersed_options_with_values,
             )
             for child in matcher.matchers
             if isinstance(child, ExecutableMatcher)
@@ -86,10 +88,16 @@ _AWS_EC2_TERMINATE = AnyMatcher(
     matchers=(_matcher("aws", "ec2", "terminate-instances", leading_options_with_values=_AWS_GLOBAL_OPTIONS),)
 )
 _GCLOUD_RESOURCE_DELETE = AnyMatcher(
-    matchers=tuple(
-        _matcher("gcloud", *track, *operation, leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS)
-        for track in ((), ("alpha",), ("beta",), ("preview",))
-        for operation in (("compute", "instances", "delete"), ("sql", "instances", "delete"))
+    matchers=(
+        *(
+            _matcher("gcloud", *track, *operation, leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS)
+            for track in ((), ("alpha",), ("beta",), ("preview",))
+            for operation in (("compute", "instances", "delete"),)
+        ),
+        *(
+            _matcher("gcloud", *track, "sql", "instances", "delete", leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS)
+            for track in ((), ("alpha",), ("beta",))
+        ),
     )
 )
 _AZURE_RESOURCE_DELETE = AnyMatcher(

--- a/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
@@ -47,7 +47,15 @@ _GCLOUD_GLOBAL_OPTIONS = frozenset(
     }
 )
 _GCLOUD_GLOBAL_FLAGS = frozenset(
-    {"--help", "--log-http", "--quiet", "--user-output-enabled", "--no-user-output-enabled"}
+    {
+        "--help",
+        "--log-http",
+        "--no-log-http",
+        "--quiet",
+        "-q",
+        "--user-output-enabled",
+        "--no-user-output-enabled",
+    }
 )
 _AZURE_GLOBAL_OPTIONS = frozenset({"--output", "-o", "--query", "--subscription"})
 _AZURE_GLOBAL_FLAGS = frozenset({"--debug", "--only-show-errors", "--verbose"})

--- a/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
@@ -1,0 +1,220 @@
+"""Structured rules and metadata for cloud provider command extensions."""
+
+from __future__ import annotations
+
+from .command_extension_specs import CommandExtensionSpec
+from .command_rules import AnyMatcher, CommandSafetyRule, CommandSafeVariant, ExecutableMatcher
+
+_AWS_GLOBAL_OPTIONS = frozenset(
+    {
+        "--ca-bundle",
+        "--cli-connect-timeout",
+        "--cli-read-timeout",
+        "--endpoint-url",
+        "--output",
+        "--profile",
+        "--query",
+        "--region",
+    }
+)
+_GCLOUD_GLOBAL_OPTIONS = frozenset(
+    {
+        "--access-token-file",
+        "--account",
+        "--billing-project",
+        "--configuration",
+        "--flags-file",
+        "--format",
+        "--impersonate-service-account",
+        "--project",
+        "--trace-token",
+        "--verbosity",
+    }
+)
+_AZURE_GLOBAL_OPTIONS = frozenset({"--output", "-o", "--query", "--subscription"})
+_EMPTY_STRING_SET: frozenset[str] = frozenset()
+
+
+def _matcher(
+    executable: str,
+    *subcommands: str,
+    required_flags: frozenset[str] = _EMPTY_STRING_SET,
+    leading_options_with_values: frozenset[str] = _EMPTY_STRING_SET,
+) -> ExecutableMatcher:
+    return ExecutableMatcher(
+        executables=frozenset({executable}),
+        subcommands=subcommands,
+        required_flags=required_flags,
+        allow_leading_options=bool(leading_options_with_values),
+        leading_options_with_values=leading_options_with_values,
+    )
+
+
+def _same_commands_with_flag(matcher: AnyMatcher, flag: str) -> AnyMatcher:
+    return AnyMatcher(
+        matchers=tuple(
+            ExecutableMatcher(
+                executables=child.executables,
+                subcommands=child.subcommands,
+                required_flags=frozenset({flag}),
+                allow_leading_options=child.allow_leading_options,
+                leading_options_with_values=child.leading_options_with_values,
+            )
+            for child in matcher.matchers
+            if isinstance(child, ExecutableMatcher)
+        )
+    )
+
+
+def _safe_flag_variant(matcher: AnyMatcher, *, variant_id: str, title: str, flag: str) -> CommandSafeVariant:
+    return CommandSafeVariant(
+        variant_id=variant_id,
+        title=title,
+        matcher=_same_commands_with_flag(matcher, flag),
+    )
+
+
+_AWS_RESOURCE_DELETE = AnyMatcher(
+    matchers=(
+        _matcher("aws", "ec2", "terminate-instances", leading_options_with_values=_AWS_GLOBAL_OPTIONS),
+        _matcher("aws", "rds", "delete-db-instance", leading_options_with_values=_AWS_GLOBAL_OPTIONS),
+        _matcher("aws", "rds", "delete-db-cluster", leading_options_with_values=_AWS_GLOBAL_OPTIONS),
+        _matcher("aws", "eks", "delete-cluster", leading_options_with_values=_AWS_GLOBAL_OPTIONS),
+    )
+)
+_AWS_EC2_TERMINATE = AnyMatcher(
+    matchers=(_matcher("aws", "ec2", "terminate-instances", leading_options_with_values=_AWS_GLOBAL_OPTIONS),)
+)
+_GCLOUD_RESOURCE_DELETE = AnyMatcher(
+    matchers=tuple(
+        _matcher("gcloud", *track, *operation, leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS)
+        for track in ((), ("alpha",), ("beta",), ("preview",))
+        for operation in (("compute", "instances", "delete"), ("sql", "instances", "delete"))
+    )
+)
+_AZURE_RESOURCE_DELETE = AnyMatcher(
+    matchers=(_matcher("az", "vm", "delete", leading_options_with_values=_AZURE_GLOBAL_OPTIONS),)
+)
+
+
+def _cloud_delete_rule(
+    *,
+    rule_id: str,
+    title: str,
+    description: str,
+    matcher: AnyMatcher,
+    action_class: str,
+    safer_alternative: str,
+    safe_variants: tuple[CommandSafeVariant, ...],
+) -> CommandSafetyRule:
+    return CommandSafetyRule(
+        rule_id=rule_id,
+        title=title,
+        description=description,
+        severity="critical",
+        risk_classes=("destructive_shell", "network_egress"),
+        action_classes=(action_class,),
+        safer_alternatives=(safer_alternative,),
+        matcher=matcher,
+        safe_variants=safe_variants,
+    )
+
+
+CLOUD_COMMAND_RULES = (
+    _cloud_delete_rule(
+        rule_id="command.cloud.aws.resource-deletion",
+        title="AWS resource deletion",
+        description="Identifies termination or deletion of compute, database, and cluster resources through AWS CLI.",
+        matcher=_AWS_RESOURCE_DELETE,
+        action_class="AWS destructive command",
+        safer_alternative="Describe the exact resources and confirm the active account and region before deletion.",
+        safe_variants=(
+            _safe_flag_variant(_AWS_RESOURCE_DELETE, variant_id="help", title="AWS command help", flag="--help"),
+            _safe_flag_variant(
+                _AWS_RESOURCE_DELETE,
+                variant_id="generate-cli-skeleton",
+                title="AWS request skeleton",
+                flag="--generate-cli-skeleton",
+            ),
+            _safe_flag_variant(
+                _AWS_EC2_TERMINATE,
+                variant_id="dry-run",
+                title="EC2 termination permission check",
+                flag="--dry-run",
+            ),
+        ),
+    ),
+    _cloud_delete_rule(
+        rule_id="command.cloud.gcp.resource-deletion",
+        title="Google Cloud resource deletion",
+        description="Identifies deletion of compute and database resources through Google Cloud CLI.",
+        matcher=_GCLOUD_RESOURCE_DELETE,
+        action_class="Google Cloud destructive command",
+        safer_alternative="Describe the exact resources and confirm the active project and location before deletion.",
+        safe_variants=(
+            _safe_flag_variant(
+                _GCLOUD_RESOURCE_DELETE,
+                variant_id="help",
+                title="Google Cloud command help",
+                flag="--help",
+            ),
+        ),
+    ),
+    _cloud_delete_rule(
+        rule_id="command.cloud.azure.resource-deletion",
+        title="Azure resource deletion",
+        description="Identifies deletion of virtual machines through Azure CLI.",
+        matcher=_AZURE_RESOURCE_DELETE,
+        action_class="Azure destructive command",
+        safer_alternative=(
+            "Show the exact resource and confirm the active subscription and resource group before deletion."
+        ),
+        safe_variants=(
+            _safe_flag_variant(
+                _AZURE_RESOURCE_DELETE,
+                variant_id="help",
+                title="Azure command help",
+                flag="--help",
+            ),
+        ),
+    ),
+)
+
+
+CLOUD_COMMAND_EXTENSION_SPECS = (
+    CommandExtensionSpec(
+        extension_id="command.cloud.aws",
+        name="AWS command protection",
+        description="Reviews AWS CLI operations that permanently delete compute, database, or cluster resources.",
+        action_classes=("AWS destructive command",),
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternatives=("Inspect resource state, account, region, and recovery options before deletion.",),
+        reference_urls=(
+            "https://docs.aws.amazon.com/cli/latest/reference/ec2/terminate-instances.html",
+            "https://docs.aws.amazon.com/cli/latest/reference/rds/delete-db-instance.html",
+            "https://docs.aws.amazon.com/cli/latest/reference/rds/delete-db-cluster.html",
+            "https://docs.aws.amazon.com/cli/latest/reference/eks/delete-cluster.html",
+        ),
+    ),
+    CommandExtensionSpec(
+        extension_id="command.cloud.gcp",
+        name="Google Cloud command protection",
+        description="Reviews Google Cloud CLI operations that permanently delete compute or database resources.",
+        action_classes=("Google Cloud destructive command",),
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternatives=("Inspect resource state, project, location, and recovery options before deletion.",),
+        reference_urls=(
+            "https://cloud.google.com/sdk/gcloud/reference/compute/instances/delete",
+            "https://cloud.google.com/sdk/gcloud/reference/sql/instances/delete",
+        ),
+    ),
+    CommandExtensionSpec(
+        extension_id="command.cloud.azure",
+        name="Azure command protection",
+        description="Reviews Azure CLI operations that permanently delete virtual machines.",
+        action_classes=("Azure destructive command",),
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternatives=("Inspect resource state, subscription, resource group, and attached resources first.",),
+        reference_urls=("https://learn.microsoft.com/cli/azure/vm#az-vm-delete",),
+    ),
+)

--- a/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
@@ -19,6 +19,7 @@ _AWS_GLOBAL_OPTIONS = frozenset(
         "--region",
     }
 )
+_AWS_GLOBAL_FLAGS = frozenset({"--debug", "--no-cli-pager", "--no-sign-request", "--no-verify-ssl"})
 _GCLOUD_GLOBAL_OPTIONS = frozenset(
     {
         "--access-token-file",
@@ -33,7 +34,11 @@ _GCLOUD_GLOBAL_OPTIONS = frozenset(
         "--verbosity",
     }
 )
+_GCLOUD_GLOBAL_FLAGS = frozenset(
+    {"--help", "--log-http", "--quiet", "--user-output-enabled", "--no-user-output-enabled"}
+)
 _AZURE_GLOBAL_OPTIONS = frozenset({"--output", "-o", "--query", "--subscription"})
+_AZURE_GLOBAL_FLAGS = frozenset({"--debug", "--only-show-errors", "--verbose"})
 _EMPTY_STRING_SET: frozenset[str] = frozenset()
 
 
@@ -42,16 +47,20 @@ def _matcher(
     *subcommands: str,
     required_flags: frozenset[str] = _EMPTY_STRING_SET,
     leading_options_with_values: frozenset[str] = _EMPTY_STRING_SET,
+    interspersed_flags: frozenset[str] = _EMPTY_STRING_SET,
 ) -> ExecutableMatcher:
     return ExecutableMatcher(
         executables=frozenset({executable, f"{executable}.cmd", f"{executable}.exe"}),
         subcommands=subcommands,
         required_flags=required_flags,
         interspersed_options_with_values=leading_options_with_values,
+        interspersed_flags=interspersed_flags,
     )
 
 
 def _same_commands_with_flag(matcher: AnyMatcher, flag: str) -> AnyMatcher:
+    if not all(isinstance(child, ExecutableMatcher) for child in matcher.matchers):
+        raise ValueError("Cloud safe variants require executable matcher children")
     return AnyMatcher(
         matchers=tuple(
             ExecutableMatcher(
@@ -61,6 +70,9 @@ def _same_commands_with_flag(matcher: AnyMatcher, flag: str) -> AnyMatcher:
                 allow_leading_options=child.allow_leading_options,
                 leading_options_with_values=child.leading_options_with_values,
                 interspersed_options_with_values=child.interspersed_options_with_values,
+                interspersed_flags=child.interspersed_flags,
+                options_with_values=child.options_with_values,
+                required_flags_in_all_arguments=True,
             )
             for child in matcher.matchers
             if isinstance(child, ExecutableMatcher)
@@ -78,30 +90,84 @@ def _safe_flag_variant(matcher: AnyMatcher, *, variant_id: str, title: str, flag
 
 _AWS_RESOURCE_DELETE = AnyMatcher(
     matchers=(
-        _matcher("aws", "ec2", "terminate-instances", leading_options_with_values=_AWS_GLOBAL_OPTIONS),
-        _matcher("aws", "rds", "delete-db-instance", leading_options_with_values=_AWS_GLOBAL_OPTIONS),
-        _matcher("aws", "rds", "delete-db-cluster", leading_options_with_values=_AWS_GLOBAL_OPTIONS),
-        _matcher("aws", "eks", "delete-cluster", leading_options_with_values=_AWS_GLOBAL_OPTIONS),
+        _matcher(
+            "aws",
+            "ec2",
+            "terminate-instances",
+            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
+            interspersed_flags=_AWS_GLOBAL_FLAGS,
+        ),
+        _matcher(
+            "aws",
+            "rds",
+            "delete-db-instance",
+            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
+            interspersed_flags=_AWS_GLOBAL_FLAGS,
+        ),
+        _matcher(
+            "aws",
+            "rds",
+            "delete-db-cluster",
+            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
+            interspersed_flags=_AWS_GLOBAL_FLAGS,
+        ),
+        _matcher(
+            "aws",
+            "eks",
+            "delete-cluster",
+            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
+            interspersed_flags=_AWS_GLOBAL_FLAGS,
+        ),
     )
 )
 _AWS_EC2_TERMINATE = AnyMatcher(
-    matchers=(_matcher("aws", "ec2", "terminate-instances", leading_options_with_values=_AWS_GLOBAL_OPTIONS),)
+    matchers=(
+        _matcher(
+            "aws",
+            "ec2",
+            "terminate-instances",
+            leading_options_with_values=_AWS_GLOBAL_OPTIONS,
+            interspersed_flags=_AWS_GLOBAL_FLAGS,
+        ),
+    )
 )
 _GCLOUD_RESOURCE_DELETE = AnyMatcher(
     matchers=(
         *(
-            _matcher("gcloud", *track, *operation, leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS)
+            _matcher(
+                "gcloud",
+                *track,
+                *operation,
+                leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS,
+                interspersed_flags=_GCLOUD_GLOBAL_FLAGS,
+            )
             for track in ((), ("alpha",), ("beta",), ("preview",))
             for operation in (("compute", "instances", "delete"),)
         ),
         *(
-            _matcher("gcloud", *track, "sql", "instances", "delete", leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS)
+            _matcher(
+                "gcloud",
+                *track,
+                "sql",
+                "instances",
+                "delete",
+                leading_options_with_values=_GCLOUD_GLOBAL_OPTIONS,
+                interspersed_flags=_GCLOUD_GLOBAL_FLAGS,
+            )
             for track in ((), ("alpha",), ("beta",))
         ),
     )
 )
 _AZURE_RESOURCE_DELETE = AnyMatcher(
-    matchers=(_matcher("az", "vm", "delete", leading_options_with_values=_AZURE_GLOBAL_OPTIONS),)
+    matchers=(
+        _matcher(
+            "az",
+            "vm",
+            "delete",
+            leading_options_with_values=_AZURE_GLOBAL_OPTIONS,
+            interspersed_flags=_AZURE_GLOBAL_FLAGS,
+        ),
+    )
 )
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
@@ -20,7 +20,18 @@ _AWS_GLOBAL_OPTIONS = frozenset(
         "--region",
     }
 )
-_AWS_GLOBAL_FLAGS = frozenset({"--debug", "--no-cli-pager", "--no-sign-request", "--no-verify-ssl"})
+_AWS_GLOBAL_FLAGS = frozenset(
+    {
+        "--cli-auto-prompt",
+        "--debug",
+        "--no-cli-auto-prompt",
+        "--no-cli-pager",
+        "--no-color",
+        "--no-paginate",
+        "--no-sign-request",
+        "--no-verify-ssl",
+    }
+)
 _GCLOUD_GLOBAL_OPTIONS = frozenset(
     {
         "--access-token-file",

--- a/src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_domain_extensions.py
@@ -2,9 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
-from typing import TypedDict
-
+from .command_extension_specs import CommandExtensionSpec
 from .command_rules import (
     AnyMatcher,
     CommandRuleSeverity,
@@ -12,34 +10,6 @@ from .command_rules import (
     CommandSafeVariant,
     ExecutableMatcher,
 )
-
-
-@dataclass(frozen=True, slots=True)
-class DomainCommandExtensionSpec:
-    """Static metadata for a directly enforced command domain."""
-
-    extension_id: str
-    name: str
-    description: str
-    action_classes: tuple[str, ...]
-    risk_classes: tuple[str, ...]
-    safer_alternatives: tuple[str, ...]
-    reference_urls: tuple[str, ...]
-
-
-class DomainCommandExtensionValues(TypedDict):
-    """Constructor values for one domain command extension."""
-
-    extension_id: str
-    version: str
-    name: str
-    description: str
-    action_classes: tuple[str, ...]
-    risk_classes: tuple[str, ...]
-    safer_alternatives: tuple[str, ...]
-    rules: tuple[CommandSafetyRule, ...]
-    reference_urls: tuple[str, ...]
-
 
 _DOCKER_GLOBAL_OPTIONS = frozenset({"--config", "--context", "--host", "-h", "--log-level"})
 _KUBECTL_GLOBAL_OPTIONS = frozenset(
@@ -368,7 +338,7 @@ DOMAIN_COMMAND_RULES = (
 
 
 DOMAIN_COMMAND_EXTENSION_SPECS = (
-    DomainCommandExtensionSpec(
+    CommandExtensionSpec(
         extension_id="command.kubernetes-operations",
         name="Kubernetes operation protection",
         description="Reviews cluster operations that delete resources, evict workloads, or remove releases.",
@@ -384,7 +354,7 @@ DOMAIN_COMMAND_EXTENSION_SPECS = (
             "https://helm.sh/docs/helm/helm_uninstall/",
         ),
     ),
-    DomainCommandExtensionSpec(
+    CommandExtensionSpec(
         extension_id="command.infrastructure-as-code",
         name="Infrastructure-as-code protection",
         description="Reviews infrastructure teardown through Terraform, OpenTofu, and Pulumi.",
@@ -401,20 +371,3 @@ DOMAIN_COMMAND_EXTENSION_SPECS = (
         ),
     ),
 )
-
-
-def domain_command_extension_values(spec: DomainCommandExtensionSpec) -> DomainCommandExtensionValues:
-    """Return typed registry constructor values for one domain spec."""
-
-    rules = tuple(rule for rule in DOMAIN_COMMAND_RULES if rule.rule_id.startswith(f"{spec.extension_id}."))
-    return {
-        "extension_id": spec.extension_id,
-        "version": "1.0.0",
-        "name": spec.name,
-        "description": spec.description,
-        "action_classes": spec.action_classes,
-        "risk_classes": spec.risk_classes,
-        "safer_alternatives": spec.safer_alternatives,
-        "rules": rules,
-        "reference_urls": spec.reference_urls,
-    }

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_matchers.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_matchers.py
@@ -1,0 +1,66 @@
+"""Reusable structured matcher builders for command extensions."""
+
+from __future__ import annotations
+
+from .command_rules import AnyMatcher, CommandSafeVariant, ExecutableMatcher
+
+_EMPTY_STRING_SET: frozenset[str] = frozenset()
+
+
+def executable_matcher(
+    executable: str,
+    *subcommands: str,
+    required_flags: frozenset[str] = _EMPTY_STRING_SET,
+    global_options_with_values: frozenset[str] = _EMPTY_STRING_SET,
+    global_flags: frozenset[str] = _EMPTY_STRING_SET,
+) -> ExecutableMatcher:
+    """Build a portable executable matcher with structured global options."""
+
+    return ExecutableMatcher(
+        executables=frozenset({executable, f"{executable}.cmd", f"{executable}.exe"}),
+        subcommands=subcommands,
+        required_flags=required_flags,
+        interspersed_options_with_values=global_options_with_values,
+        interspersed_flags=global_flags,
+    )
+
+
+def with_required_flag(matcher: AnyMatcher, flag: str) -> AnyMatcher:
+    """Clone executable children while adding one required flag."""
+
+    if not all(isinstance(child, ExecutableMatcher) for child in matcher.matchers):
+        raise ValueError("Safe variants require executable matcher children")
+    return AnyMatcher(
+        matchers=tuple(
+            ExecutableMatcher(
+                executables=child.executables,
+                subcommands=child.subcommands,
+                required_flags=child.required_flags | {flag},
+                forbidden_flags=child.forbidden_flags,
+                allow_leading_options=child.allow_leading_options,
+                leading_options_with_values=child.leading_options_with_values,
+                interspersed_options_with_values=child.interspersed_options_with_values,
+                interspersed_flags=child.interspersed_flags,
+                options_with_values=child.options_with_values,
+                required_flags_in_all_arguments=True,
+            )
+            for child in matcher.matchers
+            if isinstance(child, ExecutableMatcher)
+        )
+    )
+
+
+def safe_flag_variant(
+    matcher: AnyMatcher,
+    *,
+    variant_id: str,
+    title: str,
+    flag: str,
+) -> CommandSafeVariant:
+    """Build a safe variant requiring one documented side-effect-free flag."""
+
+    return CommandSafeVariant(
+        variant_id=variant_id,
+        title=title,
+        matcher=with_required_flag(matcher, flag),
+    )

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_specs.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_specs.py
@@ -1,0 +1,55 @@
+"""Shared metadata contracts for built-in command extension catalogs."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TypedDict
+
+from .command_rules import CommandSafetyRule
+
+
+@dataclass(frozen=True, slots=True)
+class CommandExtensionSpec:
+    """Static metadata for a directly enforced command domain."""
+
+    extension_id: str
+    name: str
+    description: str
+    action_classes: tuple[str, ...]
+    risk_classes: tuple[str, ...]
+    safer_alternatives: tuple[str, ...]
+    reference_urls: tuple[str, ...]
+
+
+class CommandExtensionValues(TypedDict):
+    """Constructor values for one built-in command extension."""
+
+    extension_id: str
+    version: str
+    name: str
+    description: str
+    action_classes: tuple[str, ...]
+    risk_classes: tuple[str, ...]
+    safer_alternatives: tuple[str, ...]
+    rules: tuple[CommandSafetyRule, ...]
+    reference_urls: tuple[str, ...]
+
+
+def command_extension_values(
+    spec: CommandExtensionSpec,
+    rules: tuple[CommandSafetyRule, ...],
+) -> CommandExtensionValues:
+    """Return typed registry constructor values for one extension spec."""
+
+    extension_rules = tuple(rule for rule in rules if rule.rule_id.startswith(f"{spec.extension_id}."))
+    return {
+        "extension_id": spec.extension_id,
+        "version": "1.0.0",
+        "name": spec.name,
+        "description": spec.description,
+        "action_classes": spec.action_classes,
+        "risk_classes": spec.risk_classes,
+        "safer_alternatives": spec.safer_alternatives,
+        "rules": extension_rules,
+        "reference_urls": spec.reference_urls,
+    }

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -7,10 +7,8 @@ from dataclasses import dataclass
 from pathlib import PurePosixPath
 from typing import Literal, final
 
+from .command_builtin_extension_catalog import DIRECT_COMMAND_EXTENSION_VALUES
 from .command_builtin_rules import COMMAND_ACTION_RISK_CLASSES, rules_for_extension
-from .command_cloud_extensions import CLOUD_COMMAND_EXTENSION_SPECS, CLOUD_COMMAND_RULES
-from .command_domain_extensions import DOMAIN_COMMAND_EXTENSION_SPECS, DOMAIN_COMMAND_RULES
-from .command_extension_specs import command_extension_values
 from .command_model import CanonicalCommand
 from .command_package_extensions import PACKAGE_COMMAND_EXTENSION_SPECS, PackageCommandExtensionSpec
 from .command_rules import CommandSafetyRule, MatcherEvidence, matcher_index_hints
@@ -488,12 +486,7 @@ _BUILT_IN_EXTENSIONS = (
         ),
         rules=rules_for_extension("command.shell-mutations"),
     ),
-    *(
-        CommandSafetyExtension(**command_extension_values(spec, rules))
-        for specs, rules in ((DOMAIN_COMMAND_EXTENSION_SPECS, DOMAIN_COMMAND_RULES),
-                             (CLOUD_COMMAND_EXTENSION_SPECS, CLOUD_COMMAND_RULES))
-        for spec in specs
-    ),
+    *(CommandSafetyExtension(**values) for values in DIRECT_COMMAND_EXTENSION_VALUES),
     *(_package_command_extension(spec) for spec in PACKAGE_COMMAND_EXTENSION_SPECS),
 )
 

--- a/src/codex_plugin_scanner/guard/runtime/command_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extensions.py
@@ -8,7 +8,9 @@ from pathlib import PurePosixPath
 from typing import Literal, final
 
 from .command_builtin_rules import COMMAND_ACTION_RISK_CLASSES, rules_for_extension
-from .command_domain_extensions import DOMAIN_COMMAND_EXTENSION_SPECS, domain_command_extension_values
+from .command_cloud_extensions import CLOUD_COMMAND_EXTENSION_SPECS, CLOUD_COMMAND_RULES
+from .command_domain_extensions import DOMAIN_COMMAND_EXTENSION_SPECS, DOMAIN_COMMAND_RULES
+from .command_extension_specs import command_extension_values
 from .command_model import CanonicalCommand
 from .command_package_extensions import PACKAGE_COMMAND_EXTENSION_SPECS, PackageCommandExtensionSpec
 from .command_rules import CommandSafetyRule, MatcherEvidence, matcher_index_hints
@@ -486,7 +488,12 @@ _BUILT_IN_EXTENSIONS = (
         ),
         rules=rules_for_extension("command.shell-mutations"),
     ),
-    *(CommandSafetyExtension(**domain_command_extension_values(spec)) for spec in DOMAIN_COMMAND_EXTENSION_SPECS),
+    *(
+        CommandSafetyExtension(**command_extension_values(spec, rules))
+        for specs, rules in ((DOMAIN_COMMAND_EXTENSION_SPECS, DOMAIN_COMMAND_RULES),
+                             (CLOUD_COMMAND_EXTENSION_SPECS, CLOUD_COMMAND_RULES))
+        for spec in specs
+    ),
     *(_package_command_extension(spec) for spec in PACKAGE_COMMAND_EXTENSION_SPECS),
 )
 

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -48,6 +48,7 @@ class ExecutableMatcher:
     forbidden_flags: frozenset[str] = frozenset()
     allow_leading_options: bool = False
     leading_options_with_values: frozenset[str] = frozenset()
+    interspersed_options_with_values: frozenset[str] = frozenset()
     options_with_values: frozenset[str] = frozenset()
 
     def __post_init__(self) -> None:
@@ -61,11 +62,15 @@ class ExecutableMatcher:
         normalized_leading_options = frozenset(
             value.strip().lower() for value in self.leading_options_with_values if value.strip()
         )
+        normalized_interspersed_options = frozenset(
+            value.strip().lower() for value in self.interspersed_options_with_values if value.strip()
+        )
         normalized_options = frozenset(value.strip().lower() for value in self.options_with_values if value.strip())
         object.__setattr__(self, "subcommands", normalized_subcommands)
         object.__setattr__(self, "required_flags", normalized_required_flags)
         object.__setattr__(self, "forbidden_flags", normalized_forbidden_flags)
         object.__setattr__(self, "leading_options_with_values", normalized_leading_options)
+        object.__setattr__(self, "interspersed_options_with_values", normalized_interspersed_options)
         object.__setattr__(self, "options_with_values", normalized_options)
         if normalized_required_flags & normalized_forbidden_flags:
             raise ValueError("A matcher flag cannot be both required and forbidden")
@@ -76,11 +81,15 @@ class ExecutableMatcher:
             if not _segment_matches_executable(segment, self.executables):
                 continue
             lowered_arguments = tuple(argument.lower() for argument in segment.arguments)
-            subcommand_arguments = (
-                _after_leading_options(lowered_arguments, self.leading_options_with_values)
-                if self.allow_leading_options
-                else lowered_arguments
+            subcommand_arguments = _without_options(
+                lowered_arguments,
+                self.interspersed_options_with_values,
             )
+            if self.allow_leading_options:
+                subcommand_arguments = _after_leading_options(
+                    subcommand_arguments,
+                    self.leading_options_with_values,
+                )
             if self.subcommands and subcommand_arguments[: len(self.subcommands)] != self.subcommands:
                 continue
             flag_arguments = subcommand_arguments[len(self.subcommands) :] if self.subcommands else subcommand_arguments
@@ -380,3 +389,19 @@ def _after_leading_options(arguments: tuple[str, ...], options_with_values: froz
         else:
             index += 1
     return ()
+
+
+def _without_options(arguments: tuple[str, ...], options_with_values: frozenset[str]) -> tuple[str, ...]:
+    if not options_with_values:
+        return arguments
+    retained: list[str] = []
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        option_name = argument.split("=", 1)[0]
+        if option_name not in options_with_values:
+            retained.append(argument)
+            index += 1
+            continue
+        index += 1 if "=" in argument else 2
+    return tuple(retained)

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -108,9 +108,7 @@ class ExecutableMatcher:
             present_flags = _present_flags(
                 flag_arguments,
                 options_with_values=(
-                    self.options_with_values
-                    | self.leading_options_with_values
-                    | self.interspersed_options_with_values
+                    self.options_with_values | self.leading_options_with_values | self.interspersed_options_with_values
                 ),
             )
             if not self.required_flags <= present_flags or self.forbidden_flags & present_flags:

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -419,6 +419,9 @@ def _without_options(
     index = 0
     while index < len(arguments):
         argument = arguments[index]
+        if argument == "--":
+            retained.extend(arguments[index + 1 :])
+            break
         option_name = argument.split("=", 1)[0]
         if option_name in flags:
             index += 1

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -49,7 +49,9 @@ class ExecutableMatcher:
     allow_leading_options: bool = False
     leading_options_with_values: frozenset[str] = frozenset()
     interspersed_options_with_values: frozenset[str] = frozenset()
+    interspersed_flags: frozenset[str] = frozenset()
     options_with_values: frozenset[str] = frozenset()
+    required_flags_in_all_arguments: bool = False
 
     def __post_init__(self) -> None:
         normalized = frozenset(value.strip().lower() for value in self.executables if value.strip())
@@ -65,12 +67,16 @@ class ExecutableMatcher:
         normalized_interspersed_options = frozenset(
             value.strip().lower() for value in self.interspersed_options_with_values if value.strip()
         )
+        normalized_interspersed_flags = frozenset(
+            value.strip().lower() for value in self.interspersed_flags if value.strip()
+        )
         normalized_options = frozenset(value.strip().lower() for value in self.options_with_values if value.strip())
         object.__setattr__(self, "subcommands", normalized_subcommands)
         object.__setattr__(self, "required_flags", normalized_required_flags)
         object.__setattr__(self, "forbidden_flags", normalized_forbidden_flags)
         object.__setattr__(self, "leading_options_with_values", normalized_leading_options)
         object.__setattr__(self, "interspersed_options_with_values", normalized_interspersed_options)
+        object.__setattr__(self, "interspersed_flags", normalized_interspersed_flags)
         object.__setattr__(self, "options_with_values", normalized_options)
         if normalized_required_flags & normalized_forbidden_flags:
             raise ValueError("A matcher flag cannot be both required and forbidden")
@@ -84,6 +90,7 @@ class ExecutableMatcher:
             subcommand_arguments = _without_options(
                 lowered_arguments,
                 self.interspersed_options_with_values,
+                self.interspersed_flags,
             )
             if self.allow_leading_options:
                 subcommand_arguments = _after_leading_options(
@@ -92,8 +99,20 @@ class ExecutableMatcher:
                 )
             if self.subcommands and subcommand_arguments[: len(self.subcommands)] != self.subcommands:
                 continue
-            flag_arguments = subcommand_arguments[len(self.subcommands) :] if self.subcommands else subcommand_arguments
-            present_flags = _present_flags(flag_arguments, options_with_values=self.options_with_values)
+            if self.required_flags_in_all_arguments:
+                flag_arguments = lowered_arguments
+            elif self.subcommands:
+                flag_arguments = subcommand_arguments[len(self.subcommands) :]
+            else:
+                flag_arguments = subcommand_arguments
+            present_flags = _present_flags(
+                flag_arguments,
+                options_with_values=(
+                    self.options_with_values
+                    | self.leading_options_with_values
+                    | self.interspersed_options_with_values
+                ),
+            )
             if not self.required_flags <= present_flags or self.forbidden_flags & present_flags:
                 continue
             evidence.append(
@@ -391,14 +410,21 @@ def _after_leading_options(arguments: tuple[str, ...], options_with_values: froz
     return ()
 
 
-def _without_options(arguments: tuple[str, ...], options_with_values: frozenset[str]) -> tuple[str, ...]:
-    if not options_with_values:
+def _without_options(
+    arguments: tuple[str, ...],
+    options_with_values: frozenset[str],
+    flags: frozenset[str],
+) -> tuple[str, ...]:
+    if not options_with_values and not flags:
         return arguments
     retained: list[str] = []
     index = 0
     while index < len(arguments):
         argument = arguments[index]
         option_name = argument.split("=", 1)[0]
+        if option_name in flags:
+            index += 1
+            continue
         if option_name not in options_with_values:
             retained.append(argument)
             index += 1

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -1,0 +1,118 @@
+"""Structured cloud provider command extension tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+
+
+@pytest.mark.parametrize(
+    ("command", "action_class", "rule_id"),
+    [
+        (
+            "aws --profile prod --region us-east-1 ec2 terminate-instances --instance-ids i-123",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "aws rds delete-db-instance --db-instance-identifier app-db",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "aws eks delete-cluster --name app-cluster",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "gcloud --project app-prod compute instances delete api-1 --zone us-central1-a --quiet",
+            "Google Cloud destructive command",
+            "command.cloud.gcp.resource-deletion",
+        ),
+        (
+            "gcloud beta sql instances delete app-db",
+            "Google Cloud destructive command",
+            "command.cloud.gcp.resource-deletion",
+        ),
+        (
+            "az --subscription app-prod vm delete --resource-group app --name api-1 --yes",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
+    ],
+)
+def test_cloud_rules_feed_inspection_and_runtime_hooks(
+    command: str,
+    action_class: str,
+    rule_id: str,
+    tmp_path: Path,
+) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert payload["classification"]["action_class"] == action_class
+    assert payload["controlling_rule_id"] == rule_id
+    runtime_match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert runtime_match is not None
+    assert runtime_match.action_class == action_class
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "aws ec2 terminate-instances --help",
+        "aws ec2 terminate-instances --instance-ids i-123 --dry-run",
+        "aws rds delete-db-instance --generate-cli-skeleton input",
+        "gcloud compute instances delete --help",
+        "gcloud preview sql instances delete --help",
+        "az vm delete --help",
+        "aws ec2 describe-instances --instance-ids i-123",
+        "gcloud compute instances describe api-1",
+        "az vm show --resource-group app --name api-1",
+        "grep 'terminate-instances|instances delete|vm delete' scripts/guard-test",
+        "printf '%s\\n' 'aws eks delete-cluster --name app-cluster'",
+    ],
+)
+def test_cloud_help_preview_and_read_commands_remain_safe(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "no_match"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_safe_cloud_variant_does_not_hide_destructive_segment(tmp_path: Path) -> None:
+    payload = inspect_command(
+        "aws ec2 terminate-instances --dry-run && az vm delete --name api-1 --resource-group app --yes",
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert [rule["rule_id"] for rule in payload["rules"]] == ["command.cloud.azure.resource-deletion"]
+    assert payload["controlling_rule_id"] == "command.cloud.azure.resource-deletion"
+
+
+def test_cloud_extensions_publish_primary_references() -> None:
+    for extension_id in ("command.cloud.aws", "command.cloud.gcp", "command.cloud.azure"):
+        extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.get(extension_id)
+
+        assert extension is not None
+        assert extension.reference_urls
+        assert all(url.startswith("https://") for url in extension.reference_urls)

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -77,6 +77,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.cloud.aws.resource-deletion",
         ),
         (
+            "aws -- ec2 terminate-instances --instance-ids i-123",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
             "gcloud.cmd compute --project app-prod instances delete api-1",
             "Google Cloud destructive command",
             "command.cloud.gcp.resource-deletion",

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.guard.runtime.command_cloud_extensions import _same_commands_with_flag
+from codex_plugin_scanner.guard.runtime.command_extension_matchers import with_required_flag
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
 from codex_plugin_scanner.guard.runtime.command_rules import AnyMatcher, ExecutableMatcher
@@ -154,4 +154,4 @@ def test_cloud_safe_variant_rejects_unsupported_matcher_nesting() -> None:
     nested = AnyMatcher(matchers=(AnyMatcher(matchers=(ExecutableMatcher(executables=frozenset({"aws"})),)),))
 
     with pytest.raises(ValueError, match="executable matcher children"):
-        _same_commands_with_flag(nested, "--help")
+        with_required_flag(nested, "--help")

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -92,6 +92,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.cloud.gcp.resource-deletion",
         ),
         (
+            "gcloud -q compute instances delete api-1",
+            "Google Cloud destructive command",
+            "command.cloud.gcp.resource-deletion",
+        ),
+        (
+            "gcloud --no-log-http sql instances delete app-db",
+            "Google Cloud destructive command",
+            "command.cloud.gcp.resource-deletion",
+        ),
+        (
             "az.cmd vm --subscription app-prod delete --resource-group app --name api-1 --yes",
             "Azure destructive command",
             "command.cloud.azure.resource-deletion",

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -44,6 +44,21 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Azure destructive command",
             "command.cloud.azure.resource-deletion",
         ),
+        (
+            "aws.exe ec2 --region us-east-1 terminate-instances --instance-ids i-123",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "gcloud.cmd compute --project app-prod instances delete api-1",
+            "Google Cloud destructive command",
+            "command.cloud.gcp.resource-deletion",
+        ),
+        (
+            "az.cmd vm --subscription app-prod delete --resource-group app --name api-1 --yes",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
     ],
 )
 def test_cloud_rules_feed_inspection_and_runtime_hooks(

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -57,6 +57,26 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.cloud.aws.resource-deletion",
         ),
         (
+            "aws --no-paginate ec2 terminate-instances --instance-ids i-123",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "aws ec2 --cli-auto-prompt terminate-instances --instance-ids i-123",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "aws ec2 terminate-instances --no-cli-auto-prompt --instance-ids i-123",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "aws --no-color ec2 terminate-instances --instance-ids i-123",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
             "gcloud.cmd compute --project app-prod instances delete api-1",
             "Google Cloud destructive command",
             "command.cloud.gcp.resource-deletion",

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -6,8 +6,10 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.runtime.command_cloud_extensions import _same_commands_with_flag
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.command_rules import AnyMatcher, ExecutableMatcher
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 
 
@@ -50,12 +52,27 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.cloud.aws.resource-deletion",
         ),
         (
+            "aws --no-cli-pager ec2 terminate-instances --instance-ids i-123",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
             "gcloud.cmd compute --project app-prod instances delete api-1",
             "Google Cloud destructive command",
             "command.cloud.gcp.resource-deletion",
         ),
         (
+            "gcloud --quiet compute instances delete api-1",
+            "Google Cloud destructive command",
+            "command.cloud.gcp.resource-deletion",
+        ),
+        (
             "az.cmd vm --subscription app-prod delete --resource-group app --name api-1 --yes",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
+        (
+            "az --only-show-errors vm delete --resource-group app --name api-1 --yes",
             "Azure destructive command",
             "command.cloud.azure.resource-deletion",
         ),
@@ -131,3 +148,10 @@ def test_cloud_extensions_publish_primary_references() -> None:
         assert extension is not None
         assert extension.reference_urls
         assert all(url.startswith("https://") for url in extension.reference_urls)
+
+
+def test_cloud_safe_variant_rejects_unsupported_matcher_nesting() -> None:
+    nested = AnyMatcher(matchers=(AnyMatcher(matchers=(ExecutableMatcher(executables=frozenset({"aws"})),)),))
+
+    with pytest.raises(ValueError, match="executable matcher children"):
+        _same_commands_with_flag(nested, "--help")

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -93,7 +93,7 @@ def test_command_extension_registry_is_deterministic_and_complete() -> None:
     assert "command.shell-mutations" in ids
     assert BUILT_IN_COMMAND_EXTENSION_REGISTRY.for_action_class("destructive shell command") is not None
     assert BUILT_IN_COMMAND_EXTENSION_REGISTRY.rule_for_action_class("destructive shell command") is not None
-    assert sum(extension["rule_count"] for extension in payload["extensions"]) == 25
+    assert sum(extension["rule_count"] for extension in payload["extensions"]) == 28
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -118,6 +118,28 @@ def test_executable_matcher_can_skip_declared_global_options() -> None:
     assert matcher.match(parsed)
 
 
+def test_executable_matcher_can_skip_declared_interspersed_options() -> None:
+    parsed = parse_shell_command("cloud compute --project app instances delete api-1")
+    matcher = ExecutableMatcher(
+        executables=frozenset({"cloud"}),
+        subcommands=("compute", "instances", "delete"),
+        interspersed_options_with_values=frozenset({"--project"}),
+    )
+
+    assert matcher.match(parsed)
+
+
+def test_executable_matcher_preserves_undeclared_interspersed_options() -> None:
+    parsed = parse_shell_command("cloud compute --plugin delete instances delete api-1")
+    matcher = ExecutableMatcher(
+        executables=frozenset({"cloud"}),
+        subcommands=("compute", "instances", "delete"),
+        interspersed_options_with_values=frozenset({"--project"}),
+    )
+
+    assert matcher.match(parsed) == ()
+
+
 def test_executable_matcher_does_not_treat_option_values_as_flags() -> None:
     parsed = parse_shell_command("git clean -e -f")
     matcher = ExecutableMatcher(


### PR DESCRIPTION
## Summary
- add structured AWS, Google Cloud, and Azure command extensions for destructive resource operations
- preserve safe help, inspection, request skeleton, and permission-only dry-run paths
- publish extension metadata and official command references

## Testing
- `uv run pytest -q tests/test_guard_command_cloud_extensions.py tests/test_guard_command_extensions.py tests/test_guard_runtime.py`
- `uv run pytest -q tests/test_guard_runtime_cross_harness.py tests/test_guard_command_security_boundaries.py`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime tests/test_guard_command_cloud_extensions.py`
- `uv build`
- `uv tool run --from dist/hol_guard-2.0.1086-py3-none-any.whl hol-guard command test --json 'aws ec2 terminate-instances --instance-ids i-123'`
