### PR TITLE
fix(runtime): refine command option handling

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_backup_extensions.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_backup_extensions.py
@@ -7,6 +7,7 @@ from .command_extension_specs import CommandExtensionSpec
 from .command_rules import AnyMatcher, CommandSafetyRule, CommandSafeVariant
 
 _RCLONE_GLOBAL_OPTIONS = frozenset({"--config", "--log-file", "--log-level", "--password-command", "--rc-addr"})
+_RCLONE_GLOBAL_FLAGS = frozenset({"--dry-run", "--quiet", "--verbose", "-n", "-q", "-v"})
 _RESTIC_GLOBAL_OPTIONS = frozenset(
     {
         "--cacert",
@@ -30,8 +31,12 @@ _RESTIC_GLOBAL_OPTIONS = frozenset(
         "-r",
     }
 )
+_RESTIC_GLOBAL_FLAGS = frozenset({"--quiet", "--verbose", "-q", "-v"})
 _BORG_GLOBAL_OPTIONS = frozenset(
     {
+        "-P",
+        "-a",
+        "-e",
         "-r",
         "--repo",
         "--debug-profile",
@@ -46,6 +51,7 @@ _BORG_GLOBAL_OPTIONS = frozenset(
         "--upload-ratelimit",
     }
 )
+_BORG_GLOBAL_FLAGS = frozenset({"--debug", "--show-rc", "--show-version", "--verbose", "-n", "-v"})
 _VELERO_GLOBAL_OPTIONS = frozenset(
     {
         "--features",
@@ -88,6 +94,7 @@ _RCLONE_MUTATION = AnyMatcher(
             command,
             allow_leading_options=True,
             leading_options_with_values=_RCLONE_GLOBAL_OPTIONS,
+            global_flags=_RCLONE_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         )
         for command in ("delete", "deletefile", "purge", "rmdirs", "sync", "move", "moveto", "bisync")
@@ -100,6 +107,7 @@ _RESTIC_MUTATION = AnyMatcher(
             "forget",
             allow_leading_options=True,
             leading_options_with_values=_RESTIC_GLOBAL_OPTIONS,
+            global_flags=_RESTIC_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         ),
         executable_matcher(
@@ -107,6 +115,7 @@ _RESTIC_MUTATION = AnyMatcher(
             "prune",
             allow_leading_options=True,
             leading_options_with_values=_RESTIC_GLOBAL_OPTIONS,
+            global_flags=_RESTIC_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         ),
         executable_matcher(
@@ -115,6 +124,7 @@ _RESTIC_MUTATION = AnyMatcher(
             required_flags=frozenset({"--forget"}),
             allow_leading_options=True,
             leading_options_with_values=_RESTIC_GLOBAL_OPTIONS,
+            global_flags=_RESTIC_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         ),
     )
@@ -126,6 +136,7 @@ _BORG_MUTATION = AnyMatcher(
             command,
             allow_leading_options=True,
             leading_options_with_values=_BORG_GLOBAL_OPTIONS,
+            global_flags=_BORG_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         )
         for command in ("delete", "prune", "recreate")
@@ -138,6 +149,7 @@ _BORG_DRY_RUN = AnyMatcher(
             command,
             allow_leading_options=True,
             leading_options_with_values=_BORG_GLOBAL_OPTIONS,
+            global_flags=_BORG_GLOBAL_FLAGS,
             fail_secure_unknown_options=True,
         )
         for command in ("prune", "recreate")

--- a/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
@@ -19,7 +19,7 @@ class _ParseOutcome(Enum):
 @dataclass(frozen=True, slots=True)
 class _OptionTransition:
     advance: int
-    flags: frozenset[str] = frozenset()
+    flag_assignments: frozenset[tuple[str, bool]] = frozenset()
 
 
 @dataclass(frozen=True, slots=True)
@@ -142,8 +142,8 @@ def _flag_parse_outcome(
     options_with_values: frozenset[str],
     known_flags: frozenset[str],
 ) -> _ParseOutcome:
-    pending = [(0, False)]
-    visited: set[tuple[int, bool]] = set()
+    pending: list[tuple[int, bool | None]] = [(0, None)]
+    visited: set[tuple[int, bool | None]] = set()
     found_terminal = False
     while pending:
         state = pending.pop()
@@ -152,28 +152,27 @@ def _flag_parse_outcome(
         if len(visited) >= _MAX_OPTION_PARSE_STATES:
             return _ParseOutcome.UNCERTAIN
         visited.add(state)
-        argument_index, seen = state
+        argument_index, final_assignment = state
         if argument_index >= len(arguments) or arguments[argument_index] == "--":
-            if not seen:
+            if final_assignment is not True:
                 return _ParseOutcome.NO_MATCH
             found_terminal = True
             continue
         argument = arguments[argument_index]
         if not _is_option(argument):
-            pending.append((argument_index + 1, seen))
+            pending.append((argument_index + 1, final_assignment))
             continue
         shape = _option_shape(
             argument,
             options_with_values=options_with_values,
             known_flags=known_flags,
         )
-        pending.extend(
-            (
-                argument_index + transition.advance,
-                seen or required_flag in transition.flags,
-            )
-            for transition in shape.transitions
-        )
+        for transition in shape.transitions:
+            next_assignment = final_assignment
+            for flag, enabled in transition.flag_assignments:
+                if flag == required_flag:
+                    next_assignment = enabled
+            pending.append((argument_index + transition.advance, next_assignment))
     return _ParseOutcome.MATCH if found_terminal else _ParseOutcome.NO_MATCH
 
 
@@ -189,10 +188,9 @@ def _option_shape(
             advance = 1 if separator else 2
             return _OptionShape((_OptionTransition(advance),), fully_known=True)
         if option_name in known_flags:
-            flags = {argument}
-            if long_flag_assignment_is_enabled(argument):
-                flags.add(option_name)
-            return _OptionShape((_OptionTransition(1, frozenset(flags)),), fully_known=True)
+            enabled = long_flag_assignment_is_enabled(argument)
+            assignments = frozenset({(argument, True), (option_name, enabled)})
+            return _OptionShape((_OptionTransition(1, assignments),), fully_known=True)
         if separator:
             return _OptionShape((_OptionTransition(1),), fully_known=True)
         return _OptionShape((_OptionTransition(1), _OptionTransition(2)), fully_known=False)
@@ -216,16 +214,19 @@ def _short_option_shape(
         short_option = f"-{character}"
         if short_option in options_with_values:
             advance = 1 if index + 1 < len(argument) else 2
-            transitions.add(_OptionTransition(advance, frozenset(flags)))
+            assignments = frozenset((flag, True) for flag in flags)
+            transitions.add(_OptionTransition(advance, assignments))
             return _OptionShape(tuple(transitions), fully_known=fully_known)
         if short_option in known_flags:
             flags.add(short_option)
             continue
         fully_known = False
-        transitions.add(_OptionTransition(1, frozenset(flags)))
+        assignments = frozenset((flag, True) for flag in flags)
+        transitions.add(_OptionTransition(1, assignments))
         if index + 1 == len(argument):
-            transitions.add(_OptionTransition(2, frozenset(flags)))
-    transitions.add(_OptionTransition(1, frozenset(flags)))
+            transitions.add(_OptionTransition(2, assignments))
+    assignments = frozenset((flag, True) for flag in flags)
+    transitions.add(_OptionTransition(1, assignments))
     return _OptionShape(tuple(transitions), fully_known=fully_known)
 
 

--- a/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
@@ -2,7 +2,29 @@
 
 from __future__ import annotations
 
-from functools import cache
+from dataclasses import dataclass
+from enum import Enum, auto
+from typing import Final
+
+_MAX_OPTION_PARSE_STATES: Final = 16_384
+
+
+class _ParseOutcome(Enum):
+    MATCH = auto()
+    NO_MATCH = auto()
+    UNCERTAIN = auto()
+
+
+@dataclass(frozen=True, slots=True)
+class _OptionTransition:
+    advance: int
+    flags: frozenset[str] = frozenset()
+
+
+@dataclass(frozen=True, slots=True)
+class _OptionShape:
+    transitions: tuple[_OptionTransition, ...]
+    fully_known: bool
 
 
 def matches_subcommands_conservatively(
@@ -12,38 +34,15 @@ def matches_subcommands_conservatively(
     options_with_values: frozenset[str],
     known_flags: frozenset[str],
 ) -> bool:
-    """Match a destructive prefix under any plausible unknown-option shape."""
+    """Match a destructive prefix, including when bounded parsing is uncertain."""
 
-    @cache
-    def matches(argument_index: int, subcommand_index: int) -> bool:
-        if subcommand_index == len(subcommands):
-            return True
-        if argument_index >= len(arguments):
-            return False
-        argument = arguments[argument_index]
-        if argument == "--":
-            remaining = len(subcommands) - subcommand_index
-            return arguments[argument_index + 1 : argument_index + 1 + remaining] == subcommands[subcommand_index:]
-        if _is_option(argument):
-            option_name = argument.split("=", 1)[0]
-            attached_short_option = _attached_short_value_option(argument, options_with_values)
-            last_short_is_known_flag = _last_short_option_is_known_flag(argument, known_flags)
-            if option_name in options_with_values:
-                advance = 1 if "=" in argument else 2
-                return matches(argument_index + advance, subcommand_index)
-            if attached_short_option is not None or "=" in argument or last_short_is_known_flag:
-                return matches(argument_index + 1, subcommand_index)
-            if option_name in known_flags:
-                return matches(argument_index + 1, subcommand_index)
-            return matches(argument_index + 1, subcommand_index) or matches(
-                argument_index + 2,
-                subcommand_index,
-            )
-        if argument != subcommands[subcommand_index]:
-            return False
-        return matches(argument_index + 1, subcommand_index + 1)
-
-    return matches(0, 0)
+    outcome = _subcommand_parse_outcome(
+        arguments,
+        subcommands,
+        options_with_values=options_with_values,
+        known_flags=known_flags,
+    )
+    return outcome is not _ParseOutcome.NO_MATCH
 
 
 def flags_present_in_all_option_parses(
@@ -53,76 +52,171 @@ def flags_present_in_all_option_parses(
     options_with_values: frozenset[str],
     known_flags: frozenset[str],
 ) -> bool:
-    """Return whether every plausible option parse contains each required flag."""
+    """Return whether every bounded parse certainly contains each required flag."""
 
     return all(
-        _flag_present_in_all_option_parses(
+        _flag_parse_outcome(
             arguments,
             required_flag,
             options_with_values=options_with_values,
             known_flags=known_flags,
         )
+        is _ParseOutcome.MATCH
         for required_flag in required_flags
     )
 
 
-def _flag_present_in_all_option_parses(
+def known_option_advance(
+    argument: str,
+    *,
+    options_with_values: frozenset[str],
+    known_flags: frozenset[str],
+) -> int | None:
+    """Return the deterministic token advance for a fully known option shape."""
+
+    if not _is_option(argument):
+        return None
+    shape = _option_shape(
+        argument,
+        options_with_values=options_with_values,
+        known_flags=known_flags,
+    )
+    advances = {transition.advance for transition in shape.transitions}
+    if not shape.fully_known or len(advances) != 1:
+        return None
+    return advances.pop()
+
+
+def _subcommand_parse_outcome(
+    arguments: tuple[str, ...],
+    subcommands: tuple[str, ...],
+    *,
+    options_with_values: frozenset[str],
+    known_flags: frozenset[str],
+) -> _ParseOutcome:
+    pending = [(0, 0)]
+    visited: set[tuple[int, int]] = set()
+    while pending:
+        state = pending.pop()
+        if state in visited:
+            continue
+        if len(visited) >= _MAX_OPTION_PARSE_STATES:
+            return _ParseOutcome.UNCERTAIN
+        visited.add(state)
+        argument_index, subcommand_index = state
+        if subcommand_index == len(subcommands):
+            return _ParseOutcome.MATCH
+        if argument_index >= len(arguments):
+            continue
+        argument = arguments[argument_index]
+        if argument == "--":
+            remaining = len(subcommands) - subcommand_index
+            if arguments[argument_index + 1 : argument_index + 1 + remaining] == subcommands[subcommand_index:]:
+                return _ParseOutcome.MATCH
+            continue
+        if _is_option(argument):
+            shape = _option_shape(
+                argument,
+                options_with_values=options_with_values,
+                known_flags=known_flags,
+            )
+            pending.extend((argument_index + transition.advance, subcommand_index) for transition in shape.transitions)
+            continue
+        if argument == subcommands[subcommand_index]:
+            pending.append((argument_index + 1, subcommand_index + 1))
+    return _ParseOutcome.NO_MATCH
+
+
+def _flag_parse_outcome(
     arguments: tuple[str, ...],
     required_flag: str,
     *,
     options_with_values: frozenset[str],
     known_flags: frozenset[str],
-) -> bool:
-    @cache
-    def present(argument_index: int, seen: bool) -> bool:
-        if argument_index >= len(arguments):
-            return seen
+) -> _ParseOutcome:
+    pending = [(0, False)]
+    visited: set[tuple[int, bool]] = set()
+    found_terminal = False
+    while pending:
+        state = pending.pop()
+        if state in visited:
+            continue
+        if len(visited) >= _MAX_OPTION_PARSE_STATES:
+            return _ParseOutcome.UNCERTAIN
+        visited.add(state)
+        argument_index, seen = state
+        if argument_index >= len(arguments) or arguments[argument_index] == "--":
+            if not seen:
+                return _ParseOutcome.NO_MATCH
+            found_terminal = True
+            continue
         argument = arguments[argument_index]
-        if argument == "--":
-            return seen
         if not _is_option(argument):
-            return present(argument_index + 1, seen)
-        option_name = argument.split("=", 1)[0]
-        attached_short_option = _attached_short_value_option(argument, options_with_values)
-        if option_name in options_with_values:
-            advance = 1 if "=" in argument else 2
-            return present(argument_index + advance, seen)
-        if attached_short_option is not None:
-            return present(argument_index + 1, seen)
-        token_flags = _flags_in_option_token(argument, options_with_values)
-        next_seen = seen or required_flag in token_flags
-        if option_name in known_flags or "=" in argument or _last_short_option_is_known_flag(argument, known_flags):
-            return present(argument_index + 1, next_seen)
-        return present(argument_index + 1, next_seen) and present(argument_index + 2, seen)
+            pending.append((argument_index + 1, seen))
+            continue
+        shape = _option_shape(
+            argument,
+            options_with_values=options_with_values,
+            known_flags=known_flags,
+        )
+        pending.extend(
+            (
+                argument_index + transition.advance,
+                seen or required_flag in transition.flags,
+            )
+            for transition in shape.transitions
+        )
+    return _ParseOutcome.MATCH if found_terminal else _ParseOutcome.NO_MATCH
 
-    return present(0, False)
+
+def _option_shape(
+    argument: str,
+    *,
+    options_with_values: frozenset[str],
+    known_flags: frozenset[str],
+) -> _OptionShape:
+    if argument.startswith("--"):
+        option_name, separator, _value = argument.partition("=")
+        if option_name in options_with_values:
+            advance = 1 if separator else 2
+            return _OptionShape((_OptionTransition(advance),), fully_known=True)
+        if option_name in known_flags:
+            return _OptionShape((_OptionTransition(1, frozenset({option_name, argument})),), fully_known=True)
+        if separator:
+            return _OptionShape((_OptionTransition(1),), fully_known=True)
+        return _OptionShape((_OptionTransition(1), _OptionTransition(2)), fully_known=False)
+    return _short_option_shape(
+        argument,
+        options_with_values=options_with_values,
+        known_flags=known_flags,
+    )
+
+
+def _short_option_shape(
+    argument: str,
+    *,
+    options_with_values: frozenset[str],
+    known_flags: frozenset[str],
+) -> _OptionShape:
+    transitions: set[_OptionTransition] = set()
+    flags: set[str] = set()
+    fully_known = True
+    for index, character in enumerate(argument[1:], start=1):
+        short_option = f"-{character}"
+        if short_option in options_with_values:
+            advance = 1 if index + 1 < len(argument) else 2
+            transitions.add(_OptionTransition(advance, frozenset(flags)))
+            return _OptionShape(tuple(transitions), fully_known=fully_known)
+        if short_option in known_flags:
+            flags.add(short_option)
+            continue
+        fully_known = False
+        transitions.add(_OptionTransition(1, frozenset(flags)))
+        if index + 1 == len(argument):
+            transitions.add(_OptionTransition(2, frozenset(flags)))
+    transitions.add(_OptionTransition(1, frozenset(flags)))
+    return _OptionShape(tuple(transitions), fully_known=fully_known)
 
 
 def _is_option(argument: str) -> bool:
     return len(argument) > 1 and argument.startswith("-")
-
-
-def _attached_short_value_option(argument: str, options_with_values: frozenset[str]) -> str | None:
-    if len(argument) <= 2 or not argument.startswith("-") or argument.startswith("--"):
-        return None
-    option = argument[:2]
-    return option if option in options_with_values else None
-
-
-def _last_short_option_is_known_flag(argument: str, known_flags: frozenset[str]) -> bool:
-    return len(argument) > 2 and not argument.startswith("--") and f"-{argument[-1]}" in known_flags
-
-
-def _flags_in_option_token(argument: str, options_with_values: frozenset[str]) -> frozenset[str]:
-    flags = {argument}
-    if "=" in argument:
-        flags.add(argument.split("=", 1)[0])
-    if argument.startswith("-") and not argument.startswith("--") and len(argument) > 2:
-        for character in argument[1:]:
-            if not character.isalnum():
-                continue
-            short_flag = f"-{character}"
-            flags.add(short_flag)
-            if short_flag in options_with_values:
-                break
-    return frozenset(flags)

--- a/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_option_parsing.py
@@ -7,6 +7,7 @@ from enum import Enum, auto
 from typing import Final
 
 _MAX_OPTION_PARSE_STATES: Final = 16_384
+_TRUTHY_FLAG_VALUES: Final = frozenset({"1", "on", "true", "yes"})
 
 
 class _ParseOutcome(Enum):
@@ -85,6 +86,13 @@ def known_option_advance(
     if not shape.fully_known or len(advances) != 1:
         return None
     return advances.pop()
+
+
+def long_flag_assignment_is_enabled(argument: str) -> bool:
+    """Return whether a long flag is bare or explicitly assigned a truthy value."""
+
+    _option_name, separator, value = argument.partition("=")
+    return not separator or value.lower() in _TRUTHY_FLAG_VALUES
 
 
 def _subcommand_parse_outcome(
@@ -181,7 +189,10 @@ def _option_shape(
             advance = 1 if separator else 2
             return _OptionShape((_OptionTransition(advance),), fully_known=True)
         if option_name in known_flags:
-            return _OptionShape((_OptionTransition(1, frozenset({option_name, argument})),), fully_known=True)
+            flags = {argument}
+            if long_flag_assignment_is_enabled(argument):
+                flags.add(option_name)
+            return _OptionShape((_OptionTransition(1, frozenset(flags)),), fully_known=True)
         if separator:
             return _OptionShape((_OptionTransition(1),), fully_known=True)
         return _OptionShape((_OptionTransition(1), _OptionTransition(2)), fully_known=False)

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -7,7 +7,11 @@ from typing import Literal, final
 
 from .command_matcher_contracts import CommandMatcher, MatcherEvidence
 from .command_model import CanonicalCommand, CommandSegment
-from .command_option_parsing import flags_present_in_all_option_parses, matches_subcommands_conservatively
+from .command_option_parsing import (
+    flags_present_in_all_option_parses,
+    known_option_advance,
+    matches_subcommands_conservatively,
+)
 
 CommandRuleSeverity = Literal["critical", "high", "medium", "low"]
 CommandRuleMode = Literal["required", "enforce", "review", "monitor", "disabled"]
@@ -78,6 +82,7 @@ class ExecutableMatcher:
                 subcommand_arguments = _after_leading_options(
                     subcommand_arguments,
                     self.leading_options_with_values,
+                    self.interspersed_flags,
                 )
             if (
                 self.subcommands
@@ -435,7 +440,11 @@ def _present_flags(
     return frozenset(flags)
 
 
-def _after_leading_options(arguments: tuple[str, ...], options_with_values: frozenset[str]) -> tuple[str, ...]:
+def _after_leading_options(
+    arguments: tuple[str, ...],
+    options_with_values: frozenset[str],
+    flags: frozenset[str],
+) -> tuple[str, ...]:
     index = 0
     while index < len(arguments):
         argument = arguments[index]
@@ -443,11 +452,12 @@ def _after_leading_options(arguments: tuple[str, ...], options_with_values: froz
             return arguments[index + 1 :]
         if not argument.startswith("-"):
             return arguments[index:]
-        option_name = argument.split("=", 1)[0]
-        if option_name in options_with_values and "=" not in argument:
-            index += 2
-        else:
-            index += 1
+        advance = known_option_advance(
+            argument,
+            options_with_values=options_with_values,
+            known_flags=flags,
+        )
+        index += advance if advance is not None else 1
     return ()
 
 
@@ -465,19 +475,14 @@ def _without_options(
         if argument == "--":
             retained.extend(arguments[index + 1 :])
             break
-        option_name = argument.split("=", 1)[0]
-        attached_short_option = (
-            argument[:2]
-            if len(argument) > 2 and argument[0] == "-" and argument[1] != "-" and argument[:2] in options_with_values
-            else None
+        advance = known_option_advance(
+            argument,
+            options_with_values=options_with_values,
+            known_flags=flags,
         )
-        if option_name in flags:
-            index += 1
-            continue
-        if option_name not in options_with_values and attached_short_option is None:
+        if advance is None:
             retained.append(argument)
             index += 1
             continue
-        is_attached_short = attached_short_option is not None and option_name not in options_with_values
-        index += 1 if "=" in argument or is_attached_short else 2
+        index += advance
     return tuple(retained)

--- a/src/codex_plugin_scanner/guard/runtime/command_rules.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_rules.py
@@ -10,6 +10,7 @@ from .command_model import CanonicalCommand, CommandSegment
 from .command_option_parsing import (
     flags_present_in_all_option_parses,
     known_option_advance,
+    long_flag_assignment_is_enabled,
     matches_subcommands_conservatively,
 )
 
@@ -19,7 +20,6 @@ CommandRuleMode = Literal["required", "enforce", "review", "monitor", "disabled"
 _VALID_SEVERITIES = frozenset({"critical", "high", "medium", "low"})
 _VALID_MODES = frozenset({"required", "enforce", "review", "monitor", "disabled"})
 _EMPTY_STRING_SET: frozenset[str] = frozenset()
-_TRUTHY_FLAG_VALUES = frozenset({"1", "on", "true", "yes"})
 
 
 @final
@@ -435,7 +435,7 @@ def _present_flags(
         index += 2 if option_name in options_with_values and "=" not in argument else 1
     for option_name, (argument, option_value, is_value_option) in effective_long_options.items():
         flags.add(argument)
-        if is_value_option or option_value is None or option_value in _TRUTHY_FLAG_VALUES:
+        if is_value_option or option_value is None or long_flag_assignment_is_enabled(argument):
             flags.add(option_name)
     return frozenset(flags)
 

--- a/tests/test_guard_command_backup_extensions.py
+++ b/tests/test_guard_command_backup_extensions.py
@@ -52,6 +52,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.backup.rclone.mutation",
         ),
         (
+            "rclone purge remote:archive --dry-run --dry-run=false",
+            "Rclone destructive command",
+            "command.backup.rclone.mutation",
+        ),
+        (
+            "rclone purge remote:archive --dry-run=true --dry-run=false",
+            "Rclone destructive command",
+            "command.backup.rclone.mutation",
+        ),
+        (
             "rclone -ab value purge remote:archive",
             "Rclone destructive command",
             "command.backup.rclone.mutation",
@@ -84,6 +94,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
         ),
         (
             "restic -qrs3:archive forget latest --prune",
+            "Restic destructive command",
+            "command.backup.restic.mutation",
+        ),
+        (
+            "restic forget latest --dry-run --dry-run=false",
             "Restic destructive command",
             "command.backup.restic.mutation",
         ),
@@ -132,6 +147,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Borg destructive command",
             "command.backup.borg.mutation",
         ),
+        (
+            "borg prune --keep-daily 7 /archive --dry-run --dry-run=false",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
         ("velero backup delete release-1", "Velero destructive command", "command.backup.velero.deletion"),
         (
             "velero --namespace prod backup delete release-1",
@@ -146,6 +166,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
         ("velero -nprod schedule delete nightly", "Velero destructive command", "command.backup.velero.deletion"),
         (
             "velero -vnprod backup delete release-1",
+            "Velero destructive command",
+            "command.backup.velero.deletion",
+        ),
+        (
+            "velero backup delete release-1 --help --help=false",
             "Velero destructive command",
             "command.backup.velero.deletion",
         ),
@@ -193,6 +218,8 @@ def test_backup_rules_feed_runtime_hooks(
         "rclone sync source: destination: --dry-run",
         "rclone purge remote:archive --dry-run=true",
         "rclone purge remote:archive --dry-run=1",
+        "rclone purge remote:archive --dry-run=false --dry-run",
+        "rclone purge remote:archive --dry-run=false --dry-run=true",
         "rclone -n purge remote:archive",
         "restic -r s3:archive forget latest --dry-run",
         "restic rewrite --forget latest --dry-run",
@@ -212,15 +239,18 @@ def test_backup_rules_feed_runtime_hooks(
         "restic --compression max snapshots",
         "restic -qr forget snapshots",
         "restic -qrforget snapshots",
+        "restic forget latest --dry-run=false --dry-run",
         "borg list /archive",
         "borg --remote-ratelimit 1000 list /archive",
         "borg prune -Pfoo -n --keep-daily 7 /archive",
         "borg prune -afoo -n --keep-daily 7 /archive",
         "borg recreate -efoo -n /archive",
         "borg -vr prune list",
+        "borg prune --keep-daily 7 /archive --dry-run=false --dry-run",
         "velero backup describe release-1",
         "velero --future-global-option cluster backup describe release-1",
         "velero -vnprod backup describe release-1",
+        "velero backup delete release-1 --help=false --help",
         "grep 'rclone sync|restic forget|borg prune|velero backup delete' docs",
     ],
 )

--- a/tests/test_guard_command_backup_extensions.py
+++ b/tests/test_guard_command_backup_extensions.py
@@ -6,8 +6,13 @@ from pathlib import Path
 
 import pytest
 
+from codex_plugin_scanner.guard.runtime import command_option_parsing
 from codex_plugin_scanner.guard.runtime.command_extensions import BUILT_IN_COMMAND_EXTENSION_REGISTRY
 from codex_plugin_scanner.guard.runtime.command_inspection import inspect_command
+from codex_plugin_scanner.guard.runtime.command_option_parsing import (
+    flags_present_in_all_option_parses,
+    matches_subcommands_conservatively,
+)
 from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sensitive_tool_action_request
 
 
@@ -62,6 +67,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Restic destructive command",
             "command.backup.restic.mutation",
         ),
+        (
+            "restic -qr repository forget latest --prune",
+            "Restic destructive command",
+            "command.backup.restic.mutation",
+        ),
+        (
+            "restic -qrs3:archive forget latest --prune",
+            "Restic destructive command",
+            "command.backup.restic.mutation",
+        ),
         ("restic rewrite --forget latest", "Restic destructive command", "command.backup.restic.mutation"),
         ("borg.cmd prune --keep-daily 7 /archive", "Borg destructive command", "command.backup.borg.mutation"),
         ("borg delete /archive::old", "Borg destructive command", "command.backup.borg.mutation"),
@@ -82,6 +97,31 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "Borg destructive command",
             "command.backup.borg.mutation",
         ),
+        (
+            "borg -Pfoo-n prune --keep-daily 7 /archive",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
+        (
+            "borg -afoo-n prune --keep-daily 7 /archive",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
+        (
+            "borg -efoo-n recreate /archive",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
+        (
+            "borg -vr /archive prune --keep-daily 7",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
+        (
+            "borg -vr/archive prune --keep-daily 7",
+            "Borg destructive command",
+            "command.backup.borg.mutation",
+        ),
         ("velero backup delete release-1", "Velero destructive command", "command.backup.velero.deletion"),
         (
             "velero --namespace prod backup delete release-1",
@@ -94,6 +134,11 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.backup.velero.deletion",
         ),
         ("velero -nprod schedule delete nightly", "Velero destructive command", "command.backup.velero.deletion"),
+        (
+            "velero -vnprod backup delete release-1",
+            "Velero destructive command",
+            "command.backup.velero.deletion",
+        ),
         (
             "velero --future-global-option cluster backup delete release-1",
             "Velero destructive command",
@@ -150,12 +195,20 @@ def test_backup_rules_feed_runtime_hooks(
         "rclone lsl remote:archive",
         "rclone --log-level DEBUG lsl remote:archive",
         "rclone -ab value lsl remote:archive",
+        "rclone -vn purge remote:archive",
         "restic snapshots",
         "restic --compression max snapshots",
+        "restic -qr forget snapshots",
+        "restic -qrforget snapshots",
         "borg list /archive",
         "borg --remote-ratelimit 1000 list /archive",
+        "borg prune -Pfoo -n --keep-daily 7 /archive",
+        "borg prune -afoo -n --keep-daily 7 /archive",
+        "borg recreate -efoo -n /archive",
+        "borg -vr prune list",
         "velero backup describe release-1",
         "velero --future-global-option cluster backup describe release-1",
+        "velero -vnprod backup describe release-1",
         "grep 'rclone sync|restic forget|borg prune|velero backup delete' docs",
     ],
 )
@@ -179,6 +232,50 @@ def test_backup_interactive_mode_remains_reviewable(tmp_path: Path) -> None:
 
     assert payload["status"] == "review"
     assert payload["controlling_rule_id"] == "command.backup.rclone.mutation"
+
+
+def test_backup_option_parsing_handles_deep_option_sequences(tmp_path: Path) -> None:
+    repeated_options = " ".join("--x=y" for _ in range(1200))
+    destructive_command = f"rclone {repeated_options} purge remote:archive"
+    safe_command = f"rclone {repeated_options} -n purge remote:archive"
+
+    destructive_payload = inspect_command(destructive_command, cwd=tmp_path, home_dir=tmp_path)
+    destructive_runtime = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": destructive_command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+    safe_payload = inspect_command(safe_command, cwd=tmp_path, home_dir=tmp_path)
+    safe_runtime = extract_sensitive_tool_action_request(
+        "Shell",
+        {"command": safe_command},
+        cwd=tmp_path,
+        home_dir=tmp_path,
+    )
+
+    assert destructive_payload["status"] == "review"
+    assert destructive_runtime is not None
+    assert safe_payload["status"] == "no_match"
+    assert safe_runtime is None
+
+
+def test_backup_option_parse_limit_fails_secure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(command_option_parsing, "_MAX_OPTION_PARSE_STATES", 1)
+    arguments = ("--future=value", "purge", "remote:archive")
+
+    assert matches_subcommands_conservatively(
+        arguments,
+        ("purge",),
+        options_with_values=frozenset(),
+        known_flags=frozenset({"-n"}),
+    )
+    assert not flags_present_in_all_option_parses(
+        arguments,
+        frozenset({"-n"}),
+        options_with_values=frozenset(),
+        known_flags=frozenset({"-n"}),
+    )
 
 
 def test_backup_extensions_publish_official_references() -> None:

--- a/tests/test_guard_command_backup_extensions.py
+++ b/tests/test_guard_command_backup_extensions.py
@@ -42,6 +42,16 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.backup.rclone.mutation",
         ),
         (
+            "rclone purge remote:archive --dry-run=false",
+            "Rclone destructive command",
+            "command.backup.rclone.mutation",
+        ),
+        (
+            "rclone purge remote:archive --dry-run=0",
+            "Rclone destructive command",
+            "command.backup.rclone.mutation",
+        ),
+        (
             "rclone -ab value purge remote:archive",
             "Rclone destructive command",
             "command.backup.rclone.mutation",
@@ -181,6 +191,8 @@ def test_backup_rules_feed_runtime_hooks(
     "command",
     [
         "rclone sync source: destination: --dry-run",
+        "rclone purge remote:archive --dry-run=true",
+        "rclone purge remote:archive --dry-run=1",
         "rclone -n purge remote:archive",
         "restic -r s3:archive forget latest --dry-run",
         "restic rewrite --forget latest --dry-run",

--- a/tests/test_guard_command_cloud_extensions.py
+++ b/tests/test_guard_command_cloud_extensions.py
@@ -102,6 +102,21 @@ from codex_plugin_scanner.guard.runtime.secret_file_requests import extract_sens
             "command.cloud.azure.resource-deletion",
         ),
         (
+            "aws ec2 terminate-instances --instance-ids i-123 --dry-run --dry-run=false",
+            "AWS destructive command",
+            "command.cloud.aws.resource-deletion",
+        ),
+        (
+            "gcloud compute instances delete api-1 --help --help=false",
+            "Google Cloud destructive command",
+            "command.cloud.gcp.resource-deletion",
+        ),
+        (
+            "az vm delete --resource-group app --name api-1 --help --help=false",
+            "Azure destructive command",
+            "command.cloud.azure.resource-deletion",
+        ),
+        (
             "aws.exe ec2 --region us-east-1 terminate-instances --instance-ids i-123",
             "AWS destructive command",
             "command.cloud.aws.resource-deletion",
@@ -221,6 +236,9 @@ def test_cloud_rules_feed_inspection_and_runtime_hooks(
         "aws --future-global-option account ec2 terminate-instances --instance-ids i-123 --dry-run",
         "gcloud --future-global-option account compute instances delete api-1 --help",
         "az --future-global-option tenant vm delete --resource-group app --name api-1 --help",
+        "aws ec2 terminate-instances --instance-ids i-123 --dry-run=false --dry-run",
+        "gcloud compute instances delete api-1 --help=false --help",
+        "az vm delete --resource-group app --name api-1 --help=false --help",
         "aws ec2 describe-instances --instance-ids i-123",
         "aws --future-global-option account ec2 describe-instances --instance-ids i-123",
         "gcloud compute instances describe api-1",


### PR DESCRIPTION
## Summary
- make command option handling bounded and consistent
- preserve preview and observer classifications across supported CLI forms

## Testing
- `uv run --no-sync pytest tests/test_guard_command_backup_extensions.py --tb=short -q`
- `uv run --no-sync pytest tests/test_guard_command_*.py --tb=short -q`
- `uv build`
