### PR TITLE
chore(release): sync repository version to 2.0.1103 [skip release publish]

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "hol-guard"
-version = "2.0.1100"
+version = "2.0.1103"
 description = "Open-source antivirus and runtime protection for AI agents, tools, MCP servers, plugins, skills, and package installs."
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/codex_plugin_scanner/version.py
+++ b/src/codex_plugin_scanner/version.py
@@ -1,3 +1,3 @@
 """Single source of truth for tool version."""
 
-__version__ = "2.0.1100"
+__version__ = "2.0.1103"

--- a/uv.lock
+++ b/uv.lock
@@ -1171,7 +1171,7 @@ wheels = [
 
 [[package]]
 name = "hol-guard"
-version = "2.0.1100"
+version = "2.0.1103"
 source = { editable = "." }
 dependencies = [
     { name = "cisco-ai-skill-scanner" },


### PR DESCRIPTION
## Summary
- sync repository version files to 2.0.1103 after publish
- keep repo-visible version metadata aligned with the released package artifacts

## Testing
- `uv sync --frozen && uv run --no-sync python scripts/sync_repo_version.py --version "2.0.1103"`
