### PR TITLE
Exclude redirects from managed-service safe variants

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_model.py
@@ -37,6 +37,32 @@ MAX_COMMAND_TOKENS = 2_048
 _SHELL_SCRIPT_EXECUTABLES = frozenset({"ash", "bash", "dash", "sh", "zsh"})
 
 
+def _shell_tokens_without_redirects(command: str) -> tuple[str, ...]:
+    redirects = extract_command_redirects(command, extract_heredocs(command))
+    if not redirects:
+        return _tokens_without_heredoc_declarations(shell_tokens(command)[0])
+    masked = list(command)
+    for redirect in redirects:
+        masked[redirect.start : redirect.end] = " " * (redirect.end - redirect.start)
+    return _tokens_without_heredoc_declarations(shell_tokens("".join(masked))[0])
+
+
+def _tokens_without_heredoc_declarations(tokens: tuple[str, ...]) -> tuple[str, ...]:
+    arguments: list[str] = []
+    index = 0
+    while index < len(tokens):
+        token = tokens[index]
+        if token in {"<<", "<<-"}:
+            index += 2
+            continue
+        if token.startswith(("<<-", "<<")):
+            index += 1
+            continue
+        arguments.append(token)
+        index += 1
+    return tuple(arguments)
+
+
 @dataclass(frozen=True, slots=True)
 class CommandSegment:
     """One executable segment from a normalized command string."""
@@ -226,12 +252,13 @@ def parse_shell_command(
         if not exact and confidence == "exact":
             confidence = "fallback"
             uncertainty_reason = "malformed_shell_quoting"
-        environment_names, executable_index, wrappers = leading_environment(tokens)
+        command_tokens = _shell_tokens_without_redirects(segment_text)
+        environment_names, executable_index, wrappers = leading_environment(command_tokens)
         for wrapper in wrappers:
             if wrapper not in segment_wrappers:
                 segment_wrappers.append(wrapper)
-        executable = tokens[executable_index] if executable_index < len(tokens) else None
-        arguments = tokens[executable_index + 1 :] if executable is not None else ()
+        executable = command_tokens[executable_index] if executable_index < len(command_tokens) else None
+        arguments = command_tokens[executable_index + 1 :] if executable is not None else ()
         start = normalized_text.find(segment_text, max(cursor, source_offset))
         if start < 0:
             start = normalized_text.find(segment_text)
@@ -429,9 +456,10 @@ def _segments_for_embedded(
         context_prefix=execution_context,
     ):
         tokens, _exact = shell_tokens(segment_text)
-        environment_names, executable_index, wrappers = leading_environment(tokens)
-        executable = tokens[executable_index] if executable_index < len(tokens) else None
-        arguments = tokens[executable_index + 1 :] if executable is not None else ()
+        command_tokens = _shell_tokens_without_redirects(segment_text)
+        environment_names, executable_index, wrappers = leading_environment(command_tokens)
+        executable = command_tokens[executable_index] if executable_index < len(command_tokens) else None
+        arguments = command_tokens[executable_index + 1 :] if executable is not None else ()
         start = source_offset + local_offset
         results.append(
             CommandSegment(

--- a/src/codex_plugin_scanner/guard/runtime/command_model.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_model.py
@@ -37,30 +37,20 @@ MAX_COMMAND_TOKENS = 2_048
 _SHELL_SCRIPT_EXECUTABLES = frozenset({"ash", "bash", "dash", "sh", "zsh"})
 
 
-def _shell_tokens_without_redirects(command: str) -> tuple[str, ...]:
-    redirects = extract_command_redirects(command, extract_heredocs(command))
-    if not redirects:
-        return _tokens_without_heredoc_declarations(shell_tokens(command)[0])
+def _shell_tokens_without_redirects(
+    command: str,
+    *,
+    source_offset: int,
+    redirects: tuple[CommandRedirect, ...],
+) -> tuple[str, ...]:
     masked = list(command)
     for redirect in redirects:
-        masked[redirect.start : redirect.end] = " " * (redirect.end - redirect.start)
-    return _tokens_without_heredoc_declarations(shell_tokens("".join(masked))[0])
-
-
-def _tokens_without_heredoc_declarations(tokens: tuple[str, ...]) -> tuple[str, ...]:
-    arguments: list[str] = []
-    index = 0
-    while index < len(tokens):
-        token = tokens[index]
-        if token in {"<<", "<<-"}:
-            index += 2
+        local_start = redirect.start - source_offset
+        local_end = redirect.end - source_offset
+        if local_start < 0 or local_end > len(masked):
             continue
-        if token.startswith(("<<-", "<<")):
-            index += 1
-            continue
-        arguments.append(token)
-        index += 1
-    return tuple(arguments)
+        masked[local_start:local_end] = " " * (local_end - local_start)
+    return shell_tokens("".join(masked))[0]
 
 
 @dataclass(frozen=True, slots=True)
@@ -212,7 +202,9 @@ def parse_shell_command(
         uncertainty_reason = "wrapper_normalization_limit_exceeded"
 
     heredocs = extract_heredocs(normalized_text)
-    segment_texts = _execution_segment_texts(mask_heredoc_bodies(normalized_text, heredocs))
+    masked_command = mask_heredoc_bodies(normalized_text, heredocs)
+    command_redirects = extract_command_redirects(masked_command, heredocs)
+    segment_texts = _execution_segment_texts(masked_command)
     if len(segment_texts) > MAX_COMMAND_SEGMENTS:
         return CanonicalCommand(
             raw_text=raw_text,
@@ -252,13 +244,6 @@ def parse_shell_command(
         if not exact and confidence == "exact":
             confidence = "fallback"
             uncertainty_reason = "malformed_shell_quoting"
-        command_tokens = _shell_tokens_without_redirects(segment_text)
-        environment_names, executable_index, wrappers = leading_environment(command_tokens)
-        for wrapper in wrappers:
-            if wrapper not in segment_wrappers:
-                segment_wrappers.append(wrapper)
-        executable = command_tokens[executable_index] if executable_index < len(command_tokens) else None
-        arguments = command_tokens[executable_index + 1 :] if executable is not None else ()
         start = normalized_text.find(segment_text, max(cursor, source_offset))
         if start < 0:
             start = normalized_text.find(segment_text)
@@ -266,6 +251,17 @@ def parse_shell_command(
             start = min(cursor, len(normalized_text))
         end = min(start + len(segment_text), len(normalized_text))
         cursor = end
+        command_tokens = _shell_tokens_without_redirects(
+            segment_text,
+            source_offset=start,
+            redirects=command_redirects,
+        )
+        environment_names, executable_index, wrappers = leading_environment(command_tokens)
+        for wrapper in wrappers:
+            if wrapper not in segment_wrappers:
+                segment_wrappers.append(wrapper)
+        executable = command_tokens[executable_index] if executable_index < len(command_tokens) else None
+        arguments = command_tokens[executable_index + 1 :] if executable is not None else ()
         segments.append(
             CommandSegment(
                 text=segment_text,
@@ -299,7 +295,7 @@ def parse_shell_command(
         extraction_provenance=extraction_provenance,
         wrapper_chain=(*normalization.wrapper_chain, *segment_wrappers),
         segments=tuple(segments),
-        redirects=extract_command_redirects(mask_heredoc_bodies(normalized_text, heredocs), heredocs),
+        redirects=command_redirects,
         embedded_commands=embedded_commands,
         confidence=confidence,
         uncertainty_reason=uncertainty_reason,
@@ -451,12 +447,18 @@ def _segments_for_embedded(
     source_offset: int,
 ) -> tuple[CommandSegment, ...]:
     results: list[CommandSegment] = []
+    heredocs = extract_heredocs(command)
+    redirects = extract_command_redirects(mask_heredoc_bodies(command, heredocs), heredocs)
     for context, pipeline_index, segment_text, local_offset in _execution_segment_texts(
         command,
         context_prefix=execution_context,
     ):
         tokens, _exact = shell_tokens(segment_text)
-        command_tokens = _shell_tokens_without_redirects(segment_text)
+        command_tokens = _shell_tokens_without_redirects(
+            segment_text,
+            source_offset=local_offset,
+            redirects=redirects,
+        )
         environment_names, executable_index, wrappers = leading_environment(command_tokens)
         executable = command_tokens[executable_index] if executable_index < len(command_tokens) else None
         arguments = command_tokens[executable_index + 1 :] if executable is not None else ()

--- a/src/codex_plugin_scanner/guard/runtime/shell_structure.py
+++ b/src/codex_plugin_scanner/guard/runtime/shell_structure.py
@@ -35,7 +35,8 @@ class ShellCommandSubstitution:
 
 
 _HEREDOC_OPERATOR_PATTERN = re.compile(
-    r"(?<!<)(?P<operator><<-?)[ \t]*(?P<quote>['\"]?)(?P<delimiter>[A-Za-z_][A-Za-z0-9_]*)(?P=quote)"
+    r"(?<!<)(?P<operator><<-?)[ \t]*(?P<quote>['\"]?)"
+    r"(?P<delimiter>(?:[A-Za-z_][A-Za-z0-9_]*|--[A-Za-z0-9][A-Za-z0-9_-]*))(?P=quote)"
 )
 
 

--- a/tests/test_guard_command_managed_service_extensions.py
+++ b/tests/test_guard_command_managed_service_extensions.py
@@ -186,6 +186,33 @@ def test_safe_managed_variant_does_not_hide_destructive_segment(tmp_path: Path) 
     assert payload["controlling_rule_id"] == "command.payment.delete"
 
 
+@pytest.mark.parametrize(
+    ("command", "rule_id"),
+    [
+        ("aws route53 delete-hosted-zone --id Z123 > --help", "command.dns.delete"),
+        ("aws route53 delete-hosted-zone --id Z123 >--help", "command.dns.delete"),
+        ("stripe products delete prod_123 2> --help", "command.payment.delete"),
+        ("stripe products delete prod_123 2>--help", "command.payment.delete"),
+        ("aws route53 delete-hosted-zone --id Z123 << --help\npayload\n--help", "command.dns.delete"),
+    ],
+)
+def test_help_redirection_target_does_not_hide_destructive_command(
+    command: str,
+    rule_id: str,
+    tmp_path: Path,
+) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert rule_id in {rule["rule_id"] for rule in payload["rules"]}
+    assert extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    ) is not None
+
+
 def test_managed_service_extensions_publish_official_references() -> None:
     for extension_id in (
         "command.dns",

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -55,6 +55,12 @@ def test_parse_shell_command_excludes_redirects_from_cli_arguments(command: str)
     assert any("--help" in token for token in parsed.segments[0].tokens)
 
 
+def test_parse_shell_command_preserves_quoted_heredoc_like_argument() -> None:
+    parsed = parse_shell_command("tool delete target '<<--help'")
+
+    assert parsed.segments[0].arguments == ("delete", "target", "<<--help")
+
+
 def test_parse_shell_command_skips_all_sudo_options_with_values() -> None:
     parsed = parse_shell_command(
         "sudo --command-timeout 10 --login-class staff git --config-env token=TOKEN push --force"

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -40,6 +40,21 @@ def test_parse_shell_command_tracks_sudo_and_nested_environment_wrapper() -> Non
     assert parsed.path_overridden is True
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "aws route53 delete-hosted-zone --id Z123 > --help",
+        "stripe products delete prod_123 2>--help",
+    ],
+)
+def test_parse_shell_command_excludes_redirects_from_cli_arguments(command: str) -> None:
+    parsed = parse_shell_command(command)
+
+    assert "--help" not in parsed.segments[0].arguments
+    assert parsed.redirects[0].target == "--help"
+    assert any("--help" in token for token in parsed.segments[0].tokens)
+
+
 def test_parse_shell_command_skips_all_sudo_options_with_values() -> None:
     parsed = parse_shell_command(
         "sudo --command-timeout 10 --login-class staff git --config-env token=TOKEN push --force"


### PR DESCRIPTION
## Summary

- exclude shell redirection syntax and targets from canonical CLI arguments while preserving raw tokens and redirect identity
- keep destructive managed-service rules active when a redirect target is named `--help`
- recognize option-shaped heredoc delimiters and cover output, error, attached, and heredoc forms

## Security boundary

Safe command variants now evaluate only arguments delivered to the executable. Shell-consumed redirect targets cannot satisfy a CLI safety flag.

## Testing

- `uv run pytest tests/test_guard_command_*extensions.py tests/test_guard_command_model.py -q`
- `uv run pytest tests/test_guard_data_flow.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/command_model.py src/codex_plugin_scanner/guard/runtime/shell_structure.py tests/test_guard_command_model.py tests/test_guard_command_managed_service_extensions.py`
- `uv run --with basedpyright basedpyright src/codex_plugin_scanner/guard/runtime/command_model.py src/codex_plugin_scanner/guard/runtime/shell_structure.py --level error`
- `uv build`
