### PR TITLE
fix(update): install detected release exactly

### DIFF
--- a/src/codex_plugin_scanner/guard/cli/update_commands.py
+++ b/src/codex_plugin_scanner/guard/cli/update_commands.py
@@ -201,7 +201,18 @@ def run_guard_update(
         vcs_install=vcs_install,
         local_source_install=local_source_install,
     )
-    command = _update_command(installer, use_pypi=use_pypi, wheel_path=requested_wheel_path)
+    target_version = None
+    if version_check.get("update_available") is True:
+        latest_version = version_check.get("latest_version")
+        if isinstance(latest_version, str) and latest_version.strip():
+            target_version = latest_version.strip()
+            use_pypi = True
+    command = _update_command(
+        installer,
+        use_pypi=use_pypi,
+        target_version=target_version,
+        wheel_path=requested_wheel_path,
+    )
     execution_command = _execution_update_command(command, installer=installer, context=context)
     if force_pypi_reinstall:
         payload["recovery_reinstall"] = True

--- a/tests/test_guard_cli.py
+++ b/tests/test_guard_cli.py
@@ -3892,6 +3892,30 @@ args = ["workspace-skill.js", "--changed"]
         assert commands == [["pipx", "upgrade", "hol-guard"]]
         assert output["status"] == "updated"
 
+    def test_guard_update_pins_detected_stable_release_from_uv_canary(self, tmp_path, monkeypatch, capsys):
+        home_dir = tmp_path / "home"
+        commands: list[list[str]] = []
+
+        def fake_run(command: list[str], **_: object):
+            commands.append(command)
+            return subprocess.CompletedProcess(command, 0, stdout="updated", stderr="")
+
+        monkeypatch.setattr(guard_update_commands_module.subprocess, "run", fake_run)
+        monkeypatch.setattr(guard_update_commands_module.sys, "prefix", "/mock-home/.local/share/uv/tools/hol-guard")
+        monkeypatch.setattr(guard_update_commands_module, "_direct_url_payload", lambda: None)
+        monkeypatch.setattr(guard_update_commands_module, "_current_version", lambda: "2.0.1091.dev10044056673277")
+        monkeypatch.setattr(guard_update_commands_module, "_current_version_from_subprocess", lambda: "2.0.1092")
+        monkeypatch.setattr(guard_update_commands_module, "_latest_version_from_pypi", lambda: "2.0.1092")
+
+        rc = main(["guard", "update", "--home", str(home_dir), "--json"])
+        output = json.loads(capsys.readouterr().out)
+
+        assert rc == 0
+        assert output["installer"] == "uv"
+        assert commands == [["uv", "tool", "install", "--force", "hol-guard==2.0.1092"]]
+        assert output["resulting_version"] == "2.0.1092"
+        assert output["status"] == "updated"
+
     def test_guard_update_marks_already_current_pipx_runs_as_current(self, tmp_path, monkeypatch, capsys):
         home_dir = tmp_path / "home"
         commands: list[list[str]] = []

--- a/tests/test_guard_phase03_local_install.py
+++ b/tests/test_guard_phase03_local_install.py
@@ -32,6 +32,7 @@ def test_update_failure_redacts_output_and_returns_retry_command(monkeypatch: py
     monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.0")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
     monkeypatch.setattr(update_commands, "_installer_kind", lambda: "pip")
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.1")
     monkeypatch.setattr(update_commands.sys, "executable", "/opt/guard/bin/python")
     monkeypatch.setattr(update_commands.sysconfig, "get_path", lambda name: "/opt/guard/bin")
     monkeypatch.setattr(
@@ -41,7 +42,15 @@ def test_update_failure_redacts_output_and_returns_retry_command(monkeypatch: py
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["/opt/guard/bin/python", "-m", "pip", "install", "--upgrade", "hol-guard"]
+        assert command == [
+            "/opt/guard/bin/python",
+            "-m",
+            "pip",
+            "install",
+            "--upgrade",
+            "--force-reinstall",
+            "hol-guard==2.0.1",
+        ]
         return subprocess.CompletedProcess(command, 1, "", "AUTH_TOKEN=hunter2\nnetwork unreachable")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -50,7 +59,9 @@ def test_update_failure_redacts_output_and_returns_retry_command(monkeypatch: py
 
     assert exit_code == 1
     assert payload["status"] == "failed"
-    assert payload["retry_command"] == "/opt/guard/bin/python -m pip install --upgrade hol-guard"
+    assert payload["retry_command"] == (
+        "/opt/guard/bin/python -m pip install --upgrade --force-reinstall hol-guard==2.0.1"
+    )
     assert "network unreachable" in str(payload["stderr"])
     assert "hunter2" not in json.dumps(payload)
     assert payload["binary_diagnostics"]["path_status"] == "path_mismatch"
@@ -167,7 +178,7 @@ def test_update_uses_real_pipx_binary_when_guard_package_shims_are_installed(
     monkeypatch.setattr(update_commands, "_refresh_package_shims_after_update", lambda **_: (None, None))
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["/opt/homebrew/bin/pipx", "upgrade", "hol-guard"]
+        assert command == ["/opt/homebrew/bin/pipx", "install", "--force", "hol-guard==2.0.830"]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -176,7 +187,7 @@ def test_update_uses_real_pipx_binary_when_guard_package_shims_are_installed(
 
     assert exit_code == 0
     assert payload["status"] == "updated"
-    assert payload["command"] == ["pipx", "upgrade", "hol-guard"]
+    assert payload["command"] == ["pipx", "install", "--force", "hol-guard==2.0.830"]
 
 
 def test_build_guard_install_surface_payload_stays_local(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -380,7 +391,7 @@ def test_update_repairs_missing_pipx_local_source_install(monkeypatch: pytest.Mo
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard"]
+    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard==2.0.489"]
     assert payload["recovery_source_install"] is True
     assert payload["source_install"]["path_exists"] is False
     assert payload["status"] == "updated"
@@ -409,7 +420,7 @@ def test_update_treats_nonzero_pipx_repair_as_updated_when_version_changed(
     monkeypatch.setattr(update_commands, "_sync_dashboard_assets", lambda: {"notes": ["synced dashboard"]})
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["pipx", "install", "--force", "hol-guard"]
+        assert command == ["pipx", "install", "--force", "hol-guard==2.0.628"]
         return subprocess.CompletedProcess(
             command,
             1,
@@ -974,10 +985,7 @@ def test_update_syncs_dashboard_assets_after_partial_stale_upgrade(monkeypatch: 
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands == [
-        ["pipx", "upgrade", "hol-guard"],
-        ["pipx", "install", "--force", "hol-guard==2.0.489"],
-    ]
+    assert captured_commands == [["pipx", "install", "--force", "hol-guard==2.0.489"]]
     assert payload["status"] == "stale"
     assert payload["changed"] is True
     assert payload["dashboard_sync"] == {"notes": ["synced dashboard"]}
@@ -1064,7 +1072,7 @@ def test_update_records_package_shim_refresh_after_successful_update(
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["pipx", "upgrade", "hol-guard"]
+        assert command == ["pipx", "install", "--force", "hol-guard==2.0.830"]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -1099,7 +1107,7 @@ def test_update_keeps_success_when_package_shim_refresh_warns(
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        assert command == ["pipx", "upgrade", "hol-guard"]
+        assert command == ["pipx", "install", "--force", "hol-guard==2.0.830"]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.830", "")
 
     monkeypatch.setattr(update_commands.subprocess, "run", fake_run)
@@ -1151,15 +1159,12 @@ def test_update_skips_package_shim_refresh_for_stale_no_change(
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands == [
-        ["pipx", "upgrade", "hol-guard"],
-        ["pipx", "install", "--force", "hol-guard==2.0.585"],
-    ]
+    assert captured_commands == [["pipx", "install", "--force", "hol-guard==2.0.585"]]
     assert payload["status"] == "stale"
     assert refresh_attempted is False
 
 
-def test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change(
+def test_update_marks_pinned_pipx_install_as_stale_when_version_does_not_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.584")
@@ -1189,10 +1194,7 @@ def test_update_marks_plain_pipx_upgrade_as_stale_when_version_does_not_change(
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands == [
-        ["pipx", "upgrade", "hol-guard"],
-        ["pipx", "install", "--force", "hol-guard==2.0.585"],
-    ]
+    assert captured_commands == [["pipx", "install", "--force", "hol-guard==2.0.585"]]
     assert payload["status"] == "stale"
     assert payload["changed"] is False
     assert payload["resulting_version"] == "2.0.584"
@@ -1215,13 +1217,6 @@ def test_update_reports_blocked_when_force_install_hits_dependency_conflict(
     )
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
-        if command == ["pipx", "upgrade", "hol-guard"]:
-            return subprocess.CompletedProcess(
-                command,
-                0,
-                "hol-guard is already at latest version 2.0.741",
-                "upgrading hol-guard...\n",
-            )
         assert command == ["pipx", "install", "--force", "hol-guard==2.0.749"]
         return subprocess.CompletedProcess(
             command,
@@ -1242,7 +1237,7 @@ def test_update_reports_blocked_when_force_install_hits_dependency_conflict(
     assert "retry_command" not in payload
 
 
-def test_update_retries_force_pipx_install_when_upgrade_reaches_latest_version(
+def test_update_installs_detected_pipx_release_directly(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.584")
@@ -1256,18 +1251,10 @@ def test_update_retries_force_pipx_install_when_upgrade_reaches_latest_version(
     )
 
     captured_commands: list[list[str]] = []
-    version_reads = iter(["2.0.584", "2.0.585"])
-    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: next(version_reads))
+    monkeypatch.setattr(update_commands, "_current_version_from_subprocess", lambda: "2.0.585")
 
     def fake_run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         captured_commands.append(command)
-        if command == ["pipx", "upgrade", "hol-guard"]:
-            return subprocess.CompletedProcess(
-                command,
-                0,
-                "hol-guard is already at latest version 2.0.584",
-                "upgrading hol-guard...\n",
-            )
         assert command == ["pipx", "install", "--force", "hol-guard==2.0.585"]
         return subprocess.CompletedProcess(command, 0, "installed hol-guard 2.0.585", "")
 
@@ -1276,10 +1263,7 @@ def test_update_retries_force_pipx_install_when_upgrade_reaches_latest_version(
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands == [
-        ["pipx", "upgrade", "hol-guard"],
-        ["pipx", "install", "--force", "hol-guard==2.0.585"],
-    ]
+    assert captured_commands == [["pipx", "install", "--force", "hol-guard==2.0.585"]]
     assert payload["status"] == "updated"
     assert payload["resulting_version"] == "2.0.585"
 
@@ -1318,7 +1302,7 @@ def test_update_switches_git_install_to_pypi_when_release_is_newer(monkeypatch: 
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard"]
+    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard==2.0.489"]
     assert payload["upgrade_source"] == "pypi"
     assert payload["status"] == "updated"
     assert payload["message"] == "Updated HOL Guard from 2.0.345 to 2.0.489."
@@ -1358,7 +1342,7 @@ def test_update_marks_git_install_stale_when_pypi_upgrade_leaves_old_version(mon
     payload, exit_code = update_commands.run_guard_update(dry_run=False)
 
     assert exit_code == 0
-    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard"]
+    assert captured_commands[0] == ["pipx", "install", "--force", "hol-guard==2.0.489"]
     assert payload["status"] == "stale"
     assert "behind PyPI 2.0.489" in str(payload["message"])
     assert "pipx install --force hol-guard" in str(payload["message"])

--- a/tests/test_guard_phase03_remainder.py
+++ b/tests/test_guard_phase03_remainder.py
@@ -58,18 +58,19 @@ def test_update_is_skipped_when_managed_policy_is_invalid(monkeypatch: pytest.Mo
     assert payload["reason_code"] == "mdm_update_owned"
 
 
-def test_update_detects_uv_tool_install_and_plans_uv_upgrade(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_update_detects_uv_tool_install_and_pins_latest_version(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(update_commands.sys, "prefix", "/Users/test/.local/share/uv/tools/hol-guard")
     monkeypatch.setattr(update_commands.shutil, "which", lambda name: f"/Users/test/.local/bin/{name}")
     monkeypatch.setattr(update_commands, "_current_version", lambda: "2.0.0")
     monkeypatch.setattr(update_commands, "_direct_url_payload", lambda: None)
+    monkeypatch.setattr(update_commands, "_latest_version_from_pypi", lambda: "2.0.10")
 
     payload, exit_code = update_commands.run_guard_update(dry_run=True)
 
     assert exit_code == 0
     assert payload["installer"] == "uv"
-    assert payload["command"] == ["uv", "tool", "upgrade", "hol-guard"]
-    assert payload["retry_command"] == "uv tool upgrade hol-guard"
+    assert payload["command"] == ["uv", "tool", "install", "--force", "hol-guard==2.0.10"]
+    assert payload["retry_command"] == "uv tool install --force hol-guard==2.0.10"
     assert payload["binary_diagnostics"]["path_status"] == "uv_tool_shim_detected"
 
 


### PR DESCRIPTION
## Summary
- pin the exact newer release already returned by the package index check
- prevent tool installers from selecting a stale release during updates

## Testing
- `uv run pytest -q tests/test_guard_cli.py -k 'guard_update' tests/test_dashboard_update.py`
- `uv run ruff format --check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_cli.py`
- `uv run ruff check src/codex_plugin_scanner/guard/cli/update_commands.py tests/test_guard_cli.py`
- `uv build`
