### PR TITLE
fix(commands): refine safe variant evaluation

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_builtin_rules.py
@@ -83,7 +83,12 @@ _GIT_FORCE_REFSPEC = SubcommandOperandPrefixMatcher(
 )
 
 
-def _git_matcher(subcommand: str, *, required_flags: frozenset[str]) -> ExecutableMatcher:
+def _git_matcher(
+    subcommand: str,
+    *,
+    required_flags: frozenset[str],
+    inverse_flag_pairs: frozenset[tuple[str, str]] = frozenset(),
+) -> ExecutableMatcher:
     return ExecutableMatcher(
         executables=frozenset({"git"}),
         subcommands=(subcommand,),
@@ -91,6 +96,7 @@ def _git_matcher(subcommand: str, *, required_flags: frozenset[str]) -> Executab
         allow_leading_options=True,
         leading_options_with_values=_GIT_GLOBAL_OPTIONS_WITH_VALUES,
         options_with_values=_GIT_SUBCOMMAND_OPTIONS_WITH_VALUES.get(subcommand, frozenset()),
+        inverse_flag_pairs=inverse_flag_pairs,
     )
 
 
@@ -272,8 +278,16 @@ BUILT_IN_COMMAND_RULES = (
                 title="Git clean preview",
                 matcher=AnyMatcher(
                     matchers=(
-                        _git_matcher("clean", required_flags=frozenset({"-n"})),
-                        _git_matcher("clean", required_flags=frozenset({"--dry-run"})),
+                        _git_matcher(
+                            "clean",
+                            required_flags=frozenset({"-n"}),
+                            inverse_flag_pairs=frozenset({("-n", "--no-dry-run")}),
+                        ),
+                        _git_matcher(
+                            "clean",
+                            required_flags=frozenset({"--dry-run"}),
+                            inverse_flag_pairs=frozenset({("--dry-run", "--no-dry-run")}),
+                        ),
                     )
                 ),
             ),
@@ -296,7 +310,11 @@ BUILT_IN_COMMAND_RULES = (
             CommandSafeVariant(
                 variant_id="dry-run",
                 title="Git push preview",
-                matcher=_git_matcher("push", required_flags=frozenset({"--dry-run"})),
+                matcher=_git_matcher(
+                    "push",
+                    required_flags=frozenset({"--dry-run"}),
+                    inverse_flag_pairs=frozenset({("--dry-run", "--no-dry-run")}),
+                ),
             ),
         ),
     ),

--- a/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_cloud_extensions.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from .command_extension_matchers import executable_matcher, safe_flag_variant
+from .command_extension_matchers import executable_matcher, safe_flag_variant, safe_option_variant
 from .command_extension_specs import CommandExtensionSpec
 from .command_rules import AnyMatcher, CommandSafetyRule, CommandSafeVariant
 
@@ -188,17 +188,19 @@ CLOUD_COMMAND_RULES = (
         safer_alternative="Describe the exact resources and confirm the active account and region before deletion.",
         safe_variants=(
             safe_flag_variant(_AWS_RESOURCE_DELETE, variant_id="help", title="AWS command help", flag="--help"),
-            safe_flag_variant(
+            safe_option_variant(
                 _AWS_RESOURCE_DELETE,
                 variant_id="generate-cli-skeleton",
                 title="AWS request skeleton",
-                flag="--generate-cli-skeleton",
+                option="--generate-cli-skeleton",
+                allowed_values=frozenset({"input", "output", "yaml-input"}),
             ),
             safe_flag_variant(
                 _AWS_EC2_TERMINATE,
                 variant_id="dry-run",
                 title="EC2 termination permission check",
                 flag="--dry-run",
+                inverse_flag="--no-dry-run",
             ),
         ),
     ),

--- a/src/codex_plugin_scanner/guard/runtime/command_extension_matchers.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_extension_matchers.py
@@ -41,7 +41,7 @@ def executable_matcher(
     )
 
 
-def with_required_flag(matcher: AnyMatcher, flag: str) -> AnyMatcher:
+def with_required_flag(matcher: AnyMatcher, flag: str, *, inverse_flag: str | None = None) -> AnyMatcher:
     """Clone executable children while adding one required flag."""
 
     if not all(isinstance(child, ExecutableMatcher) for child in matcher.matchers):
@@ -58,6 +58,12 @@ def with_required_flag(matcher: AnyMatcher, flag: str) -> AnyMatcher:
                 interspersed_options_with_values=child.interspersed_options_with_values,
                 interspersed_flags=child.interspersed_flags,
                 options_with_values=child.options_with_values,
+                inverse_flag_pairs=(
+                    child.inverse_flag_pairs | {(flag, inverse_flag)}
+                    if inverse_flag is not None
+                    else child.inverse_flag_pairs
+                ),
+                required_option_values=child.required_option_values,
                 required_flags_in_all_arguments=True,
                 fail_secure_unknown_options=child.fail_secure_unknown_options,
             )
@@ -73,11 +79,53 @@ def safe_flag_variant(
     variant_id: str,
     title: str,
     flag: str,
+    inverse_flag: str | None = None,
 ) -> CommandSafeVariant:
     """Build a safe variant requiring one documented side-effect-free flag."""
 
     return CommandSafeVariant(
         variant_id=variant_id,
         title=title,
-        matcher=with_required_flag(matcher, flag),
+        matcher=with_required_flag(matcher, flag, inverse_flag=inverse_flag),
+    )
+
+
+def safe_option_variant(
+    matcher: AnyMatcher,
+    *,
+    variant_id: str,
+    title: str,
+    option: str,
+    allowed_values: frozenset[str],
+) -> CommandSafeVariant:
+    """Build a safe variant requiring one declared value-taking option."""
+
+    if not allowed_values:
+        raise ValueError("Safe option variants require at least one allowed value")
+    if not all(isinstance(child, ExecutableMatcher) for child in matcher.matchers):
+        raise ValueError("Safe variants require executable matcher children")
+    return CommandSafeVariant(
+        variant_id=variant_id,
+        title=title,
+        matcher=AnyMatcher(
+            matchers=tuple(
+                ExecutableMatcher(
+                    executables=child.executables,
+                    subcommands=child.subcommands,
+                    required_flags=child.required_flags,
+                    forbidden_flags=child.forbidden_flags,
+                    allow_leading_options=child.allow_leading_options,
+                    leading_options_with_values=child.leading_options_with_values,
+                    interspersed_options_with_values=child.interspersed_options_with_values,
+                    interspersed_flags=child.interspersed_flags,
+                    options_with_values=child.options_with_values | {option},
+                    inverse_flag_pairs=child.inverse_flag_pairs,
+                    required_option_values=(*child.required_option_values, (option, allowed_values)),
+                    required_flags_in_all_arguments=True,
+                    fail_secure_unknown_options=child.fail_secure_unknown_options,
+                )
+                for child in matcher.matchers
+                if isinstance(child, ExecutableMatcher)
+            )
+        ),
     )

--- a/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
@@ -86,7 +86,7 @@ def _flag_present_in_all_option_parses(
         attached_short_option = _attached_short_value_option(argument, options_with_values)
         if option_name in options_with_values:
             advance = 1 if "=" in argument else 2
-            return present(argument_index + advance, seen)
+            return present(argument_index + advance, seen or required_flag == option_name)
         if attached_short_option is not None:
             return present(argument_index + 1, seen)
         token_flags = _flags_in_option_token(argument, options_with_values)

--- a/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
@@ -2,7 +2,118 @@
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from functools import cache
+
+_EMPTY_STRING_SET: frozenset[str] = frozenset()
+_TRUTHY_FLAG_VALUES = frozenset({"1", "on", "true", "yes"})
+_FALSEY_FLAG_VALUES = frozenset({"0", "false", "no", "off"})
+
+
+@dataclass(frozen=True, slots=True)
+class _EffectiveOption:
+    name: str
+    token: str
+    value: str | None
+    is_value_option: bool
+    positive_flag: str | None = None
+    negative_flag: str | None = None
+    positive_polarity: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class ArgumentSemantics:
+    present_flags: frozenset[str]
+    effective_options: tuple[tuple[str, str, str | None], ...]
+
+    def option_value(self, option: str) -> str | None:
+        return next((value for name, _token, value in self.effective_options if name == option), None)
+
+    def option_token(self, option: str) -> str | None:
+        return next((token for name, token, _value in self.effective_options if name == option), None)
+
+
+def argument_semantics(
+    arguments: tuple[str, ...],
+    *,
+    options_with_values: frozenset[str] = _EMPTY_STRING_SET,
+    inverse_flag_pairs: frozenset[tuple[str, str]] = frozenset(),
+) -> ArgumentSemantics:
+    flags: set[str] = set()
+    inverse_aliases = {
+        alias: (positive, negative, alias == positive)
+        for positive, negative in inverse_flag_pairs
+        for alias in (positive, negative)
+    }
+    effective_options: dict[str, _EffectiveOption] = {}
+    index = 0
+    while index < len(arguments):
+        argument = arguments[index]
+        if argument == "--":
+            break
+        option_name, separator, option_value = argument.partition("=")
+        is_long_option = argument.startswith("--")
+        is_value_option = option_name in options_with_values
+        inverse_alias = inverse_aliases.get(option_name)
+        if is_long_option or inverse_alias is not None:
+            if is_value_option and not separator:
+                option_value = arguments[index + 1] if index + 1 < len(arguments) else ""
+            effective_name = inverse_alias[0] if inverse_alias is not None else option_name
+            effective_options[effective_name] = _EffectiveOption(
+                name=effective_name,
+                token=argument,
+                value=option_value if separator or is_value_option else None,
+                is_value_option=is_value_option,
+                positive_flag=inverse_alias[0] if inverse_alias is not None else None,
+                negative_flag=inverse_alias[1] if inverse_alias is not None else None,
+                positive_polarity=inverse_alias[2] if inverse_alias is not None else True,
+            )
+        else:
+            flags.add(argument)
+            if argument.startswith("-") and separator:
+                flags.add(option_name)
+        if inverse_alias is None and option_name.startswith("-") and not option_name.startswith("--"):
+            for character in option_name[1:]:
+                if not character.isalnum():
+                    continue
+                short_flag = f"-{character}"
+                short_alias = inverse_aliases.get(short_flag)
+                if short_alias is None:
+                    flags.add(short_flag)
+                else:
+                    effective_options[short_alias[0]] = _EffectiveOption(
+                        name=short_alias[0],
+                        token=short_flag,
+                        value=None,
+                        is_value_option=False,
+                        positive_flag=short_alias[0],
+                        negative_flag=short_alias[1],
+                        positive_polarity=short_alias[2],
+                    )
+                if short_flag in options_with_values:
+                    break
+        index += 2 if option_name in options_with_values and "=" not in argument else 1
+    for option in effective_options.values():
+        flags.add(option.token)
+        if option.positive_flag is not None and option.negative_flag is not None:
+            assigned_value = _boolean_flag_value(option.value)
+            if assigned_value is not None:
+                enabled = assigned_value if option.positive_polarity else not assigned_value
+                flags.add(option.positive_flag if enabled else option.negative_flag)
+        elif option.is_value_option or option.value is None or option.value in _TRUTHY_FLAG_VALUES:
+            flags.add(option.name)
+    return ArgumentSemantics(
+        present_flags=frozenset(flags),
+        effective_options=tuple((name, option.token, option.value) for name, option in effective_options.items()),
+    )
+
+
+def _boolean_flag_value(value: str | None) -> bool | None:
+    if value is None or value in _TRUTHY_FLAG_VALUES:
+        return True
+    if value in _FALSEY_FLAG_VALUES:
+        return False
+    return None
 
 
 def matches_subcommands_conservatively(

--- a/src/codex_plugin_scanner/guard/runtime/command_remote_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_remote_extensions.py
@@ -261,8 +261,20 @@ REMOTE_COMMAND_RULES = (
         safer_alternative="Run the same rsync command with --dry-run and inspect every deletion first.",
         severity="critical",
         safe_variants=(
-            safe_flag_variant(_RSYNC_MUTATION, variant_id="dry-run", title="Rsync dry run", flag="--dry-run"),
-            safe_flag_variant(_RSYNC_MUTATION, variant_id="short-dry-run", title="Rsync short dry run", flag="-n"),
+            safe_flag_variant(
+                _RSYNC_MUTATION,
+                variant_id="dry-run",
+                title="Rsync dry run",
+                flag="--dry-run",
+                inverse_flag="--no-dry-run",
+            ),
+            safe_flag_variant(
+                _RSYNC_MUTATION,
+                variant_id="short-dry-run",
+                title="Rsync short dry run",
+                flag="-n",
+                inverse_flag="--no-dry-run",
+            ),
         ),
     ),
 )

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -16,6 +16,7 @@ _VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
 _VALID_MODES = frozenset({"required", "enforce", "review", "monitor", "disabled"})
 _EMPTY_STRING_SET: frozenset[str] = frozenset()
 _TRUTHY_FLAG_VALUES = frozenset({"1", "on", "true", "yes"})
+_FALSEY_FLAG_VALUES = frozenset({"0", "false", "no", "off"})
 
 
 @final
@@ -32,6 +33,8 @@ class ExecutableMatcher:
     interspersed_options_with_values: frozenset[str] = frozenset()
     interspersed_flags: frozenset[str] = frozenset()
     options_with_values: frozenset[str] = frozenset()
+    inverse_flag_pairs: frozenset[tuple[str, str]] = frozenset()
+    required_option_values: tuple[tuple[str, frozenset[str]], ...] = ()
     required_flags_in_all_arguments: bool = False
     fail_secure_unknown_options: bool = False
 
@@ -53,6 +56,24 @@ class ExecutableMatcher:
             value.strip().lower() for value in self.interspersed_flags if value.strip()
         )
         normalized_options = frozenset(value.strip().lower() for value in self.options_with_values if value.strip())
+        normalized_inverse_pairs = frozenset(
+            (positive.strip().lower(), negative.strip().lower())
+            for positive, negative in self.inverse_flag_pairs
+            if positive.strip() and negative.strip()
+        )
+        normalized_required_option_values = tuple(
+            sorted(
+                [
+                    (
+                        option.strip().lower(),
+                        frozenset(value.strip().lower() for value in values if value.strip()),
+                    )
+                    for option, values in self.required_option_values
+                    if option.strip()
+                ],
+                key=lambda item: item[0],
+            )
+        )
         object.__setattr__(self, "subcommands", normalized_subcommands)
         object.__setattr__(self, "required_flags", normalized_required_flags)
         object.__setattr__(self, "forbidden_flags", normalized_forbidden_flags)
@@ -60,8 +81,18 @@ class ExecutableMatcher:
         object.__setattr__(self, "interspersed_options_with_values", normalized_interspersed_options)
         object.__setattr__(self, "interspersed_flags", normalized_interspersed_flags)
         object.__setattr__(self, "options_with_values", normalized_options)
+        object.__setattr__(self, "inverse_flag_pairs", normalized_inverse_pairs)
+        object.__setattr__(self, "required_option_values", normalized_required_option_values)
         if normalized_required_flags & normalized_forbidden_flags:
             raise ValueError("A matcher flag cannot be both required and forbidden")
+        inverse_names = [name for pair in normalized_inverse_pairs for name in pair]
+        if len(inverse_names) != len(set(inverse_names)):
+            raise ValueError("Inverse flag pairs cannot reuse an option name")
+        required_option_names = [option for option, _values in normalized_required_option_values]
+        if len(required_option_names) != len(set(required_option_names)):
+            raise ValueError("Required option values cannot declare an option more than once")
+        if any(not values for _option, values in normalized_required_option_values):
+            raise ValueError("Required option values cannot be empty")
 
     def match(self, command: CanonicalCommand) -> tuple[MatcherEvidence, ...]:
         evidence: list[MatcherEvidence] = []
@@ -103,25 +134,42 @@ class ExecutableMatcher:
                 flag_arguments = subcommand_arguments[len(self.subcommands) :]
             else:
                 flag_arguments = subcommand_arguments
-            present_flags = _present_flags(
+            semantics = _argument_semantics(
                 flag_arguments,
                 options_with_values=(
                     self.options_with_values | self.leading_options_with_values | self.interspersed_options_with_values
                 ),
+                inverse_flag_pairs=self.inverse_flag_pairs,
             )
-            required_flags_present = self.required_flags <= present_flags
+            required_semantics_present = self.required_flags <= semantics.present_flags and not any(
+                semantics.option_value(option) not in allowed_values
+                for option, allowed_values in self.required_option_values
+            )
             if self.fail_secure_unknown_options and self.required_flags_in_all_arguments:
-                required_flags_present = flags_present_in_all_option_parses(
+                conservative_requirements = set(self.required_flags)
+                for positive, negative in self.inverse_flag_pairs:
+                    if not conservative_requirements.intersection({positive, negative}):
+                        continue
+                    conservative_requirements.difference_update({positive, negative})
+                    effective_token = semantics.option_token(positive)
+                    if effective_token is not None:
+                        conservative_requirements.add(effective_token.split("=", 1)[0])
+                required_semantics_present = required_semantics_present and flags_present_in_all_option_parses(
                     lowered_arguments,
-                    self.required_flags,
+                    frozenset(conservative_requirements) | {option for option, _values in self.required_option_values},
                     options_with_values=(
                         self.options_with_values
                         | self.leading_options_with_values
                         | self.interspersed_options_with_values
                     ),
-                    known_flags=self.interspersed_flags | self.required_flags | self.forbidden_flags,
+                    known_flags=(
+                        self.interspersed_flags
+                        | self.required_flags
+                        | self.forbidden_flags
+                        | {name for pair in self.inverse_flag_pairs for name in pair}
+                    ),
                 )
-            if not required_flags_present or self.forbidden_flags & present_flags:
+            if not required_semantics_present or self.forbidden_flags & semantics.present_flags:
                 continue
             evidence.append(
                 MatcherEvidence(
@@ -154,7 +202,9 @@ class ArgumentMatcher:
         for index, segment in enumerate(command.segments):
             if not _segment_matches_executable(segment, self.executables):
                 continue
-            present_arguments = _present_flags(tuple(argument.lower() for argument in segment.arguments))
+            present_arguments = _argument_semantics(
+                tuple(argument.lower() for argument in segment.arguments)
+            ).present_flags
             if not self.required_arguments <= present_arguments:
                 continue
             evidence.append(
@@ -345,7 +395,9 @@ def matcher_index_hints(matcher: CommandMatcher) -> MatcherIndexHints:
     if isinstance(matcher, ExecutableMatcher):
         return MatcherIndexHints(
             executables=matcher.executables,
-            keywords=frozenset((*matcher.subcommands, *matcher.required_flags)),
+            keywords=frozenset(
+                (*matcher.subcommands, *matcher.required_flags, *(name for name, _ in matcher.required_option_values))
+            ),
         )
     if isinstance(matcher, ArgumentMatcher):
         return MatcherIndexHints(
@@ -391,14 +443,42 @@ def _normalize_option_token(value: str) -> str:
     return stripped.lower() if stripped.startswith("--") else stripped
 
 
-def _present_flags(
+@dataclass(frozen=True, slots=True)
+class _EffectiveOption:
+    name: str
+    token: str
+    value: str | None
+    is_value_option: bool
+    positive_flag: str | None = None
+    negative_flag: str | None = None
+    positive_polarity: bool = True
+
+
+@dataclass(frozen=True, slots=True)
+class _ArgumentSemantics:
+    present_flags: frozenset[str]
+    effective_options: tuple[tuple[str, str, str | None], ...]
+
+    def option_value(self, option: str) -> str | None:
+        return next((value for name, _token, value in self.effective_options if name == option), None)
+
+    def option_token(self, option: str) -> str | None:
+        return next((token for name, token, _value in self.effective_options if name == option), None)
+
+
+def _argument_semantics(
     arguments: tuple[str, ...],
     *,
     options_with_values: frozenset[str] = _EMPTY_STRING_SET,
-) -> frozenset[str]:
+    inverse_flag_pairs: frozenset[tuple[str, str]] = frozenset(),
+) -> _ArgumentSemantics:
     flags: set[str] = set()
-    # Safe variants honor the final long-option assignment, matching common CLI parsers.
-    effective_long_options: dict[str, tuple[str, str | None, bool]] = {}
+    inverse_aliases = {
+        alias: (positive, negative, alias == positive)
+        for positive, negative in inverse_flag_pairs
+        for alias in (positive, negative)
+    }
+    effective_options: dict[str, _EffectiveOption] = {}
     index = 0
     while index < len(arguments):
         argument = arguments[index]
@@ -407,32 +487,66 @@ def _present_flags(
         option_name, separator, option_value = argument.partition("=")
         is_long_option = argument.startswith("--")
         is_value_option = option_name in options_with_values
-        if is_long_option:
+        inverse_alias = inverse_aliases.get(option_name)
+        if is_long_option or inverse_alias is not None:
             if is_value_option and not separator:
                 option_value = arguments[index + 1] if index + 1 < len(arguments) else ""
-            effective_long_options[option_name] = (
-                argument,
-                option_value if separator or is_value_option else None,
-                is_value_option,
+            effective_name = inverse_alias[0] if inverse_alias is not None else option_name
+            effective_options[effective_name] = _EffectiveOption(
+                name=effective_name,
+                token=argument,
+                value=option_value if separator or is_value_option else None,
+                is_value_option=is_value_option,
+                positive_flag=inverse_alias[0] if inverse_alias is not None else None,
+                negative_flag=inverse_alias[1] if inverse_alias is not None else None,
+                positive_polarity=inverse_alias[2] if inverse_alias is not None else True,
             )
         else:
             flags.add(argument)
             if argument.startswith("-") and separator:
                 flags.add(option_name)
-        if option_name.startswith("-") and not option_name.startswith("--") and len(option_name) > 2:
+        if inverse_alias is None and option_name.startswith("-") and not option_name.startswith("--"):
             for character in option_name[1:]:
                 if not character.isalnum():
                     continue
                 short_flag = f"-{character}"
-                flags.add(short_flag)
+                short_alias = inverse_aliases.get(short_flag)
+                if short_alias is None:
+                    flags.add(short_flag)
+                else:
+                    effective_options[short_alias[0]] = _EffectiveOption(
+                        name=short_alias[0],
+                        token=short_flag,
+                        value=None,
+                        is_value_option=False,
+                        positive_flag=short_alias[0],
+                        negative_flag=short_alias[1],
+                        positive_polarity=short_alias[2],
+                    )
                 if short_flag in options_with_values:
                     break
         index += 2 if option_name in options_with_values and "=" not in argument else 1
-    for option_name, (argument, option_value, is_value_option) in effective_long_options.items():
-        flags.add(argument)
-        if is_value_option or option_value is None or option_value in _TRUTHY_FLAG_VALUES:
-            flags.add(option_name)
-    return frozenset(flags)
+    for option in effective_options.values():
+        flags.add(option.token)
+        if option.positive_flag is not None and option.negative_flag is not None:
+            assigned_value = _boolean_flag_value(option.value)
+            if assigned_value is not None:
+                enabled = assigned_value if option.positive_polarity else not assigned_value
+                flags.add(option.positive_flag if enabled else option.negative_flag)
+        elif option.is_value_option or option.value is None or option.value in _TRUTHY_FLAG_VALUES:
+            flags.add(option.name)
+    return _ArgumentSemantics(
+        present_flags=frozenset(flags),
+        effective_options=tuple((name, option.token, option.value) for name, option in effective_options.items()),
+    )
+
+
+def _boolean_flag_value(value: str | None) -> bool | None:
+    if value is None or value in _TRUTHY_FLAG_VALUES:
+        return True
+    if value in _FALSEY_FLAG_VALUES:
+        return False
+    return None
 
 
 def _after_leading_options(arguments: tuple[str, ...], options_with_values: frozenset[str]) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -7,16 +7,17 @@ from typing import Literal, final
 
 from .command_matcher_contracts import CommandMatcher, MatcherEvidence
 from .command_model import CanonicalCommand, CommandSegment
-from .command_option_parsing import flags_present_in_all_option_parses, matches_subcommands_conservatively
+from .command_option_parsing import (
+    argument_semantics,
+    flags_present_in_all_option_parses,
+    matches_subcommands_conservatively,
+)
 
 CommandRuleSeverity = Literal["critical", "high", "medium", "low"]
 CommandRuleMode = Literal["required", "enforce", "review", "monitor", "disabled"]
 
 _VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
 _VALID_MODES = frozenset({"required", "enforce", "review", "monitor", "disabled"})
-_EMPTY_STRING_SET: frozenset[str] = frozenset()
-_TRUTHY_FLAG_VALUES = frozenset({"1", "on", "true", "yes"})
-_FALSEY_FLAG_VALUES = frozenset({"0", "false", "no", "off"})
 
 
 @final
@@ -134,7 +135,7 @@ class ExecutableMatcher:
                 flag_arguments = subcommand_arguments[len(self.subcommands) :]
             else:
                 flag_arguments = subcommand_arguments
-            semantics = _argument_semantics(
+            semantics = argument_semantics(
                 flag_arguments,
                 options_with_values=(
                     self.options_with_values | self.leading_options_with_values | self.interspersed_options_with_values
@@ -202,7 +203,7 @@ class ArgumentMatcher:
         for index, segment in enumerate(command.segments):
             if not _segment_matches_executable(segment, self.executables):
                 continue
-            present_arguments = _argument_semantics(
+            present_arguments = argument_semantics(
                 tuple(argument.lower() for argument in segment.arguments)
             ).present_flags
             if not self.required_arguments <= present_arguments:
@@ -441,112 +442,6 @@ def _segment_matches_executable(segment: CommandSegment, executables: frozenset[
 def _normalize_option_token(value: str) -> str:
     stripped = value.strip()
     return stripped.lower() if stripped.startswith("--") else stripped
-
-
-@dataclass(frozen=True, slots=True)
-class _EffectiveOption:
-    name: str
-    token: str
-    value: str | None
-    is_value_option: bool
-    positive_flag: str | None = None
-    negative_flag: str | None = None
-    positive_polarity: bool = True
-
-
-@dataclass(frozen=True, slots=True)
-class _ArgumentSemantics:
-    present_flags: frozenset[str]
-    effective_options: tuple[tuple[str, str, str | None], ...]
-
-    def option_value(self, option: str) -> str | None:
-        return next((value for name, _token, value in self.effective_options if name == option), None)
-
-    def option_token(self, option: str) -> str | None:
-        return next((token for name, token, _value in self.effective_options if name == option), None)
-
-
-def _argument_semantics(
-    arguments: tuple[str, ...],
-    *,
-    options_with_values: frozenset[str] = _EMPTY_STRING_SET,
-    inverse_flag_pairs: frozenset[tuple[str, str]] = frozenset(),
-) -> _ArgumentSemantics:
-    flags: set[str] = set()
-    inverse_aliases = {
-        alias: (positive, negative, alias == positive)
-        for positive, negative in inverse_flag_pairs
-        for alias in (positive, negative)
-    }
-    effective_options: dict[str, _EffectiveOption] = {}
-    index = 0
-    while index < len(arguments):
-        argument = arguments[index]
-        if argument == "--":
-            break
-        option_name, separator, option_value = argument.partition("=")
-        is_long_option = argument.startswith("--")
-        is_value_option = option_name in options_with_values
-        inverse_alias = inverse_aliases.get(option_name)
-        if is_long_option or inverse_alias is not None:
-            if is_value_option and not separator:
-                option_value = arguments[index + 1] if index + 1 < len(arguments) else ""
-            effective_name = inverse_alias[0] if inverse_alias is not None else option_name
-            effective_options[effective_name] = _EffectiveOption(
-                name=effective_name,
-                token=argument,
-                value=option_value if separator or is_value_option else None,
-                is_value_option=is_value_option,
-                positive_flag=inverse_alias[0] if inverse_alias is not None else None,
-                negative_flag=inverse_alias[1] if inverse_alias is not None else None,
-                positive_polarity=inverse_alias[2] if inverse_alias is not None else True,
-            )
-        else:
-            flags.add(argument)
-            if argument.startswith("-") and separator:
-                flags.add(option_name)
-        if inverse_alias is None and option_name.startswith("-") and not option_name.startswith("--"):
-            for character in option_name[1:]:
-                if not character.isalnum():
-                    continue
-                short_flag = f"-{character}"
-                short_alias = inverse_aliases.get(short_flag)
-                if short_alias is None:
-                    flags.add(short_flag)
-                else:
-                    effective_options[short_alias[0]] = _EffectiveOption(
-                        name=short_alias[0],
-                        token=short_flag,
-                        value=None,
-                        is_value_option=False,
-                        positive_flag=short_alias[0],
-                        negative_flag=short_alias[1],
-                        positive_polarity=short_alias[2],
-                    )
-                if short_flag in options_with_values:
-                    break
-        index += 2 if option_name in options_with_values and "=" not in argument else 1
-    for option in effective_options.values():
-        flags.add(option.token)
-        if option.positive_flag is not None and option.negative_flag is not None:
-            assigned_value = _boolean_flag_value(option.value)
-            if assigned_value is not None:
-                enabled = assigned_value if option.positive_polarity else not assigned_value
-                flags.add(option.positive_flag if enabled else option.negative_flag)
-        elif option.is_value_option or option.value is None or option.value in _TRUTHY_FLAG_VALUES:
-            flags.add(option.name)
-    return _ArgumentSemantics(
-        present_flags=frozenset(flags),
-        effective_options=tuple((name, option.token, option.value) for name, option in effective_options.items()),
-    )
-
-
-def _boolean_flag_value(value: str | None) -> bool | None:
-    if value is None or value in _TRUTHY_FLAG_VALUES:
-        return True
-    if value in _FALSEY_FLAG_VALUES:
-        return False
-    return None
 
 
 def _after_leading_options(arguments: tuple[str, ...], options_with_values: frozenset[str]) -> tuple[str, ...]:

--- a/src/codex_plugin_scanner/guard/runtime/command_storage_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_storage_extensions.py
@@ -299,7 +299,13 @@ STORAGE_COMMAND_RULES = (
         action_class="AWS storage destructive command",
         safe_variants=(
             safe_flag_variant(_AWS_STORAGE_DELETE, variant_id="help", title="AWS storage command help", flag="--help"),
-            safe_flag_variant(_AWS_STORAGE_DRY_RUN, variant_id="dry-run", title="AWS S3 dry run", flag="--dryrun"),
+            safe_flag_variant(
+                _AWS_STORAGE_DRY_RUN,
+                variant_id="dry-run",
+                title="AWS S3 dry run",
+                flag="--dryrun",
+                inverse_flag="--no-dryrun",
+            ),
         ),
     ),
     _storage_rule(

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -6,7 +6,7 @@ from pathlib import Path
 
 import pytest
 
-from codex_plugin_scanner.guard.runtime.command_extension_matchers import with_required_flag
+from codex_plugin_scanner.guard.runtime.command_extension_matchers import safe_option_variant, with_required_flag
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
 from codex_plugin_scanner.guard.runtime.command_rules import AnyMatcher, ExecutableMatcher
@@ -214,7 +214,12 @@ def test_cloud_rules_feed_inspection_and_runtime_hooks(
     [
         "aws ec2 terminate-instances --help",
         "aws ec2 terminate-instances --instance-ids i-123 --dry-run",
+        "aws ec2 terminate-instances --instance-ids i-123 --no-dry-run --dry-run",
+        "aws ec2 terminate-instances --instance-ids i-123 --no-dry-run=false",
         "aws rds delete-db-instance --generate-cli-skeleton input",
+        "aws rds delete-db-instance --generate-cli-skeleton=output",
+        "aws rds delete-db-instance --generate-cli-skeleton=yaml-input",
+        "aws rds delete-db-instance --generate-cli-skeleton=bogus --generate-cli-skeleton=output",
         "gcloud compute instances delete --help",
         "gcloud preview sql instances delete --help",
         "az vm delete --help",
@@ -246,6 +251,30 @@ def test_cloud_help_preview_and_read_commands_remain_safe(command: str, tmp_path
     )
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        "aws ec2 terminate-instances --instance-ids i-123 --dry-run --no-dry-run",
+        "aws ec2 terminate-instances --instance-ids i-123 --dry-run=true --no-dry-run=true",
+        "aws rds delete-db-instance --generate-cli-skeleton=bogus",
+        "aws rds delete-db-instance --generate-cli-skeleton=output --generate-cli-skeleton=bogus",
+    ],
+)
+def test_cloud_disabled_or_invalid_safe_options_remain_live_execution(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is not None
+    )
+
+
 def test_safe_cloud_variant_does_not_hide_destructive_segment(tmp_path: Path) -> None:
     payload = inspect_command(
         "aws ec2 terminate-instances --dry-run && az vm delete --name api-1 --resource-group app --yes",
@@ -271,3 +300,24 @@ def test_cloud_safe_variant_rejects_unsupported_matcher_nesting() -> None:
 
     with pytest.raises(ValueError, match="executable matcher children"):
         with_required_flag(nested, "--help")
+    with pytest.raises(ValueError, match="executable matcher children"):
+        safe_option_variant(
+            nested,
+            variant_id="skeleton",
+            title="Request skeleton",
+            option="--generate-cli-skeleton",
+            allowed_values=frozenset({"output"}),
+        )
+
+
+def test_cloud_safe_option_variant_requires_allowed_values() -> None:
+    matcher = AnyMatcher(matchers=(ExecutableMatcher(executables=frozenset({"aws"})),))
+
+    with pytest.raises(ValueError, match="at least one allowed value"):
+        safe_option_variant(
+            matcher,
+            variant_id="skeleton",
+            title="Request skeleton",
+            option="--generate-cli-skeleton",
+            allowed_values=frozenset(),
+        )

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -176,9 +176,7 @@ def test_structured_core_rules_feed_runtime_classification(
     [
         "git clean -nfdx",
         "git clean --dry-run -fdx",
-        "git clean --no-dry-run -nfdx",
         "git push origin main --force --dry-run",
-        "git push origin main --force --no-dry-run --dry-run",
         "git push --dry-run origin +refs/heads/main:refs/heads/main",
         "shutdown --help",
         "mkfs --version",
@@ -194,28 +192,6 @@ def test_structured_safe_variants_remain_runtime_safe(command: str, tmp_path: Pa
     )
 
     assert match is None
-
-
-@pytest.mark.parametrize(
-    "command",
-    [
-        "git clean -nfdx --no-dry-run",
-        "git clean --dry-run -fdx --no-dry-run",
-        "git push origin main --force --dry-run --no-dry-run",
-    ],
-)
-def test_disabled_git_preview_aliases_remain_runtime_sensitive(command: str, tmp_path: Path) -> None:
-    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
-    match = extract_sensitive_tool_action_request(
-        "Shell",
-        {"command": command},
-        cwd=tmp_path,
-        home_dir=tmp_path,
-    )
-
-    assert payload["status"] == "review"
-    assert match is not None
-    assert match.action_class == "git destructive command"
 
 
 def test_git_clean_exclude_value_is_not_treated_as_preview_flag(tmp_path: Path) -> None:

--- a/tests/test_guard_command_extensions.py
+++ b/tests/test_guard_command_extensions.py
@@ -176,7 +176,9 @@ def test_structured_core_rules_feed_runtime_classification(
     [
         "git clean -nfdx",
         "git clean --dry-run -fdx",
+        "git clean --no-dry-run -nfdx",
         "git push origin main --force --dry-run",
+        "git push origin main --force --no-dry-run --dry-run",
         "git push --dry-run origin +refs/heads/main:refs/heads/main",
         "shutdown --help",
         "mkfs --version",
@@ -192,6 +194,28 @@ def test_structured_safe_variants_remain_runtime_safe(command: str, tmp_path: Pa
     )
 
     assert match is None
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git clean -nfdx --no-dry-run",
+        "git clean --dry-run -fdx --no-dry-run",
+        "git push origin main --force --dry-run --no-dry-run",
+    ],
+)
+def test_disabled_git_preview_aliases_remain_runtime_sensitive(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+    match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert payload["status"] == "review"
+    assert match is not None
+    assert match.action_class == "git destructive command"
 
 
 def test_git_clean_exclude_value_is_not_treated_as_preview_flag(tmp_path: Path) -> None:

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -158,6 +158,102 @@ def test_executable_matcher_uses_effective_exact_option_value(arguments: str, ma
     assert bool(evidence) is matches
 
 
+@pytest.mark.parametrize(
+    ("arguments", "matches"),
+    [
+        ("--dry-run", True),
+        ("--dry-run --no-dry-run", False),
+        ("--no-dry-run --dry-run", True),
+        ("--dry-run=true --no-dry-run=true", False),
+        ("--dry-run=false --no-dry-run=false", True),
+        ("--no-dry-run=false --dry-run=false", False),
+        ("--unknown --dry-run", False),
+    ],
+)
+def test_executable_matcher_uses_effective_inverse_boolean_alias(arguments: str, matches: bool) -> None:
+    matcher = ExecutableMatcher(
+        executables=frozenset({"tool"}),
+        subcommands=("delete",),
+        required_flags=frozenset({"--dry-run"}),
+        inverse_flag_pairs=frozenset({("--dry-run", "--no-dry-run")}),
+        required_flags_in_all_arguments=True,
+        fail_secure_unknown_options=True,
+    )
+
+    evidence = matcher.match(parse_shell_command(f"tool delete target {arguments}"))
+
+    assert bool(evidence) is matches
+
+
+@pytest.mark.parametrize(
+    ("arguments", "matches"),
+    [
+        ("-an", True),
+        ("-an --no-dry-run", False),
+        ("--no-dry-run -an", True),
+    ],
+)
+def test_executable_matcher_orders_short_flag_and_long_inverse(arguments: str, matches: bool) -> None:
+    matcher = ExecutableMatcher(
+        executables=frozenset({"tool"}),
+        subcommands=("delete",),
+        required_flags=frozenset({"-n"}),
+        inverse_flag_pairs=frozenset({("-n", "--no-dry-run")}),
+    )
+
+    evidence = matcher.match(parse_shell_command(f"tool delete target {arguments}"))
+
+    assert bool(evidence) is matches
+
+
+@pytest.mark.parametrize(
+    ("arguments", "matches"),
+    [
+        ("--generate-cli-skeleton input", True),
+        ("--generate-cli-skeleton=output", True),
+        ("--generate-cli-skeleton=yaml-input", True),
+        ("--generate-cli-skeleton=bogus", False),
+        ("--generate-cli-skeleton=output --generate-cli-skeleton=bogus", False),
+        ("--generate-cli-skeleton=bogus --generate-cli-skeleton=output", True),
+        ("--unknown --generate-cli-skeleton=output", False),
+    ],
+)
+def test_executable_matcher_requires_allowed_effective_option_value(arguments: str, matches: bool) -> None:
+    matcher = ExecutableMatcher(
+        executables=frozenset({"tool"}),
+        subcommands=("delete",),
+        options_with_values=frozenset({"--generate-cli-skeleton"}),
+        required_option_values=(("--generate-cli-skeleton", frozenset({"input", "output", "yaml-input"})),),
+        required_flags_in_all_arguments=True,
+        fail_secure_unknown_options=True,
+    )
+
+    evidence = matcher.match(parse_shell_command(f"tool delete target {arguments}"))
+
+    assert bool(evidence) is matches
+
+
+def test_executable_matcher_rejects_ambiguous_option_semantics() -> None:
+    with pytest.raises(ValueError, match="cannot reuse an option name"):
+        ExecutableMatcher(
+            executables=frozenset({"tool"}),
+            inverse_flag_pairs=frozenset(
+                {
+                    ("--dry-run", "--no-dry-run"),
+                    ("--preview", "--no-dry-run"),
+                }
+            ),
+        )
+    with pytest.raises(ValueError, match="cannot declare an option more than once"):
+        ExecutableMatcher(
+            executables=frozenset({"tool"}),
+            required_option_values=(
+                ("--format", frozenset({"json"})),
+                ("--format", frozenset({"yaml"})),
+            ),
+        )
+
+
 def test_executable_matcher_can_skip_declared_global_options() -> None:
     parsed = parse_shell_command("git --no-pager -C repo push origin main --force")
     matcher = ExecutableMatcher(

--- a/tests/test_guard_command_remote_extensions.py
+++ b/tests/test_guard_command_remote_extensions.py
@@ -150,6 +150,8 @@ def test_remote_rules_feed_runtime_hooks(
         "rsync -av ./out/ host.example:/srv/app/",
         "rsync -av --delete ./out/ host.example:/srv/app/ --dry-run",
         "rsync -avn --delete ./out/ host.example:/srv/app/",
+        "rsync -av --delete ./out/ host.example:/srv/app/ --no-dry-run --dry-run",
+        "rsync -av --delete ./out/ host.example:/srv/app/ --no-dry-run -n",
         "grep 'ssh host command|scp source target|rsync --delete' docs",
         "echo ssh host.example uptime",
     ],
@@ -167,6 +169,27 @@ def test_remote_observer_and_preview_commands_remain_safe(command: str, tmp_path
         )
         is None
     )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "rsync -av --delete ./out/ host.example:/srv/app/ --dry-run --no-dry-run",
+        "rsync -avn --delete ./out/ host.example:/srv/app/ --no-dry-run",
+    ],
+)
+def test_rsync_disabled_preview_aliases_remain_live_execution(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+
+    assert payload["status"] == "review"
+    runtime_match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    assert runtime_match is not None
+    assert runtime_match.action_class == "Rsync destructive command"
 
 
 def test_remote_extensions_publish_official_references() -> None:

--- a/tests/test_guard_command_safe_variants.py
+++ b/tests/test_guard_command_safe_variants.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.cli import main
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 
@@ -48,3 +50,38 @@ def test_disabled_git_preview_aliases_remain_runtime_sensitive(command: str, tmp
     assert payload["status"] == "review"
     assert match is not None
     assert match.action_class == "git destructive command"
+
+
+@pytest.mark.parametrize(
+    ("command", "expected_status", "expected_matched"),
+    [
+        (
+            "aws ec2 terminate-instances --instance-ids i-123 --dry-run --no-dry-run",
+            "review",
+            True,
+        ),
+        (
+            "aws ec2 terminate-instances --instance-ids i-123 --no-dry-run --dry-run",
+            "no_match",
+            False,
+        ),
+        ("aws rds delete-db-instance --generate-cli-skeleton=output", "no_match", False),
+    ],
+)
+def test_command_test_cli_honors_effective_safe_option_semantics(
+    command: str,
+    expected_status: str,
+    expected_matched: bool,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    exit_code = main(["guard", "command", "test", "--json", command])
+    payload = json.loads(capsys.readouterr().out)
+
+    assert exit_code == 0
+    assert payload["status"] == expected_status
+    assert payload["classification"]["matched"] is expected_matched

--- a/tests/test_guard_command_safe_variants.py
+++ b/tests/test_guard_command_safe_variants.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git clean --no-dry-run -nfdx",
+        "git push origin main --force --no-dry-run --dry-run",
+    ],
+)
+def test_effective_git_preview_aliases_remain_runtime_safe(command: str, tmp_path: Path) -> None:
+    assert inspect_command(command, cwd=tmp_path, home_dir=tmp_path)["status"] == "no_match"
+    assert (
+        extract_sensitive_tool_action_request(
+            "Shell",
+            {"command": command},
+            cwd=tmp_path,
+            home_dir=tmp_path,
+        )
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "git clean -nfdx --no-dry-run",
+        "git clean --dry-run -fdx --no-dry-run",
+        "git push origin main --force --dry-run --no-dry-run",
+    ],
+)
+def test_disabled_git_preview_aliases_remain_runtime_sensitive(command: str, tmp_path: Path) -> None:
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+    match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert payload["status"] == "review"
+    assert match is not None
+    assert match.action_class == "git destructive command"

--- a/tests/test_guard_command_storage_extensions.py
+++ b/tests/test_guard_command_storage_extensions.py
@@ -132,6 +132,7 @@ def test_storage_rules_feed_runtime_hooks(
     [
         "aws s3 rm s3://archive/private.json --dryrun",
         "aws s3 sync ./out s3://archive --delete --dryrun",
+        "aws s3 rm s3://archive/private.json --no-dryrun --dryrun",
         "gcloud storage rsync ./out gs://archive --delete-unmatched-destination-objects --dry-run",
         "gsutil -m rsync -d -n ./out gs://archive",
         "az storage blob delete-batch --source archive --dryrun",
@@ -165,6 +166,21 @@ def test_storage_preview_and_read_commands_remain_safe(command: str, tmp_path: P
         )
         is None
     )
+
+
+def test_storage_disabled_dry_run_alias_remains_runtime_sensitive(tmp_path: Path) -> None:
+    command = "aws s3 rm s3://archive/private.json --dryrun --no-dryrun"
+    payload = inspect_command(command, cwd=tmp_path, home_dir=tmp_path)
+    runtime_match = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert payload["status"] == "review"
+    assert runtime_match is not None
+    assert runtime_match.action_class == "AWS storage destructive command"
 
 
 def test_storage_safe_segment_does_not_hide_later_deletion(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- refine structured safe-variant option evaluation
- preserve conservative parsing for declared command options
- add focused runtime regression coverage

## Verification
- `pytest -q tests/test_guard_command_*.py --tb=short` (705 passed)
- focused command tests (283 passed)
- changed-file Ruff and format checks
- basedpyright
- `uv build`
- local wheel CLI smoke