### PR TITLE
Guard explicit TypeScript package overrides

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
+++ b/src/codex_plugin_scanner/guard/runtime/package_intent_parser.py
@@ -313,6 +313,8 @@ def _is_verified_read_only_typescript_check(
     tokens: tuple[str, ...],
     evidence: LocalPackageExecutionEvidence,
 ) -> bool:
+    if any(token == "--package" or token.startswith("--package=") for token in tokens[1:]):
+        return False
     if evidence.package_name not in {"tsc", "typescript"} or evidence.executable_name != "tsc":
         return False
     required_files = (evidence.manager, evidence.local_executable, *evidence.manifests, *evidence.lockfiles)

--- a/tests/test_guard_package_intent.py
+++ b/tests/test_guard_package_intent.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import pytest
 
 from codex_plugin_scanner.guard.runtime import package_intent_parser
-from codex_plugin_scanner.guard.runtime.command_model import parse_shell_command
 from codex_plugin_scanner.guard.runtime.package_intent import (
     extract_package_intent_request,
     parse_manifest_dependency_changes,
@@ -321,9 +320,18 @@ def test_parse_package_intent_allows_verified_local_typescript_check(
     assert parse_package_intent(command, workspace=workspace) is None
 
 
-def test_parse_package_intent_allows_explicit_verified_typescript_package(
+@pytest.mark.parametrize(
+    "command",
+    (
+        "npx --package typescript tsc --noEmit",
+        "npx --package tsc@file:./evil tsc --noEmit",
+        "npx --package=tsc@file:./evil tsc --noEmit",
+    ),
+)
+def test_parse_package_intent_keeps_explicit_typescript_package_guarded(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
+    command: str,
 ) -> None:
     _write_text(tmp_path / "package.json", '{"devDependencies":{"typescript":"^5.9.0"}}\n')
     _write_text(tmp_path / "package-lock.json", '{"packages":{"node_modules/typescript":{"version":"5.9.0"}}}\n')
@@ -335,7 +343,7 @@ def test_parse_package_intent_allows_explicit_verified_typescript_package(
     manager.chmod(0o755)
     monkeypatch.setenv("PATH", str(manager.parent))
 
-    assert parse_package_intent("npx --package typescript tsc --noEmit", workspace=tmp_path) is None
+    assert parse_package_intent(command, workspace=tmp_path) is not None
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- keep explicit `npx --package` selections on Guard's reviewed package-execution path
- preserve automatic allowance for verified local `npx tsc --noEmit` checks without package overrides
- add regressions for spaced and equals-form local package sources

## Security boundary

The TypeScript fast path now applies only when package identity comes from the positional executable and matches verified workspace evidence. An explicit package selector can change what `npx` installs and executes, so it is never eligible for automatic allowance.

## Verification

- `uv run pytest tests/test_guard_package_intent.py tests/test_guard_package_runner_identity.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/package_intent_parser.py tests/test_guard_package_intent.py`
- `uv run --with basedpyright basedpyright src/codex_plugin_scanner/guard/runtime/package_intent_parser.py --level error`
- `uv build`
