### PR TITLE
feat(commands): add CI and platform extensions

### DIFF
--- a/docs/guard/command-cicd-platform-extension-coverage.md
+++ b/docs/guard/command-cicd-platform-extension-coverage.md
@@ -9,7 +9,7 @@ Guard evaluates remote pipeline and hosting operations from the canonical parsed
 | `command.cicd.github` | Cancel or delete workflow runs; disable workflows | Help, run view, workflow view |
 | `command.cicd.gitlab` | Cancel one or more pipelines | Dry run, help |
 | `command.cicd.circleci` | Start a remote pipeline | Help, local configuration validation |
-| `command.platform.vercel` | Remove deployments or projects; promote or roll back production | Help, project inspection, promotion status |
+| `command.platform.vercel` | Remove deployments or projects; deploy, promote, or roll back production | Help, project inspection, promotion status |
 | `command.platform.netlify` | Delete sites; deploy to production | Help, draft deploys, dry builds |
 | `command.platform.heroku` | Destroy apps; promote pipelines; roll back releases | Help, app and release inspection |
 

--- a/docs/guard/command-cicd-platform-extension-coverage.md
+++ b/docs/guard/command-cicd-platform-extension-coverage.md
@@ -1,0 +1,28 @@
+# CI/CD and Platform Command Extension Coverage
+
+Guard evaluates remote pipeline and hosting operations from the canonical parsed command model. Rules match executable, subcommand, and flag structure while preserving documented preview and help variants.
+
+## Extensions
+
+| Extension | Reviewed operations | Safe counterparts |
+| --- | --- | --- |
+| `command.cicd.github` | Cancel or delete workflow runs; disable workflows | Help, run view, workflow view |
+| `command.cicd.gitlab` | Cancel one or more pipelines | Dry run, help |
+| `command.cicd.circleci` | Start a remote pipeline | Help, local configuration validation |
+| `command.platform.vercel` | Remove deployments or projects; promote or roll back production | Help, project inspection, promotion status |
+| `command.platform.netlify` | Delete sites; deploy to production | Help, draft deploys, dry builds |
+| `command.platform.heroku` | Destroy apps; promote pipelines; roll back releases | Help, app and release inspection |
+
+Global repository, account, team, site, app, host, and authentication options are normalized wherever the CLI accepts them. Reordered operation flags and native Windows launcher suffixes use the same rules.
+
+## References
+
+- [GitHub CLI run cancel](https://cli.github.com/manual/gh_run_cancel)
+- [GitHub CLI run delete](https://cli.github.com/manual/gh_run_delete)
+- [GitHub CLI workflow disable](https://cli.github.com/manual/gh_workflow_disable)
+- [GitLab CLI cancel pipeline](https://docs.gitlab.com/cli/ci/cancel/pipeline/)
+- [CircleCI pipeline management](https://circleci.com/docs/guides/toolkit/how-to-use-the-circleci-local-cli/)
+- [Vercel CLI](https://vercel.com/docs/cli)
+- [Netlify CLI guide](https://docs.netlify.com/api-and-cli-guides/cli-guides/get-started-with-cli/)
+- [Heroku CLI commands](https://devcenter.heroku.com/articles/heroku-cli-commands)
+- [Heroku pipelines](https://devcenter.heroku.com/articles/pipelines)

--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_extension_catalog.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_extension_catalog.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 from .command_backup_extensions import BACKUP_COMMAND_EXTENSION_SPECS, BACKUP_COMMAND_RULES
+from .command_cicd_extensions import CICD_COMMAND_EXTENSION_SPECS, CICD_COMMAND_RULES
 from .command_cloud_extensions import CLOUD_COMMAND_EXTENSION_SPECS, CLOUD_COMMAND_RULES
 from .command_database_extensions import DATABASE_COMMAND_EXTENSION_SPECS, DATABASE_COMMAND_RULES
 from .command_domain_extensions import DOMAIN_COMMAND_EXTENSION_SPECS, DOMAIN_COMMAND_RULES
 from .command_extension_specs import CommandExtensionValues, command_extension_values
+from .command_platform_extensions import PLATFORM_COMMAND_EXTENSION_SPECS, PLATFORM_COMMAND_RULES
 from .command_remote_extensions import REMOTE_COMMAND_EXTENSION_SPECS, REMOTE_COMMAND_RULES
 from .command_storage_extensions import STORAGE_COMMAND_EXTENSION_SPECS, STORAGE_COMMAND_RULES
 
@@ -17,6 +19,8 @@ _DIRECT_EXTENSION_CATALOGS = (
     (STORAGE_COMMAND_EXTENSION_SPECS, STORAGE_COMMAND_RULES),
     (BACKUP_COMMAND_EXTENSION_SPECS, BACKUP_COMMAND_RULES),
     (REMOTE_COMMAND_EXTENSION_SPECS, REMOTE_COMMAND_RULES),
+    (CICD_COMMAND_EXTENSION_SPECS, CICD_COMMAND_RULES),
+    (PLATFORM_COMMAND_EXTENSION_SPECS, PLATFORM_COMMAND_RULES),
 )
 
 DIRECT_COMMAND_EXTENSION_VALUES: tuple[CommandExtensionValues, ...] = tuple(

--- a/src/codex_plugin_scanner/guard/runtime/command_cicd_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_cicd_extensions.py
@@ -1,0 +1,174 @@
+"""Structured rules and metadata for CI/CD command extensions."""
+
+from __future__ import annotations
+
+from .command_extension_matchers import executable_matcher, safe_flag_variant
+from .command_extension_specs import CommandExtensionSpec
+from .command_rules import AnyMatcher, CommandSafetyRule, CommandSafeVariant
+
+_GH_GLOBAL_OPTIONS = frozenset({"--hostname", "--repo", "-R"})
+_GH_GLOBAL_FLAGS = frozenset({"--help"})
+_GLAB_GLOBAL_OPTIONS = frozenset({"--repo", "-R"})
+_GLAB_GLOBAL_FLAGS = frozenset({"--help", "-h"})
+_CIRCLECI_GLOBAL_OPTIONS = frozenset({"--host", "--token"})
+_CIRCLECI_GLOBAL_FLAGS = frozenset({"--help", "-h", "--skip-update-check"})
+
+_GH_RUN_ADMINISTRATION = AnyMatcher(
+    matchers=tuple(
+        executable_matcher(
+            "gh",
+            "run",
+            operation,
+            global_options_with_values=_GH_GLOBAL_OPTIONS,
+            global_flags=_GH_GLOBAL_FLAGS,
+        )
+        for operation in ("cancel", "delete")
+    )
+)
+_GH_WORKFLOW_DISABLE = AnyMatcher(
+    matchers=(
+        executable_matcher(
+            "gh",
+            "workflow",
+            "disable",
+            global_options_with_values=_GH_GLOBAL_OPTIONS,
+            global_flags=_GH_GLOBAL_FLAGS,
+        ),
+    )
+)
+_GLAB_PIPELINE_CANCEL = AnyMatcher(
+    matchers=(
+        executable_matcher(
+            "glab",
+            "ci",
+            "cancel",
+            "pipeline",
+            global_options_with_values=_GLAB_GLOBAL_OPTIONS,
+            global_flags=_GLAB_GLOBAL_FLAGS,
+        ),
+    )
+)
+_CIRCLECI_PIPELINE_RUN = AnyMatcher(
+    matchers=(
+        executable_matcher(
+            "circleci",
+            "pipeline",
+            "run",
+            global_options_with_values=_CIRCLECI_GLOBAL_OPTIONS,
+            global_flags=_CIRCLECI_GLOBAL_FLAGS,
+        ),
+    )
+)
+
+
+def _cicd_rule(
+    *,
+    rule_id: str,
+    title: str,
+    description: str,
+    matcher: AnyMatcher,
+    action_class: str,
+    safer_alternative: str,
+    safe_variants: tuple[CommandSafeVariant, ...],
+) -> CommandSafetyRule:
+    return CommandSafetyRule(
+        rule_id=rule_id,
+        title=title,
+        description=description,
+        severity="high",
+        risk_classes=("execution", "network_egress"),
+        action_classes=(action_class,),
+        safer_alternatives=(safer_alternative,),
+        matcher=matcher,
+        safe_variants=safe_variants,
+    )
+
+
+CICD_COMMAND_RULES = (
+    _cicd_rule(
+        rule_id="command.cicd.github.run-administration",
+        title="GitHub Actions run administration",
+        description="Identifies cancellation or deletion of GitHub Actions workflow runs.",
+        matcher=_GH_RUN_ADMINISTRATION,
+        action_class="GitHub Actions administrative command",
+        safer_alternative=(
+            "Inspect the workflow run before canceling it, and retain run history unless deletion is required."
+        ),
+        safe_variants=(
+            safe_flag_variant(_GH_RUN_ADMINISTRATION, variant_id="help", title="Command help", flag="--help"),
+        ),
+    ),
+    _cicd_rule(
+        rule_id="command.cicd.github.workflow-disable",
+        title="GitHub Actions workflow disable",
+        description="Identifies disabling a GitHub Actions workflow.",
+        matcher=_GH_WORKFLOW_DISABLE,
+        action_class="GitHub Actions administrative command",
+        safer_alternative="View the workflow and confirm the target repository before disabling it.",
+        safe_variants=(
+            safe_flag_variant(_GH_WORKFLOW_DISABLE, variant_id="help", title="Command help", flag="--help"),
+        ),
+    ),
+    _cicd_rule(
+        rule_id="command.cicd.gitlab.pipeline-cancel",
+        title="GitLab pipeline cancellation",
+        description="Identifies cancellation of one or more GitLab CI/CD pipelines.",
+        matcher=_GLAB_PIPELINE_CANCEL,
+        action_class="GitLab pipeline administrative command",
+        safer_alternative="Preview the selected pipeline IDs with --dry-run before cancellation.",
+        safe_variants=(
+            safe_flag_variant(
+                _GLAB_PIPELINE_CANCEL, variant_id="dry-run", title="Cancellation preview", flag="--dry-run"
+            ),
+            safe_flag_variant(_GLAB_PIPELINE_CANCEL, variant_id="help", title="Command help", flag="--help"),
+            safe_flag_variant(_GLAB_PIPELINE_CANCEL, variant_id="short-help", title="Command help", flag="-h"),
+        ),
+    ),
+    _cicd_rule(
+        rule_id="command.cicd.circleci.pipeline-run",
+        title="CircleCI pipeline execution",
+        description="Identifies remote CircleCI pipeline execution.",
+        matcher=_CIRCLECI_PIPELINE_RUN,
+        action_class="CircleCI pipeline execution command",
+        safer_alternative="Validate the configuration and inspect the pipeline definition before starting remote work.",
+        safe_variants=(
+            safe_flag_variant(_CIRCLECI_PIPELINE_RUN, variant_id="help", title="Command help", flag="--help"),
+            safe_flag_variant(_CIRCLECI_PIPELINE_RUN, variant_id="short-help", title="Command help", flag="-h"),
+        ),
+    ),
+)
+
+
+CICD_COMMAND_EXTENSION_SPECS = (
+    CommandExtensionSpec(
+        extension_id="command.cicd.github",
+        name="GitHub Actions command protection",
+        description="Reviews workflow-run cancellation, deletion, and workflow disabling through GitHub CLI.",
+        action_classes=("GitHub Actions administrative command",),
+        risk_classes=("execution", "network_egress"),
+        safer_alternatives=("Inspect workflow and run state before changing remote CI/CD state.",),
+        reference_urls=(
+            "https://cli.github.com/manual/gh_run_cancel",
+            "https://cli.github.com/manual/gh_run_delete",
+            "https://cli.github.com/manual/gh_workflow_disable",
+        ),
+    ),
+    CommandExtensionSpec(
+        extension_id="command.cicd.gitlab",
+        name="GitLab CI/CD command protection",
+        description="Reviews remote pipeline cancellation through GitLab CLI.",
+        action_classes=("GitLab pipeline administrative command",),
+        risk_classes=("execution", "network_egress"),
+        safer_alternatives=("Use the documented dry run before canceling selected pipelines.",),
+        reference_urls=("https://docs.gitlab.com/cli/ci/cancel/pipeline/",),
+    ),
+    CommandExtensionSpec(
+        extension_id="command.cicd.circleci",
+        name="CircleCI command protection",
+        description="Reviews remote pipeline execution through CircleCI CLI.",
+        action_classes=("CircleCI pipeline execution command",),
+        risk_classes=("execution", "network_egress"),
+        safer_alternatives=("Validate configuration and inspect the pipeline definition before execution.",),
+        reference_urls=("https://circleci.com/docs/guides/toolkit/how-to-use-the-circleci-local-cli/",),
+    ),
+)

--- a/src/codex_plugin_scanner/guard/runtime/command_platform_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_platform_extensions.py
@@ -1,0 +1,237 @@
+"""Structured rules and metadata for hosting platform command extensions."""
+
+from __future__ import annotations
+
+from .command_extension_matchers import executable_matcher, safe_flag_variant
+from .command_extension_specs import CommandExtensionSpec
+from .command_rules import AnyMatcher, CommandRuleSeverity, CommandSafetyRule, CommandSafeVariant
+
+_VERCEL_GLOBAL_OPTIONS = frozenset({"--cwd", "--global-config", "--local-config", "--scope", "--token"})
+_VERCEL_GLOBAL_FLAGS = frozenset({"--debug", "--help", "--no-color"})
+_NETLIFY_GLOBAL_OPTIONS = frozenset({"--config", "--filter", "--site"})
+_NETLIFY_GLOBAL_FLAGS = frozenset({"--debug", "--help", "-h"})
+_HEROKU_GLOBAL_OPTIONS = frozenset({"--app", "-a", "--remote", "-r"})
+_HEROKU_GLOBAL_FLAGS = frozenset({"--help", "-h", "--prompt"})
+
+_VERCEL_DELETION = AnyMatcher(
+    matchers=tuple(
+        executable_matcher(
+            "vercel",
+            *operation,
+            global_options_with_values=_VERCEL_GLOBAL_OPTIONS,
+            global_flags=_VERCEL_GLOBAL_FLAGS,
+        )
+        for operation in (("remove",), ("project", "rm"))
+    )
+)
+_VERCEL_PRODUCTION_CHANGE = AnyMatcher(
+    matchers=tuple(
+        executable_matcher(
+            "vercel",
+            *operation,
+            global_options_with_values=_VERCEL_GLOBAL_OPTIONS,
+            global_flags=_VERCEL_GLOBAL_FLAGS,
+        )
+        for operation in (("promote",), ("rollback",))
+    )
+)
+_VERCEL_PRODUCTION_STATUS = executable_matcher(
+    "vercel",
+    "promote",
+    "status",
+    global_options_with_values=_VERCEL_GLOBAL_OPTIONS,
+    global_flags=_VERCEL_GLOBAL_FLAGS,
+)
+_NETLIFY_SITE_DELETE = AnyMatcher(
+    matchers=(
+        executable_matcher(
+            "netlify",
+            "sites:delete",
+            global_options_with_values=_NETLIFY_GLOBAL_OPTIONS,
+            global_flags=_NETLIFY_GLOBAL_FLAGS,
+        ),
+    )
+)
+_NETLIFY_PRODUCTION_DEPLOY = AnyMatcher(
+    matchers=tuple(
+        executable_matcher(
+            "netlify",
+            "deploy",
+            required_flags=frozenset({flag}),
+            global_options_with_values=_NETLIFY_GLOBAL_OPTIONS,
+            global_flags=_NETLIFY_GLOBAL_FLAGS,
+        )
+        for flag in ("--prod", "-p")
+    )
+)
+_HEROKU_DESTRUCTION = AnyMatcher(
+    matchers=(
+        executable_matcher(
+            "heroku",
+            "apps:destroy",
+            global_options_with_values=_HEROKU_GLOBAL_OPTIONS,
+            global_flags=_HEROKU_GLOBAL_FLAGS,
+        ),
+    )
+)
+_HEROKU_RELEASE_CHANGE = AnyMatcher(
+    matchers=tuple(
+        executable_matcher(
+            "heroku",
+            operation,
+            global_options_with_values=_HEROKU_GLOBAL_OPTIONS,
+            global_flags=_HEROKU_GLOBAL_FLAGS,
+        )
+        for operation in ("pipelines:promote", "releases:rollback")
+    )
+)
+
+
+def _platform_rule(
+    *,
+    rule_id: str,
+    title: str,
+    description: str,
+    matcher: AnyMatcher,
+    action_class: str,
+    safer_alternative: str,
+    severity: CommandRuleSeverity,
+    safe_variants: tuple[CommandSafeVariant, ...],
+) -> CommandSafetyRule:
+    return CommandSafetyRule(
+        rule_id=rule_id,
+        title=title,
+        description=description,
+        severity=severity,
+        risk_classes=("destructive_shell", "network_egress"),
+        action_classes=(action_class,),
+        safer_alternatives=(safer_alternative,),
+        matcher=matcher,
+        safe_variants=safe_variants,
+    )
+
+
+PLATFORM_COMMAND_RULES = (
+    _platform_rule(
+        rule_id="command.platform.vercel.deletion",
+        title="Vercel resource deletion",
+        description="Identifies removal of Vercel deployments or projects.",
+        matcher=_VERCEL_DELETION,
+        action_class="Vercel destructive command",
+        safer_alternative="Inspect the deployment or project before removing it.",
+        severity="critical",
+        safe_variants=(safe_flag_variant(_VERCEL_DELETION, variant_id="help", title="Command help", flag="--help"),),
+    ),
+    _platform_rule(
+        rule_id="command.platform.vercel.production-change",
+        title="Vercel production change",
+        description="Identifies promotion or rollback of a Vercel production deployment.",
+        matcher=_VERCEL_PRODUCTION_CHANGE,
+        action_class="Vercel production command",
+        safer_alternative="Inspect deployment state or promotion status before changing production.",
+        severity="high",
+        safe_variants=(
+            CommandSafeVariant(
+                variant_id="status",
+                title="Promotion status inspection",
+                matcher=_VERCEL_PRODUCTION_STATUS,
+            ),
+            safe_flag_variant(_VERCEL_PRODUCTION_CHANGE, variant_id="help", title="Command help", flag="--help"),
+        ),
+    ),
+    _platform_rule(
+        rule_id="command.platform.netlify.site-deletion",
+        title="Netlify site deletion",
+        description="Identifies permanent deletion of a Netlify site.",
+        matcher=_NETLIFY_SITE_DELETE,
+        action_class="Netlify destructive command",
+        safer_alternative="Inspect the linked site and its deploy history before deletion.",
+        severity="critical",
+        safe_variants=(
+            safe_flag_variant(_NETLIFY_SITE_DELETE, variant_id="help", title="Command help", flag="--help"),
+            safe_flag_variant(_NETLIFY_SITE_DELETE, variant_id="short-help", title="Command help", flag="-h"),
+        ),
+    ),
+    _platform_rule(
+        rule_id="command.platform.netlify.production-deploy",
+        title="Netlify production deployment",
+        description="Identifies a Netlify deployment directed to the primary site URL.",
+        matcher=_NETLIFY_PRODUCTION_DEPLOY,
+        action_class="Netlify production command",
+        safer_alternative="Create a draft deploy first and inspect it before publishing to production.",
+        severity="high",
+        safe_variants=(
+            safe_flag_variant(_NETLIFY_PRODUCTION_DEPLOY, variant_id="help", title="Command help", flag="--help"),
+            safe_flag_variant(_NETLIFY_PRODUCTION_DEPLOY, variant_id="short-help", title="Command help", flag="-h"),
+        ),
+    ),
+    _platform_rule(
+        rule_id="command.platform.heroku.app-destruction",
+        title="Heroku app destruction",
+        description="Identifies permanent destruction of a Heroku app.",
+        matcher=_HEROKU_DESTRUCTION,
+        action_class="Heroku destructive command",
+        safer_alternative="Inspect app identity, releases, and backups before destruction.",
+        severity="critical",
+        safe_variants=(
+            safe_flag_variant(_HEROKU_DESTRUCTION, variant_id="help", title="Command help", flag="--help"),
+            safe_flag_variant(_HEROKU_DESTRUCTION, variant_id="short-help", title="Command help", flag="-h"),
+        ),
+    ),
+    _platform_rule(
+        rule_id="command.platform.heroku.release-change",
+        title="Heroku release change",
+        description="Identifies promotion or rollback of Heroku releases.",
+        matcher=_HEROKU_RELEASE_CHANGE,
+        action_class="Heroku release command",
+        safer_alternative="Inspect pipeline or release state before promotion or rollback.",
+        severity="high",
+        safe_variants=(
+            safe_flag_variant(_HEROKU_RELEASE_CHANGE, variant_id="help", title="Command help", flag="--help"),
+            safe_flag_variant(_HEROKU_RELEASE_CHANGE, variant_id="short-help", title="Command help", flag="-h"),
+        ),
+    ),
+)
+
+
+PLATFORM_COMMAND_EXTENSION_SPECS = (
+    CommandExtensionSpec(
+        extension_id="command.platform.vercel",
+        name="Vercel command protection",
+        description="Reviews deployment and project deletion plus production promotion and rollback.",
+        action_classes=("Vercel destructive command", "Vercel production command"),
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternatives=("Inspect deployment, project, and promotion state before remote changes.",),
+        reference_urls=(
+            "https://vercel.com/docs/cli/remove",
+            "https://vercel.com/docs/cli/project",
+            "https://vercel.com/docs/cli/promote",
+            "https://vercel.com/docs/cli/rollback",
+        ),
+    ),
+    CommandExtensionSpec(
+        extension_id="command.platform.netlify",
+        name="Netlify command protection",
+        description="Reviews site deletion and production deployments.",
+        action_classes=("Netlify destructive command", "Netlify production command"),
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternatives=("Inspect the linked site and create a draft deploy before production changes.",),
+        reference_urls=(
+            "https://cli.netlify.com/commands/sites/",
+            "https://docs.netlify.com/api-and-cli-guides/cli-guides/get-started-with-cli/",
+        ),
+    ),
+    CommandExtensionSpec(
+        extension_id="command.platform.heroku",
+        name="Heroku command protection",
+        description="Reviews app destruction, pipeline promotion, and release rollback.",
+        action_classes=("Heroku destructive command", "Heroku release command"),
+        risk_classes=("destructive_shell", "network_egress"),
+        safer_alternatives=("Inspect app, pipeline, and release state before remote changes.",),
+        reference_urls=(
+            "https://devcenter.heroku.com/articles/heroku-cli-commands#heroku-apps-destroy",
+            "https://devcenter.heroku.com/articles/pipelines#promoting",
+            "https://devcenter.heroku.com/articles/releases#rollback",
+        ),
+    ),
+)

--- a/src/codex_plugin_scanner/guard/runtime/command_platform_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_platform_extensions.py
@@ -6,9 +6,23 @@ from .command_extension_matchers import executable_matcher, safe_flag_variant
 from .command_extension_specs import CommandExtensionSpec
 from .command_rules import AnyMatcher, CommandRuleSeverity, CommandSafetyRule, CommandSafeVariant
 
-_VERCEL_GLOBAL_OPTIONS = frozenset({"--cwd", "--global-config", "--local-config", "--scope", "--token"})
+_VERCEL_GLOBAL_OPTIONS = frozenset(
+    {
+        "--cwd",
+        "--global-config",
+        "--local-config",
+        "-A",
+        "--project",
+        "--scope",
+        "-S",
+        "--team",
+        "-T",
+        "--token",
+        "-t",
+    }
+)
 _VERCEL_GLOBAL_FLAGS = frozenset({"--debug", "--help", "--no-color"})
-_NETLIFY_GLOBAL_OPTIONS = frozenset({"--config", "--filter", "--site"})
+_NETLIFY_GLOBAL_OPTIONS = frozenset({"--auth", "--config", "--filter", "--site"})
 _NETLIFY_GLOBAL_FLAGS = frozenset({"--debug", "--help", "-h"})
 _HEROKU_GLOBAL_OPTIONS = frozenset({"--app", "-a", "--remote", "-r"})
 _HEROKU_GLOBAL_FLAGS = frozenset({"--help", "-h", "--prompt"})
@@ -21,18 +35,30 @@ _VERCEL_DELETION = AnyMatcher(
             global_options_with_values=_VERCEL_GLOBAL_OPTIONS,
             global_flags=_VERCEL_GLOBAL_FLAGS,
         )
-        for operation in (("remove",), ("project", "rm"))
+        for operation in (("remove",), ("rm",), ("project", "rm"))
     )
 )
 _VERCEL_PRODUCTION_CHANGE = AnyMatcher(
-    matchers=tuple(
-        executable_matcher(
-            "vercel",
-            *operation,
-            global_options_with_values=_VERCEL_GLOBAL_OPTIONS,
-            global_flags=_VERCEL_GLOBAL_FLAGS,
-        )
-        for operation in (("promote",), ("rollback",))
+    matchers=(
+        *(
+            executable_matcher(
+                "vercel",
+                *operation,
+                global_options_with_values=_VERCEL_GLOBAL_OPTIONS,
+                global_flags=_VERCEL_GLOBAL_FLAGS,
+            )
+            for operation in (("promote",), ("rollback",))
+        ),
+        *(
+            executable_matcher(
+                "vercel",
+                "deploy",
+                required_flags=frozenset({flag}),
+                global_options_with_values=_VERCEL_GLOBAL_OPTIONS,
+                global_flags=_VERCEL_GLOBAL_FLAGS,
+            )
+            for flag in ("--prod", "-p")
+        ),
     )
 )
 _VERCEL_PRODUCTION_STATUS = executable_matcher(
@@ -125,7 +151,7 @@ PLATFORM_COMMAND_RULES = (
     _platform_rule(
         rule_id="command.platform.vercel.production-change",
         title="Vercel production change",
-        description="Identifies promotion or rollback of a Vercel production deployment.",
+        description="Identifies deployment, promotion, or rollback of a Vercel production deployment.",
         matcher=_VERCEL_PRODUCTION_CHANGE,
         action_class="Vercel production command",
         safer_alternative="Inspect deployment state or promotion status before changing production.",
@@ -198,7 +224,7 @@ PLATFORM_COMMAND_EXTENSION_SPECS = (
     CommandExtensionSpec(
         extension_id="command.platform.vercel",
         name="Vercel command protection",
-        description="Reviews deployment and project deletion plus production promotion and rollback.",
+        description="Reviews deployment and project deletion plus production deployment, promotion, and rollback.",
         action_classes=("Vercel destructive command", "Vercel production command"),
         risk_classes=("destructive_shell", "network_egress"),
         safer_alternatives=("Inspect deployment, project, and promotion state before remote changes.",),

--- a/tests/test_guard_command_cicd_extensions.py
+++ b/tests/test_guard_command_cicd_extensions.py
@@ -1,0 +1,112 @@
+"""Structured CI/CD command extension tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+
+
+@pytest.mark.parametrize(
+    ("command", "action_class", "rule_id"),
+    [
+        ("gh run cancel 123", "GitHub Actions administrative command", "command.cicd.github.run-administration"),
+        ("gh run delete 123", "GitHub Actions administrative command", "command.cicd.github.run-administration"),
+        (
+            "gh --repo owner/project workflow disable release.yml",
+            "GitHub Actions administrative command",
+            "command.cicd.github.workflow-disable",
+        ),
+        (
+            "glab ci cancel pipeline 1504182795",
+            "GitLab pipeline administrative command",
+            "command.cicd.gitlab.pipeline-cancel",
+        ),
+        (
+            "circleci --host https://ci.example.test pipeline run org-id project-id",
+            "CircleCI pipeline execution command",
+            "command.cicd.circleci.pipeline-run",
+        ),
+        (
+            "gh.exe run --repo owner/project delete 123",
+            "GitHub Actions administrative command",
+            "command.cicd.github.run-administration",
+        ),
+        (
+            "glab.cmd ci cancel --repo group/project pipeline 1504182795",
+            "GitLab pipeline administrative command",
+            "command.cicd.gitlab.pipeline-cancel",
+        ),
+    ],
+)
+def test_cicd_rules_feed_inspection_and_runtime_hooks(
+    command: str,
+    action_class: str,
+    rule_id: str,
+    tmp_path: Path,
+) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert payload["classification"]["action_class"] == action_class
+    assert payload["controlling_rule_id"] == rule_id
+    runtime_match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert runtime_match is not None
+    assert runtime_match.action_class == action_class
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "gh run cancel --help",
+        "gh workflow view release.yml",
+        "gh run view 123",
+        "glab ci cancel pipeline 1504182795 --dry-run",
+        "glab ci cancel pipeline --help",
+        "circleci pipeline run --help",
+        "circleci config validate .circleci/config.yml",
+        "grep 'gh run delete|glab ci cancel' scripts/checks.sh",
+        "printf '%s\\n' 'circleci pipeline run org project'",
+    ],
+)
+def test_cicd_help_preview_and_read_commands_remain_safe(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "no_match"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_cicd_safe_variant_does_not_hide_destructive_segment(tmp_path: Path) -> None:
+    payload = inspect_command(
+        "glab ci cancel pipeline 10 --dry-run && gh workflow disable release.yml",
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert [rule["rule_id"] for rule in payload["rules"]] == ["command.cicd.github.workflow-disable"]
+
+
+def test_cicd_extensions_publish_primary_references() -> None:
+    for extension_id in ("command.cicd.github", "command.cicd.gitlab", "command.cicd.circleci"):
+        extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.get(extension_id)
+
+        assert extension is not None
+        assert extension.reference_urls
+        assert all(url.startswith("https://") for url in extension.reference_urls)

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -93,7 +93,7 @@ def test_command_extension_registry_is_deterministic_and_complete() -> None:
     assert "command.shell-mutations" in ids
     assert BUILT_IN_COMMAND_EXTENSION_REGISTRY.for_action_class("destructive shell command") is not None
     assert BUILT_IN_COMMAND_EXTENSION_REGISTRY.rule_for_action_class("destructive shell command") is not None
-    assert sum(extension["rule_count"] for extension in payload["extensions"]) == 47
+    assert sum(extension["rule_count"] for extension in payload["extensions"]) == 57
 
 
 @pytest.mark.parametrize(

--- a/tests/test_guard_command_platform_extensions.py
+++ b/tests/test_guard_command_platform_extensions.py
@@ -15,9 +15,17 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
     ("command", "action_class", "rule_id"),
     [
         ("vercel remove app.example.test", "Vercel destructive command", "command.platform.vercel.deletion"),
+        ("vercel rm app.example.test", "Vercel destructive command", "command.platform.vercel.deletion"),
         ("vercel project rm web", "Vercel destructive command", "command.platform.vercel.deletion"),
         ("vercel promote deployment-id", "Vercel production command", "command.platform.vercel.production-change"),
+        (
+            "vercel -t token-value -S team promote deployment-id",
+            "Vercel production command",
+            "command.platform.vercel.production-change",
+        ),
         ("vercel rollback deployment-id", "Vercel production command", "command.platform.vercel.production-change"),
+        ("vercel deploy --prod", "Vercel production command", "command.platform.vercel.production-change"),
+        ("vercel deploy -p", "Vercel production command", "command.platform.vercel.production-change"),
         (
             "netlify sites:delete --site site-id",
             "Netlify destructive command",
@@ -35,6 +43,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
         ("vercel.cmd --scope team project rm web", "Vercel destructive command", "command.platform.vercel.deletion"),
         (
             "netlify.exe deploy --site site-id --prod",
+            "Netlify production command",
+            "command.platform.netlify.production-deploy",
+        ),
+        (
+            "netlify --auth token-value deploy --prod",
             "Netlify production command",
             "command.platform.netlify.production-deploy",
         ),
@@ -67,6 +80,7 @@ def test_platform_rules_feed_inspection_and_runtime_hooks(
         "vercel remove --help",
         "vercel promote status web",
         "vercel project inspect web",
+        "vercel list --prod",
         "netlify sites:delete --help",
         "netlify deploy --dir dist",
         "netlify build --dry",

--- a/tests/test_guard_command_platform_extensions.py
+++ b/tests/test_guard_command_platform_extensions.py
@@ -1,0 +1,111 @@
+"""Structured hosting platform command extension tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
+from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+
+
+@pytest.mark.parametrize(
+    ("command", "action_class", "rule_id"),
+    [
+        ("vercel remove app.example.test", "Vercel destructive command", "command.platform.vercel.deletion"),
+        ("vercel project rm web", "Vercel destructive command", "command.platform.vercel.deletion"),
+        ("vercel promote deployment-id", "Vercel production command", "command.platform.vercel.production-change"),
+        ("vercel rollback deployment-id", "Vercel production command", "command.platform.vercel.production-change"),
+        (
+            "netlify sites:delete --site site-id",
+            "Netlify destructive command",
+            "command.platform.netlify.site-deletion",
+        ),
+        (
+            "netlify deploy --prod --dir dist",
+            "Netlify production command",
+            "command.platform.netlify.production-deploy",
+        ),
+        ("netlify deploy -p --dir dist", "Netlify production command", "command.platform.netlify.production-deploy"),
+        ("heroku apps:destroy --app web", "Heroku destructive command", "command.platform.heroku.app-destruction"),
+        ("heroku pipelines:promote -a web", "Heroku release command", "command.platform.heroku.release-change"),
+        ("heroku releases:rollback v42 -a web", "Heroku release command", "command.platform.heroku.release-change"),
+        ("vercel.cmd --scope team project rm web", "Vercel destructive command", "command.platform.vercel.deletion"),
+        (
+            "netlify.exe deploy --site site-id --prod",
+            "Netlify production command",
+            "command.platform.netlify.production-deploy",
+        ),
+    ],
+)
+def test_platform_rules_feed_inspection_and_runtime_hooks(
+    command: str,
+    action_class: str,
+    rule_id: str,
+    tmp_path: Path,
+) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert payload["classification"]["action_class"] == action_class
+    assert payload["controlling_rule_id"] == rule_id
+    runtime_match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert runtime_match is not None
+    assert runtime_match.action_class == action_class
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "vercel remove --help",
+        "vercel promote status web",
+        "vercel project inspect web",
+        "netlify sites:delete --help",
+        "netlify deploy --dir dist",
+        "netlify build --dry",
+        "heroku apps:destroy --help",
+        "heroku apps:info -a web",
+        "heroku releases:info v42 -a web",
+        "grep 'vercel remove|netlify sites:delete' scripts/checks.sh",
+        "printf '%s\\n' 'heroku apps:destroy -a web'",
+    ],
+)
+def test_platform_help_preview_and_read_commands_remain_safe(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "no_match"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
+def test_platform_safe_variant_does_not_hide_destructive_segment(tmp_path: Path) -> None:
+    payload = inspect_command(
+        "vercel remove --help && heroku apps:destroy -a web",
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert [rule["rule_id"] for rule in payload["rules"]] == ["command.platform.heroku.app-destruction"]
+
+
+def test_platform_extensions_publish_primary_references() -> None:
+    for extension_id in ("command.platform.vercel", "command.platform.netlify", "command.platform.heroku"):
+        extension = BUILT_IN_COMMAND_EXTENSION_REGISTRY.get(extension_id)
+
+        assert extension is not None
+        assert extension.reference_urls
+        assert all(url.startswith("https://") for url in extension.reference_urls)


### PR DESCRIPTION
## Summary
- add structured command protection for remote pipeline administration and execution
- review destructive and production-changing hosting operations while preserving documented previews and inspection variants

## Testing
- `uv run --no-sync pytest tests/test_guard_command_*extensions.py tests/test_guard_command_extension_registry.py --tb=short`
- `uv run --no-sync ruff check src/codex_plugin_scanner/guard/runtime/command_cicd_extensions.py src/codex_plugin_scanner/guard/runtime/command_platform_extensions.py tests/test_guard_command_cicd_extensions.py tests/test_guard_command_platform_extensions.py`
- `uv tool run basedpyright src/codex_plugin_scanner/guard/runtime/command_cicd_extensions.py src/codex_plugin_scanner/guard/runtime/command_platform_extensions.py`
- `uv build`
- `uv tool run --from dist/hol_guard-2.0.1096-py3-none-any.whl hol-guard --version`
