### PR TITLE
fix(runtime): remove stale package parser imports

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass, replace
 from pathlib import Path
 
 from ..protect import _collect_package_specs
-from .command_model import CanonicalCommand, CommandSegment, parse_shell_command
+from .command_model import CanonicalCommand
 from .homebrew_intent import parse_brew_intent
 from .mcp_protection import _command_name, _package_token
 from .package_intent_common import (


### PR DESCRIPTION
## Summary
- remove stale package parser imports left after execution-context restoration
- restore repository-wide Ruff validation

## Testing
- `ruff check src/`
- `uv run --no-sync pytest -q tests/test_guard_package_runner_identity.py tests/test_guard_package_intent.py --tb=short`
