### PR TITLE
hotfix(guard): restore _execution_context_hash and return statement

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -1054,6 +1054,20 @@ def _normalized_command_segments(
                 current_cwd=effective_shell_cwd,
                 current_source=shell_cwd_source,
             )
+    return tuple(segments)
+
+
+def _execution_context_hash(command_text: str, segment_index: int) -> str:
+    payload = json.dumps(
+        {
+            "schema": "local-package-execution-context-v1",
+            "command": command_text,
+            "segment_index": segment_index,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    return f"sha256:{hashlib.sha256(payload.encode('utf-8')).hexdigest()}"
 
 
 def _raw_command_segments(tokens: list[str]) -> tuple[list[str], ...]:


### PR DESCRIPTION
Hotfix for broken merge from #1535. The conflict resolution accidentally deleted:

1. The `_execution_context_hash` function definition (called on line 1048) — caused `NameError`
2. The `return tuple(segments)` at end of `_normalized_command_segments` — caused `TypeError: 'NoneType' object is not iterable`

Both are restored. Tests: 42 passed.