### PR TITLE
Preserve quoted redirect arguments

### DIFF
--- a/src/codex_plugin_scanner/guard/runtime/command_structure.py
+++ b/src/codex_plugin_scanner/guard/runtime/command_structure.py
@@ -8,7 +8,7 @@ import re
 from dataclasses import dataclass
 from typing import Literal, Protocol
 
-from .shell_structure import ShellHeredoc
+from .shell_structure import ShellHeredoc, ShellScanState
 
 _REDIRECT_PATTERN = re.compile(
     r"(?<![<>])(?P<operator>(?:\d*)>>?|(?:\d*)<)(?![<>&])\s*(?P<target>\"[^\"]+\"|'[^']+'|[^ \t\r\n;&|<>]+)"
@@ -110,8 +110,19 @@ def extract_command_redirects(
 
     redirects: list[CommandRedirect] = []
     heredoc_operator_starts = {item.operator_start for item in heredocs}
-    for match in _REDIRECT_PATTERN.finditer(command):
-        if match.start() in heredoc_operator_starts:
+    state = ShellScanState()
+    index = 0
+    while index < len(command):
+        next_index = state.advance(command, index)
+        if next_index != index + 1:
+            index = next_index
+            continue
+        if not state.is_top_level:
+            index += 1
+            continue
+        match = _REDIRECT_PATTERN.match(command, index)
+        if match is None or match.start() in heredoc_operator_starts:
+            index += 1
             continue
         redirects.append(
             CommandRedirect(
@@ -121,6 +132,7 @@ def extract_command_redirects(
                 end=match.end(),
             )
         )
+        index = match.end()
     redirects.extend(
         CommandRedirect(
             operator="<<-" if heredoc.strip_tabs else "<<",

--- a/tests/test_guard_command_model.py
+++ b/tests/test_guard_command_model.py
@@ -61,6 +61,14 @@ def test_parse_shell_command_preserves_quoted_heredoc_like_argument() -> None:
     assert parsed.segments[0].arguments == ("delete", "target", "<<--help")
 
 
+@pytest.mark.parametrize("argument", ["< --help", "> --help", "2> --help", "value>--help"])
+def test_parse_shell_command_preserves_quoted_redirect_like_argument(argument: str) -> None:
+    parsed = parse_shell_command(f"tool delete '{argument}'")
+
+    assert parsed.segments[0].arguments == ("delete", argument)
+    assert parsed.redirects == ()
+
+
 def test_parse_shell_command_skips_all_sudo_options_with_values() -> None:
     parsed = parse_shell_command(
         "sudo --command-timeout 10 --login-class staff git --config-env token=TOKEN push --force"


### PR DESCRIPTION
## Summary

- make redirect extraction honor shell quote state
- preserve quoted redirect-like text as executable arguments
- retain redirect span masking for actual shell redirections

## Security boundary

Canonical arguments now exclude only redirect syntax recognized at the shell's top level. Redirect-like text inside quoted CLI arguments remains executable input.

## Testing

- `uv run pytest tests/test_guard_command_*extensions.py tests/test_guard_command_model.py -q`
- `uv run pytest tests/test_guard_command_model.py tests/test_guard_command_managed_service_extensions.py tests/test_guard_data_flow.py -q`
- `uv run ruff check src/codex_plugin_scanner/guard/runtime/command_structure.py tests/test_guard_command_model.py`
- `uv run --with basedpyright basedpyright src/codex_plugin_scanner/guard/runtime/command_structure.py --level error`
- `uv build`
