### PR TITLE
fix(runtime): normalize attached short options

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -425,10 +425,7 @@ def _without_options(
         option_name = argument.split("=", 1)[0]
         attached_short_option = (
             argument[:2]
-            if len(argument) > 2
-            and argument[0] == "-"
-            and argument[1] != "-"
-            and argument[:2] in options_with_values
+            if len(argument) > 2 and argument[0] == "-" and argument[1] != "-" and argument[:2] in options_with_values
             else None
         )
         if option_name in flags:

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -423,12 +423,24 @@ def _without_options(
             retained.extend(arguments[index + 1 :])
             break
         option_name = argument.split("=", 1)[0]
+        attached_short_option = next(
+            (
+                option
+                for option in options_with_values
+                if len(option) == 2
+                and option.startswith("-")
+                and not option.startswith("--")
+                and argument.startswith(option)
+                and len(argument) > len(option)
+            ),
+            None,
+        )
         if option_name in flags:
             index += 1
             continue
-        if option_name not in options_with_values:
+        if option_name not in options_with_values and attached_short_option is None:
             retained.append(argument)
             index += 1
             continue
-        index += 1 if "=" in argument else 2
+        index += 1 if "=" in argument or attached_short_option is not None else 2
     return tuple(retained)

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -423,17 +423,13 @@ def _without_options(
             retained.extend(arguments[index + 1 :])
             break
         option_name = argument.split("=", 1)[0]
-        attached_short_option = next(
-            (
-                option
-                for option in options_with_values
-                if len(option) == 2
-                and option.startswith("-")
-                and not option.startswith("--")
-                and argument.startswith(option)
-                and len(argument) > len(option)
-            ),
-            None,
+        attached_short_option = (
+            argument[:2]
+            if len(argument) > 2
+            and argument[0] == "-"
+            and argument[1] != "-"
+            and argument[:2] in options_with_values
+            else None
         )
         if option_name in flags:
             index += 1
@@ -442,5 +438,6 @@ def _without_options(
             retained.append(argument)
             index += 1
             continue
-        index += 1 if "=" in argument or attached_short_option is not None else 2
+        is_attached_short = attached_short_option is not None and option_name not in options_with_values
+        index += 1 if "=" in argument or is_attached_short else 2
     return tuple(retained)

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -121,6 +121,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Azure destructive command",
             "command.cloud.azure.resource-deletion",
         ),
+        (
+            "az --output table vm delete --resource-group app --name api-1 --yes",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
+        (
+            "az vm --output table delete --resource-group app --name api-1 --yes",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
     ],
 )
 def test_cloud_rules_feed_inspection_and_runtime_hooks(

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -111,6 +111,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Azure destructive command",
             "command.cloud.azure.resource-deletion",
         ),
+        (
+            "az -otable vm delete --resource-group app --name api-1 --yes",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
+        (
+            "az vm -otable delete --resource-group app --name api-1 --yes",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
     ],
 )
 def test_cloud_rules_feed_inspection_and_runtime_hooks(


### PR DESCRIPTION
## Summary
- normalize attached short-option values during structured command matching
- preserve cloud command classification when output options use attached values

## Testing
- `uv run --no-sync pytest tests/test_guard_command_cloud_extensions.py tests/test_guard_command_extensions.py tests/test_guard_risk.py -q`
- `uv tool run --no-cache ruff check src/codex_plugin_scanner/guard/runtime/command_rules.py tests/test_guard_command_cloud_extensions.py`
- `uv tool run --no-cache --from basedpyright basedpyright --level error --pythonpath .venv/bin/python src/codex_plugin_scanner/guard/runtime/command_rules.py`
- `uv build`
- no-cache wheel smoke for an Azure command with an attached output option
