### PR TITLE
fix(commands): strengthen structured safety classification

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
@@ -19,6 +19,7 @@ from .command_rules import (
 )
 from .command_search_messaging_extensions import SEARCH_MESSAGING_COMMAND_RULES
 from .command_storage_extensions import STORAGE_COMMAND_RULES
+from .command_structured_matchers import SubcommandOperandPrefixMatcher
 
 COMMAND_ACTION_RISK_CLASSES: dict[str, tuple[str, ...]] = {
     "credential exfiltration shell command": (
@@ -73,6 +74,13 @@ _GIT_SUBCOMMAND_OPTIONS_WITH_VALUES = {
     "push": frozenset({"--exec", "--push-option", "--receive-pack", "--repo", "-o"}),
     "reset": frozenset({"--pathspec-from-file"}),
 }
+_GIT_FORCE_REFSPEC = SubcommandOperandPrefixMatcher(
+    executables=frozenset({"git"}),
+    subcommands=("push",),
+    operand_prefixes=frozenset({"+"}),
+    leading_options_with_values=_GIT_GLOBAL_OPTIONS_WITH_VALUES,
+    options_with_values=_GIT_SUBCOMMAND_OPTIONS_WITH_VALUES["push"],
+)
 
 
 def _git_matcher(subcommand: str, *, required_flags: frozenset[str]) -> ExecutableMatcher:
@@ -279,6 +287,7 @@ BUILT_IN_COMMAND_RULES = (
             matchers=(
                 _git_matcher("push", required_flags=frozenset({"--force"})),
                 _git_matcher("push", required_flags=frozenset({"-f"})),
+                _GIT_FORCE_REFSPEC,
             )
         ),
         action_class="git destructive command",

--- a/src/codex_plugin_scanner/guard/runtime/command_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_model.py
@@ -333,6 +333,16 @@ def _embedded_execution(
         )
         executable = executable_name(owner.executable) if owner is not None else None
         if executable not in _SHELL_SCRIPT_EXECUTABLES:
+            if not heredoc.quoted:
+                _append_substitution_execution(
+                    heredoc.body,
+                    source_offset=heredoc.body_start,
+                    context_prefix=f"heredoc:{index}:substitution",
+                    excluded_ranges=(),
+                    embedded=embedded,
+                    segments=segments,
+                    depth=0,
+                )
             continue
         context = f"heredoc:{index}"
         embedded.append(

--- a/src/codex_plugin_scanner/guard/runtime/command_search_messaging_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_search_messaging_extensions.py
@@ -68,17 +68,20 @@ class CurlElasticsearchDeleteMatcher:
         return tuple(evidence)
 
     def _matches_target(self, target: str) -> bool:
-        lowered = target.lower()
+        normalized = target.strip("'\"")
+        lowered = normalized.lower()
         if lowered.startswith(("$elasticsearch_", "${elasticsearch_")):
             return "/" in lowered
         try:
-            parsed = urlsplit(target)
+            explicit_scheme = "://" in normalized
+            parsed = urlsplit(normalized if explicit_scheme else f"//{normalized}")
             port = parsed.port
         except ValueError:
             return False
         hostname = parsed.hostname or ""
         recognizable_host = port in self.service_ports or "elasticsearch" in hostname.split(".")
-        return parsed.scheme in {"http", "https"} and recognizable_host and parsed.path not in {"", "/"}
+        supported_scheme = parsed.scheme in {"http", "https"} if explicit_scheme else not parsed.scheme
+        return supported_scheme and recognizable_host and parsed.path not in {"", "/"}
 
 
 def _curl_method_and_targets(arguments: tuple[str, ...]) -> tuple[str | None, tuple[str, ...]]:
@@ -98,11 +101,19 @@ def _curl_method_and_targets(arguments: tuple[str, ...]) -> tuple[str | None, tu
             method = arguments[index + 1].lower()
             index += 2
             continue
+        if lowered == "--url" and index + 1 < len(arguments):
+            targets.append(arguments[index + 1].strip("'\""))
+            index += 2
+            continue
+        if lowered.startswith("--url="):
+            targets.append(argument.split("=", 1)[1].strip("'\""))
+            index += 1
+            continue
         if lowered.startswith("--request="):
             method = lowered.split("=", 1)[1]
         elif argument.startswith("-X") and len(argument) > 2:
             method = argument[2:].lower()
-        if argument.startswith(("http://", "https://", "$")):
+        if not argument.startswith("-"):
             targets.append(argument.strip("'\""))
         index += 1
     return method, tuple(targets)

--- a/src/codex_plugin_scanner/guard/runtime/command_structured_matchers.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_structured_matchers.py
@@ -58,6 +58,59 @@ class LeadingOperandCountMatcher:
 
 @final
 @dataclass(frozen=True, slots=True)
+class SubcommandOperandPrefixMatcher:
+    """Match prefixed operands for a subcommand without scanning option values."""
+
+    executables: frozenset[str]
+    subcommands: tuple[str, ...]
+    operand_prefixes: frozenset[str]
+    leading_options_with_values: frozenset[str] = frozenset()
+    options_with_values: frozenset[str] = frozenset()
+
+    def __post_init__(self) -> None:
+        normalized_executables = frozenset(value.strip().lower() for value in self.executables if value.strip())
+        normalized_subcommands = tuple(value.strip().lower() for value in self.subcommands if value.strip())
+        normalized_prefixes = frozenset(value for value in self.operand_prefixes if value)
+        if not normalized_executables or not normalized_subcommands or not normalized_prefixes:
+            raise ValueError("SubcommandOperandPrefixMatcher requires executables, subcommands, and prefixes")
+        object.__setattr__(self, "executables", normalized_executables)
+        object.__setattr__(self, "subcommands", normalized_subcommands)
+        object.__setattr__(self, "operand_prefixes", normalized_prefixes)
+
+    def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
+        evidence: list[MatcherEvidence] = []
+        for index, segment in enumerate(command.segments):
+            if not _segment_matches_executable(segment, self.executables):
+                continue
+            _flags, leading_operands = leading_flags_and_operands(
+                segment.arguments,
+                options_with_values=self.leading_options_with_values,
+            )
+            lowered = tuple(value.lower() for value in leading_operands)
+            if lowered[: len(self.subcommands)] != self.subcommands:
+                continue
+            operands = _operands_without_options(
+                leading_operands[len(self.subcommands) :],
+                options_with_values=self.options_with_values,
+            )
+            if not any(
+                len(operand) > len(prefix) and operand.startswith(prefix)
+                for operand in operands
+                for prefix in self.operand_prefixes
+            ):
+                continue
+            evidence.append(
+                MatcherEvidence(
+                    segment_index=index,
+                    executable=segment.executable,
+                    detail="Matched a structured subcommand operand prefix.",
+                )
+            )
+        return tuple(evidence)
+
+
+@final
+@dataclass(frozen=True, slots=True)
 class OptionValueKeyMatcher:
     """Match documented option values whose leading key has execution semantics."""
 
@@ -159,6 +212,8 @@ def structured_matcher_index_hints(matcher: CommandMatcher) -> tuple[frozenset[s
 
     if isinstance(matcher, LeadingOperandCountMatcher):
         return matcher.executables, frozenset()
+    if isinstance(matcher, SubcommandOperandPrefixMatcher):
+        return matcher.executables, frozenset(matcher.subcommands)
     if isinstance(matcher, OptionValueKeyMatcher):
         return matcher.executables, matcher.option_names
     if isinstance(matcher, EnvironmentNameMatcher):
@@ -237,7 +292,16 @@ def _option_values(arguments: tuple[str, ...], option_names: frozenset[str]) -> 
             ),
             None,
         )
+        clustered_match = _clustered_short_value(argument, option_names)
         if matched_option is None:
+            if clustered_match is not None:
+                _option, value = clustered_match
+                if value:
+                    values.append(value)
+                elif index + 1 < len(arguments):
+                    values.append(arguments[index + 1])
+                    index += 2
+                    continue
             index += 1
             continue
         if argument == matched_option:
@@ -251,6 +315,49 @@ def _option_values(arguments: tuple[str, ...], option_names: frozenset[str]) -> 
             values.append(argument[len(matched_option) :])
         index += 1
     return tuple(values)
+
+
+def _operands_without_options(
+    arguments: tuple[str, ...],
+    *,
+    options_with_values: frozenset[str],
+) -> tuple[str, ...]:
+    operands: list[str] = []
+    index = 0
+    parse_options = True
+    while index < len(arguments):
+        argument = arguments[index]
+        if parse_options and argument == "--":
+            parse_options = False
+            index += 1
+            continue
+        if parse_options and argument.startswith("-") and argument != "-":
+            option_name = _normalize_option_token(argument.split("=", 1)[0])
+            clustered_match = _clustered_short_value(argument, options_with_values)
+            takes_separate_value = option_name in options_with_values and "=" not in argument
+            if clustered_match is not None:
+                _option, attached_value = clustered_match
+                takes_separate_value = not attached_value
+            index += 2 if takes_separate_value else 1
+            continue
+        operands.append(argument)
+        index += 1
+    return tuple(operands)
+
+
+def _clustered_short_value(
+    argument: str,
+    option_names: frozenset[str],
+) -> tuple[str, str] | None:
+    if not argument.startswith("-") or argument.startswith("--") or len(argument) <= 2:
+        return None
+    for offset, character in enumerate(argument[1:], start=1):
+        if not character.isalnum():
+            return None
+        option = f"-{character}"
+        if option in option_names:
+            return option, argument[offset + 1 :]
+    return None
 
 
 def _normalize_option_token(value: str) -> str:

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -174,28 +174,6 @@ def test_structured_core_rules_feed_runtime_classification(
 @pytest.mark.parametrize(
     "command",
     [
-        "git push origin +main",
-        "git push origin +refs/heads/main:refs/heads/main",
-    ],
-)
-def test_git_force_push_refspecs_feed_runtime_classification(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-    match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-
-    assert payload["status"] == "review"
-    assert payload["controlling_rule_id"] == "command.git.force-push"
-    assert match is not None
-    assert match.action_class == "git destructive command"
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
         "git clean -nfdx",
         "git clean --dry-run -fdx",
         "git push origin main --force --dry-run",

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -70,6 +70,10 @@ def test_command_inspection_maps_existing_sensitive_actions_to_extensions(
     [
         "grep 'git reset|rm -rf|browser' scripts/guard-test",
         "printf '%s\\n' 'rm -rf ./build'",
+        "printf '%s\\n' '+refs/heads/main:refs/heads/main'",
+        "git push --push-option +audit origin main",
+        "git push --push-option=+audit origin main",
+        "git push -o+audit origin main",
         "bunx vitest run __tests__/guard-review.test.ts",
         "rg 'destructive shell command' src tests | head -20",
         "git status --short",
@@ -170,9 +174,32 @@ def test_structured_core_rules_feed_runtime_classification(
 @pytest.mark.parametrize(
     "command",
     [
+        "git push origin +main",
+        "git push origin +refs/heads/main:refs/heads/main",
+    ],
+)
+def test_git_force_push_refspecs_feed_runtime_classification(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+    match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert payload["status"] == "review"
+    assert payload["controlling_rule_id"] == "command.git.force-push"
+    assert match is not None
+    assert match.action_class == "git destructive command"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
         "git clean -nfdx",
         "git clean --dry-run -fdx",
         "git push origin main --force --dry-run",
+        "git push --dry-run origin +refs/heads/main:refs/heads/main",
         "shutdown --help",
         "mkfs --version",
         "Format-Volume -DriveLetter D -WhatIf",
@@ -405,9 +432,12 @@ def test_command_cli_lists_one_extension_and_rejects_unknown_ids(capsys: pytest.
 def test_inspection_does_not_classify_literal_heredoc_data(tmp_path: Path) -> None:
     body = "r" + "m -rf ./build"
     data = inspect_command(f"cat <<'EOF'\n{body}\nEOF", cwd=tmp_path, home_dir=tmp_path)
+    expanded = inspect_command(f"cat <<EOF\n$({body})\nEOF", cwd=tmp_path, home_dir=tmp_path)
     script = inspect_command(f"bash <<'EOF'\n{body}\nEOF", cwd=tmp_path, home_dir=tmp_path)
 
     assert data["status"] == "no_match"
+    assert expanded["status"] == "review"
+    assert "command.filesystem.recursive-delete" in {rule["rule_id"] for rule in expanded["rules"]}
     assert script["status"] == "review"
     assert "command.filesystem.recursive-delete" in {rule["rule_id"] for rule in script["rules"]}
 

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -219,6 +219,17 @@ def test_parse_shell_command_distinguishes_heredoc_data_from_executable_script()
     assert script.redirects[0].target == "EOF"
 
 
+def test_parse_shell_command_extracts_substitutions_from_unquoted_data_heredocs() -> None:
+    body = "r" + "m -rf ./build"
+    expanded = parse_shell_command(f"cat <<EOF\n$({body})\nEOF")
+    literal = parse_shell_command(f"cat <<'EOF'\n$({body})\nEOF")
+
+    assert [segment.executable for segment in expanded.segments] == ["cat", "rm"]
+    assert expanded.segments[1].execution_context == "heredoc:0:substitution:0:0"
+    assert literal.embedded_commands == ()
+    assert [segment.executable for segment in literal.segments] == ["cat"]
+
+
 def test_parse_shell_command_preserves_tab_stripped_heredoc_segment_spans() -> None:
     command = "bash <<-EOF\n\techo hello\nEOF"
 

--- a/tests/test_guard_command_remote_extensions.py
+++ b/tests/test_guard_command_remote_extensions.py
@@ -50,6 +50,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.remote.ssh.configured-execution",
         ),
         (
+            "ssh -voProxyCommand='sh -c id' host.example",
+            "SSH configured execution command",
+            "command.remote.ssh.configured-execution",
+        ),
+        (
+            "ssh -4oRemoteCommand='id' host.example",
+            "SSH configured execution command",
+            "command.remote.ssh.configured-execution",
+        ),
+        (
             "ssh -oLocalCommand='sh -c id' -oPermitLocalCommand=yes host.example",
             "SSH configured execution command",
             "command.remote.ssh.configured-execution",
@@ -120,6 +130,7 @@ def test_remote_rules_feed_runtime_hooks(
         "ssh host.example",
         "ssh -G host.example uptime",
         "ssh -vG host.example uptime",
+        "ssh -vGoProxyCommand='sh -c id' host.example",
         "ssh -V",
         "ssh -V host.example uptime",
         "ssh -Q cipher host.example uptime",
@@ -128,6 +139,8 @@ def test_remote_rules_feed_runtime_hooks(
         "ssh -O check host.example uptime",
         "ssh -o StrictHostKeyChecking=no host.example",
         "ssh -vo StrictHostKeyChecking=no host.example",
+        "ssh -voStrictHostKeyChecking=no host.example",
+        "ssh -voProxyCommand=none host.example",
         "ssh -G -oProxyCommand='sh -c id' host.example",
         "ssh -oProxyCommand=none host.example",
         "ssh -oLocalCommand='sh -c id' host.example",

--- a/tests/test_guard_command_search_messaging_extensions.py
+++ b/tests/test_guard_command_search_messaging_extensions.py
@@ -30,6 +30,26 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.search.elasticsearch.delete",
         ),
         (
+            "curl -X DELETE --url localhost:9200/customer-index",
+            "Elasticsearch destructive command",
+            "command.search.elasticsearch.delete",
+        ),
+        (
+            "curl -X DELETE --url=http://localhost:9200/customer-index",
+            "Elasticsearch destructive command",
+            "command.search.elasticsearch.delete",
+        ),
+        (
+            "curl -X DELETE --url=localhost:9200/customer-index",
+            "Elasticsearch destructive command",
+            "command.search.elasticsearch.delete",
+        ),
+        (
+            "curl -X DELETE elasticsearch:9200/customer-index",
+            "Elasticsearch destructive command",
+            "command.search.elasticsearch.delete",
+        ),
+        (
             "kafka-topics.sh --bootstrap-server localhost:9092 --delete --topic events",
             "Kafka destructive command",
             "command.messaging.kafka.delete",
@@ -113,8 +133,11 @@ def test_search_messaging_rules_feed_runtime_hooks(
     [
         "curl -X DELETE https://api.example.com/users/1",
         "curl -X DELETE https://api.example.com/_snapshot/old",
+        "curl -X DELETE --url api.example.com/users/1",
+        "curl -X DELETE --url=https://api.example.com/users/1",
         "curl -x http://localhost:9200/customer-index https://api.example.com/users/1",
         "curl http://localhost:9200/customer-index",
+        "curl --url localhost:9200/customer-index",
         "curl -X GET http://localhost:9200/customer-index",
         "kafka-topics.sh --bootstrap-server localhost:9092 --list",
         "kafka-topics.sh --delete --help",

--- a/tests/test_guard_command_specialized_variants.py
+++ b/tests/test_guard_command_specialized_variants.py
@@ -1,0 +1,32 @@
+"""Focused regressions for specialized structured command variants."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git push origin +main",
+        "git push origin +refs/heads/main:refs/heads/main",
+    ],
+)
+def test_git_force_push_refspecs_feed_runtime_classification(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+    match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert payload["status"] == "review"
+    assert payload["controlling_rule_id"] == "command.git.force-push"
+    assert match is not None
+    assert match.action_class == "git destructive command"


### PR DESCRIPTION
## Summary
- strengthen structured command classification for specialized destructive command forms
- preserve preview, observer, literal-data, and non-target command behavior with regression coverage

## Testing
- `uv run --no-sync pytest tests/test_guard_command_model.py tests/test_guard_command_extensions.py tests/test_guard_command_specialized_variants.py tests/test_guard_command_remote_extensions.py tests/test_guard_command_search_messaging_extensions.py --tb=short -q`
- `ruff check src/codex_plugin_scanner/guard/runtime/command_structured_matchers.py src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py src/codex_plugin_scanner/guard/runtime/command_model.py src/codex_plugin_scanner/guard/runtime/command_search_messaging_extensions.py tests/test_guard_command_extensions.py tests/test_guard_command_model.py tests/test_guard_command_specialized_variants.py tests/test_guard_command_remote_extensions.py tests/test_guard_command_search_messaging_extensions.py`
- `uv run --no-sync basedpyright`
- `uv build`
- `uv tool run --from dist/hol_guard-*.whl hol-guard --version`
