### PR TITLE
fix(commands): honor effective safe flag values

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -14,6 +14,7 @@ CommandRuleMode = Literal["required", "enforce", "review", "monitor", "disabled"
 _VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
 _VALID_MODES = frozenset({"required", "enforce", "review", "monitor", "disabled"})
 _EMPTY_STRING_SET: frozenset[str] = frozenset()
+_TRUTHY_FLAG_VALUES = frozenset({"1", "on", "true", "yes"})
 
 
 @final
@@ -366,14 +367,28 @@ def _present_flags(
     options_with_values: frozenset[str] = _EMPTY_STRING_SET,
 ) -> frozenset[str]:
     flags: set[str] = set()
+    # Safe variants honor the final long-option assignment, matching common CLI parsers.
+    effective_long_options: dict[str, tuple[str, str | None, bool]] = {}
     index = 0
     while index < len(arguments):
         argument = arguments[index]
         if argument == "--":
             break
-        flags.add(argument)
-        if argument.startswith("-") and "=" in argument:
-            flags.add(argument.split("=", 1)[0])
+        option_name, separator, option_value = argument.partition("=")
+        is_long_option = argument.startswith("--")
+        is_value_option = option_name in options_with_values
+        if is_long_option:
+            if is_value_option and not separator:
+                option_value = arguments[index + 1] if index + 1 < len(arguments) else ""
+            effective_long_options[option_name] = (
+                argument,
+                option_value if separator or is_value_option else None,
+                is_value_option,
+            )
+        else:
+            flags.add(argument)
+            if argument.startswith("-") and separator:
+                flags.add(option_name)
         if argument.startswith("-") and not argument.startswith("--") and len(argument) > 2:
             for character in argument[1:]:
                 if not character.isalnum():
@@ -382,8 +397,11 @@ def _present_flags(
                 flags.add(short_flag)
                 if short_flag in options_with_values:
                     break
-        option_name = argument.split("=", 1)[0]
         index += 2 if option_name in options_with_values and "=" not in argument else 1
+    for option_name, (argument, option_value, is_value_option) in effective_long_options.items():
+        flags.add(argument)
+        if is_value_option or option_value is None or option_value in _TRUTHY_FLAG_VALUES:
+            flags.add(option_name)
     return frozenset(flags)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -389,8 +389,8 @@ def _present_flags(
             flags.add(argument)
             if argument.startswith("-") and separator:
                 flags.add(option_name)
-        if argument.startswith("-") and not argument.startswith("--") and len(argument) > 2:
-            for character in argument[1:]:
+        if option_name.startswith("-") and not option_name.startswith("--") and len(option_name) > 2:
+            for character in option_name[1:]:
                 if not character.isalnum():
                     continue
                 short_flag = f"-{character}"

--- a/tests/test_guard_command_database_extensions.py
+++ b/tests/test_guard_command_database_extensions.py
@@ -145,6 +145,50 @@ def test_database_observer_and_preview_commands_remain_safe(command: str, tmp_pa
     )
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "mongorestore --drop --dryRun=false --archive=backup.archive",
+        "mongorestore --drop --dryRun --dryRun=false --archive=backup.archive",
+    ],
+)
+def test_mongodb_false_or_overridden_dry_run_remains_live_execution(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is not None
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "mongorestore --drop --dryRun=true --archive=backup.archive",
+        "mongorestore --drop --dryRun=false --dryRun --archive=backup.archive",
+    ],
+)
+def test_mongodb_truthy_or_effective_dry_run_remains_quiet(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "no_match"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
 def test_database_extensions_publish_official_references() -> None:
     for extension_id in (
         "command.database.postgresql",

--- a/tests/test_guard_command_domain_extensions.py
+++ b/tests/test_guard_command_domain_extensions.py
@@ -143,6 +143,65 @@ def test_kubernetes_dry_run_none_remains_live_execution(command: str, tmp_path: 
     ) is not None
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "docker system prune --help=false",
+        "docker system prune --help --help=false",
+        "kubectl delete deployment api --help=false",
+        "kubectl delete deployment api --dry-run=client --dry-run=none",
+        "kubectl drain node-a --dry-run=server --dry-run=false",
+        "helm uninstall api --dry-run=false",
+        "helm uninstall api --dry-run --dry-run=false",
+        "terraform destroy --help=false",
+        "tofu destroy --help --help=false",
+        "pulumi destroy --preview-only=false",
+        "pulumi destroy --preview-only --preview-only=false",
+    ],
+)
+def test_false_or_overridden_safe_variants_remain_live_execution(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is not None
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "docker system prune --help=true",
+        "kubectl delete deployment api --help=true",
+        "kubectl delete deployment api --dry-run=none --dry-run=client",
+        "helm uninstall api --dry-run=true",
+        "terraform destroy --help=true",
+        "tofu destroy --help=false --help",
+        "pulumi destroy --preview-only=true",
+        "pulumi destroy --preview-only=false --preview-only=yes",
+    ],
+)
+def test_truthy_or_effective_safe_variants_remain_quiet(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "no_match"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
 def test_container_argument_named_help_remains_runtime_execution(tmp_path: Path) -> None:
     payload = inspect_command("docker run alpine --help", cwd=tmp_path, home_dir=tmp_path)
 

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import pytest
+
 from codex_plugin_scanner.guard.runtime.command_model import MAX_COMMAND_BYTES, parse_shell_command
 from codex_plugin_scanner.guard.runtime.command_rules import (
     AllMatcher,
@@ -103,6 +105,56 @@ def test_executable_matcher_normalizes_flag_value_and_windows_path_forms() -> No
     )
 
     assert matcher.match(parsed)
+
+
+@pytest.mark.parametrize(
+    ("arguments", "matches"),
+    [
+        ("--help", True),
+        ("--help=true", True),
+        ("--help=1", True),
+        ("--help=yes", True),
+        ("--help=on", True),
+        ("--help=false", False),
+        ("--help=0", False),
+        ("--help=no", False),
+        ("--help=off", False),
+        ("--help --help=false", False),
+        ("--help=false --help", True),
+        ("--help=true --help=off --help=yes", True),
+    ],
+)
+def test_executable_matcher_uses_effective_boolean_flag_value(arguments: str, matches: bool) -> None:
+    matcher = ExecutableMatcher(
+        executables=frozenset({"tool"}),
+        subcommands=("delete",),
+        required_flags=frozenset({"--help"}),
+    )
+
+    evidence = matcher.match(parse_shell_command(f"tool delete target {arguments}"))
+
+    assert bool(evidence) is matches
+
+
+@pytest.mark.parametrize(
+    ("arguments", "matches"),
+    [
+        ("--dry-run=client", True),
+        ("--dry-run=client --dry-run=none", False),
+        ("--dry-run=none --dry-run=client", True),
+        ("--dry-run=client --dry-run=false", False),
+    ],
+)
+def test_executable_matcher_uses_effective_exact_option_value(arguments: str, matches: bool) -> None:
+    matcher = ExecutableMatcher(
+        executables=frozenset({"tool"}),
+        subcommands=("delete",),
+        required_flags=frozenset({"--dry-run=client"}),
+    )
+
+    evidence = matcher.match(parse_shell_command(f"tool delete target {arguments}"))
+
+    assert bool(evidence) is matches
 
 
 def test_executable_matcher_can_skip_declared_global_options() -> None:

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -119,6 +119,7 @@ def test_executable_matcher_normalizes_flag_value_and_windows_path_forms() -> No
         ("--help=0", False),
         ("--help=no", False),
         ("--help=off", False),
+        ("--help=auto", False),
         ("--help --help=false", False),
         ("--help=false --help", True),
         ("--help=true --help=off --help=yes", True),
@@ -199,6 +200,17 @@ def test_executable_matcher_does_not_treat_option_values_as_flags() -> None:
         subcommands=("clean",),
         required_flags=frozenset({"-f"}),
         options_with_values=frozenset({"-e"}),
+    )
+
+    assert matcher.match(parsed) == ()
+
+
+def test_executable_matcher_does_not_unpack_attached_short_option_value() -> None:
+    parsed = parse_shell_command("tool delete -d=client")
+    matcher = ExecutableMatcher(
+        executables=frozenset({"tool"}),
+        subcommands=("delete",),
+        required_flags=frozenset({"-c"}),
     )
 
     assert matcher.match(parsed) == ()


### PR DESCRIPTION
## Summary
- evaluate the effective final value of safe command flags before suppressing review
- add matcher and runtime coverage for disabled, repeated, and enabled safe variants

## Testing
- `pytest tests/test_guard_command_model.py tests/test_guard_command_domain_extensions.py tests/test_guard_command_database_extensions.py --tb=short`
- `pytest tests/test_guard_command_*extensions.py --tb=short`
- `ruff check src/codex_plugin_scanner/guard/runtime/command_rules.py tests/test_guard_command_model.py tests/test_guard_command_domain_extensions.py tests/test_guard_command_database_extensions.py`
- `basedpyright --level error src/codex_plugin_scanner/guard/runtime/command_rules.py`
- `uv build`
- `uv tool run --from dist/hol_guard-2.0.1098-py3-none-any.whl hol-guard --version`
